### PR TITLE
feat(intercept): @hyperfixi/intercept — service-worker request interception (5 cache strategies)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1204,6 +1204,10 @@
       "resolved": "packages/intent-element",
       "link": true
     },
+    "node_modules/@hyperfixi/intercept": {
+      "resolved": "packages/intercept",
+      "link": true
+    },
     "node_modules/@hyperfixi/mcp-server": {
       "resolved": "packages/mcp-server",
       "link": true
@@ -20074,6 +20078,39 @@
         "@hyperfixi/core": {
           "optional": true
         }
+      }
+    },
+    "packages/intercept": {
+      "name": "@hyperfixi/intercept",
+      "version": "2.3.1",
+      "license": "MIT",
+      "dependencies": {
+        "@hyperfixi/core": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "happy-dom": "^15.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/intercept/node_modules/happy-dom": {
+      "version": "15.11.7",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-15.11.7.tgz",
+      "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^4.5.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "packages/language-server": {

--- a/packages/intercept/LICENSE
+++ b/packages/intercept/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2025 LokaScript Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/intercept/package.json
+++ b/packages/intercept/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@hyperfixi/intercept",
+  "version": "2.3.1",
+  "description": "Service-worker request-interception plugin for hyperfixi — adds the `intercept ... end` feature with precache / route strategies / offline fallback (upstream _hyperscript 0.9.90).",
+  "type": "module",
+  "sideEffects": false,
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./sw": "./dist/intercept-sw.js"
+  },
+  "scripts": {
+    "build": "tsup && npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --outDir dist --noEmit false",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:check": "vitest run --reporter=dot 2>&1 | tail -5",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hyperfixi/core": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "happy-dom": "^15.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^4.0.0"
+  },
+  "files": [
+    "dist",
+    "src",
+    "LICENSE"
+  ],
+  "keywords": [
+    "hyperfixi",
+    "hyperscript",
+    "service-worker",
+    "intercept",
+    "cache",
+    "offline",
+    "plugin",
+    "_hyperscript",
+    "v0.9.90"
+  ],
+  "author": "LokaScript Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/codetalcott/hyperfixi.git",
+    "directory": "packages/intercept"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/intercept/src/index.ts
+++ b/packages/intercept/src/index.ts
@@ -1,0 +1,74 @@
+/**
+ * @hyperfixi/intercept — service-worker request-interception plugin.
+ *
+ * Adds the upstream _hyperscript 0.9.90 `intercept ... end` feature to
+ * hyperfixi. The plugin auto-registers a service worker that routes matching
+ * requests through configurable caching strategies.
+ *
+ * ```ts
+ * import { createRuntime, installPlugin } from '@hyperfixi/core';
+ * import { interceptPlugin } from '@hyperfixi/intercept';
+ *
+ * const runtime = createRuntime();
+ * installPlugin(runtime, interceptPlugin);
+ * ```
+ *
+ * DSL (v1 — string-literal URLs only):
+ *
+ * ```
+ * intercept "/"
+ *   precache "/", "/index.html", "/app.js" as "v2"
+ *   on "/api/*" use network-first
+ *   on "*.css", "*.js" use cache-first
+ *   offline fallback "/offline.html"
+ * end
+ * ```
+ *
+ * **Ship as strictly opt-in.** Service-worker registration has strong UX and
+ * security implications — never enable by default. Users must also serve
+ * `dist/intercept-sw.js` at the path configured via `swUrl` (default
+ * `/hyperfixi-sw.js`).
+ */
+
+import type { HyperfixiPlugin, HyperfixiPluginContext } from '@hyperfixi/core';
+import { parseInterceptFeature, makeEvaluateInterceptFeature } from './parse';
+
+export type { InterceptConfig, Strategy } from './types';
+export type { InterceptFeatureNode } from './parse';
+export { _resetForTest } from './parse';
+export { matchesPattern, findRoute, cacheKeyFor } from './pattern-match';
+
+export interface InterceptPluginOptions {
+  /**
+   * URL where the service-worker runtime is hosted. Default
+   * `'/hyperfixi-sw.js'`. You must serve the `dist/intercept-sw.js` file
+   * shipped in this package at that path.
+   */
+  swUrl?: string;
+}
+
+const DEFAULT_SW_URL = '/hyperfixi-sw.js';
+
+/**
+ * Factory for a configured intercept plugin. Use when you need a non-default
+ * `swUrl`; otherwise import `interceptPlugin` directly.
+ */
+export function createInterceptPlugin(options: InterceptPluginOptions = {}): HyperfixiPlugin {
+  const swUrl = options.swUrl ?? DEFAULT_SW_URL;
+  return {
+    name: '@hyperfixi/intercept',
+    install(ctx: HyperfixiPluginContext) {
+      const { parserExtensions } = ctx;
+      parserExtensions.registerFeature('intercept', parseInterceptFeature as never);
+      parserExtensions.registerNodeEvaluator(
+        'interceptFeature',
+        makeEvaluateInterceptFeature(swUrl) as never
+      );
+    },
+  };
+}
+
+/** Default plugin — uses `/hyperfixi-sw.js` as the service-worker path. */
+export const interceptPlugin: HyperfixiPlugin = createInterceptPlugin();
+
+export default interceptPlugin;

--- a/packages/intercept/src/integration.test.ts
+++ b/packages/intercept/src/integration.test.ts
@@ -1,0 +1,256 @@
+/**
+ * End-to-end integration — parse + installPlugin + execute round-trip.
+ *
+ * happy-dom doesn't ship `navigator.serviceWorker`, so we install a mock onto
+ * the global navigator before the runtime is touched. The mock records the
+ * register call + any postMessage calls so we can assert the full pipeline.
+ *
+ * Uses the `registry.snapshot()` / `registry.restore(baseline)` pattern to
+ * isolate plugin installations from other test files in the process.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Runtime, parse, getParserExtensionRegistry, installPlugin } from '@hyperfixi/core';
+import { createInterceptPlugin, _resetForTest } from './index';
+
+// --- Mock service-worker registry --------------------------------------------
+
+interface MockSW {
+  state: 'installing' | 'waiting' | 'activated';
+  postedMessages: unknown[];
+  listeners: Map<string, Array<() => void>>;
+  postMessage(msg: unknown): void;
+  addEventListener(ev: string, cb: () => void): void;
+  _advanceTo(state: 'activated'): void;
+}
+
+interface MockRegistration {
+  installing: MockSW | null;
+  waiting: MockSW | null;
+  active: MockSW | null;
+}
+
+interface MockNavigator {
+  lastScope?: string;
+  lastUrl?: string;
+  registrations: MockRegistration[];
+  register(url: string, opts: { scope: string }): Promise<MockRegistration>;
+  /** Resolve the next register() call with an SW starting in this state. */
+  _nextInitialState: 'installing' | 'activated';
+  /** If set, register() rejects with this error. */
+  _nextError?: Error;
+}
+
+function makeSW(state: MockSW['state']): MockSW {
+  const sw: MockSW = {
+    state,
+    postedMessages: [],
+    listeners: new Map(),
+    postMessage(msg) {
+      this.postedMessages.push(msg);
+    },
+    addEventListener(ev, cb) {
+      const arr = this.listeners.get(ev) ?? [];
+      arr.push(cb);
+      this.listeners.set(ev, arr);
+    },
+    _advanceTo(next) {
+      this.state = next;
+      const cbs = this.listeners.get('statechange') ?? [];
+      for (const cb of cbs) cb();
+    },
+  };
+  return sw;
+}
+
+function installMockNavigator(): MockNavigator {
+  const mock: MockNavigator = {
+    registrations: [],
+    _nextInitialState: 'activated',
+    async register(url, opts) {
+      if (this._nextError) {
+        const err = this._nextError;
+        this._nextError = undefined;
+        throw err;
+      }
+      this.lastUrl = url;
+      this.lastScope = opts.scope;
+      const sw = makeSW(this._nextInitialState);
+      const reg: MockRegistration = {
+        installing: this._nextInitialState === 'installing' ? sw : null,
+        waiting: null,
+        active: this._nextInitialState === 'activated' ? sw : null,
+      };
+      this.registrations.push(reg);
+      return reg;
+    },
+  };
+  Object.defineProperty(navigator, 'serviceWorker', {
+    value: mock,
+    configurable: true,
+    writable: true,
+  });
+  return mock;
+}
+
+function uninstallMockNavigator(): void {
+  const desc = Object.getOwnPropertyDescriptor(navigator, 'serviceWorker');
+  if (desc) {
+    // Just overwrite with an object lacking postMessage so `'serviceWorker' in navigator`
+    // returns false for the next test's "not supported" scenario if needed.
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    // Also delete for the "not supported" test — re-add when needed.
+    delete (navigator as unknown as { serviceWorker?: unknown }).serviceWorker;
+  }
+}
+
+function getSW(reg: MockRegistration): MockSW {
+  return (reg.installing || reg.waiting || reg.active)!;
+}
+
+// --- Tests --------------------------------------------------------------------
+
+describe('@hyperfixi/intercept — integration', () => {
+  const registry = getParserExtensionRegistry();
+  let baseline: ReturnType<typeof registry.snapshot>;
+  let runtime: Runtime;
+  let mockNav: MockNavigator;
+  const plugin = createInterceptPlugin({ swUrl: '/hyperfixi-sw.js' });
+
+  beforeEach(() => {
+    baseline = registry.snapshot();
+    _resetForTest();
+    runtime = new Runtime();
+    installPlugin(runtime, plugin);
+    mockNav = installMockNavigator();
+  });
+
+  afterEach(() => {
+    registry.restore(baseline);
+    uninstallMockNavigator();
+    vi.restoreAllMocks();
+  });
+
+  function parseOrThrow(input: string): ReturnType<typeof parse>['node'] {
+    const r = parse(input);
+    if (!r.success) {
+      throw new Error(`parse failed: ${JSON.stringify(r.errors)}`);
+    }
+    return r.node!;
+  }
+
+  function makeCtx(me: HTMLElement): Parameters<Runtime['execute']>[1] {
+    return {
+      me,
+      it: null,
+      you: null,
+      result: null,
+      locals: new Map(),
+      globals: new Map(),
+      variables: new Map(),
+      events: new Map(),
+    } as unknown as Parameters<Runtime['execute']>[1];
+  }
+
+  it('registers the SW at the configured scope with the configured URL', async () => {
+    const el = document.createElement('div');
+    const node = parseOrThrow('intercept "/app"\nend');
+    await runtime.execute(node as never, makeCtx(el));
+
+    expect(mockNav.lastUrl).toBe('/hyperfixi-sw.js');
+    expect(mockNav.lastScope).toBe('/app');
+  });
+
+  it('posts the config once the SW is active (eager path)', async () => {
+    mockNav._nextInitialState = 'activated';
+    const el = document.createElement('div');
+    const node = parseOrThrow(
+      'intercept "/"\n' +
+        '  precache "/" as "v9"\n' +
+        '  on "/api/*" use network-first\n' +
+        '  offline fallback "/offline.html"\n' +
+        'end'
+    );
+    await runtime.execute(node as never, makeCtx(el));
+
+    const reg = mockNav.registrations[0]!;
+    const sw = getSW(reg);
+    expect(sw.postedMessages.length).toBe(1);
+    const msg = sw.postedMessages[0] as {
+      type: string;
+      config: { scope: string; precache: unknown; routes: unknown; offlineFallback: string };
+    };
+    expect(msg.type).toBe('hs:intercept:config');
+    expect(msg.config.scope).toBe('/');
+    expect(msg.config.precache).toEqual({ urls: ['/'], version: 'v9' });
+    expect(msg.config.routes).toEqual([{ patterns: ['/api/*'], strategy: 'network-first' }]);
+    expect(msg.config.offlineFallback).toBe('/offline.html');
+  });
+
+  it('defers posting until the SW transitions to activated (statechange path)', async () => {
+    mockNav._nextInitialState = 'installing';
+    const el = document.createElement('div');
+    const node = parseOrThrow('intercept "/"\n  precache "/a"\nend');
+    await runtime.execute(node as never, makeCtx(el));
+
+    const reg = mockNav.registrations[0]!;
+    const sw = getSW(reg);
+    expect(sw.postedMessages.length).toBe(0);
+
+    sw._advanceTo('activated');
+    expect(sw.postedMessages.length).toBe(1);
+    expect((sw.postedMessages[0] as { type: string }).type).toBe('hs:intercept:config');
+  });
+
+  it('warns and skips when the plugin is invoked a second time', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const el = document.createElement('div');
+
+    await runtime.execute(parseOrThrow('intercept "/"\nend') as never, makeCtx(el));
+    expect(mockNav.registrations.length).toBe(1);
+
+    await runtime.execute(parseOrThrow('intercept "/other"\nend') as never, makeCtx(el));
+    expect(mockNav.registrations.length).toBe(1); // still just one
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/only one intercept declaration/));
+  });
+
+  it('warns when navigator.serviceWorker is unavailable', async () => {
+    uninstallMockNavigator();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const el = document.createElement('div');
+    const node = parseOrThrow('intercept "/"\nend');
+    await runtime.execute(node as never, makeCtx(el));
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/service worker not supported/));
+  });
+
+  it('prints the SecurityError hint when scope is wider than the SW directory', async () => {
+    const secErr = new Error('scope mismatch');
+    secErr.name = 'SecurityError';
+    mockNav._nextError = secErr;
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const el = document.createElement('div');
+    const node = parseOrThrow('intercept "/app"\nend');
+    await runtime.execute(node as never, makeCtx(el));
+
+    expect(errSpy).toHaveBeenCalled();
+    const msg = errSpy.mock.calls[0]!.join(' ');
+    expect(msg).toMatch(/scope '\/app'/);
+    expect(msg).toMatch(/Service-Worker-Allowed: \/app/);
+  });
+
+  it('logs the error on non-security registration failures', async () => {
+    mockNav._nextError = new Error('boom');
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const el = document.createElement('div');
+    const node = parseOrThrow('intercept "/"\nend');
+    await runtime.execute(node as never, makeCtx(el));
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/registration failed/),
+      expect.any(Error)
+    );
+  });
+});

