### PR TITLE
Fix remaining pre-existing failures + dom-mutation hang + test-infra

### DIFF
--- a/packages/core/docs/PRE-EXISTING-FAILURES.md
+++ b/packages/core/docs/PRE-EXISTING-FAILURES.md
@@ -1,22 +1,17 @@
 # Pre-existing test failures — triage
 
-> **Next session: start here.** This is the handoff/checklist for the remaining
-> pre-existing test work. The "Fixed in this PR" section is done (PR #237). Pick
-> up the **"NOT fixed — genuine issues for follow-up"** section, in this order:
-> (1) the real `when`/`where` falsy-guard bug (`<command> when <falsy>` does not
-> skip) + rewrite the 10 `conditional-modifiers` tests against real parsing;
-> (2) wire `::name` global reads through `notifyGlobalRead`;
-> (3) decide the `parser` `first of` AST shape; then `start-view-transition`.
-> Cross-session context (the 79%→82% parity arc, PRs #236/#237) is in the
-> auto-loaded memory note `project-expression-parity-completion`.
+> **Status: all triaged items resolved.** PR #237 fixed the stale tests; the
+> follow-up below fixed the four genuine issues. Cross-session context (the
+> 79%→82% parity arc, PRs #236/#237) is in the auto-loaded memory note
+> `project-expression-parity-completion`.
 
 A sweep (2026-05-31) of the failing vitest tests that existed on `main`,
-unrelated to the expression-parity arc. This PR fixes the **stale tests** (where
-the production behavior is correct/intentional and only the test expectation had
-drifted) and documents the rest — genuine bugs and design-ambiguous cases that
-deserve focused follow-ups rather than a rushed batch fix.
+unrelated to the expression-parity arc. PR #237 fixed the **stale tests** (where
+the production behavior was correct/intentional and only the test expectation had
+drifted). The follow-up fixed the genuine bugs and settled the design-ambiguous
+cases.
 
-## Fixed in this PR (stale tests — production behavior is correct)
+## Fixed in PR #237 (stale tests — production behavior is correct)
 
 | Test                                                   | Was                                                                   | Now                                                                                          |
 | ------------------------------------------------------ | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
@@ -27,43 +22,107 @@ deserve focused follow-ups rather than a rushed batch fix.
 | `runtime-objectliteral.test.ts` ×3                     | set `context.variables` (a vestigial field the evaluator never reads) | populate `context.locals` (the field `evaluateIdentifier` resolves)                          |
 | `class-manipulation.test.ts` "warn when var not found" | spied `console.warn`                                                  | spies `debug.command` (diagnostics route through the debug system, deliberately not console) |
 
-## NOT fixed — genuine issues for focused follow-up
+## Fixed in follow-up (genuine issues)
 
-### `conditional-modifiers.test.ts` (10) — entangled with a real `when`/`where` bug
+### 1. `when` command-modifier guard now skips on falsy — real bug
 
-The 10 unit tests build synthetic `{ type: 'expression' }` condition nodes (cast
-`as unknown as ASTNode`) and assume a mock evaluator handles the guard — an old
-runtime API. The current runtime evaluates the guard via `evaluateAST`, which
-rightly rejects the synthetic type. **But** a real end-to-end check surfaced a
-genuine bug worth its own fix:
+`add .active to me when false` used to still add `.active`: the runtime guard
+(`runtime/command-adapter.ts` — `mods.when || mods.where`) was correct, but the
+**traditional command parsers** never attached the condition, so the statement
+loop silently discarded the trailing `when <cond>` tokens.
 
-```
-add .active to me when false   // still adds .active — the falsy guard does NOT skip
-```
+**Fix:** `parseCommand()` (`parser/parser.ts`) is now a thin wrapper around
+`parseCommandCore()` that, after the command-specific parse, consumes a trailing
+`when` and attaches the parsed condition to `modifiers.when` (block commands with
+a body are skipped). The runtime then evaluates it and skips on falsy.
 
-`when true` works (same as no guard), so the guard is effectively ignored.
-Rewriting the 10 tests against real parsing would _expose_ this bug, not paper
-over it. **Action: fix the `when`/`where` command-modifier guard (skip on falsy),
-then rewrite these tests against real `<command> when <condition>` parsing.**
+**`where` is NOT an equivalent surface guard.** `where` is a real collection-
+filter operator (binding power 28 in the pratt parser; `case 'where'` in
+`parser/runtime.ts`), so `me where false` binds as a filter expression
+(`collectionExpression`, operator `where`) during target parsing and never
+reaches the guard position. Making `where` a trailing guard would break the
+legitimate filter operator, so **`when` is the canonical command guard.** The
+runtime still honors a hand-built / semantic `modifiers.where`; it is just
+unreachable via the `<command> … where <cond>` surface.
 
-### `plugin.test.ts` "global read hook — `::name`" (1) — real feature gap
+The 9 synthetic unit tests (which built `{ type:'expression' }` nodes + a mock
+evaluator the adapter no longer consults) were rewritten in
+`runtime/conditional-modifiers.test.ts` to drive the **real parser + runtime**
+end-to-end, including a test pinning the `when`-guard / `where`-filter
+distinction so it isn't accidentally "re-fixed" into a regression.
 
-`::name` explicit-global reads don't fire the registered global-read hook
-(`expected [] to include 'x'`). `notifyGlobalRead` fires for `$name` globals
-(`evaluateIdentifier`) but the `::name` path isn't wired to it. **Action: route
-`::name` reads through `notifyGlobalRead`.**
+### 2. `::name` explicit-global reads now fire `notifyGlobalRead`
 
-### `parser.test.ts` "first of" (1) — AST-shape design decision
+`::name` parses to `{ type:'identifier', name, scope:'global' }`.
+`evaluateIdentifier` (`parser/runtime.ts`) never inspected `node.scope`, so it
+fired the global-read hook only on the `$name` path. Added an explicit-global
+branch (before the locals lookup): when `node.scope === 'global'` and the global
+exists, fire `notifyGlobalRead(name, context)` and return the value (falling
+through to the normal lookups otherwise). Symmetric with the existing
+`::name`-write path. Covered by `plugin.test.ts` "global read hook — `::name`".
 
-`first of items` now parses as a `callExpression` (`first(items)`); the test
-expects a `binaryExpression` with operator `of`. The behavior is correct
-(`first of [10,20,30]` → 10); only the AST shape changed. Whether the canonical
-shape should be a positional/binary node or a call is a design decision — left
-for the owner rather than guessing.
+### 3. `first of items` AST shape — decided: `callExpression`
 
-### `start-view-transition.test.ts` (1) — needs investigation
+`first of X` parses as a `callExpression` (`first(X)`), evaluated correctly by
+the `first`/`last` case in `evaluateCallExpression`. The old test expected
+`binaryExpression('of')` — **rejected as the canonical shape.** `first of X` is
+positional/index access ("first element of X"), semantically distinct from
+property-access `of` (`value of me` → `me.value`); the binary-`of` evaluator
+treats the left side as a property path and would compute `items['first']`
+(undefined). The "more honest" alternative is a dedicated `positionalExpression`
+node (used by the hybrid parser), not binary `of` — out of scope for a test fix.
+`parser.test.ts` updated to assert the `callExpression` shape, with a comment.
 
-"wraps body in withViewTransition when API supported" expects the options object
-(`{ transitionName: 'fade' }`) as the 2nd argument to the view-transition call;
-the command currently passes only 1 argument. Could be a small real gap or a
-test expecting unimplemented behavior — investigate before changing.
+### 5. `dom-mutation.test.ts` — hang (whole-suite blocker) + 6 stale assertions
+
+The file **hung indefinitely** (blocking any full `src/commands` run), masking
+several stale assertions. Root cause of the hang: the test passed invalid
+semantic position names (`start`/`end`) to `insertContentSemantic`. The valid
+`SemanticPosition` vocabulary is `before / prepend / append / after / into`, so
+`toInsertPosition('start')` returned `undefined`, which flowed into
+`element.insertAdjacentHTML(undefined, …)` — that **hangs under happy-dom**
+(a real DOM throws `SyntaxError`).
+
+Fixes:
+
+- **Helper hardening** (`commands/helpers/dom-mutation.ts`) — defense-in-depth so
+  a bad position can never hang again: `toInsertPosition` now throws on an
+  unknown name (its return type already promised a value), and `insertText`
+  validates the position before calling `insertAdjacentHTML`/`insertAdjacentText`.
+  No production caller passes dynamic positions, so this only converts a hang
+  into a clear error.
+- **Test fixes** (`dom-mutation.test.ts`, all 6 stale assertions, no production
+  behavior changed):
+  - position-name drift: `start`→`prepend`, `end`→`append`, `replace`→`into`
+    (the `toInsertPosition` and `insertContentSemantic` cases);
+  - `replace` semantics: the helper replaces a target's _content_ (`innerHTML`,
+    the documented `into` behavior), so the three tests asserting the _element_
+    was removed (`#target` becomes null) were corrected to assert
+    content-replacement;
+  - `removeElements` mix: an orphan (no parent) isn't removed, so the count is 1,
+    not 2;
+  - `swapElements`: `document.body` also holds the `beforeEach` `target` div, so
+    the absolute-index assertions were rewritten as relative-order checks.
+
+Result: 44/44 passing; the full `src/commands/helpers` directory now completes
+instead of hanging.
+
+**`swapElements` audit (follow-up).** `swapElements` is correct for normal cases
+(same-parent adjacent/non-adjacent, cross-parent, same-element no-op) but **threw
+an uncaught `HierarchyRequestError` for an ancestor/descendant pair** (moving a
+node into its own subtree). Hardened to return `false` for nested pairs — same
+graceful-failure contract as the orphan case — and added edge-case tests
+(cross-parent, same-element, nested). Note: `swapElements` currently has **no
+production callers** (the `swap`/`morph` command does _content_ swapping via the
+morph adapter, not element-position swapping); it remains an exported helper, so
+it was hardened rather than removed. Removal is a separate API-surface decision.
+
+### 4. `start-view-transition` forwards `transitionName`
+
+The parsed `transitionName` was discarded (`void input.transitionName`).
+`withViewTransition(callback, options?)` (`lib/view-transitions.ts`) now accepts
+an options object and maps `transitionName` to the View Transitions API `types`
+(modern object form, with a safe fallback to the callback form for browsers that
+only support it). `commands/animation/start-view-transition.ts` forwards
+`{ transitionName }` when a name is present. Covered by the
+`start-view-transition.test.ts` "wraps body in withViewTransition" test.

--- a/packages/core/src/commands/animation/start-view-transition.ts
+++ b/packages/core/src/commands/animation/start-view-transition.ts
@@ -108,12 +108,14 @@ export class StartViewTransitionCommand implements DecoratedCommand {
       return { usedViewTransition: false, commandsExecuted };
     }
 
-    // `transitionName` is accepted by the parser for syntax compatibility
-    // (upstream `start view transition using "slide"`) but currently has no
-    // runtime effect — the View Transitions API takes names via CSS
-    // `view-transition-name`, not via the JS call.
-    void input.transitionName;
-    await withViewTransition(runBody);
+    // Forward the parsed `transitionName` (upstream `start view transition
+    // using "slide"`) to the helper, which maps it to the View Transitions API
+    // `types` so CSS can target the transition via
+    // `:active-view-transition-type(...)`. No-op where the object form is
+    // unsupported (names can also be applied per-element via CSS
+    // `view-transition-name`).
+    const options = input.transitionName ? { transitionName: input.transitionName } : undefined;
+    await withViewTransition(runBody, options);
     return { usedViewTransition: true, commandsExecuted };
   }
 }

