### PR TITLE
feat(semantic): wire intercept/worker/eventsource for Class-B languages (Phase 1)

### DIFF
--- a/packages/semantic/src/generators/profiles/arabic.ts
+++ b/packages/semantic/src/generators/profiles/arabic.ts
@@ -155,6 +155,14 @@ export const arabicProfile: LanguageProfile = {
     stream: { primary: 'تدفق', alternatives: ['بث'], normalized: 'stream' },
     live: { primary: 'مباشر', alternatives: ['حي'], normalized: 'live' },
     socket: { primary: 'مقبس', alternatives: ['websocket'], normalized: 'socket' },
+    // Reactive / realtime commands (bind pending i18n grammar reconciliation)
+    intercept: { primary: 'اعترض', alternatives: ['اعتراض', 'intercept'], normalized: 'intercept' },
+    worker: { primary: 'عامل', alternatives: ['worker'], normalized: 'worker' },
+    eventsource: {
+      primary: 'eventsource',
+      alternatives: ['مصدر-الأحداث'],
+      normalized: 'eventsource',
+    },
   },
   tokenization: {
     prefixes: ['ال', 'و', 'ف', 'ب', 'ك', 'ل'],

--- a/packages/semantic/src/generators/profiles/bengali.ts
+++ b/packages/semantic/src/generators/profiles/bengali.ts
@@ -151,6 +151,18 @@ export const bengaliProfile: LanguageProfile = {
     stream: { primary: 'স্ট্রিম', alternatives: ['স্রোত', 'প্রবাহ'], normalized: 'stream' },
     live: { primary: 'লাইভ', alternatives: ['সরাসরি', 'প্রত্যক্ষ'], normalized: 'live' },
     socket: { primary: 'সকেট', alternatives: ['ওয়েবসকেট'], normalized: 'socket' },
+    // Reactive / realtime commands (bind pending i18n grammar reconciliation)
+    intercept: {
+      primary: 'আটকাও',
+      alternatives: ['ইন্টারসেপ্ট', 'intercept'],
+      normalized: 'intercept',
+    },
+    worker: { primary: 'কর্মী', alternatives: ['ওয়ার্কার', 'worker'], normalized: 'worker' },
+    eventsource: {
+      primary: 'eventsource',
+      alternatives: ['ইভেন্টসোর্স'],
+      normalized: 'eventsource',
+    },
   },
   tokenization: {
     particles: ['কে', 'তে', 'থেকে', 'র', 'এর', 'দিয়ে', 'জন্য', 'পর্যন্ত'],

--- a/packages/semantic/src/generators/profiles/chinese.ts
+++ b/packages/semantic/src/generators/profiles/chinese.ts
@@ -149,6 +149,10 @@ export const chineseProfile: LanguageProfile = {
     stream: { primary: '流', alternatives: ['流式传输'], normalized: 'stream' },
     live: { primary: '实时', alternatives: ['直播'], normalized: 'live' },
     socket: { primary: '套接字', alternatives: ['websocket'], normalized: 'socket' },
+    // Reactive / realtime commands (bind pending i18n grammar reconciliation)
+    intercept: { primary: '拦截', alternatives: ['intercept'], normalized: 'intercept' },
+    worker: { primary: '工作线程', alternatives: ['工作者', 'worker'], normalized: 'worker' },
+    eventsource: { primary: 'eventsource', alternatives: ['事件源'], normalized: 'eventsource' },
   },
   tokenization: {
     boundaryStrategy: 'character',

--- a/packages/semantic/src/generators/profiles/he.ts
+++ b/packages/semantic/src/generators/profiles/he.ts
@@ -156,6 +156,14 @@ export const hebrewProfile: LanguageProfile = {
     stream: { primary: 'הזרם', alternatives: ['סטרים', 'שידור'], normalized: 'stream' },
     live: { primary: 'חי', alternatives: ['בזמן-אמת', 'לייב'], normalized: 'live' },
     socket: { primary: 'שקע', alternatives: ['סוקט', 'ווב-סוקט'], normalized: 'socket' },
+    // Reactive / realtime commands (bind pending i18n grammar reconciliation)
+    intercept: { primary: 'יירט', alternatives: ['יירוט', 'intercept'], normalized: 'intercept' },
+    worker: { primary: 'עובד', alternatives: ['worker'], normalized: 'worker' },
+    eventsource: {
+      primary: 'eventsource',
+      alternatives: ['מקור-אירועים'],
+      normalized: 'eventsource',
+    },
   },
   tokenization: {
     prefixes: ['ה', 'ו', 'ב', 'כ', 'ל', 'מ', 'ש'], // Common Hebrew prefixes

--- a/packages/semantic/src/generators/profiles/japanese.ts
+++ b/packages/semantic/src/generators/profiles/japanese.ts
@@ -169,6 +169,18 @@ export const japaneseProfile: LanguageProfile = {
     stream: { primary: 'ストリーム', alternatives: ['配信'], normalized: 'stream' },
     live: { primary: 'ライブ', alternatives: ['実時間'], normalized: 'live' },
     socket: { primary: 'ソケット', alternatives: ['websocket'], normalized: 'socket' },
+    // Reactive / realtime commands (bind pending i18n grammar reconciliation)
+    intercept: {
+      primary: 'インターセプト',
+      alternatives: ['傍受', 'intercept'],
+      normalized: 'intercept',
+    },
+    worker: { primary: 'ワーカー', alternatives: ['worker'], normalized: 'worker' },
+    eventsource: {
+      primary: 'eventsource',
+      alternatives: ['イベントソース'],
+      normalized: 'eventsource',
+    },
   },
   tokenization: {
     particles: ['を', 'に', 'で', 'から', 'の', 'が', 'は', 'も', 'へ', 'と'],

--- a/packages/semantic/src/generators/profiles/korean.ts
+++ b/packages/semantic/src/generators/profiles/korean.ts
@@ -152,6 +152,18 @@ export const koreanProfile: LanguageProfile = {
     stream: { primary: '스트림', alternatives: ['스트리밍'], normalized: 'stream' },
     live: { primary: '실시간', alternatives: ['라이브'], normalized: 'live' },
     socket: { primary: '소켓', alternatives: ['websocket'], normalized: 'socket' },
+    // Reactive / realtime commands (bind pending i18n grammar reconciliation)
+    intercept: {
+      primary: '가로채기',
+      alternatives: ['인터셉트', 'intercept'],
+      normalized: 'intercept',
+    },
+    worker: { primary: '워커', alternatives: ['worker'], normalized: 'worker' },
+    eventsource: {
+      primary: 'eventsource',
+      alternatives: ['이벤트소스'],
+      normalized: 'eventsource',
+    },
   },
   tokenization: {
     particles: ['을', '를', '이', '가', '은', '는', '에', '에서', '으로', '로', '와', '과', '도'],

--- a/packages/semantic/src/generators/profiles/quechua.ts
+++ b/packages/semantic/src/generators/profiles/quechua.ts
@@ -152,6 +152,14 @@ export const quechuaProfile: LanguageProfile = {
     },
     live: { primary: 'kawsachkaq', alternatives: ['kunan-pacha', 'kawsay'], normalized: 'live' },
     socket: { primary: 'tinkina', alternatives: ["t'oqo", 'tinkiy-tinkina'], normalized: 'socket' },
+    // Reactive / realtime commands (bind pending i18n grammar reconciliation)
+    intercept: { primary: "hark'ay", alternatives: ['intercept'], normalized: 'intercept' },
+    worker: { primary: "llamk'aq", alternatives: ['worker'], normalized: 'worker' },
+    eventsource: {
+      primary: 'eventsource',
+      alternatives: ['kawsay-pukyu'],
+      normalized: 'eventsource',
+    },
   },
   eventHandler: {
     keyword: { primary: 'pi', alternatives: ['kaqtin'] },

--- a/packages/semantic/src/generators/profiles/turkish.ts
+++ b/packages/semantic/src/generators/profiles/turkish.ts
@@ -196,6 +196,18 @@ export const turkishProfile: LanguageProfile = {
     stream: { primary: 'yayınla', alternatives: ['akıt', 'akış'], normalized: 'stream' },
     live: { primary: 'canlı', alternatives: ['gerçek-zamanlı'], normalized: 'live' },
     socket: { primary: 'soket', alternatives: ['websocket'], normalized: 'socket' },
+    // Reactive / realtime commands (bind pending i18n grammar reconciliation)
+    intercept: {
+      primary: 'yakala',
+      alternatives: ['araya-gir', 'intercept'],
+      normalized: 'intercept',
+    },
+    worker: { primary: 'işçi', alternatives: ['worker'], normalized: 'worker' },
+    eventsource: {
+      primary: 'eventsource',
+      alternatives: ['olay-kaynağı'],
+      normalized: 'eventsource',
+    },
   },
   eventHandler: {
     // Event marker: da/de/ta/te (locative case suffix with vowel harmony), used in SOV pattern

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-06T11:15:49.091Z",
-  "commit": "246dc92",
+  "timestamp": "2026-06-06T13:50:01.029Z",
+  "commit": "18c853a",
   "languages": {
     "ar": {
-      "parseSuccess": 127,
-      "parseFailure": 27,
-      "parseRate": 0.8246753246753247,
-      "avgConfidence": 0.8857370769830244,
-      "bundleSize": 393048,
+      "parseSuccess": 128,
+      "parseFailure": 26,
+      "parseRate": 0.8311688311688312,
+      "avgConfidence": 0.8827235060690946,
+      "bundleSize": 394629,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -581,7 +581,8 @@
           "success": false
         },
         "intercept-cache-strategies": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-removable": {
           "success": false
@@ -601,11 +602,11 @@
       }
     },
     "bn": {
-      "parseSuccess": 149,
-      "parseFailure": 5,
-      "parseRate": 0.9675324675324676,
-      "avgConfidence": 0.784041759880686,
-      "bundleSize": 393048,
+      "parseSuccess": 150,
+      "parseFailure": 4,
+      "parseRate": 0.974025974025974,
+      "avgConfidence": 0.7821481481481481,
+      "bundleSize": 394629,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1200,7 +1201,8 @@
           "confidence": 0.5
         },
         "intercept-cache-strategies": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-removable": {
           "success": true,
@@ -1225,7 +1227,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.904066811909949,
-      "bundleSize": 393048,
+      "bundleSize": 394629,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1849,7 +1851,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 393048,
+      "bundleSize": 394629,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2474,7 +2476,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9563543936092955,
-      "bundleSize": 393048,
+      "bundleSize": 394629,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3098,7 +3100,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.9623988226637233,
-      "bundleSize": 393048,
+      "bundleSize": 394629,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3716,11 +3718,11 @@
       }
     },
     "he": {
-      "parseSuccess": 125,
-      "parseFailure": 29,
-      "parseRate": 0.8116883116883117,
-      "avgConfidence": 0.8276317460317466,
-      "bundleSize": 393048,
+      "parseSuccess": 128,
+      "parseFailure": 26,
+      "parseRate": 0.8311688311688312,
+      "avgConfidence": 0.8199528769841276,
+      "bundleSize": 394629,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4254,13 +4256,15 @@
           "success": false
         },
         "eventsource-basic": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "socket-basic": {
           "success": false
         },
         "worker-basic": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "keydown-key-is-syntax": {
           "success": false
@@ -4295,7 +4299,8 @@
           "success": false
         },
         "intercept-cache-strategies": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-removable": {
           "success": false
@@ -4316,7 +4321,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 1,
-      "bundleSize": 393048,
+      "bundleSize": 394629,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -4940,7 +4945,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9563543936092955,
-      "bundleSize": 393048,
+      "bundleSize": 394629,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5564,7 +5569,7 @@
       "parseFailure": 6,
       "parseRate": 0.961038961038961,
       "avgConfidence": 0.9705705705705706,
-      "bundleSize": 393048,
+      "bundleSize": 394629,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6179,11 +6184,11 @@
       }
     },
     "ja": {
-      "parseSuccess": 145,
-      "parseFailure": 9,
-      "parseRate": 0.9415584415584416,
-      "avgConfidence": 0.7834044882320744,
-      "bundleSize": 393048,
+      "parseSuccess": 147,
+      "parseFailure": 7,
+      "parseRate": 0.9545454545454546,
+      "avgConfidence": 0.7795486448547673,
+      "bundleSize": 394629,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6712,7 +6717,8 @@
           "confidence": 0.5
         },
         "worker-basic": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "keydown-key-is-syntax": {
           "success": true,
@@ -6774,7 +6780,8 @@
           "confidence": 0.5
         },
         "intercept-cache-strategies": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-removable": {
           "success": true,
@@ -6795,11 +6802,11 @@
       }
     },
     "ko": {
-      "parseSuccess": 140,
-      "parseFailure": 14,
-      "parseRate": 0.9090909090909091,
-      "avgConfidence": 0.5380158730158731,
-      "bundleSize": 393048,
+      "parseSuccess": 142,
+      "parseFailure": 12,
+      "parseRate": 0.922077922077922,
+      "avgConfidence": 0.5374804381846635,
+      "bundleSize": 394629,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7293,7 +7300,8 @@
           "confidence": 0.5
         },
         "worker-basic": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "fetch-with-headers": {
           "success": true,
@@ -7385,7 +7393,8 @@
           "confidence": 0.5
         },
         "intercept-cache-strategies": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-removable": {
           "success": true,
