### PR TITLE
chore(testing-framework): regenerate multilingual baseline (English → 100%)

### DIFF
--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-02T14:26:14.263Z",
-  "commit": "4c66664b",
+  "timestamp": "2026-06-04T03:21:45.585Z",
+  "commit": "2bd138a",
   "languages": {
     "ar": {
-      "parseSuccess": 125,
-      "parseFailure": 39,
-      "parseRate": 0.7621951219512195,
-      "avgConfidence": 0.8919088702147528,
-      "bundleSize": 389339,
+      "parseSuccess": 127,
+      "parseFailure": 27,
+      "parseRate": 0.8246753246753247,
+      "avgConfidence": 0.8857370769830244,
+      "bundleSize": 391277,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -549,10 +549,12 @@
           "confidence": 0.5
         },
         "live-derived-value": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "live-multiple-deps": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "when-value-changes": {
           "success": false
@@ -578,36 +580,6 @@
         "caret-var-on-target": {
           "success": false
         },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
-          "success": false
-        },
         "intercept-cache-strategies": {
           "success": false
         },
@@ -628,12 +600,632 @@
         }
       }
     },
+    "bn": {
+      "parseSuccess": 149,
+      "parseFailure": 5,
+      "parseRate": 0.9675324675324676,
+      "avgConfidence": 0.784041759880686,
+      "bundleSize": 391277,
+      "patterns": {
+        "toggle-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-class-on-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-to-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-content-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "settle-animations": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "trigger-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 1
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "async-block": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-mirror": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 1
+        },
+        "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
+          "success": true,
+          "confidence": 1
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-once": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-debounce": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-throttle": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
+          "success": true,
+          "confidence": 1
+        },
+        "slide-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-inner-html-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-interpolation": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-list-build": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-send": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "on-custom-event-receive": {
+          "success": true,
+          "confidence": 1
+        },
+        "breakpoint-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-value-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-multiple-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "install-behavior": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-style": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "put-before": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "put-after": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "append-content": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "send-with-detail": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "multiple-events": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "default-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "input-clear": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-color-variable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "get-attribute-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "eventsource-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "socket-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "worker-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "live-multiple-deps": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "bind-auto-detect": {
+          "success": false
+        },
+        "bind-two-way": {
+          "success": false
+        },
+        "bind-explicit-property": {
+          "success": false
+        },
+        "bind-non-form-display": {
+          "success": false
+        },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "caret-var-on-target": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "intercept-cache-strategies": {
+          "success": false
+        },
+        "behavior-removable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-draggable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-sortable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-resizable": {
+          "success": true,
+          "confidence": 0.5
+        }
+      }
+    },
     "de": {
-      "parseSuccess": 146,
-      "parseFailure": 18,
-      "parseRate": 0.8902439024390244,
-      "avgConfidence": 0.9234398782343985,
-      "bundleSize": 389339,
+      "parseSuccess": 148,
+      "parseFailure": 6,
+      "parseRate": 0.961038961038961,
+      "avgConfidence": 0.9177177177177175,
+      "bundleSize": 391277,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1208,10 +1800,12 @@
           "confidence": 0.5
         },
         "live-derived-value": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "live-multiple-deps": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-auto-detect": {
           "success": false
@@ -1223,36 +1817,6 @@
           "success": false
         },
         "bind-non-form-display": {
-          "success": false
-        },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
           "success": false
         },
         "intercept-cache-strategies": {
@@ -1276,11 +1840,11 @@
       }
     },
     "en": {
-      "parseSuccess": 144,
-      "parseFailure": 20,
-      "parseRate": 0.8780487804878049,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 389339,
+      "bundleSize": 391277,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1767,17 +2331,20 @@
           "confidence": 1
         },
         "eventsource-basic": {
-          "success": false
+          "success": true,
+          "confidence": 1
         },
         "socket-basic": {
-          "success": false
+          "success": true,
+          "confidence": 1
         },
         "socket-send": {
           "success": true,
           "confidence": 1
         },
         "worker-basic": {
-          "success": false
+          "success": true,
+          "confidence": 1
         },
         "fetch-with-headers": {
           "success": true,
@@ -1828,10 +2395,12 @@
           "confidence": 1
         },
         "live-derived-value": {
-          "success": false
+          "success": true,
+          "confidence": 1
         },
         "live-multiple-deps": {
-          "success": false
+          "success": true,
+          "confidence": 1
         },
         "when-value-changes": {
           "success": true,
@@ -1842,16 +2411,20 @@
           "confidence": 1
         },
         "bind-auto-detect": {
-          "success": false
+          "success": true,
+          "confidence": 1
         },
         "bind-two-way": {
-          "success": false
+          "success": true,
+          "confidence": 1
         },
         "bind-explicit-property": {
-          "success": false
+          "success": true,
+          "confidence": 1
         },
         "bind-non-form-display": {
-          "success": false
+          "success": true,
+          "confidence": 1
         },
         "caret-var-write": {
           "success": true,
@@ -1869,38 +2442,9 @@
           "success": true,
           "confidence": 1
         },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
