### PR TITLE
fix(ci): correct claude-code-action inputs and skip dependabot PRs

### DIFF
--- a/.github/workflows/claude-maintenance.yml
+++ b/.github/workflows/claude-maintenance.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: claude-sonnet-4-20250514
           prompt: |
             Perform a weekly maintenance audit of the LokaScript monorepo.
 
@@ -71,5 +70,6 @@ jobs:
             - Prioritized list of things to address this week
 
             Use labels: `maintenance`, `automated`
-          allowed_tools: |
-            Bash(npm:*),Bash(gh issue:*),Bash(gh run:*),Bash(gh pr:*),Bash(git log:*),Bash(date:*),Read,Grep,Glob
+          claude_args: |
+            --model claude-sonnet-4-20250514
+            --allowedTools "Bash(npm:*),Bash(gh issue:*),Bash(gh run:*),Bash(gh pr:*),Bash(git log:*),Bash(date:*),Read,Grep,Glob"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
     permissions:
       contents: read
       pull-requests: write
@@ -25,7 +25,6 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: claude-sonnet-4-20250514
           prompt: |
             Review this pull request for the LokaScript monorepo. Focus on:
 
@@ -39,5 +38,6 @@ jobs:
 
             Provide structured feedback with inline comments on specific lines where issues are found.
             Categorize findings as: Critical (must fix), Warning (should fix), Suggestion (nice to have).
-          allowed_tools: |
-            Bash(npm run typecheck:*),Bash(npm test:*),Read,Grep,Glob
+          claude_args: |
+            --model claude-sonnet-4-20250514
+            --allowedTools "Bash(npm run typecheck:*),Bash(npm test:*),Read,Grep,Glob"

--- a/.github/workflows/claude-security.yml
+++ b/.github/workflows/claude-security.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   security:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: claude-sonnet-4-20250514
           prompt: |
             Analyze issue #${{ github.event.issue.number }} for the LokaScript monorepo.
 
@@ -37,5 +36,6 @@ jobs:
             - Type: bug, feature-request, question, documentation
             - Priority: priority:critical, priority:high, priority:medium, priority:low
             - Package: pkg:core, pkg:semantic, pkg:i18n, pkg:vite-plugin, pkg:other
-          allowed_tools: |
-            Bash(gh issue:*),Bash(gh search:*),Read,Grep,Glob
+          claude_args: |
+            --model claude-sonnet-4-20250514
+            --allowedTools "Bash(gh issue:*),Bash(gh search:*),Read,Grep,Glob"


### PR DESCRIPTION
## Summary

- Move `model` and `allowed_tools` from direct inputs to `claude_args` (they're not valid action inputs, causing warnings)
- Skip Claude review and security workflows for dependabot PRs (dependabot can't access repo secrets, causing failures)

## Test plan

- [ ] Claude review workflow passes on this PR (non-dependabot)
- [ ] Claude security workflow passes on this PR
- [ ] Dependabot PRs no longer trigger failing Claude workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)