### PR TITLE
ci: workspace → CI build-order drift guard (zero-dep)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,12 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
+      # Cheap guard: zero-dep node script that verifies ci.yml builds every
+      # workspace runtime dependency before its consumer. Runs before
+      # `npm ci` so drift fails fast without paying install cost.
+      - name: Verify CI build order
+        run: node scripts/check-ci-build-order.cjs
+
       - name: Install dependencies
         run: npm ci
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,8 @@
 npx lint-staged
+
+# Verify CI workflow build order is in sync with workspace deps.
+# Runs only when the ci.yml workflow or a workspace package.json is staged —
+# most commits skip this entirely (zero cost).
+if git diff --cached --name-only | grep -qE '^(packages/[^/]+/package\.json|\.github/workflows/ci\.yml)$'; then
+  node scripts/check-ci-build-order.cjs || exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "docs:dev": "npm run dev --workspace=apps/docs-site",
     "docs:build": "npm run build --workspace=apps/docs-site",
     "check:fresh": "./scripts/ensure-fresh.sh packages/framework packages/semantic packages/aot-compiler packages/compilation-service packages/mcp-server",
+    "check:ci-order": "node scripts/check-ci-build-order.cjs",
+    "check:ci-order:test": "node --test scripts/check-ci-build-order.test.cjs",
     "compatibility:monitor": "node scripts/compatibility-monitor.js",
     "compatibility:improve": "node scripts/improvement-workflow.js",
     "compatibility:cycle": "npm run compatibility:monitor && npm run compatibility:improve",