-          "success": false
-        },
         "intercept-cache-strategies": {
-          "success": false
+          "success": true,
+          "confidence": 1
         },
         "behavior-removable": {
           "success": true,
@@ -1921,11 +2465,11 @@
       }
     },
     "es": {
-      "parseSuccess": 146,
-      "parseFailure": 18,
-      "parseRate": 0.8902439024390244,
-      "avgConfidence": 0.978234398782344,
-      "bundleSize": 389339,
+      "parseSuccess": 148,
+      "parseFailure": 6,
+      "parseRate": 0.961038961038961,
+      "avgConfidence": 0.9717717717717718,
+      "bundleSize": 391277,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2500,10 +3044,12 @@
           "confidence": 0.5
         },
         "live-derived-value": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "live-multiple-deps": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-auto-detect": {
           "success": false
@@ -2515,36 +3061,6 @@
           "success": false
         },
         "bind-non-form-display": {
-          "success": false
-        },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
           "success": false
         },
         "intercept-cache-strategies": {
@@ -2569,10 +3085,10 @@
     },
     "fr": {
       "parseSuccess": 146,
-      "parseFailure": 18,
-      "parseRate": 0.8902439024390244,
+      "parseFailure": 8,
+      "parseRate": 0.948051948051948,
       "avgConfidence": 0.978234398782344,
-      "bundleSize": 389339,
+      "bundleSize": 391277,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3162,36 +3678,6 @@
           "success": false
         },
         "bind-non-form-display": {
-          "success": false
-        },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
           "success": false
         },
         "intercept-cache-strategies": {
@@ -3215,11 +3701,11 @@
       }
     },
     "he": {
-      "parseSuccess": 123,
-      "parseFailure": 41,
-      "parseRate": 0.75,
-      "avgConfidence": 0.8329590914956775,
-      "bundleSize": 389339,
+      "parseSuccess": 125,
+      "parseFailure": 29,
+      "parseRate": 0.8116883116883117,
+      "avgConfidence": 0.8276317460317466,
+      "bundleSize": 391277,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -3765,10 +4251,12 @@
           "success": false
         },
         "live-derived-value": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "live-multiple-deps": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "when-value-changes": {
           "success": false
@@ -3789,36 +4277,6 @@
           "success": false
         },
         "caret-var-write": {
-          "success": false
-        },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
           "success": false
         },
         "intercept-cache-strategies": {
@@ -3839,11 +4297,11 @@
       }
     },
     "hi": {
-      "parseSuccess": 163,
+      "parseSuccess": 153,
       "parseFailure": 1,
-      "parseRate": 0.9939024390243902,
-      "avgConfidence": 0.9846625766871165,
-      "bundleSize": 389339,
+      "parseRate": 0.9935064935064936,
+      "avgConfidence": 1,
+      "bundleSize": 391277,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -4437,26 +4895,6 @@
           "success": true,
           "confidence": 1
         },
-        "component-hello-world": {
-          "success": true,
-          "confidence": 1
-        },
-        "component-click-counter": {
-          "success": true,
-          "confidence": 1
-        },
-        "component-with-conditional": {
-          "success": true,
-          "confidence": 1
-        },
-        "component-with-attrs": {
-          "success": true,
-          "confidence": 1
-        },
-        "component-with-slots": {
-          "success": true,
-          "confidence": 1
-        },
         "intercept-cache-strategies": {
           "success": true,
           "confidence": 1
@@ -4479,35 +4917,15 @@
         },
         "repeat-until-event": {
           "success": false
-        },
-        "hx-live-attribute": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "hx-live-with-mutator": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "sse-connect-swap": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "sse-multi-event": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "ws-connect-send": {
-          "success": true,
-          "confidence": 0.5
         }
       }
     },
     "id": {
-      "parseSuccess": 146,
-      "parseFailure": 18,
-      "parseRate": 0.8902439024390244,
-      "avgConfidence": 0.978234398782344,
-      "bundleSize": 389339,
+      "parseSuccess": 148,
+      "parseFailure": 6,
+      "parseRate": 0.961038961038961,
+      "avgConfidence": 0.9717717717717718,
+      "bundleSize": 391277,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5082,10 +5500,12 @@
           "confidence": 0.5
         },
         "live-derived-value": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "live-multiple-deps": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-auto-detect": {
           "success": false