--- a/packages/intercept/src/parse.test.ts
+++ b/packages/intercept/src/parse.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Parser tests — drive the real `parse()` from @hyperfixi/core after
+ * installing the plugin, then inspect the resulting AST. This validates both
+ * our parser function and its integration with `registerFeature` dispatch.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { parse, getParserExtensionRegistry } from '@hyperfixi/core';
+import { createInterceptPlugin, _resetForTest } from './index';
+import type { InterceptFeatureNode } from './parse';
+
+// Install the plugin against the shared parser-extension registry. We only
+// need the *parser* hooks for these tests — no runtime, no navigator.
+const registry = getParserExtensionRegistry();
+const plugin = createInterceptPlugin({ swUrl: '/hyperfixi-sw.js' });
+
+function installParserHooksOnly(): void {
+  plugin.install({
+    commandRegistry: {} as never,
+    parserExtensions: registry,
+    runtime: {} as never,
+  });
+}
+
+describe('parseInterceptFeature', () => {
+  let baseline: ReturnType<typeof registry.snapshot>;
+
+  beforeAll(() => {
+    installParserHooksOnly();
+  });
+
+  beforeEach(() => {
+    baseline = registry.snapshot();
+    _resetForTest();
+    installParserHooksOnly();
+  });
+
+  afterEach(() => {
+    registry.restore(baseline);
+  });
+
+  function getFeature(input: string): InterceptFeatureNode {
+    const r = parse(input);
+    expect(r.success, `parse failed: ${JSON.stringify(r.errors)}`).toBe(true);
+    // Top-level `parse` returns the single statement directly, or a Program
+    // node with `statements` when there are multiple. We only parse one
+    // feature per test, so the node is either the feature directly or
+    // accessible via .statements[0].
+    const root = r.node as { type?: string; statements?: InterceptFeatureNode[] };
+    const node =
+      root?.type === 'interceptFeature'
+        ? (root as unknown as InterceptFeatureNode)
+        : root?.statements?.find(s => s?.type === 'interceptFeature');
+    expect(node, `expected an interceptFeature node; got root.type=${root?.type}`).toBeDefined();
+    return node!;
+  }
+
+  it('parses a minimal intercept with only scope and end', () => {
+    const node = getFeature('intercept "/"\nend');
+    expect(node.config.scope).toBe('/');
+    expect(node.config.precache).toBe(null);
+    expect(node.config.routes).toEqual([]);
+    expect(node.config.offlineFallback).toBe(null);
+  });
+
+  it('parses precache with a single URL and no version', () => {
+    const node = getFeature('intercept "/"\n  precache "/index.html"\nend');
+    expect(node.config.precache).toEqual({ urls: ['/index.html'], version: null });
+  });
+
+  it('parses precache with multiple URLs and a version', () => {
+    const node = getFeature('intercept "/"\n  precache "/", "/app.js", "/style.css" as "v3"\nend');
+    expect(node.config.precache).toEqual({
+      urls: ['/', '/app.js', '/style.css'],
+      version: 'v3',
+    });
+  });
+
+  it('parses a route with a single pattern and strategy', () => {
+    const node = getFeature('intercept "/"\n  on "/api/*" use network-first\nend');
+    expect(node.config.routes).toEqual([{ patterns: ['/api/*'], strategy: 'network-first' }]);
+  });
+
+  it('parses a route with multiple patterns', () => {
+    const node = getFeature('intercept "/"\n  on "*.css", "*.js" use cache-first\nend');
+    expect(node.config.routes).toEqual([{ patterns: ['*.css', '*.js'], strategy: 'cache-first' }]);
+  });
+
+  it('accepts all five cache strategies', () => {
+    const strategies = [
+      'cache-first',
+      'network-first',
+      'stale-while-revalidate',
+      'network-only',
+      'cache-only',
+    ];
+    for (const strat of strategies) {
+      const node = getFeature(`intercept "/"\n  on "/a" use ${strat}\nend`);
+      expect(node.config.routes[0]!.strategy).toBe(strat);
+    }
+  });
+
+  it('rejects an unknown strategy', () => {
+    const r = parse('intercept "/"\n  on "/a" use bogus\nend');
+    expect(r.success).toBe(false);
+    const msg = (r.errors ?? [r.error]).map(e => e?.message).join(' | ');
+    expect(msg).toMatch(/unknown strategy/);
+  });
+
+  it('parses multiple routes in order', () => {
+    const node = getFeature(
+      'intercept "/"\n' +
+        '  on "/api/*" use network-first\n' +
+        '  on "*.css" use cache-first\n' +
+        'end'
+    );
+    expect(node.config.routes).toEqual([
+      { patterns: ['/api/*'], strategy: 'network-first' },
+      { patterns: ['*.css'], strategy: 'cache-first' },
+    ]);
+  });
+
+  it('parses offline fallback', () => {
+    const node = getFeature('intercept "/"\n  offline fallback "/offline.html"\nend');
+    expect(node.config.offlineFallback).toBe('/offline.html');
+  });
+
+  it('parses a full upstream-equivalent config', () => {
+    const node = getFeature(
+      'intercept "/"\n' +
+        '  precache "/", "/index.html" as "v2"\n' +
+        '  on "/api/*" use network-first\n' +
+        '  on "*.css", "*.js" use cache-first\n' +
+        '  offline fallback "/offline.html"\n' +
+        'end'
+    );
+    expect(node.config).toEqual({
+      scope: '/',
+      precache: { urls: ['/', '/index.html'], version: 'v2' },
+      routes: [
+        { patterns: ['/api/*'], strategy: 'network-first' },
+        { patterns: ['*.css', '*.js'], strategy: 'cache-first' },
+      ],
+      offlineFallback: '/offline.html',
+    });
+  });
+
+  it('rejects a naked-path scope (v1 requires string literals)', () => {
+    const r = parse('intercept /\nend');
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects intercept without a terminating end', () => {
+    const r = parse('intercept "/"\n  precache "/"');
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects an unknown clause keyword', () => {
+    const r = parse('intercept "/"\n  bogus "/x"\nend');
+    expect(r.success).toBe(false);
+  });
+
+  it('emits the correct AST node type', () => {
+    const node = getFeature('intercept "/"\nend');
+    expect(node.type).toBe('interceptFeature');
+  });
+});