--- a/scripts/check-ci-build-order.cjs
+++ b/scripts/check-ci-build-order.cjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * check-ci-build-order — workspace → CI build-order drift guard
+ *
+ * Fails if any workspace package listed in .github/workflows/ci.yml has a
+ * workspace dependency that is either (a) missing from the workflow or
+ * (b) appears *after* it in the workflow's build sequence.
+ *
+ * Why this exists: when `@lokascript/intent` was extracted as a new
+ * workspace package in 2026-04-09, nothing updated ci.yml. The CI
+ * pipeline stayed red on `main` for 11 days before anyone noticed — the
+ * build just failed with a cryptic "Cannot find module" error from
+ * `packages/framework`.
+ *
+ * Zero runtime deps — uses only node built-ins so it stays cheap to run
+ * in both the pre-commit hook and the CI lint-typecheck step.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const PACKAGES_DIR = path.join(REPO_ROOT, 'packages');
+const CI_WORKFLOW = path.join(REPO_ROOT, '.github', 'workflows', 'ci.yml');
+
+const WORKSPACE_SCOPES = ['@lokascript/', '@hyperfixi/'];
+
+/**
+ * Read every packages/*\/package.json. Returns a map of package name → dir name
+ * and a map of package name → array of workspace dependency names.
+ *
+ * "Workspace dependency" = a dep in the `dependencies` or `devDependencies`
+ * field that matches one of WORKSPACE_SCOPES.
+ */
+function loadWorkspaces() {
+  const nameToDir = new Map();
+  const nameToDeps = new Map();
+
+  const dirs = fs.readdirSync(PACKAGES_DIR, { withFileTypes: true });
+  for (const dirent of dirs) {
+    if (!dirent.isDirectory()) continue;
+    const pkgPath = path.join(PACKAGES_DIR, dirent.name, 'package.json');
+    let raw;
+    try {
+      raw = fs.readFileSync(pkgPath, 'utf8');
+    } catch {
+      continue; // directory without package.json — skip
+    }
+    let pkg;
+    try {
+      pkg = JSON.parse(raw);
+    } catch {
+      throw new Error(`check-ci-build-order: invalid JSON in ${pkgPath}`);
+    }
+
+    if (!pkg.name) continue;
+    nameToDir.set(pkg.name, dirent.name);
+
+    // Only runtime `dependencies` affect CI build ordering: those resolve
+    // to imports that tsc/bundlers pull from the dep's built dist. peerDeps
+    // are provided by consumers; devDeps are only needed in downstream
+    // test/lint jobs (which pull the shared build-artifacts bundle).
+    // Scoping here to `dependencies` matches the actual failure mode and
+    // avoids false positives on peer/dev relationships.
+    const deps = new Set();
+    const runtimeDeps = pkg.dependencies || {};
+    for (const depName of Object.keys(runtimeDeps)) {
+      if (WORKSPACE_SCOPES.some(scope => depName.startsWith(scope))) {
+        deps.add(depName);
+      }
+    }
+    nameToDeps.set(pkg.name, [...deps]);
+  }
+
+  return { nameToDir, nameToDeps };
+}
+
+/**
+ * Extract the ordered list of `npm run build --prefix packages/<name>` steps
+ * from the CI workflow. Returns an array of directory names in build order.
+ *
+ * We only parse `run:` values — regex is sufficient and avoids pulling in
+ * a YAML library just for this one pattern. Any future workflow edit that
+ * uses a different invocation syntax (e.g. a shared composite action) will
+ * need this function updated.
+ */
+function loadWorkflowBuildOrder() {
+  let text;
+  try {
+    text = fs.readFileSync(CI_WORKFLOW, 'utf8');
+  } catch (err) {
+    throw new Error(`check-ci-build-order: cannot read ${CI_WORKFLOW}: ${err.message}`);
+  }
+
+  // The build job's relevant lines look like:
+  //   run: npm run build --prefix packages/<name>
+  // or
+  //   run: npm run build:browser --prefix packages/<name>
+  //
+  // We only care about the first `run:` occurrence per package because
+  // subsequent calls (e.g. build:browser) happen after the main build.
+  const pattern = /npm run build(?::[a-zA-Z-]+)?\s+--prefix\s+packages\/([a-zA-Z0-9-]+)/g;
+  const seen = new Set();
+  const order = [];
+  let m;
+  while ((m = pattern.exec(text)) !== null) {
+    const dir = m[1];
+    if (!seen.has(dir)) {
+      seen.add(dir);
+      order.push(dir);
+    }
+  }
+  return order;
+}
+
+/**
+ * Core check. Returns an array of human-readable failure messages;
+ * empty array means all good.
+ */
+function check({ nameToDir, nameToDeps }, workflowOrder) {
+  const failures = [];
+
+  // Invert: dir name → package name, so we can resolve workflow-order entries
+  // back to their package name and look up their deps.
+  const dirToName = new Map();
+  for (const [name, dir] of nameToDir) dirToName.set(dir, name);
+
+  // Workflow entries with no matching package on disk — likely stale.
+  for (const dir of workflowOrder) {
+    if (!dirToName.has(dir)) {
+      failures.push(
+        `Workflow references packages/${dir} but no such workspace package exists. ` +
+          `Remove the build step from .github/workflows/ci.yml or add the package.`
+      );
+    }
+  }
+
+  // Position of each package in the workflow, by package name.
+  const workflowPos = new Map();
+  for (let i = 0; i < workflowOrder.length; i++) {
+    const name = dirToName.get(workflowOrder[i]);
+    if (name) workflowPos.set(name, i);
+  }
+
+  // Check each built package's deps.
+  for (const [name, pos] of workflowPos) {
+    const deps = nameToDeps.get(name) || [];
+    for (const dep of deps) {
+      if (!nameToDir.has(dep)) continue; // external dep with a workspace-looking name (rare) — skip
+      const depPos = workflowPos.get(dep);
+      if (depPos === undefined) {
+        failures.push(
+          `Workspace package ${dep} is a dependency of ${name} but is NOT built in ` +
+            `.github/workflows/ci.yml. Add a "Build ${dep} package" step before the ` +
+            `"Build ${name} package" step (around line matching "npm run build --prefix ` +
+            `packages/${nameToDir.get(name)}").`
+        );
+      } else if (depPos > pos) {
+        failures.push(
+          `Workspace package ${dep} is built AFTER its dependent ${name} in ` +
+            `.github/workflows/ci.yml. Move the "Build ${dep} package" step to run ` +
+            `before the "Build ${name} package" step.`
+        );
+      }
+    }
+  }
+
+  return failures;
+}
+
+function main() {
+  const workspaces = loadWorkspaces();
+  const workflowOrder = loadWorkflowBuildOrder();
+  const failures = check(workspaces, workflowOrder);
+
+  if (failures.length === 0) {
+    // Keep success output minimal so the pre-commit hook feels invisible.
+    process.stdout.write('check-ci-build-order: OK\n');
+    process.exit(0);
+  }
+
+  process.stderr.write('check-ci-build-order: FAIL\n\n');
+  for (const msg of failures) {
+    process.stderr.write(`  • ${msg}\n\n`);
+  }
+  process.stderr.write(
+    `Fix the workflow at ${path.relative(REPO_ROOT, CI_WORKFLOW)} and re-run.\n`
+  );
+  process.exit(1);
+}
+
+if (require.main === module) {
+  main();
+}
+
+// Export for tests.
+module.exports = { loadWorkspaces, loadWorkflowBuildOrder, check };