@@ -7410,7 +7419,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9788148148148148,
-      "bundleSize": 393048,
+      "bundleSize": 394629,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8031,7 +8040,7 @@
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.8057838660578391,
-      "bundleSize": 393048,
+      "bundleSize": 394629,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8648,7 +8657,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8087872185911407,
-      "bundleSize": 393048,
+      "bundleSize": 394629,
       "patterns": {
         "blur-element": {
           "success": true,
@@ -9268,11 +9277,11 @@
       }
     },
     "qu": {
-      "parseSuccess": 133,
-      "parseFailure": 21,
-      "parseRate": 0.8636363636363636,
-      "avgConfidence": 0.6804511278195489,
-      "bundleSize": 393048,
+      "parseSuccess": 135,
+      "parseFailure": 19,
+      "parseRate": 0.8766233766233766,
+      "avgConfidence": 0.6777777777777778,
+      "bundleSize": 394629,
       "patterns": {
         "toggle-class-basic": {
           "success": false
@@ -9787,7 +9796,8 @@
           "confidence": 0.5
         },
         "worker-basic": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "on-custom-event-receive": {
           "success": false
@@ -9851,7 +9861,8 @@
           "confidence": 0.5
         },
         "intercept-cache-strategies": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-removable": {
           "success": true,
@@ -9876,7 +9887,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.8610217596972569,
-      "bundleSize": 393048,
+      "bundleSize": 394629,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10498,7 +10509,7 @@
       "parseFailure": 13,
       "parseRate": 0.9155844155844156,
       "avgConfidence": 0.8513227513227517,
-      "bundleSize": 393048,
+      "bundleSize": 394629,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11110,7 +11121,7 @@
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.9300934985866488,
-      "bundleSize": 393048,
+      "bundleSize": 394629,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11727,7 +11738,7 @@
       "parseFailure": 29,
       "parseRate": 0.8116883116883117,
       "avgConfidence": 0.8532549019607846,
-      "bundleSize": 393048,
+      "bundleSize": 394629,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12319,11 +12330,11 @@
       }
     },
     "tr": {
-      "parseSuccess": 142,
-      "parseFailure": 12,
-      "parseRate": 0.922077922077922,
-      "avgConfidence": 0.7756651017214398,
-      "bundleSize": 393048,
+      "parseSuccess": 144,
+      "parseFailure": 10,
+      "parseRate": 0.935064935064935,
+      "avgConfidence": 0.7718364197530865,
+      "bundleSize": 394629,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -12850,7 +12861,8 @@
           "confidence": 0.5
         },
         "worker-basic": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "keydown-key-is-syntax": {
           "success": true,
@@ -12911,7 +12923,8 @@
           "confidence": 0.5
         },
         "intercept-cache-strategies": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-removable": {
           "success": true,
