### PR TITLE
Fix 8 stale pre-existing test failures + triage the rest

### DIFF
--- a/packages/core/docs/PRE-EXISTING-FAILURES.md
+++ b/packages/core/docs/PRE-EXISTING-FAILURES.md
@@ -1,0 +1,59 @@
+# Pre-existing test failures — triage
+
+A sweep (2026-05-31) of the failing vitest tests that existed on `main`,
+unrelated to the expression-parity arc. This PR fixes the **stale tests** (where
+the production behavior is correct/intentional and only the test expectation had
+drifted) and documents the rest — genuine bugs and design-ambiguous cases that
+deserve focused follow-ups rather than a rushed batch fix.
+
+## Fixed in this PR (stale tests — production behavior is correct)
+
+| Test                                                   | Was                                                                   | Now                                                                                          |
+| ------------------------------------------------------ | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `runtime.test.ts` "meaningful error messages"          | expected "Unsupported AST node type for evaluation"                   | "Unknown AST node type" (the canonical message in `runtime.ts:226`)                          |
+| `runtime.test.ts` "missing context elements"           | expected "Invalid hide target"                                        | "no target specified" (the actual descriptive `hide` error)                                  |
+| `plugin.test.ts` "unknown node type throws"            | regex `/Unsupported AST node type/`                                   | `/Unknown AST node type/`                                                                    |
+| `element-resolution.test.ts` "no target element"       | ASCII hyphen `-`                                                      | em-dash `—` (matches the code)                                                               |
+| `runtime-objectliteral.test.ts` ×3                     | set `context.variables` (a vestigial field the evaluator never reads) | populate `context.locals` (the field `evaluateIdentifier` resolves)                          |
+| `class-manipulation.test.ts` "warn when var not found" | spied `console.warn`                                                  | spies `debug.command` (diagnostics route through the debug system, deliberately not console) |
+
+## NOT fixed — genuine issues for focused follow-up
+
+### `conditional-modifiers.test.ts` (10) — entangled with a real `when`/`where` bug
+
+The 10 unit tests build synthetic `{ type: 'expression' }` condition nodes (cast
+`as unknown as ASTNode`) and assume a mock evaluator handles the guard — an old
+runtime API. The current runtime evaluates the guard via `evaluateAST`, which
+rightly rejects the synthetic type. **But** a real end-to-end check surfaced a
+genuine bug worth its own fix:
+
+```
+add .active to me when false   // still adds .active — the falsy guard does NOT skip
+```
+
+`when true` works (same as no guard), so the guard is effectively ignored.
+Rewriting the 10 tests against real parsing would _expose_ this bug, not paper
+over it. **Action: fix the `when`/`where` command-modifier guard (skip on falsy),
+then rewrite these tests against real `<command> when <condition>` parsing.**
+
+### `plugin.test.ts` "global read hook — `::name`" (1) — real feature gap
+
+`::name` explicit-global reads don't fire the registered global-read hook
+(`expected [] to include 'x'`). `notifyGlobalRead` fires for `$name` globals
+(`evaluateIdentifier`) but the `::name` path isn't wired to it. **Action: route
+`::name` reads through `notifyGlobalRead`.**
+
+### `parser.test.ts` "first of" (1) — AST-shape design decision
+
+`first of items` now parses as a `callExpression` (`first(items)`); the test
+expects a `binaryExpression` with operator `of`. The behavior is correct
+(`first of [10,20,30]` → 10); only the AST shape changed. Whether the canonical
+shape should be a positional/binary node or a call is a design decision — left
+for the owner rather than guessing.
+
+### `start-view-transition.test.ts` (1) — needs investigation
+
+"wraps body in withViewTransition when API supported" expects the options object
+(`{ transitionName: 'fade' }`) as the 2nd argument to the view-transition call;
+the command currently passes only 1 argument. Could be a small real gap or a
+test expecting unimplemented behavior — investigate before changing.

--- a/packages/core/docs/PRE-EXISTING-FAILURES.md
+++ b/packages/core/docs/PRE-EXISTING-FAILURES.md
@@ -1,5 +1,15 @@
 # Pre-existing test failures — triage
 