--- a/scripts/check-ci-build-order.test.cjs
+++ b/scripts/check-ci-build-order.test.cjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Tests for scripts/check-ci-build-order.cjs
+ *
+ * Uses node's built-in test runner to keep the zero-runtime-deps story —
+ * no vitest, no jest, no extra install. Run with:
+ *     node --test scripts/check-ci-build-order.test.cjs
+ */
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { check, loadWorkflowBuildOrder, loadWorkspaces } = require('./check-ci-build-order.cjs');
+
+/** Build a minimal workspaces object matching the shape `check()` expects. */
+function workspaces(defs) {
+  const nameToDir = new Map();
+  const nameToDeps = new Map();
+  for (const { name, dir, deps = [] } of defs) {
+    nameToDir.set(name, dir);
+    nameToDeps.set(name, deps);
+  }
+  return { nameToDir, nameToDeps };
+}
+
+test('check: passes when order is correct and all deps are present', () => {
+  const ws = workspaces([
+    { name: '@x/a', dir: 'a', deps: [] },
+    { name: '@x/b', dir: 'b', deps: ['@x/a'] },
+  ]);
+  const order = ['a', 'b'];
+  assert.deepEqual(check(ws, order), []);
+});
+
+test('check: fails when a dep is missing from the workflow', () => {
+  const ws = workspaces([
+    { name: '@x/a', dir: 'a', deps: [] },
+    { name: '@x/b', dir: 'b', deps: ['@x/a'] },
+  ]);
+  const order = ['b']; // 'a' missing
+  const failures = check(ws, order);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /@x\/a is a dependency of @x\/b but is NOT built/);
+});
+
+test('check: fails when a dep is built AFTER its consumer', () => {
+  const ws = workspaces([
+    { name: '@x/a', dir: 'a', deps: [] },
+    { name: '@x/b', dir: 'b', deps: ['@x/a'] },
+  ]);
+  const order = ['b', 'a']; // wrong order
+  const failures = check(ws, order);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /@x\/a is built AFTER its dependent @x\/b/);
+});
+
+test('check: flags stale workflow entries with no matching package', () => {
+  const ws = workspaces([{ name: '@x/a', dir: 'a', deps: [] }]);
+  const order = ['a', 'ghost-package'];
+  const failures = check(ws, order);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /packages\/ghost-package but no such workspace package exists/);
+});
+
+test('check: ignores packages not in the workflow (they may be private/unpublished)', () => {
+  // Only `b` is in the workflow; `a` exists on disk but isn't a dep of `b` and isn't built.
+  const ws = workspaces([
+    { name: '@x/a', dir: 'a', deps: [] },
+    { name: '@x/b', dir: 'b', deps: [] },
+  ]);
+  const order = ['b'];
+  assert.deepEqual(check(ws, order), []);
+});
+
+test('check: ignores non-workspace lookalike deps', () => {
+  // '@x/not-a-workspace' is NOT in nameToDir, so the dep is skipped cleanly.
+  const ws = workspaces([
+    { name: '@x/a', dir: 'a', deps: ['@x/not-a-workspace'] },
+  ]);
+  const order = ['a'];
+  assert.deepEqual(check(ws, order), []);
+});
+
+test('check: reports multiple failures in one run', () => {
+  const ws = workspaces([
+    { name: '@x/a', dir: 'a', deps: [] },
+    { name: '@x/b', dir: 'b', deps: ['@x/a'] },
+    { name: '@x/c', dir: 'c', deps: ['@x/missing'] },
+    { name: '@x/missing', dir: 'missing', deps: [] },
+  ]);
+  const order = ['b', 'c']; // a missing, missing missing
+  const failures = check(ws, order);
+  assert.equal(failures.length, 2);
+});
+
+test('check: transitive deps across multiple packages', () => {
+  const ws = workspaces([
+    { name: '@x/a', dir: 'a', deps: [] },
+    { name: '@x/b', dir: 'b', deps: ['@x/a'] },
+    { name: '@x/c', dir: 'c', deps: ['@x/b'] },
+  ]);
+  // c before b: caught. b before a: caught.
+  // Failures emerge in workflow-position iteration order, so c's failure
+  // (b after c) surfaces first, then b's failure (a after b).
+  const order = ['c', 'b', 'a'];
+  const failures = check(ws, order);
+  assert.equal(failures.length, 2);
+  assert.match(failures[0], /@x\/b is built AFTER its dependent @x\/c/);
+  assert.match(failures[1], /@x\/a is built AFTER its dependent @x\/b/);
+});
+
+// Integration smoke: the real repo should pass the guard. Pins the contract
+// so a future refactor that breaks loader semantics fails this test.
+test('integration: real repository state passes the guard', () => {
+  const ws = loadWorkspaces();
+  const order = loadWorkflowBuildOrder();
+  assert.deepEqual(check(ws, order), []);
+});


