### PR TITLE
feat(domain-toolkit): introduce @lokascript/domain-toolkit (lint rules + framework LatinExtended promote)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,9 @@ jobs:
       - name: Verify reference data
         run: npm run verify:reference --prefix packages/core
 
+      - name: Lint domains (cross-file invariants)
+        run: npm run lint:domains
+
   # ============================================
   # Job 4: Unit Tests
   # ============================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Build semantic package
         run: npm run build --prefix packages/semantic
 
+      - name: Build domain-toolkit package
+        run: npm run build --prefix packages/domain-toolkit
+
       - name: Build behaviors package
         run: npm run build --prefix packages/behaviors
 
@@ -177,6 +180,7 @@ jobs:
             packages/domain-flow/dist/
             packages/domain-voice/dist/
             packages/domain-learn/dist/
+            packages/domain-toolkit/dist/
             packages/semantic/dist/
             packages/i18n/dist/
             packages/core/dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -2018,6 +2018,10 @@
       "resolved": "packages/domain-todo",
       "link": true
     },
+    "node_modules/@lokascript/domain-toolkit": {
+      "resolved": "packages/domain-toolkit",
+      "link": true
+    },
     "node_modules/@lokascript/domain-voice": {
       "resolved": "packages/domain-voice",
       "link": true
@@ -19963,6 +19967,7 @@
         "@lokascript/framework": "*"
       },
       "devDependencies": {
+        "@lokascript/domain-toolkit": "*",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19978,6 +19983,21 @@
       "license": "MIT",
       "dependencies": {
         "@lokascript/framework": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.0.0"
+      }
+    },
+    "packages/domain-toolkit": {
+      "name": "@lokascript/domain-toolkit",
+      "version": "0.1.0",
+      "dependencies": {
+        "@lokascript/framework": "*",
+        "@lokascript/intent": "*",
+        "@lokascript/semantic": "*"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19865,6 +19865,7 @@
         "@lokascript/framework": "*"
       },
       "devDependencies": {
+        "@lokascript/domain-toolkit": "*",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19882,6 +19883,7 @@
         "@lokascript/framework": "*"
       },
       "devDependencies": {
+        "@lokascript/domain-toolkit": "*",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19899,6 +19901,7 @@
         "@lokascript/framework": "*"
       },
       "devDependencies": {
+        "@lokascript/domain-toolkit": "*",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19916,6 +19919,7 @@
         "@lokascript/framework": "*"
       },
       "devDependencies": {
+        "@lokascript/domain-toolkit": "*",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19933,6 +19937,7 @@
         "@lokascript/framework": "*"
       },
       "devDependencies": {
+        "@lokascript/domain-toolkit": "*",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19950,6 +19955,7 @@
         "@lokascript/framework": "*"
       },
       "devDependencies": {
+        "@lokascript/domain-toolkit": "*",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19985,6 +19991,7 @@
         "@lokascript/framework": "*"
       },
       "devDependencies": {
+        "@lokascript/domain-toolkit": "*",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -20014,6 +20021,7 @@
         "@lokascript/framework": "*"
       },
       "devDependencies": {
+        "@lokascript/domain-toolkit": "*",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:coverage": "npm run test:coverage --workspaces",
     "lint": "npm run lint --workspaces",
     "lint:fix": "npm run lint:fix --workspaces",
+    "lint:domains": "for pkg in sql bdd behaviorspec flow jsx llm todo voice; do npm test --prefix packages/domain-$pkg -- --run lint || exit 1; done",
     "typecheck": "npm run typecheck --workspaces",
     "generate:language-assets": "npm run generate:language-assets --prefix packages/semantic",
     "clean": "npm run clean --workspaces && rm -rf node_modules",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:coverage": "npm run test:coverage --workspaces",
     "lint": "npm run lint --workspaces",
     "lint:fix": "npm run lint:fix --workspaces",
-    "lint:domains": "for pkg in sql bdd behaviorspec flow jsx llm todo voice; do npm test --prefix packages/domain-$pkg -- --run lint || exit 1; done",
+    "lint:domains": "for pkg in sql bdd behaviorspec flow jsx learn llm todo voice; do npm test --prefix packages/domain-$pkg -- --run lint || exit 1; done",
     "typecheck": "npm run typecheck --workspaces",
     "generate:language-assets": "npm run generate:language-assets --prefix packages/semantic",
     "clean": "npm run clean --workspaces && rm -rf node_modules",

--- a/packages/domain-bdd/package.json
+++ b/packages/domain-bdd/package.json
@@ -26,6 +26,7 @@
     "@lokascript/framework": "*"
   },
   "devDependencies": {
+    "@lokascript/domain-toolkit": "*",
     "@types/node": "^20.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",

--- a/packages/domain-bdd/src/__test__/lint.test.ts
+++ b/packages/domain-bdd/src/__test__/lint.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { lintDomain, formatResult } from '@lokascript/domain-toolkit';
+import type { DomainLintInput } from '@lokascript/domain-toolkit';
+
+import { allSchemas } from '../schemas';
+import {
+  englishProfile,
+  spanishProfile,
+  japaneseProfile,
+  arabicProfile,
+  koreanProfile,
+  chineseProfile,
+  turkishProfile,
+  frenchProfile,
+} from '../profiles';
+import {
+  EnglishBDDTokenizer,
+  SpanishBDDTokenizer,
+  JapaneseBDDTokenizer,
+  ArabicBDDTokenizer,
+  KoreanBDDTokenizer,
+  ChineseBDDTokenizer,
+  TurkishBDDTokenizer,
+  FrenchBDDTokenizer,
+} from '../tokenizers';
+
+function buildInput(): DomainLintInput {
+  return {
+    name: 'bdd',
+    schemas: allSchemas,
+    profiles: [
+      englishProfile,
+      spanishProfile,
+      japaneseProfile,
+      arabicProfile,
+      koreanProfile,
+      chineseProfile,
+      turkishProfile,
+      frenchProfile,
+    ],
+    tokenizers: {
+      en: new EnglishBDDTokenizer(),
+      es: new SpanishBDDTokenizer(),
+      ja: new JapaneseBDDTokenizer(),
+      ar: new ArabicBDDTokenizer(),
+      ko: new KoreanBDDTokenizer(),
+      zh: new ChineseBDDTokenizer(),
+      tr: new TurkishBDDTokenizer(),
+      fr: new FrenchBDDTokenizer(),
+    },
+  };
+}
+
+describe('domain-bdd: lint', () => {
+  it('passes all enabled rules with zero errors', () => {
+    const result = lintDomain(buildInput());
+    if (result.errorCount > 0 || result.warningCount > 0) {
+      // eslint-disable-next-line no-console
+      console.log(formatResult(result));
+    }
+    expect(result.errorCount).toBe(0);
+  });
+});

--- a/packages/domain-bdd/src/tokenizers/index.ts
+++ b/packages/domain-bdd/src/tokenizers/index.ts
@@ -6,41 +6,17 @@
  * plus a CSS selector extractor for DOM element references (#id, .class).
  */
 
-import { BaseTokenizer, getDefaultExtractors } from '@lokascript/framework';
+import {
+  BaseTokenizer,
+  getDefaultExtractors,
+  LatinExtendedIdentifierExtractor,
+} from '@lokascript/framework';
 import type {
   TokenKind,
   KeywordEntry,
   ValueExtractor,
   ExtractionResult,
 } from '@lokascript/framework';
-
-// =============================================================================
-// Latin Extended Identifier Extractor (Turkish, French, etc.)
-// =============================================================================
-
-/**
- * Extracts identifiers that mix ASCII and extended Latin characters
- * (e.g., Turkish ıİğĞüÜşŞçÇöÖ, French éèêëàâçô, etc.).
- *
- * The default IdentifierExtractor only handles [a-zA-Z0-9_], which causes
- * words like "varsayalım" to be split at the "ı" boundary. This extractor
- * uses Unicode \p{L} to handle all letter characters as a single word.
- */
-class LatinExtendedIdentifierExtractor implements ValueExtractor {
-  readonly name = 'latin-extended-identifier';
-
-  canExtract(input: string, position: number): boolean {
-    return /\p{L}/u.test(input[position]);
-  }
-
-  extract(input: string, position: number): ExtractionResult | null {
-    let end = position;
-    while (end < input.length && /[\p{L}\p{N}_-]/u.test(input[end])) {
-      end++;
-    }
-    return end > position ? { value: input.slice(position, end), length: end - position } : null;
-  }
-}
 
 /**
  * Get extractors for languages with extended Latin characters (Turkish, French).

--- a/packages/domain-behaviorspec/package.json
+++ b/packages/domain-behaviorspec/package.json
@@ -26,6 +26,7 @@
     "@lokascript/framework": "*"
   },
   "devDependencies": {
+    "@lokascript/domain-toolkit": "*",
     "@types/node": "^20.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",

--- a/packages/domain-behaviorspec/src/__test__/lint.test.ts
+++ b/packages/domain-behaviorspec/src/__test__/lint.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { lintDomain, formatResult } from '@lokascript/domain-toolkit';
+import type { DomainLintInput } from '@lokascript/domain-toolkit';
+
+import { allSchemas } from '../schemas';
+import {
+  englishProfile,
+  spanishProfile,
+  japaneseProfile,
+  arabicProfile,
+  koreanProfile,
+  chineseProfile,
+  turkishProfile,
+  frenchProfile,
+} from '../profiles';
+import {
+  EnglishBehaviorSpecTokenizer,
+  SpanishBehaviorSpecTokenizer,
+  JapaneseBehaviorSpecTokenizer,
+  ArabicBehaviorSpecTokenizer,
+  KoreanBehaviorSpecTokenizer,
+  ChineseBehaviorSpecTokenizer,
+  TurkishBehaviorSpecTokenizer,
+  FrenchBehaviorSpecTokenizer,
+} from '../tokenizers';
+
+function buildInput(): DomainLintInput {
+  return {
+    name: 'behaviorspec',
+    schemas: allSchemas,
+    profiles: [
+      englishProfile,
+      spanishProfile,
+      japaneseProfile,
+      arabicProfile,
+      koreanProfile,
+      chineseProfile,
+      turkishProfile,
+      frenchProfile,
+    ],
+    tokenizers: {
+      en: new EnglishBehaviorSpecTokenizer(),
+      es: new SpanishBehaviorSpecTokenizer(),
+      ja: new JapaneseBehaviorSpecTokenizer(),
+      ar: new ArabicBehaviorSpecTokenizer(),
+      ko: new KoreanBehaviorSpecTokenizer(),
+      zh: new ChineseBehaviorSpecTokenizer(),
+      tr: new TurkishBehaviorSpecTokenizer(),
+      fr: new FrenchBehaviorSpecTokenizer(),
+    },
+  };
+}
+
+describe('domain-behaviorspec: lint', () => {
+  it('passes all enabled rules with zero errors', () => {
+    const result = lintDomain(buildInput());
+    if (result.errorCount > 0 || result.warningCount > 0) {
+      // eslint-disable-next-line no-console
+      console.log(formatResult(result));
+    }
+    expect(result.errorCount).toBe(0);
+  });
+});

--- a/packages/domain-behaviorspec/src/tokenizers/index.ts
+++ b/packages/domain-behaviorspec/src/tokenizers/index.ts
@@ -8,7 +8,11 @@
  * 8 languages: EN, ES, JA, AR, KO, ZH, FR, TR
  */
 
-import { BaseTokenizer, getDefaultExtractors } from '@lokascript/framework';
+import {
+  BaseTokenizer,
+  getDefaultExtractors,
+  LatinExtendedIdentifierExtractor,
+} from '@lokascript/framework';
 import type {
   TokenKind,
   KeywordEntry,
@@ -121,6 +125,26 @@ function getBehaviorSpecExtractors(): ValueExtractor[] {
   ];
 }
 
+/**
+ * Variant for Latin-script languages with diacritics (es/fr/tr/etc.).
+ * Replaces the default ASCII identifier extractor with one that accepts the
+ * full Unicode letter range, so words like `característica` or `varsayalım`
+ * tokenize as a single identifier instead of splitting at the diacritic.
+ */
+function getLatinExtendedBehaviorSpecExtractors(): ValueExtractor[] {
+  const filtered = getDefaultExtractors().filter(
+    e => e.name !== 'identifier' && e.name !== 'unicode-identifier'
+  );
+  return [
+    new CSSSelectorExtractor(),
+    new URLExtractor(),
+    new DurationExtractor(),
+    new DimensionExtractor(),
+    new LatinExtendedIdentifierExtractor(),
+    ...filtered,
+  ];
+}
+
 /** Standard classifyToken logic shared by Latin-script tokenizers */
 function classifyLatinToken(token: string, keywords: Set<string>): TokenKind {
   if (keywords.has(token.toLowerCase())) return 'keyword';
@@ -210,7 +234,7 @@ export class SpanishBehaviorSpecTokenizer extends BaseTokenizer {
 
   constructor() {
     super();
-    this.registerExtractors(getBehaviorSpecExtractors());
+    this.registerExtractors(getLatinExtendedBehaviorSpecExtractors());
   }
 
   classifyToken(token: string): TokenKind {
@@ -479,7 +503,7 @@ export class FrenchBehaviorSpecTokenizer extends BaseTokenizer {
 
   constructor() {
     super();
-    this.registerExtractors(getBehaviorSpecExtractors());
+    this.registerExtractors(getLatinExtendedBehaviorSpecExtractors());
   }
 
   classifyToken(token: string): TokenKind {
@@ -512,7 +536,7 @@ export class TurkishBehaviorSpecTokenizer extends BaseTokenizer {
 
   constructor() {
     super();
-    this.registerExtractors(getBehaviorSpecExtractors());
+    this.registerExtractors(getLatinExtendedBehaviorSpecExtractors());
   }
 
   classifyToken(token: string): TokenKind {

--- a/packages/domain-flow/package.json
+++ b/packages/domain-flow/package.json
@@ -26,6 +26,7 @@
     "@lokascript/framework": "*"
   },
   "devDependencies": {
+    "@lokascript/domain-toolkit": "*",
     "@types/node": "^20.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",

--- a/packages/domain-flow/src/__test__/lint.test.ts
+++ b/packages/domain-flow/src/__test__/lint.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { lintDomain, formatResult } from '@lokascript/domain-toolkit';
+import type { DomainLintInput } from '@lokascript/domain-toolkit';
+
+import { allSchemas } from '../schemas';
+import {
+  englishProfile,
+  spanishProfile,
+  japaneseProfile,
+  arabicProfile,
+  koreanProfile,
+  chineseProfile,
+  turkishProfile,
+  frenchProfile,
+} from '../profiles';
+import {
+  EnglishFlowTokenizer,
+  SpanishFlowTokenizer,
+  JapaneseFlowTokenizer,
+  ArabicFlowTokenizer,
+  KoreanFlowTokenizer,
+  ChineseFlowTokenizer,
+  TurkishFlowTokenizer,
+  FrenchFlowTokenizer,
+} from '../tokenizers';
+
+function buildInput(): DomainLintInput {
+  return {
+    name: 'flow',
+    schemas: allSchemas,
+    profiles: [
+      englishProfile,
+      spanishProfile,
+      japaneseProfile,
+      arabicProfile,
+      koreanProfile,
+      chineseProfile,
+      turkishProfile,
+      frenchProfile,
+    ],
+    tokenizers: {
+      en: EnglishFlowTokenizer,
+      es: SpanishFlowTokenizer,
+      ja: JapaneseFlowTokenizer,
+      ar: ArabicFlowTokenizer,
+      ko: KoreanFlowTokenizer,
+      zh: ChineseFlowTokenizer,
+      tr: TurkishFlowTokenizer,
+      fr: FrenchFlowTokenizer,
+    },
+  };
+}
+
+describe('domain-flow: lint', () => {
+  it('passes all enabled rules with zero errors', () => {
+    const result = lintDomain(buildInput());
+    if (result.errorCount > 0 || result.warningCount > 0) {
+      // eslint-disable-next-line no-console
+      console.log(formatResult(result));
+    }
+    expect(result.errorCount).toBe(0);
+  });
+});

--- a/packages/domain-flow/src/tokenizers/index.ts
+++ b/packages/domain-flow/src/tokenizers/index.ts
@@ -11,7 +11,7 @@
  * - Latin extended identifiers (diacritics in Spanish)
  */
 
-import { createSimpleTokenizer } from '@lokascript/framework';
+import { createSimpleTokenizer, LatinExtendedIdentifierExtractor } from '@lokascript/framework';
 import type { LanguageTokenizer, ValueExtractor, ExtractionResult } from '@lokascript/framework';
 
 // =============================================================================
@@ -93,27 +93,6 @@ class DurationExtractor implements ValueExtractor {
       return { value: input.slice(position, end), length: end - position };
     }
 
-    return { value: input.slice(position, end), length: end - position };
-  }
-}
-
-// =============================================================================
-// Latin Extended Identifier Extractor (diacritics for Spanish)
-// =============================================================================
-
-class LatinExtendedIdentifierExtractor implements ValueExtractor {
-  readonly name = 'latin-extended-identifier';
-
-  canExtract(input: string, position: number): boolean {
-    return /\p{L}/u.test(input[position]);
-  }
-
-  extract(input: string, position: number): ExtractionResult | null {
-    let end = position;
-    while (end < input.length && /[\p{L}\p{N}_-]/u.test(input[end])) {
-      end++;
-    }
-    if (end === position) return null;
     return { value: input.slice(position, end), length: end - position };
   }
 }

--- a/packages/domain-jsx/package.json
+++ b/packages/domain-jsx/package.json
@@ -26,6 +26,7 @@
     "@lokascript/framework": "*"
   },
   "devDependencies": {
+    "@lokascript/domain-toolkit": "*",
     "@types/node": "^20.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",

--- a/packages/domain-jsx/src/__test__/lint.test.ts
+++ b/packages/domain-jsx/src/__test__/lint.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { lintDomain, formatResult } from '@lokascript/domain-toolkit';
+import type { DomainLintInput } from '@lokascript/domain-toolkit';
+
+import { allSchemas } from '../schemas';
+import {
+  englishProfile,
+  spanishProfile,
+  japaneseProfile,
+  arabicProfile,
+  koreanProfile,
+  chineseProfile,
+  turkishProfile,
+  frenchProfile,
+} from '../profiles';
+import {
+  EnglishJSXTokenizer,
+  SpanishJSXTokenizer,
+  JapaneseJSXTokenizer,
+  ArabicJSXTokenizer,
+  KoreanJSXTokenizer,
+  ChineseJSXTokenizer,
+  TurkishJSXTokenizer,
+  FrenchJSXTokenizer,
+} from '../tokenizers';
+
+function buildInput(): DomainLintInput {
+  return {
+    name: 'jsx',
+    schemas: allSchemas,
+    profiles: [
+      englishProfile,
+      spanishProfile,
+      japaneseProfile,
+      arabicProfile,
+      koreanProfile,
+      chineseProfile,
+      turkishProfile,
+      frenchProfile,
+    ],
+    tokenizers: {
+      en: EnglishJSXTokenizer,
+      es: SpanishJSXTokenizer,
+      ja: JapaneseJSXTokenizer,
+      ar: ArabicJSXTokenizer,
+      ko: KoreanJSXTokenizer,
+      zh: ChineseJSXTokenizer,
+      tr: TurkishJSXTokenizer,
+      fr: FrenchJSXTokenizer,
+    },
+  };
+}
+
+describe('domain-jsx: lint', () => {
+  it('passes all enabled rules with zero errors', () => {
+    const result = lintDomain(buildInput());
+    if (result.errorCount > 0 || result.warningCount > 0) {
+      // eslint-disable-next-line no-console
+      console.log(formatResult(result));
+    }
+    expect(result.errorCount).toBe(0);
+  });
+});

--- a/packages/domain-jsx/src/tokenizers/index.ts
+++ b/packages/domain-jsx/src/tokenizers/index.ts
@@ -5,34 +5,14 @@
  * createSimpleTokenizer() factory to eliminate boilerplate.
  */
 
-import { createSimpleTokenizer } from '@lokascript/framework';
-import type { LanguageTokenizer, ValueExtractor, ExtractionResult } from '@lokascript/framework';
+import { createSimpleTokenizer, LatinExtendedIdentifierExtractor } from '@lokascript/framework';
+import type { LanguageTokenizer } from '@lokascript/framework';
 
 // =============================================================================
 // Shared keyword lists
 // =============================================================================
 
 const JSX_COMMANDS = ['element', 'component', 'render', 'state', 'effect', 'fragment'];
-
-// =============================================================================
-// Latin Extended Identifier Extractor
-// Handles Turkish (ö, ş, ç, ğ, ü, ı) and French (é, è, ê, ë, à, â, ç, ô)
-// =============================================================================
-
-class LatinExtendedIdentifierExtractor implements ValueExtractor {
-  readonly name = 'latin-extended-identifier';
-  canExtract(input: string, position: number): boolean {
-    return /\p{L}/u.test(input[position]);
-  }
-  extract(input: string, position: number): ExtractionResult | null {
-    let end = position;
-    while (end < input.length && /[\p{L}\p{N}_-]/u.test(input[end])) {
-      end++;
-    }
-    if (end === position) return null;
-    return { value: input.slice(position, end), length: end - position };
-  }
-}
 
 // =============================================================================
 // English JSX Tokenizer

--- a/packages/domain-jsx/src/tokenizers/index.ts
+++ b/packages/domain-jsx/src/tokenizers/index.ts
@@ -49,6 +49,8 @@ export const EnglishJSXTokenizer = createSimpleTokenizer({
 
 export const SpanishJSXTokenizer = createSimpleTokenizer({
   language: 'es',
+  // Keep ñ, á, é, í, ó, ú identifiers intact (e.g. component/prop names).
+  customExtractors: [new LatinExtendedIdentifierExtractor()],
   keywords: [
     'elemento',
     'componente',

--- a/packages/domain-learn/package.json
+++ b/packages/domain-learn/package.json
@@ -26,6 +26,7 @@
     "@lokascript/framework": "*"
   },
   "devDependencies": {
+    "@lokascript/domain-toolkit": "*",
     "@types/node": "^20.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",

--- a/packages/domain-learn/src/__test__/lint.test.ts
+++ b/packages/domain-learn/src/__test__/lint.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { lintDomain, formatResult } from '@lokascript/domain-toolkit';
+import type { DomainLintInput } from '@lokascript/domain-toolkit';
+
+import { allSchemas } from '../schemas';
+import {
+  enProfile,
+  jaProfile,
+  esProfile,
+  arProfile,
+  zhProfile,
+  koProfile,
+  frProfile,
+  trProfile,
+  deProfile,
+  ptProfile,
+} from '../profiles';
+import {
+  EnglishLearnTokenizer,
+  JapaneseLearnTokenizer,
+  SpanishLearnTokenizer,
+  ArabicLearnTokenizer,
+  ChineseLearnTokenizer,
+  KoreanLearnTokenizer,
+  FrenchLearnTokenizer,
+  TurkishLearnTokenizer,
+  GermanLearnTokenizer,
+  PortugueseLearnTokenizer,
+} from '../tokenizers';
+
+// domain-learn's profile shape wraps `patternProfile` inside a larger
+// LearnLanguageProfile config. Extract the inner PatternGenLanguageProfile
+// for the linter. The 10 languages (+ German, Portuguese vs. other
+// domains' 8) are all covered.
+function buildInput(): DomainLintInput {
+  return {
+    name: 'learn',
+    schemas: allSchemas,
+    profiles: [
+      enProfile.patternProfile,
+      jaProfile.patternProfile,
+      esProfile.patternProfile,
+      arProfile.patternProfile,
+      zhProfile.patternProfile,
+      koProfile.patternProfile,
+      frProfile.patternProfile,
+      trProfile.patternProfile,
+      deProfile.patternProfile,
+      ptProfile.patternProfile,
+    ],
+    tokenizers: {
+      en: EnglishLearnTokenizer,
+      ja: JapaneseLearnTokenizer,
+      es: SpanishLearnTokenizer,
+      ar: ArabicLearnTokenizer,
+      zh: ChineseLearnTokenizer,
+      ko: KoreanLearnTokenizer,
+      fr: FrenchLearnTokenizer,
+      tr: TurkishLearnTokenizer,
+      de: GermanLearnTokenizer,
+      pt: PortugueseLearnTokenizer,
+    },
+    waivers: [
+      // Turkish dative suffix `-e` on `send.destination` is an agglutinative
+      // suffix that, in idiomatic Turkish, attaches directly to the preceding
+      // noun (e.g., `kullanıcıya` not `kullanıcı -e`). The standalone form
+      // tokenizes as `['-', 'e']`, which R7 correctly flags. Fixing the
+      // schema requires Turkish expertise to choose the right alternative
+      // (plain postposition? inflected forms?); defer to a Turkish speaker.
+      {
+        rule: 'marker-tokenization',
+        reason: 'Turkish dative suffix -e; needs native-speaker refinement',
+        matches: { lang: 'tr', word: '-e' },
+      },
+    ],
+  };
+}
+
+describe('domain-learn: lint', () => {
+  it('passes all enabled rules with zero errors', () => {
+    const result = lintDomain(buildInput());
+    if (result.errorCount > 0 || result.warningCount > 0) {
+      // eslint-disable-next-line no-console
+      console.log(formatResult(result));
+    }
+    expect(result.errorCount).toBe(0);
+  });
+});

--- a/packages/domain-learn/src/tokenizers/index.ts
+++ b/packages/domain-learn/src/tokenizers/index.ts
@@ -11,28 +11,8 @@
  * - Non-Latin script handling (Japanese, Arabic, Korean, Chinese)
  */
 
-import { createSimpleTokenizer } from '@lokascript/framework';
-import type { LanguageTokenizer, ValueExtractor, ExtractionResult } from '@lokascript/framework';
-
-// ─── Shared Extractors ──────────────────────────────────────────
-
-/** Handles Latin-script languages with diacritics (French é,à; Turkish ç,ü,ş; German ü,ö,ä) */
-class LatinExtendedIdentifierExtractor implements ValueExtractor {
-  readonly name = 'latin-extended-identifier';
-
-  canExtract(input: string, position: number): boolean {
-    return /\p{L}/u.test(input[position]);
-  }
-
-  extract(input: string, position: number): ExtractionResult | null {
-    let end = position;
-    while (end < input.length && /[\p{L}\p{N}_-]/u.test(input[end])) {
-      end++;
-    }
-    if (end === position) return null;
-    return { value: input.slice(position, end), length: end - position };
-  }
-}
+import { createSimpleTokenizer, LatinExtendedIdentifierExtractor } from '@lokascript/framework';
+import type { LanguageTokenizer } from '@lokascript/framework';
 
 // ─── English ────────────────────────────────────────────────────
 

--- a/packages/domain-llm/package.json
+++ b/packages/domain-llm/package.json
@@ -26,6 +26,7 @@
     "@lokascript/framework": "*"
   },
   "devDependencies": {
+    "@lokascript/domain-toolkit": "*",
     "@types/node": "^20.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",

--- a/packages/domain-llm/src/__test__/lint.test.ts
+++ b/packages/domain-llm/src/__test__/lint.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { lintDomain, formatResult } from '@lokascript/domain-toolkit';
+import type { DomainLintInput } from '@lokascript/domain-toolkit';
+
+import { allSchemas } from '../schemas';
+import {
+  englishProfile,
+  spanishProfile,
+  japaneseProfile,
+  arabicProfile,
+  koreanProfile,
+  chineseProfile,
+  turkishProfile,
+  frenchProfile,
+} from '../profiles';
+import {
+  EnglishLLMTokenizer,
+  SpanishLLMTokenizer,
+  JapaneseLLMTokenizer,
+  ArabicLLMTokenizer,
+  KoreanLLMTokenizer,
+  ChineseLLMTokenizer,
+  TurkishLLMTokenizer,
+  FrenchLLMTokenizer,
+} from '../tokenizers';
+
+function buildInput(): DomainLintInput {
+  return {
+    name: 'llm',
+    schemas: allSchemas,
+    profiles: [
+      englishProfile,
+      spanishProfile,
+      japaneseProfile,
+      arabicProfile,
+      koreanProfile,
+      chineseProfile,
+      turkishProfile,
+      frenchProfile,
+    ],
+    tokenizers: {
+      en: EnglishLLMTokenizer,
+      es: SpanishLLMTokenizer,
+      ja: JapaneseLLMTokenizer,
+      ar: ArabicLLMTokenizer,
+      ko: KoreanLLMTokenizer,
+      zh: ChineseLLMTokenizer,
+      tr: TurkishLLMTokenizer,
+      fr: FrenchLLMTokenizer,
+    },
+  };
+}
+
+describe('domain-llm: lint', () => {
+  it('passes all enabled rules with zero errors', () => {
+    const result = lintDomain(buildInput());
+    if (result.errorCount > 0 || result.warningCount > 0) {
+      // eslint-disable-next-line no-console
+      console.log(formatResult(result));
+    }
+    expect(result.errorCount).toBe(0);
+  });
+});

--- a/packages/domain-llm/src/tokenizers/index.ts
+++ b/packages/domain-llm/src/tokenizers/index.ts
@@ -6,7 +6,7 @@
  * Each tokenizer handles keyword classification for command verbs and markers.
  */
 
-import { createSimpleTokenizer } from '@lokascript/framework';
+import { createSimpleTokenizer, LatinExtendedIdentifierExtractor } from '@lokascript/framework';
 import type { LanguageTokenizer, ValueExtractor, ExtractionResult } from '@lokascript/framework';
 
 // =============================================================================
@@ -31,28 +31,6 @@ class CSSSelectorExtractor implements ValueExtractor {
       end++;
     }
     if (end === position + 1) return null;
-    return { value: input.slice(position, end), length: end - position };
-  }
-}
-
-// =============================================================================
-// Latin Extended Identifier Extractor
-// Handles diacritics in Spanish (é, ó, ú, ñ) and other Latin-script languages
-// =============================================================================
-
-class LatinExtendedIdentifierExtractor implements ValueExtractor {
-  readonly name = 'latin-extended-identifier';
-
-  canExtract(input: string, position: number): boolean {
-    return /\p{L}/u.test(input[position]);
-  }
-
-  extract(input: string, position: number): ExtractionResult | null {
-    let end = position;
-    while (end < input.length && /[\p{L}\p{N}_-]/u.test(input[end])) {
-      end++;
-    }
-    if (end === position) return null;
     return { value: input.slice(position, end), length: end - position };
   }
 }

--- a/packages/domain-sql/src/__test__/lint.test.ts
+++ b/packages/domain-sql/src/__test__/lint.test.ts
@@ -22,6 +22,7 @@ import {
   TurkishSQLTokenizer,
   FrenchSQLTokenizer,
 } from '../tokenizers';
+import { COMMAND_KEYWORDS, MARKERS } from '../generators/sql-renderer';
 
 function buildInput(): DomainLintInput {
   return {
@@ -37,6 +38,10 @@ function buildInput(): DomainLintInput {
       zh: ChineseSQLTokenizer,
       tr: TurkishSQLTokenizer,
       fr: FrenchSQLTokenizer,
+    },
+    renderer: {
+      commandKeywords: COMMAND_KEYWORDS,
+      markers: MARKERS,
     },
   };
 }

--- a/packages/domain-sql/src/__test__/lint.test.ts
+++ b/packages/domain-sql/src/__test__/lint.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Domain lint: structural + cross-file invariants for domain-sql.
+ *
+ * Uses @lokascript/domain-toolkit to check the domain's schemas, profiles,
+ * tokenizers, and renderer tables stay consistent. Fails CI on errors;
+ * warnings are printed for visibility but don't fail.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { lintDomain, formatResult } from '@lokascript/domain-toolkit';
+import type { DomainLintInput } from '@lokascript/domain-toolkit';
+
+import { allSchemas } from '../schemas';
+import { allProfiles } from '../profiles';
+import {
+  EnglishSQLTokenizer,
+  SpanishSQLTokenizer,
+  JapaneseSQLTokenizer,
+  ArabicSQLTokenizer,
+  KoreanSQLTokenizer,
+  ChineseSQLTokenizer,
+  TurkishSQLTokenizer,
+  FrenchSQLTokenizer,
+} from '../tokenizers';
+
+function buildInput(): DomainLintInput {
+  return {
+    name: 'sql',
+    schemas: allSchemas,
+    profiles: allProfiles,
+    tokenizers: {
+      en: EnglishSQLTokenizer,
+      es: SpanishSQLTokenizer,
+      ja: JapaneseSQLTokenizer,
+      ar: ArabicSQLTokenizer,
+      ko: KoreanSQLTokenizer,
+      zh: ChineseSQLTokenizer,
+      tr: TurkishSQLTokenizer,
+      fr: FrenchSQLTokenizer,
+    },
+  };
+}
+
+describe('domain-sql: lint', () => {
+  it('passes all enabled rules with zero errors', () => {
+    const result = lintDomain(buildInput());
+
+    if (result.errorCount > 0 || result.warningCount > 0) {
+      // Print the formatted report so CI logs are legible on failure.
+      // eslint-disable-next-line no-console
+      console.log(formatResult(result));
+    }
+
+    expect(result.errorCount).toBe(0);
+  });
+});

--- a/packages/domain-sql/src/generators/sql-renderer.ts
+++ b/packages/domain-sql/src/generators/sql-renderer.ts
@@ -12,7 +12,7 @@ import { extractRoleValue } from '@lokascript/framework';
 // Keyword Tables
 // =============================================================================
 
-const COMMAND_KEYWORDS: Record<string, Record<string, string>> = {
+export const COMMAND_KEYWORDS: Record<string, Record<string, string>> = {
   select: {
     en: 'select',
     es: 'seleccionar',
@@ -55,7 +55,7 @@ const COMMAND_KEYWORDS: Record<string, Record<string, string>> = {
   },
 };
 
-const MARKERS: Record<string, Record<string, string>> = {
+export const MARKERS: Record<string, Record<string, string>> = {
   from: { en: 'from', es: 'de', ja: 'から', ar: 'من', ko: '에서', zh: '从', tr: 'den', fr: 'de' },
   into: { en: 'into', es: 'en', ja: 'に', ar: 'في', ko: '에', zh: '到', tr: 'e', fr: 'dans' },
   where: {

--- a/packages/domain-sql/src/tokenizers/index.ts
+++ b/packages/domain-sql/src/tokenizers/index.ts
@@ -7,30 +7,8 @@
  * normalization.
  */
 
-import { createSimpleTokenizer } from '@lokascript/framework';
-import type { LanguageTokenizer, ValueExtractor, ExtractionResult } from '@lokascript/framework';
-
-// =============================================================================
-// Latin Extended Identifier Extractor
-// Handles Latin-script languages with diacritics (French é,à,ù; Turkish ç,ü,ş)
-// =============================================================================
-
-class LatinExtendedIdentifierExtractor implements ValueExtractor {
-  readonly name = 'latin-extended-identifier';
-
-  canExtract(input: string, position: number): boolean {
-    return /\p{L}/u.test(input[position]);
-  }
-
-  extract(input: string, position: number): ExtractionResult | null {
-    let end = position;
-    while (end < input.length && /[\p{L}\p{N}_-]/u.test(input[end])) {
-      end++;
-    }
-    if (end === position) return null;
-    return { value: input.slice(position, end), length: end - position };
-  }
-}
+import { createSimpleTokenizer, LatinExtendedIdentifierExtractor } from '@lokascript/framework';
+import type { LanguageTokenizer } from '@lokascript/framework';
 
 // =============================================================================
 // English SQL Tokenizer

--- a/packages/domain-todo/package.json
+++ b/packages/domain-todo/package.json
@@ -26,6 +26,7 @@
     "@lokascript/framework": "*"
   },
   "devDependencies": {
+    "@lokascript/domain-toolkit": "*",
     "@types/node": "^20.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",

--- a/packages/domain-todo/src/__test__/lint.test.ts
+++ b/packages/domain-todo/src/__test__/lint.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { lintDomain, formatResult } from '@lokascript/domain-toolkit';
+import type { DomainLintInput } from '@lokascript/domain-toolkit';
+
+import { allSchemas } from '../schemas';
+import { allProfiles } from '../profiles';
+import {
+  EnglishTodoTokenizer,
+  SpanishTodoTokenizer,
+  JapaneseTodoTokenizer,
+  ArabicTodoTokenizer,
+  KoreanTodoTokenizer,
+  ChineseTodoTokenizer,
+  TurkishTodoTokenizer,
+  FrenchTodoTokenizer,
+} from '../tokenizers';
+
+function buildInput(): DomainLintInput {
+  return {
+    name: 'todo',
+    schemas: allSchemas,
+    profiles: allProfiles,
+    tokenizers: {
+      en: EnglishTodoTokenizer,
+      es: SpanishTodoTokenizer,
+      ja: JapaneseTodoTokenizer,
+      ar: ArabicTodoTokenizer,
+      ko: KoreanTodoTokenizer,
+      zh: ChineseTodoTokenizer,
+      tr: TurkishTodoTokenizer,
+      fr: FrenchTodoTokenizer,
+    },
+  };
+}
+
+describe('domain-todo: lint', () => {
+  it('passes all enabled rules with zero errors', () => {
+    const result = lintDomain(buildInput());
+    if (result.errorCount > 0 || result.warningCount > 0) {
+      // eslint-disable-next-line no-console
+      console.log(formatResult(result));
+    }
+    expect(result.errorCount).toBe(0);
+  });
+});

--- a/packages/domain-todo/src/tokenizers/index.ts
+++ b/packages/domain-todo/src/tokenizers/index.ts
@@ -5,30 +5,8 @@
  * framework's createSimpleTokenizer factory.
  */
 
-import { createSimpleTokenizer } from '@lokascript/framework';
-import type { LanguageTokenizer, ValueExtractor, ExtractionResult } from '@lokascript/framework';
-
-// =============================================================================
-// Latin Extended Identifier Extractor
-// Handles Latin-script languages with diacritics (French à; Turkish ş,ç,ü)
-// =============================================================================
-
-class LatinExtendedIdentifierExtractor implements ValueExtractor {
-  readonly name = 'latin-extended-identifier';
-
-  canExtract(input: string, position: number): boolean {
-    return /\p{L}/u.test(input[position]);
-  }
-
-  extract(input: string, position: number): ExtractionResult | null {
-    let end = position;
-    while (end < input.length && /[\p{L}\p{N}_-]/u.test(input[end])) {
-      end++;
-    }
-    if (end === position) return null;
-    return { value: input.slice(position, end), length: end - position };
-  }
-}
+import { createSimpleTokenizer, LatinExtendedIdentifierExtractor } from '@lokascript/framework';
+import type { LanguageTokenizer } from '@lokascript/framework';
 
 // =============================================================================
 // English

--- a/packages/domain-toolkit/package.json
+++ b/packages/domain-toolkit/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "@lokascript/domain-sql",
-  "version": "2.3.1",
-  "description": "Multilingual SQL DSL built on @lokascript/framework - proof of cross-domain generality",
+  "name": "@lokascript/domain-toolkit",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Lint rules for @lokascript/domain-* packages. Checks schema structure + cross-file invariants (profile ↔ tokenizer ↔ schema ↔ renderer agreement).",
   "type": "module",
   "sideEffects": false,
   "main": "dist/index.cjs",
@@ -23,10 +24,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@lokascript/framework": "*"
+    "@lokascript/framework": "*",
+    "@lokascript/intent": "*",
+    "@lokascript/semantic": "*"
   },
   "devDependencies": {
-    "@lokascript/domain-toolkit": "*",
     "@types/node": "^20.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
@@ -34,29 +36,6 @@
   },
   "files": [
     "dist",
-    "src",
-    "LICENSE"
-  ],
-  "keywords": [
-    "sql",
-    "multilingual",
-    "dsl",
-    "i18n",
-    "parser",
-    "lokascript",
-    "framework"
-  ],
-  "author": "LokaScript Contributors",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/codetalcott/hyperfixi.git",
-    "directory": "packages/domain-sql"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "src"
+  ]
 }

--- a/packages/domain-toolkit/src/format.ts
+++ b/packages/domain-toolkit/src/format.ts
@@ -1,0 +1,23 @@
+/**
+ * Pretty-print lint results for test output.
+ */
+
+import type { LintFinding, LintResult, Severity } from './types';
+
+const SEVERITY_GLYPH: Record<Severity, string> = {
+  error: '✗',
+  warning: '⚠',
+  note: 'ℹ',
+};
+
+export function formatFinding(finding: LintFinding): string {
+  const glyph = SEVERITY_GLYPH[finding.severity];
+  return `  ${glyph} [${finding.rule}] ${finding.message}`;
+}
+
+export function formatResult(result: LintResult): string {
+  const header = `domain-toolkit: lint(${result.domain}) — ${result.errorCount} error(s), ${result.warningCount} warning(s)`;
+  if (result.findings.length === 0) return `${header}\n  (clean)`;
+  const body = result.findings.map(formatFinding).join('\n');
+  return `${header}\n${body}`;
+}

--- a/packages/domain-toolkit/src/index.ts
+++ b/packages/domain-toolkit/src/index.ts
@@ -20,23 +20,43 @@
  */
 
 import { runRules } from './rules';
-import type { DomainLintInput, LintResult } from './types';
+import type { DomainLintInput, LintFinding, LintResult, LintWaiver } from './types';
 
 export type {
   DomainLintInput,
   LintResult,
   LintFinding,
   LintRule,
+  LintWaiver,
   Severity,
   RendererTables,
 } from './types';
 export { formatResult, formatFinding } from './format';
 
+function matchesWaiver(finding: LintFinding, waiver: LintWaiver): boolean {
+  if (finding.rule !== waiver.rule) return false;
+  if (!waiver.matches) return true;
+  const ctx = finding.context ?? {};
+  for (const [key, expected] of Object.entries(waiver.matches)) {
+    if (ctx[key] !== expected) return false;
+  }
+  return true;
+}
+
+function applyWaivers(
+  findings: LintFinding[],
+  waivers: readonly LintWaiver[] | undefined
+): LintFinding[] {
+  if (!waivers || waivers.length === 0) return findings;
+  return findings.filter(f => !waivers.some(w => matchesWaiver(f, w)));
+}
+
 /**
  * Lint a domain against all enabled rules and return a structured result.
  */
 export function lintDomain(input: DomainLintInput): LintResult {
-  const findings = runRules(input);
+  const raw = runRules(input);
+  const findings = applyWaivers(raw, input.waivers);
   const errorCount = findings.filter(f => f.severity === 'error').length;
   const warningCount = findings.filter(f => f.severity === 'warning').length;
 

--- a/packages/domain-toolkit/src/index.ts
+++ b/packages/domain-toolkit/src/index.ts
@@ -1,0 +1,49 @@
+/**
+ * @lokascript/domain-toolkit
+ *
+ * Lint rules for @lokascript/domain-* packages. Checks schema structure
+ * and cross-file invariants (profile ↔ tokenizer ↔ schema ↔ renderer
+ * agreement). Consumed by one lint test per domain — see the integration
+ * pattern in packages/domain-sql/src/__test__/lint.test.ts.
+ *
+ * Phase 1 rules:
+ *   - Schema structure (R1, R2) — delegates to @lokascript/semantic's
+ *     existing validator.
+ *
+ * Planned rules (phase 2+):
+ *   - R5: Profile keywords present in tokenizer keyword lists.
+ *   - R6: Every schema command has profile keywords for all declared langs.
+ *   - R7: Every markerOverride word tokenizes as a single token.
+ *   - R8: Latin-script tokenizers include LatinExtendedIdentifierExtractor.
+ *   - R9: Schema role positions are unique per word-order.
+ *   - R10: Renderer table keywords match profile/schema translations.
+ */
+
+import { runRules } from './rules';
+import type { DomainLintInput, LintResult } from './types';
+
+export type {
+  DomainLintInput,
+  LintResult,
+  LintFinding,
+  LintRule,
+  Severity,
+  RendererTables,
+} from './types';
+export { formatResult, formatFinding } from './format';
+
+/**
+ * Lint a domain against all enabled rules and return a structured result.
+ */
+export function lintDomain(input: DomainLintInput): LintResult {
+  const findings = runRules(input);
+  const errorCount = findings.filter(f => f.severity === 'error').length;
+  const warningCount = findings.filter(f => f.severity === 'warning').length;
+
+  return {
+    domain: input.name,
+    findings,
+    errorCount,
+    warningCount,
+  };
+}

--- a/packages/domain-toolkit/src/rules/extractor-coverage.ts
+++ b/packages/domain-toolkit/src/rules/extractor-coverage.ts
@@ -1,0 +1,63 @@
+/**
+ * R8: Latin-script tokenizers should extract diacritic identifiers as single tokens.
+ *
+ * The default `IdentifierExtractor` matches `[a-zA-Z0-9_]*` and stops at any
+ * diacritic. Words like `añadir` split into `["a", "ñadir"]` unless the
+ * tokenizer also registers `LatinExtendedIdentifierExtractor`. This rule
+ * probes the behavior by tokenizing a canonical diacritic-containing string
+ * for each language and warning if it doesn't come back as a single token.
+ *
+ * Warning (not error) because:
+ *   - English tokenizers legitimately don't need the extended extractor.
+ *   - A domain might deliberately split compounds for its own reasons.
+ * The warning prompts the author to audit; an explicit waiver can add an
+ * opt-out once we have a mechanism for it.
+ */
+
+import type { LintFinding, LintRule } from '../types';
+
+const RULE_ID = 'extractor-coverage';
+
+/**
+ * Canonical diacritic samples per language. Each must be a single logical
+ * word in the target language. Chosen to exercise the specific characters
+ * that tend to split under the default ASCII extractor.
+ */
+const DIACRITIC_SAMPLES: Record<string, string> = {
+  es: 'añadir', // ñ
+  fr: 'déjà', // é, à
+  pt: 'coração', // ç, ã
+  de: 'größer', // ö, ß
+  tr: 'değiştir', // ğ, ş
+  it: 'però', // ò
+  pl: 'kochać', // ć
+  cs: 'příliš', // ř, í
+  // Not run for en, ja, ar, ko, zh, ru, hi, etc. — either pure ASCII
+  // (en) or non-Latin scripts where the Unicode extractor handles them.
+};
+
+export const extractorCoverageRule: LintRule = input => {
+  const findings: LintFinding[] = [];
+
+  for (const [lang, sample] of Object.entries(DIACRITIC_SAMPLES)) {
+    const tokenizer = input.tokenizers[lang];
+    if (!tokenizer) continue; // language not registered in this domain
+
+    const stream = tokenizer.tokenize(sample);
+    if (stream.tokens.length !== 1) {
+      findings.push({
+        rule: RULE_ID,
+        severity: 'warning',
+        message: `[${lang}] diacritic probe "${sample}" tokenizes as ${stream.tokens.length} tokens — tokenizer likely missing LatinExtendedIdentifierExtractor`,
+        context: {
+          domain: input.name,
+          lang,
+          sample,
+          tokenCount: stream.tokens.length,
+        },
+      });
+    }
+  }
+
+  return findings;
+};

--- a/packages/domain-toolkit/src/rules/index.ts
+++ b/packages/domain-toolkit/src/rules/index.ts
@@ -4,12 +4,20 @@
 
 import type { DomainLintInput, LintFinding, LintRule } from '../types';
 import { schemaStructureRule } from './schema-rules';
+import { keywordCoverageRule } from './keyword-coverage';
+import { markerTokenizationRule } from './marker-tokenization';
 
 /**
- * All rules in execution order. Phase 1: R1+R2 only (schema structure).
- * Phase 2 adds R5-R7; phase 3 adds R8-R10.
+ * All rules in execution order.
+ *   Phase 1: schema structure (delegates to @lokascript/semantic)
+ *   Phase 2: keyword coverage + marker tokenization
+ *   Phase 3: extractor coverage, position ordering, renderer coherence (warnings)
  */
-export const ALL_RULES: readonly LintRule[] = [schemaStructureRule];
+export const ALL_RULES: readonly LintRule[] = [
+  schemaStructureRule,
+  keywordCoverageRule,
+  markerTokenizationRule,
+];
 
 export function runRules(input: DomainLintInput): LintFinding[] {
   const findings: LintFinding[] = [];

--- a/packages/domain-toolkit/src/rules/index.ts
+++ b/packages/domain-toolkit/src/rules/index.ts
@@ -8,13 +8,14 @@ import { keywordCoverageRule } from './keyword-coverage';
 import { markerTokenizationRule } from './marker-tokenization';
 import { extractorCoverageRule } from './extractor-coverage';
 import { positionOrderingRule } from './position-ordering';
+import { rendererCoherenceRule } from './renderer-coherence';
 
 /**
  * All rules in execution order.
  *   Phase 1: schema structure (delegates to @lokascript/semantic)
  *   Phase 2: keyword coverage + marker tokenization
  *   Phase 3: extractor coverage + position ordering (warnings only)
- *   Future: R10 renderer coherence (opt-in via DomainLintInput.renderer)
+ *   Phase 3b: renderer coherence (opt-in via DomainLintInput.renderer)
  */
 export const ALL_RULES: readonly LintRule[] = [
   schemaStructureRule,
@@ -22,6 +23,7 @@ export const ALL_RULES: readonly LintRule[] = [
   markerTokenizationRule,
   extractorCoverageRule,
   positionOrderingRule,
+  rendererCoherenceRule,
 ];
 
 export function runRules(input: DomainLintInput): LintFinding[] {

--- a/packages/domain-toolkit/src/rules/index.ts
+++ b/packages/domain-toolkit/src/rules/index.ts
@@ -6,17 +6,22 @@ import type { DomainLintInput, LintFinding, LintRule } from '../types';
 import { schemaStructureRule } from './schema-rules';
 import { keywordCoverageRule } from './keyword-coverage';
 import { markerTokenizationRule } from './marker-tokenization';
+import { extractorCoverageRule } from './extractor-coverage';
+import { positionOrderingRule } from './position-ordering';
 
 /**
  * All rules in execution order.
  *   Phase 1: schema structure (delegates to @lokascript/semantic)
  *   Phase 2: keyword coverage + marker tokenization
- *   Phase 3: extractor coverage, position ordering, renderer coherence (warnings)
+ *   Phase 3: extractor coverage + position ordering (warnings only)
+ *   Future: R10 renderer coherence (opt-in via DomainLintInput.renderer)
  */
 export const ALL_RULES: readonly LintRule[] = [
   schemaStructureRule,
   keywordCoverageRule,
   markerTokenizationRule,
+  extractorCoverageRule,
+  positionOrderingRule,
 ];
 
 export function runRules(input: DomainLintInput): LintFinding[] {

--- a/packages/domain-toolkit/src/rules/index.ts
+++ b/packages/domain-toolkit/src/rules/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Rule registry — runs all enabled rules and aggregates findings.
+ */
+
+import type { DomainLintInput, LintFinding, LintRule } from '../types';
+import { schemaStructureRule } from './schema-rules';
+
+/**
+ * All rules in execution order. Phase 1: R1+R2 only (schema structure).
+ * Phase 2 adds R5-R7; phase 3 adds R8-R10.
+ */
+export const ALL_RULES: readonly LintRule[] = [schemaStructureRule];
+
+export function runRules(input: DomainLintInput): LintFinding[] {
+  const findings: LintFinding[] = [];
+  for (const rule of ALL_RULES) {
+    findings.push(...rule(input));
+  }
+  return findings;
+}

--- a/packages/domain-toolkit/src/rules/keyword-coverage.ts
+++ b/packages/domain-toolkit/src/rules/keyword-coverage.ts
@@ -1,0 +1,38 @@
+/**
+ * R6: Keyword coverage across profiles.
+ *
+ * For every schema action + every registered profile, the profile must have
+ * a `keywords[action]` entry. Without it, `createMultilingualDSL()` throws
+ * at pattern generation time ("No keyword translation for 'X' in 'Y'").
+ *
+ * This rule catches the "I added a new schema but only wired it into the
+ * English profile" class of drift.
+ */
+
+import type { LintFinding, LintRule } from '../types';
+
+const RULE_ID = 'keyword-coverage';
+
+export const keywordCoverageRule: LintRule = input => {
+  const findings: LintFinding[] = [];
+
+  for (const profile of input.profiles) {
+    for (const schema of input.schemas) {
+      const action = schema.action;
+      if (!profile.keywords[action]) {
+        findings.push({
+          rule: RULE_ID,
+          severity: 'error',
+          message: `profile [${profile.code}] has no keyword for action '${String(action)}'`,
+          context: {
+            domain: input.name,
+            lang: profile.code,
+            action: String(action),
+          },
+        });
+      }
+    }
+  }
+
+  return findings;
+};

--- a/packages/domain-toolkit/src/rules/marker-tokenization.ts
+++ b/packages/domain-toolkit/src/rules/marker-tokenization.ts
@@ -1,0 +1,124 @@
+/**
+ * R7: Marker and keyword tokenization.
+ *
+ * Every lexical item the parser needs to match atomically — marker words,
+ * profile keyword primaries, and profile keyword alternatives — must
+ * tokenize as a single token in its target language. A word that splits
+ * across multiple tokens (e.g., `añadir` → `["a", "ñadir"]` when the
+ * tokenizer lacks `LatinExtendedIdentifierExtractor`) will never match a
+ * pattern's literal token.
+ *
+ * This is the exact gap that bit us on the Spanish tokenizer mid-session.
+ */
+
+import type { LintFinding, LintRule, DomainLintInput } from '../types';
+import type { LanguageTokenizer } from '@lokascript/framework';
+
+const RULE_ID = 'marker-tokenization';
+
+function tokenCount(tokenizer: LanguageTokenizer, word: string): number {
+  const stream = tokenizer.tokenize(word);
+  return stream.tokens.length;
+}
+
+function collectLexicalItems(input: DomainLintInput): Array<{
+  lang: string;
+  word: string;
+  source: string; // "schema marker <action>.<role>" | "profile keyword <action>.primary" | ...
+}> {
+  const items: Array<{ lang: string; word: string; source: string }> = [];
+
+  // Schema marker overrides (per language)
+  for (const schema of input.schemas) {
+    for (const role of schema.roles) {
+      if (!role.markerOverride) continue;
+      for (const [lang, word] of Object.entries(role.markerOverride)) {
+        items.push({
+          lang,
+          word,
+          source: `schema markerOverride ${String(schema.action)}.${role.role}`,
+        });
+      }
+    }
+  }
+
+  // Profile keywords (primary + alternatives)
+  for (const profile of input.profiles) {
+    for (const [action, entry] of Object.entries(profile.keywords)) {
+      if (entry.primary) {
+        items.push({
+          lang: profile.code,
+          word: entry.primary,
+          source: `profile keyword ${action}.primary`,
+        });
+      }
+      for (const alt of entry.alternatives ?? []) {
+        items.push({
+          lang: profile.code,
+          word: alt,
+          source: `profile keyword ${action}.alternatives`,
+        });
+      }
+    }
+  }
+
+  // Profile role markers (primary + alternatives)
+  for (const profile of input.profiles) {
+    for (const [role, marker] of Object.entries(profile.roleMarkers ?? {})) {
+      if (marker.primary) {
+        items.push({
+          lang: profile.code,
+          word: marker.primary,
+          source: `profile roleMarker ${role}.primary`,
+        });
+      }
+      for (const alt of marker.alternatives ?? []) {
+        items.push({
+          lang: profile.code,
+          word: alt,
+          source: `profile roleMarker ${role}.alternatives`,
+        });
+      }
+    }
+  }
+
+  return items;
+}
+
+export const markerTokenizationRule: LintRule = input => {
+  const findings: LintFinding[] = [];
+  const items = collectLexicalItems(input);
+
+  for (const { lang, word, source } of items) {
+    const tokenizer = input.tokenizers[lang];
+    if (!tokenizer) {
+      // Tokenizer for this language isn't registered with the linter.
+      // R6 (keyword-coverage) catches the schema side; nothing to do here.
+      continue;
+    }
+
+    // Whitespace-containing markers (e.g., 'mettre-à-jour' is one word, but
+    // 'ask X to Y' wouldn't be) — tokenize the raw word and expect 1 token.
+    // Multi-word markers with explicit spaces are out of scope for this rule;
+    // skip them rather than flag false positives.
+    if (/\s/.test(word)) continue;
+
+    const count = tokenCount(tokenizer, word);
+    if (count !== 1) {
+      findings.push({
+        rule: RULE_ID,
+        severity: 'error',
+        message: `"${word}" tokenizes as ${count} tokens in ${lang} (${source})`,
+        context: {
+          domain: input.name,
+          lang,
+          word,
+          source,
+          tokenCount: count,
+        },
+      });
+    }
+  }
+
+  return findings;
+};

--- a/packages/domain-toolkit/src/rules/marker-tokenization.ts
+++ b/packages/domain-toolkit/src/rules/marker-tokenization.ts
@@ -97,6 +97,11 @@ export const markerTokenizationRule: LintRule = input => {
       continue;
     }
 
+    // Empty-string markers mean "no marker in this language" (an explicit
+    // opt-out pattern used by domain-learn to signal that a role is
+    // positional in some languages but marker-bearing in others).
+    if (word === '') continue;
+
     // Whitespace-containing markers (e.g., 'mettre-à-jour' is one word, but
     // 'ask X to Y' wouldn't be) — tokenize the raw word and expect 1 token.
     // Multi-word markers with explicit spaces are out of scope for this rule;

--- a/packages/domain-toolkit/src/rules/position-ordering.ts
+++ b/packages/domain-toolkit/src/rules/position-ordering.ts
@@ -1,0 +1,87 @@
+/**
+ * R9: Role position uniqueness within a schema.
+ *
+ * `sortRolesByWordOrder` in the pattern generator sorts roles descending by
+ * svoPosition or sovPosition (higher value = earlier in surface form). If two
+ * roles share the same position value, their relative order is undefined
+ * (falls through to array stability) — a latent footgun because token
+ * ordering silently changes if someone reorders the roles array.
+ *
+ * This rule warns when a schema has multiple roles AND any two share an
+ * explicit position for the same word order.
+ *
+ * Warning (not error) because:
+ *   - Single-role schemas have nothing to order.
+ *   - A schema might intentionally tie two roles when only one is present
+ *     at a time (e.g., mutually-exclusive alternatives). In practice we
+ *     haven't seen this, but the rule should prompt a review, not block.
+ *
+ * The `sovPosition: 0` default assigned when omitted is NOT flagged — only
+ * explicit non-zero collisions count. Otherwise most schemas with 3+
+ * optional roles would warn spuriously.
+ */
+
+import type { LintFinding, LintRule } from '../types';
+
+const RULE_ID = 'position-ordering';
+
+function findCollisions(
+  values: Array<{ role: string; position: number }>
+): Array<{ position: number; roles: string[] }> {
+  const byPosition = new Map<number, string[]>();
+  for (const { role, position } of values) {
+    const existing = byPosition.get(position) ?? [];
+    existing.push(role);
+    byPosition.set(position, existing);
+  }
+  return Array.from(byPosition.entries())
+    .filter(([, roles]) => roles.length > 1)
+    .map(([position, roles]) => ({ position, roles }));
+}
+
+export const positionOrderingRule: LintRule = input => {
+  const findings: LintFinding[] = [];
+
+  for (const schema of input.schemas) {
+    if (schema.roles.length < 2) continue;
+
+    const svoValues = schema.roles
+      .filter(r => typeof r.svoPosition === 'number' && r.svoPosition !== 0)
+      .map(r => ({ role: r.role, position: r.svoPosition! }));
+    const sovValues = schema.roles
+      .filter(r => typeof r.sovPosition === 'number' && r.sovPosition !== 0)
+      .map(r => ({ role: r.role, position: r.sovPosition! }));
+
+    for (const { position, roles } of findCollisions(svoValues)) {
+      findings.push({
+        rule: RULE_ID,
+        severity: 'warning',
+        message: `[${String(schema.action)}] roles ${roles.join(', ')} share svoPosition=${position} — order is undefined`,
+        context: {
+          domain: input.name,
+          action: String(schema.action),
+          wordOrder: 'SVO',
+          position,
+          roles: roles.join(','),
+        },
+      });
+    }
+
+    for (const { position, roles } of findCollisions(sovValues)) {
+      findings.push({
+        rule: RULE_ID,
+        severity: 'warning',
+        message: `[${String(schema.action)}] roles ${roles.join(', ')} share sovPosition=${position} — order is undefined`,
+        context: {
+          domain: input.name,
+          action: String(schema.action),
+          wordOrder: 'SOV',
+          position,
+          roles: roles.join(','),
+        },
+      });
+    }
+  }
+
+  return findings;
+};

--- a/packages/domain-toolkit/src/rules/renderer-coherence.ts
+++ b/packages/domain-toolkit/src/rules/renderer-coherence.ts
@@ -1,0 +1,100 @@
+/**
+ * R10: Renderer-table coherence (opt-in).
+ *
+ * Some domains ship a natural-language renderer that maintains its own
+ * per-language keyword/marker tables separate from the profile data. This
+ * rule — when the domain passes `input.renderer` — asserts that:
+ *   - Every `commandKeywords[action][lang]` matches `profile.keywords[action].primary`
+ *     for that language.
+ *   - Every `markers[name][lang]` appears as a markerOverride value somewhere
+ *     in the schemas for that language (can't pin to a specific role since
+ *     renderer marker names are arbitrary labels).
+ *
+ * Warnings only. Domains without `input.renderer` get a no-op pass — this
+ * rule is inherently opt-in because not every domain has round-trip
+ * rendering and not every renderer uses the same table shape.
+ *
+ * Catches the exact drift we fixed earlier this session: domain-sql's
+ * Turkish source marker was `dan` in the `get` schema but `den` in the
+ * renderer's MARKERS table. Had this rule existed, it would have warned
+ * the moment `get` was added with the wrong Turkish variant.
+ */
+
+import type { LintFinding, LintRule } from '../types';
+
+const RULE_ID = 'renderer-coherence';
+
+export const rendererCoherenceRule: LintRule = input => {
+  if (!input.renderer) return [];
+  const findings: LintFinding[] = [];
+
+  // commandKeywords ↔ profile primaries
+  for (const [action, langMap] of Object.entries(input.renderer.commandKeywords)) {
+    for (const [lang, rendererWord] of Object.entries(langMap)) {
+      const profile = input.profiles.find(p => p.code === lang);
+      if (!profile) continue; // lang not registered; R6 handles that
+      const profileEntry = profile.keywords[action];
+      if (!profileEntry) {
+        findings.push({
+          rule: RULE_ID,
+          severity: 'warning',
+          message: `renderer has '${action}' keyword for ${lang} ("${rendererWord}") but profile has no entry for that action`,
+          context: { domain: input.name, lang, action, rendererWord },
+        });
+        continue;
+      }
+      const profilePrimary = profileEntry.primary;
+      const profileAlts = profileEntry.alternatives ?? [];
+      if (rendererWord !== profilePrimary && !profileAlts.includes(rendererWord)) {
+        findings.push({
+          rule: RULE_ID,
+          severity: 'warning',
+          message: `renderer '${action}' keyword for ${lang} is "${rendererWord}" but profile has primary="${profilePrimary}"${profileAlts.length ? ` (alternatives: ${profileAlts.join(', ')})` : ''}`,
+          context: {
+            domain: input.name,
+            lang,
+            action,
+            rendererWord,
+            profilePrimary,
+          },
+        });
+      }
+    }
+  }
+
+  // markers ↔ schema markerOverride values (loose check — any role in any
+  // schema for that lang must have this marker value somewhere)
+  const markerByLang = new Map<string, Set<string>>();
+  for (const schema of input.schemas) {
+    for (const role of schema.roles) {
+      if (!role.markerOverride) continue;
+      for (const [lang, word] of Object.entries(role.markerOverride)) {
+        const set = markerByLang.get(lang) ?? new Set<string>();
+        set.add(word);
+        markerByLang.set(lang, set);
+      }
+    }
+  }
+
+  for (const [markerName, langMap] of Object.entries(input.renderer.markers)) {
+    for (const [lang, rendererWord] of Object.entries(langMap)) {
+      const schemaMarkers = markerByLang.get(lang);
+      if (!schemaMarkers) continue; // lang has no markerOverride anywhere; skip
+      if (!schemaMarkers.has(rendererWord)) {
+        findings.push({
+          rule: RULE_ID,
+          severity: 'warning',
+          message: `renderer marker "${markerName}" in ${lang} is "${rendererWord}" but no schema role has that markerOverride value — likely drift`,
+          context: {
+            domain: input.name,
+            lang,
+            markerName,
+            rendererWord,
+          },
+        });
+      }
+    }
+  }
+
+  return findings;
+};

--- a/packages/domain-toolkit/src/rules/schema-rules.ts
+++ b/packages/domain-toolkit/src/rules/schema-rules.ts
@@ -1,0 +1,51 @@
+/**
+ * Schema-structure rules (R1, R2).
+ *
+ * Delegates to `@lokascript/semantic`'s already-solid schema validator.
+ * We only surface its error- and warning-level items; notes are dropped
+ * to keep linter output focused.
+ */
+
+import { validateCommandSchema } from '@lokascript/semantic';
+import type { LintFinding, LintRule, Severity } from '../types';
+
+const RULE_ID = 'schema-structure';
+
+/**
+ * Maps semantic's validation severity to our linter severity.
+ * Semantic uses the same three levels, but we keep the conversion explicit.
+ */
+function toSeverity(sem: 'error' | 'warning' | 'note'): Severity {
+  return sem;
+}
+
+// Semantic's CommandSchema narrows `action` to a hardcoded union of hyperscript
+// actions; framework's CommandSchema accepts any string. Domain-specific
+// actions like 'select', 'get', 'obtener' aren't in semantic's union but the
+// validator doesn't depend on the narrower typing at runtime — it just
+// iterates roles and checks types. Cast through `unknown` is safe here and
+// scoped to this one boundary.
+type SemanticSchema = Parameters<typeof validateCommandSchema>[0];
+
+export const schemaStructureRule: LintRule = input => {
+  const findings: LintFinding[] = [];
+
+  for (const schema of input.schemas) {
+    const result = validateCommandSchema(schema as unknown as SemanticSchema);
+    for (const item of result.items) {
+      if (item.severity === 'note') continue; // skip notes — not actionable at lint time
+      findings.push({
+        rule: `${RULE_ID}:${item.code}`,
+        severity: toSeverity(item.severity),
+        message: `[${schema.action}] ${item.message}`,
+        context: {
+          domain: input.name,
+          action: String(schema.action),
+          code: item.code,
+        },
+      });
+    }
+  }
+
+  return findings;
+};

--- a/packages/domain-toolkit/src/types.ts
+++ b/packages/domain-toolkit/src/types.ts
@@ -34,12 +34,28 @@ export interface RendererTables {
   readonly markers: Record<string, Record<string, string>>;
 }
 
+/**
+ * Matcher for an acknowledged-but-unfixed finding. Each entry is an object
+ * whose fields are compared against the finding's rule + context. A finding
+ * matches a waiver if every field in the waiver matches the corresponding
+ * field on the finding (or finding.context). Matched findings are dropped
+ * from the returned result entirely.
+ *
+ * Use sparingly — waivers are real debt that should have a plan to resolve.
+ */
+export interface LintWaiver {
+  readonly rule: string;
+  readonly reason: string; // human-readable; not matched against — for audit
+  readonly matches?: Record<string, string | number | boolean>;
+}
+
 export interface DomainLintInput {
   readonly name: string;
   readonly schemas: readonly CommandSchema[];
   readonly profiles: readonly PatternGenLanguageProfile[];
   readonly tokenizers: Readonly<Record<string, LanguageTokenizer>>;
   readonly renderer?: RendererTables;
+  readonly waivers?: readonly LintWaiver[];
 }
 
 /**

--- a/packages/domain-toolkit/src/types.ts
+++ b/packages/domain-toolkit/src/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Core types for the domain linter.
+ */
+
+import type { CommandSchema } from '@lokascript/intent';
+import type { PatternGenLanguageProfile, LanguageTokenizer } from '@lokascript/framework';
+
+export type Severity = 'error' | 'warning' | 'note';
+
+export interface LintFinding {
+  readonly rule: string;
+  readonly severity: Severity;
+  readonly message: string;
+  /** Optional structured context: domain, language code, command action, role name, etc. */
+  readonly context?: Record<string, string | number | boolean>;
+}
+
+export interface LintResult {
+  readonly domain: string;
+  readonly findings: readonly LintFinding[];
+  /** Count helpers — derived from findings. */
+  readonly errorCount: number;
+  readonly warningCount: number;
+}
+
+/**
+ * Optional renderer metadata for R10 (renderer-coherence check).
+ * Domains without a renderer or without standard table shape omit this field.
+ */
+export interface RendererTables {
+  /** Keyed by action name → lang code → keyword. */
+  readonly commandKeywords: Record<string, Record<string, string>>;
+  /** Keyed by marker name → lang code → marker word. */
+  readonly markers: Record<string, Record<string, string>>;
+}
+
+export interface DomainLintInput {
+  readonly name: string;
+  readonly schemas: readonly CommandSchema[];
+  readonly profiles: readonly PatternGenLanguageProfile[];
+  readonly tokenizers: Readonly<Record<string, LanguageTokenizer>>;
+  readonly renderer?: RendererTables;
+}
+
+/**
+ * A single rule is a pure function producing findings.
+ */
+export type LintRule = (input: DomainLintInput) => LintFinding[];

--- a/packages/domain-toolkit/tsconfig.json
+++ b/packages/domain-toolkit/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "declaration": true,
+    "declarationDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/domain-toolkit/tsup.config.ts
+++ b/packages/domain-toolkit/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  external: ['@lokascript/framework', '@lokascript/intent', '@lokascript/semantic'],
+});

--- a/packages/domain-voice/package.json
+++ b/packages/domain-voice/package.json
@@ -26,6 +26,7 @@
     "@lokascript/framework": "*"
   },
   "devDependencies": {
+    "@lokascript/domain-toolkit": "*",
     "@types/node": "^20.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",

--- a/packages/domain-voice/src/__test__/lint.test.ts
+++ b/packages/domain-voice/src/__test__/lint.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { lintDomain, formatResult } from '@lokascript/domain-toolkit';
+import type { DomainLintInput } from '@lokascript/domain-toolkit';
+
+import { allSchemas } from '../schemas';
+import { allProfiles } from '../profiles';
+import {
+  EnglishVoiceTokenizer,
+  SpanishVoiceTokenizer,
+  JapaneseVoiceTokenizer,
+  ArabicVoiceTokenizer,
+  KoreanVoiceTokenizer,
+  ChineseVoiceTokenizer,
+  TurkishVoiceTokenizer,
+  FrenchVoiceTokenizer,
+} from '../tokenizers';
+
+function buildInput(): DomainLintInput {
+  return {
+    name: 'voice',
+    schemas: allSchemas,
+    profiles: allProfiles,
+    tokenizers: {
+      en: EnglishVoiceTokenizer,
+      es: SpanishVoiceTokenizer,
+      ja: JapaneseVoiceTokenizer,
+      ar: ArabicVoiceTokenizer,
+      ko: KoreanVoiceTokenizer,
+      zh: ChineseVoiceTokenizer,
+      tr: TurkishVoiceTokenizer,
+      fr: FrenchVoiceTokenizer,
+    },
+  };
+}
+
+describe('domain-voice: lint', () => {
+  it('passes all enabled rules with zero errors', () => {
+    const result = lintDomain(buildInput());
+    if (result.errorCount > 0 || result.warningCount > 0) {
+      // eslint-disable-next-line no-console
+      console.log(formatResult(result));
+    }
+    expect(result.errorCount).toBe(0);
+  });
+});

--- a/packages/framework/src/interfaces/value-extractor.ts
+++ b/packages/framework/src/interfaces/value-extractor.ts
@@ -317,6 +317,38 @@ export class UnicodeIdentifierExtractor implements ValueExtractor {
 }
 
 /**
+ * Latin Extended identifier extractor — handles Latin-script languages with
+ * diacritics (Spanish ñ/á/é/í/ó/ú; French é/à/ù/ç; Turkish ç/ş/ı/ü/ğ/ö;
+ * Portuguese ã/õ; German ä/ö/ü/ß; etc).
+ *
+ * Use this in addition to (or instead of) the default `IdentifierExtractor`
+ * for any tokenizer whose language is Latin-script and may contain diacritic
+ * characters in identifiers. Without it, words like `añadir` tokenize as
+ * `["a", "ñadir"]` because the default ASCII extractor stops at `ñ` and the
+ * Unicode extractor only kicks in when a token *starts* with a non-ASCII
+ * character.
+ *
+ * Matches contiguous runs of `/[\p{L}\p{N}_-]/u` — any Unicode letter or
+ * number, plus underscore and hyphen.
+ */
+export class LatinExtendedIdentifierExtractor implements ValueExtractor {
+  readonly name = 'latin-extended-identifier';
+
+  canExtract(input: string, position: number): boolean {
+    return /\p{L}/u.test(input[position]);
+  }
+
+  extract(input: string, position: number): ExtractionResult | null {
+    let end = position;
+    while (end < input.length && /[\p{L}\p{N}_-]/u.test(input[end])) {
+      end++;
+    }
+    if (end === position) return null;
+    return { value: input.slice(position, end), length: end - position };
+  }
+}
+
+/**
  * Whitespace extractor - handles spaces, tabs, newlines.
  */
 export class WhitespaceExtractor implements ValueExtractor {


### PR DESCRIPTION
## Summary

Introduces a new package `@lokascript/domain-toolkit` providing lint rules for domain DSLs, plus the framework refactor it depends on. Cherry-picked from `feat/mcp-multilingual-intent` as the first independent slice.

**New package:** 5 lint rules (schema-structure, keyword-coverage, marker-tokenization, extractor-coverage, position-ordering) + 1 opt-in (renderer-coherence) + waiver mechanism + lint-result formatter.

**Wiring:** all 9 existing domain packages now have a `lint.test.ts` that runs the rules against their schemas, profiles, and tokenizers. Root `npm run lint:domains` script + folded into `lint-typecheck` CI job (~5-10s added).

**Framework refactor:** `LatinExtendedIdentifierExtractor` promoted from per-domain copies into `@lokascript/framework`, deduping ~170 lines across 7 domain tokenizer indexes.

## Commits (6)

1. `fix(domain-jsx)` — add `LatinExtendedIdentifierExtractor` to Spanish tokenizer
2. `refactor(framework)` — promote `LatinExtendedIdentifierExtractor` + dedupe across 7 domains
3. `feat(domain-toolkit) phase 1` — schema-structure rules + domain-sql integration
4. `feat(domain-toolkit) phase 2` — cross-file rules + lint tests in 7 more domains
5. `feat(domain-toolkit) phase 3+4` — heuristic rules + CI wiring
6. `feat(domain-toolkit)` — renderer coherence rule + domain-learn lint + waivers

## Verification

Local on branch:
- `npm run lint:domains` — 9/9 domains lint clean
- Full test suites pass for all 9 domain packages (1030 tests + 9 lint tests)
- Typecheck clean: framework, domain-toolkit
- One waiver in domain-learn for a known Turkish `-e` dative suffix tokenization quirk (deferred to a Turkish speaker)

## Test plan

- [ ] CI `lint-typecheck` job picks up new `lint:domains` step
- [ ] CI `unit-tests` job exercises the 9 new lint test files
- [ ] No regressions across the 9 domain packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)