### PR TITLE
feat(i18n): v0.9.90 Phase 10.2 — translations for comparators (starts with, ends with, between, ignoring case)

### DIFF
--- a/packages/i18n/src/dictionaries/ar.ts
+++ b/packages/i18n/src/dictionaries/ar.ts
@@ -199,5 +199,6 @@ export const ar: Dictionary = {
     some: 'بعض',
     'starts with': 'يبدأ بـ',
     'ends with': 'ينتهي بـ',
+    'ignoring case': 'مع تجاهل الحالة',
   },
 };

--- a/packages/i18n/src/dictionaries/bn.ts
+++ b/packages/i18n/src/dictionaries/bn.ts
@@ -78,6 +78,7 @@ export const bengaliDictionary: Dictionary = {
     at: 'এ',
     in: 'এ',
     over: 'উপর',
+    between: 'মধ্যে',
     then: 'তারপর',
     and: 'এবং',
     end: 'শেষ',
@@ -172,6 +173,9 @@ export const bengaliDictionary: Dictionary = {
     length: 'দৈর্ঘ্য',
     index: 'সূচক',
     empty: 'খালি-করুন',
+    'starts with': 'দিয়ে_শুরু',
+    'ends with': 'দিয়ে_শেষ',
+    'ignoring case': 'কেস_উপেক্ষা',
   },
 };
 

--- a/packages/i18n/src/dictionaries/de.ts
+++ b/packages/i18n/src/dictionaries/de.ts
@@ -199,5 +199,6 @@ export const de: Dictionary = {
     some: 'einige',
     'starts with': 'beginnt mit',
     'ends with': 'endet mit',
+    'ignoring case': 'ohne Groß-/Kleinschreibung',
   },
 };

--- a/packages/i18n/src/dictionaries/en.ts
+++ b/packages/i18n/src/dictionaries/en.ts
@@ -243,5 +243,6 @@ export const en: Dictionary = {
     // String operations
     'starts with': 'starts with',
     'ends with': 'ends with',
+    'ignoring case': 'ignoring case',
   },
 };

--- a/packages/i18n/src/dictionaries/es.ts
+++ b/packages/i18n/src/dictionaries/es.ts
@@ -199,5 +199,6 @@ export const es: Dictionary = {
     some: 'algún',
     'starts with': 'empieza con',
     'ends with': 'termina con',
+    'ignoring case': 'ignorando mayúsculas',
   },
 };

--- a/packages/i18n/src/dictionaries/fr.ts
+++ b/packages/i18n/src/dictionaries/fr.ts
@@ -199,5 +199,6 @@ export const fr: Dictionary = {
     some: 'quelques',
     'starts with': 'commence par',
     'ends with': 'finit par',
+    'ignoring case': 'en ignorant la casse',
   },
 };

--- a/packages/i18n/src/dictionaries/hi.ts
+++ b/packages/i18n/src/dictionaries/hi.ts
@@ -225,6 +225,7 @@ export const hindiDictionary: Dictionary = {
     some: 'कुछ',
     'starts with': 'से_शुरू',
     'ends with': 'पर_समाप्त',
+    'ignoring case': 'केस_अनदेखा',
   },
 };
 

--- a/packages/i18n/src/dictionaries/id.ts
+++ b/packages/i18n/src/dictionaries/id.ts
@@ -199,5 +199,6 @@ export const id: Dictionary = {
     some: 'beberapa',
     'starts with': 'dimulai dengan',
     'ends with': 'diakhiri dengan',
+    'ignoring case': 'abaikan kapital',
   },
 };

--- a/packages/i18n/src/dictionaries/it.ts
+++ b/packages/i18n/src/dictionaries/it.ts
@@ -199,5 +199,6 @@ export const it: Dictionary = {
     some: 'qualche',
     'starts with': 'inizia con',
     'ends with': 'finisce con',
+    'ignoring case': 'ignorando maiuscole',
   },
 };

--- a/packages/i18n/src/dictionaries/ja.ts
+++ b/packages/i18n/src/dictionaries/ja.ts
@@ -199,5 +199,6 @@ export const ja: Dictionary = {
     some: 'いくつか',
     'starts with': 'で始まる',
     'ends with': 'で終わる',
+    'ignoring case': '大文字小文字を無視',
   },
 };

