### PR TITLE
chore(deps): resolve Dependabot alerts (qs, tmp, yaml, brace-expansion)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12274,19 +12274,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/nx/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/nx/node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -12427,19 +12414,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/nx/node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
       }
     },
     "node_modules/object-assign": {
@@ -13872,9 +13846,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -16019,9 +15993,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.4.tgz",
-      "integrity": "sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,11 @@
     "fast-uri": "^3.1.2",
     "ip-address": "^10.1.1",
     "follow-redirects": "^1.16.0",
-    "axios": "^1.16.0"
+    "axios": "^1.16.0",
+    "tmp": "^0.2.7",
+    "qs": "^6.15.2",
+    "yaml": "^2.9.0",
+    "brace-expansion": "^5.0.6"
   },
   "lint-staged": {
     "packages/*/src/**/*.ts": [


### PR DESCRIPTION
## What

Clears **all** open Dependabot / `npm audit` findings. Dependabot surfaced 2 (`tmp` high, `qs` moderate); `npm audit` flagged 3 more (`yaml`, `brace-expansion`, and `nx`'s high alert, which is derivative of its nested `tmp`).

| Package | Change | Advisory | Severity | Scope |
| --- | --- | --- | --- | --- |
| `qs` | 6.15.1 → 6.15.2 | [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) — DoS in `qs.stringify` | moderate | runtime (express / http-server / MCP SDK) |
| `tmp` | 0.2.4 → 0.2.7 | [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65) — path traversal | high | dev (under `nx`) |
| `brace-expansion` | nested 5.0.2 dropped → hoisted 5.0.6 | GHSA-f886-m6hf-6m8v / -jxxr-4gwj-5jf2 | moderate | dev (under `nx`) |
| `yaml` | nested 2.8.0 dropped → hoisted 2.9.0 | [GHSA-48c2-rrv3-qjmp](https://github.com/advisories/GHSA-48c2-rrv3-qjmp) — stack overflow | moderate | dev (under `nx`) |

All were transitive; the vulnerable copies were stale **nested duplicates** under `nx`/`lerna` (the hoisted copies were already patched).

## How

- **`package-lock.json`** — minimal in-place `npm audit fix`. **Exactly 4 entries change** (the table above); **no platform-binary churn** — the `@esbuild/*` / `@rollup/rollup-*` optional binaries for linux/win are preserved, so CI runners stay green. (A naive `rm package-lock.json && npm install` on macOS narrows the lock to the local platform and breaks Linux CI — deliberately avoided.)
- **`package.json`** — added override floors for the four packages, matching the repo's existing security-pin convention (`follow-redirects`, `axios`, `serialize-javascript`, …), so a future lock regen can't reintroduce a vulnerable nested copy.

## Verification

- `npm audit` → **found 0 vulnerabilities**
- `@hyperfixi/core` typecheck clean
- `qs@6.15.2` loads and `stringify`s correctly (only runtime-scoped bump; it's a patch fixing a null/undefined crash, API-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)