### PR TITLE
Expression upstream-parity follow-up: 70%→79% (8 fixes, floor 78)

### DIFF
--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -25,6 +25,10 @@ const HYPERSCRIPT_TEST_ROOT =
 //   - styleRef (possessive/of):   230/361 runnable = 64%  (floor 63)
 //   - sync-eval selector path:    244/361 runnable = 68%  (floor 67)
 //   - sync-eval asExpression:      252/361 runnable = 70%  (floor 69)
+//   - Phase A product bugs:        273/361 runnable = 76%  (floor 75)
+//       splitJoin (standalone `return`), mathOperator (array `+`),
+//       objectLiteral (hyphenated keys), propertyAccess (`X of Y`),
+//       attributeRef (bare `[@attr]`).
 // Ratchet this up as the remaining parity gaps are fixed in follow-ups.
 //
 // Harness/upstream-fidelity note: upstream's `_hyperscript("expr")` is
@@ -36,7 +40,7 @@ const HYPERSCRIPT_TEST_ROOT =
 // closures (Date/Set/Map/Fragment), classRef/queryRef with interpolation, and the
 // fire-and-forget `set` tests. The products are correct (awaited `run`-based cases
 // pass); extending evalHyperScriptSync to those node types lifts them further.
-const EXPRESSION_PASS_RATE_FLOOR = 69;
+const EXPRESSION_PASS_RATE_FLOOR = 75;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -33,6 +33,9 @@ const HYPERSCRIPT_TEST_ROOT =
 //       where/sorted by/mapped to/split by/joined by on null|undefined.
 //   - `no` × `where` precedence:    282/361 runnable = 78%  (floor 77)
 //       `no X where Y` now binds as `no (X where Y)` (filter, then test empty).
+//   - possessive over collections: 286/361 runnable = 79%  (floor 78)
+//       `.cls's *color` / `'s [@attr]` / chained `'s style's display` map over
+//       all matched elements (collection-intrinsic props like `length` excluded).
 // Ratchet this up as the remaining parity gaps are fixed in follow-ups.
 //
 // Harness/upstream-fidelity note: upstream's `_hyperscript("expr")` is
@@ -44,7 +47,7 @@ const HYPERSCRIPT_TEST_ROOT =
 // closures (Date/Set/Map/Fragment), classRef/queryRef with interpolation, and the
 // fire-and-forget `set` tests. The products are correct (awaited `run`-based cases
 // pass); extending evalHyperScriptSync to those node types lifts them further.
-const EXPRESSION_PASS_RATE_FLOOR = 77;
+const EXPRESSION_PASS_RATE_FLOOR = 78;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -38,6 +38,15 @@ const HYPERSCRIPT_TEST_ROOT =
 //       all matched elements (collection-intrinsic props like `length` excluded).
 // Ratchet this up as the remaining parity gaps are fixed in follow-ups.
 //
+// Remaining gaps @ 79% are NOT clean product bugs — triaged & decided 2026-05-30:
+//   • ~12 async-shim cases (positional/closest/queryRef/relativePositional consumed
+//     via synchronous `=== el` / `.length`) — harness-only; awaited equivalents pass.
+//   • intentional known-diffs from upstream: boolean `in` (not intersection-array),
+//     checkbox `as Values` → boolean (not value). KEPT deliberately.
+//   • deferred features: relativePositional from/within/wrapping, blockLiteral,
+//     typecheck `: Type`, stringPostfix units; + low-value error-message parity.
+// See ~/.claude/plans/please-write-a-planning-optimized-fern.md → "DECISIONS".
+//
 // Harness/upstream-fidelity note: upstream's `_hyperscript("expr")` is
 // SYNCHRONOUS, but HyperFixi evaluates asynchronously. The compatibility-test.html
 // shim now tries `hyperfixi.evalHyperScriptSync` first (a sync fast-path for the

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -31,6 +31,8 @@ const HYPERSCRIPT_TEST_ROOT =
 //       attributeRef (bare `[@attr]`).
 //   - Phase B collection null-safety: 279/361 runnable = 77%  (floor 76)
 //       where/sorted by/mapped to/split by/joined by on null|undefined.