--- a/packages/i18n/src/dictionaries/ko.ts
+++ b/packages/i18n/src/dictionaries/ko.ts
@@ -199,5 +199,6 @@ export const ko: Dictionary = {
     some: '일부',
     'starts with': '로시작',
     'ends with': '로끝나는',
+    'ignoring case': '대소문자_무시',
   },
 };

--- a/packages/i18n/src/dictionaries/ms.ts
+++ b/packages/i18n/src/dictionaries/ms.ts
@@ -225,6 +225,7 @@ export const malayDictionary: Dictionary = {
     some: 'beberapa',
     'starts with': 'bermula_dengan',
     'ends with': 'berakhir_dengan',
+    'ignoring case': 'abaikan_huruf_besar_kecil',
     length: 'panjang',
     index: 'indeks',
   },

--- a/packages/i18n/src/dictionaries/pl.ts
+++ b/packages/i18n/src/dictionaries/pl.ts
@@ -199,5 +199,6 @@ export const pl: Dictionary = {
     some: 'jakiś',
     'starts with': 'zaczyna się od',
     'ends with': 'kończy się na',
+    'ignoring case': 'ignorując wielkość liter',
   },
 };

--- a/packages/i18n/src/dictionaries/pt.ts
+++ b/packages/i18n/src/dictionaries/pt.ts
@@ -199,5 +199,6 @@ export const pt: Dictionary = {
     some: 'algum',
     'starts with': 'começa com',
     'ends with': 'termina com',
+    'ignoring case': 'ignorando maiúsculas',
   },
 };

--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -199,5 +199,6 @@ export const qu: Dictionary = {
     some: 'wakin',
     'starts with': 'qallarisqa wan',
     'ends with': 'tukusqa wan',
+    'ignoring case': 'hatun-huchuy qillqata-saqiy',
   },
 };

--- a/packages/i18n/src/dictionaries/ru.ts
+++ b/packages/i18n/src/dictionaries/ru.ts
@@ -225,6 +225,7 @@ export const russianDictionary: Dictionary = {
     some: 'некоторые',
     'starts with': 'начинается_с',
     'ends with': 'заканчивается_на',
+    'ignoring case': 'без_учёта_регистра',
   },
 };
 

--- a/packages/i18n/src/dictionaries/sw.ts
+++ b/packages/i18n/src/dictionaries/sw.ts
@@ -199,5 +199,6 @@ export const sw: Dictionary = {
     some: 'baadhi',
     'starts with': 'huanza na',
     'ends with': 'huisha na',
+    'ignoring case': 'puuza herufi kubwa ndogo',
   },
 };

--- a/packages/i18n/src/dictionaries/th.ts
+++ b/packages/i18n/src/dictionaries/th.ts
@@ -78,6 +78,7 @@ export const thaiDictionary: Dictionary = {
     at: 'ที่',
     in: 'ใน',
     over: 'เหนือ',
+    between: 'ระหว่าง',
     then: 'แล้ว',
     and: 'และ',
     end: 'จบ',
@@ -172,6 +173,9 @@ export const thaiDictionary: Dictionary = {
     length: 'ความยาว',
     index: 'ดัชนี',
     empty: 'ล้าง',
+    'starts with': 'ขึ้นต้นด้วย',
+    'ends with': 'ลงท้ายด้วย',
+    'ignoring case': 'ไม่สนตัวพิมพ์',
   },
 };
 

--- a/packages/i18n/src/dictionaries/tl.ts
+++ b/packages/i18n/src/dictionaries/tl.ts
@@ -225,6 +225,7 @@ export const tagalogDictionary: Dictionary = {
     some: 'ilan',
     'starts with': 'nagsisimula_sa',
     'ends with': 'nagtatapos_sa',
+    'ignoring case': 'huwag_pansinin_ang_case',
     length: 'haba',
     index: 'indeks',
   },