### PR DESCRIPTION
## Summary

Prevents a recurrence of the 11-day CI brown-out on `main` (2026-04-10 → 2026-04-21), where `@lokascript/intent` was extracted as a new workspace package but `.github/workflows/ci.yml` wasn't updated. Every CI run failed with `Cannot find module '@lokascript/intent'` for 11 days before anyone noticed.

Follows the spike at [~/.claude/plans/intent-packages-spike.md](~/.claude/plans/intent-packages-spike.md).

## What it catches

- A CI-built workspace package has a runtime `dependencies` entry on another workspace package that is NOT listed in the workflow's build steps.
- A CI-built workspace package is built BEFORE its workspace dependency in the workflow.
- The workflow references a `packages/X` that doesn't exist on disk (stale entries).

**Scope:** runtime `dependencies` only. `peerDependencies` / `devDependencies` intentionally excluded — they don't affect CI build order (peer deps are provided by consumers; dev deps are only resolved in downstream test/lint jobs that load the shared build-artifacts bundle).

## Implementation

- `scripts/check-ci-build-order.cjs` (~130 LOC, **zero runtime deps**, runs in <100ms). Uses regex to extract `npm run build --prefix packages/<name>` steps from ci.yml; no YAML library needed.
- `scripts/check-ci-build-order.test.cjs` — 9 tests using node's built-in `node --test` runner.

## Wiring — minimizing Actions minutes

Two layers, belt-and-suspenders:

1. **Pre-commit hook** (`.husky/pre-commit`) — runs only when a workspace `package.json` or `ci.yml` is staged, so ~95% of commits skip the check entirely. Catches drift before CI is ever invoked, saving a wasted CI run.
2. **CI safety net** — one step added to the existing `lint-typecheck` job BEFORE `npm ci`, so drift fails fast without paying install cost. ~2s overhead when happy. Catches bypassed hooks, fork PRs, and Dependabot PRs.

**Marginal CI minutes:** +~2 seconds per PR. Break-even is avoiding one brown-out.

## npm scripts

- `npm run check:ci-order` — run the guard
- `npm run check:ci-order:test` — run the guard's own tests

## Test plan

- [x] 9/9 unit tests pass (`node --test scripts/check-ci-build-order.test.cjs`)
- [x] Clean run on current `main`: exits 0
- [x] Synthetic "intent removed from workflow" reproduces the original brown-out bug: exits 1 with actionable message
- [x] Synthetic "intent after framework" reproduces wrong-order bug: exits 1 with actionable message
- [x] Pre-commit hook fires on staged ci.yml edit (verified during this PR's own commit — `check-ci-build-order: OK` output in lint-staged chain)
- [ ] CI run on this PR completes green

## Alternatives considered (see spike doc)

Rejected: collapsing `@lokascript/intent` back into `framework` (undoes deliberate protocol extraction, doesn't solve the generic workspace→CI drift class of bug). Kept the split, hardened the seam instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)