@@ -5097,36 +5517,6 @@
           "success": false
         },
         "bind-non-form-display": {
-          "success": false
-        },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
           "success": false
         },
         "intercept-cache-strategies": {
@@ -5150,11 +5540,11 @@
       }
     },
     "it": {
-      "parseSuccess": 140,
-      "parseFailure": 24,
-      "parseRate": 0.8536585365853658,
-      "avgConfidence": 0.9974603174603175,
-      "bundleSize": 389339,
+      "parseSuccess": 141,
+      "parseFailure": 13,
+      "parseRate": 0.9155844155844156,
+      "avgConfidence": 0.9939322301024429,
+      "bundleSize": 391277,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5720,7 +6110,8 @@
           "success": false
         },
         "socket-basic": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "worker-basic": {
           "success": false
@@ -5741,36 +6132,6 @@
           "success": false
         },
         "bind-non-form-display": {
-          "success": false
-        },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
           "success": false
         },
         "intercept-cache-strategies": {
@@ -5791,11 +6152,11 @@
       }
     },
     "ja": {
-      "parseSuccess": 143,
-      "parseFailure": 21,
-      "parseRate": 0.8719512195121951,
-      "avgConfidence": 0.7873681873681874,
-      "bundleSize": 389339,
+      "parseSuccess": 145,
+      "parseFailure": 9,
+      "parseRate": 0.9415584415584416,
+      "avgConfidence": 0.7834044882320744,
+      "bundleSize": 391277,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6343,10 +6704,12 @@
           "confidence": 0.5
         },
         "live-derived-value": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "live-multiple-deps": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "when-value-changes": {
           "success": false
@@ -6382,36 +6745,6 @@
         "reactive-array-push": {
           "success": true,
           "confidence": 0.5
-        },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
-          "success": false
         },
         "intercept-cache-strategies": {
           "success": false
@@ -6435,11 +6768,11 @@
       }
     },
     "ko": {
-      "parseSuccess": 138,
-      "parseFailure": 26,
-      "parseRate": 0.8414634146341463,
-      "avgConfidence": 0.5385668276972625,
-      "bundleSize": 389339,
+      "parseSuccess": 140,
+      "parseFailure": 14,
+      "parseRate": 0.9090909090909091,
+      "avgConfidence": 0.5380158730158731,
+      "bundleSize": 391277,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -6981,10 +7314,12 @@
           "confidence": 0.5
         },
         "live-derived-value": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "live-multiple-deps": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "when-value-changes": {
           "success": true,
@@ -7021,36 +7356,6 @@
         "reactive-array-push": {
           "success": true,
           "confidence": 0.5
-        },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
-          "success": false
         },
         "intercept-cache-strategies": {
           "success": false
@@ -7073,12 +7378,630 @@
         }
       }
     },
