### PR TITLE
Expression upstream-parity: 82% → 85% (classRef tokenization, selector operands, of-form possessive, ref templates, collection member-access)

### DIFF
--- a/packages/core/docs/UPSTREAM-KNOWN-DIFFS.md
+++ b/packages/core/docs/UPSTREAM-KNOWN-DIFFS.md
@@ -53,6 +53,48 @@ because `:` collides with object-literal (`{k: v}`) and ternary syntax, and the
 remaining payoff is partly the error-message parity above. Not planned unless a
 concrete need appears.
 
+## Triaged niche gaps (deliberately not fixed)
+
+Reviewed during the Phase 1–5 parity follow-up (2026-06-01) and judged
+low-value-and/or-high-risk relative to fixing. Recorded so they aren't re-opened
+as "easy wins". If a concrete user need appears, revisit individually.
+
+### `[true]` / `[false]` single-element array literal
+
+`[1]`, `['x']`, and `[true, false]` parse as array literals, but a **single**
+bracketed identifier (`[true]`, `[false]`, `[me]`) parses as a CSS **attribute
+selector** (`[true]` → `querySelectorAll("[true]")` → `[]`). Disambiguating
+`[true]` (array) from `[disabled]` (attribute selector) would touch the sensitive
+`[attr]`-selector path for ~zero real-world payoff (nobody writes `[true]`).
+
+**Decision: keep `[identifier]` as an attribute selector.**
+
+### `{[bar()]: …}` computed object-literal keys that call window globals
+
+`{[foo]: true, [bar()]: false}` where `foo`/`bar` are `window` globals — the
+computed key `bar()` calls a global function. HyperFixi resolves bare identifiers
+against locals/globals, not `window`, so `bar` isn't a function in scope
+("Cannot call non-function: bar"). Computed string/expression keys work
+(`{[expr]: v}`, hyphenated keys); only the window-global-function form differs.
+
+**Decision: accept as known-diff; do not special-case window-global resolution.**
+
+### `closest @attr` (attribute-value walk)
+
+Upstream's `closest @foo` walks ancestors for the nearest element with attribute
+`foo` and returns its **value**. HyperFixi's `closest` takes a selector
+("closest requires a string selector"). A separate feature, not a parity bug.
+
+**Decision: deferred — implement only if requested.**
+
+### `collectionExpressions` — `the result` inside `where` refers to the previous command result
+
+`get 3 then set arr to … then return arr where it > the result` expects `the
+result` inside the `where` filter to stay bound to the previous command's result
+(`3`), not rebind per element. Niche scoping interaction.
+
+**Decision: accept as known-diff.**
+
 ## Harness artifacts (product is correct; the test shape can't observe it)
 
 These upstream tests consume results in a way our async runtime can't satisfy

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -52,22 +52,26 @@ const HYPERSCRIPT_TEST_ROOT =
 //   - Phase 4 `.{expr}` / `#{expr}` templates: 307/361 runnable = 85%  (floor 84)
 //       template refs interpolate the inner EXPRESSION (`.{'c1'}` → `.c1`,
 //       `#{'d1'}` → `#d1`, `.{cls}` reads the local), in both sync + async paths.
+//   - Phase 5 member-access over collections: 308/361 runnable = 85%  (floor 84)
+//       `.cb.checked` maps `.checked` over the collection like `.cb's checked`
+//       → [true, false]. (Still 85% — adds margin, not a new integer rate.)
 // Ratchet this up as the remaining parity gaps are fixed in follow-ups.
 //
 // Remaining gaps @ 85% are NOT clean product bugs — triaged & decided 2026-05-30,
-// re-verified 2026-06-01 (54 failing of 361 runnable):
+// re-verified 2026-06-01 (53 failing of 361 runnable):
 //   • async-shim artifacts (~24, the largest bucket): positional / closest /
 //     relativePositional consumed via synchronous `=== el` / `.length`, and
 //     fire-and-forget `_hyperscript("set …")` reads (attributeRef red→blue).
 //     Harness-only — the awaited `run`-based equivalents pass.
 //   • intentional known-diffs / decided-deferred (see docs/UPSTREAM-KNOWN-DIFFS.md):
 //     boolean `in` (not intersection-array), checkbox `as Values` → boolean,
-//     error-message text not matched verbatim, `typecheck : Type` postfix.
-//   • un-triaged REAL gaps (next real work — phase 5 of the plan):
-//     query-ref `$`/`${}` interpolation (`<#$id/>`, `<[foo='${x}']/>`, element
-//     interpolation) — needs harness locals-threading into sync eval (3);
-//     objectLiteral computed-key calls, collectionExpressions `where`→previous-
-//     result, closest "attributes resolve as attributes".
+//     error-message text not matched verbatim, `typecheck : Type` postfix,
+//     `[true]` single-elt array-literal vs `[attr]` selector ambiguity,
+//     `{[bar()]:…}` window-global computed keys, `closest @attr`,
+//     collectionExpressions `where`→previous-`result` scoping.
+//   • remaining feature gap (needs harness work): query-ref `$`/`${}`
+//     interpolation (`<#$id/>`, `<[foo='${x}']/>`, element interpolation) —
+//     needs harness locals-threading into sync eval (3).
 //     See ~/.claude/plans/expression-parity-remaining.md.
 //
 // NOTE: relativePositional / blockLiteral / stringPostfix were "deferred" through

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -36,16 +36,35 @@ const HYPERSCRIPT_TEST_ROOT =
 //   - possessive over collections: 286/361 runnable = 79%  (floor 78)
 //       `.cls's *color` / `'s [@attr]` / chained `'s style's display` map over
 //       all matched elements (collection-intrinsic props like `length` excluded).
