### PR TITLE
ci: kill PR/push duplication + fix docs-PR gate deadlock (no merge queue)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,49 +1,40 @@
 # CI workflow design notes:
 #
-# Two-tier job set to avoid duplicating effort on merge.
+# Goal: no PR<->push duplication, cheap doc-only PRs, and a reliable required-
+# check gate — all without a merge queue (overkill for a solo maintainer).
 #
-#   pull_request runs the FULL matrix (every job that doesn't gate on
-#   branch name). This is the authoritative "does this PR pass" check.
+#   pull_request — the authoritative gate. Runs the fast required checks
+#   (build, export-validation, lint-typecheck, unit-tests) ALWAYS, plus the
+#   heavy jobs (browser-tests, multilingual-validation, bundle-size, mcp-demos)
+#   only when `changes.code == 'true'` (i.e. non-doc files changed). A doc-only
+#   PR therefore runs just the fast required checks → reports green → mergeable,
+#   while skipping the expensive jobs.
 #
-#   push to main / develop runs only the merge-skew detectors:
-#     - build  (does the merged code still compile?)
-#     - export-validation  (do package.json exports still resolve?)
-#     - lint-typecheck  (do cross-package types still resolve?)
-#     - unit-tests  (do critical logic paths still work?)
-#   Plus the post-merge-only effects:
-#     - coverage  (uploads to Codecov)
-#     - benchmarks  (tracks perf trends on main)
+#   push to main / develop — post-merge effects ONLY:
+#     - build      (needed by the two below)
+#     - coverage   (uploads to Codecov)
+#     - benchmarks (tracks perf trends on main)
+#   The skew detectors (export-validation, lint-typecheck, unit-tests) are NOT
+#   re-run on push: branch protection is `strict` (branch must be up to date),
+#   so the PR already validated the exact merged result. This removes the only
+#   PR<->push duplication.
 #
-#   The heavy jobs that already ran on the PR — browser-tests,
-#   multilingual-validation, bundle-size, mcp-demos — are gated to
-#   `if: github.event_name == 'pull_request'` and skipped on push.
-#   Saves ~60 min runner-time per merge.
-#
-# Why not enable a merge queue instead: keep this simple change in
-# place until there's bandwidth to set up merge_group properly.
+#   `concurrency: cancel-in-progress` means rapid pushes to a PR cancel stale
+#   runs, so the heavy jobs effectively run once per PR — most of a merge
+#   queue's minutes benefit, with none of its operational complexity.
 name: CI
 
 on:
+  # NOTE: deliberately no workflow-level `paths-ignore`. With required status
+  # checks, a paths-ignored PR skips the whole workflow, so the required checks
+  # never report and the PR is blocked forever ("Expected — waiting for status").
+  # Doc-only changes are handled per-job instead: the `changes` job sets
+  # code=false and the heavy jobs skip on it, while the fast required checks
+  # still run + report — so a docs-only PR stays cheap AND mergeable.
   push:
     branches: [main, develop]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - '.gitignore'
-      - 'LICENSE'
-      - 'examples/**'
-      - '.claude/**'
-      - '*.txt'
   pull_request:
     branches: [main, develop]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - '.gitignore'
-      - 'LICENSE'
-      - 'examples/**'
-      - '.claude/**'
-      - '*.txt'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -53,6 +44,36 @@ env:
   NODE_OPTIONS: --max-old-space-size=4096
 
 jobs:
+  # ============================================
+  # Job 0: Detect whether non-doc ("code") files changed.
+  # Heavy jobs gate on this so doc-only PRs skip them. The fast required checks
+  # do NOT gate on it — they must always report so the branch-protection gate
+  # is satisfied (a doc-only PR still needs them green to merge).
+  # ============================================
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    # Only consumed by the PR-only heavy jobs, so no need to run it on push.
+    if: github.event_name == 'pull_request'
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # `code` is true when any changed file is OUTSIDE the doc set.
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!examples/**'
+              - '!.claude/**'
+              - '!**/*.txt'
+              - '!.gitignore'
+              - '!LICENSE'
+
   # ============================================
   # Job 1: Build All Packages (runs once, shared by all jobs)
   # ============================================
