### PR TITLE
Expression upstream-parity: 85% → 86% (query-ref $/${} interpolation)

### DIFF
--- a/packages/core/src/compatibility/browser-tests/expressions.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/expressions.spec.ts
@@ -55,10 +55,16 @@ const HYPERSCRIPT_TEST_ROOT =
 //   - Phase 5 member-access over collections: 308/361 runnable = 85%  (floor 84)
 //       `.cb.checked` maps `.checked` over the collection like `.cb's checked`
 //       → [true, false]. (Still 85% — adds margin, not a new integer rate.)
+//   - Phase 6 query-ref `$`/`${}` interpolation: 311/361 runnable = 86%  (floor 85)
+//       `<#$id/>` / `<[foo='${x}']/>` / `<${el} + div/>` substitute a local /
+//       expression (or DOM element, via the `data-hs-query-id` marker trick) into
+//       the selector, in both sync + async paths. `$=` (attribute ends-with) stays
+//       literal via the `/\$[^=]/` gate. queryRef.js 10→13.
 // Ratchet this up as the remaining parity gaps are fixed in follow-ups.
 //
-// Remaining gaps @ 85% are NOT clean product bugs — triaged & decided 2026-05-30,
-// re-verified 2026-06-01 (53 failing of 361 runnable):
+// Remaining gaps @ 86% are NOT clean product bugs — triaged & decided 2026-05-30,
+// re-verified 2026-06-01 (50 failing of 361 runnable, after Phase 6 shipped the
+// last real feature gap — query-ref interpolation, 3 cases):
 //   • async-shim artifacts (~24, the largest bucket): positional / closest /
 //     relativePositional consumed via synchronous `=== el` / `.length`, and
 //     fire-and-forget `_hyperscript("set …")` reads (attributeRef red→blue).
@@ -69,10 +75,8 @@ const HYPERSCRIPT_TEST_ROOT =
 //     `[true]` single-elt array-literal vs `[attr]` selector ambiguity,
 //     `{[bar()]:…}` window-global computed keys, `closest @attr`,
 //     collectionExpressions `where`→previous-`result` scoping.
-//   • remaining feature gap (needs harness work): query-ref `$`/`${}`
-//     interpolation (`<#$id/>`, `<[foo='${x}']/>`, element interpolation) —
-//     needs harness locals-threading into sync eval (3).
-//     See ~/.claude/plans/expression-parity-remaining.md.
+//   See ~/.claude/plans/expression-parity-remaining.md. No remaining clean
+//   feature gaps — the residual is async-shim artifacts + intentional diffs.
 //
 // NOTE: relativePositional / blockLiteral / stringPostfix were "deferred" through
 // 79%; PR #236 SHIPPED all three (blockLiteral 4/4, stringPostfix 3/3, +6
@@ -84,14 +88,15 @@ const HYPERSCRIPT_TEST_ROOT =
 // pure-expression subset — currently selector references) and falls back to the
 // async Promise otherwise. Cases still gated by this (consume the result
 // synchronously but aren't yet sync-evaluable): the remaining asExpression
-// closures (Date/Set/Map/Fragment), classRef/queryRef with interpolation, and the
-// fire-and-forget `set` tests. The products are correct (awaited `run`-based cases
-// pass); extending evalHyperScriptSync to those node types lifts them further.
+// closures (Date/Set/Map/Fragment) and the fire-and-forget `set` tests.
+// (classRef/queryRef interpolation is now sync-evaluable — Phases 4 & 6.) The
+// products are correct (awaited `run`-based cases pass); extending
+// evalHyperScriptSync to those node types lifts them further.
 //
 // The remaining gap below 100% is mostly intentional divergences + harness
 // artifacts — see docs/UPSTREAM-KNOWN-DIFFS.md (checkbox `as Values` → boolean,
 // boolean `in`, error-message text, sync `=== el` / fire-and-forget `set`).