--- a/packages/core/src/commands/helpers/__tests__/dom-mutation.test.ts
+++ b/packages/core/src/commands/helpers/__tests__/dom-mutation.test.ts
@@ -44,11 +44,13 @@ describe('DOM Mutation Helpers', () => {
 
   describe('toInsertPosition', () => {
     it('should map semantic positions to InsertPosition values', () => {
+      // SemanticPosition vocabulary is before/prepend/append/after/into —
+      // NOT start/end/replace (those aren't keys; they map to undefined).
       expect(toInsertPosition('before')).toBe('beforebegin');
-      expect(toInsertPosition('start' as any)).toBe('afterbegin');
-      expect(toInsertPosition('end' as any)).toBe('beforeend');
+      expect(toInsertPosition('prepend')).toBe('afterbegin');
+      expect(toInsertPosition('append')).toBe('beforeend');
       expect(toInsertPosition('after')).toBe('afterend');
-      expect(toInsertPosition('replace' as any)).toBe('replace');
+      expect(toInsertPosition('into')).toBe('replace');
     });
   });
 
@@ -79,15 +81,18 @@ describe('DOM Mutation Helpers', () => {
       expect(target.nextElementSibling?.textContent).toBe('After');
     });
 
-    it('should replace target with HTML (replace)', () => {
+    it('should replace target content with HTML (replace)', () => {
       const parent = target.parentElement!;
       const originalChildCount = parent.children.length;
 
       insertContent(target, '<p>Replacement</p>', 'replace');
 
-      expect(parent.children.length).toBe(originalChildCount); // Same count
-      expect(parent.querySelector('#target')).toBeNull(); // Original gone
-      expect(parent.querySelector('p')?.textContent).toBe('Replacement');
+      // 'replace' (the `into` semantic) replaces the target's *content*, not the
+      // element itself — target stays put, its children are swapped out.
+      expect(parent.children.length).toBe(originalChildCount); // target still there
+      expect(parent.querySelector('#target')).not.toBeNull();
+      expect(target.querySelector('span')).toBeNull(); // original child gone
+      expect(target.querySelector('p')?.textContent).toBe('Replacement');
     });
   });
 
@@ -98,13 +103,14 @@ describe('DOM Mutation Helpers', () => {
       expect(target.querySelector('p')).toBeNull(); // No element created
     });
 
-    it('should replace target with text node (replace)', () => {
+    it('should replace target content with text (replace)', () => {
       const parent = target.parentElement!;
 
       insertContent(target, 'Just text', 'replace');
 
-      expect(parent.querySelector('#target')).toBeNull();
-      expect(parent.textContent).toContain('Just text');
+      // Content-replacement: target keeps its place, text becomes its content.
+      expect(parent.querySelector('#target')).not.toBeNull();
+      expect(target.textContent).toBe('Just text');
     });
   });
 
@@ -138,13 +144,14 @@ describe('DOM Mutation Helpers', () => {
       expect(target.nextElementSibling).toBe(newElement);
     });
 
-    it('should replace target with element (replace)', () => {
+    it('should replace target content with element (replace)', () => {
       const parent = target.parentElement!;
 
       insertContent(target, newElement, 'replace');
 
-      expect(parent.querySelector('#target')).toBeNull();
-      expect(parent.querySelector('p')).toBe(newElement);
+      // Content-replacement: target keeps its place, newElement becomes its child.
+      expect(parent.querySelector('#target')).not.toBeNull();
+      expect(target.firstElementChild).toBe(newElement);
     });
   });
 
@@ -157,8 +164,8 @@ describe('DOM Mutation Helpers', () => {
     it('should handle all semantic positions', () => {
       const testCases: Array<[string, () => boolean]> = [
         ['before', () => !!target.previousElementSibling],
-        ['start', () => target.firstElementChild?.tagName === 'P'],
-        ['end', () => target.lastElementChild?.tagName === 'P'],
+        ['prepend', () => target.firstElementChild?.tagName === 'P'],
+        ['append', () => target.lastElementChild?.tagName === 'P'],
         ['after', () => !!target.nextElementSibling],
       ];
 
@@ -231,7 +238,9 @@ describe('DOM Mutation Helpers', () => {
 
       const count = removeElements([attached, orphan]);
 
-      expect(count).toBe(2);
+      // Only the attached element is actually removed; the orphan has no parent,
+      // so removeElement returns false for it and it is not counted.
+      expect(count).toBe(1);
     });
   });
 
@@ -246,8 +255,10 @@ describe('DOM Mutation Helpers', () => {
       const result = swapElements(elem1, elem2);
 
       expect(result).toBe(true);
-      expect(document.body.children[0].id).toBe('second');
-      expect(document.body.children[1].id).toBe('first');
+      // document.body also holds the `target` div from the outer beforeEach, so
+      // assert the swap by relative order, not absolute body indices.
+      expect(elem2.nextElementSibling).toBe(elem1);
+      expect(elem1.previousElementSibling).toBe(elem2);
     });
 
     it('should return false if elements not in DOM', () => {
@@ -269,6 +280,48 @@ describe('DOM Mutation Helpers', () => {
       swapElements(elem1, elem2);
 
       expect(elem2.nextElementSibling).toBe(elem1);
+    });
+
+    it('should swap elements across different parents', () => {
+      const x = document.createElement('div');
+      const y = document.createElement('div');
+      const e1 = document.createElement('span');
+      const e2 = document.createElement('span');
+      e1.id = 'e1';
+      e2.id = 'e2';
+      x.appendChild(e1);
+      y.appendChild(e2);
+      document.body.append(x, y);
+
+      const result = swapElements(e1, e2);
+
+      expect(result).toBe(true);
+      expect(x.firstElementChild).toBe(e2); // e1 left x, e2 took its place
+      expect(y.firstElementChild).toBe(e1);
+    });
+
+    it('should treat swapping an element with itself as a no-op success', () => {
+      const elem = document.createElement('div');
+      elem.id = 'solo';
+      document.body.appendChild(elem);
+
+      const result = swapElements(elem, elem);
+
+      expect(result).toBe(true);
+      expect(document.body.contains(elem)).toBe(true);
+    });
+
+    it('should return false (not throw) for an ancestor/descendant pair', () => {
+      const outer = document.createElement('div');
+      const inner = document.createElement('div');
+      outer.appendChild(inner);
+      document.body.appendChild(outer);
+
+      // Swapping a node with one inside its own subtree is impossible; the helper
+      // must fail gracefully rather than throw a DOM HierarchyRequestError.
+      expect(swapElements(outer, inner)).toBe(false);
+      expect(swapElements(inner, outer)).toBe(false);
+      expect(outer.contains(inner)).toBe(true); // tree untouched
     });
   });
 

--- a/packages/core/src/commands/helpers/dom-mutation.ts
+++ b/packages/core/src/commands/helpers/dom-mutation.ts
@@ -52,7 +52,17 @@ const positionMap: Record<SemanticPosition, ContentInsertPosition> = {
  * ```
  */
 export function toInsertPosition(position: SemanticPosition): ContentInsertPosition {
-  return positionMap[position];
+  const mapped = positionMap[position];
+  if (mapped === undefined) {
+    // Guard the contract: this function promises a ContentInsertPosition. An
+    // unknown name (e.g. the wrong vocabulary `start`/`end`) would otherwise
+    // return undefined and flow into `insertAdjacentHTML(undefined, …)`, which
+    // hangs under happy-dom instead of throwing like a real DOM. Fail loudly.
+    throw new Error(
+      `Unknown semantic position '${position}'. Valid positions: ${Object.keys(positionMap).join(', ')}.`
+    );
+  }
+  return mapped;
 }
 
 /**
@@ -179,6 +189,20 @@ function insertElement(
 function insertText(target: HTMLElement, content: string, position: ContentInsertPosition): void {
   // Cast to DOM InsertPosition - 'replace' is handled before this function is called
   const domPosition = position as globalThis.InsertPosition;
+  // Defense-in-depth: an invalid position passed straight to
+  // insertAdjacentHTML/Text throws SyntaxError in a real browser but *hangs*
+  // under happy-dom. Reject it here so a bad caller fails fast instead.
+  const VALID: ReadonlyArray<globalThis.InsertPosition> = [
+    'beforebegin',
+    'afterbegin',
+    'beforeend',
+    'afterend',
+  ];
+  if (!VALID.includes(domPosition)) {
+    throw new Error(
+      `Invalid insert position '${position}'. Expected one of ${VALID.join(', ')} (or 'replace').`
+    );
+  }
   if (looksLikeHTML(content)) {
     target.insertAdjacentHTML(domPosition, content);
   } else {
@@ -241,6 +265,19 @@ export function removeElements(elements: HTMLElement[]): number {
  */
 export function swapElements(element1: HTMLElement, element2: HTMLElement): boolean {
   if (!element1.parentNode || !element2.parentNode) {
+    return false;
+  }
+
+  // Swapping an element with itself is a no-op that trivially "succeeds".
+  if (element1 === element2) {
+    return true;
+  }
+
+  // Refuse nested pairs: moving one element into the other's subtree would throw
+  // HierarchyRequestError (a node can't contain itself). Fail gracefully — same
+  // contract as the orphan case above — rather than letting the DOM exception
+  // escape to the caller.
+  if (element1.contains(element2) || element2.contains(element1)) {
     return false;
   }
 

--- a/packages/core/src/lib/view-transitions.ts
+++ b/packages/core/src/lib/view-transitions.ts
@@ -13,6 +13,18 @@
 
 export type TransitionCallback = () => void | Promise<void>;
 
+export interface ViewTransitionOptions {
+  /**
+   * Maps to the View Transitions API "types" (the object form,
+   * `startViewTransition({ update, types })`). CSS can then target the
+   * transition via `:active-view-transition-type(<name>)`. Where the object
+   * form is unsupported, this is a no-op — the call falls back to the
+   * callback form and the name carries no runtime effect (consistent with
+   * naming individual elements via the CSS `view-transition-name` property).
+   */
+  transitionName?: string;
+}
+
 interface ViewTransitionLike {
   finished: Promise<void>;
 }
@@ -31,6 +43,7 @@ export function isViewTransitionsSupported(): boolean {
 
 interface QueuedTransition {
   callback: TransitionCallback;
+  options?: ViewTransitionOptions;
   resolve: () => void;
   reject: (reason?: unknown) => void;
 }
@@ -38,15 +51,34 @@ interface QueuedTransition {
 const queue: QueuedTransition[] = [];
 let processing = false;
 
-async function runOne(callback: TransitionCallback): Promise<void> {
+async function runOne(
+  callback: TransitionCallback,
+  options?: ViewTransitionOptions
+): Promise<void> {
   const start = getStartViewTransition();
   if (!start) {
     await callback();
     return;
   }
-  const transition = start(async () => {
+  const update = async () => {
     await callback();
-  });
+  };
+  let transition: ViewTransitionLike;
+  if (options?.transitionName) {
+    // Prefer the modern object form so the name surfaces as a transition type
+    // CSS can target. Browsers with only the callback form throw on the object
+    // argument ("update is not a function"); fall back to the callback form.
+    try {
+      transition = (start as unknown as (o: object) => ViewTransitionLike)({
+        update,
+        types: [options.transitionName],
+      });
+    } catch {
+      transition = start(update);
+    }
+  } else {
+    transition = start(update);
+  }
   // `finished` rejects if either the callback throws or the animation
   // fails. Propagate either — silent swallowing previously hid real DOM
   // update errors from the caller.
@@ -60,7 +92,7 @@ async function drain(): Promise<void> {
     while (queue.length > 0) {
       const item = queue.shift()!;
       try {
-        await runOne(item.callback);
+        await runOne(item.callback, item.options);
         item.resolve();
       } catch (error) {
         item.reject(error);
@@ -76,10 +108,15 @@ async function drain(): Promise<void> {
  *
  * Falls back to direct execution when the API is unsupported. Multiple calls
  * in flight execute sequentially, so transitions never cancel each other.
+ *
+ * @param options Optional view-transition options (e.g. `transitionName`).
  */
-export function withViewTransition(callback: TransitionCallback): Promise<void> {
+export function withViewTransition(
+  callback: TransitionCallback,
+  options?: ViewTransitionOptions
+): Promise<void> {
   return new Promise((resolve, reject) => {
-    queue.push({ callback, resolve, reject });
+    queue.push({ callback, options, resolve, reject });
     drain().catch(reject);
   });
 }

--- a/packages/core/src/parser/parser.test.ts
+++ b/packages/core/src/parser/parser.test.ts
@@ -623,17 +623,24 @@ describe('Hyperscript AST Parser', () => {
     });
 
     it('should parse "first of" positional expressions', () => {
+      // Canonical shape: `first of X` is positional/index access ("first element
+      // of X"), emitted as a callExpression — `first(X)` — which the runtime
+      // evaluates via the first/last case in evaluateCallExpression. This is
+      // deliberately NOT a `binaryExpression('of')`: that operator means
+      // property access (`value of me` → me.value) and would compute
+      // items['first'] (undefined) here. See PRE-EXISTING-FAILURES.md.
       expectAST('first of items', {
-        type: 'binaryExpression',
-        operator: 'of',
-        left: {
+        type: 'callExpression',
+        callee: {
           type: 'identifier',
           name: 'first',
         },
-        right: {
-          type: 'identifier',
-          name: 'items',
-        },
+        arguments: [
+          {
+            type: 'identifier',
+            name: 'items',
+          },
+        ],
       });
     });
 

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -3241,7 +3241,48 @@ export class Parser {
     }
   }
 
+  /**
+   * Parse a command, then attach any trailing `when`/`where` conditional guard.
+   *
+   * Traditional command parsers (parseAddCommand, the generic argument loop,
+   * etc.) stop at the command's own arguments and leave a trailing
+   * `... when <cond>` / `... where <cond>` in the token stream — which the
+   * statement loop in parseEventHandler would otherwise silently discard via its
+   * "skip unexpected tokens" pass. Capturing the guard here, centrally, makes
+   * every command support the modifier uniformly. The runtime (CommandAdapterV2)
+   * evaluates `modifiers.when` / `modifiers.where` and skips the command on a
+   * falsy result.
+   *
+   * The semantic-parse path already maps its `condition` role into
+   * `modifiers.when` and consumes the tokens via skipToCommandBoundary(), so by
+   * the time we peek here there is nothing left to attach — no double handling.
+   */
   private parseCommand(): CommandNode {
+    const node = this.parseCommandCore();
+
+    // Block commands (if/unless/repeat/for/tell) own their bodies through `end`;
+    // a trailing guard is not idiomatic there, so restrict to ordinary commands.
+    if (
+      node &&
+      node.type === 'command' &&
+      !node.body &&
+      (this.check('when') || this.check('where'))
+    ) {
+      const keyword = this.peek().value.toLowerCase(); // 'when' | 'where'
+      this.advance(); // consume the when/where keyword
+      const condition = this.parseExpression();
+      if (condition) {
+        node.modifiers = {
+          ...(node.modifiers ?? {}),
+          [keyword]: condition as ExpressionNode,
+        };
+      }
+    }
+
+    return node;
+  }
+
+  private parseCommandCore(): CommandNode {
     // Try semantic-first parsing if available
     // Semantic parsing uses modifiers format ({args: [patient], modifiers: {into: dest}})
     // Command handlers now accept both formats via fallback logic

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -507,6 +507,17 @@ async function evaluateIdentifier(node: IdentifierNode, context: ExecutionContex
   if (name === 'document') {
     return getExpr(context, 'document').evaluate(context);
   }
+  // Explicit-global reference (`::name`). The parser tags these with
+  // scope: 'global' and a bare name. They target context.globals directly
+  // (ignoring any local of the same name) and must fire the global-read hook —
+  // symmetric with the `::name` write path (setVariableValue('global') →
+  // notifyGlobalWrite). Unlike the `$name` branch below, the name is already
+  // bare, so we pass it through unchanged. Falls through to the normal lookups
+  // (incl. globalThis) when the global isn't present in context.
+  if ((node as { scope?: string }).scope === 'global' && context.globals?.has(name)) {
+    notifyGlobalRead(name, context);
+    return context.globals.get(name);
+  }
   if (context.locals && context.locals.has(name)) {
     notifyLocalRead(name, context);
     return context.locals.get(name);

--- a/packages/core/src/runtime/conditional-modifiers.test.ts
+++ b/packages/core/src/runtime/conditional-modifiers.test.ts
@@ -1,348 +1,169 @@
 /**
- * Tests for when/where conditional modifiers
+ * Tests for the `when` conditional command modifier (guard).
  *
- * These modifiers allow any command to be conditionally executed:
- *   show #element when <condition>
- *   hide #element where <condition>
+ * `when` lets any command be conditionally executed:
+ *   add .active to me when <condition>
+ * The command runs only when the guard evaluates truthy, and is skipped on
+ * falsy. The runtime (CommandAdapterV2) evaluates `modifiers.when` (and, for
+ * hand-built / semantic ASTs, `modifiers.where`).
  *
- * Both 'when' and 'where' are treated as identical conditional guards.
+ * Note: `where` is NOT an equivalent surface guard. It is a real collection-
+ * filter operator (`<collection> where <predicate>`), so a trailing `where`
+ * after a command's target binds as a filter expression and never reaches the
+ * guard position. `when` is the unambiguous command guard; the tests below pin
+ * that distinction so it is not accidentally "fixed" into a regression.
+ *
+ * Unlike the original version of this suite (which built synthetic
+ * `{ type: 'expression' }` nodes and a mock evaluator the runtime no longer
+ * consults), these tests drive the *real* parser + runtime end-to-end. That
+ * way they exercise both halves of the feature — the parser attaching the guard
+ * to `modifiers.when` / `modifiers.where`, and the runtime (CommandAdapterV2)
+ * skipping on a falsy result. A regression in either half fails a test here.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { CommandAdapterV2, type CommandWithParseInput } from './command-adapter';
-import type { ExecutionContext, TypedExecutionContext } from '../types/core';
-import type { ASTNode } from '../types/base-types';
+import { describe, it, expect, afterEach } from 'vitest';
+import { Runtime } from './runtime';
+import { parse } from '../parser/parser';
+import type { CommandNode, ExecutionContext } from '../types/core';
 
 // ========== Test Utilities ==========
 
-function createTestElement(html: string): HTMLElement {
+const created: HTMLElement[] = [];
+
+function createTestElement(html = '<div id="test">Content</div>'): HTMLElement {
   const container = document.createElement('div');
   container.innerHTML = html.trim();
   const element = container.firstElementChild as HTMLElement;
   document.body.appendChild(element);
+  created.push(element);
   return element;
 }
 
-function cleanupElement(element: HTMLElement): void {
-  if (element.parentNode) {
-    element.parentNode.removeChild(element);
-  }
-}
-
-function createMockContext(me: HTMLElement): ExecutionContext & TypedExecutionContext {
+function createContext(me: HTMLElement): ExecutionContext {
   return {
     me,
-    you: undefined,
-    it: undefined,
-    result: undefined,
+    it: null,
+    you: null,
+    result: null,
     locals: new Map(),
-    target: me,
-    detail: undefined,
-  } as unknown as ExecutionContext & TypedExecutionContext;
+    globals: new Map(),
+    variables: new Map(),
+    events: new Map(),
+  } as unknown as ExecutionContext;
 }
 
-// Mock command that tracks execution
-class MockCommand implements CommandWithParseInput {
-  name = 'mockCommand';
-  metadata = {
-    description: 'Mock command for testing',
-    syntax: 'mock',
-    examples: [] as string[],
-  };
-
-  executionCount = 0;
-
-  async parseInput(
-    _raw: { args: ASTNode[]; modifiers: Record<string, any> },
-    _evaluator: unknown,
-    _context: ExecutionContext
-  ): Promise<{ executed: boolean }> {
-    return { executed: true };
-  }
-
-  async execute(_input: { executed: boolean }, _context: TypedExecutionContext): Promise<void> {
-    this.executionCount++;
-  }
+/** Parse a single command and return its (typed) node. */
+function parseCommandNode(source: string): CommandNode {
+  const result = parse(source);
+  expect(result.success, `failed to parse: ${source}`).toBe(true);
+  return result.node as unknown as CommandNode;
 }
+
+/** Parse + execute a single command against a fresh element; return the element. */
+async function run(source: string): Promise<HTMLElement> {
+  const el = createTestElement();
+  const result = parse(source);
+  expect(result.success, `failed to parse: ${source}`).toBe(true);
+  await new Runtime().execute(result.node!, createContext(el));
+  return el;
+}
+
+afterEach(() => {
+  for (const el of created.splice(0)) {
+    el.parentNode?.removeChild(el);
+  }
+});
 
 // ========== Tests ==========
 
 describe('when/where conditional modifiers', () => {
-  let testElements: HTMLElement[] = [];
-  let mockCommand: MockCommand;
+  describe('parser attaches the guard', () => {
+    it('stores a `when` guard on modifiers.when', () => {
+      const node = parseCommandNode('add .active to me when false');
+      expect(node.modifiers?.when).toBeDefined();
+      expect(node.modifiers?.where).toBeUndefined();
+    });
 
-  beforeEach(() => {
-    mockCommand = new MockCommand();
-  });
+    it('parses trailing `where` as the collection-filter operator, not a guard', () => {
+      // `where` is a real collection-filter operator (binding power 28 in the
+      // pratt parser, evaluated by the `where` case in the runtime), so
+      // `me where false` binds as a filter expression during target parsing and
+      // never reaches the command-guard position. `when` has no such collision,
+      // which is why `when` — not `where` — is the command guard. See
+      // PRE-EXISTING-FAILURES.md. (The runtime still honors a hand-built /
+      // semantic `modifiers.where`; it is just unreachable via this surface.)
+      const node = parseCommandNode('add .active to me where false');
+      expect(node.modifiers?.where).toBeUndefined();
+      const lastArg = node.args[node.args.length - 1] as { operator?: string } | undefined;
+      expect(lastArg?.operator).toBe('where');
+    });
 
-  afterEach(() => {
-    testElements.forEach(el => cleanupElement(el));
-    testElements = [];
+    it('leaves modifiers unset when there is no guard', () => {
+      const node = parseCommandNode('add .active to me');
+      expect(node.modifiers?.when).toBeUndefined();
+      expect(node.modifiers?.where).toBeUndefined();
+    });
   });
 
   describe('when modifier', () => {
-    it('should execute command when condition is true', async () => {
-      const element = createTestElement('<div id="test">Content</div>');
-      testElements.push(element);
-
-      const context = createMockContext(element);
-
-      // Mock evaluator that returns true for the condition
-      const mockEvaluator = {
-        evaluate: vi.fn().mockResolvedValue(true),
-      };
-
-      const adapter = new CommandAdapterV2(mockCommand, mockEvaluator as any);
-
-      // Execute with when modifier set to true condition
-      await adapter.execute(context, {
-        args: [],
-        modifiers: {
-          when: { type: 'expression', value: true } as unknown as ASTNode,
-        },
-      });
-
-      expect(mockCommand.executionCount).toBe(1);
+    it('executes the command when the condition is truthy', async () => {
+      const el = await run('add .active to me when true');
+      expect(el.classList.contains('active')).toBe(true);
     });
 
-    it('should skip command when condition is false', async () => {
-      const element = createTestElement('<div id="test">Content</div>');
-      testElements.push(element);
-
-      const context = createMockContext(element);
-
-      // Mock evaluator that returns false for the condition
-      const mockEvaluator = {
-        evaluate: vi.fn().mockResolvedValue(false),
-      };
-
-      const adapter = new CommandAdapterV2(mockCommand, mockEvaluator as any);
-
-      // Execute with when modifier set to false condition
-      const result = await adapter.execute(context, {
-        args: [],
-        modifiers: {
-          when: { type: 'expression', value: false } as unknown as ASTNode,
-        },
-      });
-
-      expect(mockCommand.executionCount).toBe(0);
-      expect(result).toBeUndefined();
+    it('skips the command when the condition is falsy', async () => {
+      const el = await run('add .active to me when false');
+      expect(el.classList.contains('active')).toBe(false);
     });
 
-    it('should evaluate expression for condition', async () => {
-      const element = createTestElement('<div id="test">Content</div>');
-      testElements.push(element);
+    it('evaluates a comparison expression as the condition', async () => {
+      const truthy = await run('add .active to me when 1 is 1');
+      expect(truthy.classList.contains('active')).toBe(true);
 
-      const context = createMockContext(element);
-
-      // Mock evaluator that evaluates the expression
-      const mockEvaluator = {
-        evaluate: vi.fn().mockResolvedValue(true),
-      };
-
-      const adapter = new CommandAdapterV2(mockCommand, mockEvaluator as any);
-
-      const conditionExpr = {
-        type: 'expression',
-        operator: 'is not',
-        left: { type: 'identifier', name: 'result' },
-        right: { type: 'literal', value: 'empty' },
-      } as unknown as ASTNode;
-
-      await adapter.execute(context, {
-        args: [],
-        modifiers: { when: conditionExpr },
-      });
-
-      // Verify the evaluator was called with the condition expression
-      expect(mockEvaluator.evaluate).toHaveBeenCalledWith(conditionExpr, context);
-      expect(mockCommand.executionCount).toBe(1);
+      const falsy = await run('add .active to me when 1 is 2');
+      expect(falsy.classList.contains('active')).toBe(false);
     });
   });
 
-  describe('where modifier', () => {
-    it('should execute command when condition is true', async () => {
-      const element = createTestElement('<div id="test">Content</div>');
-      testElements.push(element);
+  describe('when (guard) vs where (filter operator)', () => {
+    it('`when false` guards the command (skipped), `where false` does not', async () => {
+      // `when` is the command guard: a falsy condition skips execution.
+      const whenEl = await run('add .active to me when false');
+      expect(whenEl.classList.contains('active')).toBe(false);
 
-      const context = createMockContext(element);
-
-      const mockEvaluator = {
-        evaluate: vi.fn().mockResolvedValue(true),
-      };
-
-      const adapter = new CommandAdapterV2(mockCommand, mockEvaluator as any);
-
-      await adapter.execute(context, {
-        args: [],
-        modifiers: {
-          where: { type: 'expression', value: true } as unknown as ASTNode,
-        },
-      });
-
-      expect(mockCommand.executionCount).toBe(1);
-    });
-
-    it('should skip command when condition is false', async () => {
-      const element = createTestElement('<div id="test">Content</div>');
-      testElements.push(element);
-
-      const context = createMockContext(element);
-
-      const mockEvaluator = {
-        evaluate: vi.fn().mockResolvedValue(false),
-      };
-
-      const adapter = new CommandAdapterV2(mockCommand, mockEvaluator as any);
-
-      const result = await adapter.execute(context, {
-        args: [],
-        modifiers: {
-          where: { type: 'expression', value: false } as unknown as ASTNode,
-        },
-      });
-
-      expect(mockCommand.executionCount).toBe(0);
-      expect(result).toBeUndefined();
-    });
-  });
-
-  describe('when and where equivalence', () => {
-    it('should treat when and where identically', async () => {
-      const element = createTestElement('<div id="test">Content</div>');
-      testElements.push(element);
-
-      const context = createMockContext(element);
-
-      const mockEvaluator = {
-        evaluate: vi.fn().mockResolvedValue(true),
-      };
-
-      const mockCommand1 = new MockCommand();
-      const mockCommand2 = new MockCommand();
-      const adapter1 = new CommandAdapterV2(mockCommand1, mockEvaluator as any);
-      const adapter2 = new CommandAdapterV2(mockCommand2, mockEvaluator as any);
-
-      // Execute with 'when'
-      await adapter1.execute(context, {
-        args: [],
-        modifiers: { when: { type: 'expression', value: true } as unknown as ASTNode },
-      });
-
-      // Execute with 'where'
-      await adapter2.execute(context, {
-        args: [],
-        modifiers: { where: { type: 'expression', value: true } as unknown as ASTNode },
-      });
-
-      // Both should have executed
-      expect(mockCommand1.executionCount).toBe(1);
-      expect(mockCommand2.executionCount).toBe(1);
+      // `where` is the collection-filter operator, not a guard, so it never
+      // skips the command — `me where false` binds as the target expression.
+      const whereEl = await run('add .active to me where false');
+      expect(whereEl.classList.contains('active')).toBe(true);
     });
   });
 
   describe('no modifier', () => {
-    it('should execute command normally without when/where', async () => {
-      const element = createTestElement('<div id="test">Content</div>');
-      testElements.push(element);
-
-      const context = createMockContext(element);
-
-      const mockEvaluator = {
-        evaluate: vi.fn().mockResolvedValue('some value'),
-      };
-
-      const adapter = new CommandAdapterV2(mockCommand, mockEvaluator as any);
-
-      await adapter.execute(context, {
-        args: [],
-        modifiers: {},
-      });
-
-      expect(mockCommand.executionCount).toBe(1);
+    it('executes the command normally', async () => {
+      const el = await run('add .active to me');
+      expect(el.classList.contains('active')).toBe(true);
     });
   });
 
-  describe('falsy values', () => {
-    it('should skip when condition evaluates to 0', async () => {
-      const element = createTestElement('<div id="test">Content</div>');
-      testElements.push(element);
-
-      const context = createMockContext(element);
-
-      const mockEvaluator = {
-        evaluate: vi.fn().mockResolvedValue(0),
-      };
-
-      const adapter = new CommandAdapterV2(mockCommand, mockEvaluator as any);
-
-      await adapter.execute(context, {
-        args: [],
-        modifiers: { when: { type: 'expression', value: 0 } as unknown as ASTNode },
-      });
-
-      expect(mockCommand.executionCount).toBe(0);
+  describe('falsy values skip execution', () => {
+    it('skips when the condition is 0', async () => {
+      const el = await run('add .active to me when 0');
+      expect(el.classList.contains('active')).toBe(false);
     });
 
-    it('should skip when condition evaluates to empty string', async () => {
-      const element = createTestElement('<div id="test">Content</div>');
-      testElements.push(element);
-
-      const context = createMockContext(element);
-
-      const mockEvaluator = {
-        evaluate: vi.fn().mockResolvedValue(''),
-      };
-
-      const adapter = new CommandAdapterV2(mockCommand, mockEvaluator as any);
-
-      await adapter.execute(context, {
-        args: [],
-        modifiers: { when: { type: 'expression', value: '' } as unknown as ASTNode },
-      });
-
-      expect(mockCommand.executionCount).toBe(0);
+    it('skips when the condition is an empty string', async () => {
+      const el = await run('add .active to me when ""');
+      expect(el.classList.contains('active')).toBe(false);
     });
 
-    it('should skip when condition evaluates to null', async () => {
-      const element = createTestElement('<div id="test">Content</div>');
-      testElements.push(element);
-
-      const context = createMockContext(element);
-
-      const mockEvaluator = {
-        evaluate: vi.fn().mockResolvedValue(null),
-      };
-
-      const adapter = new CommandAdapterV2(mockCommand, mockEvaluator as any);
-
-      await adapter.execute(context, {
-        args: [],
-        modifiers: { when: { type: 'expression', value: null } as unknown as ASTNode },
-      });
-
-      expect(mockCommand.executionCount).toBe(0);
+    it('skips when the condition is an undefined variable', async () => {
+      const el = await run('add .active to me when $missing');
+      expect(el.classList.contains('active')).toBe(false);
     });
 
-    it('should execute when condition evaluates to truthy value', async () => {
-      const element = createTestElement('<div id="test">Content</div>');
-      testElements.push(element);
-
-      const context = createMockContext(element);
-
-      const mockEvaluator = {
-        evaluate: vi.fn().mockResolvedValue('non-empty'),
-      };
-
-      const adapter = new CommandAdapterV2(mockCommand, mockEvaluator as any);
-
-      await adapter.execute(context, {
-        args: [],
-        modifiers: { when: { type: 'expression', value: 'non-empty' } as unknown as ASTNode },
-      });
-
-      expect(mockCommand.executionCount).toBe(1);
+    it('runs when the condition is a non-empty string', async () => {
+      const el = await run('add .active to me when "yes"');
+      expect(el.classList.contains('active')).toBe(true);
     });
   });
 });

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -19,7 +19,13 @@ export default defineConfig({
     // - Legacy integration tests - testing removed APIs (Phase 7 consolidation)
     exclude: [
       'node_modules',
-      'dist',
+      // Build artifacts: exclude compiled *.test.js duplicates anywhere. A bare
+      // 'dist' only catches the top-level dist; the rollup typescript cache
+      // mirrors the build under .rollup.cache/**/dist/**, and a CLI substring
+      // filter (e.g. `vitest run src/commands`) matches those compiled copies —
+      // doubling the suite with stale duplicates that crash forks. Glob both.
+      '**/dist/**',
+      '**/.rollup.cache/**',
       // Playwright browser tests - require real browser
       'src/compatibility/browser-tests/**/*.spec.ts',
       'src/multilingual/browser-e2e.spec.ts',


### PR DESCRIPTION
Closes out the four genuine follow-ups tracked in `packages/core/docs/PRE-EXISTING-FAILURES.md`, fixes a whole-suite-blocking test hang discovered while verifying, and stops vitest from collecting stale compiled test duplicates.

## Follow-up issues (from PRE-EXISTING-FAILURES.md)

1. **`when` guard ignored** — `add .active to me when false` used to still add the class. The runtime guard was correct, but traditional command parsers never attached the condition (the statement loop silently discarded the trailing `when` tokens). `parseCommand()` now wraps `parseCommandCore()` and attaches a trailing `when <cond>` to `modifiers.when`. **`where` is intentionally NOT a guard** — it's a real collection-filter operator (`me where false` binds as a filter expression); pinned in the rewritten tests.
2. **`::name` reads skip hook** — `evaluateIdentifier` now fires `notifyGlobalRead` for `scope:'global'` identifiers, symmetric with the write path.
3. **`first of` AST shape** — `parser.test` asserts the `callExpression` shape (positional/index access), not `binaryExpression('of')` (property access), which would compute `items['first']`. Decision recorded in the doc.
4. **`start view transition`** — `withViewTransition(cb, {transitionName})` maps the name to the View Transitions API `types` (object form, callback-form fallback).

## dom-mutation hang (whole-suite blocker)

`dom-mutation.test.ts` hung indefinitely (blocking any full `src/commands` run). Root cause: tests passed invalid semantic positions (`start`/`end`) → `toInsertPosition` returned `undefined` → `insertAdjacentHTML(undefined)` **hangs under happy-dom**.

- **Helper hardening:** `toInsertPosition` throws on an unknown name; `insertText` validates the position before `insertAdjacentHTML`/`insertAdjacentText`.
- **7 stale assertions fixed** (no production behavior changed): position-name drift; `replace` is content-replacement (per the helper's docs); `removeElements` orphan count; `swapElements` relative ordering.
- **`swapElements` audit:** correct for normal/cross-parent/same-element cases; threw an uncaught `HierarchyRequestError` for ancestor/descendant pairs → now returns `false`. It has **no production callers** (the `swap`/`morph` command does *content* swapping); hardened rather than removed, with edge-case tests added.

## Test infra

`vitest.config.ts` excludes `**/dist/**` and `**/.rollup.cache/**` so compiled `*.test.js` duplicates (emitted by the `rollup.browser-*.config.mjs` bundle builds) are never collected — they were doubling the suite and crashing forks.

## Verification

- Changed-file suites: **177 passed**
- parser + runtime: **1566 passed**
- full `src/commands/helpers`: **864 passed** (previously hung forever)
- typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)