### PR TITLE
Expression parity feature gaps: 79%→82% (relativePositional, stringPostfix, blockLiteral, set-@attr, custom converters)

### DIFF
--- a/packages/core/docs/UPSTREAM-KNOWN-DIFFS.md
+++ b/packages/core/docs/UPSTREAM-KNOWN-DIFFS.md
@@ -1,0 +1,78 @@
+# Upstream `_hyperscript` parity — known differences
+
+This records the places where HyperFixi **intentionally** diverges from upstream
+`_hyperscript`, plus the structural reasons some upstream expression tests can't
+pass through our browser-parity harness. None of these are bugs; they are
+deliberate semantics choices or harness artifacts. They show up as failures in
+`src/compatibility/browser-tests/expressions.spec.ts` and should **not** be
+"fixed" by contorting the engine — change this document if a decision changes.
+
+The harness pass-rate floor is `EXPRESSION_PASS_RATE_FLOOR` in
+[`expressions.spec.ts`](../src/compatibility/browser-tests/expressions.spec.ts).
+It only ratchets up; the gap between it and 100% is mostly the items below.
+
+## Intentional semantic divergences
+
+### `as Values` on a checkbox → boolean (not the value string)
+
+Upstream converts a checked checkbox to its `value` attribute. HyperFixi's
+`getInputValue` (`src/expressions/conversion/index.ts`) returns the boolean
+`checked` state for checkboxes — this is unit-tested and deliberate (a checkbox
+models a boolean, and `input as Values` over a form is more useful with real
+booleans than value strings). Affects ~3 upstream `asExpression` cases
+("converts an input element into Values", "converts checkboxes into a Value",
+"converts a complete form into Values").
+
+**Decision: keep checkbox → boolean.** Do not flip silently.
+
+### bare `in` → boolean membership (not an intersection array)
+
+Upstream `1 in [1, 2, 3]` returns the intersection `[1]`. HyperFixi keeps `in`
+/ `is in` as a **boolean** membership test (`1 in [1,2,3]` → `true`), which is
+what the comparison operators and the vast majority of user code expect. Affects
+the `in.js` "query return values" / "null value in array" cases.
+
+**Decision: keep boolean `in` / `is in`.**
+
+### Error-message text is not matched verbatim
+
+A few upstream tests assert exact error strings, e.g. `typecheck` "Typecheck
+failed!" and "You must parenthesize logical/math operations with different
+operators". HyperFixi raises equivalent errors with different wording. Matching
+the exact text has no user value and would couple us to upstream phrasing.
+
+**Decision: accept as known-diff; do not match upstream error text.**
+
+## Deferred feature
+
+### `typecheck` postfix `X : Type` syntax
+
+Upstream supports a postfix `:` typecheck (`'foo' : String`, `null : String!`).
+HyperFixi already implements the `X is a Type` form; the `:` variant is deferred
+because `:` collides with object-literal (`{k: v}`) and ternary syntax, and the
+remaining payoff is partly the error-message parity above. Not planned unless a
+concrete need appears.
+
+## Harness artifacts (product is correct; the test shape can't observe it)
+
+These upstream tests consume results in a way our async runtime can't satisfy
+through the compatibility shim. The equivalent **awaited** behavior is correct
+and covered by `src/compatibility/expression-parity-phaseb.test.ts` and unit
+suites.
+
+- **Synchronous `_hyperscript(expr) === el`** — e.g. several
+  `relativePositionalExpression` / `positionalExpression` / `closest` cases
+  compare the result of `_hyperscript(...)` to an element _synchronously_.
+  HyperFixi evaluates asynchronously; the sync fast-path (`evaluateExpressionSync`
+  in `runtime.ts`) covers pure values but not DOM-collection queries by design.
+  The parse + evaluation are correct (awaited `run`-based equivalents pass).
+- **Fire-and-forget `_hyperscript("set …")`** — `attributeRef` / `possessive`
+  `set`/`put` cases call the command without awaiting, then read immediately.
+  Lifting them needs synchronous _command_ execution (commands mutate state), a
+  deliberately out-of-scope architectural change. The write paths themselves are
+  correct (see the Track A guards).
+- **`_hyperscript.config.conversions` in the harness sandbox** — the 2 custom-
+  converter cases register on `_hyperscript.config` inside the harness test-body
+  sandbox, where `_hyperscript.config` isn't exposed. The product API
+  (`hyperfixi.config.conversions` + dynamic resolvers) is implemented and guarded
+  (Track E); only the harness plumbing is missing.

--- a/packages/core/src/api/hyperscript-api.ts
+++ b/packages/core/src/api/hyperscript-api.ts
@@ -30,6 +30,7 @@ import type { ASTNode, ExecutionContext, ParseError } from '../types/base-types'
 import type { RuntimeHooks } from '../types/hooks';
 import type { SemanticAnalyzerInterface } from '../parser/types';
 import { createSemanticAdapter } from '../parser/semantic-integration';
