### PR TITLE
feat(semantic): add `live` reactive block command

### DIFF
--- a/packages/hyperscript-adapter/src/generated/syntax-table.ts
+++ b/packages/hyperscript-adapter/src/generated/syntax-table.ts
@@ -37,6 +37,7 @@ export const SYNTAX: Record<string, readonly [string, string][]> = {
   init: [],
   install: [['patient', ''], ['destination', 'on']],
   js: [['patient', '']],
+  live: [],
   log: [['patient', '']],
   make: [['patient', '']],
   measure: [['patient', ''], ['source', 'of']],

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -95,6 +95,15 @@ export interface CommandSchema {
   readonly category: CommandCategory;
   /** Whether this command typically has a body (like event handlers) */
   readonly hasBody?: boolean;
+  /**
+   * Generate a bare keyword pattern even when the command has no roles.
+   * Normally `getDefinedSchemas` only emits patterns for schemas with at least
+   * one role (a roleless keyword like `compound`/`else`/`async` would otherwise
+   * match greedily and mis-parse). Block keywords that legitimately stand alone
+   * before a body — `live <body> end` — opt in here so a `[keyword]` pattern is
+   * generated and the construct parses (body handled like other block bodies).
+   */
+  readonly bareKeyword?: boolean;
   /** Notes about special handling */
   readonly notes?: string;
   /**
@@ -524,6 +533,28 @@ export const bindSchema: CommandSchema = {
     MISSING_VALUE: 'Add "to <element>" to specify the binding source',
     INVALID_SYNTAX: 'Use syntax: bind <variable> to <element>',
   },
+};
+
+/**
+ * Live command: a reactive block whose body re-runs when its tracked
+ * dependencies change.
+ *
+ * Patterns:
+ * - EN: live put `Count: ${$count}` into me end
+ *
+ * `live` takes no leading role — the body immediately follows the keyword —
+ * so it opts into `bareKeyword` pattern generation. Like other block commands
+ * (`repeat`/`for`), the body is parsed by the surrounding block machinery; the
+ * command node itself just carries the `live` action.
+ */
+export const liveSchema: CommandSchema = {
+  action: 'live',
+  description: 'Reactive block: re-run the body when its dependencies change',
+  category: 'control-flow',
+  primaryRole: 'patient',
+  hasBody: true,
+  bareKeyword: true,
+  roles: [],
 };
 
 /**
@@ -2282,6 +2313,7 @@ export const commandSchemas: Record<ActionType, CommandSchema> = {
   render: renderSchema,
   // Reactivity
   bind: bindSchema,
+  live: liveSchema,
   // Meta commands (for compound structures)
   compound: {
     action: 'compound',
@@ -2311,7 +2343,7 @@ export function getSchemasByCategory(category: CommandCategory): CommandSchema[]
  * Get all fully-defined schemas (with roles).
  */
 export function getDefinedSchemas(): CommandSchema[] {
-  return Object.values(commandSchemas).filter(s => s.roles.length > 0);
+  return Object.values(commandSchemas).filter(s => s.roles.length > 0 || s.bareKeyword === true);
 }
 
 // =============================================================================

--- a/packages/semantic/src/types.ts
+++ b/packages/semantic/src/types.ts
@@ -110,6 +110,7 @@ export type ActionType =
   | 'behavior'
   // Reactivity
   | 'bind'
+  | 'live'
   // Meta (for compound nodes)
   | 'compound';
 

--- a/packages/semantic/test/live-command.test.ts
+++ b/packages/semantic/test/live-command.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Live Block Tests
+ *
+ * `live` is a reactive block whose body re-runs when its tracked dependencies
+ * change. It takes no leading role (the body follows the keyword directly), so
+ * its schema opts into `bareKeyword` pattern generation. Like other block
+ * commands (`repeat`/`for`), the parsed command node carries the `live` action;
+ * the body is handled by the surrounding block machinery.
+ */
+import { describe, it, expect } from 'vitest';
+import { parse, canParse } from '../src';
+import type { CommandSemanticNode } from '../src/types';
+
+describe('live block', () => {
+  it('parses a derived-value live block', () => {
+    const node = parse('live put `Count: ${$count}` into me end', 'en') as CommandSemanticNode;
+    expect(node.action).toBe('live');
+  });
+
+  it('parses a live block with multiple dependencies', () => {
+    const node = parse('live put `${$price * $quantity}` into #total end', 'en') as CommandSemanticNode;
+    expect(node.action).toBe('live');
+  });
+
+  it('canParse reports true for a live block', () => {
+    expect(canParse('live put `Count: ${$count}` into me end', 'en')).toBe(true);
+  });
+
+  it('does not hijack a non-block command that merely contains text', () => {
+    // sanity: ordinary commands are unaffected by the bare `live` keyword pattern
+    expect((parse('toggle .active', 'en') as CommandSemanticNode).action).toBe('toggle');
+    expect((parse('put :x into me', 'en') as CommandSemanticNode).action).toBe('put');
+  });
+});


### PR DESCRIPTION
## Summary

Next priority toward English → 100%. Adds the **`live` reactive block** to the semantic parser, closing the `live-derived-value` and `live-multiple-deps` English Bucket-B gaps. Both previously returned `null`.

`live <body> end` re-runs its body when tracked dependencies change. Unlike other block commands (`repeat`/`for`/`while`), it has **no leading role** — the body follows the keyword directly. The pattern generator only emits patterns for schemas with ≥1 role, because a bare roleless keyword (`compound`/`else`/`async`/`init`) would otherwise match greedily and mis-parse everything.

## Approach

A narrow opt-in rather than a broad filter change:

- **`bareKeyword` schema flag** — block keywords that legitimately stand alone before a body opt in, so a `[keyword]` pattern is generated. Only `live` sets it; `compound`/`else`/`async`/`init` (the other zero-role `hasBody` schemas) are deliberately untouched, so no greedy mis-parsing.
- `getDefinedSchemas` now includes `roles.length > 0 || bareKeyword === true`.
- Consistent with existing blocks: the parsed node carries the `live` action; the body is handled by the block machinery (`repeat`/`for` produce the action node without an attached body too).

## Changes

- **`types.ts`** — add `live` to `ActionType`
- **`command-schemas.ts`** — add the `bareKeyword` flag, `liveSchema`, register it, relax `getDefinedSchemas`
- **`hyperscript-adapter/syntax-table.ts`** — regenerated (`commandSchemas` changed; prevents the `derive-syntax` drift failure)
- **`test/live-command.test.ts`** — parse, `canParse`, and a non-hijack guard

## Verification

- `live put \`Count: ${$count}\` into me end` → `{ action: 'live' }` ✅
- Guards: `toggle .active` / `put :x into me` unaffected ✅
- semantic: **5191 pass** (only env-only missing-browser-bundle artifacts fail in a fresh checkout); hyperscript-adapter: **207 pass** (incl. derive-syntax drift); i18n: **619 pass** (schema-alignment incl. — en dict already carries `live`); typecheck clean. No regressions.

`live` patterns are generated for every language (the keyword is already in all 24 profiles from Phase 8).

https://claude.ai/code/session_01Ntx571RWUKVCjYN16kzLHf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntx571RWUKVCjYN16kzLHf)_