+    "ms": {
+      "parseSuccess": 147,
+      "parseFailure": 7,
+      "parseRate": 0.9545454545454546,
+      "avgConfidence": 0.9885865457294029,
+      "bundleSize": 391277,
+      "patterns": {
+        "toggle-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-class-on-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-to-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-content-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-before": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-after": {
+          "success": true,
+          "confidence": 1
+        },
+        "append-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "settle-animations": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-with-detail": {
+          "success": true,
+          "confidence": 1
+        },
+        "trigger-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "multiple-events": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 1
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 1
+        },
+        "async-block": {
+          "success": true,
+          "confidence": 1
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-mirror": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-clear": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 1
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-color-variable": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
+        "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
+          "success": true,
+          "confidence": 1
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 1
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-once": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-debounce": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-throttle": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 1
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 1
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
+          "success": true,
+          "confidence": 1
+        },
+        "slide-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 1
+        },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 1
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-inner-html-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-interpolation": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-list-build": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-send": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "on-custom-event-receive": {
+          "success": true,
+          "confidence": 1
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 1
+        },
+        "breakpoint-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 1
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 1
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-value-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-multiple-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
+          "success": true,
+          "confidence": 1
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 1
+        },
+        "behavior-removable": {
+          "success": true,
+          "confidence": 1
+        },
+        "behavior-draggable": {
+          "success": true,
+          "confidence": 1
+        },
+        "behavior-sortable": {
+          "success": true,
+          "confidence": 1
+        },
+        "behavior-resizable": {
+          "success": true,
+          "confidence": 1
+        },
+        "install-behavior": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "eventsource-basic": {
+          "success": false
+        },
+        "socket-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "worker-basic": {
+          "success": false
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "live-multiple-deps": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "bind-auto-detect": {
+          "success": false
+        },
+        "bind-two-way": {
+          "success": false
+        },
+        "bind-explicit-property": {
+          "success": false
+        },
+        "bind-non-form-display": {
+          "success": false
+        },
+        "intercept-cache-strategies": {
+          "success": false
+        }
+      }
+    },
     "pl": {
-      "parseSuccess": 138,
-      "parseFailure": 26,
-      "parseRate": 0.8414634146341463,
-      "avgConfidence": 0.8235104669887284,
-      "bundleSize": 389339,
+      "parseSuccess": 139,
+      "parseFailure": 15,
+      "parseRate": 0.9025974025974026,
+      "avgConfidence": 0.8211830535571548,
+      "bundleSize": 391277,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -7636,7 +8559,8 @@
           "success": false
         },
         "socket-basic": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "worker-basic": {
           "success": false
@@ -7663,36 +8587,6 @@
           "success": false
         },
         "bind-non-form-display": {
-          "success": false
-        },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
           "success": false
         },
         "intercept-cache-strategies": {
@@ -7713,11 +8607,11 @@
       }
     },
     "pt": {
-      "parseSuccess": 146,
-      "parseFailure": 18,
-      "parseRate": 0.8902439024390244,
-      "avgConfidence": 0.8235920852359214,
-      "bundleSize": 389339,
+      "parseSuccess": 148,
+      "parseFailure": 6,
+      "parseRate": 0.961038961038961,
+      "avgConfidence": 0.8192192192192198,
+      "bundleSize": 391277,
       "patterns": {
         "blur-element": {
           "success": true,
@@ -8292,10 +9186,12 @@
           "confidence": 0.5
         },
         "live-derived-value": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "live-multiple-deps": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-auto-detect": {
           "success": false
@@ -8307,36 +9203,6 @@
           "success": false
         },
         "bind-non-form-display": {
-          "success": false
-        },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
           "success": false
         },
         "intercept-cache-strategies": {
@@ -8359,12 +9225,616 @@
         }
       }
     },
