### PR TITLE
fix(build): repoint npm run build off lerna (lerna 9 + minimatch override conflict)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "apps/*"
   ],
   "scripts": {
-    "build": "lerna run build",
+    "build": "npm run build:workspaces",
     "build:workspaces": "npm run build --workspaces --if-present",
     "build:packages": "npm run build --workspace=packages/* --if-present",
     "test": "npm run test --workspaces",


### PR DESCRIPTION
## Problem

`npm run build` (= `lerna run build`) crashes on `main`:

```
lerna ERR! TypeError: (0 , import_minimatch2.default) is not a function
    at matchesRootPath (node_modules/lerna/dist/index.js:3221)
```

## Root cause

lerna 9.0.7 (the latest) has an internal split-brain minimatch need:

- lerna's own bundled code does `import minimatch from 'minimatch'` (default
  import) — needs minimatch **≤8** (callable default export).
- lerna's bundled `nx` engine does `import { minimatch }` (named import) —
  needs minimatch **≥9**.

Normally npm gives lerna-core and nx separate minimatch copies and it works.
But the repo's `overrides` has `"minimatch": "^10.2.3"` — a **required
Dependabot security fix** (commit `e3cd6eeb`, "resolve 27 of 33 Dependabot
security vulnerabilities") — which forces `^10` onto lerna's own code, breaking
it. npm's nested overrides can't re-split lerna-core and nx onto different
minimatch majors (they collapse to one copy; npm flags it `invalid`), and the
security override can't be removed.

So lerna 9.0.7 cannot run the build under the (required) override.

## Fix

Repoint `build` to the existing `build:workspaces` script:

```diff
-    "build": "lerna run build",
+    "build": "npm run build:workspaces",
```

`build:workspaces` (`npm run build --workspaces --if-present`) already exists
and is the exact build path `scripts/rebuild-all.sh` uses — so this is a
proven path, not a new one. CI and `publish.yml` build per-package in explicit
order and never used `lerna` — they're unaffected.

`lerna` is left installed but now unused; removing it (and `lerna.json`) is a
reasonable separate cleanup.

## Verification

`npm run build` — full workspace build of all packages + apps — **exits 0**,
no errors. (It crashed before this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