-const EXPRESSION_PASS_RATE_FLOOR = 84;
+const EXPRESSION_PASS_RATE_FLOOR = 85;
 
 interface TestFile {
   filename: string;

--- a/packages/core/src/compatibility/expression-parity-phasec.test.ts
+++ b/packages/core/src/compatibility/expression-parity-phasec.test.ts
@@ -126,9 +126,8 @@ describe('expression parity (Phase C) — Phase 2/3: selector operands + of-form
 
 /**
  * Phase 4: `.{expr}` / `#{expr}` template refs interpolate the inner EXPRESSION
- * (not just a bare variable) — `.{'c1'}` → `.c1`, `#{'d1'}` → `#d1`. Query-ref
- * `$`/`${}` interpolation (`<#$id/>`, `<[foo='${x}']/>`) still needs harness
- * locals-threading and stays a documented gap.
+ * (not just a bare variable) — `.{'c1'}` → `.c1`, `#{'d1'}` → `#d1`. (Query-ref
+ * `$`/`${}` interpolation — `<#$id/>`, `<[foo='${x}']/>` — ships in Phase 6 below.)
  */
 describe('expression parity (Phase C) — Phase 4: .{expr} / #{expr} template refs', () => {
   const made: Element[] = [];
@@ -184,5 +183,68 @@ describe('expression parity (Phase C) — Phase 5: member access over a collecti
   });
   it('dot form agrees with the possessive form', async () => {
     expect(await evalHyperScript('.cb.checked')).toEqual(await evalHyperScript(".cb's checked"));
+  });
+});
+
+/**
+ * Phase 6: query-ref `$var` / `${expr}` interpolation — substitute a local /
+ * expression (or DOM element) into a `<…/>` selector. Mirrors upstream
+ * `test/expressions/queryRef.js` ("$ works", "$ no curlies works", "interpolate
+ * elements into queries"). Query refs return the full collection (fromQuery), so
+ * callers index with `Array.from(value)[0]`. `$=` (attribute ends-with) must stay
+ * literal — guarded by the `/\$[^=]/` gate.
+ */
+describe('expression parity (Phase C) — Phase 6: query-ref $ / ${} interpolation', () => {
+  const made: Element[] = [];
+  afterEach(() => {
+    while (made.length) made.pop()!.remove();
+  });
+  const mount = (html: string): Element[] => {
+    const tpl = document.createElement('div');
+    tpl.innerHTML = html;
+    const els = Array.from(tpl.children);
+    for (const el of els) {
+      document.body.appendChild(el);
+      made.push(el);
+    }
+    return els;
+  };
+
+  it("string interpolation: <[foo='${x}']/> matches the attribute", async () => {
+    mount("<div foo='bar' class='c2'></div>");
+    const value = (await evalHyperScript("<[foo='${x}']/>", {
+      locals: { x: 'bar' },
+    })) as ArrayLike<unknown>;
+    expect(Array.from(value)).toHaveLength(1);
+  });
+
+  it('bare $var interpolation: <#$id/> resolves the element (collection)', async () => {
+    const [el] = mount("<div id='d1'></div>");
+    const value = (await evalHyperScript('<#$id/>', {
+      locals: { id: 'd1' },
+    })) as ArrayLike<unknown>;
+    expect(Array.from(value)[0]).toBe(el);
+  });
+
+  it('element interpolation: <${a} + div/> selects the adjacent sibling', async () => {
+    const [a, b] = mount("<div class='a'></div><div class='b'></div>");
+    const value = (await evalHyperScript('<${a} + div/>', { locals: { a } })) as ArrayLike<unknown>;
+    expect(Array.from(value)[0]).toBe(b);
+    // The temp marker must never leak onto the DOM.
+    expect(a.hasAttribute('data-hs-query-id')).toBe(false);
+  });
+
+  it('sync path: evaluateExpressionFromSourceSync resolves <#$id/> from locals', () => {
+    const [el] = mount("<div id='d2'></div>");
+    const ctx = createMockHyperscriptContext() as unknown as ExecutionContext;
+    ctx.locals!.set('id', 'd2');
+    const value = evaluateExpressionFromSourceSync('<#$id/>', ctx) as ArrayLike<unknown>;
+    expect(Array.from(value)[0]).toBe(el);
+  });
+
+  it('regression: <[title$="bar"]/> ($= ends-with) stays literal', async () => {
+    mount("<div title='foo bar'></div>");
+    const value = (await evalHyperScript('<[title$="bar"]/>')) as ArrayLike<unknown>;
+    expect(Array.from(value)).toHaveLength(1);
   });
 });

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -419,6 +419,22 @@ function evaluateSelectorSync(node: SelectorNode, context: ExecutionContext): un
   if (!node.fromQuery && /^\*[a-zA-Z][\w-]*$/.test(raw)) {
     throw new NotSyncEvaluable('selector');
   }
+  // Query-ref `$var` / `${expr}` interpolation — mirror of `evaluateSelector`.
+  // `$=` (attribute ends-with) stays literal via the `/\$[^=]/` gate.
+  if (node.fromQuery && /\$[^=]/.test(raw)) {
+    const { selector: built, elements } = interpolateQueryRefTemplateSync(raw, context);
+    const escaped = escapeSelectorForQuery(node, built);
+    const doc =
+      (context?.me as { ownerDocument?: Document } | null)?.ownerDocument ??
+      (typeof document !== 'undefined' ? document : null);
+    if (!doc) throw new NotSyncEvaluable('selector');
+    elements.forEach((el, i) => el.setAttribute('data-hs-query-id', String(i)));
+    try {
+      return Array.from(doc.querySelectorAll(escaped));
+    } finally {
+      elements.forEach(el => el.removeAttribute('data-hs-query-id'));
+    }
+  }
   // `.{expr}` / `#{expr}` template refs — interpolate before querying.
   const selector =
     !node.fromQuery && raw.includes('{') ? interpolateSelectorTemplateSync(raw, context) : raw;
@@ -1536,6 +1552,23 @@ async function evaluateSelector(node: SelectorNode, context: ExecutionContext): 
     return getExpr(context, 'styleRef').evaluate(context, selector.slice(1));
   }
 