@@ -255,6 +276,9 @@ jobs:
     name: Export Validation
     runs-on: ubuntu-latest
     needs: build
+    # PR-only: `strict` branch protection means the PR validated the merged
+    # result, so re-running this on the post-merge push would be redundant.
+    if: github.event_name == 'pull_request'
     timeout-minutes: 5
 
     steps:
@@ -312,6 +336,8 @@ jobs:
     name: Lint & Typecheck
     runs-on: ubuntu-latest
     needs: build
+    # PR-only (see export-validation): redundant on push under `strict`.
+    if: github.event_name == 'pull_request'
     timeout-minutes: 10
 
     steps:
@@ -397,6 +423,8 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     needs: build
+    # PR-only (see export-validation): redundant on push under `strict`.
+    if: github.event_name == 'pull_request'
     timeout-minutes: 15
 
     steps:
@@ -606,8 +634,9 @@ jobs:
   browser-tests:
     name: Browser Tests
     runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'pull_request'
+    needs: [build, changes]
+    # Heavy job: PR-only AND only when non-doc files changed (skips doc PRs).
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
     timeout-minutes: 30
 
     steps:
@@ -669,8 +698,9 @@ jobs:
   multilingual-validation:
     name: Multilingual Validation
     runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'pull_request'
+    needs: [build, changes]
+    # Heavy job: PR-only AND only when non-doc files changed (skips doc PRs).
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
     timeout-minutes: 15
 
     steps:
@@ -734,8 +764,9 @@ jobs:
   bundle-size:
     name: Bundle Size Analysis
     runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'pull_request'
+    needs: [build, changes]
+    # Heavy job: PR-only AND only when non-doc files changed (skips doc PRs).
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
     timeout-minutes: 10
 
     steps:
@@ -846,8 +877,9 @@ jobs:
   mcp-demos:
     name: MCP Multilingual Demos
     runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'pull_request'
+    needs: [build, changes]
+    # Heavy job: PR-only AND only when non-doc files changed (skips doc PRs).
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
     timeout-minutes: 5
 
     steps:


### PR DESCRIPTION
Reworks `ci.yml` so the required-check gate is reliable and Actions minutes aren't wasted — **without** a merge queue (its only real benefit, concurrent-merge safety, doesn't apply to a solo maintainer; it adds a queue mental model + fiddly setup for ~no extra savings here).

## Changes

1. **Remove workflow-level `paths-ignore`.** With required status checks, a paths-ignored PR skips the whole workflow → the required checks never report → the PR is blocked forever ("Expected — waiting for status"). This was a latent deadlock introduced by enabling branch protection.
2. **Add a `changes` job** (`dorny/paths-filter`) exposing `code` = "non-doc files changed". The four heavy jobs (browser-tests, multilingual-validation, bundle-size, mcp-demos) gate on it → a **doc-only PR skips them**, while the fast required checks (build/export/lint/unit) still run + report → **mergeable**.
3. **Drop export-validation / lint-typecheck / unit-tests from `push`** (gate to `pull_request`). `strict` branch protection means the PR validated the exact merged result, so re-running them post-merge was redundant — this removes the only PR↔push duplication. `push → main` now runs just **build + coverage + benchmarks**.

## Resulting matrix

| Event | Jobs |
|-------|------|
| PR (code) | changes, build, export, lint, unit, browser, multilingual, bundle, mcp |
| PR (docs-only) | changes, build, export, lint, unit *(heavy jobs skipped)* |
| push → main | build, coverage, benchmarks |

## Why this over a merge queue

- **No duplication**: skew detectors run once, on the PR.
- **Reliable gate**: required checks always report (no deadlock).
- **Cheap docs PRs**: heavy jobs skipped.
- **Solo-manageable**: plain PR → merge button, nothing new to operate.
- `concurrency: cancel-in-progress` (already present) collapses rapid PR pushes → most of a queue's minutes benefit, free.

This PR is itself a code change, so its own CI run exercises the full matrix (incl. heavy jobs) — verifying the `changes` filter resolves `code=true` for code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)