+//   - `no` × `where` precedence:    282/361 runnable = 78%  (floor 77)
+//       `no X where Y` now binds as `no (X where Y)` (filter, then test empty).
 // Ratchet this up as the remaining parity gaps are fixed in follow-ups.
 //
 // Harness/upstream-fidelity note: upstream's `_hyperscript("expr")` is
@@ -42,7 +44,7 @@ const HYPERSCRIPT_TEST_ROOT =
 // closures (Date/Set/Map/Fragment), classRef/queryRef with interpolation, and the
 // fire-and-forget `set` tests. The products are correct (awaited `run`-based cases
 // pass); extending evalHyperScriptSync to those node types lifts them further.
-const EXPRESSION_PASS_RATE_FLOOR = 76;
+const EXPRESSION_PASS_RATE_FLOOR = 77;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -29,6 +29,8 @@ const HYPERSCRIPT_TEST_ROOT =
 //       splitJoin (standalone `return`), mathOperator (array `+`),
 //       objectLiteral (hyphenated keys), propertyAccess (`X of Y`),
 //       attributeRef (bare `[@attr]`).
+//   - Phase B collection null-safety: 279/361 runnable = 77%  (floor 76)
+//       where/sorted by/mapped to/split by/joined by on null|undefined.
 // Ratchet this up as the remaining parity gaps are fixed in follow-ups.
 //
 // Harness/upstream-fidelity note: upstream's `_hyperscript("expr")` is
@@ -40,7 +42,7 @@ const HYPERSCRIPT_TEST_ROOT =
 // closures (Date/Set/Map/Fragment), classRef/queryRef with interpolation, and the
 // fire-and-forget `set` tests. The products are correct (awaited `run`-based cases
 // pass); extending evalHyperScriptSync to those node types lifts them further.
-const EXPRESSION_PASS_RATE_FLOOR = 75;
+const EXPRESSION_PASS_RATE_FLOOR = 76;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/expression-parity-phasea.test.ts
+++ b/packages/core/src/compatibility/expression-parity-phasea.test.ts
@@ -89,6 +89,32 @@ describe('expression parity (Phase A)', () => {
     });
   });
 