+//   - Phase C/D feature gaps:       297/361 runnable = 82%  (floor 81)
+//       relativePositional (`next/previous … from/within/in/with wrapping`),
+//       stringPostfix units (`1em`/`100%`), blockLiteral lambdas (`\ x -> body`),
+//       `set @attr` write-path, user-extensible `as` converters (config.conversions).
+//   - Phase 1 classRef tokenization: 301/361 runnable = 83%  (floor 82)
+//       bare class refs now store the LITERAL class name (author backslashes
+//       stripped) and re-escape `[:&()[\]\/]` at query time — `.c1:foo:bar`,
+//       `.-c1`, `.-c1\/22`, tailwind `.group-\[…\]:block`. (`.btn:hover` is now a
+//       literal class, NOT a pseudo — pseudo stays on query refs `<button:hover/>`.)
 // Ratchet this up as the remaining parity gaps are fixed in follow-ups.
 //
-// Remaining gaps @ 79% are NOT clean product bugs — triaged & decided 2026-05-30:
-//   • ~12 async-shim cases (positional/closest/queryRef/relativePositional consumed
-//     via synchronous `=== el` / `.length`) — harness-only; awaited equivalents pass.
-//   • intentional known-diffs from upstream: boolean `in` (not intersection-array),
-//     checkbox `as Values` → boolean (not value). KEPT deliberately.
-//   • deferred features: relativePositional from/within/wrapping, blockLiteral,
-//     typecheck `: Type`, stringPostfix units; + low-value error-message parity.
-// See ~/.claude/plans/please-write-a-planning-optimized-fern.md → "DECISIONS".
+// Remaining gaps @ 83% are NOT clean product bugs — triaged & decided 2026-05-30,
+// re-verified 2026-06-01 (60 failing of 361 runnable):
+//   • async-shim artifacts (~24, the largest bucket): positional / closest /
+//     relativePositional consumed via synchronous `=== el` / `.length`, and
+//     fire-and-forget `_hyperscript("set …")` reads (attributeRef red→blue).
+//     Harness-only — the awaited `run`-based equivalents pass.
+//   • intentional known-diffs / decided-deferred (see docs/UPSTREAM-KNOWN-DIFFS.md):
+//     boolean `in` (not intersection-array), checkbox `as Values` → boolean,
+//     error-message text not matched verbatim, `typecheck : Type` postfix.
+//   • un-triaged REAL gaps (next real work — phases 2-5 of the plan):
+//     possessiveExpression over classrefs (`.cls's foo`, 8) + `the X of Y's Z`
+//     of-form, `$var`/template interpolation in queryRef/idRef + `.{expr}` (4),
+//     objectLiteral computed-key calls, some.js empty-selector, collectionExpressions
+//     `where`→previous-result. See ~/.claude/plans/expression-parity-remaining.md.
+//
+// NOTE: relativePositional / blockLiteral / stringPostfix were "deferred" through
+// 79%; PR #236 SHIPPED all three (blockLiteral 4/4, stringPostfix 3/3, +6
+// relativePositional). Don't re-list them as deferred.
 //
 // Harness/upstream-fidelity note: upstream's `_hyperscript("expr")` is
 // SYNCHRONOUS, but HyperFixi evaluates asynchronously. The compatibility-test.html
@@ -60,7 +79,7 @@ const HYPERSCRIPT_TEST_ROOT =
 // The remaining gap below 100% is mostly intentional divergences + harness
 // artifacts — see docs/UPSTREAM-KNOWN-DIFFS.md (checkbox `as Values` → boolean,
 // boolean `in`, error-message text, sync `=== el` / fire-and-forget `set`).
-const EXPRESSION_PASS_RATE_FLOOR = 81;
+const EXPRESSION_PASS_RATE_FLOOR = 82;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -49,10 +49,13 @@ const HYPERSCRIPT_TEST_ROOT =
 //       `some`/`no`/`of` accept a bare selector operand (`some .aClass`); `'s`
 //       binds tighter than `of` so `the display of #foo's style` = the display of
 //       (#foo's style); `the X of <collection>` maps the read over members.
+//   - Phase 4 `.{expr}` / `#{expr}` templates: 307/361 runnable = 85%  (floor 84)
+//       template refs interpolate the inner EXPRESSION (`.{'c1'}` → `.c1`,
+//       `#{'d1'}` → `#d1`, `.{cls}` reads the local), in both sync + async paths.
 // Ratchet this up as the remaining parity gaps are fixed in follow-ups.
 //
