### PR TITLE
fix(core): resolve 5 runtime bugs found by new example Playwright tests

### DIFF
--- a/packages/core/src/commands/dom/toggle.ts
+++ b/packages/core/src/commands/dom/toggle.ts
@@ -89,6 +89,18 @@ export type ToggleCommandInput =
       untilEvent?: string;
     };
 
+/** True when an arg is `<target> as modal` (asExpression with a `modal` target). */
+function isModalAsExpression(arg: ASTNode | undefined): boolean {
+  if (!arg || (arg as Record<string, unknown>).type !== 'asExpression') return false;
+  const targetType = (arg as Record<string, unknown>).targetType;
+  // targetType is dual-shape: an identifier node { name } or a bare string.
+  const name =
+    typeof targetType === 'string'
+      ? targetType
+      : ((targetType as Record<string, unknown>)?.name as string | undefined);
+  return typeof name === 'string' && name.toLowerCase() === 'modal';
+}
+
 /** Parse modal mode from args and modifiers */
 async function parseModalMode(
   args: ASTNode[],
@@ -191,6 +203,16 @@ export class ToggleCommand implements DecoratedCommand {
     context: ExecutionContext
   ): Promise<ToggleCommandInput> {
     if (!raw.args?.length) throw new Error('toggle command requires an argument');
+
+    // `toggle <dialog> as modal`: the `as modal` conversion parses into an
+    // asExpression whose targetType is `modal`. Unwrap to the real target and
+    // force modal mode — `modal` is not a real type conversion.
+    let forceModal = false;
+    if (isModalAsExpression(raw.args[0])) {
+      forceModal = true;
+      const inner = (raw.args[0] as Record<string, unknown>).expression as ASTNode;
+      raw = { ...raw, args: [inner, ...raw.args.slice(1)] };
+    }
 
     const firstArg = raw.args[0];
 
@@ -375,7 +397,9 @@ export class ToggleCommand implements DecoratedCommand {
 
         const smartType = detectSmartElementType(elements);
         if (smartType === 'dialog') {
-          const mode = await parseModalMode(raw.args, raw.modifiers, evaluator, context);
+          const mode = forceModal
+            ? 'modal'
+            : await parseModalMode(raw.args, raw.modifiers, evaluator, context);
           return { type: 'dialog', mode, targets: elements as HTMLDialogElement[] };
         }
         if (smartType === 'details') {

--- a/packages/core/src/compatibility/browser-bundle.ts
+++ b/packages/core/src/compatibility/browser-bundle.ts
@@ -52,6 +52,16 @@ import type { LokaScriptRegistry, LokaScriptPlugin } from '../registry';
 import { registerFetchResponseType } from '../commands/async/fetch';
 import { installPlugin } from '../runtime/plugin';
 import { getParserExtensionRegistry } from '../parser/extensions';
+import {
+  validatePartialContent,
+  configurePartialValidation,
+  getPartialValidationConfig,
+  resetPartialValidationConfig,
+} from '../validation/partial-validator';
+import {
+  emitPartialValidationWarnings,
+  formatResultSummary,
+} from '../validation/partial-warning-formatter';
 
 // Import CompileResult type for browser bundle
 import type { CompileResult, NewCompileOptions } from '../api/hyperscript-api';
@@ -119,6 +129,13 @@ interface HyperFixiBrowserAPI {
     node: import('@lokascript/framework').SemanticNode,
     element?: Element
   ): Promise<unknown>;
+  // Partial template validation (development-time)
+  validatePartialContent: typeof validatePartialContent;
+  configurePartialValidation: typeof configurePartialValidation;
+  getPartialValidationConfig: typeof getPartialValidationConfig;
+  resetPartialValidationConfig: typeof resetPartialValidationConfig;
+  emitPartialValidationWarnings: typeof emitPartialValidationWarnings;
+  formatResultSummary: typeof formatResultSummary;
 }
 
 // Export to global scope for browser testing
@@ -274,6 +291,14 @@ const hyperfixiAPI = {
   // LSE SemanticNode execution — delegates to hyperscript API
   // Used by the <lse-intent> custom element via window.hyperfixi.evalLSENode()
   evalLSENode: hyperscript.evalLSENode.bind(hyperscript),
+
+  // Partial template validation (development-time)
+  validatePartialContent,
+  configurePartialValidation,
+  getPartialValidationConfig,
+  resetPartialValidationConfig,
+  emitPartialValidationWarnings,
+  formatResultSummary,
 
   // Version info
   version: '2.0.0-full',

--- a/packages/core/src/compatibility/browser-tests/gallery-extra-interactions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/gallery-extra-interactions.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * Coverage for gallery example pages that had no Playwright spec:
+ *   - dialogs/smart-element-toggle.html   (smart toggle of dialog/details/summary/select)
+ *   - fetch-and-async/infinite-scroll.html (scroll-driven dynamic append)
+ *   - forms/partial-validation.html        (validatePartialContent API + swap)
+ *   - swap-and-morph/morph-comparison.html (morph vs innerHTML state preservation)
+ *   - animation/color-cycling-debug.html   (transition template-literal interpolation)
+ *
+ * These specs assert precise DOM outcomes (exact values, counts, classes, JS
+ * properties) and fail on any uncaught page error. The intent is to surface
+ * real runtime/parser/command bugs — not to be pass-friendly.
+ */
+import { test, expect, type Page } from '@playwright/test';
+import { waitForHyperfixi, createErrorCollector } from './test-utils';
+
+const BASE_URL = process.env.BASE_URL ?? 'http://127.0.0.1:3000';
+
+async function load(page: Page, path: string): Promise<void> {
+  await page.goto(`${BASE_URL}${path}`, { waitUntil: 'domcontentloaded', timeout: 10000 });
+  await waitForHyperfixi(page);
+  await page.waitForTimeout(100); // attribute-processor scan settle
+}
+
+test.describe('smart-element-toggle.html @comprehensive', () => {
+  test('toggles native <dialog> non-modal vs modal', async ({ page }) => {
+    const errors = createErrorCollector(page);
+    errors.attach();
+    await load(page, '/examples/dialogs/smart-element-toggle.html');
+
+    const info = page.locator('#infoDialog');
+    const alert = page.locator('#alertDialog');
+    await expect(info).toHaveJSProperty('open', false);
+
+    await page.getByRole('button', { name: 'Open Non-Modal Dialog' }).click();
+    await expect(info).toHaveJSProperty('open', true);
+    // Non-modal: opened via show(), so it must NOT match :modal.
+    expect(await info.evaluate((d: HTMLDialogElement) => d.matches(':modal'))).toBe(false);
+    // Close via the in-dialog close button.
+    await info.getByRole('button', { name: 'Close' }).click();
+    await expect(info).toHaveJSProperty('open', false);
+
+    await page.getByRole('button', { name: 'Open Modal Dialog' }).click();
+    await expect(alert).toHaveJSProperty('open', true);
+    // `toggle #alertDialog modal` must open it modally (showModal), so it matches :modal.
+    expect(await alert.evaluate((d: HTMLDialogElement) => d.matches(':modal'))).toBe(true);
+
+    expect(errors.getCriticalErrors()).toEqual([]);
+  });
+
+  test('toggles <details> accordion open/closed', async ({ page }) => {
+    await load(page, '/examples/dialogs/smart-element-toggle.html');
+    const faq1 = page.locator('#faq1');
+    await expect(faq1).toHaveJSProperty('open', false);
+
+    await page.getByRole('button', { name: 'Toggle FAQ 1' }).click();
+    await expect(faq1).toHaveJSProperty('open', true);
+
+    await page.getByRole('button', { name: 'Toggle FAQ 1' }).click();
+    await expect(faq1).toHaveJSProperty('open', false);
+  });
+
+  test('toggling a <summary> opens its parent <details>', async ({ page }) => {
+    await load(page, '/examples/dialogs/smart-element-toggle.html');
+    const details = page.locator('#detailsDemo');
+    await expect(details).toHaveJSProperty('open', false);
+
+    await page.getByRole('button', { name: 'Toggle via Summary Element' }).click();
+    await expect(details).toHaveJSProperty('open', true);
+  });
+});
+
+test.describe('infinite-scroll.html @comprehensive', () => {
+  test('scrolling fires the on-scroll handler (updates position, shows loader)', async ({
+    page,
+  }) => {
+    await load(page, '/examples/fetch-and-async/infinite-scroll.html');
+
+    await expect(page.locator('#content-list .content-item')).toHaveCount(10);
+    await expect(page.locator('#scroll-position')).toHaveText('0%');
+
+    // Drive the scroll handler: jump to the bottom and fire a scroll event.
+    await page.locator('.scroll-container').evaluate(el => {
+      el.scrollTop = el.scrollHeight;
+      el.dispatchEvent(new Event('scroll'));
+    });
+
+    // The `on scroll` handler runs: it updates the scroll-position readout, then
+    // (near the bottom) flips the loading indicator on. Previously the whole
+    // handler silently failed to install because the `make a <li>…</li>` literal
+    // mis-lexed and corrupted the parse — fixed by the open/close-tag tokenizer.
+    await expect(page.locator('#scroll-position')).not.toHaveText('0%');
+    await expect(page.locator('#loading')).toHaveClass(/active/, { timeout: 1500 });
+
+    // KNOWN GAP (not asserted): items do not actually append. The handler's
+    // `make a <li …>…</li> called newItem` uses `make`'s element-literal syntax,
+    // which is broken upstream of this fix — the parser files the literal under
+    // modifiers.a with its </> stripped/mangled and make.parseInput sees an empty
+    // args[0], so make throws mid-loop. Item-append coverage is out of scope until
+    // `make <element-literal>` is reworked.
+  });
+});
+
+test.describe('partial-validation.html @comprehensive', () => {
+  test('validatePartialContent flags a full-page swap as critical', async ({ page }) => {
+    await load(page, '/examples/forms/partial-validation.html');
+
+    // The partial-validation API must be exposed on the runtime global.
+    expect(
+      await page.evaluate(() => typeof (window as any).hyperfixi?.validatePartialContent)
+    ).toBe('function');
+
+    await page.getByRole('button', { name: /Full Page/ }).click();
+
+    // A critical-severity entry must appear in the log...
+    await expect(page.locator('#validation-log .log-critical').first()).toBeVisible();
+    // ...and the swap is non-blocking, so the target receives the content.
+    await expect(page.locator('#swap-target')).toContainText('This is a full page!');
+  });
+
+  test('valid partial content reports no issues', async ({ page }) => {
+    await load(page, '/examples/forms/partial-validation.html');
+
+    await page.getByRole('button', { name: 'Swap Valid Content' }).click();
+    await expect(page.locator('#validation-log')).toContainText('No issues found');
+    await expect(page.locator('#swap-target')).toContainText('Valid Partial Content');
+  });
+});
+
+test.describe('morph-comparison.html @comprehensive', () => {
+  test('morph preserves edited form state; innerHTML destroys it', async ({ page }) => {
+    const errors = createErrorCollector(page);
+    errors.attach();
+    await load(page, '/examples/swap-and-morph/morph-comparison.html');
+
+    // --- Morph panel: edit then morph -> live value is preserved ---
+    const morphName = page.locator('#morph-name');
+    await morphName.fill('Jane Smith');
+    await page.locator('.morph-panel:has(#morph-form-container) button').click();
+    await expect(page.locator('#morph-form-timestamp')).toContainText('Updated:');
+    // Idiomorph keeps the existing input element, so the typed value survives
+    // even though the morph source HTML still says value="John Doe".
+    await expect(morphName).toHaveValue('Jane Smith');
+
+    // --- innerHTML panel: edit then innerHTML-swap -> value resets ---
+    const innerName = page.locator('#innerHTML-name');
+    await innerName.fill('Jane Smith');
+    await page.locator('#innerHTML-form-btn').click();
+    await expect(page.locator('#innerHTML-form-timestamp')).toContainText('Updated:');
+    await expect(innerName).toHaveValue('John Doe');
+
+    expect(errors.getCriticalErrors()).toEqual([]);
+  });
+});
+
+test.describe('color-cycling-debug.html @comprehensive', () => {
+  test('press-and-hold interpolates $rand into a real hsl() color', async ({ page }) => {
+    const errors = createErrorCollector(page);
+    errors.attach();
+    await load(page, '/examples/animation/color-cycling-debug.html');
+
+    const box = page.locator('#color-box');
+    const bb = await box.boundingBox();
+    expect(bb).not.toBeNull();
+    await page.mouse.move(bb!.x + bb!.width / 2, bb!.y + bb!.height / 2);
+    await page.mouse.down();
+    await page.waitForTimeout(600); // > 2 transitions @ 250ms
+    const cyclingBg = await box.evaluate(el => (el as HTMLElement).style.backgroundColor);
+    await page.mouse.up();
+
+    // The transition target was `hsl($rand 100% 90%)`. If interpolation worked
+    // the inline style is a concrete hsl()/rgb() color; if it broke, the literal
+    // "$rand" would leak through (the page's own MutationObserver flags this).
+    expect(cyclingBg).toMatch(/hsl|rgb/);
+    expect(cyclingBg).not.toContain('$rand');
+
+    const log = (await page.locator('#log').textContent()) ?? '';
+    expect(log).toContain('pointerdown event fired');
+    expect(log).not.toContain('$rand was NOT interpolated');
+    expect(log).not.toContain('UNCAUGHT');
+
+    expect(errors.getCriticalErrors()).toEqual([]);
+  });
+});

--- a/packages/core/src/compatibility/browser-tests/gallery-interactions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/gallery-interactions.spec.ts
@@ -206,6 +206,11 @@ test.describe('Intermediate @gallery @interaction', () => {
     const text = await page.locator('#user-data').textContent();
     expect(text).toBeTruthy();
     expect(text!.length).toBeGreaterThan(10);
+    // The card interpolates ${userData.name}, ${userData.email}, etc. via
+    // template literals — assert the fields actually resolved (no "undefined"
+    // leaking through) and the rendered structure is present.
+    expect(text).not.toContain('undefined');
+    expect(text).toContain('📧');
 
     expectNoCriticalErrors(collector);
   });

--- a/packages/core/src/compatibility/browser-tests/gallery-regression.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/gallery-regression.spec.ts
@@ -191,14 +191,19 @@ test.describe('Gallery Example Regression Tests @comprehensive', () => {
       // Get the color box and interact with it
       const colorBox = page.locator('#color-box');
       const box = await colorBox.boundingBox();
+      expect(box).toBeTruthy();
 
-      if (box) {
-        // Move to element and simulate mouse press/hold/release
-        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-        await page.mouse.down();
-        await page.waitForTimeout(1000); // Hold for a bit
-        await page.mouse.up();
-      }
+      const initialBg = await colorBox.evaluate(el => window.getComputedStyle(el).backgroundColor);
+
+      // Move to element and simulate mouse press/hold/release
+      await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+      await page.mouse.down();
+      await page.waitForTimeout(1000); // Hold for a bit
+      // The demo reads `my *background-color` (computed-style access). If that
+      // syntax works the color cycles; assert it actually changed mid-hold.
+      const cyclingBg = await colorBox.evaluate(el => window.getComputedStyle(el).backgroundColor);
+      expect(cyclingBg).not.toBe(initialBg);
+      await page.mouse.up();
 
       await page.waitForTimeout(500);
 

--- a/packages/core/src/compatibility/browser-tests/landing-page-examples.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/landing-page-examples.spec.ts
@@ -97,6 +97,11 @@ test.describe('Landing Page Examples @comprehensive', () => {
           el => window.getComputedStyle(el).backgroundColor
         );
 
+        // The whole point of the demo: holding cycles the background color, so
+        // the sampled color MUST differ from the initial. Without this the test
+        // passes even if cycling is completely broken.
+        expect(cyclingBg).not.toBe(initialBg);
+
         // Release
         await page.mouse.up();
         await page.waitForTimeout(100);
@@ -143,6 +148,10 @@ test.describe('Landing Page Examples @comprehensive', () => {
           el => window.getComputedStyle(el).backgroundColor
         );
 
+        // Color must have changed during the hold and be a real rgb/hsl color.
+        expect(cyclingBg).not.toBe(initialBg);
+        expect(cyclingBg).toMatch(/^rgb/);
+
         await page.mouse.up();
         await page.waitForTimeout(300);
 
@@ -177,6 +186,9 @@ test.describe('Landing Page Examples @comprehensive', () => {
         await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
         await page.mouse.down();
         await page.waitForTimeout(600);
+        // Sample mid-hold to confirm cycling actually happened before release.
+        const duringBg = await colorBox.evaluate(el => window.getComputedStyle(el).backgroundColor);
+        expect(duringBg).not.toBe(initialBg);
         await page.mouse.up();
 
         // Wait for final transition to complete
@@ -185,9 +197,11 @@ test.describe('Landing Page Examples @comprehensive', () => {
         // Color should be restored (note: 'initial' resolves to computed value)
         const finalBg = await colorBox.evaluate(el => window.getComputedStyle(el).backgroundColor);
 
-        // The final background should be either the initial value or close to it
-        // Since 'initial' is CSS keyword, it should restore to transparent or the element default
-        expect(finalBg).toBeTruthy();
+        // After release the demo runs `transition *background-color to initial`,
+        // so the final color must be a concrete rgb/rgba value and must no longer
+        // match the mid-hold cycling color.
+        expect(finalBg).toMatch(/^rgba?\(/);
+        expect(finalBg).not.toBe(duringBg);
       }
     });
 
@@ -915,7 +929,8 @@ test.describe('Landing Page Examples @comprehensive', () => {
       // Read clipboard
       const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
 
-      // Should contain the script tag
+      // The demo copies `my previous.innerText` (the install <code> snippet), so
+      // the clipboard must contain the script tag — not the string "undefined".
       expect(clipboardText).toContain('unpkg.com/hyperscript.org');
     });
   });

--- a/packages/core/src/compatibility/browser-tests/multilingual-demos.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/multilingual-demos.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Coverage for the multilingual feature-demo pages and the gallery hub that
+ * had no Playwright spec:
+ *   - multilingual/multilingual-sync.html  (shared counter/toggle, local hyperscript)
+ *   - multilingual/adaptive-rtl-ltr.html    (counter/toggle + RTL/LTR language switch)
+ *   - multilingual/dynamic-injection.html   (snippet selection; injection via CDN)
+ *   - index.html                            (gallery hub navigation)
+ *
+ * The i18n translate paths on these pages come from the unpkg CDN, so the
+ * strict assertions target only the locally-served runtime behavior. Page
+ * errors are captured; net:: (CDN) failures are filtered by createErrorCollector.
+ */
+import { test, expect, type Page } from '@playwright/test';
+import { waitForHyperfixi, createErrorCollector } from './test-utils';
+
+const BASE_URL = process.env.BASE_URL ?? 'http://127.0.0.1:3000';
+
+async function load(page: Page, path: string): Promise<void> {
+  await page.goto(`${BASE_URL}${path}`, { waitUntil: 'domcontentloaded', timeout: 15000 });
+  await waitForHyperfixi(page);
+  await page.waitForTimeout(150);
+}
+
+async function readInt(page: Page, selector: string): Promise<number> {
+  return parseInt((await page.locator(selector).textContent()) ?? '0', 10);
+}
+
+test.describe('multilingual/multilingual-sync.html @comprehensive', () => {
+  test('shared counter increments/decrements and box toggles', async ({ page }) => {
+    const errors = createErrorCollector(page);
+    errors.attach();
+    await load(page, '/examples/multilingual/multilingual-sync.html');
+
+    const start = await readInt(page, '#shared-count');
+    await page.locator('.shared-btn.inc').click();
+    await expect(page.locator('#shared-count')).toHaveText(String(start + 1));
+    await page.locator('.shared-btn.dec').click();
+    await expect(page.locator('#shared-count')).toHaveText(String(start));
+
+    const box = page.locator('#shared-box');
+    await expect(box).not.toHaveClass(/active/);
+    await box.click();
+    await expect(box).toHaveClass(/active/);
+
+    expect(errors.getCriticalErrors()).toEqual([]);
+  });
+});
+
+test.describe('multilingual/adaptive-rtl-ltr.html @comprehensive', () => {
+  test('local counter + toggle work', async ({ page }) => {
+    const errors = createErrorCollector(page);
+    errors.attach();
+    await load(page, '/examples/multilingual/adaptive-rtl-ltr.html');
+
+    const start = await readInt(page, '#counter');
+    await page.locator('.counter-btn.inc').click();
+    await expect(page.locator('#counter')).toHaveText(String(start + 1));
+    await page.locator('.counter-btn.dec').click();
+    await expect(page.locator('#counter')).toHaveText(String(start));
+
+    const box = page.locator('#toggle-box');
+    await box.click();
+    await expect(box).toHaveClass(/active/);
+
+    expect(errors.getCriticalErrors()).toEqual([]);
+  });
+
+  test('switching to an RTL language applies rtl direction and active state', async ({ page }) => {
+    await load(page, '/examples/multilingual/adaptive-rtl-ltr.html');
+
+    // English is the initial active button; #code-content is LTR.
+    await expect(page.locator('.lang-btn[data-lang="en"]')).toHaveClass(/active/);
+    await expect(page.locator('#code-content')).not.toHaveClass(/rtl/);
+
+    await page.locator('.lang-btn[data-lang="ar"]').click();
+    await expect(page.locator('.lang-btn[data-lang="ar"]')).toHaveClass(/active/);
+    await expect(page.locator('.lang-btn[data-lang="en"]')).not.toHaveClass(/active/);
+    await expect(page.locator('#code-content')).toHaveClass(/rtl/);
+  });
+});
+
+test.describe('multilingual/dynamic-injection.html @comprehensive', () => {
+  test('snippet cards render and selection updates the active card', async ({ page }) => {
+    const errors = createErrorCollector(page);
+    errors.attach();
+    await load(page, '/examples/multilingual/dynamic-injection.html');
+
+    const cards = page.locator('#snippets .snippet-card');
+    await expect(cards.first()).toBeVisible();
+    const count = await cards.count();
+    expect(count).toBeGreaterThan(1);
+
+    // Selecting the second card makes it the active one.
+    await cards.nth(1).click();
+    await expect(cards.nth(1)).toHaveClass(/active/);
+
+    expect(errors.getCriticalErrors()).toEqual([]);
+  });
+});
+
+test.describe('index.html — gallery hub @comprehensive', () => {
+  test('hub lists example links and navigates to one', async ({ page }) => {
+    const errors = createErrorCollector(page);
+    errors.attach();
+    await page.goto(`${BASE_URL}/examples/index.html`, { waitUntil: 'domcontentloaded' });
+
+    // The hub should link to the example pages.
+    const links = page.locator('a[href$=".html"]');
+    expect(await links.count()).toBeGreaterThan(15);
+    await expect(page.locator('a[href="forms/partial-validation.html"]')).toHaveCount(1);
+
+    // Following a link reaches a real example page.
+    await page.locator('a[href="toggle-and-state/toggle-class.html"]').first().click();
+    await expect(page).toHaveURL(/toggle-and-state\/toggle-class\.html$/);
+
+    expect(errors.getCriticalErrors()).toEqual([]);
+  });
+});

--- a/packages/core/src/compatibility/browser-tests/playground-pages.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/playground-pages.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * Coverage for the interactive multilingual / showcase example pages that had
+ * no Playwright spec:
+ *   - multilingual/showcase.html            (counter/toggle/mirror/tabs, local core + semantic)
+ *   - multilingual/test-minimal.html        (hyperfixi.execute on classic-i18n bundle)
+ *   - multilingual/polyglot-playground.html (local inc/dec/toggle demo)
+ *   - multilingual/playground.html          (local demo mirror; i18n via unpkg CDN)
+ *
+ * Strict assertions exercise the runtime/parser/i18n surfaces to surface bugs.
+ * Tests target locally-served bundles and avoid the unpkg CDN. (The
+ * examples/playground/* pages are intentionally excluded from the repo via
+ * .gitignore, so they are not covered here.)
+ */
+import { test, expect, type Page } from '@playwright/test';
+import { waitForHyperfixi, createErrorCollector } from './test-utils';
+
+const BASE_URL = process.env.BASE_URL ?? 'http://127.0.0.1:3000';
+
+async function load(page: Page, path: string): Promise<void> {
+  await page.goto(`${BASE_URL}${path}`, { waitUntil: 'domcontentloaded', timeout: 15000 });
+  await waitForHyperfixi(page);
+  await page.waitForTimeout(150);
+}
+
+test.describe('multilingual/showcase.html @comprehensive', () => {
+  test('counter increment/decrement/reset', async ({ page }) => {
+    const errors = createErrorCollector(page);
+    errors.attach();
+    await load(page, '/examples/multilingual/showcase.html');
+
+    const value = page.locator('#counter-value');
+    await expect(value).toHaveText('0');
+    await page.locator('#counter-demo-increment').click();
+    await expect(value).toHaveText('1');
+    await page.locator('#counter-demo-increment').click();
+    await expect(value).toHaveText('2');
+    await page.locator('#counter-demo-decrement').click();
+    await expect(value).toHaveText('1');
+    await page.locator('#counter-demo-reset').click();
+    await expect(value).toHaveText('0');
+
+    expect(errors.getCriticalErrors()).toEqual([]);
+  });
+
+  test('toggle .active on me', async ({ page }) => {
+    await load(page, '/examples/multilingual/showcase.html');
+    const btn = page.locator('#toggle-demo-toggle');
+    await expect(btn).not.toHaveClass(/active/);
+    await btn.click();
+    await expect(btn).toHaveClass(/active/);
+    await btn.click();
+    await expect(btn).not.toHaveClass(/active/);
+  });
+
+  test('input mirror via on input put my value into #mirror-output', async ({ page }) => {
+    await load(page, '/examples/multilingual/showcase.html');
+    await page.locator('#mirror-demo-mirror').fill('mirrored text');
+    await expect(page.locator('#mirror-output')).toHaveText('mirrored text');
+  });
+
+  test('tabs: multi-command handler switches active tab and panel', async ({ page }) => {
+    await load(page, '/examples/multilingual/showcase.html');
+
+    await expect(page.locator('#tabs-demo-tab1')).toHaveClass(/active/);
+    await expect(page.locator('#panel1')).toBeVisible();
+    await expect(page.locator('#panel2')).toBeHidden();
+
+    await page.locator('#tabs-demo-tab2').click();
+    await expect(page.locator('#tabs-demo-tab2')).toHaveClass(/active/);
+    await expect(page.locator('#tabs-demo-tab1')).not.toHaveClass(/active/);
+    await expect(page.locator('#panel2')).toBeVisible();
+    await expect(page.locator('#panel1')).toBeHidden();
+
+    await page.locator('#tabs-demo-tab3').click();
+    await expect(page.locator('#panel3')).toBeVisible();
+    await expect(page.locator('#panel2')).toBeHidden();
+  });
+
+  test('LokaScriptSemantic.parseSemantic is exposed and returns a real confidence', async ({
+    page,
+  }) => {
+    // showcase.html loads packages/semantic/dist/browser.global.js, so the
+    // LokaScriptSemantic global must expose the recommended parseSemantic() entry
+    // with a populated confidence (the deprecated analyzer path is not bundled).
+    await load(page, '/examples/multilingual/showcase.html');
+    await page.waitForFunction(
+      () => typeof (window as any).LokaScriptSemantic?.parseSemantic === 'function',
+      { timeout: 5000 }
+    );
+    const result = await page.evaluate(() => {
+      const r = (window as any).LokaScriptSemantic.parseSemantic('on click toggle .active', 'en');
+      return { hasNode: !!r?.node, confidence: r?.confidence };
+    });
+    expect(result.hasNode).toBe(true);
+    expect(typeof result.confidence).toBe('number');
+    expect(result.confidence).toBeGreaterThan(0);
+  });
+});
+
+test.describe('multilingual/test-minimal.html @comprehensive', () => {
+  test('hyperfixi.execute writes into #result element', async ({ page }) => {
+    const consoleErrs: string[] = [];
+    page.on('console', m => {
+      if (m.type() === 'error') consoleErrs.push(m.text());
+    });
+    page.on('pageerror', e => consoleErrs.push(`PageError: ${e.message}`));
+
+    await load(page, '/examples/multilingual/test-minimal.html');
+    await expect(page.locator('#result')).toHaveText('not clicked');
+
+    await page.locator('#test-btn').click();
+    // execute('set #result to "clicked!"') should update the element text.
+    await expect(page.locator('#result')).toHaveText('clicked!', { timeout: 5000 });
+
+    expect(consoleErrs.filter(e => /Execute failed|Parse failed/.test(e))).toEqual([]);
+  });
+});
+
+test.describe('multilingual/polyglot-playground.html — local demo @comprehensive', () => {
+  test('increment/decrement buttons drive #count', async ({ page }) => {
+    await load(page, '/examples/multilingual/polyglot-playground.html');
+    const count = page.locator('#count');
+    const start = parseInt((await count.textContent()) ?? '0', 10);
+
+    await page.locator('.demo-btn.inc').click();
+    await expect(count).toHaveText(String(start + 1));
+    await page.locator('.demo-btn.inc').click();
+    await expect(count).toHaveText(String(start + 2));
+    await page.locator('.demo-btn.dec').click();
+    await expect(count).toHaveText(String(start + 1));
+  });
+
+  test('toggle-box toggles its own .active class', async ({ page }) => {
+    await load(page, '/examples/multilingual/polyglot-playground.html');
+    const box = page.locator('#toggle-box');
+    await expect(box).not.toHaveClass(/active/);
+    await box.click();
+    await expect(box).toHaveClass(/active/);
+  });
+});
+
+test.describe('multilingual/playground.html — local mirror @comprehensive', () => {
+  // i18n translate here comes from the unpkg CDN; this test only exercises the
+  // locally-served runtime (demo input mirror), so it stays deterministic offline.
+  test('demo input mirrors into #output', async ({ page }) => {
+    await load(page, '/examples/multilingual/playground.html');
+    await page.locator('#demo-input').fill('typed value');
+    await expect(page.locator('#output')).toHaveText('typed value');
+  });
+});

--- a/packages/core/src/expressions/property-access-utils.ts
+++ b/packages/core/src/expressions/property-access-utils.ts
@@ -172,6 +172,8 @@ const SPECIAL_DOM_PROPERTIES: Record<string, (element: Element) => unknown> = {
   lastchild: el => el.lastElementChild,
   nextsibling: el => el.nextElementSibling,
   previoussibling: el => el.previousElementSibling,
+  next: el => el.nextElementSibling,
+  previous: el => el.previousElementSibling,
   values: el => collectFormValues(el),
 };
 

--- a/packages/core/src/parser/command-parsers/dom-commands.ts
+++ b/packages/core/src/parser/command-parsers/dom-commands.ts
@@ -143,6 +143,14 @@ export function parseToggleCommand(ctx: ParserContext, identifierNode: Identifie
     }
   }
 
+  // Optional bare `modal` modifier for dialogs: `toggle #dialog modal`.
+  // ToggleCommand.parseModalMode reads args[1] === 'modal'. (The `as modal`
+  // form is handled in ToggleCommand.parseInput via the asExpression target.)
+  if (ctx.check('modal')) {
+    ctx.advance();
+    args.push({ type: 'literal', value: 'modal', raw: 'modal' } as unknown as ASTNode);
+  }
+
   return CommandNodeBuilder.fromIdentifier(identifierNode)
     .withArgs(...args)
     .endingAt(ctx.getPosition())

--- a/packages/core/src/parser/tokenizer.ts
+++ b/packages/core/src/parser/tokenizer.ts
@@ -561,6 +561,14 @@ function tokenizeCSSSelector(tokenizer: Tokenizer): void {
 
 function tokenizeQueryReference(tokenizer: Tokenizer): void {
   const start = tokenizer.position;
+
+  // Open/close element literal with children (<li ...>...</li>): scan with
+  // tag-depth balancing up to the matching close tag.
+  if (looksLikeElementLiteral(tokenizer)) {
+    tokenizeElementLiteral(tokenizer, start);
+    return;
+  }
+
   let value = '';
 
   // Consume opening '<'
@@ -578,6 +586,78 @@ function tokenizeQueryReference(tokenizer: Tokenizer): void {
       value += advance(tokenizer); // consume '>'
       break;
     }
+  }
+
+  addToken(tokenizer, TokenKind.SELECTOR, value, start);
+}
+
+/**
+ * Tokenize a full open/close HTML element literal as a single SELECTOR token,
+ * balancing nested tags (`<li><div>...</div></li>`) and self-closing children,
+ * and skipping `<`/`>` inside attribute quotes. Stops after the matching
+ * top-level close tag. The `make` command builds the element from this string.
+ */
+function tokenizeElementLiteral(tokenizer: Tokenizer, start: number): void {
+  const input = tokenizer.input;
+  let value = '';
+  let depth = 0;
+  let quote = '';
+
+  while (tokenizer.position < input.length) {
+    const ch = input[tokenizer.position];
+
+    if (quote) {
+      value += advance(tokenizer);
+      if (ch === quote) quote = '';
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      value += advance(tokenizer);
+      continue;
+    }
+
+    if (ch === '<') {
+      const next = input[tokenizer.position + 1];
+      if (next === '/') {
+        // Closing tag — consume through '>'.
+        while (tokenizer.position < input.length && input[tokenizer.position] !== '>') {
+          value += advance(tokenizer);
+        }
+        if (tokenizer.position < input.length) value += advance(tokenizer); // '>'
+        depth--;
+        if (depth <= 0) break;
+        continue;
+      }
+      // Opening tag — consume through '>', detecting a self-closing '/>'.
+      let selfClose = false;
+      let tagQuote = '';
+      while (tokenizer.position < input.length) {
+        const c2 = input[tokenizer.position];
+        if (tagQuote) {
+          value += advance(tokenizer);
+          if (c2 === tagQuote) tagQuote = '';
+          continue;
+        }
+        if (c2 === '"' || c2 === "'") {
+          tagQuote = c2;
+          value += advance(tokenizer);
+          continue;
+        }
+        if (c2 === '>') {
+          selfClose = input[tokenizer.position - 1] === '/';
+          value += advance(tokenizer); // '>'
+          break;
+        }
+        value += advance(tokenizer);
+      }
+      if (!selfClose) depth++;
+      if (depth <= 0) break; // self-closing root with no children
+      continue;
+    }
+
+    // Content character (text between tags).
+    value += advance(tokenizer);
   }
 
   addToken(tokenizer, TokenKind.SELECTOR, value, start);
@@ -1006,7 +1086,30 @@ function isAlphaNumeric(char: string): boolean {
   return /[a-zA-Z0-9]/.test(char);
 }
 
+/**
+ * Does `<` at the current position open an HTML element literal with children,
+ * e.g. `<li class='x'>...</li>`? True when `<` is immediately followed by a tag
+ * name and a matching `</tagname>` close tag exists ahead. Distinct from a
+ * comparison operator (`x < 10`, `a < b`), where `<` is followed by space/digit.
+ */
+function looksLikeElementLiteral(tokenizer: Tokenizer): boolean {
+  const input = tokenizer.input;
+  const afterLt = input[tokenizer.position + 1];
+  if (!afterLt || !/[a-zA-Z]/.test(afterLt)) return false;
+  let p = tokenizer.position + 1;
+  let tag = '';
+  while (p < input.length && /[a-zA-Z0-9-]/.test(input[p])) {
+    tag += input[p];
+    p++;
+  }
+  return tag.length > 0 && input.indexOf('</' + tag + '>', p) !== -1;
+}
+
 function looksLikeQueryReference(tokenizer: Tokenizer): boolean {
+  // Open/close element literal (<li ...>...</li>) — handled by the tag-balancing
+  // scanner in tokenizeQueryReference; recognize it before the self-closing scan.
+  if (looksLikeElementLiteral(tokenizer)) return true;
+
   // Look ahead to see if this pattern matches <.../>
   // A query reference should contain valid selector characters and end with />
   let pos = tokenizer.position + 1; // Start after <

--- a/packages/semantic/src/browser.ts
+++ b/packages/semantic/src/browser.ts
@@ -106,6 +106,11 @@ export {
 // Core parsing functions from the parser module
 export { parse, canParse } from './parser';
 
+// Recommended full-parser entry: returns { node, confidence, error }.
+// Exposed on the browser global so pages can read a real confidence score
+// (the deprecated createSemanticAnalyzer().analyze() path is not bundled here).
+export { parseWithConfidence as parseSemantic } from './utils/confidence-calculator';
+
 // Explicit mode parsing and utilities
 export { parseAny, parseExplicit, isExplicitSyntax } from './explicit';
 


### PR DESCRIPTION
## Summary

Adds Playwright coverage for previously-untested example pages and hardens shallow assertions in existing specs. The new tests surfaced **5 real runtime bugs**, all fixed here:

- **toggle modal** — `toggle #dialog modal` and `toggle #dialog as modal` now open modally. The parser dropped the modifier (bare `modal` discarded; `as modal` swallowed into an `asExpression`), so `parseModalMode` never received it. Fixed in `dom-commands.ts` (consume bare `modal`) + `toggle.ts` (unwrap the `as modal` `asExpression`).
- **on-scroll handler silently dead** — an open/close HTML literal like `make a <li>…</li>` mis-lexed (its `<` was treated as a comparison operator), corrupting the whole parse into a phantom `on page` handler so the element's handlers never installed. The tokenizer now lexes open/close element literals as a single token (`tokenizeElementLiteral`).
- **partial-validation API missing from the browser global** — `validatePartialContent` & co. were exported from `src/index.ts` but never attached to `window.hyperfixi`. Added in `browser-bundle.ts`.
- **semantic confidence unavailable in the browser** — exported the recommended `parseSemantic()` on the `LokaScriptSemantic` browser global (`semantic/src/browser.ts`).
- **`my previous.innerText` → `undefined`** — `previous`/`next` were missing from `SPECIAL_DOM_PROPERTIES`. Added.

### Tests
- New specs: `gallery-extra-interactions`, `multilingual-demos`, `playground-pages` (target only repo-tracked example pages; `examples/playground/*` and `examples/experiments/*` are gitignored and intentionally not covered).
- Hardened existing specs: `landing-page-examples` (color-cycling now asserts the color actually changes/restores), `gallery-regression` (`my *property` asserts cycling), `gallery-interactions` (fetch-data asserts no `undefined` leakage).

### Notes
- One layered issue is documented, not fixed: `make a <…element literal…> called X` is broken upstream of this change (the literal is filed under `modifiers.a` with `<`/`>` stripped; `make.parseInput` reads an empty `args[0]`). The tokenizer fix restores handler installation; full item-append support needs a separate `make <element-literal>` rework. Captured in a code comment in the infinite-scroll test.

## Test plan
- [x] `npm run test:check --prefix packages/core` (6200+ vitest) — pass
- [x] New + hardened example specs — green (`--project=full`)
- [x] Regression: full `browser-tests` suite vs baseline — **95 → 93** pre-existing failures (zero regressions; 2 pre-existing failures fixed)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)