+    "qu": {
+      "parseSuccess": 133,
+      "parseFailure": 21,
+      "parseRate": 0.8636363636363636,
+      "avgConfidence": 0.6804511278195489,
+      "bundleSize": 391277,
+      "patterns": {
+        "toggle-class-basic": {
+          "success": false
+        },
+        "toggle-class-on-other": {
+          "success": false
+        },
+        "add-class-basic": {
+          "success": false
+        },
+        "add-class-to-other": {
+          "success": false
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "settle-animations": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 1
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "async-block": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-once": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 1
+        },
+        "slide-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 1
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-send": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "breakpoint-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-basic": {
+          "success": false
+        },
+        "remove-class-from-all": {
+          "success": false
+        },
+        "set-text-basic": {
+          "success": false
+        },
+        "set-attribute": {
+          "success": false
+        },
+        "set-style": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "put-content-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "put-before": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "put-after": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "append-content": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "send-with-detail": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "trigger-event": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "multiple-events": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "default-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "install-behavior": {
+          "success": false
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "js-inline": {
+          "success": false
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "input-mirror": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "input-char-count": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "input-clear": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "window-resize": {
+          "success": false
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-color-variable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "next-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "event-debounce": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "event-throttle": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "event-key-combo": {
+          "success": false
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "fade-out-remove": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-text-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-inner-html-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "get-attribute-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "template-literal-interpolation": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "template-literal-list-build": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "eventsource-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "socket-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "worker-basic": {
+          "success": false
+        },
+        "on-custom-event-receive": {
+          "success": false
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "live-multiple-deps": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "when-value-changes": {
+          "success": false
+        },
+        "when-multiple-changes": {
+          "success": false
+        },
+        "bind-auto-detect": {
+          "success": false
+        },
+        "bind-two-way": {
+          "success": false
+        },
+        "bind-explicit-property": {
+          "success": false
+        },
+        "bind-non-form-display": {
+          "success": false
+        },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "caret-var-on-target": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "intercept-cache-strategies": {
+          "success": false
+        },
+        "behavior-removable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-draggable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-sortable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-resizable": {
+          "success": true,
+          "confidence": 0.5
+        }
+      }
+    },
     "ru": {
       "parseSuccess": 144,
-      "parseFailure": 20,
-      "parseRate": 0.8780487804878049,
+      "parseFailure": 10,
+      "parseRate": 0.935064935064935,
       "avgConfidence": 0.878571428571429,
-      "bundleSize": 389339,
+      "bundleSize": 391277,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -8969,36 +10439,6 @@
         "bind-non-form-display": {
           "success": false
         },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
-          "success": false
-        },
         "intercept-cache-strategies": {
           "success": false
         }
@@ -9006,10 +10446,10 @@
     },
     "sw": {
       "parseSuccess": 139,
-      "parseFailure": 25,
-      "parseRate": 0.8475609756097561,
+      "parseFailure": 15,
+      "parseRate": 0.9025974025974026,
       "avgConfidence": 0.8563777549389063,
-      "bundleSize": 389339,
+      "bundleSize": 391277,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -9593,36 +11033,6 @@
           "success": false
         },
         "bind-non-form-display": {
-          "success": false
-        },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
           "success": false
         },
         "intercept-cache-strategies": {
@@ -9645,11 +11055,11 @@
       }
     },
     "th": {
-      "parseSuccess": 144,
-      "parseFailure": 20,
-      "parseRate": 0.8780487804878049,
-      "avgConfidence": 0.9360670194003523,
-      "bundleSize": 389339,
+      "parseSuccess": 146,
+      "parseFailure": 8,
+      "parseRate": 0.948051948051948,
+      "avgConfidence": 0.9300934985866488,
+      "bundleSize": 391277,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10237,10 +11647,12 @@
           "success": false
         },
         "live-derived-value": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "live-multiple-deps": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-auto-detect": {
           "success": false
@@ -10254,47 +11666,17 @@
         "bind-non-form-display": {
           "success": false
         },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
-          "success": false
-        },
         "intercept-cache-strategies": {
           "success": false
         }
       }
     },
     "tl": {
-      "parseSuccess": 120,
-      "parseFailure": 44,
-      "parseRate": 0.7317073170731707,
-      "avgConfidence": 0.8679738562091506,
-      "bundleSize": 389339,
+      "parseSuccess": 125,
+      "parseFailure": 29,
+      "parseRate": 0.8116883116883117,
+      "avgConfidence": 0.8532549019607846,
+      "bundleSize": 391277,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10831,7 +12213,8 @@
           "success": false
         },
         "template-literal-list-build": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "eventsource-basic": {
           "success": true,
@@ -10846,16 +12229,20 @@
           "confidence": 0.5
         },
         "breakpoint-command": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "beep-debug-expression": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "live-derived-value": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "live-multiple-deps": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-auto-detect": {
           "success": false
@@ -10875,47 +12262,17 @@
         "caret-var-on-target": {
           "success": false
         },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
-          "success": false
-        },
         "intercept-cache-strategies": {
           "success": false
         }
       }
     },
     "tr": {
-      "parseSuccess": 140,
-      "parseFailure": 24,
-      "parseRate": 0.8536585365853658,
-      "avgConfidence": 0.7796031746031746,
-      "bundleSize": 389339,
+      "parseSuccess": 142,
+      "parseFailure": 12,
+      "parseRate": 0.922077922077922,
+      "avgConfidence": 0.7756651017214398,
+      "bundleSize": 391277,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -11461,10 +12818,12 @@
           "confidence": 0.5
         },
         "live-derived-value": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "live-multiple-deps": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "when-value-changes": {
           "success": false
@@ -11500,36 +12859,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
-          "success": false
-        },
         "intercept-cache-strategies": {
           "success": false
         },