+> **Next session: start here.** This is the handoff/checklist for the remaining
+> pre-existing test work. The "Fixed in this PR" section is done (PR #237). Pick
+> up the **"NOT fixed — genuine issues for follow-up"** section, in this order:
+> (1) the real `when`/`where` falsy-guard bug (`<command> when <falsy>` does not
+> skip) + rewrite the 10 `conditional-modifiers` tests against real parsing;
+> (2) wire `::name` global reads through `notifyGlobalRead`;
+> (3) decide the `parser` `first of` AST shape; then `start-view-transition`.
+> Cross-session context (the 79%→82% parity arc, PRs #236/#237) is in the
+> auto-loaded memory note `project-expression-parity-completion`.
+
 A sweep (2026-05-31) of the failing vitest tests that existed on `main`,
 unrelated to the expression-parity arc. This PR fixes the **stale tests** (where
 the production behavior is correct/intentional and only the test expectation had

--- a/packages/core/src/commands/helpers/__tests__/class-manipulation.test.ts
+++ b/packages/core/src/commands/helpers/__tests__/class-manipulation.test.ts
@@ -8,6 +8,7 @@ import {
   resolveDynamicClasses,
 } from '../class-manipulation';
 import type { TypedExecutionContext } from '../../../types/core';
+import { debug } from '../../../utils/debug';
 
 describe('Class Manipulation Helpers', () => {
   describe('parseClasses', () => {
@@ -171,7 +172,7 @@ describe('Class Manipulation Helpers', () => {
 
   describe('resolveDynamicClasses', () => {
     let mockContext: TypedExecutionContext;
-    let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+    let debugSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
       mockContext = {
@@ -179,7 +180,9 @@ describe('Class Manipulation Helpers', () => {
         globals: new Map<string, unknown>(),
       } as TypedExecutionContext;
 
-      consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      // A missing dynamic-class variable is reported via the debug system
+      // (debug.command), not console.warn — keeps production output quiet.
+      debugSpy = vi.spyOn(debug, 'command').mockImplementation(() => {});
     });
 
     it('should resolve dynamic class from locals', () => {
@@ -217,7 +220,7 @@ describe('Class Manipulation Helpers', () => {
     it('should warn when dynamic variable not found', () => {
       const result = resolveDynamicClasses(['{missing}'], mockContext);
       expect(result).toEqual([]);
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect(debugSpy).toHaveBeenCalledWith(
         expect.stringContaining("Dynamic class variable 'missing' not found")
       );
     });

--- a/packages/core/src/commands/helpers/__tests__/element-resolution.test.ts
+++ b/packages/core/src/commands/helpers/__tests__/element-resolution.test.ts
@@ -97,7 +97,7 @@ describe('Element Resolution Helpers', () => {
         const context = createMockContext({ me: null });
 
         expect(() => resolveElement(undefined, context)).toThrow(
-          'No target element - provide explicit target or ensure context.me is set'
+          'No target element — provide explicit target or ensure context.me is set'
         );
       });
     });

--- a/packages/core/src/runtime/plugin.test.ts
+++ b/packages/core/src/runtime/plugin.test.ts
@@ -296,7 +296,7 @@ describe('Plugin system (v0.9.90 Phase 5)', () => {
       const el = document.createElement('div');
       const ctx = createContext(el);
       const node = { type: 'nobodyKnowsThis' } as unknown as ASTNode;
-      await expect(runtime.execute(node, ctx)).rejects.toThrow(/Unsupported AST node type/);
+      await expect(runtime.execute(node, ctx)).rejects.toThrow(/Unknown AST node type/);
     });
   });
 

--- a/packages/core/src/runtime/runtime-objectliteral.test.ts
+++ b/packages/core/src/runtime/runtime-objectliteral.test.ts
@@ -99,10 +99,8 @@ describe('Runtime Object Literal Evaluation', () => {
 
   it('should evaluate object literals with variable values', async () => {
     const context = createTypedExecutionContext();
-    (context as { variables: Map<string, unknown> }).variables = new Map<string, unknown>([
-      ['myColor', 'green'],
-      ['mySize', 16],
-    ]);
+    context.locals.set('myColor', 'green');
+    context.locals.set('mySize', 16);
 
     const node = {
       type: 'objectLiteral',
@@ -128,9 +126,7 @@ describe('Runtime Object Literal Evaluation', () => {
 
   it('should evaluate object literals with nested expressions', async () => {
     const context = createTypedExecutionContext();
-    (context as { variables: Map<string, unknown> }).variables = new Map<string, unknown>([
-      ['baseSize', 10],
-    ]);
+    context.locals.set('baseSize', 10);
 
     const node = {
       type: 'objectLiteral',
@@ -156,10 +152,8 @@ describe('Runtime Object Literal Evaluation', () => {
 
   it('should handle object literals with dynamic keys', async () => {
     const context = createTypedExecutionContext();
-    (context as { variables: Map<string, unknown> }).variables = new Map<string, unknown>([
-      ['keyName', 'dynamicProperty'],
-      ['value', 'dynamicValue'],
-    ]);
+    context.locals.set('keyName', 'dynamicProperty');
+    context.locals.set('value', 'dynamicValue');
 
     const node = {
       type: 'objectLiteral',

--- a/packages/core/src/runtime/runtime.test.ts
+++ b/packages/core/src/runtime/runtime.test.ts
@@ -213,7 +213,7 @@ describe('Hyperscript Runtime', () => {
       const invalidAst = { type: 'invalidNode' };
 
       await expect(runtime.execute(invalidAst, context)).rejects.toThrow(
-        'Unsupported AST node type for evaluation: invalidNode'
+        'Unknown AST node type: invalidNode'
       );
     });
 
@@ -222,7 +222,7 @@ describe('Hyperscript Runtime', () => {
       const ast = parse('hide me').node!;
 
       // V2 commands provide more descriptive error messages about invalid targets
-      await expect(runtime.execute(ast, context)).rejects.toThrow('Invalid hide target');
+      await expect(runtime.execute(ast, context)).rejects.toThrow('no target specified');
     });
   });
 


### PR DESCRIPTION
## Context

A sweep of vitest tests failing on `main` that predate the expression-parity
arc (the "pre-existing failures" called out in #236's verification). Triaged
each as **stale test** (production behavior correct, test expectation drifted)
vs **real bug** vs **design decision**. This PR fixes the unambiguous stale
tests and documents the rest in `packages/core/docs/PRE-EXISTING-FAILURES.md`
for focused follow-up — no engine contortion, no rushed fixes to real bugs.

## Fixed (8 stale tests)

| Test | Fix |
| --- | --- |
| `runtime.test.ts` ×2 | "Unsupported AST node type" → "Unknown AST node type" (canonical); "Invalid hide target" → "no target specified" |
| `plugin.test.ts` | `/Unsupported/` → `/Unknown/ AST node type` regex |
| `element-resolution.test.ts` | ASCII hyphen → em-dash in the no-target message |
| `runtime-objectliteral.test.ts` ×3 | populate `context.locals` (the field `evaluateIdentifier` reads) instead of the vestigial `context.variables` |
| `class-manipulation.test.ts` | spy `debug.command` (diagnostics go through the debug system) instead of `console.warn` |

All verified green; `tsc --noEmit` clean.

## Documented for follow-up (NOT fixed — real bugs / design calls)

- **`conditional-modifiers` ×10** — synthetic-node unit tests entangled with a **real bug**: `<command> when <falsy>` does **not** skip (the guard is ignored). Surfaced by an end-to-end check; deserves its own fix + test rewrite.
- **`plugin` `::name` global-read hook** — `::name` reads aren't wired to `notifyGlobalRead` (only `$name` is).
- **`parser` "first of"** — parses as `callExpression` not `binaryExpression`; behavior correct, AST shape is a design decision.
- **`start-view-transition`** — options arg (`{ transitionName }`) not passed; needs investigation.

See `docs/PRE-EXISTING-FAILURES.md` for the full triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)