@@ -12936,7 +12949,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.8595080416272473,
-      "bundleSize": 393048,
+      "bundleSize": 394629,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13554,11 +13567,11 @@
       }
     },
     "vi": {
-      "parseSuccess": 148,
-      "parseFailure": 6,
-      "parseRate": 0.961038961038961,
-      "avgConfidence": 0.870656370656371,
-      "bundleSize": 393048,
+      "parseSuccess": 152,
+      "parseFailure": 2,
+      "parseRate": 0.987012987012987,
+      "avgConfidence": 0.8609022556390982,
+      "bundleSize": 394629,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14155,16 +14168,20 @@
           "success": false
         },
         "bind-auto-detect": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-two-way": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-explicit-property": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "bind-non-form-display": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "intercept-cache-strategies": {
           "success": true,
@@ -14173,11 +14190,11 @@
       }
     },
     "zh": {
-      "parseSuccess": 142,
-      "parseFailure": 12,
-      "parseRate": 0.922077922077922,
-      "avgConfidence": 0.9917057902973396,
-      "bundleSize": 393048,
+      "parseSuccess": 145,
+      "parseFailure": 9,
+      "parseRate": 0.9415584415584416,
+      "avgConfidence": 0.9815325670498084,
+      "bundleSize": 394629,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -14740,13 +14757,15 @@
           "confidence": 0.8222222222222222
         },
         "eventsource-basic": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "socket-basic": {
           "success": false
         },
         "worker-basic": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "live-derived-value": {
           "success": true,
@@ -14769,7 +14788,8 @@
           "success": false
         },
         "intercept-cache-strategies": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-removable": {
           "success": false
