### PR TITLE
fix(i18n,semantic): possessive property paths for bn/qu (#259)

### DIFF
--- a/packages/i18n/src/grammar/transformer.ts
+++ b/packages/i18n/src/grammar/transformer.ts
@@ -1022,7 +1022,7 @@ function translateWord(word: string, sourceLocale: string, targetLocale: string)
  */
 const POSSESSIVE_MARKERS: Record<
   string,
-  { type: 'prefix' | 'suffix' | 'preposition'; marker: string }
+  { type: 'prefix' | 'suffix' | 'preposition' | 'particle'; marker: string }
 > = {
   en: { type: 'suffix', marker: "'s" },
   es: { type: 'preposition', marker: 'de' },
@@ -1035,7 +1035,17 @@ const POSSESSIVE_MARKERS: Record<
   ar: { type: 'preposition', marker: 'لـ' },
   tr: { type: 'suffix', marker: "'ın" },
   id: { type: 'preposition', marker: 'dari' },
-  qu: { type: 'suffix', marker: '-pa' },
+  // Latin-script genitive: must be a *spaced* particle (`#picker pa`), since a
+  // glued `#pickerpa` can't be split from the selector by the tokenizer the
+  // way a non-Latin suffix (の/의/র) can.
+  qu: { type: 'particle', marker: 'pa' },
+  // Bengali SOV postposition genitive, like ja/ko — a spaced suffix the
+  // tokenizer splits off as a particle. Previously absent, so it fell back to
+  // the English `'s` marker and its possessive property paths never parsed.
+  // (Hindi `का` is intentionally omitted: its `bind` lacks a verb-final
+  // grammar rule, so fixing its possessive alone yields a wrong `on` parse —
+  // tracked as separate follow-up.)
+  bn: { type: 'suffix', marker: 'র' },
   sw: { type: 'preposition', marker: 'ya' },
 };
 
@@ -1078,6 +1088,10 @@ function translatePossessive(token: string, sourceLocale: string, targetLocale: 
     case 'suffix':
       // Japanese/Korean/Chinese: owner + marker (e.g., #buttonの, #button의)
       return `${translatedOwner}${targetMarker.marker}`;
+    case 'particle':
+      // Latin-script spaced genitive (Quechua `pa`): owner + space + marker
+      // so the tokenizer can separate it from the selector.
+      return `${translatedOwner} ${targetMarker.marker}`;
     case 'preposition':
       // Will be handled by caller - return marker + owner format
       // Store as special format to be processed later

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -675,12 +675,15 @@ export class PatternMatcher {
     tokens.advance(); // consume selector
 
     const possessiveToken = tokens.peek();
-    const profileMarker = this.currentProfile?.possessive?.marker;
+    // Agglutinative suffix markers may be written with a leading hyphen in the
+    // profile (e.g. Quechua `-pa`) but tokenize without it; normalize before
+    // comparing.
+    const profileMarker = this.currentProfile?.possessive?.marker?.replace(/^-/, '');
     const isEnglishPossessive =
       !!possessiveToken && possessiveToken.kind === 'punctuation' && possessiveToken.value === "'s";
-    // Non-English markers (の, 의, …) arrive as `particle` tokens. Match them
-    // against the active profile's possessive marker. Empty markers (Turkish,
-    // suffix-based) don't have a standalone token and are not handled here.
+    // Non-English markers (の, 의, র, pa, …) arrive as `particle` tokens. Match
+    // them against the active profile's possessive marker. Empty markers
+    // (Turkish, suffix-fused) don't have a standalone token and aren't handled here.
     const isProfilePossessive =
       !!possessiveToken &&
       !!profileMarker &&

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-06T17:55:52.450Z",
-  "commit": "99ca475",
+  "timestamp": "2026-06-06T19:31:51.605Z",
+  "commit": "e2b3016",
   "languages": {
     "ar": {
       "parseSuccess": 132,
       "parseFailure": 22,
       "parseRate": 0.8571428571428571,
       "avgConfidence": 0.9052167331579098,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -606,11 +606,11 @@
       }
     },
     "bn": {
-      "parseSuccess": 152,
-      "parseFailure": 2,
-      "parseRate": 0.987012987012987,
-      "avgConfidence": 0.791593567251462,
-      "bundleSize": 395196,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.7943001443001443,
+      "bundleSize": 395214,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -964,6 +964,14 @@
           "success": true,
           "confidence": 1
         },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -1184,12 +1192,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "bind-explicit-property": {
-          "success": false
-        },
-        "bind-non-form-display": {
-          "success": false
-        },
         "caret-var-write": {
           "success": true,
           "confidence": 0.5
@@ -1233,7 +1235,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9367465504720396,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1857,7 +1859,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2482,7 +2484,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3106,7 +3108,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.9888888888888889,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3728,7 +3730,7 @@
       "parseFailure": 22,
       "parseRate": 0.8571428571428571,
       "avgConfidence": 0.8443482443482448,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4331,7 +4333,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 1,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -4955,7 +4957,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5579,7 +5581,7 @@
       "parseFailure": 6,
       "parseRate": 0.961038961038961,
       "avgConfidence": 0.9975975975975976,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6198,7 +6200,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.793957671957672,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6819,7 +6821,7 @@
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.5570015220700152,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7436,7 +7438,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9988148148148148,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8057,7 +8059,7 @@
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.8331811263318118,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8674,7 +8676,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.838198983297023,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "blur-element": {
           "success": true,
@@ -9294,11 +9296,11 @@
       }
     },
     "qu": {
-      "parseSuccess": 145,
-      "parseFailure": 9,
-      "parseRate": 0.9415584415584416,
-      "avgConfidence": 0.6931034482758621,
-      "bundleSize": 395196,
+      "parseSuccess": 147,
+      "parseFailure": 7,
+      "parseRate": 0.9545454545454546,
+      "avgConfidence": 0.6972789115646258,
+      "bundleSize": 395214,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -9521,6 +9523,14 @@
           "confidence": 1
         },
         "bind-two-way": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
           "success": true,
           "confidence": 1
         },
@@ -9865,12 +9875,6 @@
         "when-multiple-changes": {
           "success": false
         },
-        "bind-explicit-property": {
-          "success": false
-        },
-        "bind-non-form-display": {
-          "success": false
-        },
         "caret-var-write": {
           "success": true,
           "confidence": 0.5
@@ -9914,7 +9918,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.8842005676442766,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10536,7 +10540,7 @@
       "parseFailure": 13,
       "parseRate": 0.9155844155844156,
       "avgConfidence": 0.8644827198018691,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11148,7 +11152,7 @@
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.9369428136551418,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11765,7 +11769,7 @@
       "parseFailure": 29,
       "parseRate": 0.8116883116883117,
       "avgConfidence": 0.8732549019607846,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12361,7 +12365,7 @@
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.7852359208523593,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -12978,7 +12982,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.8826868495742671,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13600,7 +13604,7 @@
       "parseFailure": 2,
       "parseRate": 0.987012987012987,
       "avgConfidence": 0.8872180451127823,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14223,7 +14227,7 @@
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.998806860551827,
-      "bundleSize": 395196,
+      "bundleSize": 395214,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -14841,7 +14845,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 395196,
+      "size": 395214,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
Extends the ja/ko possessive property-path fix (#264) to **Bengali and Quechua** — the next two Class-B languages whose `bind-explicit-property` (`bind $x to #picker's value`) and `bind-non-form-display` (`#status's textContent`) patterns were failing.

The investigation found **two distinct gaps**:

### Bengali — missing i18n marker
The i18n `POSSESSIVE_MARKERS` table simply had no `bn` entry, so `#picker's value` fell back to the English `'s` marker and rendered `#picker's মান` instead of `#pickerর মান`. Adding `bn: 'র'` (a non-Latin SOV genitive, like ja `の` / ko `의`) makes the tokenizer split it as a `particle` token, which the profile-aware matcher from #264 already handles. **No semantic change needed for bn.**

### Quechua — Latin marker can't glue
Quechua's `-pa` glued onto the selector (`#picker-pa`), and unlike CJK/Bengali markers the tokenizer can't split a *Latin* suffix from a *Latin* selector. Fixed with two small changes:
1. A new `'particle'` marker type in the transformer that emits a **spaced** Latin genitive (`#picker pa`).
2. Normalizing a leading hyphen off the profile marker in `tryMatchPossessiveSelectorExpression`, so the `pa` token matches Quechua's `-pa` profile marker (only affects hyphen-notation markers — i.e. just qu).

## Result

Full multilingual harness, `browser-priority` bundle — **zero regressions across all 24 languages**:

| Lang | Before | After | Δ |
|------|--------|-------|---|
| bn | 98.7% | **100.0%** | +2 |
| qu | 94.2% | **95.5%** | +2 |

Exactly the two possessive bind patterns each. bn reaches a full 154/154.

## Deliberately deferred

- **Hindi** (`का`): its `bind` lacks a verb-final grammar rule (it was outside the Phase-2 Class-B set), so fixing only its possessive marker yields a *wrong* `on` parse rather than `bind`. Needs the same bind-rule treatment first — separate follow-up.
- **Turkish**: its tokenizer fragments `değer` (value) into `de`+`ğer` via a greedy mid-word keyword match — a deeper tokenizer bug with broad regression surface that deserves its own focused PR.

## Verification

- bn/qu possessive forms parse as the `bind` action via direct parse; the spaced qu form and the bn split-particle form both verified.
- Baseline regenerated against `browser-priority`; diff limited to bn/qu + the two patterns each, no `↓` anywhere.
- **i18n: 623/623 tests pass** (no test regressed on the qu `#picker-pa`→`#picker pa` rendering change). Semantic logic suites pass.
- Binary patterns DB not committed (CI repopulates from source).

Part of #259. After this, the possessive property-path gap is closed for **ja, ko, bn, qu**; **hi** and **tr** remain as scoped follow-ups.

https://claude.ai/code/session_018YJ9m5ExDeWNnnhhtpjx2K

---
_Generated by [Claude Code](https://claude.ai/code/session_018YJ9m5ExDeWNnnhhtpjx2K)_