### PR TITLE
fix(parser): skip semantic parsing for the toggle command

### DIFF
--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -3065,6 +3065,9 @@ export class Parser {
     //     `at start/end of`, `before`, `after`, `into`)
     //   - increment / decrement: `by N` quantity (no semantic role marker)
     //   - add: CSS object-literal syntax
+    //   - toggle: `.class` / `@attr` / `*property` argument references —
+    //     semantic parsing drops the prefix, so `toggle @disabled` loses the
+    //     attribute reference (sibling of add / remove, which are also here)
     //   - if / unless: condition role + multi-branch bodies
     //   - make / measure / trigger / halt / remove / exit / return / closest:
     //     each carries hyperscript-specific shape that semantic doesn't capture
@@ -3086,6 +3089,7 @@ export class Parser {
       'increment',
       'decrement',
       'add',
+      'toggle',
       'if',
       'unless',
       'make',

--- a/packages/core/src/parser/toggle-skip-semantic.test.ts
+++ b/packages/core/src/parser/toggle-skip-semantic.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression test: `toggle` with @attribute / .class / *property arguments
+ *
+ * Fix: Added 'toggle' to the parser's skipSemanticParsing list, alongside its
+ * sibling DOM commands 'add' and 'remove'.
+ *
+ * With the semantic analyzer active — which is the default in eval-hyperscript,
+ * and therefore for every `_=` attribute at runtime — `toggle @disabled` was
+ * routed through semantic parsing. Semantic parsing drops the `@` prefix from
+ * the argument, so ToggleCommand.parseInput never saw the attribute reference
+ * and threw "toggle command: no valid class names found". The traditional
+ * parser emits an `attributeAccess` node that ToggleCommand handles correctly.
+ *
+ * These tests parse WITH a semantic analyzer attached (mirroring the runtime
+ * path) and assert `toggle` still reaches the traditional parser.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse } from './parser';
+import { createSemanticAdapter } from './semantic-integration';
+import { parseSemantic, isLanguageRegistered, getRegisteredLanguages } from '@lokascript/semantic';
+
+// Mirror eval-hyperscript.ts's getSemanticAnalyzer(): the semantic analyzer is
+// present for every runtime parse, so the regression only reproduces with it.
+const semanticAnalyzer = createSemanticAdapter({
+  parse: parseSemantic,
+  isRegistered: isLanguageRegistered,
+  registered: getRegisteredLanguages,
+});
+
+function parseWithSemantic(src: string) {
+  return parse(src, { semanticAnalyzer, language: 'en' } as Parameters<typeof parse>[1]);
+}
+
+/** Depth-first search for the first `toggle` command node in a parse result. */
+function findToggle(root: unknown): Record<string, unknown> | null {
+  let found: Record<string, unknown> | null = null;
+  const walk = (n: unknown): void => {
+    if (found || !n || typeof n !== 'object') return;
+    if (Array.isArray(n)) return n.forEach(walk);
+    const node = n as Record<string, unknown>;
+    if (node.type === 'command' && node.name === 'toggle') {
+      found = node;
+      return;
+    }
+    Object.values(node).forEach(walk);
+  };
+  walk(root);
+  return found;
+}
+
+describe('toggle skips the semantic parser (regression)', () => {
+  it('toggle @disabled keeps the attributeAccess node', () => {
+    const result = parseWithSemantic('on click toggle @disabled on #target');
+    expect(result.success).toBe(true);
+
+    const toggle = findToggle(result);
+    expect(toggle).not.toBeNull();
+    const firstArg = (toggle!.args as Record<string, unknown>[])[0];
+    // Traditional-parser output. Semantic parsing would drop the `@` prefix.
+    expect(firstArg.type).toBe('attributeAccess');
+    expect(firstArg.attributeName).toBe('disabled');
+  });
+
+  it('toggle @required keeps the attributeAccess node', () => {
+    const result = parseWithSemantic('on click toggle @required on #email');
+    expect(result.success).toBe(true);
+
+    const toggle = findToggle(result);
+    expect(toggle).not.toBeNull();
+    const firstArg = (toggle!.args as Record<string, unknown>[])[0];
+    expect(firstArg.type).toBe('attributeAccess');
+    expect(firstArg.attributeName).toBe('required');
+  });
+
+  it('toggle .class still parses with the semantic analyzer present', () => {
+    const result = parseWithSemantic('on click toggle .active on #box');
+    expect(result.success).toBe(true);
+    expect(findToggle(result)).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

`toggle @disabled` (and `@required`, etc.) throws **`toggle command: no valid class names found`** in the browser — e.g. on `hyperfixi.org/examples/toggle-and-state/toggle-attributes.html`, Demos 1 & 2 do nothing. `toggle .class` and `toggle *property` work fine.

## Root cause

The `_=` runtime always attaches a semantic analyzer (`eval-hyperscript.ts`, `language` defaulting to `'en'`), so every command is offered to the semantic parser first. For `toggle @disabled`, semantic parsing **strips the `@` prefix** and emits a bare `identifier` node instead of `attributeAccess` — so `ToggleCommand.parseInput` never sees the attribute reference, falls through to the class branch, and throws.

`toggle`'s sibling DOM commands `add` and `remove` — same `.class` / `@attr` / `*property` argument grammar — are already on the parser's `skipSemanticParsing` list. `toggle` was a missed entry.

## Fix

Add `'toggle'` to `skipSemanticParsing` (one line + a comment). `toggle` then uses the traditional parser, which emits the `attributeAccess` node `ToggleCommand` already handles correctly.

## Verification

- Dev-bundle browser test — all four forms work: `toggle @disabled` ✓, `@required` ✓, `.active` ✓, `*display` ✓, no console errors.
- New regression test `toggle-skip-semantic.test.ts` parses **with a semantic analyzer attached** (mirroring the runtime path); it fails without this change (`expected 'identifier' to be 'attributeAccess'`) and passes with it.
- 1512 tests pass across the parser + DOM-command suites. The one failure (`"first of" positional expressions`) is pre-existing on `main`, unrelated.

## Notes

- Multilingual `toggle` now relies on the traditional parser + keyword resolution — the same tradeoff already accepted for `add`/`remove`.
- Ships in a `@hyperfixi/core` 2.4.1 patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
