### PR TITLE
feat(core): add unified registry system for commands, events, and context

### DIFF
--- a/packages/core/src/registry/context-provider-registry.ts
+++ b/packages/core/src/registry/context-provider-registry.ts
@@ -1,0 +1,395 @@
+/**
+ * Context Provider Registry
+ *
+ * Enables registration of dynamic context values that are resolved at runtime.
+ * This extends the static CoreExecutionContext (me, it, you, event) with custom
+ * values like request, response, session, etc.
+ *
+ * Usage:
+ *   context.register('request', () => currentRequest);
+ *   context.register('response', () => responseBuilder);
+ *   context.register('session', () => getSession());
+ *
+ * Context providers are:
+ *   - Lazily evaluated when accessed
+ *   - Scoped to specific execution contexts
+ *   - Support both sync and async resolution
+ */
+
+import type { ExecutionContext, TypedExecutionContext } from '../types/core';
+
+/**
+ * Context provider function signature
+ * Can return a value synchronously or a Promise
+ */
+export type ContextProviderFn<T = unknown> = (context: ExecutionContext) => T | Promise<T>;
+
+/**
+ * Context provider definition
+ */
+export interface ContextProvider<T = unknown> {
+  /** Provider name (used as the context key) */
+  readonly name: string;
+
+  /** Human-readable description */
+  readonly description?: string;
+
+  /** Provider function that returns the context value */
+  readonly provide: ContextProviderFn<T>;
+
+  /** Whether this provider's value should be cached per-execution */
+  readonly cache?: boolean;
+
+  /** Whether this provider is async */
+  readonly async?: boolean;
+
+  /** Dependencies on other providers (for ordering) */
+  readonly dependencies?: string[];
+}
+
+/**
+ * Options for registering a context provider
+ */
+export interface ContextProviderOptions<T = unknown> {
+  /** Human-readable description */
+  description?: string;
+
+  /** Whether to cache the value per-execution (default: true) */
+  cache?: boolean;
+
+  /** Dependencies on other providers */
+  dependencies?: string[];
+}
+
+/**
+ * Registry for dynamic context providers
+ *
+ * Example:
+ *   const registry = new ContextProviderRegistry();
+ *
+ *   // Register providers
+ *   registry.register('request', () => currentRequest);
+ *   registry.register('user', async (ctx) => await getUser(ctx.locals.get('sessionId')));
+ *
+ *   // Resolve values
+ *   const request = await registry.resolve('request', context);
+ *   const user = await registry.resolve('user', context);
+ *
+ *   // Create enhanced context with all providers
+ *   const enhanced = await registry.enhance(context);
+ *   console.log(enhanced.request, enhanced.user);
+ */
+export class ContextProviderRegistry {
+  private providers = new Map<string, ContextProvider>();
+  private globalProviders = new Map<string, ContextProvider>();
+
+  /**
+   * Register a context provider
+   * @param name Provider name (becomes context property)
+   * @param provider Provider function or full provider definition
+   * @param options Optional provider options
+   */
+  register<T>(
+    name: string,
+    provider: ContextProviderFn<T> | ContextProvider<T>,
+    options?: ContextProviderOptions<T>
+  ): void {
+    const normalizedName = name.toLowerCase();
+
+    const fullProvider: ContextProvider<T> =
+      typeof provider === 'function'
+        ? {
+            name: normalizedName,
+            provide: provider,
+            cache: options?.cache ?? true,
+            description: options?.description,
+            dependencies: options?.dependencies,
+          }
+        : provider;
+
+    this.providers.set(normalizedName, fullProvider as ContextProvider);
+  }
+
+  /**
+   * Register a global context provider (available in all contexts)
+   * @param name Provider name
+   * @param provider Provider function or full provider definition
+   * @param options Optional provider options
+   */
+  registerGlobal<T>(
+    name: string,
+    provider: ContextProviderFn<T> | ContextProvider<T>,
+    options?: ContextProviderOptions<T>
+  ): void {
+    const normalizedName = name.toLowerCase();
+
+    const fullProvider: ContextProvider<T> =
+      typeof provider === 'function'
+        ? {
+            name: normalizedName,
+            provide: provider,
+            cache: options?.cache ?? true,
+            description: options?.description,
+            dependencies: options?.dependencies,
+          }
+        : provider;
+
+    this.globalProviders.set(normalizedName, fullProvider as ContextProvider);
+  }
+
+  /**
+   * Unregister a context provider
+   * @param name Provider name
+   */
+  unregister(name: string): boolean {
+    return this.providers.delete(name.toLowerCase());
+  }
+
+  /**
+   * Unregister a global context provider
+   * @param name Provider name
+   */
+  unregisterGlobal(name: string): boolean {
+    return this.globalProviders.delete(name.toLowerCase());
+  }
+
+  /**
+   * Get a registered provider
+   * @param name Provider name
+   */
+  get(name: string): ContextProvider | undefined {
+    const normalizedName = name.toLowerCase();
+    return this.providers.get(normalizedName) ?? this.globalProviders.get(normalizedName);
+  }
+
+  /**
+   * Check if a provider is registered
+   * @param name Provider name
+   */
+  has(name: string): boolean {
+    const normalizedName = name.toLowerCase();
+    return this.providers.has(normalizedName) || this.globalProviders.has(normalizedName);
+  }
+
+  /**
+   * Resolve a context value
+   * @param name Provider name
+   * @param context Execution context
+   * @param cache Optional cache map for this execution
+   * @returns Resolved value or undefined if provider not found
+   */
+  async resolve<T = unknown>(
+    name: string,
+    context: ExecutionContext,
+    cache?: Map<string, unknown>
+  ): Promise<T | undefined> {
+    const provider = this.get(name);
+
+    if (!provider) {
+      return undefined;
+    }
+
+    // Check cache
+    const cacheKey = `__provider_${provider.name}`;
+    if (provider.cache && cache?.has(cacheKey)) {
+      return cache.get(cacheKey) as T;
+    }
+
+    // Resolve dependencies first
+    if (provider.dependencies) {
+      for (const dep of provider.dependencies) {
+        await this.resolve(dep, context, cache);
+      }
+    }
+
+    // Resolve value
+    const value = await provider.provide(context);
+
+    // Cache if enabled
+    if (provider.cache && cache) {
+      cache.set(cacheKey, value);
+    }
+
+    return value as T;
+  }
+
+  /**
+   * Resolve a context value synchronously (throws if provider is async)
+   * @param name Provider name
+   * @param context Execution context
+   * @param cache Optional cache map
+   */
+  resolveSync<T = unknown>(
+    name: string,
+    context: ExecutionContext,
+    cache?: Map<string, unknown>
+  ): T | undefined {
+    const provider = this.get(name);
+
+    if (!provider) {
+      return undefined;
+    }
+
+    // Check cache
+    const cacheKey = `__provider_${provider.name}`;
+    if (provider.cache && cache?.has(cacheKey)) {
+      return cache.get(cacheKey) as T;
+    }
+
+    // Resolve value
+    const value = provider.provide(context);
+
+    // Check if async
+    if (value instanceof Promise) {
+      throw new Error(
+        `Context provider '${name}' is async. Use resolve() instead of resolveSync().`
+      );
+    }
+
+    // Cache if enabled
+    if (provider.cache && cache) {
+      cache.set(cacheKey, value);
+    }
+
+    return value as T;
+  }
+
+  /**
+   * Create an enhanced context with all providers as getters
+   * @param context Base execution context
+   * @returns Proxy with lazy provider resolution
+   */
+  enhance<T extends ExecutionContext>(context: T): T & Record<string, unknown> {
+    const registry = this;
+    const cache = new Map<string, unknown>();
+
+    return new Proxy(context, {
+      get(target, prop, receiver) {
+        // Check if it's a registered provider
+        if (typeof prop === 'string') {
+          const provider = registry.get(prop);
+          if (provider) {
+            // Try sync resolution first
+            try {
+              return registry.resolveSync(prop, target, cache);
+            } catch {
+              // Return a promise for async providers
+              return registry.resolve(prop, target, cache);
+            }
+          }
+        }
+
+        // Fall back to original property
+        return Reflect.get(target, prop, receiver);
+      },
+
+      has(target, prop) {
+        if (typeof prop === 'string' && registry.has(prop)) {
+          return true;
+        }
+        return Reflect.has(target, prop);
+      },
+    }) as T & Record<string, unknown>;
+  }
+
+  /**
+   * Pre-resolve all providers and return values as a plain object
+   * @param context Execution context
+   * @returns Object with all resolved provider values
+   */
+  async resolveAll(context: ExecutionContext): Promise<Record<string, unknown>> {
+    const cache = new Map<string, unknown>();
+    const result: Record<string, unknown> = {};
+
+    // Resolve all providers (respecting dependencies)
+    const allProviders = [...this.globalProviders.entries(), ...this.providers.entries()];
+
+    for (const [name, provider] of allProviders) {
+      try {
+        result[name] = await this.resolve(name, context, cache);
+      } catch (error) {
+        console.warn(`[ContextProviderRegistry] Failed to resolve '${name}':`, error);
+        result[name] = undefined;
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Get all registered provider names
+   */
+  getProviderNames(): string[] {
+    return [...new Set([...this.globalProviders.keys(), ...this.providers.keys()])];
+  }
+
+  /**
+   * Clear all providers
+   */
+  clear(): void {
+    this.providers.clear();
+    this.globalProviders.clear();
+  }
+}
+
+/**
+ * Factory function for creating context provider registry
+ */
+export function createContextProviderRegistry(): ContextProviderRegistry {
+  return new ContextProviderRegistry();
+}
+
+/**
+ * Default global context provider registry instance
+ */
+let defaultRegistry: ContextProviderRegistry | null = null;
+
+/**
+ * Get the default context provider registry (creates one if needed)
+ */
+export function getDefaultContextProviderRegistry(): ContextProviderRegistry {
+  if (!defaultRegistry) {
+    defaultRegistry = createContextProviderRegistry();
+  }
+  return defaultRegistry;
+}
+
+/**
+ * Built-in context provider for 'me' element
+ */
+export const meProvider: ContextProvider<Element | null> = {
+  name: 'me',
+  description: 'Current element context',
+  provide: ctx => ctx.me,
+  cache: false, // me can change during execution
+};
+
+/**
+ * Built-in context provider for 'it' (last result)
+ */
+export const itProvider: ContextProvider<unknown> = {
+  name: 'it',
+  description: 'Result of last expression',
+  provide: ctx => ctx.it,
+  cache: false, // it changes frequently
+};
+
+/**
+ * Built-in context provider for 'you' (target element)
+ */
+export const youProvider: ContextProvider<Element | null> = {
+  name: 'you',
+  description: 'Target element for operations',
+  provide: ctx => ctx.you,
+  cache: false,
+};
+
+/**
+ * Built-in context provider for current event
+ */
+export const eventProvider: ContextProvider<Event | null | undefined> = {
+  name: 'event',
+  description: 'Current DOM event',
+  provide: ctx => ctx.event,
+  cache: false,
+};

--- a/packages/core/src/registry/event-source-registry.ts
+++ b/packages/core/src/registry/event-source-registry.ts
@@ -1,0 +1,326 @@
+/**
+ * Event Source Registry
+ *
+ * Enables registration of custom event sources beyond standard DOM events.
+ * This is essential for server-side hyperscript (request events), WebSocket events,
+ * SSE streams, and other non-DOM event sources.
+ *
+ * Usage:
+ *   eventSources.register('request', requestEventSource);
+ *   eventSources.register('websocket', websocketEventSource);
+ *
+ * Event sources handle:
+ *   - Subscribing to their event stream
+ *   - Mapping events to hyperscript execution context
+ *   - Cleanup when the subscription is no longer needed
+ */
+
+import type { ExecutionContext } from '../types/core';
+import type { ASTNode } from '../types/base-types';
+
+/**
+ * Event payload passed to event handlers
+ */
+export interface EventSourcePayload {
+  /** The event type (e.g., 'request', 'message', 'connection') */
+  type: string;
+
+  /** Raw event data from the source */
+  data: unknown;
+
+  /** Target element or context object */
+  target?: Element | object | null;
+
+  /** Original native event if applicable */
+  nativeEvent?: Event;
+
+  /** Additional metadata */
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * Handler function invoked when an event source fires
+ */
+export type EventSourceHandler = (payload: EventSourcePayload, context: ExecutionContext) => void;
+
+/**
+ * Subscription returned when attaching to an event source
+ */
+export interface EventSourceSubscription {
+  /** Unique identifier for this subscription */
+  id: string;
+
+  /** Event source name */
+  source: string;
+
+  /** Event type within the source */
+  event: string;
+
+  /** Cleanup function to remove the subscription */
+  unsubscribe: () => void;
+}
+
+/**
+ * Options for subscribing to an event source
+ */
+export interface EventSourceSubscribeOptions {
+  /** The specific event type to listen for (e.g., 'GET', 'POST' for request source) */
+  event: string;
+
+  /** Event handler commands to execute */
+  handler: EventSourceHandler;
+
+  /** Target/filter criteria (e.g., URL pattern for requests) */
+  target?: string | RegExp;
+
+  /** Selector for event delegation */
+  selector?: string;
+
+  /** Additional options specific to the event source */
+  options?: Record<string, unknown>;
+}
+
+/**
+ * Interface for custom event sources
+ *
+ * Event sources are responsible for:
+ * 1. Setting up the underlying event subscription
+ * 2. Transforming native events into EventSourcePayload
+ * 3. Managing cleanup on unsubscribe
+ */
+export interface EventSource {
+  /** Unique name for this event source (e.g., 'request', 'websocket') */
+  readonly name: string;
+
+  /** Human-readable description */
+  readonly description?: string;
+
+  /** Supported event types within this source */
+  readonly supportedEvents?: string[];
+
+  /**
+   * Subscribe to events from this source
+   * @param options Subscription options
+   * @param context Execution context for the handler
+   * @returns Subscription that can be used to unsubscribe
+   */
+  subscribe(
+    options: EventSourceSubscribeOptions,
+    context: ExecutionContext
+  ): EventSourceSubscription;
+
+  /**
+   * Check if this source supports a given event type
+   * @param event Event type to check
+   */
+  supports?(event: string): boolean;
+
+  /**
+   * Initialize the event source (called once on first use)
+   */
+  initialize?(): Promise<void> | void;
+
+  /**
+   * Cleanup all subscriptions and resources
+   */
+  destroy?(): void;
+}
+
+/**
+ * Registry for custom event sources
+ *
+ * Example usage:
+ *   const registry = new EventSourceRegistry();
+ *
+ *   // Register a server-side request event source
+ *   registry.register('request', {
+ *     name: 'request',
+ *     subscribe(options, context) {
+ *       // Set up HTTP request handling
+ *       return { id: '...', source: 'request', event: options.event, unsubscribe: () => {} };
+ *     }
+ *   });
+ *
+ *   // Use in hyperscript: on request(GET, /api/users)
+ *   const sub = registry.subscribe('request', { event: 'GET', target: '/api/users', handler });
+ */
+export class EventSourceRegistry {
+  private sources = new Map<string, EventSource>();
+  private subscriptions = new Map<string, EventSourceSubscription>();
+  private nextId = 1;
+
+  /**
+   * Register a custom event source
+   * @param name Event source name (used in 'on <name>' syntax)
+   * @param source Event source implementation
+   */
+  register(name: string, source: EventSource): void {
+    const normalizedName = name.toLowerCase();
+
+    if (this.sources.has(normalizedName)) {
+      console.warn(`[EventSourceRegistry] Overwriting existing event source: ${name}`);
+    }
+
+    this.sources.set(normalizedName, source);
+  }
+
+  /**
+   * Unregister an event source
+   * @param name Event source name
+   */
+  unregister(name: string): boolean {
+    const normalizedName = name.toLowerCase();
+    const source = this.sources.get(normalizedName);
+
+    if (source) {
+      // Cleanup all subscriptions for this source
+      for (const [id, sub] of this.subscriptions.entries()) {
+        if (sub.source === normalizedName) {
+          sub.unsubscribe();
+          this.subscriptions.delete(id);
+        }
+      }
+
+      // Destroy the source
+      source.destroy?.();
+      return this.sources.delete(normalizedName);
+    }
+
+    return false;
+  }
+
+  /**
+   * Get a registered event source
+   * @param name Event source name
+   */
+  get(name: string): EventSource | undefined {
+    return this.sources.get(name.toLowerCase());
+  }
+
+  /**
+   * Check if an event source is registered
+   * @param name Event source name
+   */
+  has(name: string): boolean {
+    return this.sources.has(name.toLowerCase());
+  }
+
+  /**
+   * Subscribe to events from a registered source
+   * @param sourceName Event source name
+   * @param options Subscription options
+   * @param context Execution context
+   * @returns Subscription or undefined if source not found
+   */
+  subscribe(
+    sourceName: string,
+    options: EventSourceSubscribeOptions,
+    context: ExecutionContext
+  ): EventSourceSubscription | undefined {
+    const source = this.get(sourceName);
+
+    if (!source) {
+      console.warn(`[EventSourceRegistry] Unknown event source: ${sourceName}`);
+      return undefined;
+    }
+
+    // Initialize source if needed
+    source.initialize?.();
+
+    // Create subscription
+    const subscription = source.subscribe(options, context);
+
+    // Track subscription
+    this.subscriptions.set(subscription.id, subscription);
+
+    return subscription;
+  }
+
+  /**
+   * Unsubscribe by subscription ID
+   * @param subscriptionId Subscription ID
+   */
+  unsubscribe(subscriptionId: string): boolean {
+    const subscription = this.subscriptions.get(subscriptionId);
+
+    if (subscription) {
+      subscription.unsubscribe();
+      return this.subscriptions.delete(subscriptionId);
+    }
+
+    return false;
+  }
+
+  /**
+   * Get all registered event source names
+   */
+  getSourceNames(): string[] {
+    return Array.from(this.sources.keys());
+  }
+
+  /**
+   * Get all active subscriptions
+   */
+  getSubscriptions(): EventSourceSubscription[] {
+    return Array.from(this.subscriptions.values());
+  }
+
+  /**
+   * Check if an event type might be from a custom source
+   * Returns the source name if found, undefined otherwise
+   */
+  findSourceForEvent(event: string): string | undefined {
+    for (const [name, source] of this.sources.entries()) {
+      if (source.supports?.(event) ?? source.supportedEvents?.includes(event)) {
+        return name;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Generate a unique subscription ID
+   */
+  generateId(): string {
+    return `sub_${this.nextId++}_${Date.now().toString(36)}`;
+  }
+
+  /**
+   * Cleanup all subscriptions and destroy all sources
+   */
+  destroy(): void {
+    // Unsubscribe all
+    for (const sub of this.subscriptions.values()) {
+      sub.unsubscribe();
+    }
+    this.subscriptions.clear();
+
+    // Destroy all sources
+    for (const source of this.sources.values()) {
+      source.destroy?.();
+    }
+    this.sources.clear();
+  }
+}
+
+/**
+ * Factory function for creating event source registry
+ */
+export function createEventSourceRegistry(): EventSourceRegistry {
+  return new EventSourceRegistry();
+}
+
+/**
+ * Default global event source registry instance
+ */
+let defaultRegistry: EventSourceRegistry | null = null;
+
+/**
+ * Get the default event source registry (creates one if needed)
+ */
+export function getDefaultEventSourceRegistry(): EventSourceRegistry {
+  if (!defaultRegistry) {
+    defaultRegistry = createEventSourceRegistry();
+  }
+  return defaultRegistry;
+}

--- a/packages/core/src/registry/examples/server-commands.ts
+++ b/packages/core/src/registry/examples/server-commands.ts
@@ -1,0 +1,408 @@
+/**
+ * Example: Server-Side Commands
+ *
+ * Demonstrates how to create custom commands for server-side hyperscript.
+ * These commands work with HTTP request/response in the execution context.
+ *
+ * Usage in hyperscript:
+ *   on request(GET, /api/users)
+ *     set users to [{ name: 'Alice' }, { name: 'Bob' }]
+ *     respond with <json> users </json>
+ *
+ *   on request(POST, /api/login)
+ *     if not valid(request.body)
+ *       respond with status 400 and <json> { error: 'Invalid' } </json>
+ *     end
+ *     setHeader 'X-Auth-Token' to token
+ *     respond with <json> { success: true } </json>
+ *
+ *   on request(GET, /dashboard)
+ *     redirect to '/login' if not authenticated
+ *
+ * Installation:
+ *   import { commands } from '@hyperfixi/core/registry';
+ *   import { respondCommand, redirectCommand, setHeaderCommand } from './server-commands';
+ *
+ *   commands.register(respondCommand);
+ *   commands.register(redirectCommand);
+ *   commands.register(setHeaderCommand);
+ */
+
+import type { CommandWithParseInput } from '../../runtime/command-adapter';
+import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
+import type { ASTNode } from '../../types/base-types';
+import type { ExpressionEvaluator } from '../../core/expression-evaluator';
+
+/**
+ * Response interface (matches server-event-source.ts)
+ */
+interface ServerResponse {
+  status(code: number): ServerResponse;
+  header(name: string, value: string): ServerResponse;
+  json(data: unknown): void;
+  html(content: string): void;
+  text(content: string): void;
+  redirect(url: string, code?: number): void;
+  send(data: unknown): void;
+}
+
+// ============================================================================
+// respond command
+// ============================================================================
+
+interface RespondInput {
+  content: unknown;
+  contentType: 'json' | 'html' | 'text' | 'auto';
+  statusCode: number;
+}
+
+/**
+ * respond command - Send HTTP response
+ *
+ * Syntax:
+ *   respond with <content>
+ *   respond with status <code> and <content>
+ *   respond with <json> data </json>
+ *   respond with <html> content </html>
+ */
+export const respondCommand: CommandWithParseInput = {
+  name: 'respond',
+
+  metadata: {
+    description: 'Send HTTP response to client',
+    syntax: [
+      'respond with <content>',
+      'respond with status <code> and <content>',
+      'respond with <json> data </json>',
+      'respond with <html> content </html>',
+    ],
+    examples: [
+      'respond with users',
+      'respond with status 201 and newUser',
+      'respond with <json> { success: true } </json>',
+    ],
+    category: 'server',
+  },
+
+  async parseInput(
+    raw: { args: ASTNode[]; modifiers: Record<string, any> },
+    evaluator: ExpressionEvaluator,
+    context: ExecutionContext
+  ): Promise<RespondInput> {
+    let content: unknown = null;
+    let contentType: 'json' | 'html' | 'text' | 'auto' = 'auto';
+    let statusCode = 200;
+
+    const args = raw.args || [];
+
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+
+      // Check for 'status' keyword
+      if (arg.type === 'identifier' && (arg as any).name?.toLowerCase() === 'status') {
+        const nextArg = args[i + 1];
+        if (nextArg) {
+          statusCode = Number(await evaluator.evaluate(nextArg, context)) || 200;
+          i++; // Skip the status code arg
+        }
+        continue;
+      }
+
+      // Check for content type markers
+      if (arg.type === 'identifier') {
+        const name = ((arg as any).name || '').toLowerCase();
+        if (name === 'json') {
+          contentType = 'json';
+          continue;
+        } else if (name === 'html') {
+          contentType = 'html';
+          continue;
+        } else if (name === 'text') {
+          contentType = 'text';
+          continue;
+        }
+      }
+
+      // Evaluate content
+      if (content === null) {
+        content = await evaluator.evaluate(arg, context);
+      }
+    }
+
+    // Handle modifiers
+    if (raw.modifiers?.status) {
+      statusCode = Number(await evaluator.evaluate(raw.modifiers.status, context)) || 200;
+    }
+    if (raw.modifiers?.as) {
+      const asType = String(await evaluator.evaluate(raw.modifiers.as, context)).toLowerCase();
+      if (asType === 'json' || asType === 'html' || asType === 'text') {
+        contentType = asType;
+      }
+    }
+
+    return { content, contentType, statusCode };
+  },
+
+  async execute(input: RespondInput, context: TypedExecutionContext): Promise<void> {
+    const response = context.locals.get('response') as ServerResponse | undefined;
+
+    if (!response) {
+      throw new Error(
+        "respond command requires 'response' in context. " +
+          "Make sure you're in a server request handler."
+      );
+    }
+
+    // Set status code
+    response.status(input.statusCode);
+
+    // Send response based on content type
+    switch (input.contentType) {
+      case 'json':
+        response.json(input.content);
+        break;
+      case 'html':
+        response.html(String(input.content));
+        break;
+      case 'text':
+        response.text(String(input.content));
+        break;
+      case 'auto':
+      default:
+        // Auto-detect based on content
+        if (typeof input.content === 'object' && input.content !== null) {
+          response.json(input.content);
+        } else if (typeof input.content === 'string' && input.content.trim().startsWith('<')) {
+          response.html(input.content);
+        } else {
+          response.send(input.content);
+        }
+    }
+  },
+};
+
+// ============================================================================
+// redirect command
+// ============================================================================
+
+interface RedirectInput {
+  url: string;
+  statusCode: number;
+}
+
+/**
+ * redirect command - HTTP redirect response
+ *
+ * Syntax:
+ *   redirect to <url>
+ *   redirect to <url> with status <code>
+ *   redirect permanently to <url>
+ */
+export const redirectCommand: CommandWithParseInput = {
+  name: 'redirect',
+
+  metadata: {
+    description: 'Send HTTP redirect response',
+    syntax: [
+      'redirect to <url>',
+      'redirect to <url> with status <code>',
+      'redirect permanently to <url>',
+    ],
+    examples: [
+      'redirect to "/login"',
+      'redirect to "/dashboard" with status 303',
+      'redirect permanently to "https://new-domain.com"',
+    ],
+    category: 'server',
+  },
+
+  async parseInput(
+    raw: { args: ASTNode[]; modifiers: Record<string, any> },
+    evaluator: ExpressionEvaluator,
+    context: ExecutionContext
+  ): Promise<RedirectInput> {
+    let url = '/';
+    let statusCode = 302; // Default to temporary redirect
+
+    const args = raw.args || [];
+
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+
+      // Check for 'permanently' keyword -> 301
+      if (arg.type === 'identifier' && (arg as any).name?.toLowerCase() === 'permanently') {
+        statusCode = 301;
+        continue;
+      }
+
+      // Check for 'temporarily' keyword -> 302
+      if (arg.type === 'identifier' && (arg as any).name?.toLowerCase() === 'temporarily') {
+        statusCode = 302;
+        continue;
+      }
+
+      // Evaluate URL
+      const value = await evaluator.evaluate(arg, context);
+      if (typeof value === 'string') {
+        url = value;
+      }
+    }
+
+    // Handle modifiers
+    if (raw.modifiers?.status) {
+      statusCode = Number(await evaluator.evaluate(raw.modifiers.status, context)) || 302;
+    }
+
+    return { url, statusCode };
+  },
+
+  async execute(input: RedirectInput, context: TypedExecutionContext): Promise<void> {
+    const response = context.locals.get('response') as ServerResponse | undefined;
+
+    if (!response) {
+      throw new Error(
+        "redirect command requires 'response' in context. " +
+          "Make sure you're in a server request handler."
+      );
+    }
+
+    response.redirect(input.url, input.statusCode);
+  },
+};
+
+// ============================================================================
+// setHeader command
+// ============================================================================
+
+interface SetHeaderInput {
+  name: string;
+  value: string;
+}
+
+/**
+ * setHeader command - Set HTTP response header
+ *
+ * Syntax:
+ *   setHeader <name> to <value>
+ *   setHeader 'Content-Type' to 'application/json'
+ */
+export const setHeaderCommand: CommandWithParseInput = {
+  name: 'setHeader',
+
+  metadata: {
+    description: 'Set HTTP response header',
+    aliases: ['setheader', 'header'],
+    syntax: ['setHeader <name> to <value>', "setHeader 'Header-Name' to value"],
+    examples: [
+      "setHeader 'Content-Type' to 'application/json'",
+      "setHeader 'Cache-Control' to 'no-cache'",
+      "setHeader 'X-Custom' to customValue",
+    ],
+    category: 'server',
+  },
+
+  async parseInput(
+    raw: { args: ASTNode[]; modifiers: Record<string, any> },
+    evaluator: ExpressionEvaluator,
+    context: ExecutionContext
+  ): Promise<SetHeaderInput> {
+    let name = '';
+    let value = '';
+
+    const args = raw.args || [];
+
+    // First arg is header name
+    if (args[0]) {
+      name = String(await evaluator.evaluate(args[0], context));
+    }
+
+    // Look for 'to' modifier or second arg
+    if (raw.modifiers?.to) {
+      value = String(await evaluator.evaluate(raw.modifiers.to, context));
+    } else if (args[1]) {
+      value = String(await evaluator.evaluate(args[1], context));
+    }
+
+    return { name, value };
+  },
+
+  async execute(input: SetHeaderInput, context: TypedExecutionContext): Promise<void> {
+    const response = context.locals.get('response') as ServerResponse | undefined;
+
+    if (!response) {
+      throw new Error(
+        "setHeader command requires 'response' in context. " +
+          "Make sure you're in a server request handler."
+      );
+    }
+
+    if (!input.name) {
+      throw new Error('setHeader requires a header name');
+    }
+
+    response.header(input.name, input.value);
+  },
+};
+
+// ============================================================================
+// Server plugin bundle
+// ============================================================================
+
+import { definePlugin } from '../index';
+
+/**
+ * Server plugin - Bundle of server-side commands and context providers
+ *
+ * Installation:
+ *   import { registry } from '@hyperfixi/core';
+ *   import { serverPlugin } from '@hyperfixi/core/registry/examples/server-commands';
+ *
+ *   registry.use(serverPlugin);
+ */
+export const serverPlugin = definePlugin({
+  name: 'hyperfixi-server',
+  version: '1.0.0',
+
+  commands: [respondCommand, redirectCommand, setHeaderCommand],
+
+  contextProviders: [
+    {
+      name: 'request',
+      provide: ctx => ctx.locals.get('request'),
+      options: { description: 'Current HTTP request', cache: false },
+    },
+    {
+      name: 'response',
+      provide: ctx => ctx.locals.get('response'),
+      options: { description: 'HTTP response builder', cache: false },
+    },
+    {
+      name: 'body',
+      provide: ctx => {
+        const request = ctx.locals.get('request') as { body?: unknown } | undefined;
+        return request?.body;
+      },
+      options: { description: 'Request body', cache: true },
+    },
+    {
+      name: 'query',
+      provide: ctx => {
+        const request = ctx.locals.get('request') as { query?: unknown } | undefined;
+        return request?.query;
+      },
+      options: { description: 'Query parameters', cache: true },
+    },
+    {
+      name: 'params',
+      provide: ctx => {
+        const request = ctx.locals.get('request') as { params?: unknown } | undefined;
+        return request?.params;
+      },
+      options: { description: 'Route parameters', cache: true },
+    },
+  ],
+
+  setup(registry) {
+    console.log('[hyperfixi-server] Server plugin installed');
+  },
+});

--- a/packages/core/src/registry/examples/server-event-source.ts
+++ b/packages/core/src/registry/examples/server-event-source.ts
@@ -1,0 +1,302 @@
+/**
+ * Example: Server Request Event Source
+ *
+ * Demonstrates how to create a custom event source for server-side hyperscript.
+ * This example shows the pattern for handling HTTP requests as hyperscript events.
+ *
+ * Usage in hyperscript:
+ *   on request(GET, /api/users) respond with <json> users </json>
+ *   on request(POST, /api/users) set user to request.body then respond with user
+ *
+ * Installation:
+ *   import { eventSources } from '@hyperfixi/core/registry';
+ *   import { createRequestEventSource } from './server-event-source';
+ *
+ *   const requestSource = createRequestEventSource();
+ *   eventSources.register('request', requestSource);
+ */
+
+import type {
+  EventSource,
+  EventSourceSubscription,
+  EventSourceSubscribeOptions,
+  EventSourcePayload,
+} from '../event-source-registry';
+import type { ExecutionContext } from '../../types/core';
+
+/**
+ * HTTP Method type
+ */
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
+
+/**
+ * Simple request interface (framework-agnostic)
+ */
+export interface ServerRequest {
+  method: HttpMethod;
+  url: string;
+  path: string;
+  query: Record<string, string | string[]>;
+  params: Record<string, string>;
+  headers: Record<string, string | string[]>;
+  body: unknown;
+}
+
+/**
+ * Simple response builder interface
+ */
+export interface ServerResponse {
+  status(code: number): ServerResponse;
+  header(name: string, value: string): ServerResponse;
+  json(data: unknown): void;
+  html(content: string): void;
+  text(content: string): void;
+  redirect(url: string, code?: number): void;
+  send(data: unknown): void;
+}
+
+/**
+ * Request handler registered via the event source
+ */
+export interface RequestHandler {
+  method: HttpMethod | '*';
+  pattern: string | RegExp;
+  handler: (payload: EventSourcePayload, context: ExecutionContext) => void;
+}
+
+/**
+ * Create a server request event source
+ *
+ * This is a factory that creates an event source for handling HTTP requests.
+ * The actual request routing depends on your server framework.
+ *
+ * @example
+ * // Express integration
+ * const requestSource = createRequestEventSource();
+ * eventSources.register('request', requestSource);
+ *
+ * app.use((req, res, next) => {
+ *   requestSource.handleRequest(req, res);
+ * });
+ */
+export function createRequestEventSource(): EventSource & {
+  handleRequest(request: ServerRequest, response: ServerResponse): boolean;
+} {
+  const handlers: Map<string, RequestHandler> = new Map();
+  let nextId = 1;
+
+  const source: EventSource & {
+    handleRequest(request: ServerRequest, response: ServerResponse): boolean;
+  } = {
+    name: 'request',
+    description: 'HTTP request events for server-side hyperscript',
+    supportedEvents: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', '*'],
+
+    subscribe(
+      options: EventSourceSubscribeOptions,
+      context: ExecutionContext
+    ): EventSourceSubscription {
+      const id = `request_${nextId++}`;
+      const method = (options.event?.toUpperCase() || '*') as HttpMethod | '*';
+      const pattern = options.target || '*';
+
+      const handler: RequestHandler = {
+        method,
+        pattern: typeof pattern === 'string' ? pattern : new RegExp(pattern),
+        handler: options.handler,
+      };
+
+      handlers.set(id, handler);
+
+      return {
+        id,
+        source: 'request',
+        event: method,
+        unsubscribe: () => {
+          handlers.delete(id);
+        },
+      };
+    },
+
+    supports(event: string): boolean {
+      const upper = event.toUpperCase();
+      return (
+        upper === 'GET' ||
+        upper === 'POST' ||
+        upper === 'PUT' ||
+        upper === 'DELETE' ||
+        upper === 'PATCH' ||
+        upper === 'HEAD' ||
+        upper === 'OPTIONS' ||
+        upper === 'REQUEST' ||
+        upper === '*'
+      );
+    },
+
+    destroy(): void {
+      handlers.clear();
+    },
+
+    /**
+     * Handle an incoming HTTP request
+     * Call this from your server framework's middleware
+     *
+     * @returns true if a handler matched and processed the request
+     */
+    handleRequest(request: ServerRequest, response: ServerResponse): boolean {
+      let handled = false;
+
+      for (const [id, handler] of handlers.entries()) {
+        // Check method match
+        if (handler.method !== '*' && handler.method !== request.method) {
+          continue;
+        }
+
+        // Check pattern match
+        let matches = false;
+        if (handler.pattern === '*') {
+          matches = true;
+        } else if (typeof handler.pattern === 'string') {
+          matches = matchPath(request.path, handler.pattern);
+        } else {
+          matches = handler.pattern.test(request.path);
+        }
+
+        if (matches) {
+          const payload: EventSourcePayload = {
+            type: request.method,
+            data: {
+              request,
+              response,
+              params: extractParams(request.path, handler.pattern),
+            },
+            target: null,
+            meta: {
+              method: request.method,
+              path: request.path,
+              url: request.url,
+            },
+          };
+
+          // Create request context
+          const requestContext: ExecutionContext = {
+            me: null,
+            you: null,
+            it: request,
+            event: null,
+            locals: new Map([
+              ['request', request],
+              ['response', response],
+              ['method', request.method],
+              ['path', request.path],
+              ['query', request.query],
+              ['params', request.params],
+              ['body', request.body],
+              ['headers', request.headers],
+            ]),
+            globals: new Map(),
+            result: undefined,
+          };
+
+          handler.handler(payload, requestContext);
+          handled = true;
+        }
+      }
+
+      return handled;
+    },
+  };
+
+  return source;
+}
+
+/**
+ * Simple path matching (supports :param patterns)
+ */
+function matchPath(path: string, pattern: string): boolean {
+  if (pattern === '*' || pattern === path) {
+    return true;
+  }
+
+  // Convert Express-style patterns to regex
+  const regexPattern = pattern
+    .replace(/:[^/]+/g, '([^/]+)') // :param -> capture group
+    .replace(/\*/g, '.*'); // * -> wildcard
+
+  const regex = new RegExp(`^${regexPattern}$`);
+  return regex.test(path);
+}
+
+/**
+ * Extract path parameters from a path
+ */
+function extractParams(path: string, pattern: string | RegExp): Record<string, string> {
+  if (typeof pattern !== 'string' || !pattern.includes(':')) {
+    return {};
+  }
+
+  const params: Record<string, string> = {};
+  const patternParts = pattern.split('/');
+  const pathParts = path.split('/');
+
+  for (let i = 0; i < patternParts.length; i++) {
+    if (patternParts[i].startsWith(':')) {
+      const paramName = patternParts[i].slice(1);
+      params[paramName] = pathParts[i] || '';
+    }
+  }
+
+  return params;
+}
+
+/**
+ * Example: WebSocket event source (stub for reference)
+ */
+export function createWebSocketEventSource(): EventSource {
+  return {
+    name: 'websocket',
+    description: 'WebSocket connection events',
+    supportedEvents: ['connect', 'disconnect', 'message', 'error'],
+
+    subscribe(options, context): EventSourceSubscription {
+      // Implementation would integrate with your WebSocket library
+      return {
+        id: `ws_${Date.now()}`,
+        source: 'websocket',
+        event: options.event,
+        unsubscribe: () => {},
+      };
+    },
+
+    supports(event: string): boolean {
+      return ['connect', 'disconnect', 'message', 'error', 'websocket'].includes(
+        event.toLowerCase()
+      );
+    },
+  };
+}
+
+/**
+ * Example: Server-Sent Events (SSE) source (stub for reference)
+ */
+export function createSSEEventSource(): EventSource {
+  return {
+    name: 'sse',
+    description: 'Server-Sent Events',
+    supportedEvents: ['message', 'open', 'error'],
+
+    subscribe(options, context): EventSourceSubscription {
+      // Implementation would create SSE connection
+      return {
+        id: `sse_${Date.now()}`,
+        source: 'sse',
+        event: options.event,
+        unsubscribe: () => {},
+      };
+    },
+
+    supports(event: string): boolean {
+      return ['message', 'open', 'error', 'sse'].includes(event.toLowerCase());
+    },
+  };
+}

--- a/packages/core/src/registry/index.ts
+++ b/packages/core/src/registry/index.ts
@@ -1,0 +1,318 @@
+/**
+ * HyperFixi Registry System
+ *
+ * Unified extensibility API for commands, event sources, and context providers.
+ *
+ * Usage:
+ *   import { registry } from '@hyperfixi/core';
+ *
+ *   // Register commands
+ *   registry.commands.register('respond', respondCommand);
+ *   registry.commands.register('redirect', redirectCommand);
+ *
+ *   // Register event sources
+ *   registry.eventSources.register('request', requestEventSource);
+ *   registry.eventSources.register('websocket', websocketEventSource);
+ *
+ *   // Register context providers
+ *   registry.context.register('request', () => currentRequest);
+ *   registry.context.register('response', () => responseBuilder);
+ *
+ * Server-side Example:
+ *   // In Express middleware
+ *   app.use((req, res, next) => {
+ *     registry.context.register('request', () => req);
+ *     registry.context.register('response', () => res);
+ *     next();
+ *   });
+ *
+ *   // Hyperscript can now use:
+ *   // on request(GET, /api/users) respond with <json> users </json>
+ */
+
+// Re-export registries
+export {
+  EventSourceRegistry,
+  createEventSourceRegistry,
+  getDefaultEventSourceRegistry,
+  type EventSource,
+  type EventSourceHandler,
+  type EventSourcePayload,
+  type EventSourceSubscription,
+  type EventSourceSubscribeOptions,
+} from './event-source-registry';
+
+export {
+  ContextProviderRegistry,
+  createContextProviderRegistry,
+  getDefaultContextProviderRegistry,
+  type ContextProvider,
+  type ContextProviderFn,
+  type ContextProviderOptions,
+  meProvider,
+  itProvider,
+  youProvider,
+  eventProvider,
+} from './context-provider-registry';
+
+// Re-export command registry from existing location
+export {
+  CommandRegistryV2,
+  CommandAdapterV2,
+  createCommandRegistryV2,
+  type CommandWithParseInput,
+  type RuntimeCommand,
+} from '../runtime/command-adapter';
+
+import { CommandRegistryV2 } from '../runtime/command-adapter';
+import { EventSourceRegistry, createEventSourceRegistry } from './event-source-registry';
+import {
+  ContextProviderRegistry,
+  createContextProviderRegistry,
+} from './context-provider-registry';
+import type { CommandWithParseInput } from '../runtime/command-adapter';
+import type { EventSource } from './event-source-registry';
+import type { ContextProviderFn, ContextProviderOptions } from './context-provider-registry';
+
+/**
+ * Unified registry interface
+ *
+ * Provides a single point of access to all extension registries:
+ * - commands: Register custom hyperscript commands
+ * - eventSources: Register custom event sources (request, websocket, etc.)
+ * - context: Register dynamic context providers
+ */
+export interface HyperFixiRegistry {
+  /** Command registry for registering custom commands */
+  readonly commands: CommandRegistryV2;
+
+  /** Event source registry for custom event sources */
+  readonly eventSources: EventSourceRegistry;
+
+  /** Context provider registry for dynamic context values */
+  readonly context: ContextProviderRegistry;
+
+  /**
+   * Register a plugin that can add commands, event sources, and context providers
+   */
+  use(plugin: HyperFixiPlugin): void;
+
+  /**
+   * Reset all registries to default state
+   */
+  reset(): void;
+}
+
+/**
+ * Plugin interface for bundled extensions
+ *
+ * Plugins can register multiple commands, event sources, and context providers
+ * in a single installation.
+ */
+export interface HyperFixiPlugin {
+  /** Plugin name */
+  name: string;
+
+  /** Plugin version */
+  version?: string;
+
+  /** Commands to register */
+  commands?: CommandWithParseInput[];
+
+  /** Event sources to register */
+  eventSources?: EventSource[];
+
+  /** Context providers to register */
+  contextProviders?: Array<{
+    name: string;
+    provide: ContextProviderFn;
+    options?: ContextProviderOptions;
+  }>;
+
+  /**
+   * Optional setup function called when plugin is installed
+   */
+  setup?(registry: HyperFixiRegistry): void | Promise<void>;
+
+  /**
+   * Optional teardown function called when plugin is uninstalled
+   */
+  teardown?(registry: HyperFixiRegistry): void | Promise<void>;
+}
+
+/**
+ * Create a unified registry
+ */
+export function createRegistry(options?: {
+  commands?: CommandRegistryV2;
+  eventSources?: EventSourceRegistry;
+  context?: ContextProviderRegistry;
+}): HyperFixiRegistry {
+  const commands = options?.commands ?? new CommandRegistryV2();
+  const eventSources = options?.eventSources ?? createEventSourceRegistry();
+  const context = options?.context ?? createContextProviderRegistry();
+
+  const installedPlugins = new Set<string>();
+
+  const registry: HyperFixiRegistry = {
+    commands,
+    eventSources,
+    context,
+
+    use(plugin: HyperFixiPlugin): void {
+      if (installedPlugins.has(plugin.name)) {
+        console.warn(`[HyperFixiRegistry] Plugin '${plugin.name}' is already installed`);
+        return;
+      }
+
+      // Register commands
+      if (plugin.commands) {
+        for (const command of plugin.commands) {
+          commands.register(command);
+        }
+      }
+
+      // Register event sources
+      if (plugin.eventSources) {
+        for (const source of plugin.eventSources) {
+          eventSources.register(source.name, source);
+        }
+      }
+
+      // Register context providers
+      if (plugin.contextProviders) {
+        for (const { name, provide, options } of plugin.contextProviders) {
+          context.register(name, provide, options);
+        }
+      }
+
+      // Run setup
+      plugin.setup?.(registry);
+
+      installedPlugins.add(plugin.name);
+    },
+
+    reset(): void {
+      // Note: This creates new instances, doesn't clear existing
+      // For a full reset, create a new registry
+      installedPlugins.clear();
+    },
+  };
+
+  return registry;
+}
+
+/**
+ * Default global registry instance
+ */
+let defaultRegistry: HyperFixiRegistry | null = null;
+
+/**
+ * Get the default registry (creates one if needed)
+ */
+export function getDefaultRegistry(): HyperFixiRegistry {
+  if (!defaultRegistry) {
+    defaultRegistry = createRegistry();
+  }
+  return defaultRegistry;
+}
+
+/**
+ * Shorthand access to default registries
+ *
+ * Usage:
+ *   import { commands, eventSources, context } from '@hyperfixi/core/registry';
+ *
+ *   commands.register('respond', respondCommand);
+ *   eventSources.register('request', requestEventSource);
+ *   context.register('request', () => currentRequest);
+ */
+export const commands = {
+  /**
+   * Register a command in the default registry
+   */
+  register(command: CommandWithParseInput): void {
+    getDefaultRegistry().commands.register(command);
+  },
+
+  /**
+   * Check if a command is registered
+   */
+  has(name: string): boolean {
+    return getDefaultRegistry().commands.has(name);
+  },
+
+  /**
+   * Get all registered command names
+   */
+  names(): string[] {
+    return getDefaultRegistry().commands.getCommandNames();
+  },
+};
+
+export const eventSources = {
+  /**
+   * Register an event source in the default registry
+   */
+  register(name: string, source: EventSource): void {
+    getDefaultRegistry().eventSources.register(name, source);
+  },
+
+  /**
+   * Check if an event source is registered
+   */
+  has(name: string): boolean {
+    return getDefaultRegistry().eventSources.has(name);
+  },
+
+  /**
+   * Get all registered event source names
+   */
+  names(): string[] {
+    return getDefaultRegistry().eventSources.getSourceNames();
+  },
+};
+
+export const context = {
+  /**
+   * Register a context provider in the default registry
+   */
+  register<T>(
+    name: string,
+    provide: ContextProviderFn<T>,
+    options?: ContextProviderOptions<T>
+  ): void {
+    getDefaultRegistry().context.register(name, provide, options);
+  },
+
+  /**
+   * Check if a context provider is registered
+   */
+  has(name: string): boolean {
+    return getDefaultRegistry().context.has(name);
+  },
+
+  /**
+   * Get all registered provider names
+   */
+  names(): string[] {
+    return getDefaultRegistry().context.getProviderNames();
+  },
+};
+
+/**
+ * Type-safe plugin builder
+ *
+ * Usage:
+ *   const myPlugin = definePlugin({
+ *     name: 'my-server-plugin',
+ *     commands: [respondCommand, redirectCommand],
+ *     eventSources: [requestEventSource],
+ *     contextProviders: [
+ *       { name: 'request', provide: () => currentRequest },
+ *     ],
+ *   });
+ */
+export function definePlugin(plugin: HyperFixiPlugin): HyperFixiPlugin {
+  return plugin;
+}

--- a/packages/core/src/registry/registry.test.ts
+++ b/packages/core/src/registry/registry.test.ts
@@ -1,0 +1,600 @@
+/**
+ * Registry System Tests
+ *
+ * Tests for EventSourceRegistry, ContextProviderRegistry, and unified registry.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  EventSourceRegistry,
+  createEventSourceRegistry,
+  type EventSource,
+  type EventSourceSubscribeOptions,
+} from './event-source-registry';
+import {
+  ContextProviderRegistry,
+  createContextProviderRegistry,
+  meProvider,
+  itProvider,
+} from './context-provider-registry';
+import {
+  createRegistry,
+  commands,
+  eventSources,
+  context,
+  definePlugin,
+  type HyperFixiPlugin,
+} from './index';
+import type { ExecutionContext } from '../types/core';
+
+// ============================================================================
+// Test Utilities
+// ============================================================================
+
+function createMockContext(overrides: Partial<ExecutionContext> = {}): ExecutionContext {
+  return {
+    me: null,
+    you: null,
+    it: null,
+    event: null,
+    locals: new Map(),
+    globals: new Map(),
+    result: undefined,
+    ...overrides,
+  };
+}
+
+function createMockEventSource(name: string): EventSource {
+  const subscriptions = new Map<string, any>();
+  let nextId = 1;
+
+  return {
+    name,
+    description: `Mock ${name} event source`,
+    supportedEvents: ['event1', 'event2', 'event3'],
+
+    subscribe(options: EventSourceSubscribeOptions, context: ExecutionContext) {
+      const id = `${name}_${nextId++}`;
+      subscriptions.set(id, { options, context });
+
+      return {
+        id,
+        source: name,
+        event: options.event,
+        unsubscribe: () => {
+          subscriptions.delete(id);
+        },
+      };
+    },
+
+    supports(event: string) {
+      return this.supportedEvents!.includes(event);
+    },
+
+    destroy() {
+      subscriptions.clear();
+    },
+  };
+}
+
+// ============================================================================
+// EventSourceRegistry Tests
+// ============================================================================
+
+describe('EventSourceRegistry', () => {
+  let registry: EventSourceRegistry;
+
+  beforeEach(() => {
+    registry = createEventSourceRegistry();
+  });
+
+  describe('register/unregister', () => {
+    it('should register an event source', () => {
+      const source = createMockEventSource('test');
+      registry.register('test', source);
+
+      expect(registry.has('test')).toBe(true);
+      expect(registry.get('test')).toBe(source);
+    });
+
+    it('should normalize names to lowercase', () => {
+      const source = createMockEventSource('Test');
+      registry.register('TEST', source);
+
+      expect(registry.has('test')).toBe(true);
+      expect(registry.has('TEST')).toBe(true);
+      expect(registry.has('Test')).toBe(true);
+    });
+
+    it('should unregister an event source', () => {
+      const source = createMockEventSource('test');
+      registry.register('test', source);
+
+      const result = registry.unregister('test');
+
+      expect(result).toBe(true);
+      expect(registry.has('test')).toBe(false);
+    });
+
+    it('should return false when unregistering non-existent source', () => {
+      const result = registry.unregister('nonexistent');
+      expect(result).toBe(false);
+    });
+
+    it('should warn when overwriting existing source', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const source1 = createMockEventSource('test');
+      const source2 = createMockEventSource('test');
+
+      registry.register('test', source1);
+      registry.register('test', source2);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Overwriting existing event source')
+      );
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('subscribe/unsubscribe', () => {
+    it('should subscribe to an event source', () => {
+      const source = createMockEventSource('test');
+      registry.register('test', source);
+
+      const handler = vi.fn();
+      const context = createMockContext();
+
+      const subscription = registry.subscribe('test', { event: 'event1', handler }, context);
+
+      expect(subscription).toBeDefined();
+      expect(subscription!.source).toBe('test');
+      expect(subscription!.event).toBe('event1');
+    });
+
+    it('should return undefined for unknown source', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const handler = vi.fn();
+      const context = createMockContext();
+
+      const subscription = registry.subscribe('nonexistent', { event: 'event1', handler }, context);
+
+      expect(subscription).toBeUndefined();
+      warnSpy.mockRestore();
+    });
+
+    it('should track subscriptions', () => {
+      const source = createMockEventSource('test');
+      registry.register('test', source);
+
+      const handler = vi.fn();
+      const context = createMockContext();
+
+      registry.subscribe('test', { event: 'event1', handler }, context);
+      registry.subscribe('test', { event: 'event2', handler }, context);
+
+      const subs = registry.getSubscriptions();
+      expect(subs).toHaveLength(2);
+    });
+
+    it('should unsubscribe by ID', () => {
+      const source = createMockEventSource('test');
+      registry.register('test', source);
+
+      const handler = vi.fn();
+      const context = createMockContext();
+
+      const subscription = registry.subscribe('test', { event: 'event1', handler }, context);
+
+      const result = registry.unsubscribe(subscription!.id);
+
+      expect(result).toBe(true);
+      expect(registry.getSubscriptions()).toHaveLength(0);
+    });
+  });
+
+  describe('findSourceForEvent', () => {
+    it('should find source that supports an event', () => {
+      const source = createMockEventSource('test');
+      registry.register('test', source);
+
+      const found = registry.findSourceForEvent('event1');
+      expect(found).toBe('test');
+    });
+
+    it('should return undefined for unsupported events', () => {
+      const source = createMockEventSource('test');
+      registry.register('test', source);
+
+      const found = registry.findSourceForEvent('unknown_event');
+      expect(found).toBeUndefined();
+    });
+  });
+
+  describe('destroy', () => {
+    it('should cleanup all subscriptions and sources', () => {
+      const source = createMockEventSource('test');
+      const destroySpy = vi.spyOn(source, 'destroy');
+
+      registry.register('test', source);
+
+      const handler = vi.fn();
+      const context = createMockContext();
+      registry.subscribe('test', { event: 'event1', handler }, context);
+
+      registry.destroy();
+
+      expect(destroySpy).toHaveBeenCalled();
+      expect(registry.getSourceNames()).toHaveLength(0);
+      expect(registry.getSubscriptions()).toHaveLength(0);
+    });
+  });
+});
+
+// ============================================================================
+// ContextProviderRegistry Tests
+// ============================================================================
+
+describe('ContextProviderRegistry', () => {
+  let registry: ContextProviderRegistry;
+
+  beforeEach(() => {
+    registry = createContextProviderRegistry();
+  });
+
+  describe('register/unregister', () => {
+    it('should register a provider function', () => {
+      registry.register('test', () => 'test-value');
+
+      expect(registry.has('test')).toBe(true);
+    });
+
+    it('should register a full provider object', () => {
+      registry.register('test', {
+        name: 'test',
+        provide: () => 'test-value',
+        description: 'Test provider',
+      });
+
+      expect(registry.has('test')).toBe(true);
+      expect(registry.get('test')?.description).toBe('Test provider');
+    });
+
+    it('should normalize names to lowercase', () => {
+      registry.register('TEST', () => 'value');
+
+      expect(registry.has('test')).toBe(true);
+      expect(registry.has('TEST')).toBe(true);
+    });
+
+    it('should unregister a provider', () => {
+      registry.register('test', () => 'value');
+      const result = registry.unregister('test');
+
+      expect(result).toBe(true);
+      expect(registry.has('test')).toBe(false);
+    });
+  });
+
+  describe('resolve', () => {
+    it('should resolve a sync provider', async () => {
+      registry.register('test', () => 'sync-value');
+      const context = createMockContext();
+
+      const value = await registry.resolve('test', context);
+      expect(value).toBe('sync-value');
+    });
+
+    it('should resolve an async provider', async () => {
+      registry.register('test', async () => {
+        await new Promise(r => setTimeout(r, 10));
+        return 'async-value';
+      });
+      const context = createMockContext();
+
+      const value = await registry.resolve('test', context);
+      expect(value).toBe('async-value');
+    });
+
+    it('should return undefined for unknown provider', async () => {
+      const context = createMockContext();
+      const value = await registry.resolve('nonexistent', context);
+
+      expect(value).toBeUndefined();
+    });
+
+    it('should cache provider results when cache is enabled', async () => {
+      let callCount = 0;
+      registry.register(
+        'test',
+        () => {
+          callCount++;
+          return `value-${callCount}`;
+        },
+        { cache: true }
+      );
+
+      const context = createMockContext();
+      const cache = new Map();
+
+      const value1 = await registry.resolve('test', context, cache);
+      const value2 = await registry.resolve('test', context, cache);
+
+      expect(value1).toBe('value-1');
+      expect(value2).toBe('value-1'); // Same cached value
+      expect(callCount).toBe(1); // Called only once
+    });
+
+    it('should pass context to provider function', async () => {
+      registry.register('test', ctx => ctx.locals.get('myValue'));
+
+      const context = createMockContext({
+        locals: new Map([['myValue', 'from-context']]),
+      });
+
+      const value = await registry.resolve('test', context);
+      expect(value).toBe('from-context');
+    });
+
+    it('should resolve dependencies before provider', async () => {
+      const order: string[] = [];
+
+      registry.register('dep', () => {
+        order.push('dep');
+        return 'dep-value';
+      });
+
+      registry.register(
+        'main',
+        () => {
+          order.push('main');
+          return 'main-value';
+        },
+        { dependencies: ['dep'] }
+      );
+
+      const context = createMockContext();
+      const cache = new Map();
+
+      await registry.resolve('main', context, cache);
+
+      expect(order).toEqual(['dep', 'main']);
+    });
+  });
+
+  describe('resolveSync', () => {
+    it('should resolve sync provider synchronously', () => {
+      registry.register('test', () => 'sync-value');
+      const context = createMockContext();
+
+      const value = registry.resolveSync('test', context);
+      expect(value).toBe('sync-value');
+    });
+
+    it('should throw for async provider', () => {
+      registry.register('test', async () => 'async-value');
+      const context = createMockContext();
+
+      expect(() => registry.resolveSync('test', context)).toThrow(/is async/);
+    });
+  });
+
+  describe('enhance', () => {
+    it('should create proxy with provider getters', () => {
+      registry.register('custom', () => 'custom-value');
+      const context = createMockContext({ me: document.body as Element });
+
+      const enhanced = registry.enhance(context);
+
+      expect(enhanced.me).toBe(document.body);
+      expect((enhanced as any).custom).toBe('custom-value');
+    });
+
+    it('should report has() for registered providers', () => {
+      registry.register('custom', () => 'value');
+      const context = createMockContext();
+
+      const enhanced = registry.enhance(context);
+
+      expect('custom' in enhanced).toBe(true);
+      expect('unknown' in enhanced).toBe(false);
+    });
+  });
+
+  describe('resolveAll', () => {
+    it('should resolve all providers', async () => {
+      registry.register('a', () => 'value-a');
+      registry.register('b', () => 'value-b');
+      registry.registerGlobal('global', () => 'global-value');
+
+      const context = createMockContext();
+      const all = await registry.resolveAll(context);
+
+      expect(all.a).toBe('value-a');
+      expect(all.b).toBe('value-b');
+      expect(all.global).toBe('global-value');
+    });
+  });
+
+  describe('built-in providers', () => {
+    it('meProvider should return context.me', () => {
+      const el = document.createElement('div');
+      const context = createMockContext({ me: el });
+
+      const value = meProvider.provide(context);
+      expect(value).toBe(el);
+    });
+
+    it('itProvider should return context.it', () => {
+      const context = createMockContext({ it: 'test-it-value' });
+
+      const value = itProvider.provide(context);
+      expect(value).toBe('test-it-value');
+    });
+  });
+});
+
+// ============================================================================
+// Unified Registry Tests
+// ============================================================================
+
+describe('Unified Registry', () => {
+  describe('createRegistry', () => {
+    it('should create registry with all sub-registries', () => {
+      const registry = createRegistry();
+
+      expect(registry.commands).toBeDefined();
+      expect(registry.eventSources).toBeDefined();
+      expect(registry.context).toBeDefined();
+    });
+
+    it('should accept custom sub-registries', () => {
+      const customEventSources = createEventSourceRegistry();
+      const registry = createRegistry({ eventSources: customEventSources });
+
+      expect(registry.eventSources).toBe(customEventSources);
+    });
+  });
+
+  describe('plugin system', () => {
+    it('should install plugin commands', () => {
+      const registry = createRegistry();
+      const mockCommand = {
+        name: 'test-cmd',
+        execute: vi.fn(),
+      };
+
+      const plugin: HyperFixiPlugin = {
+        name: 'test-plugin',
+        commands: [mockCommand as any],
+      };
+
+      registry.use(plugin);
+
+      expect(registry.commands.has('test-cmd')).toBe(true);
+    });
+
+    it('should install plugin event sources', () => {
+      const registry = createRegistry();
+      const source = createMockEventSource('plugin-source');
+
+      const plugin: HyperFixiPlugin = {
+        name: 'test-plugin',
+        eventSources: [source],
+      };
+
+      registry.use(plugin);
+
+      expect(registry.eventSources.has('plugin-source')).toBe(true);
+    });
+
+    it('should install plugin context providers', () => {
+      const registry = createRegistry();
+
+      const plugin: HyperFixiPlugin = {
+        name: 'test-plugin',
+        contextProviders: [{ name: 'custom', provide: () => 'custom-value' }],
+      };
+
+      registry.use(plugin);
+
+      expect(registry.context.has('custom')).toBe(true);
+    });
+
+    it('should call plugin setup function', () => {
+      const registry = createRegistry();
+      const setupFn = vi.fn();
+
+      const plugin: HyperFixiPlugin = {
+        name: 'test-plugin',
+        setup: setupFn,
+      };
+
+      registry.use(plugin);
+
+      expect(setupFn).toHaveBeenCalledWith(registry);
+    });
+
+    it('should warn on duplicate plugin installation', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const registry = createRegistry();
+
+      const plugin: HyperFixiPlugin = {
+        name: 'test-plugin',
+      };
+
+      registry.use(plugin);
+      registry.use(plugin);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('already installed'));
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('definePlugin', () => {
+    it('should return plugin definition unchanged', () => {
+      const plugin = definePlugin({
+        name: 'my-plugin',
+        version: '1.0.0',
+        commands: [],
+      });
+
+      expect(plugin.name).toBe('my-plugin');
+      expect(plugin.version).toBe('1.0.0');
+    });
+  });
+});
+
+// ============================================================================
+// Shorthand Accessors Tests
+// ============================================================================
+
+describe('Shorthand Accessors', () => {
+  // Note: These tests modify the global default registry
+  // In a real test suite, you'd want to reset between tests
+
+  describe('commands shorthand', () => {
+    it('should register commands via shorthand', () => {
+      const mockCommand = {
+        name: 'shorthand-cmd',
+        execute: vi.fn(),
+      };
+
+      commands.register(mockCommand as any);
+
+      expect(commands.has('shorthand-cmd')).toBe(true);
+    });
+
+    it('should list command names', () => {
+      const names = commands.names();
+      expect(Array.isArray(names)).toBe(true);
+    });
+  });
+
+  describe('eventSources shorthand', () => {
+    it('should register event sources via shorthand', () => {
+      const source = createMockEventSource('shorthand-source');
+
+      eventSources.register('shorthand-source', source);
+
+      expect(eventSources.has('shorthand-source')).toBe(true);
+    });
+
+    it('should list source names', () => {
+      const names = eventSources.names();
+      expect(Array.isArray(names)).toBe(true);
+    });
+  });
+
+  describe('context shorthand', () => {
+    it('should register context providers via shorthand', () => {
+      context.register('shorthand-ctx', () => 'value');
+
+      expect(context.has('shorthand-ctx')).toBe(true);
+    });
+
+    it('should list provider names', () => {
+      const names = context.names();
+      expect(Array.isArray(names)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Implements a comprehensive extensibility API enabling:
- Command registration via `commands.register()`
- Custom event sources via `eventSources.register()` (for server-side events, WebSocket, SSE)
- Dynamic context providers via `context.register()` (for request, response, session, etc.)
- Plugin system for bundled extensions via `registry.use(plugin)`

Includes example implementations for server-side hyperscript:
- respondCommand, redirectCommand, setHeaderCommand
- Request event source for HTTP handlers
- Context providers for request/response objects

43 tests passing for the complete registry system.