### PR TITLE
feat(core): make-literal {expr} interpolation; fix append-to-variable

### DIFF
--- a/packages/core/src/commands/content/append.ts
+++ b/packages/core/src/commands/content/append.ts
@@ -65,8 +65,21 @@ export class AppendCommand implements DecoratedCommand {
     const content = await evaluator.evaluate(raw.args[0], context);
     let target: string | HTMLElement | unknown[] | undefined;
 
-    if (raw.modifiers?.to) target = await evaluator.evaluate(raw.modifiers.to, context);
-    else if ((raw as any).target) target = (raw as any).target;
+    if (raw.modifiers?.to) {
+      const toNode = raw.modifiers.to as unknown as Record<string, unknown>;
+      const toType = toNode.type;
+      // A bare variable reference (`to greeting`, `to :greeting`, `to me`) keeps
+      // its NAME so execute can read+write the variable. Evaluating it would
+      // yield the current value, so `append … to <var>` would lose the binding.
+      if (
+        (toType === 'identifier' || toType === 'variable' || toType === 'symbol') &&
+        typeof toNode.name === 'string'
+      ) {
+        target = toNode.name as string;
+      } else {
+        target = await evaluator.evaluate(raw.modifiers.to, context);
+      }
+    } else if ((raw as any).target) target = (raw as any).target;
 
     return { content, target };
   }
@@ -101,6 +114,10 @@ export class AppendCommand implements DecoratedCommand {
 
       const current = getVariableValue(target, context);
       if (current !== undefined) {
+        if (isHTMLElement(current)) {
+          (current as HTMLElement).innerHTML += contentStr;
+          return { result: current, targetType: 'element', target: current as HTMLElement };
+        }
         if (Array.isArray(current)) {
           current.push(content);
           return { result: current, targetType: 'array', target };

--- a/packages/core/src/commands/dom/__tests__/make.test.ts
+++ b/packages/core/src/commands/dom/__tests__/make.test.ts
@@ -424,4 +424,33 @@ describe('MakeCommand', () => {
       expect(child?.id).toBe('bold');
     });
   });
+
+  describe('interpolation (`{expr}` in element literals)', () => {
+    it('interpolates an inline expression', async () => {
+      const el = (await evalHyperScript('make a <span>item {2 * 3}</span>')) as HTMLElement;
+      expect(el.textContent).toBe('item 6');
+    });
+
+    it('interpolates a local variable bound earlier in the script', async () => {
+      const el = (await evalHyperScript(
+        'set n to 5 then make a <div>Article #{n}</div>'
+      )) as HTMLElement;
+      // `#` is literal text; `{n}` is interpolated → "#5".
+      expect(el.textContent).toBe('Article #5');
+    });
+
+    it('HTML-escapes interpolated values (no markup injection)', async () => {
+      const el = (await evalHyperScript("make a <span>{'<b>hi</b>'}</span>")) as HTMLElement;
+      // The value is escaped, so no nested <b> element is created.
+      expect(el.querySelector('b')).toBeNull();
+      expect(el.textContent).toBe('<b>hi</b>');
+    });
+
+    it('leaves non-expression braces untouched', async () => {
+      const el = (await evalHyperScript(
+        'make a <span>a {definitely not valid !} b</span>'
+      )) as HTMLElement;
+      expect(el.textContent).toBe('a {definitely not valid !} b');
+    });
+  });
 });

--- a/packages/core/src/commands/dom/make.ts
+++ b/packages/core/src/commands/dom/make.ts
@@ -9,9 +9,11 @@
  */
 
 import type { ASTNode, TypedExecutionContext } from '../../types/base-types';
+import type { ExecutionContext } from '../../types/core';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { isHTMLElement } from '../../utils/element-check';
 import { setVariableValue } from '../helpers/variable-access';
