### PR TITLE
fix(i18n): make command-boundary modifiers locale-aware

### DIFF
--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -959,6 +959,44 @@ describe('Line Structure Preservation', () => {
 });
 
 // =============================================================================
+// Cross-Language Command Boundary Tests
+// =============================================================================
+
+describe('Cross-Language Command Boundaries', () => {
+  // A grammatical marker (preposition/postposition) that binds an argument to
+  // its verb must never be mistaken for a command boundary. The English base
+  // set covers `to`/`on`/etc.; these cases verify the same protection for
+  // localized markers sourced from each language's profile.
+  const hasStandaloneThen = (s: string) => /(^|\s)then(\s|$)/.test(s);
+
+  it('does not split a Japanese object marker (を) from its verb', () => {
+    // Without locale-aware boundary modifiers, `を` before the command verb
+    // `増加` was treated as a boundary, injecting a spurious `then`.
+    const result = new GrammarTransformer('ja', 'en').transform('#count を 増加');
+
+    expect(hasStandaloneThen(result)).toBe(false);
+    expect(result).toBe('#count increment');
+  });
+
+  it('does not split a Korean object marker (을) from its verb', () => {
+    const result = new GrammarTransformer('ko', 'en').transform('.active 을 토글');
+
+    expect(hasStandaloneThen(result)).toBe(false);
+    expect(result).toBe('.active toggle');
+  });
+
+  it('still keeps English base-set prepositions attached', () => {
+    // `by` is in the English base set; the argument after it must stay
+    // attached to the command rather than starting a new one.
+    const result = new GrammarTransformer('en', 'en').transform('increment #count by 2');
+
+    expect(result).not.toContain('\n');
+    expect(hasStandaloneThen(result)).toBe(false);
+    expect(result).toBe('increment #count by 2');
+  });
+});
+
+// =============================================================================
 // Has/Have Operator Translation Tests
 // =============================================================================
 

--- a/packages/i18n/src/grammar/transformer.ts
+++ b/packages/i18n/src/grammar/transformer.ts
@@ -345,7 +345,13 @@ function reconstructWithLineStructure(
  * - "on <event> <command>" stays together (event handler with first command)
  * - Modifiers like "to", "from" don't trigger splits
  */
-/** Modifier keywords that should not trigger command boundary splits */
+/**
+ * English modifier keywords that should not trigger command boundary splits.
+ * These are the base set; localized equivalents (e.g. Japanese `に`, Spanish
+ * `a`, Arabic `إلى`) are layered on per source locale by
+ * `getBoundaryModifiersForLocale`, so a preposition in a non-English source
+ * is also recognized as a modifier rather than a spurious command boundary.
+ */
 const BOUNDARY_MODIFIERS = new Set([
   'to',
   'into',
@@ -359,6 +365,37 @@ const BOUNDARY_MODIFIERS = new Set([
   'of',
   'over',
 ]);
+
+/**
+ * Boundary modifiers resolved for a given source locale: the English base set
+ * (always kept, since input may mix English keywords) plus every grammatical
+ * marker form declared by the locale's profile. Profile markers are the
+ * surface realizations of semantic roles (destination, source, style, …) —
+ * they always bind to a following value, so none should be treated as a
+ * command boundary. Cached per locale because profiles are static.
+ */
+const boundaryModifiersCache = new Map<string, Set<string>>();
+
+function getBoundaryModifiersForLocale(locale: string): Set<string> {
+  const cached = boundaryModifiersCache.get(locale);
+  if (cached) return cached;
+
+  const modifiers = new Set(BOUNDARY_MODIFIERS);
+
+  const profile = getProfile(locale);
+  profile?.markers.forEach(marker => {
+    const form = marker.form.replace(/^-|-$/g, '').toLowerCase();
+    if (form) modifiers.add(form);
+
+    marker.alternatives?.forEach(alt => {
+      const altForm = alt.replace(/^-|-$/g, '').toLowerCase();
+      if (altForm) modifiers.add(altForm);
+    });
+  });
+
+  boundaryModifiersCache.set(locale, modifiers);
+  return modifiers;
+}
 
 /**
  * Block-introducing keywords whose body should not be split at command
@@ -375,6 +412,7 @@ const BLOCK_HEAD_KEYWORDS = new Set(['live', 'when', 'unless']);
 
 function splitOnCommandBoundaries(input: string, sourceLocale: string): string[] {
   const commandKeywords = getCommandKeywordsForLocale(sourceLocale);
+  const boundaryModifiers = getBoundaryModifiersForLocale(sourceLocale);
   const tokens = input.split(/\s+/);
 
   if (tokens.length === 0) return [input];
@@ -429,7 +467,7 @@ function splitOnCommandBoundaries(input: string, sourceLocale: string): string[]
         continue;
       }
 
-      if (!BOUNDARY_MODIFIERS.has(prevLower) && !commandKeywords.has(prevLower)) {
+      if (!boundaryModifiers.has(prevLower) && !commandKeywords.has(prevLower)) {
         // This looks like a command boundary - save current part and start new one
         parts.push(currentPart.join(' '));
         currentPart = [token];


### PR DESCRIPTION
## Summary

`splitOnCommandBoundaries` (in `packages/i18n/src/grammar/transformer.ts`) decides whether a command keyword begins a new command. It guards against splitting after a preposition via the `BOUNDARY_MODIFIERS` set — but that set was **English-only** (`to`, `on`, `into`, …).

For a **non-English source locale**, a grammatical marker sitting between an argument and its verb was mistaken for a command boundary, injecting a spurious `then`:

| Source | Input | Before | After |
| --- | --- | --- | --- |
| ja | `#count を 増加` | `#count then increment` ❌ | `#count increment` ✅ |
| ko | `.active 을 토글` | `.active then toggle` ❌ | `.active toggle` ✅ |

## Change

- Add `getBoundaryModifiersForLocale(locale)`: the English base set **plus** every grammatical marker form (and `alternatives`) declared by the source locale's profile (`getProfile(locale).markers`). These markers are the surface realizations of semantic roles (destination, source, style, …) and always bind to a following value, so none should trigger a boundary split.
- Result is **cached per locale** (profiles are static).
- `splitOnCommandBoundaries` now consults the locale-aware set instead of the static English one.

English behavior is unchanged — the base set is always retained, since input may mix English keywords.

## Context

This generalizes the previously-merged English-only `BOUNDARY_MODIFIERS` exclusion to the "or its cross-language equivalent" case. The earlier English fix is already on `main`; this PR is purely the locale-aware extension.

## Tests

- New `Cross-Language Command Boundaries` describe block: ja (`を`) and ko (`을`) markers no longer split, plus an English base-set positive case (`increment #count by 2`).
- Full `@lokascript/i18n` suite green: **617 tests** across 13 files; `typecheck` clean.

https://claude.ai/code/session_01Ntx571RWUKVCjYN16kzLHf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntx571RWUKVCjYN16kzLHf)_