### PR TITLE
feat(semantic): add `bind` reactive command schema (foundation)

### DIFF
--- a/packages/hyperscript-adapter/src/generated/syntax-table.ts
+++ b/packages/hyperscript-adapter/src/generated/syntax-table.ts
@@ -9,6 +9,7 @@ export const SYNTAX: Record<string, readonly [string, string][]> = {
   async: [],
   beep: [['patient', '']],
   behavior: [['patient', '']],
+  bind: [['destination', ''], ['source', 'to']],
   blur: [['patient', '']],
   break: [],
   breakpoint: [],

--- a/packages/i18n/src/dictionaries/en.ts
+++ b/packages/i18n/src/dictionaries/en.ts
@@ -55,6 +55,9 @@ export const en: Dictionary = {
     decrement: 'decrement',
     default: 'default',
 
+    // Reactivity Commands
+    bind: 'bind',
+
     // Navigation Commands
     go: 'go',
     pushUrl: 'pushUrl',

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -451,6 +451,82 @@ export const setSchema: CommandSchema = {
 };
 
 /**
+ * Bind command: reactively binds a variable to a form/element value.
+ *
+ * Patterns:
+ * - EN: bind $greeting to #name-input
+ * - ES: vincular $greeting a #name-input
+ * - JA: $greeting を #name-input に バインド
+ *
+ * Structurally mirrors `set` (a destination plus a "to"-marked operand), so it
+ * reuses the same per-language marker placement: the bound variable takes the
+ * destination slot (object marker in SOV), and the element takes the
+ * "to"-preposition slot.
+ */
+export const bindSchema: CommandSchema = {
+  action: 'bind',
+  description: 'Reactively bind a variable to an element or property value',
+  category: 'variable',
+  primaryRole: 'destination',
+  roles: [
+    {
+      role: 'destination',
+      description: 'The variable to bind',
+      required: true,
+      expectedTypes: ['reference', 'expression'],
+      svoPosition: 1,
+      sovPosition: 1,
+      // Bound variable mirrors `set`'s destination marking.
+      markerOverride: {
+        en: '', // "bind $x to #input"
+        ja: 'を', // variable gets object marker
+        ko: '를',
+        tr: 'i',
+        ar: '',
+        sw: '',
+        tl: '',
+        bn: 'কে',
+        qu: 'ta',
+      },
+    },
+    {
+      role: 'source',
+      description: 'The element or property to bind to',
+      required: true,
+      expectedTypes: ['selector', 'reference', 'expression'],
+      svoPosition: 2,
+      sovPosition: 2,
+      // Element mirrors `set`'s value ("to") marking per language.
+      markerOverride: {
+        en: 'to', // "bind $x to #input"
+        es: 'a',
+        pt: 'para',
+        fr: 'à',
+        de: 'an',
+        it: 'a',
+        id: 'ke',
+        ms: 'ke',
+        vi: 'với',
+        ja: 'に',
+        ko: '에',
+        tr: 'e',
+        ar: 'إلى',
+        sw: 'kwenye',
+        tl: 'sa',
+        bn: 'তে',
+        qu: 'man',
+      },
+    },
+  ],
+  errorCodes: ['MISSING_TARGET', 'MISSING_VALUE', 'INVALID_SYNTAX'],
+  recoveryHints: {
+    MISSING_TARGET: 'Add a variable to bind: bind $name to #input',
+    MISSING_VALUE: 'Add "to <element>" to specify the binding source',
+    INVALID_SYNTAX: 'Use syntax: bind <variable> to <element>',
+  },
+};
+
+/**
  * Show command: makes an element visible.
  */
 export const showSchema: CommandSchema = {
@@ -2204,6 +2280,8 @@ export const commandSchemas: Record<ActionType, CommandSchema> = {
   exit: exitSchema,
   pick: pickSchema,
   render: renderSchema,
+  // Reactivity
+  bind: bindSchema,
   // Meta commands (for compound structures)
   compound: {
     action: 'compound',

--- a/packages/semantic/src/types.ts
+++ b/packages/semantic/src/types.ts
@@ -108,6 +108,8 @@ export type ActionType =
   | 'default'
   | 'init'
   | 'behavior'
+  // Reactivity
+  | 'bind'
   // Meta (for compound nodes)
   | 'compound';
 

--- a/packages/semantic/test/bind-command.test.ts
+++ b/packages/semantic/test/bind-command.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Bind Command Tests
+ *
+ * `bind` reactively connects a variable to an element/property value. It is
+ * structurally a two-role command (`bind <variable> to <element>`), modeled on
+ * `set`, and parses via the schema-generated pattern.
+ *
+ * Known limitation (tracked follow-up): the DB reference patterns use
+ * `$`-global variables (e.g. `bind $greeting to #name-input`), which the
+ * tokenizer currently splits into two tokens (`$` + name) and does not yet
+ * recognize as a single reference value — so `$`-globals do not parse as a
+ * leading role here. This affects `set`/`put`/`bind` alike and is a separate
+ * tokenizer fix. The tests below use `:`-locals, which parse today.
+ */
+import { describe, it, expect } from 'vitest';
+import { parse, canParse } from '../src';
+import type { CommandSemanticNode, CompoundSemanticNode } from '../src/types';
+
+describe('bind command', () => {
+  it('parses "bind :greeting to #name-input" into action + roles', () => {
+    const node = parse('bind :greeting to #name-input', 'en') as CommandSemanticNode;
+
+    expect(node.action).toBe('bind');
+    expect(node.roles.get('destination')?.value).toBe(':greeting');
+    expect(node.roles.get('source')?.value).toBe('#name-input');
+  });
+
+  it('binds to a property (possessive form)', () => {
+    const node = parse("bind :color to #picker's value", 'en') as CommandSemanticNode;
+
+    expect(node.action).toBe('bind');
+    expect(node.roles.get('destination')?.value).toBe(':color');
+  });
+
+  it('parses a then-chain of two binds into a compound', () => {
+    const node = parse('bind :name to #input-a then bind :name to #input-b', 'en') as
+      | CompoundSemanticNode
+      | CommandSemanticNode;
+
+    if (node.kind === 'compound') {
+      const actions = node.commands.map(c => (c as CommandSemanticNode).action);
+      expect(actions).toEqual(['bind', 'bind']);
+    } else {
+      // Single-clause fallback still yields a bind command.
+      expect((node as CommandSemanticNode).action).toBe('bind');
+    }
+  });
+
+  it('canParse reports true for a basic bind', () => {
+    expect(canParse('bind :greeting to #name-input', 'en')).toBe(true);
+  });
+
+  // Documents the tracked tokenizer follow-up: $-globals are not yet supported
+  // as a leading role value (same gap affects `set $x to 5`).
+  it.todo('parses "bind $greeting to #name-input" once $-global tokenization lands');
+});


### PR DESCRIPTION
## Summary

Part of the **English → 100% pattern-coverage** effort. The "English 20 triage" found that 10 of English's 20 multilingual-baseline failures are genuine semantic-parser gaps (the other 10 are HTML-markup patterns the hyperscript parser shouldn't grade). This PR closes the cleanest of those gaps: **`bind` had no semantic command schema, so `bind …` returned `null` from the parser.**

`bind <variable> to <element>` is structurally a two-role command, so it mirrors `set` — the bound variable takes the destination slot (object marker in SOV languages), the element takes the `to`-preposition slot, reusing `set`'s per-language marker placement.

## Changes

- **`types.ts`** — add `bind` to the `ActionType` union
- **`command-schemas.ts`** — add `bindSchema` (`destination` + `source` roles) and register it; auto-covered by the existing schema-consistency invariants
- **`i18n/en.ts`** — add the `bind` command dictionary entry (required by the schema ↔ i18n alignment test)
- **`test/bind-command.test.ts`** — parse, possessive-source, then-chain, and `canParse` coverage

## Verification

- `bind :greeting to #name-input` → `{ action: 'bind', destination: ':greeting', source: '#name-input' }`
- semantic logic suite: **5180 pass** (the only failures are pre-existing missing browser-bundle artifacts in CI's build step, unrelated)
- i18n suite: **618 pass**; schema-alignment: **129 pass**; `typecheck` clean

## Scope note (important)

This is deliberately scoped as the **foundation**. While implementing, I found two foundational parser gaps underneath the reactivity patterns — bigger than a schema add, so they're tracked as follow-ups rather than bundled here:

1. **`$`-global variables aren't tokenized as a single reference.** The tokenizer splits `$greeting` into `$` + `greeting`, so it can't fill a leading role — which is why the DB's `bind $greeting to #name-input` patterns (and `set $x to 5`, `put $x into me`) still fail. `bind` with `:`-locals parses today; the `$`-global fix is cross-cutting across the tokenizer layer. Captured as an `it.todo` in the test.
2. **`live` can't be a schema.** Zero-role schemas are filtered out of pattern generation and the body-bearing path requires an event role, so `live {body} end` needs a new block-body parser path (not a schema).

Landing `bind` now de-risks and unblocks both follow-ups.

https://claude.ai/code/session_01Ntx571RWUKVCjYN16kzLHf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntx571RWUKVCjYN16kzLHf)_