### PR TITLE
ci: skip coverage on PRs, ignore examples/.claude/*.txt paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
       - 'docs/**'
       - '.gitignore'
       - 'LICENSE'
+      - 'examples/**'
+      - '.claude/**'
+      - '*.txt'
   pull_request:
     branches: [main, develop]
     paths-ignore:
@@ -15,6 +18,9 @@ on:
       - 'docs/**'
       - '.gitignore'
       - 'LICENSE'
+      - 'examples/**'
+      - '.claude/**'
+      - '*.txt'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -435,6 +441,7 @@ jobs:
     name: Coverage Report
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     timeout-minutes: 20
 
     steps:


### PR DESCRIPTION
## Summary

Two independent CI-minutes savings, single-file diff to `.github/workflows/ci.yml`:

- **Gate `coverage` job to main pushes only** (mirrors the existing `benchmarks` job pattern). Codecov badge still updates from main pushes; PRs save the ~3.5 min Codecov upload step.
- **Widen `paths-ignore`** (push + pull_request) to add `examples/**`, `.claude/**`, `*.txt`. Documentation-only, gallery-only, or workspace-config-only changes won't burn a CI run.

Audit confirmed:
- `coverage` has no downstream `needs:`; not a required status check anywhere in `.github/`, README, or CLAUDE.md.
- Playwright bundle/gallery tests load examples from a running HTTP server, not from a CI re-trigger; `packages/framework/vitest.config.ts:16` already excludes `examples/` from coverage.
- `.claude/**` and `*.txt` have zero test-input references across the monorepo.

## Test plan

- [ ] Confirm this PR's Checks tab shows **no `coverage` job** and no `benchmarks` job; all other jobs (`build`, `lint-typecheck`, `unit-tests`, `browser-tests`, `multilingual-validation`, `bundle-size`, `export-validation`) run.
- [ ] After merge, watch the next push to `main` and confirm `coverage` runs and Codecov upload succeeds.
- [ ] Optional: open a throwaway draft PR editing only an `examples/**` file to confirm `paths-ignore` skips the workflow entirely.

## Rollback

Single-file revert. Coverage gating and the `paths-ignore` widening are independently revertable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)