### PR TITLE
chore(release): post-v2.4.0 mechanics — components pretest, CI un-flag, release-smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,11 +475,6 @@ jobs:
         run: npm test --prefix packages/speech -- --run
 
       - name: Test components
-        # Known pre-existing failures in v2 reactive ^var rendering integration
-        # tests — `set` command target resolution gap surfaces in the component
-        # init path. Tracked separately; doesn't block v2.4.0 since the package
-        # is still iterating on v2 reactive features.
-        continue-on-error: true
         run: npm test --prefix packages/components -- --run
 
   # ============================================

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,8 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     permissions:
       contents: write
       id-token: write # Required for npm trusted publishing (OIDC provenance)
@@ -293,3 +295,44 @@ jobs:
               echo "- \`$PKG_NAME@$PKG_VER\`"
             done
           } >> $GITHUB_STEP_SUMMARY
+
+  release-smoke:
+    name: Release smoke test
+    needs: publish
+    if: ${{ github.event.inputs.dry-run == 'false' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Install Playwright chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run release smoke test
+        run: |
+          VERSION="${{ needs.publish.outputs.version }}"
+          # A fresh publish can take a few minutes to propagate across the npm
+          # CDN. Retry the harness up to 3 times with a 90s backoff.
+          for attempt in 1 2 3; do
+            echo "::group::release-smoke attempt $attempt (v$VERSION)"
+            if node examples/release-smoke/run.mjs "$VERSION"; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "attempt $attempt failed; waiting 90s for npm CDN propagation…"
+            sleep 90
+          done
+          echo "::error::release smoke test failed after 3 attempts"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,8 @@ Two parallel arcs landed since v2.3.1: **upstream `_hyperscript` 0.9.90 parity**
 ### Changed (internal)
 
 - **Evaluator consolidation**: Retired the `BaseExpressionEvaluator` class hierarchy and 4 helper modules (~2,700 LOC removed) in favor of the single canonical evaluator at `parser/runtime.ts:evaluateAST` with the `ExpressionRegistry` on `ExecutionContext`. Both consolidation arcs (α + β) closed.
-- **Domain DSLs**: Extracted a shared internal config package (workspace-only) consumed by all 8 domain DSLs.
+- **Domain DSLs**: Extracted a shared config package (`@hyperfixi/domain-config`) consumed by all 8 domain DSLs.
+- **Published infrastructure packages**: `@lokascript/intent`, `@hyperfixi/domain-config`, `@hyperfixi/planner`, and `@hyperfixi/intent-element` are published to npm as transitive dependencies (required for `@hyperfixi/core` and the domain DSLs to install cleanly from the registry). They are infra deps — users do not install them directly. (These were published from post-tag fix-forward commits; the `v2.4.0` git tag predates them.)
 
 ## [2.3.1] - 2026-04-23
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "tsup && npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --outDir dist --noEmit false",
+    "pretest": "../../scripts/ensure-fresh.sh ../core ../reactivity",
     "test": "vitest",
     "test:run": "vitest run",
     "test:check": "vitest run --reporter=dot 2>&1 | tail -5",


### PR DESCRIPTION
Four release-mechanics follow-ups from the v2.4.0 cycle. No runtime/source changes; published v2.4.0 is functionally correct.

## Changes

**Components: harden + un-flag** — `packages/components` was the only tested package without a `pretest` ensure-fresh hook, so its tests ran against whatever `core`/`reactivity` `dist/` was on disk. Stale `dist` (pre-`^var`-parser) reproduces the exact "`set` can't resolve target" symptom. Added the hook; removed the stale `continue-on-error` + "known failures" comment from the `ci.yml` Test components step (added in the v2.4.0 release commit when CI was already green — the step has passed in every run since).

**CHANGELOG** — note that `@lokascript/intent`, `@hyperfixi/domain-config`, `@hyperfixi/planner`, `@hyperfixi/intent-element` are published to npm as transitive infra deps (the `[2.4.0]` entry assumed they'd stay private; they were published from post-tag fix-forward commits).

**publish.yml** — added a post-publish `release-smoke` job that runs `examples/release-smoke/run.mjs` against the just-published version (`needs: publish`, skipped on dry-run, hard-fails, 3× retry for npm CDN propagation). A future release can no longer ship an uninstallable package without CI going red.

## Note on the original brief

The "8 failing tests / needs a real fix + patch release" framing was stale. The `^var` parser/writer fixes landed *before* the v2.4.0 tag; CI's components step is `success` in every recent run; and the published `@hyperfixi/components@2.4.0` works correctly when verified against the published `core`/`reactivity`. The genuine gap was the missing build-freshness hook.

## Verification

- `pretest` hook fires → `ensure-fresh` rebuilds stale `core`+`reactivity` → **58/58 components tests pass**
- Both workflow YAMLs parse clean; `release-smoke` wired to `publish.outputs.version`
- `node examples/release-smoke/run.mjs 2.4.0` → **✅ 8/8 checks green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)