+import { conversionConfig, type ConversionConfig } from '../expressions/conversion';
 import {
   parseSemantic,
   isLanguageRegistered,
@@ -188,6 +189,14 @@ export interface HyperscriptConfig {
    * Default: false.
    */
   logAll: boolean;
+
+  /**
+   * User-extensible `as` conversion registry (upstream
+   * `_hyperscript.config.conversions`). Add a named converter
+   * (`config.conversions.Foo = val => …`) or push a dynamic resolver
+   * (`config.conversions.dynamicResolvers.push((name, val) => …)`).
+   */
+  conversions: ConversionConfig;
 }
 
 /**
@@ -208,6 +217,9 @@ export const config: HyperscriptConfig = {
   language: 'en',
   confidenceThreshold: DEFAULT_CONFIDENCE_THRESHOLD,
   logAll: false,
+  // Shared singleton so `convertValue` and `config.conversions` see the same
+  // registry (named converters + dynamicResolvers).
+  conversions: conversionConfig.conversions,
 };
 
 /**

--- a/packages/core/src/commands/data/set.ts
+++ b/packages/core/src/commands/data/set.ts
@@ -96,6 +96,17 @@ export class SetCommand implements DecoratedCommand {
       }
     }
 
+    // Attribute write targets: `set @attr to V`, `set [@attr] to V`,
+    // `set @attr of X to V`, `set X[@attr] to V`. Intercept before the generic
+    // property/member paths so the attributeAccess node routes to setAttribute
+    // (otherwise the computed-member path would key the write on the attribute's
+    // *current* value instead of writing the attribute).
+    const attrTarget = await this.resolveAttributeWriteTarget(firstArg, raw, evaluator, context);
+    if (attrTarget) {
+      const value = await this.extractValue(raw, evaluator, context);
+      return { type: 'attribute', element: attrTarget.element, name: attrTarget.name, value };
+    }
+
     // Unified PropertyTarget resolution: handles propertyOfExpression, propertyAccess, possessiveExpression
     const propertyTarget = await resolveAnyPropertyTarget(
       firstArg as import('../../types/base-types').ASTNode,
@@ -272,6 +283,58 @@ export class SetCommand implements DecoratedCommand {
   }
 
   // ========== Private Helpers ==========
+
+  /**
+   * Recognize attribute write targets and resolve the element they apply to.
+   * Covers `set @attr to V` / `set [@attr] to V` (a standalone attributeAccess,
+   * written to the `on` target or `me`), `set @attr of X to V` (binary `of` with
+   * an attributeAccess LHS), and `set X[@attr] to V` (a computed member whose
+   * property is an attributeAccess). Returns null for non-attribute targets so
+   * the caller falls through to the existing property/member/variable paths.
+   */
+  private async resolveAttributeWriteTarget(
+    firstArg: Record<string, unknown>,
+    raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },
+    evaluator: ExpressionEvaluator,
+    context: ExecutionContext
+  ): Promise<{ element: HTMLElement; name: string } | null> {
+    const node = firstArg as Record<string, any>;
+
+    // Standalone `@attr` / `[@attr]` — writes to the `on` target or `me`.
+    if (node?.type === 'attributeAccess') {
+      const element = await this.resolveElement(raw.modifiers.on, evaluator, context);
+      return { element, name: node.attributeName as string };
+    }
+
+    // `@attr of X` / `[@attr] of X` — binary `of` with an attributeAccess LHS.
+    if (
+      node?.type === 'binaryExpression' &&
+      node.operator === 'of' &&
+      node.left?.type === 'attributeAccess'
+    ) {
+      const element = await this.evaluateToElement(node.right as ASTNode, evaluator, context);
+      if (element) return { element, name: node.left.attributeName as string };
+    }
+
+    // `X[@attr]` — computed member access whose property is an attributeAccess.
+    if (node?.type === 'memberExpression' && node.property?.type === 'attributeAccess') {
+      const element = await this.evaluateToElement(node.object as ASTNode, evaluator, context);
+      if (element) return { element, name: node.property.attributeName as string };
+    }
+
+    return null;
+  }
+
+  /** Evaluate an AST node to a single HTMLElement (unwrapping selector arrays). */
+  private async evaluateToElement(
+    node: ASTNode,
+    evaluator: ExpressionEvaluator,
+    context: ExecutionContext
+  ): Promise<HTMLElement | null> {
+    const value = await evaluator.evaluate(node, context);
+    const el = Array.isArray(value) ? value[0] : value;
+    return isHTMLElement(el) ? (el as HTMLElement) : null;
+  }
 
   private async tryParseMemberExpression(
     firstArg: Record<string, unknown>,

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -56,7 +56,7 @@ const HYPERSCRIPT_TEST_ROOT =
 // closures (Date/Set/Map/Fragment), classRef/queryRef with interpolation, and the
 // fire-and-forget `set` tests. The products are correct (awaited `run`-based cases
 // pass); extending evalHyperScriptSync to those node types lifts them further.
-const EXPRESSION_PASS_RATE_FLOOR = 78;
+const EXPRESSION_PASS_RATE_FLOOR = 79;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -56,6 +56,10 @@ const HYPERSCRIPT_TEST_ROOT =
 // closures (Date/Set/Map/Fragment), classRef/queryRef with interpolation, and the
 // fire-and-forget `set` tests. The products are correct (awaited `run`-based cases
 // pass); extending evalHyperScriptSync to those node types lifts them further.
+//
+// The remaining gap below 100% is mostly intentional divergences + harness
+// artifacts — see docs/UPSTREAM-KNOWN-DIFFS.md (checkbox `as Values` → boolean,
+// boolean `in`, error-message text, sync `=== el` / fire-and-forget `set`).
 const EXPRESSION_PASS_RATE_FLOOR = 80;
 
 interface TestFile {

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -56,7 +56,7 @@ const HYPERSCRIPT_TEST_ROOT =
 // closures (Date/Set/Map/Fragment), classRef/queryRef with interpolation, and the
 // fire-and-forget `set` tests. The products are correct (awaited `run`-based cases
 // pass); extending evalHyperScriptSync to those node types lifts them further.
-const EXPRESSION_PASS_RATE_FLOOR = 79;
+const EXPRESSION_PASS_RATE_FLOOR = 80;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -60,7 +60,7 @@ const HYPERSCRIPT_TEST_ROOT =
 // The remaining gap below 100% is mostly intentional divergences + harness
 // artifacts — see docs/UPSTREAM-KNOWN-DIFFS.md (checkbox `as Values` → boolean,
 // boolean `in`, error-message text, sync `=== el` / fire-and-forget `set`).
-const EXPRESSION_PASS_RATE_FLOOR = 80;
+const EXPRESSION_PASS_RATE_FLOOR = 81;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/expression-parity-phaseb.test.ts
+++ b/packages/core/src/compatibility/expression-parity-phaseb.test.ts
@@ -57,4 +57,59 @@ describe('expression parity (Phase B)', () => {
     // Known gap (deferred): bare `x@attr` member-short adjacency is a parse-level
     // read-syntax gap (affects reads too, not just set) — use `x[@attr]` instead.
   });
+
+  describe('Track B — relativePositional from/within/in/with-wrapping', () => {
+    // `next <sel> from <el> [within <el> | in <coll>] [with wrapping]` previously
+    // errored with "Unexpected token: from"; parseNavigationFunction now consumes
+    // the modifiers and the runtime applies upstream document-order scan semantics
+    // (returning `undefined` on no-match, matching upstream).
+    function setup() {
+      document.body.innerHTML =
+        "<div id='d1' class='c1'></div><p class='c1'></p>" +
+        "<div id='d2' class='c1'></div><p class='c1'></p>" +
+        "<div id='d3' class='c1'></div>";
+    }
+    const id = (s: string) => document.getElementById(s);
+
+    it('next <div/> from #d1 → next matching sibling', async () => {
+      setup();
+      expect(await evalHyperScript('the next <div/> from #d1')).toBe(id('d2'));
+    });
+    it('next <div/> from the last → undefined (no match, no wrap)', async () => {
+      setup();
+      expect(await evalHyperScript('the next <div/> from #d3')).toBeUndefined();
+    });
+    it('previous <div/> from #d2 → previous matching sibling', async () => {
+      setup();
+      expect(await evalHyperScript('the previous <div/> from #d2')).toBe(id('d1'));
+    });
+    it('next … with wrapping wraps to the first match', async () => {
+      setup();
+      expect(await evalHyperScript('the next <div/> from #d3 with wrapping')).toBe(id('d1'));
+    });
+    it('next … in <collection> scans the array', async () => {
+      setup();
+      expect(await evalHyperScript('the next <div/> from #d1 in .c1')).toBe(id('d2'));
+    });
+    it('next <h1/> … in <collection> → undefined (no match)', async () => {
+      setup();
+      expect(await evalHyperScript('the next <h1/> from #d1 in .c1')).toBeUndefined();
+    });
+    it('previous <h1/> … in <collection> → undefined (no match)', async () => {
+      setup();
+      expect(await evalHyperScript('the previous <h1/> from #d1 in .c1')).toBeUndefined();
+    });
+    it('within <container> constrains the search root', async () => {
+      document.body.innerHTML =
+        "<div id='d1' class='c1'><div id='d2' class='c1'></div><div id='d3' class='c1'></div></div>" +
+        "<div id='d4' class='c1'></div>";
+      expect(await evalHyperScript('the next .c1 from #d2 within #d1')).toBe(id('d3'));
+      expect(await evalHyperScript('the next .c1 from #d3 within #d1')).toBeUndefined();
+    });
+    it('bare `next <sel>` (no modifiers) keeps the legacy tree-walk', async () => {
+      document.body.innerHTML = "<div id='b1'></div><div id='b2' class='target'></div>";
+      const b1 = id('b1')!;
+      expect(await evalHyperScript('next .target', { me: b1 })).toBe(id('b2'));
+    });
+  });
 });