+  // Query-ref `$var` / `${expr}` interpolation (upstream queryRef template form).
+  // Gated to fromQuery + a `$` NOT followed by `=`, so `<[attr$='x']/>` stays
+  // literal. Elements are tagged `data-hs-query-id` for the query, then untagged.
+  if (typeof selector === 'string' && node.fromQuery && /\$[^=]/.test(selector)) {
+    const { selector: built, elements } = await interpolateQueryRefTemplate(selector, context);
+    const escaped = escapeSelectorForQuery(node, built);
+    elements.forEach((el, i) => el.setAttribute('data-hs-query-id', String(i)));
+    try {
+      // `elementWithSelector` runs querySelectorAll synchronously inside
+      // `.evaluate()`; markers stay set until the awaited result resolves, then
+      // `finally` removes them — never leaking `data-hs-query-id` onto the DOM.
+      return await getExpr(context, 'elementWithSelector').evaluate(context, escaped);
+    } finally {
+      elements.forEach(el => el.removeAttribute('data-hs-query-id'));
+    }
+  }
+
   // `.{expr}` / `#{expr}` template refs — interpolate before querying.
   if (typeof selector === 'string' && !node.fromQuery && selector.includes('{')) {
     selector = await interpolateSelectorTemplate(selector, context);
@@ -1650,6 +1683,88 @@ function interpolateSelectorTemplate(selector: string, context: ExecutionContext
   return replaceAsync(selector, /\{([^}]*)\}/g, async (_m: string, inner: string) =>
     String((await evaluateExpressionFromSource(inner.trim(), context)) ?? '')
   );
+}
+
+// Query-ref (`<…/>`) template interpolation: `$var` / `${expr}` substitute a
+// local/expression (or DOM element) into the selector — upstream's queryRef
+// template form (`QueryRef.parse` + `TemplatedQueryElementCollection`). Upstream
+// `parseStringTemplate` reads an EXPRESSION after `$` whether or not braces are
+// present, so bare `$var` and `${expr}` are the same operation (evaluate the
+// inner expression); we treat them identically, which also yields element
+// resolution for free. Distinct from the `.{expr}` brace form above, which is
+// gated to non-query refs.
+//
+// `$=` (CSS attribute ends-with, `<[attr$='x']/>`) must stay literal — the regex
+// only matches `$` followed by `{` or an identifier-start char, never `=`.
+const QUERY_REF_INTERP_RE = /\$\{([^}]+)\}|\$([a-zA-Z_$][a-zA-Z0-9_.$]*)/g;
+
+/** Split a fromQuery selector into literal-string and inner-expression segments. */
+function scanQueryRefTemplate(selector: string): Array<{ lit: string } | { expr: string }> {
+  const segs: Array<{ lit: string } | { expr: string }> = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  QUERY_REF_INTERP_RE.lastIndex = 0;
+  while ((m = QUERY_REF_INTERP_RE.exec(selector)) !== null) {
+    if (m.index > last) segs.push({ lit: selector.slice(last, m.index) });
+    segs.push({ expr: m[1] ?? m[2] });
+    last = m.index + m[0].length;
+  }
+  if (last < selector.length) segs.push({ lit: selector.slice(last) });
+  return segs;
+}
+
+/**
+ * Assemble the final selector + element list from a scan and its evaluated
+ * values (one per `{ expr }` segment, in order). Interpolated Elements get the
+ * upstream `[data-hs-query-id='<i>']` marker; everything else stringifies.
+ */
+function assembleQueryRef(
+  segs: Array<{ lit: string } | { expr: string }>,
+  values: unknown[]
+): { selector: string; elements: Element[] } {
+  let out = '';
+  const elements: Element[] = [];
+  let vi = 0;
+  for (const s of segs) {
+    if ('lit' in s) {
+      out += s.lit;
+      continue;
+    }
+    const v = values[vi++];
+    if (isElement(v)) {
+      out += `[data-hs-query-id='${elements.length}']`;
+      elements.push(v);
+    } else {
+      out += String(v ?? '');
+    }
+  }
+  return { selector: out, elements };
+}
+
+async function interpolateQueryRefTemplate(
+  selector: string,
+  context: ExecutionContext
+): Promise<{ selector: string; elements: Element[] }> {
+  const segs = scanQueryRefTemplate(selector);
+  const values = await Promise.all(
+    segs
+      .filter((s): s is { expr: string } => 'expr' in s)
+      .map(s => evaluateExpressionFromSource(s.expr, context))
+  );
+  return assembleQueryRef(segs, values);
+}
+
+function interpolateQueryRefTemplateSync(
+  selector: string,
+  context: ExecutionContext
+): { selector: string; elements: Element[] } {
+  const segs = scanQueryRefTemplate(selector);
+  // `evaluateExpressionFromSourceSync` throws `NotSyncEvaluable` for non-sync
+  // inner exprs — let it propagate so the caller falls back to the async path.
+  const values = segs
+    .filter((s): s is { expr: string } => 'expr' in s)
+    .map(s => evaluateExpressionFromSourceSync(s.expr, context));
+  return assembleQueryRef(segs, values);
 }
 
 /**

--- a/packages/core/src/parser/tokenizer.ts
+++ b/packages/core/src/parser/tokenizer.ts
@@ -1164,12 +1164,14 @@ function looksLikeQueryReference(tokenizer: Tokenizer): boolean {
       char === ')' ||
       char === '*' || // For [attr*="value"]
       char === '^' || // For [attr^="value"]
-      char === '$' || // For [attr$="value"]
+      char === '$' || // For [attr$="value"] and `$var` / `${expr}` interpolation
       char === '~' || // For [attr~="value"]
       char === '|' || // For [attr|="value"]
       char === '>' || // For child combinator
       char === '+' || // For adjacent sibling combinator
-      char === ',' // For multiple selectors
+      char === ',' || // For multiple selectors
+      char === '{' || // For `${expr}` interpolation (e.g. <[foo='${x}']/>)
+      char === '}' // For `${expr}` interpolation
     ) {
       foundValidContent = true;
       pos++;


### PR DESCRIPTION
## What

Query refs can now interpolate locals / expressions / DOM elements into the selector — closing the last real capability gap from the expression-parity arc.

| Syntax | Behavior |
| --- | --- |
| `<#$id/>` | bare `$var` substitution |
| `<[foo='${x}']/>` | `${expr}` string interpolation |
| `<${el} + div/>` | DOM-element interpolation via upstream's `data-hs-query-id` marker trick |

Both the **sync** and **async** selector-eval paths are covered. Element markers are set/removed in `try/finally`, so `data-hs-query-id` never leaks onto the DOM.

## How

- **`runtime.ts`** — new `scanQueryRefTemplate` / `assembleQueryRef` / `interpolateQueryRefTemplate{,Sync}` helpers; a `fromQuery`-gated branch added to both `evaluateSelector` (async) and `evaluateSelectorSync`. Bare `$var` and `${expr}` both evaluate the inner expression (matches upstream `parseStringTemplate`), which gives element resolution for free.
- **`tokenizer.ts`** — `looksLikeQueryReference`'s lookahead now accepts `{`/`}`, so `<[foo='${x}']/>` and `<${el}/>` tokenize as query refs. Safe: recognition still requires a terminating `/>`.
- **`$=` stays literal** — CSS attribute *ends-with* (`<[title$="x"]/>`) is preserved via upstream's own `/\$[^=]/` gate (there's a live upstream test for it).

## Verification

- `queryRef.js` **10 → 13** (3 interpolation cases now green)
- Overall expression parity harness **308 → 311 / 361 = 86%** (was 85%)
- Ratcheted `EXPRESSION_PASS_RATE_FLOOR` **84 → 85**
- Added **Phase 6** source-level regression guards (string / bare-var / element interpolation + marker-cleanup assertion + sync-path + the `$=`-stays-literal regression)
- `npm run typecheck` clean; vitest sweep **2653 passed / 0 failures** across `parser/`, `expressions/`, `compatibility/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)