--- a/packages/intercept/src/parse.ts
+++ b/packages/intercept/src/parse.ts
@@ -1,0 +1,217 @@
+/**
+ * `intercept "<scope>" ... end` — top-level feature parser + evaluator.
+ *
+ * Grammar (v1 — string-literal URLs only):
+ *
+ *   intercept "<scope>"
+ *     precache "<url>"[, "<url>"]* [as "<version>"]
+ *     on "<pattern>"[, "<pattern>"]* use <strategy>
+ *     on ...                                       (any number)
+ *     offline fallback "<url>"
+ *   end
+ *
+ * Upstream (`_hyperscript/src/ext/intercept.js`) also supports naked paths
+ * via `consumeNakedPath` — deferred to v2. String literals are unambiguous
+ * and cover the same use cases.
+ *
+ * The entire config is built at parse time (no runtime expressions). The
+ * evaluator just hands the config to `registerSW()` which takes care of
+ * the navigator.serviceWorker dance.
+ */
+
+import type { ASTNode, ExecutionContext, InterceptConfig, Strategy } from './types';
+import { registerSW, resetInstalledForTest } from './register-sw';
+
+export { resetInstalledForTest as _resetForTest };
+
+const VALID_STRATEGIES: readonly Strategy[] = [
+  'cache-first',
+  'network-first',
+  'stale-while-revalidate',
+  'network-only',
+  'cache-only',
+];
+
+export interface InterceptFeatureNode extends ASTNode {
+  type: 'interceptFeature';
+  config: InterceptConfig;
+}
+
+/** Minimal shape of the tokens the parser hands us. */
+interface ParseToken {
+  kind: string;
+  value: string;
+  start?: number;
+  end?: number;
+  line?: number;
+  column?: number;
+}
+
+/**
+ * Narrow slice of `ParserContext` this parser actually uses. Keeps the plugin
+ * decoupled from `@hyperfixi/core`'s internal type surface; matches the
+ * reactivity/components pattern.
+ */
+interface ParserCtx {
+  peek(): ParseToken;
+  advance(): ParseToken;
+  previous(): ParseToken;
+  match(...types: string[]): boolean;
+  matchOperator(operator: string): boolean;
+  check(value: string): boolean;
+  isAtEnd(): boolean;
+  getPosition(): { start: number; end: number; line?: number; column?: number };
+}
+
+/** Strip surrounding quotes from a STRING token's raw value. */
+function unquote(raw: string): string {
+  if (raw.length >= 2) {
+    const first = raw[0];
+    const last = raw[raw.length - 1];
+    if ((first === '"' || first === "'" || first === '`') && first === last) {
+      return raw.slice(1, -1);
+    }
+  }
+  return raw;
+}
+
+/** Consume and return a quoted-string token's content. Throws on non-string. */
+function consumeString(ctx: ParserCtx, role: string): string {
+  const tok = ctx.peek();
+  if (tok.kind !== 'string') {
+    throw new Error(
+      `intercept: expected a quoted string (${role}), got ${tok.kind} '${tok.value}'`
+    );
+  }
+  ctx.advance();
+  return unquote(tok.value);
+}
+
+/** Consume a comma (operator token). */
+function matchComma(ctx: ParserCtx): boolean {
+  return ctx.matchOperator(',');
+}
+
+/**
+ * Parse the `intercept` feature body after the `intercept` keyword has already
+ * been consumed by the parser dispatcher.
+ */
+export function parseInterceptFeature(ctxAny: unknown, tokenAny: unknown): ASTNode {
+  const ctx = ctxAny as ParserCtx;
+  const startToken = tokenAny as ParseToken;
+
+  // Scope — required first argument.
+  const scope = consumeString(ctx, 'scope');
+
+  const config: InterceptConfig = {
+    scope,
+    precache: null,
+    routes: [],
+    offlineFallback: null,
+  };
+
+  while (!ctx.isAtEnd() && !ctx.check('end')) {
+    if (ctx.match('precache')) {
+      parsePrecacheClause(ctx, config);
+    } else if (ctx.match('on')) {
+      parseRouteClause(ctx, config);
+    } else if (ctx.match('offline')) {
+      parseOfflineClause(ctx, config);
+    } else {
+      const tok = ctx.peek();
+      throw new Error(
+        `intercept: expected 'precache', 'on', 'offline', or 'end', got '${tok.value}'`
+      );
+    }
+  }
+
+  // Consume the terminating `end`.
+  if (!ctx.match('end')) {
+    throw new Error("intercept: missing 'end' terminator");
+  }
+
+  return {
+    type: 'interceptFeature',
+    config,
+    start: startToken?.start ?? 0,
+    end: ctx.getPosition().end,
+    line: startToken?.line,
+    column: startToken?.column,
+  } as InterceptFeatureNode;
+}
+
+function parsePrecacheClause(ctx: ParserCtx, config: InterceptConfig): void {
+  const urls: string[] = [];
+  urls.push(consumeString(ctx, 'precache URL'));
+  while (matchComma(ctx)) urls.push(consumeString(ctx, 'precache URL'));
+
+  let version: string | null = null;
+  if (ctx.match('as')) version = consumeString(ctx, 'precache version');
+
+  config.precache = { urls, version };
+}
+
+function parseRouteClause(ctx: ParserCtx, config: InterceptConfig): void {
+  const patterns: string[] = [];
+  patterns.push(consumeString(ctx, 'route pattern'));
+  while (matchComma(ctx)) patterns.push(consumeString(ctx, 'route pattern'));
+
+  if (!ctx.match('use')) {
+    throw new Error("intercept: expected 'use' after route patterns");
+  }
+
+  const strategy = consumeStrategy(ctx);
+  config.routes.push({ patterns, strategy });
+}
+
+function parseOfflineClause(ctx: ParserCtx, config: InterceptConfig): void {
+  if (!ctx.match('fallback')) {
+    throw new Error("intercept: expected 'fallback' after 'offline'");
+  }
+  config.offlineFallback = consumeString(ctx, 'offline fallback URL');
+}
+
+function consumeStrategy(ctx: ParserCtx): Strategy {
+  // Strategies are hyphenated identifiers. The tokenizer emits each segment
+  // as a separate identifier (with '-' as an operator between), so we
+  // reconstruct the name by joining identifier-operator-identifier sequences.
+  const first = ctx.peek();
+  if (first.kind !== 'identifier') {
+    throw new Error(`intercept: expected strategy name, got ${first.kind} '${first.value}'`);
+  }
+  let name = first.value;
+  ctx.advance();
+  while (ctx.matchOperator('-')) {
+    const next = ctx.peek();
+    if (next.kind !== 'identifier') {
+      throw new Error(`intercept: malformed strategy name near '${next.value}'`);
+    }
+    name += '-' + next.value;
+    ctx.advance();
+  }
+  if (!(VALID_STRATEGIES as readonly string[]).includes(name)) {
+    throw new Error(
+      `intercept: unknown strategy '${name}'. Expected one of: ${VALID_STRATEGIES.join(', ')}`
+    );
+  }
+  return name as Strategy;
+}
+
+/**
+ * Build an evaluator for `interceptFeature` nodes. The evaluator is a thin
+ * wrapper around `registerSW` — it extracts the config from the AST node and
+ * fires the SW registration. Returns `undefined` (no value).
+ *
+ * `swUrl` is captured at plugin-install time so each plugin instance can
+ * target a different location if needed.
+ */
+export function makeEvaluateInterceptFeature(
+  swUrl: string
+): (node: ASTNode, ctx: unknown) => unknown | Promise<unknown> {
+  return async function evaluateInterceptFeature(node, _ctx) {
+    const n = node as InterceptFeatureNode;
+    void (_ctx as ExecutionContext); // reserved for future use (logging, etc.)
+    await registerSW(n.config, swUrl);
+    return undefined;
+  };
+}