@@ -11553,10 +12882,10 @@
     },
     "uk": {
       "parseSuccess": 144,
-      "parseFailure": 20,
-      "parseRate": 0.8780487804878049,
+      "parseFailure": 10,
+      "parseRate": 0.935064935064935,
       "avgConfidence": 0.8769841269841274,
-      "bundleSize": 389339,
+      "bundleSize": 391277,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12161,47 +13490,17 @@
         "bind-non-form-display": {
           "success": false
         },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
-          "success": false
-        },
         "intercept-cache-strategies": {
           "success": false
         }
       }
     },
     "vi": {
-      "parseSuccess": 144,
-      "parseFailure": 20,
-      "parseRate": 0.8780487804878049,
-      "avgConfidence": 0.8809523809523814,
-      "bundleSize": 389339,
+      "parseSuccess": 145,
+      "parseFailure": 9,
+      "parseRate": 0.9415584415584416,
+      "avgConfidence": 0.8783251231527098,
+      "bundleSize": 391277,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12783,7 +14082,8 @@
           "success": false
         },
         "socket-basic": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "worker-basic": {
           "success": false
@@ -12806,47 +14106,17 @@
         "bind-non-form-display": {
           "success": false
         },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
-          "success": false
-        },
         "intercept-cache-strategies": {
           "success": false
         }
       }
     },
     "zh": {
-      "parseSuccess": 140,
-      "parseFailure": 24,
-      "parseRate": 0.8536585365853658,
-      "avgConfidence": 0.9987301587301587,
-      "bundleSize": 389339,
+      "parseSuccess": 142,
+      "parseFailure": 12,
+      "parseRate": 0.922077922077922,
+      "avgConfidence": 0.9917057902973396,
+      "bundleSize": 391277,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13418,10 +14688,12 @@
           "success": false
         },
         "live-derived-value": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "live-multiple-deps": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-auto-detect": {
           "success": false
@@ -13433,36 +14705,6 @@
           "success": false
         },
         "bind-non-form-display": {
-          "success": false
-        },
-        "hx-live-attribute": {
-          "success": false
-        },
-        "hx-live-with-mutator": {
-          "success": false
-        },
-        "sse-connect-swap": {
-          "success": false
-        },
-        "sse-multi-event": {
-          "success": false
-        },
-        "ws-connect-send": {
-          "success": false
-        },
-        "component-hello-world": {
-          "success": false
-        },
-        "component-click-counter": {
-          "success": false
-        },
-        "component-with-conditional": {
-          "success": false
-        },
-        "component-with-attrs": {
-          "success": false
-        },
-        "component-with-slots": {
           "success": false
         },
         "intercept-cache-strategies": {
@@ -13485,7 +14727,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 389339,
+      "size": 391277,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Regenerates `packages/testing-framework/baselines/multilingual-priority.json` against current `main` (`2bd138a`), baking the entire English-parity arc into the tracked per-language numbers. The previous baseline was stamped `4c66664` — **before** any of the engine PRs — so it understated every language.

## What changed in the numbers

| | Before (`4c66664`) | After (`2bd138a`) |
|---|---|---|
| **English** | 87.8% (144/164) | **100.0% (154/154)** |
| Cross-language avg | ~75% | **~92.5%** |
| Patterns graded / lang | 164 | 154 |
| Languages tracked | 21 | 24 |

Every language rose **+5–13 pts**, driven by two merged efforts:

- **Engine gains (#251–#254):** `bind` / `live` / `eventsource` / `socket` / `worker` / `intercept` block commands and `$`-global reference values now parse.
- **Denominator correction (#255):** the 10 HTML-markup patterns (`hx-live`, `sse`/`ws-connect`, `<script type="text/hyperscript-template">` components) are excluded from the semantic-parse set — they're graded by the DOM/Playwright suites, not the hyperscript text parser.

Three languages newly present in the patterns DB (**bn, ms, qu**) are now tracked at 86–97% (previously absent).

## Gains-only — no genuine regression

Verified `pass → fail` count across patterns present in both baselines = **0**. The one apparent dip — Hindi `99.39% → 99.35%` (−0.04pt) — is purely the 10 HTML patterns leaving its set (they'd been credited as spurious "successes" in the pre-fix baseline). Hindi's single real failure is unchanged (153/154), and the delta is far inside the harness's 2pt regression tolerance.

## Reproduction

```bash
npm run build --prefix packages/semantic   # engine gains live here; dist was stale
npm run test:multilingual -- --full --bundle browser-priority --save-baseline
```

(`--bundle browser-priority` pins the existing prebuilt semantic bundle for size measurement — matches what the old baseline recorded and avoids an in-sandbox rebuild. Bundle size refreshed 389339 → 391277 from the new command schemas.)

This is the optional follow-up noted on #255 — the arc (#250–#255 + this) is now fully reflected in the committed metrics.

https://claude.ai/code/session_01Ntx571RWUKVCjYN16kzLHf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntx571RWUKVCjYN16kzLHf)_