### PR TITLE
feat(semantic): wire reactive/realtime commands for Western languages (es/pt/fr/de/it)

### DIFF
--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -485,17 +485,37 @@ export const bindSchema: CommandSchema = {
       expectedTypes: ['reference', 'expression'],
       svoPosition: 1,
       sovPosition: 1,
-      // Bound variable mirrors `set`'s destination marking.
+      // Bound variable mirrors `set`'s destination marking. The bound
+      // variable is bare in SVO/VSO/V2 languages (no leading preposition);
+      // SOV/agglutinative languages attach an object marker after it. Every
+      // supported language is listed explicitly so the generator never falls
+      // back to a default destination preposition (which produced a spurious
+      // marker, e.g. "vincular en {var}" for Spanish).
       markerOverride: {
         en: '', // "bind $x to #input"
-        ja: 'を', // variable gets object marker
-        ko: '를',
-        tr: 'i',
+        es: '',
+        pt: '',
+        fr: '',
+        de: '',
+        it: '',
+        id: '',
+        ms: '',
+        vi: '',
+        ru: '',
+        uk: '',
+        pl: '',
+        th: '',
+        zh: '',
+        he: '',
         ar: '',
         sw: '',
         tl: '',
+        ja: 'を', // variable gets object marker
+        ko: '를',
+        tr: 'i',
         bn: 'কে',
         qu: 'ta',
+        hi: 'को',
       },
     },
     {
@@ -505,14 +525,17 @@ export const bindSchema: CommandSchema = {
       expectedTypes: ['selector', 'reference', 'expression'],
       svoPosition: 2,
       sovPosition: 2,
-      // Element mirrors `set`'s value ("to") marking per language.
+      // Element mirrors `set`/`add`/`put`'s value ("to") marking per language.
+      // Each language uses its generic destination preposition (the same one
+      // the i18n translator and the other "to"-commands emit) so that
+      // auto-generated translations parse — e.g. German "zu", Italian "in".
       markerOverride: {
         en: 'to', // "bind $x to #input"
         es: 'a',
         pt: 'para',
         fr: 'à',
-        de: 'an',
-        it: 'a',
+        de: 'zu',
+        it: 'in',
         id: 'ke',
         ms: 'ke',
         vi: 'với',

--- a/packages/semantic/src/generators/profiles/french.ts
+++ b/packages/semantic/src/generators/profiles/french.ts
@@ -148,6 +148,15 @@ export const frenchProfile: LanguageProfile = {
     stream: { primary: 'flux', alternatives: ['streaming'], normalized: 'stream' },
     live: { primary: 'en-direct', alternatives: ['direct'], normalized: 'live' },
     socket: { primary: 'socket', alternatives: ['websocket'], normalized: 'socket' },
+    // Reactive / realtime commands
+    bind: { primary: 'lier', alternatives: ['relier', 'bind'], normalized: 'bind' },
+    intercept: { primary: 'intercepter', alternatives: ['intercept'], normalized: 'intercept' },
+    worker: { primary: 'travailleur', alternatives: ['worker'], normalized: 'worker' },
+    eventsource: {
+      primary: 'eventsource',
+      alternatives: ['source-d-evenements'],
+      normalized: 'eventsource',
+    },
   },
   eventHandler: {
     keyword: { primary: 'sur', alternatives: ['lors'], normalized: 'on' },

--- a/packages/semantic/src/generators/profiles/german.ts
+++ b/packages/semantic/src/generators/profiles/german.ts
@@ -149,6 +149,15 @@ export const germanProfile: LanguageProfile = {
     stream: { primary: 'stream', alternatives: ['Strom'], normalized: 'stream' },
     live: { primary: 'direkt', alternatives: ['live', 'echtzeit'], normalized: 'live' },
     socket: { primary: 'socket', alternatives: ['websocket'], normalized: 'socket' },
+    // Reactive / realtime commands
+    bind: { primary: 'binden', alternatives: ['verknuepfen', 'bind'], normalized: 'bind' },
+    intercept: { primary: 'abfangen', alternatives: ['intercept'], normalized: 'intercept' },
+    worker: { primary: 'arbeiter', alternatives: ['worker'], normalized: 'worker' },
+    eventsource: {
+      primary: 'eventsource',
+      alternatives: ['ereignisquelle'],
+      normalized: 'eventsource',
+    },
   },
   eventHandler: {
     keyword: { primary: 'bei', alternatives: ['auf'], normalized: 'on' },

--- a/packages/semantic/src/generators/profiles/italian.ts
+++ b/packages/semantic/src/generators/profiles/italian.ts
@@ -171,6 +171,15 @@ export const italianProfile: LanguageProfile = {
     stream: { primary: 'trasmettere', alternatives: ['flusso', 'streaming'], normalized: 'stream' },
     live: { primary: 'in-diretta', alternatives: ['diretta', 'dal-vivo'], normalized: 'live' },
     socket: { primary: 'socket', alternatives: ['presa', 'websocket'], normalized: 'socket' },
+    // Reactive / realtime commands
+    bind: { primary: 'vincolare', alternatives: ['legare', 'bind'], normalized: 'bind' },
+    intercept: { primary: 'intercettare', alternatives: ['intercept'], normalized: 'intercept' },
+    worker: { primary: 'lavoratore', alternatives: ['worker'], normalized: 'worker' },
+    eventsource: {
+      primary: 'eventsource',
+      alternatives: ['sorgente-eventi'],
+      normalized: 'eventsource',
+    },
   },
   eventHandler: {
     keyword: { primary: 'su', alternatives: ['al'], normalized: 'on' },

--- a/packages/semantic/src/generators/profiles/portuguese.ts
+++ b/packages/semantic/src/generators/profiles/portuguese.ts
@@ -147,6 +147,15 @@ export const portugueseProfile: LanguageProfile = {
     stream: { primary: 'transmitir', alternatives: ['fluxo'], normalized: 'stream' },
     live: { primary: 'ao-vivo', alternatives: ['vivo', 'direto'], normalized: 'live' },
     socket: { primary: 'soquete', alternatives: ['websocket'], normalized: 'socket' },
+    // Reactive / realtime commands
+    bind: { primary: 'vincular', alternatives: ['ligar', 'bind'], normalized: 'bind' },
+    intercept: { primary: 'interceptar', alternatives: ['intercept'], normalized: 'intercept' },
+    worker: { primary: 'trabalhador', alternatives: ['worker'], normalized: 'worker' },
+    eventsource: {
+      primary: 'eventsource',
+      alternatives: ['fonte-de-eventos'],
+      normalized: 'eventsource',
+    },
   },
   eventHandler: {
     keyword: { primary: 'em', alternatives: ['ao'], normalized: 'on' },

--- a/packages/semantic/src/generators/profiles/spanish.ts
+++ b/packages/semantic/src/generators/profiles/spanish.ts
@@ -183,6 +183,15 @@ export const spanishProfile: LanguageProfile = {
     stream: { primary: 'transmitir', alternatives: ['flujo'], normalized: 'stream' },
     live: { primary: 'en-vivo', alternatives: ['vivo', 'directo'], normalized: 'live' },
     socket: { primary: 'socket', alternatives: ['websocket'], normalized: 'socket' },
+    // Reactive / realtime commands
+    bind: { primary: 'vincular', alternatives: ['enlazar', 'bind'], normalized: 'bind' },
+    intercept: { primary: 'interceptar', alternatives: ['intercept'], normalized: 'intercept' },
+    worker: { primary: 'trabajador', alternatives: ['worker'], normalized: 'worker' },
+    eventsource: {
+      primary: 'eventsource',
+      alternatives: ['fuente-de-eventos'],
+      normalized: 'eventsource',
+    },
   },
   eventHandler: {
     keyword: { primary: 'al', alternatives: ['cuando', 'en'], normalized: 'on' },

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-04T03:21:45.585Z",
-  "commit": "2bd138a",
+  "timestamp": "2026-06-05T18:50:33.437Z",
+  "commit": "19d0bf6",
   "languages": {
     "ar": {
       "parseSuccess": 127,
       "parseFailure": 27,
       "parseRate": 0.8246753246753247,
       "avgConfidence": 0.8857370769830244,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -605,7 +605,7 @@
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.784041759880686,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1221,11 +1221,11 @@
       }
     },
     "de": {
-      "parseSuccess": 148,
-      "parseFailure": 6,
-      "parseRate": 0.961038961038961,
-      "avgConfidence": 0.9177177177177175,
-      "bundleSize": 391277,
+      "parseSuccess": 153,
+      "parseFailure": 1,
+      "parseRate": 0.9935064935064936,
+      "avgConfidence": 0.904066811909949,
+      "bundleSize": 392690,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1808,19 +1808,24 @@
           "confidence": 0.5
         },
         "bind-auto-detect": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-two-way": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-explicit-property": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-non-form-display": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "intercept-cache-strategies": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-removable": {
           "success": false
@@ -1844,7 +1849,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2465,11 +2470,11 @@
       }
     },
     "es": {
-      "parseSuccess": 148,
-      "parseFailure": 6,
-      "parseRate": 0.961038961038961,
-      "avgConfidence": 0.9717717717717718,
-      "bundleSize": 391277,
+      "parseSuccess": 153,
+      "parseFailure": 1,
+      "parseRate": 0.9935064935064936,
+      "avgConfidence": 0.9563543936092955,
+      "bundleSize": 392690,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3052,19 +3057,24 @@
           "confidence": 0.5
         },
         "bind-auto-detect": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-two-way": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-explicit-property": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-non-form-display": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "intercept-cache-strategies": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-removable": {
           "success": false
@@ -3084,11 +3094,11 @@
       }
     },
     "fr": {
-      "parseSuccess": 146,
-      "parseFailure": 8,
-      "parseRate": 0.948051948051948,
-      "avgConfidence": 0.978234398782344,
-      "bundleSize": 391277,
+      "parseSuccess": 151,
+      "parseFailure": 3,
+      "parseRate": 0.9805194805194806,
+      "avgConfidence": 0.9623988226637233,
+      "bundleSize": 392690,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3669,19 +3679,24 @@
           "success": false
         },
         "bind-auto-detect": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-two-way": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-explicit-property": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-non-form-display": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "intercept-cache-strategies": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-removable": {
           "success": false
@@ -3705,7 +3720,7 @@
       "parseFailure": 29,
       "parseRate": 0.8116883116883117,
       "avgConfidence": 0.8276317460317466,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4301,7 +4316,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 1,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -4925,7 +4940,7 @@
       "parseFailure": 6,
       "parseRate": 0.961038961038961,
       "avgConfidence": 0.9717717717717718,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5540,11 +5555,11 @@
       }
     },
     "it": {
-      "parseSuccess": 141,
-      "parseFailure": 13,
-      "parseRate": 0.9155844155844156,
-      "avgConfidence": 0.9939322301024429,
-      "bundleSize": 391277,
+      "parseSuccess": 148,
+      "parseFailure": 6,
+      "parseRate": 0.961038961038961,
+      "avgConfidence": 0.9705705705705706,
+      "bundleSize": 392690,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6107,14 +6122,16 @@
           "confidence": 0.8222222222222222
         },
         "eventsource-basic": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "socket-basic": {
           "success": true,
           "confidence": 0.5
         },
         "worker-basic": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "live-derived-value": {
           "success": false
@@ -6123,19 +6140,24 @@
           "success": false
         },
         "bind-auto-detect": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-two-way": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-explicit-property": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-non-form-display": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "intercept-cache-strategies": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-removable": {
           "success": false
@@ -6156,7 +6178,7 @@
       "parseFailure": 9,
       "parseRate": 0.9415584415584416,
       "avgConfidence": 0.7834044882320744,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6772,7 +6794,7 @@
       "parseFailure": 14,
       "parseRate": 0.9090909090909091,
       "avgConfidence": 0.5380158730158731,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7383,7 +7405,7 @@
       "parseFailure": 7,
       "parseRate": 0.9545454545454546,
       "avgConfidence": 0.9885865457294029,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8001,7 +8023,7 @@
       "parseFailure": 15,
       "parseRate": 0.9025974025974026,
       "avgConfidence": 0.8211830535571548,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8607,11 +8629,11 @@
       }
     },
     "pt": {
-      "parseSuccess": 148,
-      "parseFailure": 6,
-      "parseRate": 0.961038961038961,
-      "avgConfidence": 0.8192192192192198,
-      "bundleSize": 391277,
+      "parseSuccess": 153,
+      "parseFailure": 1,
+      "parseRate": 0.9935064935064936,
+      "avgConfidence": 0.8087872185911407,
+      "bundleSize": 392690,
       "patterns": {
         "blur-element": {
           "success": true,
@@ -9194,19 +9216,24 @@
           "confidence": 0.5
         },
         "bind-auto-detect": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-two-way": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-explicit-property": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-non-form-display": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "intercept-cache-strategies": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-removable": {
           "success": false
@@ -9230,7 +9257,7 @@
       "parseFailure": 21,
       "parseRate": 0.8636363636363636,
       "avgConfidence": 0.6804511278195489,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "toggle-class-basic": {
           "success": false
@@ -9834,7 +9861,7 @@
       "parseFailure": 10,
       "parseRate": 0.935064935064935,
       "avgConfidence": 0.878571428571429,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10449,7 +10476,7 @@
       "parseFailure": 15,
       "parseRate": 0.9025974025974026,
       "avgConfidence": 0.8563777549389063,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11059,7 +11086,7 @@
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.9300934985866488,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11676,7 +11703,7 @@
       "parseFailure": 29,
       "parseRate": 0.8116883116883117,
       "avgConfidence": 0.8532549019607846,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12272,7 +12299,7 @@
       "parseFailure": 12,
       "parseRate": 0.922077922077922,
       "avgConfidence": 0.7756651017214398,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -12885,7 +12912,7 @@
       "parseFailure": 10,
       "parseRate": 0.935064935064935,
       "avgConfidence": 0.8769841269841274,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13500,7 +13527,7 @@
       "parseFailure": 9,
       "parseRate": 0.9415584415584416,
       "avgConfidence": 0.8783251231527098,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14116,7 +14143,7 @@
       "parseFailure": 12,
       "parseRate": 0.922077922077922,
       "avgConfidence": 0.9917057902973396,
-      "bundleSize": 391277,
+      "bundleSize": 392690,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -14727,7 +14754,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 391277,
+      "size": 392690,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

**Phase 1, batch 1** of moving all languages toward 100% semantic parse rate. Makes the reactive/realtime commands (`bind`, `intercept`, `worker`, `eventsource`) parse in the five Western languages (**es, pt, fr, de, it**).

Investigation showed the gap had **two root causes**, not one:

### 1. Engine — `bind` schema marker generation (benefits all languages)
- **Destination role (the bound variable):** only a handful of languages had an explicit empty marker; the rest fell back to a default destination preposition, generating a *spurious* marker — e.g. `vincular en {var}` for Spanish — that never matched the real translated text. Now every supported language is listed explicitly: bare for SVO/VSO/V2, object-marker for SOV/agglutinative.
- **Source role (the `to` element):** the schema overrode de→`an` / it→`a`, diverging from the **generic** destination preposition that the i18n translator and the sibling `set`/`add`/`put` commands emit (de→`zu`, it→`in`). Aligned so the auto-generated example translations parse and bind is consistent with the other "to"-commands within each language.

### 2. Keywords — the five Western profiles lacked the command verbs
`bind`/`intercept`/`worker`/`eventsource` were never translated, so the tokenizer rejected them. Added idiomatic entries (native primary + English form as a parse-alternative for robustness): `vincular`/`interceptar`/`trabalhador`/`lier`/`binden`/`abfangen`/`vincolare`/…

## Result

Full multilingual harness (browser-priority bundle):

| Lang | Before | After |
|------|--------|-------|
| es | 96.1% | **99.4%** |
| pt | 96.1% | **99.4%** |
| de | 96.1% | **99.4%** |
| fr | 94.8% | **98.1%** |
| it | 91.6% | **96.1%** |

Cross-language average **92.5% → 93.2%**, **zero regressions** across the other 19 languages.

Remaining fails in these five are Bucket B (unimplemented behaviors) and Bucket C (language-specific tokenizer gaps) — out of scope for keyword wiring, tracked separately.

## Validation
- Baseline regenerated and verified **identical** against the committed patterns DB — the stored translation text is unchanged; the gain is entirely in the parser, so **no binary DB churn**.
- **5290** semantic unit tests pass.

## Follow-up batches
East-Asian (ja/ko/zh), Slavic (ru/uk/pl), and the RTL/SOV/indigenous set (ar/he/tr/qu/th/vi/id/ms/bn/sw/tl/hi). The engine `bind` fix here is global, so those batches are keyword-wiring + per-language marker checks.

https://claude.ai/code/session_01Ntx571RWUKVCjYN16kzLHf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntx571RWUKVCjYN16kzLHf)_