### PR TITLE
fix(semantic): parse possessive property paths in ja/ko (#259)

### DIFF
--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -659,27 +659,39 @@ export class PatternMatcher {
 
   /**
    * Try to match a possessive selector expression like "#element's *opacity".
-   * Pattern: selector + "'s" + (selector | identifier)
-   * Returns a property-path value if matched, or null if not.
+   * Pattern: selector + possessive-marker + (selector | identifier)
+   *
+   * The possessive marker is English `'s` (a punctuation token) or, for other
+   * languages, the active profile's `possessive.marker` emitted as a `particle`
+   * token (e.g. Japanese `の`, Korean `의`). Returns a property-path value if
+   * matched, or null if not.
    */
   private tryMatchPossessiveSelectorExpression(tokens: TokenStream): SemanticValue | null {
     const token = tokens.peek();
     if (!token || token.kind !== 'selector') return null;
 
-    // Look ahead for: 's (possessive marker)
+    // Look ahead for the possessive marker.
     const mark = tokens.mark();
     tokens.advance(); // consume selector
 
     const possessiveToken = tokens.peek();
-    if (
-      !possessiveToken ||
-      possessiveToken.kind !== 'punctuation' ||
-      possessiveToken.value !== "'s"
-    ) {
+    const profileMarker = this.currentProfile?.possessive?.marker;
+    const isEnglishPossessive =
+      !!possessiveToken && possessiveToken.kind === 'punctuation' && possessiveToken.value === "'s";
+    // Non-English markers (の, 의, …) arrive as `particle` tokens. Match them
+    // against the active profile's possessive marker. Empty markers (Turkish,
+    // suffix-based) don't have a standalone token and are not handled here.
+    const isProfilePossessive =
+      !!possessiveToken &&
+      !!profileMarker &&
+      profileMarker !== "'s" &&
+      possessiveToken.value === profileMarker &&
+      (possessiveToken.kind === 'particle' || possessiveToken.kind === 'punctuation');
+    if (!isEnglishPossessive && !isProfilePossessive) {
       tokens.reset(mark);
       return null;
     }
-    tokens.advance(); // consume 's
+    tokens.advance(); // consume the possessive marker
 
     const propertyToken = tokens.peek();
     if (!propertyToken) {
@@ -687,8 +699,14 @@ export class PatternMatcher {
       return null;
     }
 
-    // Property can be a selector (*opacity) or identifier
-    if (propertyToken.kind !== 'selector' && propertyToken.kind !== 'identifier') {
+    // English keeps the historical selector-or-identifier property (e.g.
+    // `#element's *opacity`). For profile markers, only an identifier is a
+    // property — otherwise a target+patient construct like `#button の .active`
+    // ("toggle .active on #button") would be mis-read as a property path.
+    const propertyOk =
+      propertyToken.kind === 'identifier' ||
+      (isEnglishPossessive && propertyToken.kind === 'selector');
+    if (!propertyOk) {
       tokens.reset(mark);
       return null;
     }

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-06T14:25:26.864Z",
-  "commit": "606e928",
+  "timestamp": "2026-06-06T17:55:52.450Z",
+  "commit": "99ca475",
   "languages": {
     "ar": {
       "parseSuccess": 132,
       "parseFailure": 22,
       "parseRate": 0.8571428571428571,
       "avgConfidence": 0.9052167331579098,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -610,7 +610,7 @@
       "parseFailure": 2,
       "parseRate": 0.987012987012987,
       "avgConfidence": 0.791593567251462,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1233,7 +1233,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9367465504720396,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1857,7 +1857,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2482,7 +2482,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3106,7 +3106,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.9888888888888889,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3728,7 +3728,7 @@
       "parseFailure": 22,
       "parseRate": 0.8571428571428571,
       "avgConfidence": 0.8443482443482448,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4331,7 +4331,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 1,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -4955,7 +4955,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5579,7 +5579,7 @@
       "parseFailure": 6,
       "parseRate": 0.961038961038961,
       "avgConfidence": 0.9975975975975976,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6194,11 +6194,11 @@
       }
     },
     "ja": {
-      "parseSuccess": 148,
-      "parseFailure": 6,
-      "parseRate": 0.961038961038961,
-      "avgConfidence": 0.7911733161733162,
-      "bundleSize": 395057,
+      "parseSuccess": 150,
+      "parseFailure": 4,
+      "parseRate": 0.974025974025974,
+      "avgConfidence": 0.793957671957672,
+      "bundleSize": 395196,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6536,6 +6536,14 @@
           "success": true,
           "confidence": 1
         },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
         "input-validation": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -6766,12 +6774,6 @@
           "success": false
         },
         "when-multiple-changes": {
-          "success": false
-        },
-        "bind-explicit-property": {
-          "success": false
-        },
-        "bind-non-form-display": {
           "success": false
         },
         "caret-var-write": {
@@ -6813,11 +6815,11 @@
       }
     },
     "ko": {
-      "parseSuccess": 144,
-      "parseFailure": 10,
-      "parseRate": 0.935064935064935,
-      "avgConfidence": 0.5508487654320988,
-      "bundleSize": 395057,
+      "parseSuccess": 146,
+      "parseFailure": 8,
+      "parseRate": 0.948051948051948,
+      "avgConfidence": 0.5570015220700152,
+      "bundleSize": 395196,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -6872,6 +6874,14 @@
           "confidence": 1
         },
         "bind-two-way": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
           "success": true,
           "confidence": 1
         },
@@ -7382,12 +7392,6 @@
         "when-multiple-changes": {
           "success": true,
           "confidence": 0.5
-        },
-        "bind-explicit-property": {
-          "success": false
-        },
-        "bind-non-form-display": {
-          "success": false
         },
         "caret-var-write": {
           "success": true,
@@ -7432,7 +7436,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9988148148148148,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8053,7 +8057,7 @@
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.8331811263318118,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8670,7 +8674,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.838198983297023,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "blur-element": {
           "success": true,
@@ -9294,7 +9298,7 @@
       "parseFailure": 9,
       "parseRate": 0.9415584415584416,
       "avgConfidence": 0.6931034482758621,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -9910,7 +9914,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.8842005676442766,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10532,7 +10536,7 @@
       "parseFailure": 13,
       "parseRate": 0.9155844155844156,
       "avgConfidence": 0.8644827198018691,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11144,7 +11148,7 @@
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.9369428136551418,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11761,7 +11765,7 @@
       "parseFailure": 29,
       "parseRate": 0.8116883116883117,
       "avgConfidence": 0.8732549019607846,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12357,7 +12361,7 @@
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.7852359208523593,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -12974,7 +12978,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.8826868495742671,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13596,7 +13600,7 @@
       "parseFailure": 2,
       "parseRate": 0.987012987012987,
       "avgConfidence": 0.8872180451127823,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14219,7 +14223,7 @@
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.998806860551827,
-      "bundleSize": 395057,
+      "bundleSize": 395196,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -14837,7 +14841,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 395057,
+      "size": 395196,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
Follow-up to the Class-B `bind` work (#263): closes the **possessive property-path** gap for **Japanese and Korean** — the `bind-explicit-property` (`bind $x to #picker's value`) and `bind-non-form-display` (`#status's textContent`) patterns that #263 left failing.

## Root cause

`tryMatchPossessiveSelectorExpression` in `pattern-matcher.ts` hardcoded the English `'s` punctuation token:

```ts
if (possessiveToken.kind !== 'punctuation' || possessiveToken.value !== "'s") return null;
```

Japanese (`#picker の 値`) and Korean (`#picker의 값`) tokenize their possessive marker as a **`particle`** token (`の` / `의`), which this check rejected — so *every* possessive-property form failed in those languages, across all commands (not just bind). The `possessive.marker` config already exists per profile but was only consumed by the renderer, never at parse time.

## Fix

Make the matcher **profile-aware**: accept the active profile's `possessive.marker` as a `particle`/`punctuation` token, in addition to the English `'s`. To avoid over-matching, profile markers only treat an **identifier** as the property — so a target+patient construct like `#button の .active` ("toggle .active on #button") is *not* mis-read as a property path. Verified no regression on toggle/add/etc.

One method, ~15 lines; no tokenizer or type changes.

## Result

Full multilingual harness, `browser-priority` bundle — **zero regressions across all 24 languages**:

| Lang | Before | After | Δ |
|------|--------|-------|---|
| ja | 96.1% | **97.4%** | +2 |
| ko | 93.5% | **94.8%** | +2 |

Exactly the two possessive bind patterns flip; this is a **general possessive property-path capability** for ja/ko, not bind-specific.

## Scope / follow-up

**Turkish, Quechua, Bengali still fail these two forms** — for a different, deeper reason. Their possessive markers are agglutinative/attached and the tokenizers mangle them:
- tr: `#picker'ın değer` → `değer` splits into `de`+`ğer`, apostrophe becomes its own token
- qu: `#picker-pa chanin` → `-pa` stays glued inside one selector token `#picker-pa`
- bn: `#picker's মান` → `'s` splits into `'`+`s`

Fixing those requires per-tokenizer surgery with real regression risk, so it's deliberately left as a separate follow-up rather than forced into this clean parser change.

## Verification

- ja/ko possessive-property forms parse as the `bind` action via direct parse; regression-checked `#button の .active` (toggle), `.active を トグル`, ko toggle, and English `#picker's value` — all still correct.
- Baseline regenerated against `browser-priority`; diff limited to ja/ko + the two patterns each, no `↓` anywhere.
- Semantic logic suites pass. (Local `build-artifacts.test.ts` `.d.ts` checks fail only in this environment's partial type-build — pre-existing, unrelated.)
- Binary patterns DB not committed (CI repopulates from source).

Part of #259.

https://claude.ai/code/session_018YJ9m5ExDeWNnnhhtpjx2K

---
_Generated by [Claude Code](https://claude.ai/code/session_018YJ9m5ExDeWNnnhhtpjx2K)_