-// Remaining gaps @ 84% are NOT clean product bugs — triaged & decided 2026-05-30,
-// re-verified 2026-06-01 (56 failing of 361 runnable):
+// Remaining gaps @ 85% are NOT clean product bugs — triaged & decided 2026-05-30,
+// re-verified 2026-06-01 (54 failing of 361 runnable):
 //   • async-shim artifacts (~24, the largest bucket): positional / closest /
 //     relativePositional consumed via synchronous `=== el` / `.length`, and
 //     fire-and-forget `_hyperscript("set …")` reads (attributeRef red→blue).
@@ -60,8 +63,9 @@ const HYPERSCRIPT_TEST_ROOT =
 //   • intentional known-diffs / decided-deferred (see docs/UPSTREAM-KNOWN-DIFFS.md):
 //     boolean `in` (not intersection-array), checkbox `as Values` → boolean,
 //     error-message text not matched verbatim, `typecheck : Type` postfix.
-//   • un-triaged REAL gaps (next real work — phases 4-5 of the plan):
-//     `$var`/template interpolation in queryRef/idRef + `.{expr}` classRef (4),
+//   • un-triaged REAL gaps (next real work — phase 5 of the plan):
+//     query-ref `$`/`${}` interpolation (`<#$id/>`, `<[foo='${x}']/>`, element
+//     interpolation) — needs harness locals-threading into sync eval (3);
 //     objectLiteral computed-key calls, collectionExpressions `where`→previous-
 //     result, closest "attributes resolve as attributes".
 //     See ~/.claude/plans/expression-parity-remaining.md.
@@ -83,7 +87,7 @@ const HYPERSCRIPT_TEST_ROOT =
 // The remaining gap below 100% is mostly intentional divergences + harness
 // artifacts — see docs/UPSTREAM-KNOWN-DIFFS.md (checkbox `as Values` → boolean,
 // boolean `in`, error-message text, sync `=== el` / fire-and-forget `set`).
-const EXPRESSION_PASS_RATE_FLOOR = 83;
+const EXPRESSION_PASS_RATE_FLOOR = 84;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -45,10 +45,14 @@ const HYPERSCRIPT_TEST_ROOT =
 //       stripped) and re-escape `[:&()[\]\/]` at query time — `.c1:foo:bar`,
 //       `.-c1`, `.-c1\/22`, tailwind `.group-\[…\]:block`. (`.btn:hover` is now a
 //       literal class, NOT a pseudo — pseudo stays on query refs `<button:hover/>`.)
+//   - Phase 2/3 selector operands + of-form: 305/361 runnable = 84%  (floor 83)
+//       `some`/`no`/`of` accept a bare selector operand (`some .aClass`); `'s`
+//       binds tighter than `of` so `the display of #foo's style` = the display of
+//       (#foo's style); `the X of <collection>` maps the read over members.
 // Ratchet this up as the remaining parity gaps are fixed in follow-ups.
 //
-// Remaining gaps @ 83% are NOT clean product bugs — triaged & decided 2026-05-30,
-// re-verified 2026-06-01 (60 failing of 361 runnable):
+// Remaining gaps @ 84% are NOT clean product bugs — triaged & decided 2026-05-30,
+// re-verified 2026-06-01 (56 failing of 361 runnable):
 //   • async-shim artifacts (~24, the largest bucket): positional / closest /
 //     relativePositional consumed via synchronous `=== el` / `.length`, and
 //     fire-and-forget `_hyperscript("set …")` reads (attributeRef red→blue).
@@ -56,11 +60,11 @@ const HYPERSCRIPT_TEST_ROOT =
 //   • intentional known-diffs / decided-deferred (see docs/UPSTREAM-KNOWN-DIFFS.md):
 //     boolean `in` (not intersection-array), checkbox `as Values` → boolean,
 //     error-message text not matched verbatim, `typecheck : Type` postfix.
-//   • un-triaged REAL gaps (next real work — phases 2-5 of the plan):
-//     possessiveExpression over classrefs (`.cls's foo`, 8) + `the X of Y's Z`
-//     of-form, `$var`/template interpolation in queryRef/idRef + `.{expr}` (4),
-//     objectLiteral computed-key calls, some.js empty-selector, collectionExpressions
-//     `where`→previous-result. See ~/.claude/plans/expression-parity-remaining.md.
+//   • un-triaged REAL gaps (next real work — phases 4-5 of the plan):
+//     `$var`/template interpolation in queryRef/idRef + `.{expr}` classRef (4),
+//     objectLiteral computed-key calls, collectionExpressions `where`→previous-
+//     result, closest "attributes resolve as attributes".
+//     See ~/.claude/plans/expression-parity-remaining.md.
 //
 // NOTE: relativePositional / blockLiteral / stringPostfix were "deferred" through
 // 79%; PR #236 SHIPPED all three (blockLiteral 4/4, stringPostfix 3/3, +6
@@ -79,7 +83,7 @@ const HYPERSCRIPT_TEST_ROOT =
 // The remaining gap below 100% is mostly intentional divergences + harness
 // artifacts — see docs/UPSTREAM-KNOWN-DIFFS.md (checkbox `as Values` → boolean,
 // boolean `in`, error-message text, sync `=== el` / fire-and-forget `set`).