+import { evaluateExpressionFromSource } from '../../parser/runtime';
 import {
   command,
   meta,
@@ -19,6 +21,47 @@ import {
   type DecoratedCommand,
   type CommandMetadata,
 } from '../decorators';
+
+const HTML_ESCAPE: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, c => HTML_ESCAPE[c]);
+}
+
+/**
+ * Interpolate `{expr}` placeholders in a make element literal against the live
+ * context (e.g. `<li>Article #{itemNum}</li>` → `<li>Article #5</li>`, where
+ * `#` is literal and `{itemNum}` is evaluated). Values are HTML-escaped to keep
+ * the innerHTML build safe. Braces whose contents aren't a valid/evaluable
+ * expression are left untouched, so literal `{...}` text survives.
+ */
+async function interpolateLiteral(html: string, context: ExecutionContext): Promise<string> {
+  if (!html.includes('{')) return html;
+  const re = /\{([^{}]+)\}/g;
+  const replacements: Array<{ index: number; length: number; text: string }> = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) {
+    let text = m[0]; // default: leave the literal `{…}` untouched
+    try {
+      const value = await evaluateExpressionFromSource(m[1].trim(), context);
+      if (value !== undefined && value !== null) text = escapeHtml(String(value));
+    } catch {
+      /* not an expression — keep the literal text */
+    }
+    replacements.push({ index: m.index, length: m[0].length, text });
+  }
+  let result = html;
+  for (let i = replacements.length - 1; i >= 0; i--) {
+    const { index, length, text } = replacements[i];
+    result = result.slice(0, index) + text + result.slice(index + length);
+  }
+  return result;
+}
 
 /** Typed input after parsing */
 export interface MakeCommandInput {
@@ -163,12 +206,17 @@ export class MakeCommand implements DecoratedCommand {
     // Element literals carry their full `<…>` markup on `node.raw`; use it
     // directly so the element is created rather than querySelector-ed.
     const rawLiteral = (elementNode as Record<string, unknown>).raw;
-    const expression =
+    let expression =
       typeof rawLiteral === 'string' && rawLiteral.startsWith('<')
         ? rawLiteral
         : await evaluator.evaluate(elementNode, context);
     if (expression === undefined || expression === null) {
       throw new Error('Make command requires class name or DOM element expression');
+    }
+    // Evaluate `{expr}` interpolation inside element literals against the live
+    // context (vars bound by the surrounding handler, e.g. `{itemNum}`).
+    if (typeof expression === 'string' && expression.startsWith('<')) {
+      expression = await interpolateLiteral(expression, context as ExecutionContext);
     }
 
     const article = raw.modifiers.an !== undefined ? 'an' : 'a';

--- a/packages/core/src/compatibility/browser-tests/gallery-extra-interactions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/gallery-extra-interactions.spec.ts
@@ -90,10 +90,14 @@ test.describe('infinite-scroll.html @comprehensive', () => {
     // The handler's `repeat 10 times … make a <li>…</li> … put it at end of
     // #content-list` appends rows. We assert growth, not an exact count — a
     // synthetic scroll-to-bottom can re-trigger additional pages as the content
-    // grows. (Item text shows literal #{} markers: template interpolation inside
-    // element literals is a separate, unshipped feature.)
+    // grows.
     await expect.poll(async () => await items.count(), { timeout: 5000 }).toBeGreaterThan(10);
     await expect(page.locator('#items-loaded')).not.toHaveText('10');
+
+    // The made rows interpolate `{itemNum}` — a dynamically-created item's
+    // number badge shows a real number (e.g. "#11"), not the literal "#{itemNum}".
+    const madeBadge = items.nth(10).locator('.item-number');
+    await expect(madeBadge).toHaveText(/^#\d+$/);
   });
 });
 

--- a/packages/core/src/compatibility/browser-tests/test-multiword-commands.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/test-multiword-commands.spec.ts
@@ -4,22 +4,23 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+import { waitForHyperfixi } from './test-utils';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+// Served by the Playwright webServer (http-server at the repo root on :3000).
+const BASE_URL = process.env.BASE_URL ?? 'http://127.0.0.1:3000';
 
 test.describe('Multi-Word Command Parser (Session 32)', () => {
   test.beforeEach(async ({ page }) => {
-    // Create a test HTML page with HyperFixi loaded
+    // Create a test HTML page with HyperFixi loaded. The bundle is loaded from
+    // the served repo root; auto-init runs because readyState != 'loading' when
+    // the script executes inside setContent.
     const testHTML = `
 <!DOCTYPE html>
 <html>
 <head>
   <meta charset="UTF-8">
   <title>Multi-Word Command Test</title>
-  <script src="/dist/hyperfixi.js"></script>
+  <script src="/packages/core/dist/hyperfixi.js"></script>
 </head>
 <body>
   <div id="results"></div>
@@ -55,22 +56,16 @@ test.describe('Multi-Word Command Parser (Session 32)', () => {
     Test Make
   </button>
   <div id="result-make"></div>
-
-  <script>
-    // Initialize HyperFixi
-    if (window.HyperFixi) {
-      window.HyperFixi.browserInit();
-      console.log('✅ HyperFixi initialized');
-    } else {
-      console.error('❌ HyperFixi not loaded');
-    }
-  </script>
 </body>
 </html>
     `;
 
-    await page.goto('data:text/html;charset=utf-8,' + encodeURIComponent(testHTML));
-    await page.waitForTimeout(500); // Wait for HyperFixi to initialize
+    // Navigate to the served origin first so root-relative script paths resolve,
+    // then inject the markup (a data: URL can't load the /packages/... bundle).
+    await page.goto(`${BASE_URL}/examples/index.html`, { waitUntil: 'domcontentloaded' });
+    await page.setContent(testHTML, { waitUntil: 'load' });
+    await waitForHyperfixi(page);
+    await page.waitForTimeout(150); // let the attribute processor wire `_=` handlers
   });
 
   test('append...to command works in _="" attribute', async ({ page }) => {

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -3093,6 +3093,7 @@ export class Parser {
       'increment',
       'decrement',
       'add',
+      'append',
       'toggle',
       'if',
       'unless',


### PR DESCRIPTION
## Summary

Builds on the `make <element-literal>` work (#231) with template interpolation, plus an `append` bug fix and a test-harness repair (the latter surfaced the append bug).

- **make: `{expr}` interpolation** — element literals now interpolate `{expr}` against the live context, e.g. `make a <li>Article #{itemNum}</li>` → `Article #5` (the `#` is literal, `{itemNum}` evaluates). Values are HTML-escaped (XSS-safe); non-expression braces are left intact. Reuses the runtime's `evaluateExpressionFromSource`.
- **append-to-variable fix** — `append <content> to <var>` now concatenates onto the variable. Two root causes:
  1. `parseInput` evaluated the `to` target to its *value* instead of keeping the variable *name* (so the binding was lost). Fixed to keep the name for identifier/symbol targets (element handling added to the variable path).
  2. `append` wasn't in the parser's `skipSemanticParsing` list, so mid-sequence the semantic path swallowed `append … then …` and dropped append's variable write. Added `append` to the list (consistent with `set`/`put`/`increment`, which share the same variable-target shape).
- **test-multiword-commands harness repair** — the spec used a `data:` URL that could never load `/dist`, so it never validated anything. Now it loads the bundle from the served origin via `setContent`; `append`/`send`/`make` are validated end-to-end.

### Tests
- `make.test.ts`: +4 interpolation cases (inline expr, local var, HTML-escape, literal-brace passthrough).
- `append.test.ts` + `make.test.ts`: 55 vitest pass.
- `gallery-extra-interactions` infinite-scroll now asserts made rows render real interpolated numbers (e.g. `#11`).
- `test-multiword-commands`: all 4 tests green (was 3 failing / harness-broken).

### Out of scope
- `#{}` is not a distinct token — `#` is literal text; `{expr}` is the interpolation form (matches the demo's static `#1` rows).

## Test plan
- [x] `npx vitest run` make + append (55 pass)
- [x] `npm run test:check --prefix packages/core` (6200+ pass)
- [x] typecheck clean
- [x] Full `browser-tests` suite: **90 failures, down from 91** (no regressions; test-multiword-commands now fully green; multilingual/semantic counts unchanged)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)