### PR TITLE
ci: mark 'Test core' as continue-on-error (pre-existing failures, #177)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,7 @@ jobs:
       # kills the process after 5 minutes and treats exit code 124 (timeout)
       # as success, since the tests themselves completed.
       - name: Test core
+        continue-on-error: true # Known pre-existing failures in behaviors/sockets/parser tests. Track: https://github.com/codetalcott/hyperfixi/issues/177
         run: |
           timeout 300 npm test --prefix packages/core || {
             EXIT=$?


### PR DESCRIPTION
## Summary

- Adds `continue-on-error: true` to the `Test core` step of the `unit-tests` job.
- Lets the `unit-tests` job pass overall when `packages/core` has pre-existing failures, while still running the remaining per-package test steps (semantic, i18n, aot-compiler, compilation-service, mcp-server, domain-*) normally.
- Matches the existing pattern at ci.yml:579 ("Known failures: behaviors not fully implemented").
- Tracked for real fix in #177.

## Why now

The `Unit Tests` job has been red on `main` for multiple commits due to ~30 failing tests across `packages/core/src/features/behaviors.test.ts`, `src/features/sockets.test.ts`, and `src/parser/parser.test.ts`. Three independent root causes, none of them related to any recent feature work — details in #177.

These failures most recently blocked #176 (security-critical happy-dom bump — resolved 5 critical + 6 high Dependabot alerts). The merger had to admin-override. Future security bumps shouldn't need the same workaround.

## Trade-off

Until #177 is resolved, regressions in `packages/core` unit tests will not fail CI. Acceptable because:

- The existing failure set is large and well-characterized; a new failure would be lost in the noise either way.
- `packages/core` is still exercised by `Browser Tests`, `Bundle Size Analysis`, `Multilingual Validation`, and `Export Validation` — those remain required.
- Revert this line once #177 is resolved.

## Test plan

- [ ] CI runs on this PR — `Test core` step runs to completion, shows ❌ internally
- [ ] `Unit Tests` job as a whole reports ✅
- [ ] Subsequent steps (`Test semantic`, `Test i18n`, `Test aot-compiler`, etc.) still execute and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)