-const EXPRESSION_PASS_RATE_FLOOR = 82;
+const EXPRESSION_PASS_RATE_FLOOR = 83;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/expression-parity-phasec.test.ts
+++ b/packages/core/src/compatibility/expression-parity-phasec.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Expression-parity Phase C — regression guards (source-level, run in CI's unit
+ * job) mirroring the upstream cases fixed in the post-#236 parity follow-up.
+ *
+ * Phase 1: classRef CSS tokenization + escaping. Upstream `_hyperscript` stores
+ * a bare class ref as the LITERAL class name (author backslashes stripped) and
+ * re-escapes CSS-special chars (`escapeSelector`: `[:&()[\]\/]`) before
+ * querySelectorAll. We match that for bare `.`-refs; pseudo-class selection
+ * stays on query refs (`<button:hover/>`).
+ *
+ * These run under happy-dom; querySelectorAll escape handling is exercised in
+ * the chromium parity harness (expressions.spec.ts) too.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { tokenize, TokenKind } from '../parser/tokenizer';
+import { evaluateExpressionFromSourceSync } from '../parser/runtime';
+import { createMockHyperscriptContext } from '../test-setup';
+import type { ExecutionContext } from '../types/core';
+
+describe('expression parity (Phase C) — Phase 1: classRef tokenization + escaping', () => {
+  describe('tokenization captures the literal class name', () => {
+    const cases: Array<[string, string]> = [
+      ['.c1:foo:bar', '.c1:foo:bar'], // multiple colons (`:` is a literal class char)
+      ['.-c1', '.-c1'], // leading minus
+      ['.-c1\\/22', '.-c1/22'], // escaped slash → literal `/`
+      [
+        '.group-\\[:nth-of-type\\(3\\)_\\&\\]:block',
+        '.group-[:nth-of-type(3)_&]:block', // tailwind: backslashes stripped to literal
+      ],
+    ];
+    for (const [src, expected] of cases) {
+      it(`tokenizes ${JSON.stringify(src)} → ${JSON.stringify(expected)}`, () => {
+        const tokens = tokenize(src).filter(t => t.kind !== TokenKind.EOF);
+        expect(tokens).toHaveLength(1);
+        expect(tokens[0]).toMatchObject({ kind: TokenKind.SELECTOR, value: expected });
+      });
+    }
+  });
+
+  describe('DOM resolution matches the literal class', () => {
+    let context: ExecutionContext;
+    const made: Element[] = [];
+
+    const mount = (className: string) => {
+      const el = document.createElement('div');
+      el.className = className;
+      document.body.appendChild(el);
+      made.push(el);
+      return el;
+    };
+
+    beforeEach(() => {
+      context = createMockHyperscriptContext();
+    });
+    afterEach(() => {
+      while (made.length) made.pop()!.remove();
+    });
+
+    const resolves = (className: string, source: string) => {
+      const el = mount(className);
+      const result = evaluateExpressionFromSourceSync(source, context) as Element[];
+      expect(Array.from(result)).toContain(el);
+    };
+
+    it('.c1:foo:bar matches class "c1:foo:bar"', () => resolves('c1:foo:bar', '.c1:foo:bar'));
+    it('.-c1 matches class "-c1"', () => resolves('-c1', '.-c1'));
+    it('.-c1\\/22 matches class "-c1/22"', () => resolves('-c1/22', '.-c1\\/22'));
+    it('tailwind insanity matches the literal class', () =>
+      resolves('group-[:nth-of-type(3)_&]:block', '.group-\\[:nth-of-type\\(3\\)_\\&\\]:block'));
+
+    it('bare .btn:hover is a LITERAL class, not a pseudo (upstream-faithful)', () => {
+      // Matches a class literally named `btn:hover`; pseudo selection is on
+      // query refs (`<button:hover/>`). Do not regress to pseudo semantics here.
+      resolves('btn:hover', '.btn:hover');
+    });
+  });
+});

--- a/packages/core/src/compatibility/expression-parity-phasec.test.ts
+++ b/packages/core/src/compatibility/expression-parity-phasec.test.ts
@@ -123,3 +123,39 @@ describe('expression parity (Phase C) — Phase 2/3: selector operands + of-form
     });
   });
 });
+
+/**
+ * Phase 4: `.{expr}` / `#{expr}` template refs interpolate the inner EXPRESSION
+ * (not just a bare variable) — `.{'c1'}` → `.c1`, `#{'d1'}` → `#d1`. Query-ref
+ * `$`/`${}` interpolation (`<#$id/>`, `<[foo='${x}']/>`) still needs harness
+ * locals-threading and stays a documented gap.
+ */
+describe('expression parity (Phase C) — Phase 4: .{expr} / #{expr} template refs', () => {
+  const made: Element[] = [];
+  afterEach(() => {
+    while (made.length) made.pop()!.remove();
+  });
+  const mount = (html: string) => {
+    const tpl = document.createElement('div');
+    tpl.innerHTML = html;
+    const el = tpl.firstElementChild!;
+    document.body.appendChild(el);
+    made.push(el);
+    return el;
+  };
+
+  it("classRef literal template: .{'c1'} matches class c1", async () => {
+    mount("<div class='c1'></div>");
+    expect(Array.from((await evalHyperScript(".{'c1'}")) as ArrayLike<unknown>)).toHaveLength(1);
+  });
+  it("idRef literal template: #{'d1'} resolves the element", async () => {
+    const el = mount("<div id='d1'></div>");
+    expect(await evalHyperScript("#{'d1'}")).toBe(el);
+  });
+  it('classRef variable template: .{cls} reads the local', async () => {
+    mount("<div class='c1'></div>");
+    expect(
+      Array.from((await evalHyperScript('.{cls}', { locals: { cls: 'c1' } })) as ArrayLike<unknown>)
+    ).toHaveLength(1);
+  });
+});