--- a/packages/core/src/compatibility/expression-parity-phaseb.test.ts
+++ b/packages/core/src/compatibility/expression-parity-phaseb.test.ts
@@ -10,7 +10,7 @@
  * Companion to expression-parity-phasea.test.ts.
  */
 import { describe, it, expect } from 'vitest';
-import { evalHyperScript } from './eval-hyperscript';
+import { evalHyperScript, evalHyperScriptSync } from './eval-hyperscript';
 import { conversionConfig } from '../expressions/conversion';
 
 describe('expression parity (Phase B)', () => {
@@ -166,6 +166,32 @@ describe('expression parity (Phase B)', () => {
     });
     it('still warns + passes through for a truly unknown type', async () => {
       expect(await evalHyperScript('1 as DefinitelyNotAType')).toBe(1);
+    });
+  });
+
+  describe('Track D — blockLiteral lambdas', () => {
+    // `\-> expr`, `\ x -> expr`, `\ x, y -> expr` errored at parse. They now
+    // produce a function; the body is evaluated synchronously when possible so
+    // the closure works as a plain JS callback (e.g. Array.map).
+    it('no-arg lambda', async () => {
+      const fn = (await evalHyperScript('\\-> true')) as () => unknown;
+      expect(fn()).toBe(true);
+    });
+    it('identity lambda', async () => {
+      const fn = (await evalHyperScript('\\ x -> x')) as (a: unknown) => unknown;
+      expect(fn(true)).toBe(true);
+      expect(fn(42)).toBe(42);
+    });
+    it('two-arg lambda', async () => {
+      const fn = (await evalHyperScript('\\ x, y -> y')) as (a: unknown, b: unknown) => unknown;
+      expect(fn(false, true)).toBe(true);
+    });
+    it('used as a synchronous Array.map callback (member-access body)', async () => {
+      expect(await evalHyperScript("['a', 'ab', 'abc'].map(\\ s -> s.length)")).toEqual([1, 2, 3]);
+    });
+    it('the synchronous fast-path returns the function directly', () => {
+      const fn = evalHyperScriptSync('\\ x -> x') as (a: unknown) => unknown;
+      expect(fn('hi')).toBe('hi');
     });
   });
 });

--- a/packages/core/src/compatibility/expression-parity-phaseb.test.ts
+++ b/packages/core/src/compatibility/expression-parity-phaseb.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Expression upstream-parity regression guards (Phase B — feature gaps).
+ *
+ * Mirrors failing cases from the upstream `_hyperscript` expression test suite
+ * that the browser parity harness exercises against the built bundle
+ * (src/compatibility/browser-tests/expressions.spec.ts). Running them through
+ * `evalHyperScript` guards the fixes at the source level so a regression surfaces
+ * in unit tests, not just the slower Playwright harness.
+ *
+ * Companion to expression-parity-phasea.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { evalHyperScript } from './eval-hyperscript';
+
+describe('expression parity (Phase B)', () => {
+  describe('Track A — set attribute write-path (attributeRef / possessiveExpression)', () => {
+    // `set @attr to V` / `[@attr]` / `my @attr` / `my [@attr]` / `@attr of X` /
+    // `X[@attr]` must route to setAttribute on the resolved element. Previously
+    // the attributeAccess target fell through to the property/member path and the
+    // write was silently dropped (or keyed on the attribute's current value).
+    async function setAttr(code: string): Promise<string | null> {
+      const div = document.createElement('div');
+      div.setAttribute('data-foo', 'red');
+      document.body.appendChild(div);
+      await evalHyperScript(code, { me: div, locals: { x: div } });
+      return div.getAttribute('data-foo');
+    }
+
+    it('writes a standalone @attr to the context element', async () => {
+      expect(await setAttr('set @data-foo to "blue"')).toBe('blue');
+    });
+    it('writes a bracketed [@attr]', async () => {
+      expect(await setAttr('set [@data-foo] to "blue"')).toBe('blue');
+    });
+    it('writes a possessive my @attr', async () => {
+      expect(await setAttr('set my @data-foo to "blue"')).toBe('blue');
+    });
+    it('writes a bracketed possessive my [@attr]', async () => {
+      expect(await setAttr('set my [@data-foo] to "blue"')).toBe('blue');
+    });
+    it('writes @attr of X (indirect)', async () => {
+      expect(await setAttr('set @data-foo of x to "blue"')).toBe('blue');
+    });
+    it('writes [@attr] of X (indirect, bracketed)', async () => {
+      expect(await setAttr('set [@data-foo] of x to "blue"')).toBe('blue');
+    });
+    it('writes X[@attr] (computed member)', async () => {
+      expect(await setAttr('set x[@data-foo] to "blue"')).toBe('blue');
+    });
+
+    // Guard the read path stays intact.
+    it('still reads a bare [@attr] off the context element', async () => {
+      const div = document.createElement('div');
+      div.setAttribute('data-bar', 'green');
+      expect(await evalHyperScript('[@data-bar]', { me: div })).toBe('green');
+    });
+    // Known gap (deferred): bare `x@attr` member-short adjacency is a parse-level
+    // read-syntax gap (affects reads too, not just set) — use `x[@attr]` instead.
+  });
+});

