### PR TITLE
chore(scripts): cover reactivity/components/speech in test-check-all

### DIFF
--- a/scripts/test-check-all.sh
+++ b/scripts/test-check-all.sh
@@ -10,7 +10,10 @@
 set -e
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# `core` before `reactivity` — reactivity's build consumes core's dist.
 "$REPO_ROOT/scripts/ensure-fresh.sh" \
+  "$REPO_ROOT/packages/core" \
+  "$REPO_ROOT/packages/reactivity" \
   "$REPO_ROOT/packages/framework" \
   "$REPO_ROOT/packages/semantic" \
   "$REPO_ROOT/packages/aot-compiler" \
@@ -51,6 +54,11 @@ PACKAGES=(
   # Plugin & bundling
   "vite-plugin:Vite Plugin"
   "smart-bundling:Smart Bundling"
+
+  # Runtime plugins (HyperfixiPlugin) — reactivity before components (dep order)
+  "reactivity:Reactivity"
+  "components:Components"
+  "speech:Speech"
 
   # Other
   "developer-tools:Developer Tools"


### PR DESCRIPTION
Follow-up to #221. `npm run test:check` skipped the three HyperfixiPlugin packages — `reactivity`, `components`, `speech` were absent from the `PACKAGES` array in `scripts/test-check-all.sh`.

## Change

- Add `reactivity`, `components`, `speech` to the `PACKAGES` array (new "Runtime plugins" section, reactivity before components per dep order).
- Add `core` + `reactivity` to the upfront `ensure-fresh` list. `pretest` hooks don't fire for the `:check` variant, so `test-check-all` must ensure workspace-dep `dist/` freshness itself — otherwise these tests hit the same stale-dist failure mode just fixed for components in #221. `core` is listed before `reactivity` since reactivity's build consumes core's `dist`.

## Verification

- `bash -n scripts/test-check-all.sh` — clean
- `npm run test:check` per package: reactivity **44 passed**, components **58 passed**, speech **17 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)