--- a/packages/core/src/compatibility/expression-parity-phasec.test.ts
+++ b/packages/core/src/compatibility/expression-parity-phasec.test.ts
@@ -159,3 +159,30 @@ describe('expression parity (Phase C) — Phase 4: .{expr} / #{expr} template re
     ).toHaveLength(1);
   });
 });
+
+/**
+ * Phase 5: dot member-access maps over a classRef/queryRef collection, matching
+ * the possessive form — `.cb.checked` === `.cb's checked` → [true, false].
+ */
+describe('expression parity (Phase C) — Phase 5: member access over a collection', () => {
+  const made: Element[] = [];
+  afterEach(() => {
+    while (made.length) made.pop()!.remove();
+  });
+  beforeEach(() => {
+    const wrap = document.createElement('div');
+    wrap.innerHTML =
+      "<input class='cb' type='checkbox' checked /><input class='cb' type='checkbox' />";
+    for (const el of Array.from(wrap.children)) {
+      document.body.appendChild(el);
+      made.push(el);
+    }
+  });
+
+  it('.cb.checked maps .checked over the collection', async () => {
+    expect(await evalHyperScript('.cb.checked')).toEqual([true, false]);
+  });
+  it('dot form agrees with the possessive form', async () => {
+    expect(await evalHyperScript('.cb.checked')).toEqual(await evalHyperScript(".cb's checked"));
+  });
+});

--- a/packages/core/src/compatibility/expression-parity-phasec.test.ts
+++ b/packages/core/src/compatibility/expression-parity-phasec.test.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { tokenize, TokenKind } from '../parser/tokenizer';
 import { evaluateExpressionFromSourceSync } from '../parser/runtime';
+import { evalHyperScript } from './eval-hyperscript';
 import { createMockHyperscriptContext } from '../test-setup';
 import type { ExecutionContext } from '../types/core';
 
@@ -30,7 +31,7 @@ describe('expression parity (Phase C) — Phase 1: classRef tokenization + escap
     ];
     for (const [src, expected] of cases) {
       it(`tokenizes ${JSON.stringify(src)} → ${JSON.stringify(expected)}`, () => {
-        const tokens = tokenize(src).filter(t => t.kind !== TokenKind.EOF);
+        const tokens = tokenize(src);
         expect(tokens).toHaveLength(1);
         expect(tokens[0]).toMatchObject({ kind: TokenKind.SELECTOR, value: expected });
       });
@@ -72,6 +73,53 @@ describe('expression parity (Phase C) — Phase 1: classRef tokenization + escap
       // Matches a class literally named `btn:hover`; pseudo selection is on
       // query refs (`<button:hover/>`). Do not regress to pseudo semantics here.
       resolves('btn:hover', '.btn:hover');
+    });
+  });
+});
+
+/**
+ * Phase 2: a bare class/selector now works as an expression OPERAND after `of`,
+ * `some`, `no` (`some .aClass`, `the display of .foo…`). Phase 3: `the X of Y's Z`
+ * binds `'s` tighter than `of` (`the display of #foo's style` = the display of
+ * (#foo's style)), and `the X of <collection>` maps the read over every member.
+ */
+describe('expression parity (Phase C) — Phase 2/3: selector operands + of-form possessive', () => {
+  const made: Element[] = [];
+  afterEach(() => {
+    while (made.length) made.pop()!.remove();
+  });
+  const mount = (html: string) => {
+    const tpl = document.createElement('div');
+    tpl.innerHTML = html;
+    const el = tpl.firstElementChild!;
+    document.body.appendChild(el);
+    made.push(el);
+    return el;
+  };
+
+  it('some <bare selector> evaluates (false for an empty selector)', async () => {
+    expect(await evalHyperScript('some .aClassThatDoesNotExist')).toBe(false);
+  });
+
+  it('some <bare selector> is true when the selector matches', async () => {
+    mount("<div class='exists-marker'></div>");
+    expect(await evalHyperScript('some .exists-marker')).toBe(true);
+  });
+
+  describe('the <prop> of <ref>’s <prop> binds possessive tighter than of', () => {
+    beforeEach(() => mount("<div id='foo' class='foo' style='display: inline'></div>"));
+
+    it("idref:   the display of #foo's style → 'inline'", async () => {
+      expect(await evalHyperScript("the display of #foo's style")).toBe('inline');
+    });
+    it("classref: the display of .foo's style → ['inline'] (maps over collection)", async () => {
+      expect(await evalHyperScript("the display of .foo's style")).toEqual(['inline']);
+    });
+    it("queryref: the display of <.foo/>'s style → ['inline']", async () => {
+      expect(await evalHyperScript("the display of <.foo/>'s style")).toEqual(['inline']);
+    });
+    it('scalar `the X of Y` (no trailing possessive) is unchanged', async () => {
+      expect(await evalHyperScript('the id of #foo')).toBe('foo');
     });
   });
 });

