### PR TITLE
fix(semantic): wire bind for ms/sw/th/tl (#259)

### DIFF
--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -537,7 +537,7 @@ export const bindSchema: CommandSchema = {
         de: 'zu',
         it: 'in',
         id: 'ke',
-        ms: 'ke',
+        ms: 'to', // no i18n grammar profile: prepositions stay English in generated text
         vi: 'vào', // generic destination preposition (matches set/put `into`), not "với"/with
         ru: 'в', // generic destination preposition (matches set/put `into`)
         uk: 'в',
@@ -548,7 +548,8 @@ export const bindSchema: CommandSchema = {
         ar: 'إلى',
         zh: '到', // bind target uses 到 (arrive/to), not the default 从/"from"
         he: 'ל', // "to" prefix preposition
-        sw: 'kwenye',
+        sw: 'kwa', // matches the generic `kwa` the transformer emits (not `kwenye`)
+        th: 'ใน', // generic destination preposition the transformer emits
         tl: 'sa',
         bn: 'তে',
         qu: 'man',

--- a/packages/semantic/src/generators/profiles/thai.ts
+++ b/packages/semantic/src/generators/profiles/thai.ts
@@ -156,6 +156,9 @@ export const thaiProfile: LanguageProfile = {
       alternatives: ['websocket', 'เว็บซ็อกเก็ต'],
       normalized: 'socket',
     },
+    // Reactive: bind (generated text keeps the English verb; native primary
+    // for future i18n dictionary support)
+    bind: { primary: 'ผูก', alternatives: ['bind'], normalized: 'bind' },
   },
   tokenization: {
     boundaryStrategy: 'character', // Character-based like Chinese/Japanese

--- a/packages/semantic/src/generators/profiles/tl.ts
+++ b/packages/semantic/src/generators/profiles/tl.ts
@@ -153,6 +153,9 @@ export const tagalogProfile: LanguageProfile = {
     stream: { primary: 'i-stream', alternatives: ['stream', 'agos'], normalized: 'stream' },
     live: { primary: 'live', alternatives: ['tuwiran', 'direkta'], normalized: 'live' },
     socket: { primary: 'socket', alternatives: ['websocket'], normalized: 'socket' },
+    // Reactive: bind (generated text keeps the English verb; native primary
+    // for future i18n dictionary support)
+    bind: { primary: 'itali', alternatives: ['iugnay', 'bind'], normalized: 'bind' },
   },
   eventHandler: {
     keyword: { primary: 'kapag', normalized: 'on' },

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-06T20:27:36.921Z",
-  "commit": "6d2001f",
+  "timestamp": "2026-06-07T01:09:13.663Z",
+  "commit": "147ac2d",
   "languages": {
     "ar": {
       "parseSuccess": 132,
       "parseFailure": 22,
       "parseRate": 0.8571428571428571,
       "avgConfidence": 0.9052167331579098,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -610,7 +610,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7943001443001443,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1235,7 +1235,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9367465504720396,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1859,7 +1859,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2484,7 +2484,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3108,7 +3108,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.9888888888888889,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3730,7 +3730,7 @@
       "parseFailure": 22,
       "parseRate": 0.8571428571428571,
       "avgConfidence": 0.8443482443482448,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4333,7 +4333,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 1,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -4957,7 +4957,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5581,7 +5581,7 @@
       "parseFailure": 6,
       "parseRate": 0.961038961038961,
       "avgConfidence": 0.9975975975975976,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6200,7 +6200,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.793957671957672,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6821,7 +6821,7 @@
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.5570015220700152,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7434,11 +7434,11 @@
       }
     },
     "ms": {
-      "parseSuccess": 150,
-      "parseFailure": 4,
-      "parseRate": 0.974025974025974,
-      "avgConfidence": 0.9988148148148148,
-      "bundleSize": 395277,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.9988455988455989,
+      "bundleSize": 395292,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8000,6 +8000,22 @@
           "success": true,
           "confidence": 1
         },
+        "bind-auto-detect": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-two-way": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
         "caret-var-write": {
           "success": true,
           "confidence": 1
@@ -8039,18 +8055,6 @@
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
-        },
-        "bind-auto-detect": {
-          "success": false
-        },
-        "bind-two-way": {
-          "success": false
-        },
-        "bind-explicit-property": {
-          "success": false
-        },
-        "bind-non-form-display": {
-          "success": false
         }
       }
     },
@@ -8059,7 +8063,7 @@
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.8331811263318118,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8676,7 +8680,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.838198983297023,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "blur-element": {
           "success": true,
@@ -9300,7 +9304,7 @@
       "parseFailure": 7,
       "parseRate": 0.9545454545454546,
       "avgConfidence": 0.6972789115646258,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -9918,7 +9922,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.8842005676442766,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10536,11 +10540,11 @@
       }
     },
     "sw": {
-      "parseSuccess": 141,
-      "parseFailure": 13,
-      "parseRate": 0.9155844155844156,
-      "avgConfidence": 0.8644827198018691,
-      "bundleSize": 395277,
+      "parseSuccess": 145,
+      "parseFailure": 9,
+      "parseRate": 0.9415584415584416,
+      "avgConfidence": 0.8682211275314727,
+      "bundleSize": 395292,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10643,6 +10647,22 @@
           "confidence": 1
         },
         "when-multiple-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-auto-detect": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-two-way": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
           "success": true,
           "confidence": 1
         },
