### PR TITLE
fix(core): make `make <element-literal>` create elements end-to-end

### DIFF
--- a/packages/core/src/commands/dom/__tests__/make.test.ts
+++ b/packages/core/src/commands/dom/__tests__/make.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { MakeCommand } from '../make';
+import { evalHyperScript } from '../../../compatibility/eval-hyperscript';
 import type { ExecutionContext, TypedExecutionContext } from '../../../types/core';
 import type { ASTNode } from '../../../types/base-types';
 
@@ -228,6 +229,31 @@ describe('MakeCommand', () => {
       expect(el.classList.contains('bar')).toBe(true);
     });
 
+    it('should create element from open/close HTML literal with text', async () => {
+      const context = createMockContext();
+      const result = await command.execute(
+        { article: 'a' as const, expression: '<div>created element</div>' },
+        context
+      );
+
+      const el = result as HTMLElement;
+      expect(el.tagName).toBe('DIV');
+      expect(el.textContent).toBe('created element');
+    });
+
+    it('should create nested open/close element with attributes', async () => {
+      const context = createMockContext();
+      const result = await command.execute(
+        { article: 'a' as const, expression: "<li class='item'><span>1</span></li>" },
+        context
+      );
+
+      const el = result as HTMLElement;
+      expect(el.tagName).toBe('LI');
+      expect(el.classList.contains('item')).toBe(true);
+      expect(el.querySelector('span')?.textContent).toBe('1');
+    });
+
     it('should set context.it to created element', async () => {
       const context = createMockContext();
       const input = {
@@ -361,6 +387,41 @@ describe('MakeCommand', () => {
       expect(result).toBeInstanceOf(URL);
       expect((result as URL).pathname).toBe('/page');
       expect(context.it).toBe(result);
+    });
+  });
+
+  // These go through the REAL parser + runtime (evalHyperScript), which the
+  // unit tests above bypass. They guard the integration gap that previously
+  // left `make <element-literal>` broken end-to-end: the parser files the
+  // element under modifiers.a (not args[0]) and the literal must be created,
+  // not querySelector-ed.
+  describe('integration (parser → runtime)', () => {
+    it('creates a self-closing element with id + classes', async () => {
+      const el = (await evalHyperScript('make a <div#created.box.big/>')) as HTMLElement;
+      expect(el.tagName).toBe('DIV');
+      expect(el.id).toBe('created');
+      expect(el.classList.contains('box')).toBe(true);
+      expect(el.classList.contains('big')).toBe(true);
+    });
+
+    it('creates an open/close element with text content', async () => {
+      const el = (await evalHyperScript('make a <div>created element</div>')) as HTMLElement;
+      expect(el.tagName).toBe('DIV');
+      expect(el.textContent).toBe('created element');
+    });
+
+    it('binds the created element to `it` for a following command', async () => {
+      document.body.innerHTML = '<div id="make-out"></div>';
+      await evalHyperScript('make a <div>created element</div> then put it into #make-out');
+      expect(document.getElementById('make-out')?.textContent).toContain('created element');
+    });
+
+    it('binds the created element to a `called` variable', async () => {
+      document.body.innerHTML = '<div id="make-out2"></div>';
+      await evalHyperScript('make a <b#bold/> called madeEl then put madeEl into #make-out2');
+      const child = document.getElementById('make-out2')?.firstElementChild as HTMLElement | null;
+      expect(child?.tagName).toBe('B');
+      expect(child?.id).toBe('bold');
     });
   });
 });

--- a/packages/core/src/commands/dom/make.ts
+++ b/packages/core/src/commands/dom/make.ts
@@ -56,6 +56,23 @@ function createDOMElement(expr: string): HTMLElement {
   return element;
 }
 