--- a/packages/core/src/expressions/properties/index.ts
+++ b/packages/core/src/expressions/properties/index.ts
@@ -45,7 +45,7 @@ function readPossessiveValue(element: unknown, property: string): unknown {
  * of primitives or plain objects — so `[1, 2, 3]'s length` still reads the
  * array's own property rather than mapping element-wise.
  */
-function isMappableCollection(v: unknown): boolean {
+export function isMappableCollection(v: unknown): boolean {
   let items: unknown[];
   if (Array.isArray(v)) {
     items = v;

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -3666,8 +3666,13 @@ export class Parser {
 
     this.advance(); // consume "of"
 
-    // Parse the target expression (e.g., #test-input)
-    const target = this.parsePrimary();
+    // Parse the target through parseCall (not parsePrimary) so a trailing
+    // possessive binds to the TARGET, not the whole `of` expression:
+    // `the display of #foo's style` = `the display of (#foo's style)`, i.e.
+    // propertyOf(display, possessive(#foo, style)) — NOT (the display of #foo)'s
+    // style. `'s` binds tighter than `of`. parseCall is a safe superset of
+    // parsePrimary for targets with no postfix (`the value of me` unchanged).
+    const target = this.parseCall();
 
     // Return a propertyOfExpression node
     return {

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -24,6 +24,7 @@ export { setGlobal };
 // through `context.registry` so bundle entries control which categories ship.
 import { isElement, getElementProperty } from '../expressions/property-access-utils';
 import { convertValue } from '../expressions/conversion/index';
+import { isMappableCollection } from '../expressions/properties/index';
 import {
   evaluateWhere,
   evaluateSortedBy,
@@ -1378,6 +1379,15 @@ async function evaluateMemberExpression(node: MemberNode, context: ExecutionCont
     // falls back to a direct lookup.
     if (object instanceof Element && typeof propertyName === 'string') {
       return getElementProperty(object, propertyName);
+    }
+
+    // A classRef/queryRef collection maps `.prop` over every member, so the dot
+    // form matches the possessive form: `.cb.checked` === `.cb's checked` →
+    // [true, false]. Same guard as the possessive evaluator (element/host
+    // collections only; skips collection-own props so `.items.length` is still
+    // the count) — delegate to it for one source of truth.
+    if (isMappableCollection(object) && !(propertyName in (object as object))) {
+      return getExpr(context, 'possessive').evaluate(context, object, propertyName);
     }
 
     return object?.[propertyName];

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -418,7 +418,7 @@ function evaluateSelectorSync(node: SelectorNode, context: ExecutionContext): un
   if (!node.fromQuery && /^\*[a-zA-Z][\w-]*$/.test(selector)) {
     throw new NotSyncEvaluable('selector');
   }
-  const escaped = escapeClassColons(selector);
+  const escaped = escapeSelectorForQuery(node, selector);
   const doc =
     (context?.me as { ownerDocument?: Document } | null)?.ownerDocument ??
     (typeof document !== 'undefined' ? document : null);
@@ -1523,7 +1523,7 @@ async function evaluateSelector(node: SelectorNode, context: ExecutionContext): 
     return getExpr(context, 'styleRef').evaluate(context, selector.slice(1));
   }
 
-  const escaped = typeof selector === 'string' ? escapeClassColons(selector) : selector;
+  const escaped = typeof selector === 'string' ? escapeSelectorForQuery(node, selector) : selector;
   const result = await getExpr(context, 'elementWithSelector').evaluate(context, escaped);
 
   // Bare `#id` unwraps to single element. `<#id/>` (query-form, marked by
@@ -1585,6 +1585,37 @@ const PSEUDO_CLASS_COLON_RE = new RegExp(
 );
 function escapeClassColons(selector: string): string {
   return selector.replace(PSEUDO_CLASS_COLON_RE, '$1\\:');
+}
+
+// Upstream `_hyperscript` runtime.escapeSelector: a *bare* class ref (`.foo`)
+// captures the LITERAL class name (the tokenizer strips author backslashes), so
+// the CSS-special chars must be re-escaped before querySelectorAll. This is how
+// modern utility-class names match — `.c1:foo:bar` → `.c1\:foo\:bar` (class
+// literally named `c1:foo:bar`), `.group-[…]:block` likewise.
+//
+// NOTE (intentional, upstream-faithful): inside a *bare class ref* a colon is a
+// LITERAL class char, NOT a pseudo-class — `.btn:hover` matches a class named
+// `btn:hover`, not hovered `.btn`. Pseudo-class selection lives on QUERY refs
+// (`<button:hover/>`), which keep the pseudo-preserving escapeClassColons path.
+// Do not "fix" this back to pseudo semantics for bare refs.
+const BARE_REF_ESCAPE_RE = /[:&()[\]/]/g;
+function escapeBareRefSelector(selector: string): string {
+  const prefix = selector[0]; // '.' (only bare class refs route here)
+  return prefix + selector.slice(1).replace(BARE_REF_ESCAPE_RE, '\\$&');
+}
+
+/**
+ * Choose the right escaping for a selector node before querySelectorAll:
+ *   - bare class ref (`.foo`, not a `<…/>` query, no `{…}` template) → upstream
+ *     escapeSelector (literal class name).
+ *   - everything else (query refs, id refs, templates) → the pseudo-preserving
+ *     escapeClassColons, so `<button:hover/>` etc. keep working.
+ */
+function escapeSelectorForQuery(node: SelectorNode, selector: string): string {
+  if (!node.fromQuery && selector.startsWith('.') && !selector.includes('{')) {
+    return escapeBareRefSelector(selector);
+  }
+  return escapeClassColons(selector);
 }
 
 /**

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -412,12 +412,15 @@ function evaluateObjectLiteralSync(node: any, context: ExecutionContext): Record
  * `NotSyncEvaluable` to defer to the async path.
  */
 function evaluateSelectorSync(node: SelectorNode, context: ExecutionContext): unknown {
-  const selector = node.value;
-  if (typeof selector !== 'string') throw new NotSyncEvaluable('selector');
+  const raw = node.value;
+  if (typeof raw !== 'string') throw new NotSyncEvaluable('selector');
   // Style references go through the async styleRef expression — defer.
-  if (!node.fromQuery && /^\*[a-zA-Z][\w-]*$/.test(selector)) {
+  if (!node.fromQuery && /^\*[a-zA-Z][\w-]*$/.test(raw)) {
     throw new NotSyncEvaluable('selector');
   }
+  // `.{expr}` / `#{expr}` template refs — interpolate before querying.
+  const selector =
+    !node.fromQuery && raw.includes('{') ? interpolateSelectorTemplateSync(raw, context) : raw;
   const escaped = escapeSelectorForQuery(node, selector);
   const doc =
     (context?.me as { ownerDocument?: Document } | null)?.ownerDocument ??
@@ -1513,7 +1516,7 @@ async function evaluateCallExpression(node: CallNode, context: ExecutionContext)
  * only `#id` selectors yield a single element.
  */
 async function evaluateSelector(node: SelectorNode, context: ExecutionContext): Promise<any> {
-  const selector = node.value;
+  let selector = node.value;
 
   // Style reference: `*color`, `*text-align`, `*computed-color`. The leading `*`
   // here is NOT the universal CSS selector — it reads a style property off the
@@ -1521,6 +1524,11 @@ async function evaluateSelector(node: SelectorNode, context: ExecutionContext): 
   // than querySelectorAll, which would throw on `*color`.
   if (typeof selector === 'string' && !node.fromQuery && /^\*[a-zA-Z][\w-]*$/.test(selector)) {
     return getExpr(context, 'styleRef').evaluate(context, selector.slice(1));
+  }
+
+  // `.{expr}` / `#{expr}` template refs — interpolate before querying.
+  if (typeof selector === 'string' && !node.fromQuery && selector.includes('{')) {
+    selector = await interpolateSelectorTemplate(selector, context);
   }
 
   const escaped = typeof selector === 'string' ? escapeSelectorForQuery(node, selector) : selector;
@@ -1616,6 +1624,22 @@ function escapeSelectorForQuery(node: SelectorNode, selector: string): string {
     return escapeBareRefSelector(selector);
   }
   return escapeClassColons(selector);
+}
+
+// Non-query `.{expr}` / `#{expr}` template refs (upstream classRef/idRef template
+// form): each `{…}` is evaluated as an EXPRESSION against the context and
+// substituted — `.{'c1'}` → `.c1`, `#{id}` → `#<value-of-id>`. Gated to non-query
+// refs; query refs use the `$`/`${}` interpolation syntax on a separate path, so
+// their braces (inside `${…}`) are left untouched here.
+function interpolateSelectorTemplateSync(selector: string, context: ExecutionContext): string {
+  return selector.replace(/\{([^}]*)\}/g, (_m, inner: string) =>
+    String(evaluateExpressionFromSourceSync(inner.trim(), context) ?? '')
+  );
+}
+function interpolateSelectorTemplate(selector: string, context: ExecutionContext): Promise<string> {
+  return replaceAsync(selector, /\{([^}]*)\}/g, async (_m: string, inner: string) =>
+    String((await evaluateExpressionFromSource(inner.trim(), context)) ?? '')
+  );
 }
 
 /**

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -1125,12 +1125,12 @@ async function evaluatePropertyOfExpressionNode(
     throw new Error(`Cannot access property "${propertyName}" of ${target}`);
   }
 
-  if (isElement(target)) {
-    return getElementProperty(target, propertyName);
-  }
-
-  const value = (target as any)[propertyName];
-  return typeof value === 'function' ? value.bind(target) : value;
+  // `the X of Y` and `Y's X` are the same access — delegate to the possessive
+  // expression so a collection target maps the read over every member
+  // (`the display of .foo's style` → ["inline"]) while a single element/object
+  // reads identically (readPossessiveValue uses getElementProperty for
+  // Elements, the same as the old single-element branch here).
+  return getExpr(context, 'possessive').evaluate(context, target, propertyName);
 }
 
 /**

--- a/packages/core/src/parser/tokenizer.ts
+++ b/packages/core/src/parser/tokenizer.ts
@@ -222,7 +222,9 @@ export function tokenize(input: string): Token[] {
       if (
         isCSSSelectorContext &&
         !isAdjacentToPrev &&
-        (isAlpha(peek(tokenizer)) || peek(tokenizer) === '{')
+        // Class name can start with a letter, a `{` template, or a leading `-`
+        // (`.-c1`, `.-c1\/22`) — matches upstream's class-ref guard.
+        (isAlpha(peek(tokenizer)) || peek(tokenizer) === '{' || peek(tokenizer) === '-')
       ) {
         tokenizeCSSSelector(tokenizer);
         continue;
@@ -552,7 +554,16 @@ function tokenizeCSSSelector(tokenizer: Tokenizer): void {
 
   while (tokenizer.position < tokenizer.input.length) {
     const char = tokenizer.input[tokenizer.position];
-    if (isAlphaNumeric(char) || char === '-' || char === '_' || char === ':') {
+    if (char === '\\') {
+      // CSS escape: drop the author's backslash, keep the literal escaped char
+      // so the stored selector is the *literal* class name (`.-c1\/22` → class
+      // `-c1/22`, `.group-\[…\]:block` → `group-[…]:block`). It is re-escaped at
+      // query time by escapeBareRefSelector — mirrors upstream consumeClassReference.
+      advance(tokenizer); // consume + discard '\'
+      if (tokenizer.position < tokenizer.input.length) {
+        value += advance(tokenizer); // keep the escaped char verbatim
+      }
+    } else if (isAlphaNumeric(char) || char === '-' || char === '_' || char === ':') {
       value += advance(tokenizer);
     } else {
       break;

--- a/packages/core/src/parser/tokenizer.ts
+++ b/packages/core/src/parser/tokenizer.ts
@@ -190,6 +190,14 @@ export function tokenize(input: string): Token[] {
         'previous',
         'closest',
         'random',
+        // `the display of .foo's style` — the class after `of` is a selector
+        // operand, not member access on the `of` keyword. (`of #foo` already
+        // tokenizes as a selector; this aligns the `.`-ref path.)
+        'of',
+        // Collection quantifiers take a bare selector operand:
+        // `some .foo`, `no .foo` (mirrors `some <.foo/>`, which already works).
+        'some',
+        'no',
       ]);
       // Commands like add, remove, toggle can be followed by class selectors
       const isCommandContext =


### PR DESCRIPTION
Resumes the expression upstream-parity arc from the documented baseline (82%, floor 81) through five focused phases to **85% (308/361 runnable, floor 84)**. **+11 cases cleared, zero regressions** (broad 5497-test sweep green). One commit per phase, each root-caused against the real upstream test inputs, guarded by source-level tests, and floor-ratcheted only after a green harness run.

## Phases

| Phase | Commit | What | Δ |
| --- | --- | --- | --- |
| 1 | `43b0ff61` | **classRef CSS tokenization** — bare class refs store the *literal* class name (strip author `\`) and re-escape `[:&()[\]\/]` at query time: `.c1:foo:bar`, `.-c1`, `.-c1\/22`, Tailwind `.group-\[…\]:block` | +4 (82→83%) |
| 2-3 | `910e07de` | **selector operands + of-form possessive** — `some`/`no`/`of` accept a bare selector operand (`some .aClass`); `'s` binds tighter than `of` (`the display of #foo's style` = the display of `(#foo's style)`); `the X of <collection>` maps over members | +4 (83→84%) |
| 4 | `75a6caa7` | **`.{expr}` / `#{expr}` template refs** interpolate the inner *expression* (`.{'c1'}`→`.c1`, `.{cls}` reads the local), sync + async | +2 (84→85%) |
| 5 | `c5b028af` | **dot member-access over collections** — `.cb.checked` → `[true,false]`, matching the possessive `.cb's checked` | +1 (margin) |
| docs | `e8c7b0f6` | record the triaged niche gaps as known-diffs | — |

## Intentional behavior change worth a look

Phase 1 makes a **bare** class ref `.btn:hover` match a class *literally named* `btn:hover` (upstream-faithful, Tailwind-friendly) rather than a `:hover` pseudo-class. Pseudo-class selection stays on **query refs** (`<button:hover/>`), where every pseudo-class test already lives — so no test regressed. Documented in code so it isn't reverted by accident.

## Verification

- Parity harness (`expressions.spec.ts`, chromium): **85%**, floor assertion (84) passes.
- **20 new source-level guards** in `expression-parity-phasec.test.ts` (tokenization + happy-dom resolution + eval).
- `typecheck` clean; broad sweep (parser/expressions/commands/runtime/integration/registry/multilingual/compatibility) **5497 passed / 0 failed**.

## Not in scope (documented in `docs/UPSTREAM-KNOWN-DIFFS.md`)

The remaining 53 are intentional known-diffs (boolean `in`, checkbox `as Values`, error text, `typecheck :Type`), harness artifacts (sync `=== el`, fire-and-forget `set`), and triaged niche gaps (`[true]` array-literal ambiguity, window-global computed keys, `closest @attr`, `where`→`result` scoping). The one open *feature* gap is query-ref `$`/`${}` interpolation (needs harness locals-threading). The big sync-command lever (~28 cases) stays deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)