--- a/packages/intercept/src/pattern-match.test.ts
+++ b/packages/intercept/src/pattern-match.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { matchesPattern, findRoute, cacheKeyFor } from './pattern-match';
+import type { Strategy } from './types';
+
+describe('matchesPattern', () => {
+  it('matches everything with *', () => {
+    expect(matchesPattern('/', '*')).toBe(true);
+    expect(matchesPattern('/anything/nested', '*')).toBe(true);
+    expect(matchesPattern('', '*')).toBe(true);
+  });
+
+  it('matches extension suffix with *.ext', () => {
+    expect(matchesPattern('/style.css', '*.css')).toBe(true);
+    expect(matchesPattern('/assets/style.css', '*.css')).toBe(true);
+    expect(matchesPattern('/style.js', '*.css')).toBe(false);
+    expect(matchesPattern('/cssfile', '*.css')).toBe(false);
+  });
+
+  it('matches directory prefix with /prefix/*', () => {
+    expect(matchesPattern('/api/users', '/api/*')).toBe(true);
+    expect(matchesPattern('/api/users/42', '/api/*')).toBe(true);
+    expect(matchesPattern('/api/', '/api/*')).toBe(true);
+    expect(matchesPattern('/other', '/api/*')).toBe(false);
+    expect(matchesPattern('/apib/x', '/api/*')).toBe(false);
+  });
+
+  it('matches exact path', () => {
+    expect(matchesPattern('/', '/')).toBe(true);
+    expect(matchesPattern('/index.html', '/index.html')).toBe(true);
+    expect(matchesPattern('/index.html', '/index')).toBe(false);
+  });
+});
+
+describe('findRoute', () => {
+  const routes: Array<{ patterns: string[]; strategy: Strategy }> = [
+    { patterns: ['/api/*'], strategy: 'network-first' },
+    { patterns: ['*.css', '*.js'], strategy: 'cache-first' },
+    { patterns: ['/'], strategy: 'stale-while-revalidate' },
+  ];
+
+  it('returns the first matching route', () => {
+    expect(findRoute('/api/users', routes)?.strategy).toBe('network-first');
+    expect(findRoute('/style.css', routes)?.strategy).toBe('cache-first');
+    expect(findRoute('/', routes)?.strategy).toBe('stale-while-revalidate');
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(findRoute('/unknown.html', routes)).toBe(null);
+  });
+
+  it('checks each pattern within a route', () => {
+    expect(findRoute('/app.js', routes)?.strategy).toBe('cache-first');
+  });
+
+  it('respects route order — earlier routes win on overlap', () => {
+    const overlapping: Array<{ patterns: string[]; strategy: Strategy }> = [
+      { patterns: ['*'], strategy: 'network-only' },
+      { patterns: ['/api/*'], strategy: 'network-first' },
+    ];
+    expect(findRoute('/api/x', overlapping)?.strategy).toBe('network-only');
+  });
+});
+
+describe('cacheKeyFor', () => {
+  it('returns the configured version when present', () => {
+    expect(cacheKeyFor({ precache: { urls: [], version: 'v2' } })).toBe('v2');
+  });
+  it('defaults to hs-v1 when no precache', () => {
+    expect(cacheKeyFor({ precache: null })).toBe('hs-v1');
+  });
+  it('defaults to hs-v1 when precache has no version', () => {
+    expect(cacheKeyFor({ precache: { urls: ['/'], version: null } })).toBe('hs-v1');
+  });
+});