--- a/packages/core/src/compatibility/expression-parity-phaseb.test.ts
+++ b/packages/core/src/compatibility/expression-parity-phaseb.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { evalHyperScript } from './eval-hyperscript';
+import { conversionConfig } from '../expressions/conversion';
 
 describe('expression parity (Phase B)', () => {
   describe('Track A — set attribute write-path (attributeRef / possessiveExpression)', () => {
@@ -139,6 +140,32 @@ describe('expression parity (Phase B)', () => {
     it('does not disturb arithmetic', async () => {
       expect(await evalHyperScript('1 + 1')).toBe(2);
       expect(await evalHyperScript('2 * 3')).toBe(6);
+    });
+  });
+
+  describe('Track E — custom `as` conversions (config.conversions)', () => {
+    // Upstream `_hyperscript.config.conversions` — a named converter or a
+    // dynamic resolver extends the `as` target types.
+    it('resolves a named custom converter', async () => {
+      (conversionConfig.conversions as Record<string, unknown>).Foo = (val: unknown) => 'foo' + val;
+      try {
+        expect(await evalHyperScript('1 as Foo')).toBe('foo1');
+      } finally {
+        delete (conversionConfig.conversions as Record<string, unknown>).Foo;
+      }
+    });
+    it('resolves a dynamic converter (first non-undefined wins)', async () => {
+      const resolver = (conversion: string, val: unknown) =>
+        conversion.indexOf('Foo:') === 0 ? conversion.split(':')[1] + val : undefined;
+      conversionConfig.conversions.dynamicResolvers.push(resolver);
+      try {
+        expect(await evalHyperScript('1 as Foo:Bar')).toBe('Bar1');
+      } finally {
+        conversionConfig.conversions.dynamicResolvers.pop();
+      }
+    });
+    it('still warns + passes through for a truly unknown type', async () => {
+      expect(await evalHyperScript('1 as DefinitelyNotAType')).toBe(1);
     });
   });
 });

--- a/packages/core/src/compatibility/expression-parity-phaseb.test.ts
+++ b/packages/core/src/compatibility/expression-parity-phaseb.test.ts
@@ -112,4 +112,33 @@ describe('expression parity (Phase B)', () => {
       expect(await evalHyperScript('next .target', { me: b1 })).toBe(id('b2'));
     });
   });
+
+  describe('Track C — stringPostfix measurement units', () => {
+    // `1em` / `100%` / `(0 + 1) px` etc. errored with "Unexpected token: em".
+    // A trailing CSS unit (or a `%` with no operand) now stringifies the value.
+    it('appends CSS units to a number', async () => {
+      expect(await evalHyperScript('1em')).toBe('1em');
+      expect(await evalHyperScript('1px')).toBe('1px');
+      expect(await evalHyperScript('-1px')).toBe('-1px');
+    });
+    it('handles the % unit', async () => {
+      expect(await evalHyperScript('100%')).toBe('100%');
+    });
+    it('allows a space before the unit', async () => {
+      expect(await evalHyperScript('1 em')).toBe('1em');
+      expect(await evalHyperScript('100 %')).toBe('100%');
+    });
+    it('applies to parenthesized expression roots', async () => {
+      expect(await evalHyperScript('(0 + 1) em')).toBe('1em');
+      expect(await evalHyperScript('(100 + 0) %')).toBe('100%');
+    });
+    it('keeps `%` as modulo when a right operand follows', async () => {
+      expect(await evalHyperScript('100 % 5')).toBe(0);
+      expect(await evalHyperScript('10 % 3')).toBe(1);
+    });
+    it('does not disturb arithmetic', async () => {
+      expect(await evalHyperScript('1 + 1')).toBe(2);
+      expect(await evalHyperScript('2 * 3')).toBe(6);
+    });
+  });
 });

--- a/packages/core/src/expressions/conversion/index.ts
+++ b/packages/core/src/expressions/conversion/index.ts
@@ -17,6 +17,27 @@ export interface ConversionFunction {
   (value: unknown, context?: ExecutionContext): unknown;
 }
 
+/** A user-registered dynamic converter: `(conversionName, value) => result | undefined`. */
+export type DynamicConversionResolver = (conversion: string, value: unknown) => unknown;
+
+/**
+ * User-extensible conversion registry, exposed on the global as
+ * `hyperfixi.config.conversions` (and `_hyperscript.config.conversions` in the
+ * compat shim). Mirrors upstream `_hyperscript.config.conversions`:
+ *   - string keys map a target type name → converter function `(val) => result`
+ *   - `dynamicResolvers` is an array of `(conversionName, val) => result|undefined`
+ *     tried in order for any type not matched by a built-in or a named entry.
+ * Checked by `convertValue` before falling back to the "unknown type" warning.
+ */
+export interface ConversionConfig {
+  [type: string]: ConversionFunction | DynamicConversionResolver[] | undefined;
+  dynamicResolvers: DynamicConversionResolver[];
+}
+
+export const conversionConfig: { conversions: ConversionConfig } = {
+  conversions: { dynamicResolvers: [] },
+};
+
 export const defaultConversions: Record<string, ConversionFunction> = {
   // Basic type conversions
   Array: (value: unknown) => {
@@ -428,8 +449,20 @@ export function convertValue(value: unknown, type: string, context?: ExecutionCo
     }
   }
 
-  // Unknown conversion type — return the original value (custom conversions via
-  // global config are not yet supported).
+  // User-registered conversions (upstream `_hyperscript.config.conversions`):
+  // a named converter, then the dynamic resolvers (first non-undefined wins).
+  const named = conversionConfig.conversions[type];
+  if (typeof named === 'function') {
+    return (named as ConversionFunction)(value, context);
+  }
+  for (const resolver of conversionConfig.conversions.dynamicResolvers) {
+    const resolved = resolver(type, value);
+    if (resolved !== undefined) {
+      return resolved;
+    }
+  }
+
+  // Unknown conversion type — return the original value unchanged.
   console.warn(`Unknown conversion type: ${type}`);
   return value;
 }