--- a/packages/i18n/src/dictionaries/tr.ts
+++ b/packages/i18n/src/dictionaries/tr.ts
@@ -199,5 +199,6 @@ export const tr: Dictionary = {
     some: 'bazı',
     'starts with': 'ile başlar',
     'ends with': 'ile biter',
+    'ignoring case': 'büyük küçük harf duyarsız',
   },
 };

--- a/packages/i18n/src/dictionaries/uk.ts
+++ b/packages/i18n/src/dictionaries/uk.ts
@@ -225,6 +225,7 @@ export const ukrainianDictionary: Dictionary = {
     some: 'деякі',
     'starts with': 'починається_з',
     'ends with': 'закінчується_на',
+    'ignoring case': 'без_урахування_регістру',
   },
 };
 

--- a/packages/i18n/src/dictionaries/vi.ts
+++ b/packages/i18n/src/dictionaries/vi.ts
@@ -84,6 +84,7 @@ export const vi: Dictionary = {
     in: 'trong',
     at: 'tại',
     of: 'của',
+    between: 'giữa',
     the: '',
     times: 'lần',
   },
@@ -198,5 +199,8 @@ export const vi: Dictionary = {
     children: 'con',
     closest: 'gần nhất',
     empty: 'làm-rỗng',
+    'starts with': 'bắt đầu bằng',
+    'ends with': 'kết thúc bằng',
+    'ignoring case': 'không phân biệt hoa thường',
   },
 };

--- a/packages/i18n/src/dictionaries/zh.ts
+++ b/packages/i18n/src/dictionaries/zh.ts
@@ -199,5 +199,6 @@ export const zh: Dictionary = {
     some: '一些',
     'starts with': '以开头',
     'ends with': '以结尾',
+    'ignoring case': '忽略大小写',
   },
 };

--- a/packages/i18n/src/schema-alignment.test.ts
+++ b/packages/i18n/src/schema-alignment.test.ts
@@ -117,4 +117,31 @@ describe('Schema ↔ i18n alignment', () => {
       });
     });
   });
+
+  describe('Phase 2 comparators (v0.9.90) are present in all complete languages', () => {
+    // Expression operators wired into the core Pratt parser. Unlike Phase 1
+    // commands, these live in the hand-written `expressions` category (or
+    // `modifiers` for `between`) rather than deriving from semantic profiles.
+    const PHASE_2_COMPARATORS = ['starts with', 'ends with', 'between', 'ignoring case'] as const;
+
+    COMPLETE_LANGUAGES.forEach(code => {
+      const dict = dictionaries[code] as Dictionary | undefined;
+      if (!dict) return;
+
+      it(`${code}: has all Phase 2 comparators (any category)`, () => {
+        const missing: string[] = [];
+        for (const op of PHASE_2_COMPARATORS) {
+          if (!findInDictionary(dict, op)) {
+            missing.push(op);
+          }
+        }
+        expect(
+          missing,
+          `Missing Phase 2 comparators in ${code}: ${missing.join(', ')}. ` +
+            `Add to packages/i18n/src/dictionaries/${code}.ts's \`expressions\` ` +
+            `category (or \`modifiers\` for \`between\`).`
+        ).toEqual([]);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `ignoring case` to all 23 COMPLETE_LANGUAGES' `expressions` category
- Backfills `starts with` / `ends with` / `between` in `bn`, `th`, `vi` — pre-existing gaps surfaced by the new test
- Extends `schema-alignment.test.ts` with `PHASE_2_COMPARATORS` block
- i18n-only — no semantic profile changes (expression operators are hand-written in `expressions`, not derived from `profile.keywords`)
- Stacks on #163 (Phase 10.1)

## Test plan
- [x] `npm run test:run --prefix packages/i18n` PASS (587 tests, +22 new)
- [x] `npm run typecheck --prefix packages/i18n` clean
- [x] `src/translator.test.ts` — round-trip smoke passes
- [x] Core no-regression: `npm run test:check --prefix packages/core` PASS

## Deferred
- Compound negated forms (`does not start with`, `is not between`) — the translator composes these from base+`does not`/`is not` already
- Quechua translations are best-effort; native-speaker review welcomed downstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)