--- a/packages/intercept/src/pattern-match.ts
+++ b/packages/intercept/src/pattern-match.ts
@@ -1,0 +1,41 @@
+/**
+ * URL pattern matcher — shared between the SW runtime and unit tests.
+ *
+ * Mirrors upstream `intercept-sw.js`'s matcher rules:
+ *   `*`            → match anything
+ *   `*.ext`        → match any path ending with `.ext`
+ *   `/prefix/*`    → match any path starting with `/prefix/`
+ *   `/exact`       → match only the exact path
+ *
+ * Intentionally tiny: the service-worker context is sensitive to startup cost,
+ * and users rarely need full glob/regex matching at this layer. If you need
+ * something more expressive, filter inside the `intercept` body.
+ */
+
+import type { InterceptConfig, Strategy } from './types';
+
+export interface Route {
+  patterns: string[];
+  strategy: Strategy;
+}
+
+export function matchesPattern(path: string, pattern: string): boolean {
+  if (pattern === '*') return true;
+  if (pattern.startsWith('*.')) return path.endsWith(pattern.slice(1));
+  if (pattern.endsWith('/*')) return path.startsWith(pattern.slice(0, -1));
+  return pattern === path;
+}
+
+export function findRoute(path: string, routes: Route[]): Route | null {
+  for (const r of routes) {
+    for (const p of r.patterns) {
+      if (matchesPattern(path, p)) return r;
+    }
+  }
+  return null;
+}
+
+/** Resolve the cache key a runtime should use for a given config. */
+export function cacheKeyFor(config: Pick<InterceptConfig, 'precache'>): string {
+  return config.precache?.version || 'hs-v1';
+}