--- a/packages/core/src/expressions/positional/index.test.ts
+++ b/packages/core/src/expressions/positional/index.test.ts
@@ -236,9 +236,11 @@ describe('Positional Expressions', () => {
         expect(positionalExpressions.next.validate!([])).toBeNull();
         expect(positionalExpressions.next.validate!(['selector'])).toBeNull();
         expect(positionalExpressions.next.validate!(['selector', document.body])).toBeNull();
+        // 3rd arg is the relative-positional modifiers object (from/within/in/wrapping).
+        expect(positionalExpressions.next.validate!(['selector', document.body, {}])).toBeNull();
         expect(
-          positionalExpressions.next.validate!(['selector', document.body, 'extra'])
-        ).toContain('at most 2 arguments');
+          positionalExpressions.next.validate!(['selector', document.body, {}, 'extra'])
+        ).toContain('at most 3 arguments');
         expect(positionalExpressions.next.validate!([123])).toContain('must be a string');
         expect(positionalExpressions.next.validate!(['selector', 'not-element'])).toContain(
           'must be an Element'
@@ -288,9 +290,13 @@ describe('Positional Expressions', () => {
         expect(positionalExpressions.previous.validate!([])).toBeNull();
         expect(positionalExpressions.previous.validate!(['selector'])).toBeNull();
         expect(positionalExpressions.previous.validate!(['selector', document.body])).toBeNull();
+        // 3rd arg is the relative-positional modifiers object (from/within/in/wrapping).
         expect(
-          positionalExpressions.previous.validate!(['selector', document.body, 'extra'])
-        ).toContain('at most 2 arguments');
+          positionalExpressions.previous.validate!(['selector', document.body, {}])
+        ).toBeNull();
+        expect(
+          positionalExpressions.previous.validate!(['selector', document.body, {}, 'extra'])
+        ).toContain('at most 3 arguments');
         expect(positionalExpressions.previous.validate!([123])).toContain('must be a string');
         expect(positionalExpressions.previous.validate!(['selector', 'not-element'])).toContain(
           'must be an Element'

--- a/packages/core/src/expressions/positional/index.ts
+++ b/packages/core/src/expressions/positional/index.ts
@@ -181,14 +181,31 @@ export const atExpression: ExpressionImplementation = {
 // DOM Relative Positional Expressions
 // ============================================================================
 
+/**
+ * Modifiers for the relative positional expression
+ * (`next <sel> from <el> [within <el> | in <coll>] [with wrapping]`).
+ * Passed as the 3rd argument to `next`/`previous` only when the parser captured
+ * an explicit `from`/`within`/`in`/`with wrapping` clause; the bare `next <sel>`
+ * form leaves it undefined and keeps the legacy tree-walk behavior.
+ */
+export interface RelativePositionalOptions {
+  within?: Element | null;
+  inElt?: unknown;
+  inSearch?: boolean;
+  wrapping?: boolean;
+}
+
 export const nextExpression: ExpressionImplementation = {
   name: 'next',
   category: 'Reference',
   evaluatesTo: 'Element',
   operators: ['next'],
 
-  async evaluate(context: ExecutionContext, ...args: unknown[]): Promise<HTMLElement | null> {
-    const [selector, fromElement] = args;
+  async evaluate(
+    context: ExecutionContext,
+    ...args: unknown[]
+  ): Promise<HTMLElement | null | undefined> {
+    const [selector, fromElement, options] = args;
     const startElement = (fromElement as HTMLElement | undefined) || context.me;
 
     if (!startElement || !(startElement instanceof Element)) {
@@ -200,12 +217,27 @@ export const nextExpression: ExpressionImplementation = {
       return startElement.nextElementSibling as HTMLElement | null;
     }
 
-    // Find next element matching selector in DOM tree
+    // Explicit `from/within/in/wrapping` clause → upstream document-order scan.
+    if (options) {
+      return scanRelative(
+        startElement,
+        selector as string,
+        options as RelativePositionalOptions,
+        true
+      );
+    }
+
+    // Bare `next <sel>` (relative to me) keeps the existing tree-walk behavior.
     return findNextElementInDOM(startElement, selector as string);
   },
 
   validate(args: unknown[]): string | null {
-    const maxError = validateMaxArgs(args, 2, 'next', 'optional selector, optional fromElement');
+    const maxError = validateMaxArgs(
+      args,
+      3,
+      'next',
+      'optional selector, optional fromElement, optional modifiers'
+    );
     if (maxError) return maxError;
     if (args.length >= 1 && args[0] != null && typeof args[0] !== 'string') {
       return 'selector must be a string';
@@ -223,8 +255,11 @@ export const previousExpression: ExpressionImplementation = {
   evaluatesTo: 'Element',
   operators: ['previous', 'prev'],
 
-  async evaluate(context: ExecutionContext, ...args: unknown[]): Promise<HTMLElement | null> {
-    const [selector, fromElement] = args;
+  async evaluate(
+    context: ExecutionContext,
+    ...args: unknown[]
+  ): Promise<HTMLElement | null | undefined> {
+    const [selector, fromElement, options] = args;
     const startElement = (fromElement as HTMLElement | undefined) || context.me;
 
     if (!startElement || !(startElement instanceof Element)) {
@@ -236,6 +271,16 @@ export const previousExpression: ExpressionImplementation = {
       return startElement.previousElementSibling as HTMLElement | null;
     }
 
+    // Explicit `from/within/in/wrapping` clause → upstream document-order scan.
+    if (options) {
+      return scanRelative(
+        startElement,
+        selector as string,
+        options as RelativePositionalOptions,
+        false
+      );
+    }
+
     // Find previous element matching selector in DOM tree
     return findPreviousElementInDOM(startElement, selector as string);
   },
@@ -243,9 +288,9 @@ export const previousExpression: ExpressionImplementation = {
   validate(args: unknown[]): string | null {
     const maxError = validateMaxArgs(
       args,
-      2,
+      3,
       'previous',
-      'optional selector, optional fromElement'
+      'optional selector, optional fromElement, optional modifiers'
     );
     if (maxError) return maxError;
     if (args.length >= 1 && args[0] != null && typeof args[0] !== 'string') {
@@ -315,6 +360,96 @@ function findPreviousElementInDOM(startElement: Element, selector: string): HTML
   }
 
   return null;
+}
+
+// ----------------------------------------------------------------------------
+// Relative positional scan (upstream `from/within/in/with wrapping` semantics).
+// Ported from _hyperscript/src/parsetree/expressions/positional.js — returns
+// `undefined` (not null) on no-match to match upstream's contract.
+// ----------------------------------------------------------------------------
+
+const DOCUMENT_POSITION_PRECEDING = 2; // Node.DOCUMENT_POSITION_PRECEDING
+const DOCUMENT_POSITION_FOLLOWING = 4; // Node.DOCUMENT_POSITION_FOLLOWING
+
+function scanForwardQuery(
+  start: Element,
+  root: ParentNode,
+  match: string,
+  wrap: boolean
+): HTMLElement | undefined {
+  const results = root.querySelectorAll(match);
+  for (let i = 0; i < results.length; i++) {
+    const elt = results[i];
+    if (elt.compareDocumentPosition(start) === DOCUMENT_POSITION_PRECEDING) {
+      return elt as HTMLElement;
+    }
+  }
+  return wrap ? (results[0] as HTMLElement | undefined) : undefined;
+}
+
+function scanBackwardsQuery(
+  start: Element,
+  root: ParentNode,
+  match: string,
+  wrap: boolean
+): HTMLElement | undefined {
+  const results = root.querySelectorAll(match);
+  for (let i = results.length - 1; i >= 0; i--) {
+    const elt = results[i];
+    if (elt.compareDocumentPosition(start) === DOCUMENT_POSITION_FOLLOWING) {
+      return elt as HTMLElement;
+    }
+  }
+  return wrap ? (results[results.length - 1] as HTMLElement | undefined) : undefined;
+}
+
+function scanForwardArray(
+  start: Element,
+  arrayLike: unknown,
+  match: string,
+  wrap: boolean
+): HTMLElement | undefined {
+  const array = Array.from((arrayLike as Iterable<Element>) ?? []) as Element[];
+  const matches: Element[] = [];
+  for (const elt of array) {
+    if ((elt.matches && elt.matches(match)) || elt === start) {
+      matches.push(elt);
+    }
+  }
+  for (let i = 0; i < matches.length - 1; i++) {
+    if (matches[i] === start) {
+      return matches[i + 1] as HTMLElement;
+    }
+  }
+  if (wrap) {
+    const first = matches[0];
+    if (first && first.matches && first.matches(match)) {
+      return first as HTMLElement;
+    }
+  }
+  return undefined;
+}
+
+/** Resolve a relative positional scan to a single element (or undefined). */
+function scanRelative(
+  start: Element,
+  selector: string,
+  options: RelativePositionalOptions,
+  forward: boolean
+): HTMLElement | undefined {
+  if (options.inSearch) {
+    if (options.inElt == null) return undefined;
+    const array = forward
+      ? Array.from(options.inElt as Iterable<Element>)
+      : Array.from(options.inElt as Iterable<Element>).reverse();
+    return scanForwardArray(start, array, selector, !!options.wrapping);
+  }
+  const root: ParentNode | null =
+    (options.within as Element | null) ?? (typeof document !== 'undefined' ? document.body : null);
+  if (!root) return undefined;
+  return forward
+    ? scanForwardQuery(start, root, selector, !!options.wrapping)
+    : scanBackwardsQuery(start, root, selector, !!options.wrapping);
 }
 
 // ============================================================================

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -3378,7 +3378,63 @@ export class Parser {
       args.push(this.parsePrimary());
     }
 
-    return this.createCallExpression(this.createIdentifier(funcName), args);
+    const callNode = this.createCallExpression(this.createIdentifier(funcName), args);
+
+    // Relative positional modifiers for `next`/`previous`:
+    //   next <sel> from <el> [within <el> | in <coll>] [with wrapping]
+    if (funcName === 'next' || funcName === 'previous') {
+      const relativePositional = this.parseRelativePositionalModifiers();
+      if (relativePositional) {
+        (callNode as unknown as Record<string, unknown>).relativePositional = relativePositional;
+      }
+    }
+
+    return callNode;
+  }
+
+  /**
+   * Parse the trailing `from <el> [within <el> | in <coll>] [with wrapping]`
+   * modifiers of a relative positional expression (`next`/`previous`). Returns
+   * null when none are present so the bare `next <sel>` form is unchanged.
+   */
+  private parseRelativePositionalModifiers(): {
+    from?: ASTNode;
+    within?: ASTNode;
+    inElt?: ASTNode;
+    inSearch: boolean;
+    wrapping: boolean;
+  } | null {
+    if (!this.check('from') && !this.check('within') && !this.check('in') && !this.check('with')) {
+      return null;
+    }
+
+    let from: ASTNode | undefined;
+    let within: ASTNode | undefined;
+    let inElt: ASTNode | undefined;
+    let inSearch = false;
+    let wrapping = false;
+
+    if (this.match('from')) {
+      from = this.parseRelativePositionalOperand();
+    }
+    if (this.match('in')) {
+      inSearch = true;
+      inElt = this.parseRelativePositionalOperand();
+    } else if (this.match('within')) {
+      within = this.parseRelativePositionalOperand();
+    }
+    if (this.match('with')) {
+      this.match('wrapping');
+      wrapping = true;
+    }
+
+    return { from, within, inElt, inSearch, wrapping };
+  }
+
+  /** Parse a single relative-positional operand: optional `the` + a primary. */
+  private parseRelativePositionalOperand(): ASTNode {
+    this.match('the');
+    return this.parsePrimary();
   }
 
   /**

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -3483,6 +3483,27 @@ export class Parser {
         false
       );
     } else {
+      // Bracketed attribute access: `my [@attr]`, `its [@data-x]`. Mirror the
+      // computed-member shape `X[@attr]` (property is an attributeAccess node)
+      // so the set write-path and read-path treat it as an attribute, not a key.
+      if (this.check('[') && this.tokens[this.current + 1]?.value?.startsWith('@')) {
+        this.advance(); // consume '['
+        const attrToken = this.advance();
+        this.consume(']', "Expected ']' after attribute reference");
+        return this.createMemberExpression(
+          this.createIdentifier(contextVar),
+          {
+            type: 'attributeAccess',
+            attributeName: attrToken.value.substring(1),
+            start: attrToken.start,
+            end: attrToken.end,
+            line: attrToken.line,
+            column: attrToken.column,
+          } as ASTNode,
+          true
+        );
+      }
+
       // Check for attribute access syntax: my @attr, its @attr, your @attr
       // Use @-prefixed identifier (matching possessive expression pattern at line 1168-1170)
       // so evaluateMemberExpression can handle it via propertyName.startsWith('@')

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -1708,6 +1708,11 @@ export class Parser {
       return this.parseDollarExpression();
     }
 
+    // Block literal (lambda): `\-> expr`, `\ x -> expr`, `\ x, y -> expr`.
+    if (this.peek().value === '\\') {
+      return this.parseBlockLiteral();
+    }
+
     // Handle standalone attribute reference syntax (@attribute)
     if (isSymbol(this.peek()) && this.peek().value.startsWith('@')) {
       const attrToken = this.advance();
@@ -1726,6 +1731,48 @@ export class Parser {
     this.addError(`Unexpected token: ${token.value} at line ${token.line}, column ${token.column}`);
     this.advance(); // Always advance past unparseable tokens to prevent infinite loops
     return this.createErrorNode();
+  }
+
+  /**
+   * Parse a block-literal (lambda) expression: `\-> expr`, `\ x -> expr`,
+   * `\ x, y -> expr`. Mirrors upstream `_hyperscript`'s BlockLiteral — the body
+   * is a single expression; the result is a function binding the parameters.
+   * `->` tokenizes as `-` then `>`.
+   */
+  private parseBlockLiteral(): ASTNode {
+    const start = this.peek().start;
+    this.advance(); // consume '\'
+
+    const parameters: string[] = [];
+    // Parameters run until the `->` arrow (a `-` followed by `>`).
+    while (!this.isAtEnd() && !(this.check('-') && this.tokens[this.current + 1]?.value === '>')) {
+      if (this.checkIdentifier()) {
+        parameters.push(this.advance().value);
+        this.match(','); // optional separator between params
+      } else {
+        this.addError(`Unexpected token in block literal parameters: ${this.peek().value}`);
+        break;
+      }
+    }
+
+    if (!(this.check('-') && this.tokens[this.current + 1]?.value === '>')) {
+      this.addError("Expected '->' in block literal");
+      return this.createErrorNode();
+    }
+    this.advance(); // consume '-'
+    this.advance(); // consume '>'
+
+    const body = this.parseExpression();
+
+    return {
+      type: 'blockLiteral',
+      parameters,
+      body,
+      start,
+      end: this.previous().end,
+      line: this.previous().line,
+      column: this.previous().column,
+    } as ASTNode;
   }
 
   private parseDollarExpression(): ASTNode {

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -107,6 +107,42 @@ export type ParseResult = CoreParseResult;
 export type { ParseError } from './types';
 
 /**
+ * CSS measurement units recognized as string-postfix expressions, e.g. `1em`
+ * → "1em". Mirrors upstream `_hyperscript` STRING_POSTFIXES (CSS values level 4,
+ * minus `in`, which collides with the hyperscript `in` operator). `%` is handled
+ * separately (it doubles as the modulo operator).
+ */
+const STRING_POSTFIX_UNITS = new Set([
+  'em',
+  'ex',
+  'cap',
+  'ch',
+  'ic',
+  'rem',
+  'lh',
+  'rlh',
+  'vw',
+  'vh',
+  'vi',
+  'vb',
+  'vmin',
+  'vmax',
+  'cm',
+  'mm',
+  'Q',
+  'pc',
+  'pt',
+  'px',
+]);
+
+/**
+ * Binding power for the string-postfix operator. Chosen to sit between binary
+ * `+`/`-` (40) and unary `-`/`+` (80) so `-1px` parses as `(-1)px` → "-1px"
+ * while `1em + 2px` parses as `"1em" + "2px"` → "1em2px".
+ */
+const STRING_POSTFIX_BP = 60;
+
+/**
  * Parse a time expression string (e.g., "200ms", "1s", "2h") to milliseconds.
  * The tokenizer already validates the format (TIME_UNITS: ms, s, seconds, minutes, hours, days).
  */
@@ -596,6 +632,18 @@ export class Parser {
     while (!this.isAtEnd()) {
       const nextToken = this.peek();
 
+      // String postfix (`1em`, `100%`, `(0 + 1) px`): a CSS unit token, or a
+      // `%` with no following operand, turns the left expression into a string.
+      // Binds at STRING_POSTFIX_BP (looser than unary `-`/`+` so `-1px` → "-1px",
+      // tighter than binary `+` so `1em + 2px` → "1em2px").
+      if (STRING_POSTFIX_BP >= minBp) {
+        const postfix = this.tryParseStringPostfix(left, nextToken);
+        if (postfix) {
+          left = postfix;
+          continue;
+        }
+      }
+
       // Check infix table FIRST — operators like 'in' are both stop tokens
       // and comparison operators; the Pratt table takes priority.
       const infixEntry = Parser.PRATT_TABLE.get(nextToken.value);
@@ -678,6 +726,53 @@ export class Parser {
     this.prattCache.set(cacheKey, { node: left, endPos: this.current });
 
     return left;
+  }
+
+  /**
+   * Try to parse a trailing string-postfix measurement unit on `left`.
+   * Returns a `stringPostfix` node (consuming the unit token) or null.
+   * Mirrors upstream `_hyperscript`'s StringPostfixExpression — `"" + val + unit`.
+   */
+  private tryParseStringPostfix(left: ASTNode, nextToken: Token): ASTNode | null {
+    const v = nextToken.value;
+    let unit: string | null = null;
+    if (STRING_POSTFIX_UNITS.has(v)) {
+      unit = v;
+    } else if (v === '%') {
+      // `%` is the modulo operator only when a right operand follows; otherwise
+      // it's a percentage string postfix (`100%`, `100 %`, `(100 + 0) %`).
+      const after = this.current + 1 < this.tokens.length ? this.tokens[this.current + 1] : null;
+      if (!this.canStartOperand(after)) {
+        unit = '%';
+      }
+    }
+    if (unit == null) return null;
+
+    const unitToken = this.advance();
+    return {
+      type: 'stringPostfix',
+      expression: left,
+      unit,
+      start: (left as { start?: number }).start,
+      end: unitToken.end,
+      line: (left as { line?: number }).line,
+      column: (left as { column?: number }).column,
+    } as ASTNode;
+  }
+
+  /** Whether `t` can begin an operand (used to disambiguate `%` postfix vs modulo). */
+  private canStartOperand(t: Token | null): boolean {
+    if (!t) return false;
+    const v = t.value;
+    if (PRATT_STOP_TOKENS.has(v) || PRATT_STOP_DELIMITERS.has(v)) return false;
+    if (
+      t.kind === 'number' ||
+      t.kind === 'string' ||
+      t.kind === 'identifier' ||
+      t.kind === 'symbol'
+    )
+      return true;
+    return ['(', '[', '{', '-', '+', '!', '#', '.', '<', '$', '@'].includes(v);
   }
 
   /** Create a PrattContext adapter that bridges the Pratt interface to the Parser's internal state. */

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -216,6 +216,8 @@ export async function evaluateAST(node: ASTNode, context: ExecutionContext): Pro
       return evaluatePropertyOfExpressionNode(n, context);
     case 'templateLiteral':
       return evaluateTemplateLiteralNode(n, context);
+    case 'stringPostfix':
+      return evaluateStringPostfixNode(n, context);
 
     default: {
       // Allow plugins to register evaluators for custom AST node types.
@@ -313,6 +315,8 @@ export function evaluateExpressionSync(node: ASTNode, context: ExecutionContext)
       const value = evaluateExpressionSync(n.expression, context);
       return convertValue(value, normalizeAsTargetType(n.targetType), context);
     }
+    case 'stringPostfix':
+      return `${evaluateExpressionSync(n.expression, context)}${n.unit}`;
     default:
       throw new NotSyncEvaluable(n?.type ?? 'unknown');
   }
@@ -987,6 +991,18 @@ async function evaluateObjectLiteralNode(
 }
 
 /** Resolve `@attr` on `me`. Returns `@attr` literal when there is no element. */
+/**
+ * Evaluate a string-postfix measurement expression (`1em`, `100%`, `(0 + 1) px`).
+ * Mirrors upstream `_hyperscript`: `"" + value + unit`.
+ */
+async function evaluateStringPostfixNode(
+  node: { expression: ASTNode; unit: string },
+  context: ExecutionContext
+): Promise<string> {
+  const value = await evaluateAST(node.expression, context);
+  return `${value}${node.unit}`;
+}
+
 async function evaluateAttributeAccessNode(
   node: AttributeAccessNode,
   context: ExecutionContext

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -218,6 +218,8 @@ export async function evaluateAST(node: ASTNode, context: ExecutionContext): Pro
       return evaluateTemplateLiteralNode(n, context);
     case 'stringPostfix':
       return evaluateStringPostfixNode(n, context);
+    case 'blockLiteral':
+      return makeBlockLiteralClosure(n, context);
 
     default: {
       // Allow plugins to register evaluators for custom AST node types.
@@ -317,6 +319,29 @@ export function evaluateExpressionSync(node: ASTNode, context: ExecutionContext)
     }
     case 'stringPostfix':
       return `${evaluateExpressionSync(n.expression, context)}${n.unit}`;
+    case 'blockLiteral':
+      return makeBlockLiteralClosure(n, context);
+    case 'memberExpression': {
+      // Plain property reads only. DOM/collection targets defer to the async
+      // path, which has styleRef/classref special-casing this naive read would
+      // get wrong.
+      const obj = evaluateExpressionSync(n.object, context);
+      if (obj == null) return undefined;
+      if (
+        obj instanceof Element ||
+        Array.isArray(obj) ||
+        (typeof Node !== 'undefined' && obj instanceof Node)
+      ) {
+        throw new NotSyncEvaluable('memberExpression');
+      }
+      const prop = n.computed
+        ? String(evaluateExpressionSync(n.property, context))
+        : (n.property?.name as string);
+      const value = (obj as Record<string, unknown>)[prop];
+      return typeof value === 'function'
+        ? (value as (...a: unknown[]) => unknown).bind(obj)
+        : value;
+    }
     default:
       throw new NotSyncEvaluable(n?.type ?? 'unknown');
   }
@@ -991,6 +1016,33 @@ async function evaluateObjectLiteralNode(
 }
 
 /** Resolve `@attr` on `me`. Returns `@attr` literal when there is no element. */
+/**
+ * Build the closure for a block-literal (lambda) node: `\ x, y -> body`.
+ * Binds positional arguments to the declared parameters in a child scope and
+ * evaluates the body. The body is evaluated synchronously when possible (so the
+ * closure can be used as a synchronous JS callback, e.g. `arr.map(\ s -> …)`),
+ * falling back to async evaluation for bodies the sync path can't handle.
+ */
+function makeBlockLiteralClosure(
+  node: { parameters: string[]; body: ASTNode },
+  context: ExecutionContext
+): (...args: unknown[]) => unknown {
+  const params = node.parameters ?? [];
+  return (...args: unknown[]) => {
+    const locals = new Map(context.locals ?? new Map());
+    params.forEach((name, i) => locals.set(name, args[i]));
+    const childContext = { ...context, locals } as ExecutionContext;
+    try {
+      return evaluateExpressionSync(node.body, childContext);
+    } catch (e) {
+      if (e instanceof NotSyncEvaluable) {
+        return evaluateAST(node.body, childContext);
+      }
+      throw e;
+    }
+  };
+}
+
 /**
  * Evaluate a string-postfix measurement expression (`1em`, `100%`, `(0 + 1) px`).
  * Mirrors upstream `_hyperscript`: `"" + value + unit`.

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -1299,6 +1299,22 @@ async function resolveCallArgs(
  * constructor invocations (`new Foo(...)`), and member-expression callees
  * (preserves `this` via `.apply`).
  */
+/** Parser-attached modifiers for `next`/`previous` relative positional calls. */
+interface RelativePositionalModifiers {
+  from?: ASTNode;
+  within?: ASTNode;
+  inElt?: ASTNode;
+  inSearch: boolean;
+  wrapping: boolean;
+}
+
+/** Unwrap a selector result (array/collection) to a single Element, or undefined. */
+function unwrapElement(value: unknown): Element | undefined {
+  if (value instanceof Element) return value;
+  if (Array.isArray(value)) return value[0] instanceof Element ? value[0] : undefined;
+  return undefined;
+}
+
 async function evaluateCallExpression(node: CallNode, context: ExecutionContext): Promise<any> {
   const callee = await evaluateAST(node.callee, context);
 
@@ -1320,9 +1336,30 @@ async function evaluateCallExpression(node: CallNode, context: ExecutionContext)
       case 'closest':
         return getExpr(context, 'closest').evaluate(context, ...args);
       case 'previous':
-        return getExpr(context, 'previous').evaluate(context, ...args);
-      case 'next':
-        return getExpr(context, 'next').evaluate(context, ...args);
+      case 'next': {
+        // Relative positional: `next <sel> from <el> [within <el>|in <coll>]
+        // [with wrapping]`. The parser attaches the modifier nodes; evaluate
+        // them here and pass an options object as the 3rd arg. The bare
+        // `next <sel>` form (no modifiers) keeps the legacy 1-arg call.
+        const relPos = (node as unknown as { relativePositional?: RelativePositionalModifiers })
+          .relativePositional;
+        if (relPos) {
+          const from = relPos.from
+            ? unwrapElement(await evaluateAST(relPos.from, context))
+            : (context.me as Element | undefined);
+          const within = relPos.within
+            ? unwrapElement(await evaluateAST(relPos.within, context))
+            : undefined;
+          const inElt = relPos.inElt ? await evaluateAST(relPos.inElt, context) : undefined;
+          return getExpr(context, funcName).evaluate(context, args[0], from, {
+            within,
+            inElt,
+            inSearch: relPos.inSearch,
+            wrapping: relPos.wrapping,
+          });
+        }
+        return getExpr(context, funcName).evaluate(context, ...args);
+      }
       case 'first':
         return getExpr(context, 'first').evaluate(context, ...args);
       case 'last':


### PR DESCRIPTION
## Context

Follow-up to #235 (which reached **79%** on the upstream `_hyperscript`
expression-parity harness). This PR closes the deferred **feature gaps** — real
product capabilities, not just a harness number — taking the harness to
**82%** (297/361 runnable), `EXPRESSION_PASS_RATE_FLOOR` 78 → **81**.

Plan: `~/.claude/plans/please-create-a-plan-jazzy-babbage.md`. Each track is one
commit, audit→fix→ratchet, with source-level regression guards in
`expression-parity-phaseb.test.ts` (31 guards). Harness-only sync-eval levers
(Phase C classRef escaping, Phase D sync-command) stay out of scope.

## Tracks

| Track | What | Harness |
| --- | --- | --- |
| **A** | `set @attr` write-path for attributeAccess targets (`set @x`, `[@x]`, `my [@x]`, `@x of y`, `x[@x]`) | product fix (awaited harness cases already green; failing ones are Phase D fire-and-forget) |
| **B** | relativePositional `next/previous <sel> from/within/in/with-wrapping` | +4 (no-match awaited cases; sync `=== el` cases are the documented async ceiling) |
| **C** | stringPostfix units `1em` / `100%` / `(0+1) px` (operand-based `%` vs modulo disambiguation) | +3 (cluster cleared) |
| **D** | blockLiteral lambdas `\ x -> body`, usable as JS callbacks (`.map`) | +4 (cluster cleared) |
| **E** | user-extensible `as` conversions (`hyperfixi.config.conversions` + dynamicResolvers) | product API (2 harness cases blocked by a separate test-sandbox shim limitation) |
| **F** | `docs/UPSTREAM-KNOWN-DIFFS.md` — intentional divergences + harness artifacts | docs |

## Verification

- Harness: `npx playwright test --project=full src/compatibility/browser-tests/expressions.spec.ts` → **297/361 = 82%**, spec green at floor 81.
- `expression-parity-phaseb.test.ts`: 31 source-level guards, all green.
- Full `parser` + `expressions` + `commands` + `runtime` vitest: **zero new failures** (the 21 reds are pre-existing on `main` — verified by stashing these changes; they're tracked for a separate cleanup PR).

## Out of scope / follow-ups

- Phase C (sync selector escaping) and Phase D (sync command execution) — deliberate async ceiling, see `UPSTREAM-KNOWN-DIFFS.md`.
- Pre-existing `main` failures (conditional-modifiers, runtime-objectliteral, plugin, element-resolution em-dash, "Unknown vs Unsupported AST node type", etc.) — separate cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)