@@ -14788,7 +14808,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 393048,
+      "size": 394629,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
**Class-B Phase 1** (keyword-only partial wins) of the multilingual reactive-command rollout tracked in #259, following the completed Class-A set (#260, #261).

Makes the verb-first / marker-tolerant reactive commands **`intercept` / `worker` / `eventsource`** parse in the 8 SOV/VSO/RTL Class-B languages: **ja, ko, zh, tr, qu, bn, ar, he**. (`hi` already parses all reactive commands, so it's excluded.)

## Why this is the low-risk slice

Unlike `bind`, these three commands' generated example text keeps the (English) verb in a position the semantic parser already accepts — so they need **only the keyword**, no i18n grammar reorder and no DB-text change. Each profile gets an idiomatic native primary plus the **English form as a parse alternative** (the English form is what matches today's stored translation text; the native primary becomes primary once the i18n dictionaries gain these verbs in Phase 2).

`bind` is **intentionally not wired here** — its stored text has the verb mid-sentence (SOV) or a malformed `把`-construction (zh), which needs the i18n `GrammarTransformer` reconciliation. That's **Phase 2** in #259 (design already scoped).

## Result

Full multilingual harness, `browser-priority` bundle (zero regressions elsewhere):

| Lang | Before | After | Δ |
|------|--------|-------|---|
| zh | 92.2% | 94.2% | +3 |
| he | 81.2% | 83.1% | +3 |
| ja | 94.2% | 95.5% | +2 |
| ko | 90.9% | 92.2% | +2 |
| tr | 92.2% | 93.5% | +2 |
| qu | 86.4% | 87.7% | +2 |
| bn | 96.8% | 97.4% | +1 |
| ar | 82.5% | 83.1% | +1 |