@@ -11117,18 +11137,6 @@
           "success": false
         },
         "live-multiple-deps": {
-          "success": false
-        },
-        "bind-auto-detect": {
-          "success": false
-        },
-        "bind-two-way": {
-          "success": false
-        },
-        "bind-explicit-property": {
-          "success": false
-        },
-        "bind-non-form-display": {
           "success": false
         },
         "behavior-removable": {
@@ -11148,11 +11156,11 @@
       }
     },
     "th": {
-      "parseSuccess": 146,
-      "parseFailure": 8,
-      "parseRate": 0.948051948051948,
-      "avgConfidence": 0.9369428136551418,
-      "bundleSize": 395277,
+      "parseSuccess": 150,
+      "parseFailure": 4,
+      "parseRate": 0.974025974025974,
+      "avgConfidence": 0.9386243386243376,
+      "bundleSize": 395292,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11391,6 +11399,22 @@
           "confidence": 1
         },
         "when-multiple-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-auto-detect": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-two-way": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
           "success": true,
           "confidence": 1
         },
@@ -11747,29 +11771,17 @@
         "worker-basic": {
           "success": false
         },
-        "bind-auto-detect": {
-          "success": false
-        },
-        "bind-two-way": {
-          "success": false
-        },
-        "bind-explicit-property": {
-          "success": false
-        },
-        "bind-non-form-display": {
-          "success": false
-        },
         "intercept-cache-strategies": {
           "success": false
         }
       }
     },
     "tl": {
-      "parseSuccess": 125,
-      "parseFailure": 29,
-      "parseRate": 0.8116883116883117,
-      "avgConfidence": 0.8732549019607846,
-      "bundleSize": 395277,
+      "parseSuccess": 129,
+      "parseFailure": 25,
+      "parseRate": 0.8376623376623377,
+      "avgConfidence": 0.8771849825201401,
+      "bundleSize": 395292,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11952,6 +11964,22 @@
           "confidence": 1
         },
         "when-multiple-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-auto-detect": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-two-way": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
           "success": true,
           "confidence": 1
         },
@@ -12337,18 +12365,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "bind-auto-detect": {
-          "success": false
-        },
-        "bind-two-way": {
-          "success": false
-        },
-        "bind-explicit-property": {
-          "success": false
-        },
-        "bind-non-form-display": {
-          "success": false
-        },
         "caret-var-write": {
           "success": false
         },
@@ -12365,7 +12381,7 @@
       "parseFailure": 6,
       "parseRate": 0.961038961038961,
       "avgConfidence": 0.7927177177177177,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -12984,7 +13000,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.8826868495742671,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13606,7 +13622,7 @@
       "parseFailure": 2,
       "parseRate": 0.987012987012987,
       "avgConfidence": 0.8872180451127823,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14229,7 +14245,7 @@
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.998806860551827,
-      "bundleSize": 395277,
+      "bundleSize": 395292,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -14847,7 +14863,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 395277,
+      "size": 395292,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
First batch of the reactive-keyword-wiring track (the option chosen from the #259 survey). Wires the `bind` command in the **four remaining languages** that still failed all four bind patterns — **Malay, Swahili, Thai, Tagalog** (16 pattern-instances).

Diagnosed per language against the *actual generated text* (not assumptions):

- **th, tl** were missing the `bind` keyword in their semantic profiles entirely → added it (native primary + English `bind` alias; the i18n dictionaries don't translate the verb yet, so generated text keeps English `bind`, which the alias matches).
- **bind's source markerOverride was misaligned.** Unlike `add` (no override → accepts the generic preposition permissively), `bind` carries explicit per-language source markers, and they didn't match what the transformer emits:
  - ms: `ke` → `to` (Malay has no i18n grammar profile, so prepositions stay English in generated text)
  - sw: `kwenye` → `kwa` (the generic preposition the transformer actually emits)
  - th: *(absent)* → `ใน`
  - tl: `sa` was already correct

## Result

Full multilingual harness, `browser-priority` bundle — **zero regressions across all 24 languages**:

| Lang | Before | After | Δ |
|------|--------|-------|---|
| ms | 97.4% | **100.0%** | +4 |
| th | 94.8% | **97.4%** | +4 |
| sw | 91.6% | **94.2%** | +4 |
| tl | 81.2% | **83.8%** | +4 |

All four bind patterns parse in each (including the possessive-property forms — these languages keep the English `'s`, or render `ya #picker`/Swahili genitive, which already parse). **ms reaches 154/154.**

## Verification

- All 4 patterns × 4 languages confirmed parsing as the `bind` action against the freshly-populated DB text.
- Baseline regenerated against `browser-priority`; diff limited to ms/sw/th/tl + the four patterns each, no `↓` anywhere.
- Semantic logic suites pass; keyword-collision validation passes (th `ผูก`, tl `itali` don't collide). Binary DB not committed (CI repopulates).

Part of #259. Next reactive batches: `live` (fr/it/pl/ru/sw/uk/vi) and `when` (ar/he/ja/pl/qu/tr).

https://claude.ai/code/session_018YJ9m5ExDeWNnnhhtpjx2K

---
_Generated by [Claude Code](https://claude.ai/code/session_018YJ9m5ExDeWNnnhhtpjx2K)_