--- a/packages/intercept/src/register-sw.ts
+++ b/packages/intercept/src/register-sw.ts
@@ -1,0 +1,74 @@
+/**
+ * navigator.serviceWorker registration + postMessage bridge.
+ *
+ * Split out from `parse.ts` so tests can exercise the registration logic with
+ * a mock `navigator.serviceWorker` without reaching into the parser surface.
+ *
+ * Upstream parity (`_hyperscript/src/ext/intercept.js:install`):
+ *   - Only one intercept declaration per app — subsequent calls warn & return.
+ *   - Register the SW at the configured scope.
+ *   - Post `{ type: 'hs:intercept:config', config }` once the SW is activated.
+ *   - Surface actionable hint on SecurityError (scope too wide for SW directory).
+ */
+
+import type { InterceptConfig } from './types';
+
+/**
+ * Module-level guard matching upstream's `InterceptFeature.installed` flag.
+ * Exposed via `resetInstalledForTest` so integration tests can run multiple
+ * scenarios in the same process.
+ */
+let INSTALLED = false;
+
+/** Test-only: reset the install guard. */
+export function resetInstalledForTest(): void {
+  INSTALLED = false;
+}
+
+/**
+ * Attempt to register the service worker and post the config. Fire-and-forget:
+ * any failure is logged but does not throw (upstream behavior).
+ */
+export async function registerSW(config: InterceptConfig, swUrl: string): Promise<void> {
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+    console.warn('[hyperfixi/intercept] service worker not supported in this environment');
+    return;
+  }
+  if (INSTALLED) {
+    console.warn(
+      '[hyperfixi/intercept] only one intercept declaration is allowed per app — ignoring subsequent declarations'
+    );
+    return;
+  }
+  INSTALLED = true;
+
+  try {
+    const registration = await navigator.serviceWorker.register(swUrl, { scope: config.scope });
+    const sw: ServiceWorker | null =
+      registration.installing || registration.waiting || registration.active;
+    if (!sw) return;
+
+    const send = (): void => {
+      sw.postMessage({ type: 'hs:intercept:config', config });
+    };
+
+    if (sw.state === 'activated') {
+      send();
+    } else {
+      sw.addEventListener('statechange', () => {
+        if (sw.state === 'activated') send();
+      });
+    }
+  } catch (err) {
+    const name = (err as { name?: string } | null)?.name;
+    if (name === 'SecurityError') {
+      console.error(
+        `[hyperfixi/intercept] scope '${config.scope}' is wider than the service worker's directory. Either:\n` +
+          `  1. Serve ${swUrl} from the site root, or\n` +
+          `  2. Add the response header: Service-Worker-Allowed: ${config.scope}`
+      );
+    } else {
+      console.error('[hyperfixi/intercept] registration failed:', err);
+    }
+  }
+}