The exact reactive patterns that flipped per language match the missing commands (e.g. zh gains `eventsource-basic`, `worker-basic`, `intercept-cache-strategies`).

## Also: a vi baseline catch-up (148 → 152)

The regenerated baseline picks up **4 vi `bind-*` patterns** flipping to pass. This is **not** a Phase-1 change — #260/#261's vi `bind` source-marker fix (`với` → `vào`) was originally baselined against a stale patterns DB, so those patterns were recorded as failing. The regenerated DB now carries the corrected `vào` text and they parse. CI fresh-`populate`s on every run (which already produces 152), so this only makes the committed baseline match what CI reproduces; the regression gate is satisfied either way.

## Verification

- Harness (`--full`, `browser-priority`) is the source of truth; per-language flips confirmed against the prior baseline.
- Baseline regenerated against `browser-priority`; diff limited to the 8 Class-B languages + the vi catch-up + metadata, **no `↓` regressions**.
- Semantic unit suite: all logic test files pass. (Local `build-artifacts.test.ts` `.d.ts`-existence checks fail only because this environment can't run the full ordered type-build — pre-existing, unrelated; they pass in CI.)
- Native primaries are best-effort idiomatic terms; since today's stored text uses the English verb, the English alias is what drives the parse wins. Primaries become load-bearing in Phase 2 (and are easy to refine then).

Part of #259. Next: **Phase 2 — `bind` grammar reconciliation** (i18n dictionaries + `GrammarTransformer` SOV/zh/ar/he rules + repopulate).

https://claude.ai/code/session_018YJ9m5ExDeWNnnhhtpjx2K

---
_Generated by [Claude Code](https://claude.ai/code/session_018YJ9m5ExDeWNnnhhtpjx2K)_