### PR TITLE
Expression upstream-parity sweep + SOV/VSO word-order flexibility

### DIFF
--- a/packages/core/compatibility-test.html
+++ b/packages/core/compatibility-test.html
@@ -22,7 +22,15 @@
         // _hyperscript compatibility shim — maps official API names to HyperFixi
         // Many official tests reference window._hyperscript directly
         window._hyperscript = function(code, ctx) {
-            return hyperfixi.evalHyperScript(code, ctx);
+            // Upstream's `_hyperscript(expr)` is SYNCHRONOUS for pure expressions
+            // (e.g. `Array.from(_hyperscript(".c1"))`, `_hyperscript("1 as Date").getTime()`).
+            // HyperFixi evaluates async, so try the synchronous fast-path first and
+            // fall back to the async Promise for commands / non-sync expressions.
+            try {
+                return hyperfixi.evalHyperScriptSync(code, ctx);
+            } catch (e) {
+                return hyperfixi.evalHyperScript(code, ctx);
+            }
         };
         window._hyperscript.processNode = function(el) {
             return hyperfixi.processNode(el);

--- a/packages/core/src/compatibility/browser-bundle.ts
+++ b/packages/core/src/compatibility/browser-bundle.ts
@@ -17,7 +17,12 @@
  * Recommended for: Complex applications, full _hyperscript compatibility
  */
 
-import { evalHyperScript, evalHyperScriptAsync, evalHyperScriptSmart } from './eval-hyperscript';
+import {
+  evalHyperScript,
+  evalHyperScriptAsync,
+  evalHyperScriptSmart,
+  evalHyperScriptSync,
+} from './eval-hyperscript';
 import { lokascript, hyperscript, config } from '../api/lokascript-api';
 import type { RuntimeHooks } from '../types/hooks';
 import { defaultAttributeProcessor } from '../dom/attribute-processor';
@@ -71,6 +76,7 @@ interface HyperFixiBrowserAPI {
   evalHyperScript: typeof evalHyperScript;
   evalHyperScriptAsync: typeof evalHyperScriptAsync;
   evalHyperScriptSmart: typeof evalHyperScriptSmart;
+  evalHyperScriptSync: typeof evalHyperScriptSync;
   compile: (code: string, options?: NewCompileOptions) => CompileResult;
   compileSync: (code: string, options?: NewCompileOptions) => CompileResult;
   compileMultilingual: (code: string, language: string) => Promise<CompileResult>;
@@ -149,6 +155,7 @@ declare global {
     evalHyperScript: typeof evalHyperScript;
     evalHyperScriptAsync: typeof evalHyperScriptAsync;
     evalHyperScriptSmart: typeof evalHyperScriptSmart;
+    evalHyperScriptSync: typeof evalHyperScriptSync;
   }
 }
 
@@ -158,6 +165,7 @@ const hyperfixiAPI = {
   evalHyperScript,
   evalHyperScriptAsync,
   evalHyperScriptSmart,
+  evalHyperScriptSync,
 
   // Convenience method that matches _hyperscript() function signature exactly
   evaluate: evalHyperScript,
@@ -346,6 +354,7 @@ if (typeof window !== 'undefined') {
   window.evalHyperScript = evalHyperScript;
   window.evalHyperScriptAsync = evalHyperScriptAsync;
   window.evalHyperScriptSmart = evalHyperScriptSmart;
+  window.evalHyperScriptSync = evalHyperScriptSync;
 
   // Initialize attribute processor when DOM is ready
   if (document.readyState === 'loading') {

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -21,6 +21,7 @@ const HYPERSCRIPT_TEST_ROOT =
 //   - harness landing:           182/361 runnable = 50%  (floor 47)
 //   - comparisonOperator cluster: 211/361 runnable = 58%  (floor 57)
 //   - asExpression/conversions:   222/361 runnable = 61%  (floor 60)
+//   - styleRef (bare `*prop`):    224/361 runnable = 62%  (floor 61)
 // Ratchet this up as the remaining parity gaps are fixed in follow-ups.
 //
 // Known harness limitation (not product gaps): a handful of upstream tests use
@@ -30,7 +31,7 @@ const HYPERSCRIPT_TEST_ROOT =
 // closures (Date/Set/Map/Fragment/Values, config.conversions custom converters)
 // can't pass without a synchronous eval path. The conversions themselves are
 // correct, as the `run`-based cases (awaited) confirm.
-const EXPRESSION_PASS_RATE_FLOOR = 60;
+const EXPRESSION_PASS_RATE_FLOOR = 61;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -24,6 +24,7 @@ const HYPERSCRIPT_TEST_ROOT =
 //   - styleRef (bare `*prop`):    224/361 runnable = 62%  (floor 61)
 //   - styleRef (possessive/of):   230/361 runnable = 64%  (floor 63)
 //   - sync-eval selector path:    244/361 runnable = 68%  (floor 67)
+//   - sync-eval asExpression:      252/361 runnable = 70%  (floor 69)
 // Ratchet this up as the remaining parity gaps are fixed in follow-ups.
 //
 // Harness/upstream-fidelity note: upstream's `_hyperscript("expr")` is
@@ -35,7 +36,7 @@ const HYPERSCRIPT_TEST_ROOT =
 // closures (Date/Set/Map/Fragment), classRef/queryRef with interpolation, and the
 // fire-and-forget `set` tests. The products are correct (awaited `run`-based cases
 // pass); extending evalHyperScriptSync to those node types lifts them further.
-const EXPRESSION_PASS_RATE_FLOOR = 67;
+const EXPRESSION_PASS_RATE_FLOOR = 69;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -20,8 +20,17 @@ const HYPERSCRIPT_TEST_ROOT =
 // History (only ever ratchet UP — a drop means a regression):
 //   - harness landing:           182/361 runnable = 50%  (floor 47)
 //   - comparisonOperator cluster: 211/361 runnable = 58%  (floor 57)
+//   - asExpression/conversions:   222/361 runnable = 61%  (floor 60)
 // Ratchet this up as the remaining parity gaps are fixed in follow-ups.
-const EXPRESSION_PASS_RATE_FLOOR = 57;
+//
+// Known harness limitation (not product gaps): a handful of upstream tests use
+// the result of the synchronous `_hyperscript("expr")` global *synchronously*
+// (e.g. `const r = _hyperscript("1 as Date"); r.getTime()`). HyperFixi evaluates
+// asynchronously, so the compatibility-test.html shim returns a Promise — those
+// closures (Date/Set/Map/Fragment/Values, config.conversions custom converters)
+// can't pass without a synchronous eval path. The conversions themselves are
+// correct, as the `run`-based cases (awaited) confirm.
+const EXPRESSION_PASS_RATE_FLOOR = 60;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -17,10 +17,11 @@ const HYPERSCRIPT_TEST_ROOT =
   process.env.HYPERSCRIPT_TEST_ROOT || resolve(__dirname, '../../../../../../_hyperscript/test');
 
 // Minimum pass rate (% of runnable upstream cases) the suite must hold.
-// Baseline as of this harness landing: 182/361 runnable = 50%. Floor set just
-// below to catch regressions without blocking on the ~179 known parity gaps;
-// ratchet this up as those gaps are fixed in follow-ups.
-const EXPRESSION_PASS_RATE_FLOOR = 47;
+// History (only ever ratchet UP — a drop means a regression):
+//   - harness landing:           182/361 runnable = 50%  (floor 47)
+//   - comparisonOperator cluster: 211/361 runnable = 58%  (floor 57)
+// Ratchet this up as the remaining parity gaps are fixed in follow-ups.
+const EXPRESSION_PASS_RATE_FLOOR = 57;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -23,16 +23,19 @@ const HYPERSCRIPT_TEST_ROOT =
 //   - asExpression/conversions:   222/361 runnable = 61%  (floor 60)
 //   - styleRef (bare `*prop`):    224/361 runnable = 62%  (floor 61)
 //   - styleRef (possessive/of):   230/361 runnable = 64%  (floor 63)
+//   - sync-eval selector path:    244/361 runnable = 68%  (floor 67)
 // Ratchet this up as the remaining parity gaps are fixed in follow-ups.
 //
-// Known harness limitation (not product gaps): a handful of upstream tests use
-// the result of the synchronous `_hyperscript("expr")` global *synchronously*
-// (e.g. `const r = _hyperscript("1 as Date"); r.getTime()`). HyperFixi evaluates
-// asynchronously, so the compatibility-test.html shim returns a Promise — those
-// closures (Date/Set/Map/Fragment/Values, config.conversions custom converters)
-// can't pass without a synchronous eval path. The conversions themselves are
-// correct, as the `run`-based cases (awaited) confirm.
-const EXPRESSION_PASS_RATE_FLOOR = 63;
+// Harness/upstream-fidelity note: upstream's `_hyperscript("expr")` is
+// SYNCHRONOUS, but HyperFixi evaluates asynchronously. The compatibility-test.html
+// shim now tries `hyperfixi.evalHyperScriptSync` first (a sync fast-path for the
+// pure-expression subset — currently selector references) and falls back to the
+// async Promise otherwise. Cases still gated by this (consume the result
+// synchronously but aren't yet sync-evaluable): the remaining asExpression
+// closures (Date/Set/Map/Fragment), classRef/queryRef with interpolation, and the
+// fire-and-forget `set` tests. The products are correct (awaited `run`-based cases
+// pass); extending evalHyperScriptSync to those node types lifts them further.
+const EXPRESSION_PASS_RATE_FLOOR = 67;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -22,6 +22,7 @@ const HYPERSCRIPT_TEST_ROOT =
 //   - comparisonOperator cluster: 211/361 runnable = 58%  (floor 57)
 //   - asExpression/conversions:   222/361 runnable = 61%  (floor 60)
 //   - styleRef (bare `*prop`):    224/361 runnable = 62%  (floor 61)
+//   - styleRef (possessive/of):   230/361 runnable = 64%  (floor 63)
 // Ratchet this up as the remaining parity gaps are fixed in follow-ups.
 //
 // Known harness limitation (not product gaps): a handful of upstream tests use
@@ -31,7 +32,7 @@ const HYPERSCRIPT_TEST_ROOT =
 // closures (Date/Set/Map/Fragment/Values, config.conversions custom converters)
 // can't pass without a synchronous eval path. The conversions themselves are
 // correct, as the `run`-based cases (awaited) confirm.
-const EXPRESSION_PASS_RATE_FLOOR = 61;
+const EXPRESSION_PASS_RATE_FLOOR = 63;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/browser-tests/semantic-package.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/semantic-package.spec.ts
@@ -181,7 +181,10 @@ test.describe('HyperFixi Semantic Parser Bundle', () => {
     });
 
     expect(translated).toBeDefined();
-    expect(translated).toContain('トグル');
+    // The renderer uses the primary keyword `切り替え` (native Japanese) for
+    // toggle; `トグル` is only a recognized alternative. This matches the
+    // canonical output asserted in packages/semantic semantic.test.ts.
+    expect(translated).toContain('切り替え');
     expect(translated).toContain('.active');
   });
 

--- a/packages/core/src/compatibility/eval-hyperscript.ts
+++ b/packages/core/src/compatibility/eval-hyperscript.ts
@@ -3,7 +3,11 @@
  * Provides evalHyperScript() function that matches the original _hyperscript API
  */
 
-import { evaluateExpressionFromSource } from '../parser/runtime';
+import {
+  evaluateExpressionFromSource,
+  evaluateExpressionFromSourceSync,
+  NotSyncEvaluable,
+} from '../parser/runtime';
 import { Parser } from '../parser/parser';
 import { Runtime } from '../runtime/runtime';
 import { tokenize } from '../parser/tokenizer';
@@ -182,6 +186,32 @@ export async function evalHyperScript(
     }
     throw error;
   }
+}
+
+/**
+ * Synchronous evaluation of a pure-expression script, matching upstream's
+ * synchronous `_hyperscript("expr")`. Returns the value directly (not a Promise)
+ * for the synchronously-evaluable subset (currently selector references).
+ *
+ * Throws `NotSyncEvaluable` (or a parse/command error) when the script needs the
+ * async pipeline — callers (the parity harness shim) fall back to
+ * `evalHyperScript`. Production code should keep using the async API; this exists
+ * so the harness faithfully mirrors upstream's sync expression semantics
+ * (e.g. `Array.from(_hyperscript(".c1"))`).
+ */
+export function evalHyperScriptSync(
+  script: string,
+  context?: HyperScriptContext | ExecutionContext
+): any {
+  if (!script || script.trim() === '') {
+    throw new Error('Cannot evaluate empty script');
+  }
+  // Commands need the async runtime — defer.
+  if (isCommand(script)) {
+    throw new NotSyncEvaluable('command');
+  }
+  const executionContext = convertContext(context);
+  return evaluateExpressionFromSourceSync(script, executionContext);
 }
 
 /**

--- a/packages/core/src/expressions/conversion/impl/index.ts
+++ b/packages/core/src/expressions/conversion/impl/index.ts
@@ -73,6 +73,13 @@ export type SupportedConversionType =
   | 'Values'
   | 'Values:Form'
   | 'Values:JSON'
+  | 'Set'
+  | 'Map'
+  | 'Keys'
+  | 'Entries'
+  | 'Reversed'
+  | 'Unique'
+  | 'Flat'
   | `Fixed:${number}`
   | string;
 
@@ -346,6 +353,87 @@ export const enhancedConverters: Record<string, EnhancedTypeConverter> = {
       );
     }
   },
+
+  // Collection conversions (upstream _hyperscript 0.9.90), kept in parallel with
+  // the functional registry in ../index.ts. Each takes (value, context) to match
+  // the EnhancedTypeConverter interface even though context is unused here.
+  Set: (value: unknown, _context: TypedExpressionContext): EvaluationResult<Set<unknown>> => {
+    try {
+      return success(new Set(value as Iterable<unknown>), 'object');
+    } catch (error) {
+      return converterError(
+        'Set',
+        'SET_CONVERSION_FAILED',
+        errorMsg('Failed to convert to Set', error),
+        ['Ensure the value is iterable']
+      );
+    }
+  },
+
+  Map: (
+    value: unknown,
+    _context: TypedExpressionContext
+  ): EvaluationResult<Map<string, unknown>> => {
+    try {
+      return success(new Map(Object.entries((value ?? {}) as Record<string, unknown>)), 'object');
+    } catch (error) {
+      return converterError(
+        'Map',
+        'MAP_CONVERSION_FAILED',
+        errorMsg('Failed to convert to Map', error),
+        ['Ensure the value is a plain object']
+      );
+    }
+  },
+
+  Keys: (value: unknown, _context: TypedExpressionContext): EvaluationResult<unknown[]> => {
+    if (value instanceof Map) return success(Array.from(value.keys()), 'array');
+    return success(Object.keys((value ?? {}) as object), 'array');
+  },
+
+  Entries: (value: unknown, _context: TypedExpressionContext): EvaluationResult<unknown[]> => {
+    if (value instanceof Map) return success(Array.from(value.entries()), 'array');
+    return success(Object.entries((value ?? {}) as object), 'array');
+  },
+
+  Reversed: (value: unknown, _context: TypedExpressionContext): EvaluationResult<unknown[]> => {
+    try {
+      return success(Array.from(value as ArrayLike<unknown>).reverse(), 'array');
+    } catch (error) {
+      return converterError(
+        'Reversed',
+        'REVERSED_CONVERSION_FAILED',
+        errorMsg('Failed to reverse value', error),
+        ['Ensure the value is array-like']
+      );
+    }
+  },
+
+  Unique: (value: unknown, _context: TypedExpressionContext): EvaluationResult<unknown[]> => {
+    try {
+      return success([...new Set(value as Iterable<unknown>)], 'array');
+    } catch (error) {
+      return converterError(
+        'Unique',
+        'UNIQUE_CONVERSION_FAILED',
+        errorMsg('Failed to dedupe value', error),
+        ['Ensure the value is iterable']
+      );
+    }
+  },
+
+  Flat: (value: unknown, _context: TypedExpressionContext): EvaluationResult<unknown[]> => {
+    try {
+      return success(Array.from(value as ArrayLike<unknown>).flat(), 'array');
+    } catch (error) {
+      return converterError(
+        'Flat',
+        'FLAT_CONVERSION_FAILED',
+        errorMsg('Failed to flatten value', error),
+        ['Ensure the value is array-like']
+      );
+    }
+  },
 };
 
 // ============================================================================
@@ -518,10 +606,10 @@ export class AsExpression
 
       const { value, type } = input;
 
-      // Handle Fixed:<precision> conversion
+      // Handle Fixed:<precision> conversion (upstream default is 0 places)
       if (type.startsWith('Fixed')) {
         const precisionMatch = type.match(/^Fixed:(\d+)$/);
-        const precision = precisionMatch ? parseInt(precisionMatch[1], 10) : 2;
+        const precision = precisionMatch ? parseInt(precisionMatch[1], 10) : 0;
         const numberResult = enhancedConverters.Number(value, context);
         if (!numberResult.success) {
           return numberResult;

--- a/packages/core/src/expressions/conversion/index.test.ts
+++ b/packages/core/src/expressions/conversion/index.test.ts
@@ -30,13 +30,15 @@ describe('Conversion Expressions', () => {
         expect(await conversionExpressions.as.evaluate(context, [1, 2, 3], 'Array')).toEqual([
           1, 2, 3,
         ]);
-        expect(await conversionExpressions.as.evaluate(context, null, 'Array')).toEqual([]);
+        // Upstream `convertValue`: null/undefined pass through unchanged.
+        expect(await conversionExpressions.as.evaluate(context, null, 'Array')).toBeNull();
       });
 
       it('should convert to String', async () => {
         expect(await conversionExpressions.as.evaluate(context, 123, 'String')).toBe('123');
         expect(await conversionExpressions.as.evaluate(context, true, 'String')).toBe('true');
-        expect(await conversionExpressions.as.evaluate(context, null, 'String')).toBe('');
+        // Upstream parity: `null as String` is null, not "".
+        expect(await conversionExpressions.as.evaluate(context, null, 'String')).toBeNull();
         expect(await conversionExpressions.as.evaluate(context, { key: 'value' }, 'String')).toBe(
           '{"key":"value"}'
         );
@@ -48,7 +50,8 @@ describe('Conversion Expressions', () => {
         expect(await conversionExpressions.as.evaluate(context, true, 'Number')).toBe(1);
         expect(await conversionExpressions.as.evaluate(context, false, 'Number')).toBe(0);
         expect(await conversionExpressions.as.evaluate(context, 'invalid', 'Number')).toBe(0);
-        expect(await conversionExpressions.as.evaluate(context, null, 'Number')).toBe(0);
+        // Upstream parity: null passes through unchanged (not coerced to 0).
+        expect(await conversionExpressions.as.evaluate(context, null, 'Number')).toBeNull();
       });
 
       it('should convert to Int', async () => {
@@ -228,9 +231,8 @@ describe('Conversion Expressions', () => {
 
     describe('Fixed precision conversion', () => {
       it('should convert to fixed precision string', async () => {
-        expect(await conversionExpressions.as.evaluate(context, 123.456789, 'Fixed')).toBe(
-          '123.46'
-        );
+        // Upstream default is `Number(value).toFixed()` → 0 decimal places.
+        expect(await conversionExpressions.as.evaluate(context, 123.456789, 'Fixed')).toBe('123');
         expect(await conversionExpressions.as.evaluate(context, 123.456789, 'Fixed:4')).toBe(
           '123.4568'
         );
@@ -460,7 +462,7 @@ describe('Conversion Expressions', () => {
 
     describe('parseFixedPrecision', () => {
       it('should parse Fixed precision', () => {
-        expect(parseFixedPrecision('Fixed')).toEqual({ precision: 2 });
+        expect(parseFixedPrecision('Fixed')).toEqual({ precision: 0 }); // upstream default
         expect(parseFixedPrecision('Fixed:4')).toEqual({ precision: 4 });
         expect(parseFixedPrecision('Fixed:0')).toEqual({ precision: 0 });
         expect(parseFixedPrecision('NotFixed')).toEqual({});

--- a/packages/core/src/expressions/conversion/index.ts
+++ b/packages/core/src/expressions/conversion/index.ts
@@ -370,6 +370,70 @@ function parseFixedPrecision(type: string): { precision?: number } {
 // Main Conversion Expression
 // ============================================================================
 
+const TYPE_ALIASES: Record<string, string> = {
+  boolean: 'Boolean',
+  bool: 'Boolean',
+  string: 'String',
+  str: 'String',
+  number: 'Number',
+  num: 'Number',
+  int: 'Int',
+  integer: 'Int',
+  float: 'Float',
+  array: 'Array',
+  object: 'Object',
+  obj: 'Object',
+  date: 'Date',
+  json: 'JSON',
+  jsonstring: 'JSONString',
+  formencoded: 'FormEncoded',
+};
+
+/**
+ * Apply an `as`-conversion synchronously. This is the canonical conversion logic
+ * shared by the (async-signature) `asExpression.evaluate` and the synchronous
+ * expression fast-path used by the parity harness. All built-in converters are
+ * synchronous, so this never needs to await.
+ */
+export function convertValue(value: unknown, type: string, context?: ExecutionContext): unknown {
+  if (typeof type !== 'string') {
+    throw new Error('Conversion type must be a string');
+  }
+
+  // Handle Fixed:<precision> conversion (a dynamic resolver upstream, so it
+  // runs before the null short-circuit below — `Number(null).toFixed()`).
+  if (type.startsWith('Fixed')) {
+    const { precision } = parseFixedPrecision(type);
+    const num = defaultConversions.Number(value) as number;
+    return num.toFixed(precision ?? 0);
+  }
+
+  // Upstream `convertValue`: null/undefined pass through unchanged for every
+  // static converter (`null as String` is null, not "").
+  if (value == null) {
+    return value;
+  }
+
+  // Built-in conversion (case-sensitive first), then case-insensitive aliases.
+  let converter = defaultConversions[type];
+  if (converter) {
+    return converter(value, context);
+  }
+
+  const aliasedType = TYPE_ALIASES[type.toLowerCase()];
+  if (aliasedType) {
+    converter = defaultConversions[aliasedType];
+    if (converter) {
+      return converter(value, context);
+    }
+  }
+
+  // Unknown conversion type — return the original value (custom conversions via
+  // global config are not yet supported).
+  console.warn(`Unknown conversion type: ${type}`);
+  return value;
+}
+
 export const asExpression: ExpressionImplementation = {
   name: 'as',
   category: 'Conversion',
@@ -380,65 +444,7 @@ export const asExpression: ExpressionImplementation = {
 
   async evaluate(context: ExecutionContext, ...args: unknown[]): Promise<unknown> {
     const [value, type] = args;
-    if (typeof type !== 'string') {
-      throw new Error('Conversion type must be a string');
-    }
-
-    // Handle Fixed:<precision> conversion (a dynamic resolver upstream, so it
-    // runs before the null short-circuit below — `Number(null).toFixed()`).
-    if (type.startsWith('Fixed')) {
-      const { precision } = parseFixedPrecision(type);
-      const num = defaultConversions.Number(value) as number;
-      return num.toFixed(precision ?? 0);
-    }
-
-    // Upstream `convertValue`: null/undefined pass through unchanged for every
-    // static converter (`null as String` is null, not "").
-    if (value == null) {
-      return value;
-    }
-
-    // Check for built-in conversion (case-sensitive first)
-    let converter = defaultConversions[type];
-    if (converter) {
-      return converter(value, context);
-    }
-
-    // Check for case-insensitive matches and common aliases
-    const lowerType = type.toLowerCase();
-    const typeAliases: Record<string, string> = {
-      boolean: 'Boolean',
-      bool: 'Boolean',
-      string: 'String',
-      str: 'String',
-      number: 'Number',
-      num: 'Number',
-      int: 'Int',
-      integer: 'Int',
-      float: 'Float',
-      array: 'Array',
-      object: 'Object',
-      obj: 'Object',
-      date: 'Date',
-      json: 'JSON',
-      jsonstring: 'JSONString',
-      formencoded: 'FormEncoded',
-    };
-
-    const aliasedType = typeAliases[lowerType];
-    if (aliasedType) {
-      converter = defaultConversions[aliasedType];
-      if (converter) {
-        return converter(value, context);
-      }
-    }
-
-    // Check for custom conversions in global config
-    // This would be extended later to support _hyperscript.config.conversions
-
-    // Fallback: return original value
-    console.warn(`Unknown conversion type: ${type}`);
-    return value;
+    return convertValue(value, type as string, context);
   },
 
   validate(args: unknown[]): string | null {

--- a/packages/core/src/expressions/conversion/index.ts
+++ b/packages/core/src/expressions/conversion/index.ts
@@ -135,15 +135,25 @@ export const defaultConversions: Record<string, ConversionFunction> = {
     return {};
   },
 
-  // HTML/DOM conversions
+  // HTML/DOM conversions. Mirrors upstream's `implicitLoop`: existing nodes are
+  // appended as-is; everything else is parsed as an HTML string. Arrays/NodeLists
+  // contribute each item, so `[<p>, "<p></p>"] as Fragment` yields two children.
   Fragment: (value: unknown) => {
-    if (!isString(value)) {
-      value = defaultConversions.String(value);
+    const frag = document.createDocumentFragment();
+    const items =
+      Array.isArray(value) || value instanceof NodeList
+        ? Array.from(value as ArrayLike<unknown>)
+        : [value];
+    for (const item of items) {
+      if (item instanceof Node) {
+        frag.append(item);
+      } else {
+        const template = document.createElement('template');
+        template.innerHTML = item == null ? '' : String(item);
+        frag.append(template.content);
+      }
     }
-
-    const template = document.createElement('template');
-    template.innerHTML = String(value);
-    return template.content;
+    return frag;
   },
 
   HTML: (value: unknown) => {
@@ -202,6 +212,27 @@ export const defaultConversions: Record<string, ConversionFunction> = {
     }
     return params.toString();
   },
+
+  // Collection conversions (upstream _hyperscript 0.9.90).
+  Set: (value: unknown) => new Set(value as Iterable<unknown>),
+
+  Map: (value: unknown) => new Map(Object.entries((value ?? {}) as Record<string, unknown>)),
+
+  Keys: (value: unknown) => {
+    if (value instanceof Map) return Array.from(value.keys());
+    return Object.keys((value ?? {}) as object);
+  },
+
+  Entries: (value: unknown) => {
+    if (value instanceof Map) return Array.from(value.entries());
+    return Object.entries((value ?? {}) as object);
+  },
+
+  Reversed: (value: unknown) => Array.from(value as ArrayLike<unknown>).reverse(),
+
+  Unique: (value: unknown) => [...new Set(value as Iterable<unknown>)],
+
+  Flat: (value: unknown) => Array.from(value as ArrayLike<unknown>).flat(),
 
   // Deprecated compound types — kept working in 0.9.90+ for migration.
   // New code should use `as Values | FormEncoded` / `as Values | JSONString`.
@@ -329,7 +360,8 @@ function getInputValue(input: HTMLInputElement | HTMLSelectElement | HTMLTextAre
 function parseFixedPrecision(type: string): { precision?: number } {
   const match = type.match(/^Fixed(?::(\d+))?$/);
   if (match) {
-    return { precision: match[1] ? parseInt(match[1], 10) : 2 };
+    // Upstream default is `Number(value).toFixed()` → 0 decimal places.
+    return { precision: match[1] ? parseInt(match[1], 10) : 0 };
   }
   return {};
 }
@@ -352,11 +384,18 @@ export const asExpression: ExpressionImplementation = {
       throw new Error('Conversion type must be a string');
     }
 
-    // Handle Fixed:<precision> conversion
+    // Handle Fixed:<precision> conversion (a dynamic resolver upstream, so it
+    // runs before the null short-circuit below — `Number(null).toFixed()`).
     if (type.startsWith('Fixed')) {
       const { precision } = parseFixedPrecision(type);
       const num = defaultConversions.Number(value) as number;
-      return num.toFixed(precision || 2);
+      return num.toFixed(precision ?? 0);
+    }
+
+    // Upstream `convertValue`: null/undefined pass through unchanged for every
+    // static converter (`null as String` is null, not "").
+    if (value == null) {
+      return value;
     }
 
     // Check for built-in conversion (case-sensitive first)

--- a/packages/core/src/expressions/logical/comparators-v0990.test.ts
+++ b/packages/core/src/expressions/logical/comparators-v0990.test.ts
@@ -50,8 +50,11 @@ describe('Comparators (v0.9.90)', () => {
     it('"hello world" does not end with "hello" → true', async () => {
       expect(await evalArg('return "hello world" does not end with "hello"')).toBe(true);
     });
-    it('non-string LHS returns false: 42 starts with "4"', async () => {
-      expect(await evalArg('return 42 starts with "4"')).toBe(false);
+    it('coerces non-string LHS to string (upstream): 42 starts with "4" → true', async () => {
+      expect(await evalArg('return 42 starts with "4"')).toBe(true);
+    });
+    it('null LHS never matches: null starts with "x" → false', async () => {
+      expect(await evalArg('return null starts with "x"')).toBe(false);
     });
   });
 

--- a/packages/core/src/expressions/logical/index.test.ts
+++ b/packages/core/src/expressions/logical/index.test.ts
@@ -403,9 +403,12 @@ describe('Logical Expressions', () => {
         expect(await logicalExpressions.startsWith.evaluate(context, 'hello', '')).toBe(true);
       });
 
-      it('should return false for non-strings', async () => {
-        expect(await logicalExpressions.startsWith.evaluate(context, 123, '1')).toBe(false);
+      it('coerces non-string operands to strings (upstream parity)', async () => {
+        // `123 starts with '12'` → '123'.startsWith('1') → true
+        expect(await logicalExpressions.startsWith.evaluate(context, 123, '1')).toBe(true);
         expect(await logicalExpressions.startsWith.evaluate(context, 'hello', 123)).toBe(false);
+        // null/undefined never match
+        expect(await logicalExpressions.startsWith.evaluate(context, null, '1')).toBe(false);
       });
 
       it('should validate arguments', () => {
@@ -426,9 +429,12 @@ describe('Logical Expressions', () => {
         expect(await logicalExpressions.endsWith.evaluate(context, 'hello', '')).toBe(true);
       });
 
-      it('should return false for non-strings', async () => {
-        expect(await logicalExpressions.endsWith.evaluate(context, 123, '3')).toBe(false);
+      it('coerces non-string operands to strings (upstream parity)', async () => {
+        // `123 ends with '3'` → '123'.endsWith('3') → true
+        expect(await logicalExpressions.endsWith.evaluate(context, 123, '3')).toBe(true);
         expect(await logicalExpressions.endsWith.evaluate(context, 'hello', 123)).toBe(false);
+        // null/undefined never match
+        expect(await logicalExpressions.endsWith.evaluate(context, null, '3')).toBe(false);
       });
 
       it('should validate arguments', () => {

--- a/packages/core/src/expressions/logical/index.ts
+++ b/packages/core/src/expressions/logical/index.ts
@@ -562,7 +562,7 @@ export const existsExpression: ExpressionImplementation = {
   async evaluate(context: ExecutionContext, value: unknown): Promise<boolean> {
     const tracking = (context as { evaluationHistory?: unknown[] }).evaluationHistory;
     const startTime = tracking ? Date.now() : 0;
-    const result = value != null;
+    const result = valueExists(value);
     if (tracking) trackEvaluation(this, context, [value], result, startTime);
     return result;
   },
@@ -571,6 +571,20 @@ export const existsExpression: ExpressionImplementation = {
     return validateArgCount(args, 1, 'exists', 'value');
   },
 };
+
+/**
+ * Existence check shared by `exists` / `does not exist`. Selector references
+ * resolve to arrays/NodeLists (empty when nothing matched), so a non-null but
+ * empty collection must count as "does not exist" — matching upstream, where
+ * `.missing exists` is false. Strings (even empty) and other values exist iff
+ * non-null.
+ */
+function valueExists(value: unknown): boolean {
+  if (value == null) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof NodeList !== 'undefined' && value instanceof NodeList) return value.length > 0;
+  return true;
+}
 
 export const doesNotExistExpression: ExpressionImplementation = {
   name: 'doesNotExist',
@@ -581,7 +595,7 @@ export const doesNotExistExpression: ExpressionImplementation = {
   async evaluate(context: ExecutionContext, value: unknown): Promise<boolean> {
     const tracking = (context as { evaluationHistory?: unknown[] }).evaluationHistory;
     const startTime = tracking ? Date.now() : 0;
-    const result = value == null;
+    const result = !valueExists(value);
     if (tracking) trackEvaluation(this, context, [value], result, startTime);
     return result;
   },
@@ -644,13 +658,19 @@ export const containsExpression: ExpressionImplementation = {
     if (isString(container) && isString(value)) {
       result = (container as string).includes(value as string);
     }
-    // Array containment
-    else if (Array.isArray(container)) {
-      result = container.includes(value);
-    }
-    // Check for NodeList (browser environment only)
-    else if (typeof NodeList !== 'undefined' && container instanceof NodeList) {
-      result = Array.from(container).includes(value as Node);
+    // Array / NodeList containment. Direct membership wins; otherwise, when the
+    // collection holds DOM nodes and `value` is a node, treat it as DOM
+    // containment so selector references work: `.outer contains #d2` (where
+    // `.outer` resolves to `[<div.outer>]`) is true because the div contains #d2.
+    else if (
+      Array.isArray(container) ||
+      (typeof NodeList !== 'undefined' && container instanceof NodeList)
+    ) {
+      const items = Array.from(container as ArrayLike<unknown>);
+      result =
+        items.includes(value) ||
+        (value instanceof Node &&
+          items.some(item => item instanceof Node && (item as Node).contains(value as Node)));
     }
     // Check if object has property (uses registry-based type checks)
     else if (isObject(container) && isString(value)) {
@@ -696,9 +716,9 @@ export const startsWithExpression: ExpressionImplementation = {
   async evaluate(context: ExecutionContext, str: unknown, prefix: unknown): Promise<boolean> {
     const tracking = (context as { evaluationHistory?: unknown[] }).evaluationHistory;
     const startTime = tracking ? Date.now() : 0;
-    // Uses registry-based type checks
-    const result =
-      isString(str) && isString(prefix) ? (str as string).startsWith(prefix as string) : false;
+    // Upstream coerces non-string operands to strings (`123 starts with '12'`),
+    // but null/undefined never match.
+    const result = str != null && prefix != null ? String(str).startsWith(String(prefix)) : false;
     if (tracking) trackEvaluation(this, context, [str, prefix], result, startTime);
     return result;
   },
@@ -717,9 +737,9 @@ export const endsWithExpression: ExpressionImplementation = {
   async evaluate(context: ExecutionContext, str: unknown, suffix: unknown): Promise<boolean> {
     const tracking = (context as { evaluationHistory?: unknown[] }).evaluationHistory;
     const startTime = tracking ? Date.now() : 0;
-    // Uses registry-based type checks
-    const result =
-      isString(str) && isString(suffix) ? (str as string).endsWith(suffix as string) : false;
+    // Upstream coerces non-string operands to strings (`123 ends with '23'`),
+    // but null/undefined never match.
+    const result = str != null && suffix != null ? String(str).endsWith(String(suffix)) : false;
     if (tracking) trackEvaluation(this, context, [str, suffix], result, startTime);
     return result;
   },

--- a/packages/core/src/expressions/missing-features-fix.test.ts
+++ b/packages/core/src/expressions/missing-features-fix.test.ts
@@ -53,9 +53,10 @@ describe('Missing Expression Features Fix - Official Test Patterns', () => {
     });
 
     it('should handle null/undefined gracefully', async () => {
+      // Upstream `convertValue` short-circuits null/undefined for every static
+      // converter, so `null as Date` is null (not an Invalid Date object).
       const result1 = await evaluateExpressionFromSource('null as Date', context);
-      expect(result1).toBeInstanceOf(Date);
-      expect(isNaN(result1.getTime())).toBe(true);
+      expect(result1).toBeNull();
     });
   });
 

--- a/packages/core/src/expressions/property-access-utils.ts
+++ b/packages/core/src/expressions/property-access-utils.ts
@@ -206,7 +206,28 @@ function collectFormValues(el: Element): FormData {
  * @param property - Property name
  * @returns Property value (with methods bound to element)
  */
+/**
+ * Read a `*`-prefixed style reference off an element (possessive/member syntax:
+ * `my *color`, `its *computed-height`). `*computed-<prop>` reads the computed
+ * style (or "" when absent); `*<prop>` reads the camelCase inline style so a
+ * valid-but-unset property is "" while an unknown property is undefined —
+ * matching upstream `*height` → "", `*bad-prop` → undefined.
+ */
+function getElementStyleValue(element: Element, styleProp: string): string | undefined {
+  if (!isHTMLElement(element)) return undefined;
+  if (styleProp.startsWith('computed-')) {
+    return getComputedStyle(element).getPropertyValue(styleProp.slice('computed-'.length)) || '';
+  }
+  const camel = styleProp.replace(/-([a-z])/g, (_m, c: string) => c.toUpperCase());
+  return (element.style as unknown as Record<string, string | undefined>)[camel];
+}
+
 export function getElementProperty(element: Element, property: string): unknown {
+  // Style reference via possessive/member (`my *color`, `its *computed-height`).
+  if (property.startsWith('*')) {
+    return getElementStyleValue(element, property.slice(1));
+  }
+
   // Handle CSS computed style properties with computed- prefix
   if (property.startsWith('computed-')) {
     const cssProperty = property.slice('computed-'.length);

--- a/packages/core/src/expressions/references/index.test.ts
+++ b/packages/core/src/expressions/references/index.test.ts
@@ -380,9 +380,11 @@ describe('Reference Expressions', () => {
         expect(widthResult).toBe('10px');
       });
 
-      it('should return undefined for unset inline properties', async () => {
+      it('distinguishes unset-but-valid ("") from unknown (undefined) properties', async () => {
+        // Upstream parity: a valid but unset inline property is "", while an
+        // unknown property name is undefined (`*height` → "", `*bad-prop` → undefined).
         const heightResult = await referenceExpressions.styleRef.evaluate(context, 'height');
-        expect(heightResult).toBeUndefined();
+        expect(heightResult).toBe('');
 
         const badPropResult = await referenceExpressions.styleRef.evaluate(context, 'bad-prop');
         expect(badPropResult).toBeUndefined();

--- a/packages/core/src/expressions/references/index.ts
+++ b/packages/core/src/expressions/references/index.ts
@@ -298,6 +298,23 @@ export const elementWithSelectorExpression: ExpressionImplementation = {
 // StyleRef Expressions (CSS property access)
 // ============================================================================
 
+/**
+ * Read a style property off an element, matching upstream `*prop` semantics:
+ *   - `computed-<prop>` → `getComputedStyle(el).getPropertyValue(prop)` (or "")
+ *   - `<prop>`          → the camelCase inline-style property, so a valid but
+ *     unset property is "" while an unknown property is `undefined`
+ *     (`*height` → "", `*bad-prop` → undefined). `getPropertyValue` can't make
+ *     that distinction (it returns "" for both).
+ */
+function readStyleValue(target: HTMLElement, property: string): string | undefined {
+  if (property.startsWith('computed-')) {
+    const cssProperty = property.substring(9); // Remove 'computed-' prefix
+    return getComputedStyle(target).getPropertyValue(cssProperty) || '';
+  }
+  const camel = property.replace(/-([a-z])/g, (_m, c: string) => c.toUpperCase());
+  return (target.style as unknown as Record<string, string | undefined>)[camel];
+}
+
 export const styleRefExpression: ExpressionImplementation = {
   name: 'styleRef',
   category: 'Reference',
@@ -316,16 +333,7 @@ export const styleRefExpression: ExpressionImplementation = {
       return undefined;
     }
 
-    // Check if it's a computed style request
-    if (property.startsWith('computed-')) {
-      const cssProperty = property.substring(9); // Remove 'computed-' prefix
-      const computedStyle = getComputedStyle(target);
-      return computedStyle.getPropertyValue(cssProperty) || '';
-    }
-
-    // Direct style property access
-    const value = target.style.getPropertyValue(property);
-    return value || undefined;
+    return readStyleValue(target, property);
   },
 
   validate(args: unknown[]): string | null {
@@ -364,16 +372,7 @@ export const possessiveStyleRefExpression: ExpressionImplementation = {
       return undefined;
     }
 
-    // Check if it's a computed style request
-    if (property.startsWith('computed-')) {
-      const cssProperty = property.substring(9); // Remove 'computed-' prefix
-      const computedStyle = getComputedStyle(target);
-      return computedStyle.getPropertyValue(cssProperty) || '';
-    }
-
-    // Direct style property access
-    const value = target.style.getPropertyValue(property);
-    return value || undefined;
+    return readStyleValue(target, property);
   },
 
   validate(args: unknown[]): string | null {
@@ -410,16 +409,7 @@ export const ofStyleRefExpression: ExpressionImplementation = {
       return undefined;
     }
 
-    // Check if it's a computed style request
-    if (property.startsWith('computed-')) {
-      const cssProperty = property.substring(9); // Remove 'computed-' prefix
-      const computedStyle = getComputedStyle(target);
-      return computedStyle.getPropertyValue(cssProperty) || '';
-    }
-
-    // Direct style property access
-    const value = target.style.getPropertyValue(property);
-    return value || undefined;
+    return readStyleValue(target, property);
   },
 
   validate(args: unknown[]): string | null {

--- a/packages/core/src/parser/boolean-conversion-fix.test.ts
+++ b/packages/core/src/parser/boolean-conversion-fix.test.ts
@@ -105,8 +105,10 @@ describe('Boolean Type Conversion - TDD Fix', () => {
       };
 
       const result = await evaluateExpressionFromSource('nullVar as Boolean', contextWithNull);
-      expect(result).toBe(false);
-      expect(typeof result).toBe('boolean');
+      // Upstream `convertValue` short-circuits null/undefined for every static
+      // converter: `null as Boolean` is null (still falsy in a boolean context),
+      // not coerced to false. Matches `null as String` → null.
+      expect(result).toBeNull();
     });
 
     it('should handle undefined as Boolean', async () => {
@@ -119,8 +121,8 @@ describe('Boolean Type Conversion - TDD Fix', () => {
         'undefinedVar as Boolean',
         contextWithUndefined
       );
-      expect(result).toBe(false);
-      expect(typeof result).toBe('boolean');
+      // Upstream parity: null/undefined pass through unchanged (still falsy).
+      expect(result).toBeUndefined();
     });
 
     it('should handle boolean literal as Boolean (passthrough)', async () => {

--- a/packages/core/src/parser/parser-constants.ts
+++ b/packages/core/src/parser/parser-constants.ts
@@ -447,6 +447,22 @@ export const COMPARISON_OPERATORS = new Set([
   'is greater than or equal to',
   'is less than or equal to',
   'really equals',
+  // Upstream parity — shortened / first-person ("am") comparison forms.
+  // `am`/`is` are interchangeable; the trailing `equal`/`to` words are optional;
+  // `contain`/`match` accept `do not`/`does not` negation with either spelling.
+  'am in', // `I am in [1, 2]`
+  'am not in',
+  'am between', // `I am between 1 and 10`
+  'am not between',
+  'is really', // strict equality without `equal to` — `2 is really 2`
+  'is not really',
+  'is equal', // loose equality without trailing `to` — `2 is equal 2`
+  'is not equal',
+  'contain', // singular subject — `I contain that`
+  'do not contain', // first-person negation — `I do not contain that`
+  'does not contains', // third-person + plural verb — `that does not contains me`
+  'do not match', // `I do not match .foo`
+  'does not match', // `x does not match .foo`
   // Postfix modifier on string comparators (upstream _hyperscript 0.9.90):
   //   "name is 'alice' ignoring case"
   //   "str starts with 'hi' ignoring case"

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -1261,6 +1261,13 @@ export class Parser {
         } else if (isSymbol(this.peek()) && this.peek().value.startsWith('@')) {
           // Attribute reference: element's @data-attr
           propertyName = this.advance().value;
+        } else if (this.check('[') && this.tokens[this.current + 1]?.value?.startsWith('@')) {
+          // Bracketed attribute reference: `element's [@data-attr]` — the long
+          // form of `element's @data-attr`. Strip the brackets and reuse the
+          // `@attr` property path so it resolves to getAttribute.
+          this.advance(); // consume '['
+          propertyName = this.advance().value; // the @attr token
+          this.consume(']', "Expected ']' after attribute reference");
         } else {
           // Normal property access. Use the permissive identifier-like predicate
           // so reserved words (e.g. `result`, `open`, `if`) are accepted as

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -3400,8 +3400,8 @@ export class Parser {
   }
 
   private parseContextPropertyAccess(contextVar: 'me' | 'it' | 'you'): MemberExpressionNode {
-    // Check for CSS property syntax: my *background-color (only applies to 'me')
-    const hasCssPrefix = contextVar === 'me' && this.match('*');
+    // Check for CSS style-ref syntax: `my *color`, `its *height`, `your *width`.
+    const hasCssPrefix = this.match('*');
 
     if (hasCssPrefix) {
       // Parse CSS property name with hyphens (e.g., background-color)
@@ -3432,9 +3432,10 @@ export class Parser {
         }
       }
 
-      // Create member expression with computed-prefix for CSS properties
-      // This tells the evaluator to use getComputedStyle
-      const cssPropertyName = `computed-${propertyName}`;
+      // Preserve the `*` so the evaluator distinguishes inline (`*color`) from
+      // computed (`*computed-color`) styles. Forcing a `computed-` prefix here
+      // wrongly made `my *color` computed and double-prefixed `my *computed-color`.
+      const cssPropertyName = `*${propertyName}`;
       return this.createMemberExpression(
         this.createIdentifier(contextVar),
         this.createIdentifier(cssPropertyName),

--- a/packages/core/src/parser/pratt-parser.ts
+++ b/packages/core/src/parser/pratt-parser.ts
@@ -427,6 +427,53 @@ export const CORE_FRAGMENT: BindingPowerFragment = new Map<string, BindingPowerE
       } as unknown as ASTNode;
     }) as BindingPowerEntry,
   ],
+  // First-person ("am") variants of the between ternary — `I am between 1 and 10`.
+  [
+    'am between',
+    leftAssoc(30, (left, _token, ctx) => {
+      const min = ctx.parseExpr(31);
+      const next = ctx.peek();
+      if (!next || next.value.toLowerCase() !== 'and') {
+        throw new Error(
+          `between requires 'and' between min and max operands, got: ${next?.value ?? '<end>'}`
+        );
+      }
+      ctx.advance(); // consume 'and'
+      const max = ctx.parseExpr(31);
+      return {
+        type: 'betweenExpression',
+        value: left,
+        min,
+        max,
+        negated: false,
+        start: (left as any).start,
+        end: (max as any).end,
+      } as unknown as ASTNode;
+    }) as BindingPowerEntry,
+  ],
+  [
+    'am not between',
+    leftAssoc(30, (left, _token, ctx) => {
+      const min = ctx.parseExpr(31);
+      const next = ctx.peek();
+      if (!next || next.value.toLowerCase() !== 'and') {
+        throw new Error(
+          `between requires 'and' between min and max operands, got: ${next?.value ?? '<end>'}`
+        );
+      }
+      ctx.advance(); // consume 'and'
+      const max = ctx.parseExpr(31);
+      return {
+        type: 'betweenExpression',
+        value: left,
+        min,
+        max,
+        negated: true,
+        start: (left as any).start,
+        end: (max as any).end,
+      } as unknown as ASTNode;
+    }) as BindingPowerEntry,
+  ],
 
   // `ignoring case` — postfix modifier on string comparators.
   // bp 25 sits between `and` (20) and comparison operators (30), so:
@@ -666,6 +713,21 @@ export const PARSER_COMPARISON_FRAGMENT: BindingPowerFragment = new Map<string, 
   ['equals', leftAssoc(30) as BindingPowerEntry],
   ['does not contain', leftAssoc(30) as BindingPowerEntry],
   ['does not include', leftAssoc(30) as BindingPowerEntry],
+
+  // Upstream parity — shortened / first-person comparison forms (see
+  // COMPARISON_OPERATORS in parser-constants.ts). Plain binary operators here;
+  // `am between` / `am not between` get betweenExpression handlers below.
+  ['am in', leftAssoc(30) as BindingPowerEntry],
+  ['am not in', leftAssoc(30) as BindingPowerEntry],
+  ['is really', leftAssoc(30) as BindingPowerEntry],
+  ['is not really', leftAssoc(30) as BindingPowerEntry],
+  ['is equal', leftAssoc(30) as BindingPowerEntry],
+  ['is not equal', leftAssoc(30) as BindingPowerEntry],
+  ['contain', leftAssoc(30) as BindingPowerEntry],
+  ['do not contain', leftAssoc(30) as BindingPowerEntry],
+  ['does not contains', leftAssoc(30) as BindingPowerEntry],
+  ['do not match', leftAssoc(30) as BindingPowerEntry],
+  ['does not match', leftAssoc(30) as BindingPowerEntry],
 
   // English-form comparison aliases (upstream parity)
   ['is equal to', leftAssoc(30) as BindingPowerEntry],

--- a/packages/core/src/parser/pratt-parser.ts
+++ b/packages/core/src/parser/pratt-parser.ts
@@ -603,34 +603,60 @@ export const CORE_FRAGMENT: BindingPowerFragment = new Map<string, BindingPowerE
   [
     'as',
     leftAssoc(70, (left, token, ctx) => {
-      const targetType = ctx.parseExpr(71);
-      // Support `Fixed:N` and similar parameterized type names. The pratt
-      // parser stops at `:` (unknown infix), leaving it as the next token.
-      // Treat the target type as an opaque string and include the suffix —
-      // `normalizeAsTargetType` in runtime.ts resolves the final string form.
-      const peeked = ctx.peek();
-      if (
-        peeked &&
-        peeked.value === ':' &&
-        targetType &&
-        (targetType as any).type === 'identifier'
-      ) {
-        ctx.advance(); // consume ':'
-        const suffix = ctx.advance();
-        if (suffix && suffix.value !== undefined) {
-          (targetType as any).name = `${(targetType as any).name}:${suffix.value}`;
-          (targetType as any).end = suffix.end;
+      // Parse one conversion type: an optional `a`/`an` article (`as a Date`,
+      // `as an Object`), the type name, and an optional `:suffix` (`Fixed:2`).
+      // The pratt parser stops at `:` (unknown infix), leaving it as the next
+      // token; `normalizeAsTargetType` in runtime.ts resolves the final string.
+      const parseConversionType = (): ASTNode => {
+        const article = ctx.peek();
+        if (article && (article.value === 'a' || article.value === 'an')) {
+          ctx.advance(); // skip optional article
         }
-      }
-      return {
+        const targetType = ctx.parseExpr(71);
+        const peeked = ctx.peek();
+        if (
+          peeked &&
+          peeked.value === ':' &&
+          targetType &&
+          (targetType as any).type === 'identifier'
+        ) {
+          ctx.advance(); // consume ':'
+          const suffix = ctx.advance();
+          if (suffix && suffix.value !== undefined) {
+            (targetType as any).name = `${(targetType as any).name}:${suffix.value}`;
+            (targetType as any).end = suffix.end;
+          }
+        }
+        return targetType;
+      };
+
+      let firstType = parseConversionType();
+      let node: ASTNode = {
         type: 'asExpression',
         expression: left,
-        targetType,
+        targetType: firstType,
         start: (left as any).start,
-        end: (targetType as any).end ?? token.end,
+        end: (firstType as any).end ?? token.end,
         line: (left as any).line ?? token.line,
         column: (left as any).column ?? token.column,
-      };
+      } as unknown as ASTNode;
+
+      // Pipe chaining: `value as JSONString | JSON` applies conversions
+      // left-to-right (each `as`-node feeds the next).
+      while (ctx.peek() && ctx.peek()!.value === '|') {
+        ctx.advance(); // consume '|'
+        const nextType = parseConversionType();
+        node = {
+          type: 'asExpression',
+          expression: node,
+          targetType: nextType,
+          start: (node as any).start,
+          end: (nextType as any).end ?? (node as any).end,
+          line: (node as any).line,
+          column: (node as any).column,
+        } as unknown as ASTNode;
+      }
+      return node;
     }) as BindingPowerEntry,
   ],
 

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -269,6 +269,84 @@ export async function evaluateASTWithResult(
  * canonical evaluator. Upstream-faithful semantics: silent-null member
  * access, late-binding `this` on method extraction.
  */
+/**
+ * Thrown by `evaluateExpressionSync` when a node can't be evaluated without the
+ * async pipeline. Callers (the upstream-parity harness shim) catch this and fall
+ * back to the async `evaluateAST`.
+ */
+export class NotSyncEvaluable extends Error {
+  constructor(nodeType: string) {
+    super(`Expression node "${nodeType}" is not synchronously evaluable`);
+    this.name = 'NotSyncEvaluable';
+  }
+}
+
+/**
+ * Synchronous fast-path for the *pure-expression* subset, used only by the
+ * upstream-parity harness so `_hyperscript("expr")` can return a value (not a
+ * Promise) — matching upstream's synchronous `_hyperscript()`. Production keeps
+ * using the canonical async `evaluateAST`; anything this can't prove is
+ * synchronous throws `NotSyncEvaluable` so the caller falls back to async.
+ *
+ * Currently covers bare selector references (`.c1`, `#id`, `<.c1/>`), which is
+ * what the classRef/queryRef parity tests need. Reuses the same selector
+ * resolution semantics as `evaluateSelector` (sans the async registry).
+ */
+export function evaluateExpressionSync(node: ASTNode, context: ExecutionContext): unknown {
+  const n = node as any;
+  switch (n?.type) {
+    case 'literal':
+      return n.value;
+    case 'selector':
+      return evaluateSelectorSync(n, context);
+    default:
+      throw new NotSyncEvaluable(n?.type ?? 'unknown');
+  }
+}
+
+/**
+ * Synchronous mirror of `evaluateSelector` for plain CSS/query selectors.
+ * Style references (`*color`) and anything needing the async pipeline throw
+ * `NotSyncEvaluable` to defer to the async path.
+ */
+function evaluateSelectorSync(node: SelectorNode, context: ExecutionContext): unknown {
+  const selector = node.value;
+  if (typeof selector !== 'string') throw new NotSyncEvaluable('selector');
+  // Style references go through the async styleRef expression — defer.
+  if (!node.fromQuery && /^\*[a-zA-Z][\w-]*$/.test(selector)) {
+    throw new NotSyncEvaluable('selector');
+  }
+  const escaped = escapeClassColons(selector);
+  const doc =
+    (context?.me as { ownerDocument?: Document } | null)?.ownerDocument ??
+    (typeof document !== 'undefined' ? document : null);
+  if (!doc) throw new NotSyncEvaluable('selector');
+  const elements = Array.from(doc.querySelectorAll(escaped));
+  // Bare `#id` unwraps to a single element/null; query-form (`<#id/>`) and class
+  // selectors return the collection — matches evaluateSelector.
+  if (!node.fromQuery && selector.startsWith('#')) {
+    return elements[0] ?? null;
+  }
+  return elements;
+}
+
+/**
+ * Synchronous counterpart to `evaluateExpressionFromSource`, used by the parity
+ * harness. Parses (sync) then evaluates via `evaluateExpressionSync`, throwing
+ * `NotSyncEvaluable` for anything outside the sync subset.
+ */
+export function evaluateExpressionFromSourceSync(
+  source: string,
+  context: ExecutionContext
+): unknown {
+  const result = parse(source);
+  if (!result.success || !result.node) {
+    const err = result.error ?? result.errors?.[0];
+    throw new Error(`Failed to parse expression: ${err?.message ?? 'unknown error'}`);
+  }
+  return evaluateExpressionSync(result.node as ASTNode, context);
+}
+
 export async function evaluateExpressionFromSource(
   source: string,
   context: ExecutionContext

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -419,6 +419,23 @@ async function evaluateBinaryExpression(node: BinaryNode, context: ExecutionCont
     }
   }
 
+  // Style reference with `of`: `*color of me`, `*computed-height of it`. The left
+  // operand is a `*prop` selector — read that style off the RIGHT element rather
+  // than indexing it (`me["red"]`, which the generic `of` branch would do).
+  if (
+    operator === 'of' &&
+    leftNode?.type === 'selector' &&
+    typeof leftNode.value === 'string' &&
+    /^\*[a-zA-Z][\w-]*$/.test(leftNode.value)
+  ) {
+    const el = await evaluateAST(node.right, context);
+    return getExpr(context, 'styleRef').evaluate(
+      context,
+      leftNode.value.slice(1),
+      el as HTMLElement
+    );
+  }
+
   const left = await evaluateAST(node.left, context);
 
   // Handle short-circuit evaluation for logical operators.

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -493,20 +493,33 @@ async function evaluateBinaryExpression(node: BinaryNode, context: ExecutionCont
     case 'is less than or equal to':
       return getExpr(context, 'lessThanOrEqual').evaluate(context, left, right);
     case '==':
+      return getExpr(context, 'equals').evaluate(context, L, R);
     case 'is':
     case 'am': // upstream alias for `is` (e.g., `if I am .active`)
     case 'equals':
-    case 'is equal to':
-      return getExpr(context, 'equals').evaluate(context, L, R);
+    case 'is equal': // shortened `is equal to`
+    case 'is equal to': {
+      // `#el is checked` / `#el is disabled`: when the RHS is a bare identifier
+      // that resolved to undefined but names a boolean property on the left
+      // element, upstream reads that property rather than comparing values.
+      const bp = booleanPropertyFallback(node, left, right);
+      return bp !== undefined ? bp : getExpr(context, 'equals').evaluate(context, L, R);
+    }
     case '!=':
-    case 'is not':
-    case 'is not equal to':
       return getExpr(context, 'notEquals').evaluate(context, L, R);
+    case 'is not':
+    case 'is not equal': // shortened `is not equal to`
+    case 'is not equal to': {
+      const bp = booleanPropertyFallback(node, left, right);
+      return bp !== undefined ? !bp : getExpr(context, 'notEquals').evaluate(context, L, R);
+    }
     case '===':
     case 'really equals':
+    case 'is really': // strict equality without `equal to`
     case 'is really equal to':
       return getExpr(context, 'strictEquals').evaluate(context, L, R);
     case '!==':
+    case 'is not really': // strict inequality without `equal to`
     case 'is not really equal to':
       return getExpr(context, 'strictNotEquals').evaluate(context, L, R);
 
@@ -515,9 +528,14 @@ async function evaluateBinaryExpression(node: BinaryNode, context: ExecutionCont
       return getExpr(context, 'as').evaluate(context, left, normalizeAsTargetType(right));
 
     case 'contains':
+    case 'contain': // singular subject — `I contain that`
+    case 'includes':
+    case 'include':
       return getExpr(context, 'contains').evaluate(context, L, R);
 
     case 'does not contain':
+    case 'do not contain': // first-person negation
+    case 'does not contains': // third-person + plural verb
     case 'does not include':
       return getExpr(context, 'doesNotContain').evaluate(context, L, R);
 
@@ -539,13 +557,25 @@ async function evaluateBinaryExpression(node: BinaryNode, context: ExecutionCont
 
     case 'match':
     case 'matches':
-      return getExpr(context, 'matches').evaluate(context, L, R);
+      return getExpr(context, 'matches').evaluate(context, L, matchTargetOf(node.right, R));
+
+    case 'does not match':
+    case 'do not match': {
+      const r = await getExpr(context, 'matches').evaluate(
+        context,
+        L,
+        matchTargetOf(node.right, R)
+      );
+      return !r;
+    }
 
     case 'in':
     case 'is in':
+    case 'am in': // first-person — `I am in [1, 2]`
       return isIn(left, right);
 
     case 'is not in':
+    case 'am not in':
       return !isIn(left, right);
 
     case 'of':
@@ -581,6 +611,38 @@ function isIn(item: unknown, container: unknown): boolean {
     return item === container || container.contains(item);
   }
   return container != null && typeof container === 'object' && (item as any) in (container as any);
+}
+
+/**
+ * `match`/`matches` semantics: a CSS-selector literal on the right
+ * (`I match .foo`) tests the LEFT element against the selector *string*, not
+ * against the elements that selector resolves to. So when the right operand is
+ * a selector node, use its raw text; otherwise use the already-evaluated value.
+ */
+function matchTargetOf(rightNode: unknown, evaluated: unknown): unknown {
+  const n = rightNode as { type?: string; value?: unknown } | null;
+  if (n && n.type === 'selector' && typeof n.value === 'string') return n.value;
+  return evaluated;
+}
+
+/**
+ * Upstream `is`/`is not` fallback: `#checkbox is checked` / `#button is
+ * disabled`. When the right operand is a bare identifier that resolved to
+ * `undefined` and names a boolean property of the left (DOM) element, read that
+ * property instead of comparing values. Returns the boolean property value, or
+ * `undefined` when the fallback does not apply (callers then compare normally).
+ */
+function booleanPropertyFallback(
+  node: { right?: unknown },
+  left: unknown,
+  right: unknown
+): boolean | undefined {
+  if (right !== undefined) return undefined; // RHS resolved → normal comparison
+  const rn = node.right as { type?: string; name?: string } | null;
+  if (!rn || rn.type !== 'identifier' || typeof rn.name !== 'string') return undefined;
+  if (left == null || typeof left !== 'object') return undefined;
+  const prop = (left as Record<string, unknown>)[rn.name];
+  return typeof prop === 'boolean' ? prop === true : undefined;
 }
 
 /**

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -1136,6 +1136,15 @@ async function evaluateCallExpression(node: CallNode, context: ExecutionContext)
  */
 async function evaluateSelector(node: SelectorNode, context: ExecutionContext): Promise<any> {
   const selector = node.value;
+
+  // Style reference: `*color`, `*text-align`, `*computed-color`. The leading `*`
+  // here is NOT the universal CSS selector — it reads a style property off the
+  // context element (upstream styleRef). Route to the styleRef expression rather
+  // than querySelectorAll, which would throw on `*color`.
+  if (typeof selector === 'string' && !node.fromQuery && /^\*[a-zA-Z][\w-]*$/.test(selector)) {
+    return getExpr(context, 'styleRef').evaluate(context, selector.slice(1));
+  }
+
   const escaped = typeof selector === 'string' ? escapeClassColons(selector) : selector;
   const result = await getExpr(context, 'elementWithSelector').evaluate(context, escaped);
 

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -18,6 +18,7 @@ export { setGlobal } from './extensions';
 // (logical operators, references, conversions, positional, properties, math) goes
 // through `context.registry` so bundle entries control which categories ship.
 import { isElement, getElementProperty } from '../expressions/property-access-utils';
+import { convertValue } from '../expressions/conversion/index';
 import {
   evaluateWhere,
   evaluateSortedBy,
@@ -296,12 +297,79 @@ export function evaluateExpressionSync(node: ASTNode, context: ExecutionContext)
   const n = node as any;
   switch (n?.type) {
     case 'literal':
+    case 'string':
       return n.value;
     case 'selector':
       return evaluateSelectorSync(n, context);
+    case 'identifier':
+      return resolveIdentifierSync(n.name, context);
+    case 'contextReference':
+      return resolveContextReferenceSync(n.contextType, context);
+    case 'arrayLiteral':
+      return (n.elements as ASTNode[]).map(el => evaluateExpressionSync(el, context));
+    case 'objectLiteral':
+      return evaluateObjectLiteralSync(n, context);
+    case 'asExpression': {
+      const value = evaluateExpressionSync(n.expression, context);
+      return convertValue(value, normalizeAsTargetType(n.targetType), context);
+    }
     default:
       throw new NotSyncEvaluable(n?.type ?? 'unknown');
   }
+}
+
+/** Sync identifier resolution mirroring `evaluateIdentifier` (sans the async
+ *  registry / reactivity hooks, which yield the same values for these reads). */
+function resolveIdentifierSync(name: string, context: ExecutionContext): unknown {
+  if (name === 'me' || name === 'my' || name === 'I') return context.me;
+  if (name === 'you' || name === 'your' || name === 'yourself') return context.you;
+  if (name === 'it' || name === 'its') return context.it ?? context.result;
+  if (name === 'window') return typeof window !== 'undefined' ? window : globalThis;
+  if (name === 'document') return typeof document !== 'undefined' ? document : undefined;
+  if (context.locals?.has(name)) return context.locals.get(name);
+  if (context.globals?.has(name)) return context.globals.get(name);
+  if (name.startsWith('$') && context.globals?.has(name.slice(1)))
+    return context.globals.get(name.slice(1));
+  if ((context as any)[name] !== undefined) return (context as any)[name];
+  if (typeof globalThis !== 'undefined' && name in globalThis)
+    return (globalThis as Record<string, unknown>)[name];
+  return undefined;
+}
+
+/** Sync `me`/`you`/`it`/`event`/`target` resolution mirroring `evaluateContextReference`. */
+function resolveContextReferenceSync(contextType: string, context: ExecutionContext): unknown {
+  switch (contextType) {
+    case 'me':
+      return context.me;
+    case 'you':
+      return context.you;
+    case 'it':
+      return context.it ?? context.result;
+    case 'event':
+      return (context as any).event;
+    case 'target':
+      return (context as any).target ?? (context as any).event?.target ?? context.me;
+    default:
+      throw new NotSyncEvaluable('contextReference');
+  }
+}
+
+/** Sync object-literal evaluation mirroring `evaluateObjectLiteralNode`. */
+function evaluateObjectLiteralSync(node: any, context: ExecutionContext): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const property of node.properties) {
+    const keyNode = property.key;
+    let key: string;
+    if (keyNode.type === 'identifier') {
+      key = keyNode.name;
+    } else if (keyNode.type === 'literal' && keyNode.valueType === 'string') {
+      key = keyNode.value;
+    } else {
+      key = String(evaluateExpressionSync(keyNode, context));
+    }
+    result[key] = evaluateExpressionSync(property.value, context);
+  }
+  return result;
 }
 
 /**

--- a/packages/semantic/src/generators/pattern-generator.ts
+++ b/packages/semantic/src/generators/pattern-generator.ts
@@ -68,6 +68,13 @@ export interface GeneratorConfig {
   generateSimpleVariants?: boolean;
   /** Whether to generate alternative keyword patterns */
   generateAlternatives?: boolean;
+  /**
+   * Whether to generate verb-first fallback patterns for SOV languages
+   * (`トグル .active` alongside the canonical `.active を トグル`). Default on.
+   * These are strictly lower priority than the canonical patterns, so native
+   * SOV order always wins; this only accepts bilingual/code-switched input.
+   */
+  generateVerbFirstVariants?: boolean;
 }
 
 const defaultConfig: GeneratorConfig = {
@@ -148,6 +155,60 @@ export function generateSimplePattern(
 }
 
 /**
+ * Generate a verb-first fallback pattern for an SOV language.
+ *
+ * Canonical SOV order is patient-then-verb (`.active を トグル`). Bilingual and
+ * code-switching authors often write the English/loanword verb first
+ * (`トグル .active`). This emits `[verb] [required role(s), UNMARKED]` at a lower
+ * priority so the canonical pattern always wins for native input — the
+ * verb-first form only matches when the input genuinely starts with the verb.
+ *
+ * Kept deliberately conservative: only commands with a single required role
+ * (patient-focused: toggle/add/remove/show/hide/…) get this fallback, which
+ * keeps the unmarked match unambiguous. Returns null otherwise.
+ */
+export function generateVerbFirstPattern(
+  schema: CommandSchema,
+  profile: LanguageProfile,
+  config: GeneratorConfig = defaultConfig
+): LanguagePattern | null {
+  if (profile.wordOrder !== 'SOV') return null;
+
+  const requiredRoles = schema.roles.filter(r => r.required);
+  if (requiredRoles.length !== 1) return null;
+
+  const keyword = profile.keywords[schema.action];
+  if (!keyword) return null;
+
+  const verbToken: PatternToken = keyword.alternatives
+    ? { type: 'literal', value: keyword.primary, alternatives: keyword.alternatives }
+    : { type: 'literal', value: keyword.primary };
+
+  // Verb first, then the required role(s) with NO marker (the marker is what
+  // disambiguates roles in canonical SOV; verb-first input typically omits it).
+  const roleTokens: PatternToken[] = requiredRoles.map(r => ({
+    type: 'role',
+    role: r.role,
+    optional: false,
+    expectedTypes: r.expectedTypes,
+  }));
+
+  return {
+    id: `${schema.action}-${profile.code}-generated-verb-first`,
+    language: profile.code,
+    command: schema.action,
+    // Strictly below the canonical (basePriority) and simple (basePriority - 5)
+    // patterns so native order is always preferred.
+    priority: (config.basePriority ?? 100) - 20,
+    template: {
+      format: `${keyword.primary} <${requiredRoles[0].role}>`,
+      tokens: [verbToken, ...roleTokens],
+    },
+    extraction: buildExtractionRulesWithDefaults(schema, profile),
+  };
+}
+
+/**
  * Generate all pattern variants for a command in a language.
  */
 export function generatePatternVariants(
@@ -165,6 +226,14 @@ export function generatePatternVariants(
     const simple = generateSimplePattern(schema, profile, config);
     if (simple) {
       patterns.push(simple);
+    }
+  }
+
+  // Verb-first fallback for SOV languages (lower priority than the above).
+  if (config.generateVerbFirstVariants !== false) {
+    const verbFirst = generateVerbFirstPattern(schema, profile, config);
+    if (verbFirst) {
+      patterns.push(verbFirst);
     }
   }
 

--- a/packages/semantic/src/generators/pattern-generator.ts
+++ b/packages/semantic/src/generators/pattern-generator.ts
@@ -581,30 +581,33 @@ function buildRoleToken(roleSpec: RoleSpec, profile: LanguageProfile): PatternTo
       }
     }
   } else if (defaultMarker) {
-    if (defaultMarker.position === 'before') {
-      // Preposition: "on #button"
-      if (defaultMarker.primary) {
-        const markerToken: PatternToken = defaultMarker.alternatives
-          ? {
-              type: 'literal',
-              value: defaultMarker.primary,
-              alternatives: defaultMarker.alternatives,
-            }
-          : { type: 'literal', value: defaultMarker.primary };
-        tokens.push(markerToken);
-      }
-      tokens.push(roleValueToken);
-    } else {
-      // Postposition/particle: "#button に"
-      tokens.push(roleValueToken);
-      const markerToken: PatternToken = defaultMarker.alternatives
+    // When the profile allows colloquial marker-dropping, the marker becomes an
+    // optional group so `.active değiştir` parses as well as `.active i değiştir`.
+    // The marked form still matches the marker literal directly (higher
+    // confidence); the unmarked form falls back through the optional group.
+    const asMarker = (): PatternToken =>
+      defaultMarker.alternatives
         ? {
             type: 'literal',
             value: defaultMarker.primary,
             alternatives: defaultMarker.alternatives,
           }
         : { type: 'literal', value: defaultMarker.primary };
-      tokens.push(markerToken);
+    const pushMarker = (marker: PatternToken): void => {
+      tokens.push(
+        profile.markersOptional ? { type: 'group', optional: true, tokens: [marker] } : marker
+      );
+    };
+    if (defaultMarker.position === 'before') {
+      // Preposition: "on #button"
+      if (defaultMarker.primary) {
+        pushMarker(asMarker());
+      }
+      tokens.push(roleValueToken);
+    } else {
+      // Postposition/particle: "#button に"
+      tokens.push(roleValueToken);
+      pushMarker(asMarker());
     }
   } else {
     // No marker, just the role value

--- a/packages/semantic/src/generators/profiles/turkish.ts
+++ b/packages/semantic/src/generators/profiles/turkish.ts
@@ -17,6 +17,10 @@ export const turkishProfile: LanguageProfile = {
   wordOrder: 'SOV',
   markingStrategy: 'case-suffix',
   usesSpaces: true,
+  // Colloquial Turkish frequently drops the accusative/case suffix
+  // (`.active değiştir` for `.active i değiştir`). Accept both — the marked form
+  // stays the higher-confidence match.
+  markersOptional: true,
   verb: {
     position: 'end',
     suffixes: ['mek', 'mak', 'yor', 'di', 'miş'],

--- a/packages/semantic/src/generators/profiles/types.ts
+++ b/packages/semantic/src/generators/profiles/types.ts
@@ -123,6 +123,15 @@ export interface LanguageProfile {
   /** Event handler pattern configuration (for simple SVO languages) */
   readonly eventHandler?: EventHandlerConfig;
   /**
+   * When true, role markers (case particles/postpositions) are emitted as
+   * OPTIONAL pattern tokens, so colloquial marker-dropping input still parses
+   * (e.g. Turkish `.active değiştir` alongside the canonical `.active i
+   * değiştir`). The canonical marked form remains the higher-confidence match;
+   * this only adds a lower-priority fallback. Leave unset (false) for languages
+   * where the particle is grammatically load-bearing (e.g. Japanese/Korean).
+   */
+  readonly markersOptional?: boolean;
+  /**
    * Default verb form for command keywords. Defaults to 'infinitive'.
    *
    * Based on software UI localization research:

--- a/packages/semantic/src/tokenizers/extractors/quechua-keyword.ts
+++ b/packages/semantic/src/tokenizers/extractors/quechua-keyword.ts
@@ -81,7 +81,22 @@ export class QuechuaKeywordExtractor implements ContextAwareExtractor {
   }
 
   canExtract(input: string, position: number): boolean {
-    return isQuechuaLetter(input[position]);
+    if (isQuechuaLetter(input[position])) return true;
+    // Hyphenated suffix notation (`-ta`, `-pi`, `-manta`, …). Without this the
+    // bare `-` is split off as a stray operator token, which breaks SOV pattern
+    // matching (`.active -ta tikray` would fail where `.active ta tikray` works).
+    return this.isHyphenatedSuffix(input, position) !== null;
+  }
+
+  /**
+   * Return the suffix (without the leading hyphen) if `position` begins a
+   * hyphenated Quechua suffix like `-ta`, else null.
+   */
+  private isHyphenatedSuffix(input: string, position: number): string | null {
+    if (input[position] !== '-') return null;
+    const match = input.slice(position).match(/^-([a-zñ'’]+)/i);
+    if (match && SUFFIXES.has(`-${match[1].toLowerCase()}`)) return match[1];
+    return null;
   }
 
   extract(input: string, position: number): ExtractionResult | null {
@@ -90,6 +105,17 @@ export class QuechuaKeywordExtractor implements ContextAwareExtractor {
     }
 
     const startPos = position;
+
+    // Hyphenated suffix (`-ta`): consume the leading hyphen and emit the bare
+    // suffix token, so it tokenizes identically to the standalone `ta` form.
+    const hyphenSuffix = this.isHyphenatedSuffix(input, position);
+    if (hyphenSuffix !== null) {
+      return {
+        value: hyphenSuffix,
+        length: hyphenSuffix.length + 1, // +1 for the consumed hyphen
+        metadata: { suffixValue: hyphenSuffix.toLowerCase() },
+      };
+    }
 
     // First, try to find the longest matching keyword starting at this position
     // This ensures compound words are recognized whole


### PR DESCRIPTION
Implements the approved plan (`expression-parity sweep + SOV/VSO word-order flexibility`). **10 commits, zero regressions** — every other failing test in the suite was confirmed to fail identically on clean `main`.

## Results

- **Expression-parity harness** (`expressions.spec.ts`, upstream `_hyperscript` cases): **50% → 70%** (182 → 252 / 361 runnable). `EXPRESSION_PASS_RATE_FLOOR` ratcheted 47 → 69 (monotonic — each cluster raised it).
- **SOV/VSO browser specs**: all 6 previously-failing specs now pass (75/75 in `semantic-multilingual` + `semantic-package`).
- Full 5254-test semantic suite green; core unit suites green (touched-file verification + pre-existing failures classified against `main`).

## What's in it

**Expression parity (core)**
- **comparisonOperator** — all 26 gaps: `am in`/`is really`/`is equal`/`contain`/`includes`/`does not match`, plus `exists`/`starts-with` coercion / `is checked`/`is disabled` boolean-property fallback.
- **conversions** — `Set`/`Map`/`Keys`/`Entries`/`Reversed`/`Unique`/`Flat`, `Fixed` default precision (0), null-passthrough, pipe `|` chaining, `as a`/`as an` article.
- **styleRef** — full 6/6: bare `*color`, possessive `my *color`, `*color of me`, with correct inline-vs-computed + ""/undefined semantics.
- **possessive** `X's [@attr]` bracketed attribute refs.

**SOV/VSO flexibility (semantic)** — native-order-highest-priority principle
- **verb-first SOV** (`トグル .active`, `토글 .active`) as a lower-priority fallback; native order always wins.
- **Turkish** colloquial marker-drop (`.active değiştir`) via opt-in `markersOptional`.
- **Quechua** hyphenated suffixes (`-ta`, `-ta t'ikray`).
- EN→JA translate: corrected a stale test expectation (renderer was already correct).

**Synchronous expression eval path (harness fidelity)**
- Upstream's `_hyperscript("expr")` is synchronous; HyperFixi is async, so the harness shim returned a Promise and tests consuming the result synchronously (`Array.from(_hyperscript(".c1"))`) failed as false-negatives. Added an **additive, opt-in** `evalHyperScriptSync` (selector/asExpression/leaf nodes) with async fallback — **production is untouched** (still async). Unblocked ~21 real passes (classRef/queryRef/idRef, asExpression Date/Set/Map/Fragment/Values).

## Deferred (documented in the plan file)

The remaining ~30% is bigger-lever or design-laden: ~12 fire-and-forget `set` tests (need sync *command* execution), the checkbox-`as Values` semantics question (boolean vs value), `config.conversions` custom-converter API, and a handful of clean W1.4 bugs (mathOperator/objectLiteral/splitJoin). None are blocking; all are catalogued for follow-up.

## Verification
```
cd packages/core && npm run build:browser
npx playwright test --project=full src/compatibility/browser-tests/expressions.spec.ts        # 252/361, floor 69
npx playwright test --project=full src/compatibility/browser-tests/semantic-*.spec.ts          # 75/75
npm run build --prefix packages/semantic && npm test --prefix packages/semantic                # 5254 pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)