--- a/packages/intercept/src/sw-entry.ts
+++ b/packages/intercept/src/sw-entry.ts
@@ -1,0 +1,111 @@
+/**
+ * Service worker runtime for @hyperfixi/intercept.
+ *
+ * Bundled separately (tsup IIFE target) into `dist/intercept-sw.js`. Users
+ * deploy this file at the path they configured when installing the plugin
+ * (default `/hyperfixi-sw.js`).
+ *
+ * Protocol: receives a message `{ type: 'hs:intercept:config', config }` from
+ * the page and applies the config to install/activate/fetch handlers.
+ *
+ * Mirrors `_hyperscript/src/ext/intercept-sw.js`.
+ */
+
+/// <reference lib="WebWorker" />
+
+import type { InterceptConfig } from './types';
+import { findRoute, cacheKeyFor } from './pattern-match';
+
+// Narrow the global `self` to the worker scope so TS picks up the right APIs.
+declare const self: ServiceWorkerGlobalScope;
+
+let config: InterceptConfig | null = null;
+
+self.addEventListener('message', (e: ExtendableMessageEvent) => {
+  const data = e.data as { type?: string; config?: InterceptConfig } | undefined;
+  if (data && data.type === 'hs:intercept:config' && data.config) {
+    config = data.config;
+  }
+});
+
+self.addEventListener('install', (e: ExtendableEvent) => {
+  if (!config || !config.precache || !config.precache.urls.length) return;
+  const key = cacheKeyFor(config);
+  e.waitUntil(caches.open(key).then(cache => cache.addAll(config!.precache!.urls)));
+});
+
+self.addEventListener('activate', (e: ExtendableEvent) => {
+  if (!config || !config.precache) return;
+  const currentVersion = cacheKeyFor(config);
+  e.waitUntil(
+    caches
+      .keys()
+      .then(names =>
+        Promise.all(names.filter(n => n !== currentVersion).map(n => caches.delete(n)))
+      )
+  );
+});
+
+self.addEventListener('fetch', (e: FetchEvent) => {
+  if (!config || e.request.method !== 'GET') return;
+
+  const path = new URL(e.request.url).pathname;
+  const route = findRoute(path, config.routes);
+  if (!route) return;
+
+  const cacheName = cacheKeyFor(config);
+  const offlineFallback = config.offlineFallback;
+
+  const fallback = (): Promise<Response> => {
+    if (offlineFallback) {
+      return caches.match(offlineFallback).then(r => r || new Response('Offline', { status: 503 }));
+    }
+    return Promise.resolve(new Response('Offline', { status: 503 }));
+  };
+
+  const fetchOk = (): Promise<Response> =>
+    fetch(e.request).then(resp => {
+      if (!resp.ok) throw new Error('non-ok response: ' + resp.status);
+      return resp;
+    });
+
+  if (route.strategy === 'cache-first') {
+    e.respondWith(
+      caches
+        .match(e.request)
+        .then(cached => {
+          if (cached) return cached;
+          return fetchOk().then(resp => {
+            // Put runs async — caller doesn't wait.
+            caches.open(cacheName).then(c => c.put(e.request, resp.clone()));
+            return resp;
+          });
+        })
+        .catch(fallback)
+    );
+  } else if (route.strategy === 'network-first') {
+    e.respondWith(
+      fetchOk()
+        .then(resp => {
+          caches.open(cacheName).then(c => c.put(e.request, resp.clone()));
+          return resp;
+        })
+        .catch(() => caches.match(e.request).then(c => c || fallback()))
+    );
+  } else if (route.strategy === 'stale-while-revalidate') {
+    e.respondWith(
+      caches.match(e.request).then(cached => {
+        const fetched = fetchOk()
+          .then(resp => {
+            caches.open(cacheName).then(c => c.put(e.request, resp.clone()));
+            return resp;
+          })
+          .catch(() => cached || fallback());
+        return cached || fetched;
+      })
+    );
+  } else if (route.strategy === 'cache-only') {
+    e.respondWith(caches.match(e.request).then(c => c || fallback()));
+  }
+  // network-only: don't intercept — let the browser handle the request.
+});

