### PR TITLE
fix(core): wire `is not` binary operator to runtime dispatch

### DIFF
--- a/packages/core/src/parser/runtime.test.ts
+++ b/packages/core/src/parser/runtime.test.ts
@@ -88,6 +88,33 @@ describe('Hyperscript Runtime Evaluator', () => {
       const result = await evaluateAST(ast.node!, context);
       expect(result).toBe(false);
     });
+
+    it('should evaluate `is` as equals', async () => {
+      const context = createMockHyperscriptContext();
+      const ast = parse('5 is 5');
+
+      expect(ast.success).toBe(true);
+      const result = await evaluateAST(ast.node!, context);
+      expect(result).toBe(true);
+    });
+
+    it('should evaluate `is not` as negated equals', async () => {
+      const context = createMockHyperscriptContext();
+      const ast = parse('5 is not 3');
+
+      expect(ast.success).toBe(true);
+      const result = await evaluateAST(ast.node!, context);
+      expect(result).toBe(true);
+    });
+
+    it('should evaluate `is not` returning false when values match', async () => {
+      const context = createMockHyperscriptContext();
+      const ast = parse('5 is not 5');
+
+      expect(ast.success).toBe(true);
+      const result = await evaluateAST(ast.node!, context);
+      expect(result).toBe(false);
+    });
   });
 
   describe('Member Expression Evaluation', () => {

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -271,6 +271,7 @@ async function evaluateBinaryExpression(node: any, context: ExecutionContext): P
     case 'is':
       return logicalExpressions.equals.evaluate(context, left, right);
     case '!=':
+    case 'is not':
       return logicalExpressions.notEquals.evaluate(context, left, right);
     case '===':
       return logicalExpressions.strictEquals.evaluate(context, left, right);


### PR DESCRIPTION
## Summary
- `is not` tokenizes (`COMPARISON_OPERATORS` in `parser-constants.ts`) and parses into a `binaryExpression` node with `operator: 'is not'`, but `evaluateBinaryExpression` in [packages/core/src/parser/runtime.ts](packages/core/src/parser/runtime.ts) had no case for it — any `X is not Y` threw `Unknown binary operator: is not`
- One-line fix parallels the existing `case '==': case 'is':` pattern — routes `is not` through `notEquals.evaluate`
- Adds 3 runtime tests: `is` as equals, `is not` as negated equals (true case), `is not` returning false when values match

## Context
Pre-existing gap surfaced during v0.9.90 Phase 3 rollout — collection-op tests had to use `!=` instead of `is not`. Orthogonal to v0.9.90 so this ships as a standalone fix off main.

## Test plan
- [x] 3 new tests in `packages/core/src/parser/runtime.test.ts`
- [x] `npm run test:check --prefix packages/core` PASS (6200+ tests, no regressions)
- [x] Verified baseline: before the fix, 13/14 tests passed in runtime.test.ts; after the fix, 16/17 pass. The pre-existing `asExpression` failure is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)