### PR TITLE
fix(testing-framework): exclude HTML-markup patterns from semantic-parse rate

### DIFF
--- a/packages/testing-framework/src/multilingual/html-pattern.test.ts
+++ b/packages/testing-framework/src/multilingual/html-pattern.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Pattern Loader Tests
+ *
+ * Covers isHtmlMarkupPattern: the guard that keeps HTML-markup patterns out of
+ * the semantic-parse denominator (they're validated by the DOM/Playwright
+ * suites, not the hyperscript text parser).
+ */
+import { describe, it, expect } from 'vitest';
+import { isHtmlMarkupPattern } from './html-pattern';
+
+describe('isHtmlMarkupPattern', () => {
+  it('flags HTML-markup patterns (excluded from semantic parsing)', () => {
+    const htmlPatterns = [
+      '<div hx-live="put $count into me"></div>',
+      '<div sse-connect="/events" sse-swap="tick" hx-target="#feed"></div>',
+      '<div ws-connect="wss://example/api"><form ws-send></form></div>',
+      '<script type="text/hyperscript-template" component="hello-world"><span>Hi</span></script>',
+      '  <button _="on click increment ^count">+</button>', // leading whitespace
+    ];
+    for (const code of htmlPatterns) {
+      expect(isHtmlMarkupPattern(code), code).toBe(true);
+    }
+  });
+
+  it('does not flag real hyperscript source', () => {
+    const hyperscript = [
+      'toggle .active on #button',
+      'on click increment $count',
+      'put :x into me',
+      'bind $greeting to #name-input',
+      'live put `Count: ${$count}` into me end',
+      'fetch /api/data as json then put it into #out',
+      '#count を 増加', // SOV, non-Latin
+    ];
+    for (const code of hyperscript) {
+      expect(isHtmlMarkupPattern(code), code).toBe(false);
+    }
+  });
+});

--- a/packages/testing-framework/src/multilingual/html-pattern.ts
+++ b/packages/testing-framework/src/multilingual/html-pattern.ts
@@ -1,0 +1,24 @@
+/**
+ * HTML-markup pattern detection.
+ *
+ * A handful of DB patterns (`hx-live`, `sse-connect`/`ws-connect`, and the
+ * `<script type="text/hyperscript-template">` component patterns) are authored
+ * as HTML markup — the hyperscript they exercise lives inside attributes
+ * (`hx-live="…"`, `_="…"`) and is processed at runtime by the htmx-compat /
+ * component layer, which is covered by the DOM + Playwright suites.
+ *
+ * The multilingual harness validates patterns with the hyperscript *text*
+ * parser, which structurally cannot parse HTML — grading these is a category
+ * error that understates the real parse rate, so they are excluded from the
+ * semantic-parse denominator.
+ *
+ * Top-level hyperscript never begins with `<` (commands start with a
+ * verb/event keyword or a `.`/`#`/`:`/`$` token), so a leading `<` is a
+ * reliable, self-maintaining signal — new HTML patterns are excluded
+ * automatically without a manual allow/deny list.
+ *
+ * Kept dependency-free so it is unit-testable without the patterns DB.
+ */
+export function isHtmlMarkupPattern(code: string): boolean {
+  return /^\s*</.test(code);
+}

--- a/packages/testing-framework/src/multilingual/pattern-loader.ts
+++ b/packages/testing-framework/src/multilingual/pattern-loader.ts
@@ -12,6 +12,9 @@ import {
   type Translation,
 } from '@hyperfixi/patterns-reference';
 import type { LanguageCode, PatternTranslation, TestConfig, SamplingStrategy } from './types';
+import { isHtmlMarkupPattern } from './html-pattern';
+
+export { isHtmlMarkupPattern };
 
 /**
  * Load patterns for testing based on configuration
@@ -25,13 +28,19 @@ export async function loadPatterns(config: TestConfig): Promise<PatternTranslati
     results.push(...translations);
   }
 
+  // Exclude HTML-markup patterns from the semantic-parse set (see
+  // isHtmlMarkupPattern): the hyperscript text parser can't grade HTML, so
+  // counting them would understate the real parse rate. They are validated by
+  // the DOM/Playwright + i18n-htmx suites instead.
+  const semanticPatterns = results.filter(p => !isHtmlMarkupPattern(p.hyperscript));
+
   // Apply sampling if in quick mode
   if (config.mode === 'quick') {
     const limit = config.quickModeLimit || 10;
-    return samplePatterns(results, { type: 'stratified', perCategory: limit });
+    return samplePatterns(semanticPatterns, { type: 'stratified', perCategory: limit });
   }
 
-  return results;
+  return semanticPatterns;
 }
 
 /**


### PR DESCRIPTION
## Summary

Final piece of the English → 100% effort (Bucket-A). The multilingual harness validates patterns with the hyperscript **text** parser, but ~10 DB patterns are authored as **HTML markup** — `hx-live`, `sse-connect`/`ws-connect`, and the `<script type="text/hyperscript-template">` component patterns. The hyperscript they exercise lives inside attributes (`hx-live="…"`, `_="…"`) and is processed at runtime by the htmx-compat / component layer, which is covered by the DOM + Playwright + i18n-htmx suites.

Grading HTML with a hyperscript parser is a category error that **understates the real parse rate**. This excludes those patterns from the semantic-parse denominator.

## Approach

- **`isHtmlMarkupPattern(code)`** — a dependency-free helper. Top-level hyperscript never begins with `<` (commands start with a verb/event keyword or a `.`/`#`/`:`/`$` token), so a leading `<` is a reliable, **self-maintaining** signal — verified to match exactly the 10 HTML patterns with zero false positives. New HTML patterns are excluded automatically (no manual allow/deny list).
- **`loadPatterns`** filters the loaded set through it.
- Kept the helper in its own module so it's unit-testable without the patterns DB.

## Why this is safe

- CI's `multilingual-validation` runs `cli.ts --quick` (sampled smoke, **no** `--regression`).
- The regression reporter is **rate-based** (per-language `parseRate` delta) — removing failures only raises the rate; there's no per-pattern-presence gate.
- No test hard-codes the total pattern count (`stats.totalPatterns > 0` only).

## Verification

- `isHtmlMarkupPattern` matches exactly the 10 HTML patterns; rejects hyperscript (incl. SOV/non-Latin like `#count を 増加`).
- testing-framework suite: **149 pass** (incl. the new helper test); typecheck clean (the lone remaining error is a pre-existing unbuilt-`@hyperfixi/core` reference in `parse-validator.ts`, which CI builds).

## Net effect

With the engine work (#251–#254) closing all 10 of English's genuine semantic-parser gaps, and this removing the 10 HTML category-errors from the denominator, English's reported semantic parse-rate reaches **~100% honestly** — each artifact measured by the right tool.

**Follow-up:** regenerate the multilingual baseline JSON to capture this plus the bind/live/realtime gains in the tracked per-language numbers.

https://claude.ai/code/session_01Ntx571RWUKVCjYN16kzLHf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntx571RWUKVCjYN16kzLHf)_