+/**
+ * Create a DOM element from a full open/close HTML literal like
+ * `<li class='x'><span>1</span></li>` (with nested children), as opposed to the
+ * `<tag#id.class/>` self-closing shorthand handled by createDOMElement.
+ */
+function createElementFromHTML(html: string): HTMLElement {
+  const template = document.createElement('template');
+  template.innerHTML = html.trim();
+  const fromTemplate = template.content.firstElementChild;
+  if (fromTemplate && isHTMLElement(fromTemplate)) return fromTemplate;
+  // Fallback for environments where <template>.content is unavailable.
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = html.trim();
+  const child = wrapper.firstElementChild;
+  return child && isHTMLElement(child) ? child : wrapper;
+}
+
 /** Create class instance using constructor lookup */
 function createClassInstance(
   className: string | HTMLElement,
@@ -106,14 +123,16 @@ async function resolveVariableName(
   context: TypedExecutionContext
 ): Promise<string | undefined> {
   if (!calledMod) return undefined;
+  // `called <name>` parses the name as a symbol or a bare identifier; use the
+  // node's name directly rather than evaluating it (the name isn't a variable).
   if (
-    calledMod.type === 'symbol' &&
+    (calledMod.type === 'symbol' || calledMod.type === 'identifier') &&
     typeof (calledMod as Record<string, unknown>).name === 'string'
   ) {
     return (calledMod as Record<string, unknown>).name as string;
   }
   const value = await evaluator.evaluate(calledMod, context);
-  return typeof value === 'string' ? value : String(value);
+  return typeof value === 'string' ? value : undefined;
 }
 
 @meta({
@@ -135,9 +154,22 @@ export class MakeCommand implements DecoratedCommand {
     evaluator: ExpressionEvaluator,
     context: TypedExecutionContext
   ): Promise<MakeCommandInput> {
+    // `make a <…>` parses the element as the value of the article modifier
+    // (a/an), not a positional arg. Fall back to args[0] for direct callers.
+    const elementNode = raw.modifiers.an ?? raw.modifiers.a ?? raw.args[0];
+    if (!elementNode) {
+      throw new Error('Make command requires class name or DOM element expression');
+    }
+    // Element literals carry their full `<…>` markup on `node.raw`; use it
+    // directly so the element is created rather than querySelector-ed.
+    const rawLiteral = (elementNode as Record<string, unknown>).raw;
     const expression =
-      raw.args.length > 0 ? await evaluator.evaluate(raw.args[0], context) : undefined;
-    if (!expression) throw new Error('Make command requires class name or DOM element expression');
+      typeof rawLiteral === 'string' && rawLiteral.startsWith('<')
+        ? rawLiteral
+        : await evaluator.evaluate(elementNode, context);
+    if (expression === undefined || expression === null) {
+      throw new Error('Make command requires class name or DOM element expression');
+    }
 
     const article = raw.modifiers.an !== undefined ? 'an' : 'a';
     const constructorArgs = await resolveConstructorArgs(raw.modifiers.from, evaluator, context);
@@ -149,10 +181,13 @@ export class MakeCommand implements DecoratedCommand {
   async execute(input: MakeCommandInput, context: TypedExecutionContext): Promise<unknown> {
     const { expression, constructorArgs = [], variableName } = input;
 
+    const isLiteral = typeof expression === 'string' && expression.startsWith('<');
     const result =
-      typeof expression === 'string' && expression.startsWith('<') && expression.endsWith('/>')
-        ? createDOMElement(expression)
-        : createClassInstance(expression, constructorArgs, context);
+      isLiteral && (expression as string).endsWith('/>')
+        ? createDOMElement(expression as string)
+        : isLiteral && /<\/[a-zA-Z]/.test(expression as string)
+          ? createElementFromHTML(expression as string)
+          : createClassInstance(expression, constructorArgs, context);
 
     Object.assign(context, { it: result });
     if (variableName) setVariableValue(variableName, result, context);

--- a/packages/core/src/compatibility/browser-tests/gallery-extra-interactions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/gallery-extra-interactions.spec.ts
@@ -70,13 +70,12 @@ test.describe('smart-element-toggle.html @comprehensive', () => {
 });
 
 test.describe('infinite-scroll.html @comprehensive', () => {
-  test('scrolling fires the on-scroll handler (updates position, shows loader)', async ({
-    page,
-  }) => {
+  test('scrolling to the bottom appends more items', async ({ page }) => {
     await load(page, '/examples/fetch-and-async/infinite-scroll.html');
 
-    await expect(page.locator('#content-list .content-item')).toHaveCount(10);
-    await expect(page.locator('#scroll-position')).toHaveText('0%');
+    const items = page.locator('#content-list .content-item');
+    await expect(items).toHaveCount(10);
+    await expect(page.locator('#items-loaded')).toHaveText('10');
 
     // Drive the scroll handler: jump to the bottom and fire a scroll event.
     await page.locator('.scroll-container').evaluate(el => {
@@ -84,19 +83,17 @@ test.describe('infinite-scroll.html @comprehensive', () => {
       el.dispatchEvent(new Event('scroll'));
     });
 
-    // The `on scroll` handler runs: it updates the scroll-position readout, then
-    // (near the bottom) flips the loading indicator on. Previously the whole
-    // handler silently failed to install because the `make a <li>…</li>` literal
-    // mis-lexed and corrupted the parse — fixed by the open/close-tag tokenizer.
-    await expect(page.locator('#scroll-position')).not.toHaveText('0%');
+    // Handler enters the near-bottom branch and flips the loader on during the
+    // simulated 1.5s fetch.
     await expect(page.locator('#loading')).toHaveClass(/active/, { timeout: 1500 });
 
-    // KNOWN GAP (not asserted): items do not actually append. The handler's
-    // `make a <li …>…</li> called newItem` uses `make`'s element-literal syntax,
-    // which is broken upstream of this fix — the parser files the literal under
-    // modifiers.a with its </> stripped/mangled and make.parseInput sees an empty
-    // args[0], so make throws mid-loop. Item-append coverage is out of scope until
-    // `make <element-literal>` is reworked.
+    // The handler's `repeat 10 times … make a <li>…</li> … put it at end of
+    // #content-list` appends rows. We assert growth, not an exact count — a
+    // synthetic scroll-to-bottom can re-trigger additional pages as the content
+    // grows. (Item text shows literal #{} markers: template interpolation inside
+    // element literals is a separate, unshipped feature.)
+    await expect.poll(async () => await items.count(), { timeout: 5000 }).toBeGreaterThan(10);
+    await expect(page.locator('#items-loaded')).not.toHaveText('10');
   });
 });
 

--- a/packages/core/src/parser/helpers/parsing-helpers.ts
+++ b/packages/core/src/parser/helpers/parsing-helpers.ts
@@ -32,7 +32,11 @@ export interface MultiWordPattern {
  */
 export const MULTI_WORD_PATTERNS: MultiWordPattern[] = [
   { command: 'append', keywords: ['to'], syntax: 'append <value> [to <target>]' },
-  { command: 'make', keywords: ['a', 'an'], syntax: 'make (a|an) <type>' },
+  {
+    command: 'make',
+    keywords: ['a', 'an', 'from', 'called'],
+    syntax: 'make (a|an) <type> [from <args>] [called <name>]',
+  },
   { command: 'send', keywords: ['to'], syntax: 'send <event> to <target>' },
   { command: 'throw', keywords: [], syntax: 'throw <error>' },
 ];

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -1380,6 +1380,10 @@ export class Parser {
       // Mark as query-form so the evaluator returns the full collection even
       // for `<#id/>` (upstream QueryRef → ElementCollection, not single element).
       (node as any).fromQuery = true;
+      // Preserve the full `<…>` markup so `make` can build an element from it
+      // (createDOMElement / innerHTML) rather than querySelector-ing the inner
+      // selector. Additive — other query-reference consumers read `value`.
+      (node as any).raw = queryValue;
       return node;
     }
 


### PR DESCRIPTION
## Summary

`make a <tag#id.class/>` (self-closing) and `make a <div>text</div>` (open/close) are documented and have tests, but were **fully broken end-to-end** — `make` threw "requires class name or DOM element expression" for every element-literal form. This reworks the parse→command path so `make` creates a real element bound to `it`.

### Root cause (4 layers)
- The parser files the element as the value of the article modifier (`modifiers.a`/`an`), not `args[0]` — which `make.parseInput` read → `undefined` → throw.
- Even if read, the node was a query-reference *selector* (would `querySelectorAll`, not create).
- Open/close literals were truncated by the parser's `slice(1, -2)`.
- `called <name>` resolved a bare identifier as a *variable* (→ `undefined`).

### Fix
- **parser.ts** — preserve the full `<…>` markup as `node.raw` (additive; query-reference `value` untouched).
- **make.ts** — `parseInput` reads the element from `modifiers.a`/`an` (falls back to `args[0]`) and uses `node.raw` for literals instead of evaluating them as selectors; `execute` builds self-closing via `createDOMElement` and open/close via `createElementFromHTML` (innerHTML); `resolveVariableName` accepts a bare identifier so `called <name>` binds correctly.
- **parsing-helpers.ts** — add `from`/`called` to make's multi-word keywords so the documented `make a <x/> from … called …` parses end-to-end.

### Tests
- `make.test.ts`: **28 pass** — added open/close execute cases + 4 **parser→runtime integration tests** (the coverage the old unit tests structurally lacked: they fed `args[0]`, a shape the real parser never produces).
- `gallery-extra-interactions` infinite-scroll: now asserts items **append** (make works in-browser via the semantic path too); assertion is growth-based since a synthetic scroll-to-bottom re-triggers pages.

### Out of scope
- `#{}`/`{}` interpolation inside literals (items render literal markers — separate, unshipped feature).
- `test-multiword-commands.spec.ts`'s pre-existing harness bug (`data:` URL can't load the bundle), so its make test stays red despite the logic now being correct.

## Test plan
- [x] `npx vitest run src/commands/dom/__tests__/make.test.ts` — 28 pass
- [x] `npm run test:check --prefix packages/core` — 6200+ pass
- [x] infinite-scroll e2e appends items (`gallery-extra-interactions`)
- [x] Full `browser-tests` suite — **93 failures, identical to baseline (zero regressions)**
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)