### PR TITLE
chore(deps): bump happy-dom to ^20.9.0 (security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10009,9 +10009,9 @@
       }
     },
     "node_modules/happy-dom": {
-      "version": "20.8.9",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
-      "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": ">=20.0.0",
@@ -19728,25 +19728,10 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "happy-dom": "^15.0.0",
+        "happy-dom": "^20.9.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
         "vitest": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/components/node_modules/happy-dom": {
-      "version": "15.11.7",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-15.11.7.tgz",
-      "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^4.5.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-mimetype": "^3.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -20126,25 +20111,10 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "happy-dom": "^15.0.0",
+        "happy-dom": "^20.9.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
         "vitest": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/intercept/node_modules/happy-dom": {
-      "version": "15.11.7",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-15.11.7.tgz",
-      "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^4.5.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-mimetype": "^3.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -20992,25 +20962,10 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "happy-dom": "^15.0.0",
+        "happy-dom": "^20.9.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
         "vitest": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/reactivity/node_modules/happy-dom": {
-      "version": "15.11.7",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-15.11.7.tgz",
-      "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^4.5.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-mimetype": "^3.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -21105,25 +21060,10 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "happy-dom": "^15.0.0",
+        "happy-dom": "^20.9.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
         "vitest": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/speech/node_modules/happy-dom": {
-      "version": "15.11.7",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-15.11.7.tgz",
-      "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^4.5.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-mimetype": "^3.0.0"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "happy-dom": "^15.0.0",
+    "happy-dom": "^20.9.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.0.0"

--- a/packages/intercept/package.json
+++ b/packages/intercept/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "happy-dom": "^15.0.0",
+    "happy-dom": "^20.9.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.0.0"

--- a/packages/reactivity/package.json
+++ b/packages/reactivity/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "happy-dom": "^15.0.0",
+    "happy-dom": "^20.9.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.0.0"

--- a/packages/speech/package.json
+++ b/packages/speech/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "happy-dom": "^15.0.0",
+    "happy-dom": "^20.9.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.0.0"


### PR DESCRIPTION
## Summary

- Bumps `happy-dom` from `^15.0.0` to `^20.9.0` in `@hyperfixi/{components,intercept,reactivity,speech}` and regenerates the root lockfile.
- Resolves **11 Dependabot alerts** (5 critical, 6 high). All four packages use happy-dom only as a dev dependency for vitest environment.
- Supersedes #174, which bumped the four `package.json` files but didn't reconcile the root `package-lock.json`, so `npm ci` kept failing on CI.

## CVEs resolved

| Severity | CVE | Advisory | Fixed in |
| --- | --- | --- | --- |
| Critical | CVE-2025-61927 | GHSA-37j7-fg3j-429f — RCE via VM context escape | 20.0.0 |
| High | CVE-2026-34226 | GHSA-w4gp-fjgq-3q4g — cross-origin cookie leak | 20.8.9 |
| High | CVE-2026-33943 | GHSA-6q6h-j7hj-3r64 — ESM export-name code injection | 20.8.8 |

After this merges, close #174 as superseded.

## Test plan

- [x] `npm install` — lockfile regenerates cleanly, all workspaces dedupe to `happy-dom@20.9.0`
- [x] `npm run test:check --prefix packages/components` → 22/22 passing
- [x] `npm run test:check --prefix packages/intercept` → 32/32 passing
- [x] `npm run test:check --prefix packages/reactivity` → 22/22 passing
- [x] `npm run test:check --prefix packages/speech` → 17/17 passing
- [ ] CI: `Build All Packages` + downstream jobs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)