--- a/packages/intercept/src/types.ts
+++ b/packages/intercept/src/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Lightweight local type stubs — mirror the speech/reactivity/components
+ * pattern of avoiding tight coupling to `@hyperfixi/core` internals. Only the
+ * plugin contract itself (`HyperfixiPlugin`, `HyperfixiPluginContext`) is
+ * imported from core; everything the parser and evaluator touch is described
+ * by these stubs.
+ */
+
+export interface ASTNode {
+  type: string;
+  start?: number;
+  end?: number;
+  line?: number;
+  column?: number;
+  [k: string]: unknown;
+}
+
+export interface ExecutionContext {
+  me?: Element | null;
+  result?: unknown;
+  it?: unknown;
+  globals?: Map<string, unknown>;
+  locals?: Map<string, unknown>;
+  [k: string]: unknown;
+}
+
+/** The five cache strategies upstream ships. */
+export type Strategy =
+  | 'cache-first'
+  | 'network-first'
+  | 'stale-while-revalidate'
+  | 'network-only'
+  | 'cache-only';
+
+/** Runtime config posted to the service worker as `hs:intercept:config`. */
+export interface InterceptConfig {
+  scope: string;
+  precache: { urls: string[]; version: string | null } | null;
+  routes: Array<{ patterns: string[]; strategy: Strategy }>;
+  offlineFallback: string | null;
+}

--- a/packages/intercept/tsconfig.json
+++ b/packages/intercept/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "WebWorker"],
+    "outDir": "dist",
+    "declaration": true,
+    "declarationDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/__test__/**"]
+}

--- a/packages/intercept/tsup.config.ts
+++ b/packages/intercept/tsup.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'tsup';
+
+// Two-entry build: the plugin itself (index) and the service-worker runtime
+// (sw-entry). The SW is emitted as `dist/intercept-sw.js` in IIFE format so it
+// can be served as a classic script from the app root — see README for setup.
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    splitting: false,
+    sourcemap: true,
+    clean: true,
+    external: ['@hyperfixi/core'],
+  },
+  {
+    // The SW runtime is a classic script that attaches listeners to `self`
+    // directly — no global export is needed, so we use the `esbuild-only`
+    // format name trick (no format suffix) via outExtension. An IIFE wrapper
+    // keeps locals scoped without leaking.
+    entry: { 'intercept-sw': 'src/sw-entry.ts' },
+    format: ['iife'],
+    splitting: false,
+    sourcemap: false,
+    clean: false,
+    platform: 'browser',
+    outExtension: () => ({ js: '.js' }),
+  },
+]);

--- a/packages/intercept/vitest.config.ts
+++ b/packages/intercept/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    // happy-dom gives us a browser-like window/navigator; we inject a mock
+    // `navigator.serviceWorker` in integration tests since happy-dom doesn't
+    // ship one.
+    environment: 'happy-dom',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- New `@hyperfixi/intercept` package — service-worker request interception with DSL:
  ```
  intercept "/"
    precache "/", "/index.html" as "v2"
    on "/api/*" use network-first
    on "*.css", "*.js" use cache-first
    offline fallback "/offline.html"
  end
  ```
- 5 cache strategies: `network-first`, `cache-first`, `stale-while-revalidate`, `network-only`, `cache-only`
- Companion SW script emitted by second tsup entry with `format: ['iife']` + `outExtension: () => ({ js: '.js' })` so users can deploy `/hyperfixi-sw.js` directly
- **v1 deviation from upstream:** quoted strings required for URLs/patterns (upstream's naked-path lexer trick doesn't port to hyperfixi's tokenizer cleanly)
- Stacks on #165 (Phase 7) — intercept touches no components code; phase7 chosen over phase8 for stacking simplicity

## Test plan
- [x] Parser tests with isolated `ParserExtensionRegistry` (no runtime needed)
- [x] Integration tests with mocked `navigator.serviceWorker` in happy-dom
- [x] 32 tests, `npm run test:run --prefix packages/intercept` PASS
- [ ] Reviewer verify: hyphenated strategy identifiers (`cache-first`) reassemble via the operator loop, not the tokenizer

🤖 Generated with [Claude Code](https://claude.com/claude-code)