### PR TITLE
feat(semantic): recognize $-global variables as reference role values

### DIFF
--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -841,10 +841,10 @@ export class PatternMatcher {
         return createLiteral(token.normalized || token.value);
 
       case 'identifier':
-        // Check if it's a variable reference (:varname)
-        // Note: :varname doesn't match the ReferenceValue union but is used as a
+        // Check if it's a variable reference (:local or $global)
+        // Note: these don't match the ReferenceValue union but are used as a
         // reference token downstream — this cast preserves existing behavior
-        if (token.value.startsWith(':')) {
+        if (token.value.startsWith(':') || token.value.startsWith('$')) {
           return createReference(token.value as ReferenceValue['value']);
         }
         // Check if it's a built-in reference

--- a/packages/semantic/src/parser/utils/type-validation.ts
+++ b/packages/semantic/src/parser/utils/type-validation.ts
@@ -119,10 +119,10 @@ export function isPropertyName(value: string): boolean {
 }
 
 /**
- * Check if a value is a variable reference (starts with :).
+ * Check if a value is a variable reference (`:local` or `$global`).
  */
 export function isVariableRef(value: string): boolean {
-  return value.startsWith(':');
+  return value.startsWith(':') || value.startsWith('$');
 }
 
 /**

--- a/packages/semantic/src/tokenizers/extractors/variable-ref.ts
+++ b/packages/semantic/src/tokenizers/extractors/variable-ref.ts
@@ -1,21 +1,30 @@
 /**
  * Variable Reference Extractor
  *
- * Extracts variable references: :varname, :count, :x
- * This is hyperscript-specific syntax for local variables.
+ * Extracts variable references:
+ * - `:varname` — element-scoped local variables (`:count`, `:x`)
+ * - `$varname` — global variables (`$count`, `$greeting`)
+ *
+ * This is hyperscript-specific syntax. Both prefixes are kept attached to the
+ * name so the reference tokenizes as a single token (otherwise `$greeting`
+ * would split into `$` + `greeting` and never fill a role).
+ *
+ * The `$` form deliberately does NOT match `${` (template-literal
+ * interpolation): the char after `$` must be an identifier start.
  */
 
 import type { ValueExtractor, ExtractionResult } from '../value-extractor-types';
 
 /**
- * VariableRefExtractor - Extracts variable references (e.g., :count, :x).
+ * VariableRefExtractor - Extracts variable references (e.g., :count, $greeting).
  */
 export class VariableRefExtractor implements ValueExtractor {
   readonly name = 'variable-ref';
 
   canExtract(input: string, position: number): boolean {
+    const ch = input[position];
     return (
-      input[position] === ':' &&
+      (ch === ':' || ch === '$') &&
       position + 1 < input.length &&
       /[a-zA-Z_]/.test(input[position + 1])
     );
@@ -24,7 +33,7 @@ export class VariableRefExtractor implements ValueExtractor {
   extract(input: string, position: number): ExtractionResult | null {
     if (!this.canExtract(input, position)) return null;
 
-    // Start after ':'
+    // Start after the ':'/'$' prefix
     let length = 1;
 
     // Continue while we have identifier characters

--- a/packages/semantic/test/bind-command.test.ts
+++ b/packages/semantic/test/bind-command.test.ts
@@ -5,12 +5,9 @@
  * structurally a two-role command (`bind <variable> to <element>`), modeled on
  * `set`, and parses via the schema-generated pattern.
  *
- * Known limitation (tracked follow-up): the DB reference patterns use
- * `$`-global variables (e.g. `bind $greeting to #name-input`), which the
- * tokenizer currently splits into two tokens (`$` + name) and does not yet
- * recognize as a single reference value — so `$`-globals do not parse as a
- * leading role here. This affects `set`/`put`/`bind` alike and is a separate
- * tokenizer fix. The tests below use `:`-locals, which parse today.
+ * Both `:`-local and `$`-global variables parse as reference role values
+ * (the `$`-global tokenizer support landed alongside this — `VariableRefExtractor`
+ * keeps `$name` whole and the matcher/type-validation treat it as a reference).
  */
 import { describe, it, expect } from 'vitest';
 import { parse, canParse } from '../src';
@@ -50,7 +47,11 @@ describe('bind command', () => {
     expect(canParse('bind :greeting to #name-input', 'en')).toBe(true);
   });
 
-  // Documents the tracked tokenizer follow-up: $-globals are not yet supported
-  // as a leading role value (same gap affects `set $x to 5`).
-  it.todo('parses "bind $greeting to #name-input" once $-global tokenization lands');
+  it('parses "bind $greeting to #name-input" with a $-global variable', () => {
+    const node = parse('bind $greeting to #name-input', 'en') as CommandSemanticNode;
+
+    expect(node.action).toBe('bind');
+    expect(node.roles.get('destination')?.value).toBe('$greeting');
+    expect(node.roles.get('source')?.value).toBe('#name-input');
+  });
 });

--- a/packages/semantic/test/extractors/variable-ref.test.ts
+++ b/packages/semantic/test/extractors/variable-ref.test.ts
@@ -1,0 +1,39 @@
+/**
+ * VariableRefExtractor Tests
+ *
+ * Covers tokenization of variable references: `:local` and `$global`.
+ * The `$` support keeps `$name` a single token (rather than splitting into
+ * `$` + `name`) so it can fill a reference role, while deliberately NOT
+ * matching `${` template-literal interpolation.
+ */
+import { describe, it, expect } from 'vitest';
+import { VariableRefExtractor } from '../../src/tokenizers/extractors/variable-ref';
+
+describe('VariableRefExtractor', () => {
+  const ex = new VariableRefExtractor();
+
+  it('extracts a :local variable whole', () => {
+    expect(ex.extract(':count', 0)?.value).toBe(':count');
+  });
+
+  it('extracts a $global variable whole', () => {
+    expect(ex.extract('$greeting', 0)?.value).toBe('$greeting');
+    expect(ex.extract('$x_1', 0)?.value).toBe('$x_1');
+  });
+
+  it('stops at non-identifier characters', () => {
+    // "$name to" → only "$name" is the variable token
+    const r = ex.extract('$name to #x', 0);
+    expect(r?.value).toBe('$name');
+    expect(r?.length).toBe(5);
+  });
+
+  it('does NOT match `${` template-literal interpolation', () => {
+    expect(ex.canExtract('${count}', 0)).toBe(false);
+  });
+
+  it('does NOT match a bare `$` or `:`', () => {
+    expect(ex.canExtract('$ 5', 0)).toBe(false);
+    expect(ex.canExtract(': x', 0)).toBe(false);
+  });
+});

--- a/packages/semantic/test/parser/utils/type-validation.test.ts
+++ b/packages/semantic/test/parser/utils/type-validation.test.ts
@@ -163,9 +163,14 @@ describe('Type Validation Utility', () => {
   });
 
   describe('isVariableRef', () => {
-    it('should return true for variable references', () => {
+    it('should return true for :local variable references', () => {
       expect(isVariableRef(':count')).toBe(true);
       expect(isVariableRef(':myVar')).toBe(true);
+    });
+
+    it('should return true for $global variable references', () => {
+      expect(isVariableRef('$count')).toBe(true);
+      expect(isVariableRef('$greeting')).toBe(true);
     });
 
     it('should return false for non-variables', () => {


### PR DESCRIPTION
## Summary

Follow-up to #251 (the `bind` schema foundation). The `bind` schema was correct, but its real DB patterns use `$`-global variables (`bind $greeting to #name-input`), which **never parsed** — and tracing that found the gap was foundational, not bind-specific.

**Root cause:** the tokenizer only kept `:local` variables whole. `$global` variables split into two tokens (`$` + name), so they could never fill a semantic role. This affected **every command**, not just `bind` — `set $x to 5`, `put $x into me`, `increment $count` all failed too.

## Fix

- **`tokenizers/extractors/variable-ref.ts`** — `VariableRefExtractor` now extracts `$name` as a single token (same as `:name`). `${` template-literal interpolation is deliberately **not** matched (the char after `$` must be an identifier start).
- **`parser/pattern-matcher.ts`** — a `$`-prefixed identifier classifies as a `reference`.
- **`parser/utils/type-validation.ts`** — `isVariableRef` accepts the `$` prefix.

## Impact (before → after)

| Input | Before | After |
| --- | --- | --- |
| `bind $greeting to #name-input` | ❌ null | ✅ `bind` (destination `$greeting`, source `#name-input`) |
| `set $x to 5` | ❌ null | ✅ `set` |
| `put $x into me` | ❌ null | ✅ `put` |
| `increment $count` | ❌ null | ✅ `increment` |

This closes the **4 `bind` patterns** from English's Bucket-B gap end-to-end, and lifts `$`-globals as a leading role across the board. `:`-locals and CSS selectors are unaffected.

## Tests

- New `test/extractors/variable-ref.test.ts` — `$`/`:` extraction, the `${` template-literal guard, bare-`$`/`:` rejection
- `bind-command.test.ts` — promoted the prior `it.todo` to a real test asserting `bind $greeting to #name-input` parses
- `type-validation.test.ts` — `isVariableRef` `$global` cases
- Full semantic suite: **5191 pass** (only env-only missing-browser-bundle artifacts fail in a fresh checkout); i18n: **618 pass**; typecheck clean. No regressions.

https://claude.ai/code/session_01Ntx571RWUKVCjYN16kzLHf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntx571RWUKVCjYN16kzLHf)_