+  describe('collection-expression null safety (collectionExpressions)', () => {
+    it('where on null returns null', async () => {
+      expect(await evalHyperScript('set x to null then return x where it > 1')).toBeNull();
+    });
+    it('sorted by on null returns null', async () => {
+      expect(await evalHyperScript('set x to null then return x sorted by it')).toBeNull();
+    });
+    it('mapped to on null returns null', async () => {
+      expect(await evalHyperScript('set x to null then return x mapped to (it * 2)')).toBeNull();
+    });
+    it('split by on null returns null', async () => {
+      expect(await evalHyperScript("set x to null then return x split by ','")).toBeNull();
+    });
+    it('joined by on null returns null', async () => {
+      expect(await evalHyperScript("set x to null then return x joined by ','")).toBeNull();
+    });
+    it('where on undefined returns undefined', async () => {
+      expect(await evalHyperScript('return doesNotExist where it > 1')).toBeUndefined();
+    });
+    it('still filters a non-null array', async () => {
+      expect(
+        await evalHyperScript('set arr to [1, 2, 3, 4, 5] then return arr where it > 3')
+      ).toEqual([4, 5]);
+    });
+  });
+
   describe('bare `[@attr]` attribute reference (attributeRef)', () => {
     it('reads an attribute off the context element', async () => {
       const div = document.createElement('div');

--- a/packages/core/src/compatibility/expression-parity-phasea.test.ts
+++ b/packages/core/src/compatibility/expression-parity-phasea.test.ts
@@ -134,6 +134,34 @@ describe('expression parity (Phase A)', () => {
     });
   });
 
+  describe('possessive over classref/queryref collections (possessiveExpression)', () => {
+    it('maps a style read over all matched elements', async () => {
+      document.body.innerHTML =
+        "<div class='pc1' style='color:red'></div><div class='pc1' style='color:red'></div>";
+      expect(await evalHyperScript(".pc1's *color")).toEqual(['red', 'red']);
+    });
+    it('maps an attribute read over all matched elements', async () => {
+      document.body.innerHTML =
+        "<div class='pc2' data-foo='bar'></div><div class='pc2' data-foo='bar'></div>";
+      expect(await evalHyperScript(".pc2's [@data-foo]")).toEqual(['bar', 'bar']);
+    });
+    it('maps a chained possessive (classref → style → display)', async () => {
+      document.body.innerHTML = "<div class='pc3' style='display: inline'></div>";
+      expect(await evalHyperScript(".pc3's style's display")).toEqual(['inline']);
+    });
+    it('maps a chained possessive on a queryref', async () => {
+      document.body.innerHTML = "<div class='pc4' style='display: inline'></div>";
+      expect(await evalHyperScript("<.pc4/>'s style's display")).toEqual(['inline']);
+    });
+    it('still reads a plain array’s own property (no element-wise mapping)', async () => {
+      expect(await evalHyperScript("[1, 2, 3]'s length")).toBe(3);
+    });
+    it('still reads a single element property (idref, not mapped)', async () => {
+      document.body.innerHTML = "<div id='pf' style='display: inline'></div>";
+      expect(await evalHyperScript("#pf's style's display")).toBe('inline');
+    });
+  });
+
   describe('bare `[@attr]` attribute reference (attributeRef)', () => {
     it('reads an attribute off the context element', async () => {
       const div = document.createElement('div');

--- a/packages/core/src/compatibility/expression-parity-phasea.test.ts
+++ b/packages/core/src/compatibility/expression-parity-phasea.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Expression upstream-parity regression guards (Phase A).
+ *
+ * These mirror failing cases from the upstream `_hyperscript` expression test
+ * suite that the browser parity harness exercises against the built bundle
+ * (src/compatibility/browser-tests/expressions.spec.ts). Running them through
+ * `evalHyperScript` here guards the fixes at the source level so a regression
+ * surfaces in unit tests, not just the slower Playwright harness.
+ */
+import { describe, it, expect } from 'vitest';
+import { evalHyperScript } from './eval-hyperscript';
+
+describe('expression parity (Phase A)', () => {
+  describe('standalone `return <expr>` (splitJoin)', () => {
+    // A single-command `return` program previously leaked the RETURN_EXECUTION
+    // control-flow signal; only `... then return` (a sequence) caught it.
+    it('returns a split array', async () => {
+      expect(await evalHyperScript('return "a,b,c" split by ","')).toEqual(['a', 'b', 'c']);
+    });
+    it('returns a joined string', async () => {
+      expect(await evalHyperScript('return ["a", "b", "c"] joined by ", "')).toBe('a, b, c');
+    });
+    it('returns a plain scalar from a standalone return', async () => {
+      expect(await evalHyperScript('return 42')).toBe(42);
+    });
+  });
+
+  describe('array `+` concatenation (mathOperator)', () => {
+    it('concatenates two arrays', async () => {
+      expect(await evalHyperScript('[1, 2] + [3, 4]')).toEqual([1, 2, 3, 4]);
+    });
+    it('appends a single value', async () => {
+      expect(await evalHyperScript('[1, 2] + 3')).toEqual([1, 2, 3]);
+    });
+    it('chains left-to-right', async () => {
+      expect(await evalHyperScript('[1] + [2] + [3]')).toEqual([1, 2, 3]);
+    });
+    it('does not mutate the original array', async () => {
+      expect(await evalHyperScript('set a to [1, 2] then set b to a + [3] then return a')).toEqual([
+        1, 2,
+      ]);
+    });
+    it('still adds numbers and concatenates strings', async () => {
+      expect(await evalHyperScript('1 + 1')).toBe(2);
+      expect(await evalHyperScript("'a' + 'b'")).toBe('ab');
+    });
+  });
+
+  describe('object-literal keys (objectLiteral)', () => {
+    it('accepts hyphenated field names as string keys', async () => {
+      expect(await evalHyperScript('{-foo:true, bar-baz:false}')).toEqual({
+        '-foo': true,
+        'bar-baz': false,
+      });
+    });
+    it('accepts mixed plain / quoted / dashed keys', async () => {
+      expect(await evalHyperScript('{plain: 1, "quoted": 2, -dashed: 3}')).toEqual({
+        plain: 1,
+        quoted: 2,
+        '-dashed': 3,
+      });
+    });
+    it('still parses plain object literals', async () => {
+      expect(await evalHyperScript('{foo:true, bar:false}')).toEqual({ foo: true, bar: false });
+    });
+  });
+
+  describe('`X of Y` property-path access (propertyAccess)', () => {
+    it('reads a property via of-form', async () => {
+      expect(await evalHyperScript('foo of foo', { locals: { foo: { foo: 'foo' } } })).toBe('foo');
+    });
+    it('handles a dotted path on the left', async () => {
+      expect(
+        await evalHyperScript('bar.doh of foo', { locals: { foo: { bar: { doh: 'foo' } } } })
+      ).toBe('foo');
+    });
+    it('handles a dotted path on the right', async () => {
+      expect(
+        await evalHyperScript('doh of foo.bar', { locals: { foo: { bar: { doh: 'foo' } } } })
+      ).toBe('foo');
+    });
+    it('chains of-forms (right-associative)', async () => {
+      expect(await evalHyperScript('c of b of a', { locals: { a: { b: { c: 'deep' } } } })).toBe(
+        'deep'
+      );
+    });
+    it('still supports dot access', async () => {
+      expect(await evalHyperScript('foo.foo', { locals: { foo: { foo: 'foo' } } })).toBe('foo');
+    });
+  });
+
+  describe('bare `[@attr]` attribute reference (attributeRef)', () => {
+    it('reads an attribute off the context element', async () => {
+      const div = document.createElement('div');
+      div.setAttribute('foo', 'c1');
+      expect(await evalHyperScript('[@foo]', { me: div })).toBe('c1');
+    });
+    it('reads a dashed attribute name', async () => {
+      const div = document.createElement('div');
+      div.setAttribute('data-foo', 'c1');
+      expect(await evalHyperScript('[@data-foo]', { me: div })).toBe('c1');
+    });
+  });
+});

--- a/packages/core/src/compatibility/expression-parity-phasea.test.ts
+++ b/packages/core/src/compatibility/expression-parity-phasea.test.ts
@@ -115,6 +115,25 @@ describe('expression parity (Phase A)', () => {
     });
   });
 
+  describe('`no` with `where` precedence (no)', () => {
+    // `no X where Y` must filter first, then test emptiness — `no (X where Y)`,
+    // not `(no X) where Y`. `no` binds looser than the collection operators.
+    it('is true when the filter removes everything', async () => {
+      expect(await evalHyperScript('no [1, 2, 3] where it > 5')).toBe(true);
+    });
+    it('is false when matches remain', async () => {
+      expect(await evalHyperScript('no [1, 2, 3] where it > 1')).toBe(false);
+    });
+    it('works with `is not`', async () => {
+      expect(await evalHyperScript('no [1, 2, 3] where it is not 2')).toBe(false);
+    });
+    it('still handles bare `no` (null / empty / non-empty)', async () => {
+      expect(await evalHyperScript('no null')).toBe(true);
+      expect(await evalHyperScript('no []')).toBe(true);
+      expect(await evalHyperScript('no [1, 2, 3]')).toBe(false);
+    });
+  });
+
   describe('bare `[@attr]` attribute reference (attributeRef)', () => {
     it('reads an attribute off the context element', async () => {
       const div = document.createElement('div');

--- a/packages/core/src/expressions/properties/index.ts
+++ b/packages/core/src/expressions/properties/index.ts
@@ -21,6 +21,53 @@ export { getElementProperty };
 /** Property names that must never be accessed on plain objects (prototype pollution prevention). */
 const UNSAFE_PROPS = new Set(['__proto__', 'constructor', 'prototype']);
 
+/**
+ * Read a single property/attribute/style off one value, applying the
+ * element/object/primitive rules shared by `possessive`/`my`/`its`/`your`.
+ */
+function readPossessiveValue(element: unknown, property: string): unknown {
+  if (element instanceof Element) {
+    return getElementProperty(element, property);
+  }
+  if (isObject(element)) {
+    if (UNSAFE_PROPS.has(property)) return undefined;
+    return (element as Record<string, unknown>)[property];
+  }
+  return (element as Record<string, unknown>)[property];
+}
+
+/**
+ * A classRef/queryRef resolves to a *collection* of elements; upstream
+ * `_hyperscript` maps a possessive over every match (`.cls's *color` →
+ * `["red", "red"]`). We map arrays / NodeLists / HTMLCollections whose items are
+ * Elements or host objects (e.g. the `CSSStyleDeclaration` that `'s style`
+ * yields, so chains like `.cls's style's display` keep mapping), but NOT arrays
+ * of primitives or plain objects — so `[1, 2, 3]'s length` still reads the
+ * array's own property rather than mapping element-wise.
+ */
+function isMappableCollection(v: unknown): boolean {
+  let items: unknown[];
+  if (Array.isArray(v)) {
+    items = v;
+  } else if (
+    (typeof NodeList !== 'undefined' && v instanceof NodeList) ||
+    (typeof HTMLCollection !== 'undefined' && v instanceof HTMLCollection)
+  ) {
+    items = Array.from(v as ArrayLike<unknown>);
+  } else {
+    return false;
+  }
+  if (items.length === 0) return false;
+  return items.every(
+    item =>
+      item instanceof Element ||
+      (item != null &&
+        typeof item === 'object' &&
+        (item as object).constructor !== Object &&
+        !Array.isArray(item))
+  );
+}
+
 // ============================================================================
 // Possessive Expressions
 // ============================================================================
@@ -41,19 +88,15 @@ export const possessiveExpression: ExpressionImplementation = {
       throw new Error('Property name must be a string');
     }
 
-    // Handle DOM element attributes and properties
-    if (element instanceof Element) {
-      return getElementProperty(element, property);
+    // classRef/queryRef collections map the property over every member — UNLESS
+    // the property belongs to the collection itself (e.g. `length` on the
+    // HTMLCollection from `'s children`, or array methods). That keeps
+    // `#x's children's length` reading the count while `.cls's *color` maps.
+    if (isMappableCollection(element) && !(property in (element as object))) {
+      return Array.from(element as ArrayLike<unknown>, item => readPossessiveValue(item, property));
     }
 
-    // Handle regular object property access
-    if (isObject(element)) {
-      if (UNSAFE_PROPS.has(property)) return undefined;
-      return (element as Record<string, unknown>)[property];
-    }
-
-    // Handle primitive values
-    return (element as Record<string, unknown>)[property];
+    return readPossessiveValue(element, property);
   },
 
   validate(args: unknown[]): string | null {

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -1713,14 +1713,48 @@ export class Parser {
       // Parse property key
       let key: ASTNode;
 
-      if (this.matchPredicate(isIdentifier)) {
-        // Unquoted property name
-        key = this.createIdentifier(this.previous().value);
+      if (this.check('[')) {
+        // Computed property key: `{ [expr]: value }`. Parse the inner
+        // expression; the runtime evaluates it to the actual key (see
+        // evaluateObjectLiteralNode / executeObjectLiteral, which String()
+        // any non-identifier/non-string key node).
+        this.advance(); // consume '['
+        key = this.parseExpression();
+        this.consume(']', "Expected ']' after computed property name in object literal");
       } else if (this.matchString()) {
         // Quoted property name
         const raw = this.previous().value;
         const value = raw.slice(1, -1); // Remove quotes
         key = this.createLiteral(value, raw);
+      } else if (this.check('-') || this.checkPredicate(isIdentifier)) {
+        // Plain or hyphenated identifier key. The tokenizer splits on '-', so
+        // reassemble `-foo` / `bar-baz` / `-dashed` into the original key text.
+        // A dash-free identifier stays an identifier node; anything containing a
+        // dash becomes a string-literal key, matching upstream `_hyperscript`
+        // (`{-foo:1}` → key "-foo").
+        let keyText = '';
+        let sawDash = false;
+        while (this.check('-')) {
+          this.advance();
+          keyText += '-';
+          sawDash = true;
+        }
+        if (this.checkPredicate(isIdentifier)) {
+          keyText += this.advance().value;
+        }
+        while (this.check('-')) {
+          this.advance();
+          keyText += '-';
+          sawDash = true;
+          if (this.checkPredicate(isIdentifier)) {
+            keyText += this.advance().value;
+          }
+        }
+        if (keyText === '' || keyText === '-') {
+          this.addError('Expected property name in object literal');
+          return this.createErrorNode();
+        }
+        key = sawDash ? this.createLiteral(keyText, keyText) : this.createIdentifier(keyText);
       } else {
         this.addError('Expected property name in object literal');
         return this.createErrorNode();
@@ -3994,7 +4028,7 @@ export class Parser {
     const startLine = this.previous().line;
     const startColumn = this.previous().column;
 
-    // Check if this is an attribute literal: [@attr="value"]
+    // Check if this is an attribute literal/reference: [@attr] or [@attr="value"]
     // The next token should start with '@'
     if (!this.isAtEnd() && this.peek().value.startsWith('@')) {
       // Attribute literal syntax - collect all tokens until ']'
@@ -4007,8 +4041,25 @@ export class Parser {
 
       this.consume(']', "Expected ']' after attribute literal");
 
+      const inner = tokens.join(''); // e.g. "@foo", "@data-foo", '@data-foo="blue"'
+
+      // Bare `[@attr]` (no `=value`) is an attribute REFERENCE — read the
+      // attribute off the context element, identical to the short form `@attr`
+      // (see the standalone `@attribute` handler above). Only the valued form
+      // `[@attr=value]` stays a literal string for the `add` command to parse.
+      if (!inner.includes('=')) {
+        return {
+          type: 'attributeAccess',
+          attributeName: inner.replace(/^@/, ''),
+          start: startPos,
+          end: this.previous().end,
+          line: startLine,
+          column: startColumn,
+        } as ASTNode;
+      }
+
       // Reconstruct the full attribute literal string: [@attr="value"]
-      const attributeString = '[' + tokens.join('') + ']';
+      const attributeString = '[' + inner + ']';
 
       // Return as a string literal that the ADD command can parse
       return {

--- a/packages/core/src/parser/pratt-parser.test.ts
+++ b/packages/core/src/parser/pratt-parser.test.ts
@@ -177,9 +177,14 @@ describe('CORE_FRAGMENT', () => {
   });
 
   it('has unary prefix operators at tier 8', () => {
-    for (const op of ['not', '!', 'no']) {
+    // Boolean negation binds tight (tier 8).
+    for (const op of ['not', '!']) {
       expect(CORE_FRAGMENT.get(op)?.prefix?.bp).toBe(80);
     }
+    // `no` (emptiness check) is intentionally LOW precedence so its operand
+    // absorbs collection operators (`no X where Y` ⇒ `no (X where Y)`),
+    // matching upstream _hyperscript. See the `no` entry in pratt-parser.ts.
+    expect(CORE_FRAGMENT.get('no')?.prefix?.bp).toBe(27);
   });
 });
 

--- a/packages/core/src/parser/pratt-parser.ts
+++ b/packages/core/src/parser/pratt-parser.ts
@@ -768,7 +768,10 @@ export const PARSER_COMPARISON_FRAGMENT: BindingPowerFragment = new Map<string, 
 
   // Equality-level keywords from parseEquality
   ['in', leftAssoc(30) as BindingPowerEntry],
-  ['of', leftAssoc(30) as BindingPowerEntry],
+  // `of` is right-associative so `c of b of a` parses as `c of (b of a)` —
+  // property `c` of (property `b` of `a`). See evaluateBinaryExpression's `of`
+  // path-access handler in runtime.ts.
+  ['of', rightAssoc(30) as BindingPowerEntry],
   ['really', leftAssoc(30) as BindingPowerEntry],
 
   // Postfix unary operators — consume operator, no right-hand side

--- a/packages/core/src/parser/pratt-parser.ts
+++ b/packages/core/src/parser/pratt-parser.ts
@@ -663,7 +663,14 @@ export const CORE_FRAGMENT: BindingPowerFragment = new Map<string, BindingPowerE
   // Tier 8: Unary prefix (bp 80)
   ['not', prefix(80) as BindingPowerEntry],
   ['!', prefix(80) as BindingPowerEntry],
-  ['no', prefix(80) as BindingPowerEntry],
+  // `no` (emptiness check) is LOW precedence in upstream `_hyperscript`: it
+  // applies to a whole filtered expression, so `no X where Y` means
+  // `no (X where Y)` — filter first, then test emptiness. Bind looser than the
+  // collection operators (`where`/`sorted by`/`mapped to`/… at bp 28) and the
+  // `in`/`of`/comparison operators (bp 30) so its operand absorbs them, while
+  // staying tighter than logical `and`/`or` (bp 10). Distinct from boolean
+  // `not`/`!`, which bind tight (bp 80).
+  ['no', prefix(27) as BindingPowerEntry],
 ]);
 
 /**

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -582,6 +582,25 @@ async function evaluateBinaryExpression(node: BinaryNode, context: ExecutionCont
     );
   }
 
+  // `X of Y` property access (upstream `_hyperscript`): the LEFT operand is a
+  // property *path* applied to the RIGHT object — NOT a value to resolve in the
+  // current scope. `foo of obj` → obj.foo; `a.b of obj` → obj.a.b. `of` is
+  // right-associative (see pratt-parser), so `c of b of a` parses as
+  // `c of (b of a)`. When the left side isn't a static path (e.g. a computed
+  // member or literal index) we fall through to the generic `case 'of'` below.
+  if (operator === 'of') {
+    const path = propertyPathOf(node.left);
+    if (path) {
+      const target = await evaluateAST(node.right, context);
+      let cur: unknown = target;
+      for (const seg of path) {
+        if (cur == null) return undefined;
+        cur = isElement(cur) ? getElementProperty(cur, seg) : (cur as any)[seg];
+      }
+      return typeof cur === 'function' ? (cur as any).bind(target) : cur;
+    }
+  }
+
   const left = await evaluateAST(node.left, context);
 
   // Handle short-circuit evaluation for logical operators.
@@ -616,6 +635,13 @@ async function evaluateBinaryExpression(node: BinaryNode, context: ExecutionCont
       // JS-native: `+` concatenates if either operand is a string.
       if (typeof left === 'string' || typeof right === 'string') {
         return String(left ?? '') + String(right ?? '');
+      }
+      // Upstream `_hyperscript` array semantics: when the left operand is an
+      // array, `+` concatenates rather than coerces. `[1,2] + [3,4]` →
+      // [1,2,3,4]; `[1,2] + 3` → [1,2,3]. Always returns a fresh array so the
+      // original is never mutated.
+      if (Array.isArray(left)) {
+        return Array.isArray(right) ? [...left, ...right] : [...left, right];
       }
       return unwrapTypedResult(
         await getExpr(context, 'addition').evaluate(context as any, { left, right })
@@ -759,6 +785,38 @@ async function evaluateBinaryExpression(node: BinaryNode, context: ExecutionCont
     default:
       throw new Error(`Unknown binary operator: ${operator}`);
   }
+}
+
+/**
+ * Extract a static property path from an expression node for `X of Y` access.
+ * `foo` → ['foo']; `a.b.c` → ['a','b','c']. Returns null when the node isn't a
+ * plain identifier / dotted member chain (e.g. computed member, call, literal),
+ * so the caller can fall back to generic evaluation.
+ */
+function propertyPathOf(node: unknown): string[] | null {
+  const n = node as {
+    type?: string;
+    name?: string;
+    object?: unknown;
+    property?: { type?: string; name?: string; value?: unknown };
+    computed?: boolean;
+  } | null;
+  if (!n) return null;
+  if (n.type === 'identifier' && typeof n.name === 'string') return [n.name];
+  if (n.type === 'memberExpression' && !n.computed) {
+    const objPath = propertyPathOf(n.object);
+    if (!objPath) return null;
+    const prop = n.property;
+    const propName =
+      prop?.type === 'identifier' && typeof prop.name === 'string'
+        ? prop.name
+        : typeof prop?.value === 'string'
+          ? prop.value
+          : null;
+    if (propName == null) return null;
+    return [...objPath, propName];
+  }
+  return null;
 }
 
 /**

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -1132,6 +1132,14 @@ async function evaluateCollectionExpression(
 ): Promise<any> {
   const collection = await evaluateAST(node.collection, context);
 
+  // Null-safety (upstream _hyperscript): every collection operator passes a
+  // null/undefined collection through unchanged rather than coercing it.
+  // `null where it > 1` → null; `null joined by ','` → null;
+  // `undefined mapped to ...` → undefined.
+  if (collection == null) {
+    return collection;
+  }
+
   // Helper: evaluate the RHS AST with `it` bound to the given element.
   const evalWithIt = async (astNode: ASTNode, it: unknown): Promise<unknown> => {
     const elementContext = { ...context, it } as ExecutionContext;

--- a/packages/core/src/runtime/runtime-base.ts
+++ b/packages/core/src/runtime/runtime-base.ts
@@ -515,19 +515,40 @@ export class RuntimeBase {
 
       switch (node.type) {
         case 'command': {
+          // A standalone `return <expr>` reaches here as a single-command
+          // program — there is no `then`-joined sequence around it to catch the
+          // control-flow signal (executeCommandSequenceWithResult handles the
+          // multi-command case). Surface the returned value the same way the
+          // sequence executor does, rather than leaking the raw
+          // RETURN_EXECUTION signal to the caller.
           // Use Result-based execution when enabled (~12-18% faster)
           if (this.options.enableResultPattern) {
-            try {
-              const result = await this.processCommandWithResult(node as CommandNode, context);
-              if (!isOk(result)) {
-                throw signalToError(result.error);
+            const result = await this.processCommandWithResult(node as CommandNode, context);
+            if (!isOk(result)) {
+              if (result.error.type === 'return') {
+                const rv = (result.error as { returnValue?: unknown }).returnValue;
+                if (rv !== undefined) {
+                  Object.assign(context, { it: rv, result: rv });
+                }
+                return rv;
               }
-              return result.value;
-            } catch (e) {
-              throw e;
+              throw signalToError(result.error);
             }
+            return result.value;
           }
-          return await this.processCommand(node as CommandNode, context);
+          try {
+            return await this.processCommand(node as CommandNode, context);
+          } catch (e) {
+            const cfe = asControlFlowError(e);
+            if (cfe?.isReturn) {
+              const rv = cfe.returnValue;
+              if (rv !== undefined) {
+                Object.assign(context, { it: rv, result: rv });
+              }
+              return rv;
+            }
+            throw e;
+          }
         }
 
         case 'eventHandler': {


### PR DESCRIPTION
Follow-up to #234. Closes more upstream `_hyperscript` expression-parity gaps, driving the parity harness (`packages/core/src/compatibility/browser-tests/expressions.spec.ts`) from **70% → 79%** (252 → 286 / 361 runnable) and ratcheting `EXPRESSION_PASS_RATE_FLOOR` 69 → 78.

**Zero regressions** — targeted vitest (parser/expressions/runtime/control-flow) shows only the 18 pre-existing failures that also fail on clean `main`. 31 source-level regression guards added in `src/compatibility/expression-parity-phasea.test.ts`.

## Fixes (one commit per cluster, each measured against the built bundle)

| Commit | Fix | Δ cases |
| --- | --- | --- |
| `114157f5` | **splitJoin** — a standalone `return <expr>` leaked the `RETURN_EXECUTION` control-flow signal; `runtime-base` now surfaces the value like the sequence executor | +7 |
| `b75b09db` | **mathOperator** array `+` concatenation (immutable) + **propertyAccess** `X of Y` property-path access (`of` made right-associative) | +10 |
| `980e1609` | **objectLiteral** hyphenated/computed keys + **attributeRef** bare `[@attr]` → attribute reference | +4 |
| `d3e03f26` | regression guards + floor 69→75 | — |
| `d9d958dc` | **collectionExpressions** null/undefined passthrough (`where`/`sorted by`/`mapped to`/`split by`/`joined by`) | +6 |
| `e2a749c9` | **no** — lowered `no` prefix binding power so `no X where Y` parses as `no (X where Y)` | +3 |
| `d3c164c5` | **possessiveExpression** maps over classref/queryref element collections (guarded so `[1,2,3]'s length` / `#x's children's length` are unchanged) | +4 |
| `b51feee2` | docs: record decisions in the harness header | — |

## Deliberately out of scope (decided 2026-05-30; documented in the harness header + memory)

The remaining 75 failures are **not clean product bugs**:
- **Async-shim (~12)** — positional/closest/queryRef/relativePositional consumed via synchronous `_hyperscript(...) === el` / `.length`. Production is async-correct; the awaited equivalents pass. Harness's known async ceiling.
- **Intentional known-diffs** — boolean `in` (not intersection-array), checkbox `as Values` → boolean (not value). Kept on purpose.
- **Deferred features** — relativePositional `from/within/with-wrapping`, blockLiteral, typecheck `: Type`, stringPostfix units; plus low-value error-message parity.

## CI notes
- Harness runs against the built bundle (`build:browser`); the Playwright parity job skips gracefully without the sibling `~/projects/_hyperscript` checkout, so the floor is enforced locally, not in CI.
- The 18 pre-existing vitest failures are unchanged by this PR (present on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)