### PR TITLE
fix(semantic): Track 1 reactive quick wins — th/tl stragglers + socket-basic

### DIFF
--- a/packages/semantic/src/generators/profiles/chinese.ts
+++ b/packages/semantic/src/generators/profiles/chinese.ts
@@ -148,7 +148,7 @@ export const chineseProfile: LanguageProfile = {
     connect: { primary: '连接', alternatives: ['连接器'], normalized: 'connect' },
     stream: { primary: '流', alternatives: ['流式传输'], normalized: 'stream' },
     live: { primary: '实时', alternatives: ['直播'], normalized: 'live' },
-    socket: { primary: '套接字', alternatives: ['websocket'], normalized: 'socket' },
+    socket: { primary: '套接字', alternatives: ['websocket', 'socket'], normalized: 'socket' },
     // Reactive / realtime commands
     bind: { primary: '绑定', alternatives: ['bind'], normalized: 'bind' },
     intercept: { primary: '拦截', alternatives: ['intercept'], normalized: 'intercept' },

--- a/packages/semantic/src/generators/profiles/he.ts
+++ b/packages/semantic/src/generators/profiles/he.ts
@@ -155,7 +155,7 @@ export const hebrewProfile: LanguageProfile = {
     connect: { primary: 'התחבר', alternatives: ['חבר', 'התחברות'], normalized: 'connect' },
     stream: { primary: 'הזרם', alternatives: ['סטרים', 'שידור'], normalized: 'stream' },
     live: { primary: 'חי', alternatives: ['בזמן-אמת', 'לייב'], normalized: 'live' },
-    socket: { primary: 'שקע', alternatives: ['סוקט', 'ווב-סוקט'], normalized: 'socket' },
+    socket: { primary: 'שקע', alternatives: ['סוקט', 'ווב-סוקט', 'socket'], normalized: 'socket' },
     // Reactive / realtime commands
     bind: { primary: 'קשור', alternatives: ['אגד', 'bind'], normalized: 'bind' },
     intercept: { primary: 'יירט', alternatives: ['יירוט', 'intercept'], normalized: 'intercept' },

--- a/packages/semantic/src/generators/profiles/russian.ts
+++ b/packages/semantic/src/generators/profiles/russian.ts
@@ -310,7 +310,11 @@ export const russianProfile: LanguageProfile = {
       alternatives: ['прямой-эфир', 'вживую'],
       normalized: 'live',
     },
-    socket: { primary: 'сокет', alternatives: ['гнездо', 'websocket'], normalized: 'socket' },
+    socket: {
+      primary: 'сокет',
+      alternatives: ['гнездо', 'websocket', 'socket'],
+      normalized: 'socket',
+    },
     // Reactive / realtime commands
     bind: { primary: 'привязать', alternatives: ['связать', 'bind'], normalized: 'bind' },
     intercept: {

--- a/packages/semantic/src/generators/profiles/thai.ts
+++ b/packages/semantic/src/generators/profiles/thai.ts
@@ -153,8 +153,21 @@ export const thaiProfile: LanguageProfile = {
     live: { primary: 'ไลฟ์', alternatives: ['สด', 'ถ่ายทอดสด'], normalized: 'live' },
     socket: {
       primary: 'ซ็อกเก็ต',
-      alternatives: ['websocket', 'เว็บซ็อกเก็ต'],
+      alternatives: ['websocket', 'เว็บซ็อกเก็ต', 'socket'],
       normalized: 'socket',
+    },
+    // Service-worker / realtime keywords (mirrors #262 ja/he wiring; native
+    // primary + English alternative, eventsource keeps the canonical English form)
+    intercept: {
+      primary: 'ดักจับ',
+      alternatives: ['intercept', 'สกัดกั้น'],
+      normalized: 'intercept',
+    },
+    worker: { primary: 'เวิร์กเกอร์', alternatives: ['worker'], normalized: 'worker' },
+    eventsource: {
+      primary: 'eventsource',
+      alternatives: ['อีเวนต์ซอร์ส'],
+      normalized: 'eventsource',
     },
     // Reactive: bind (generated text keeps the English verb; native primary
     // for future i18n dictionary support)

--- a/packages/semantic/src/generators/profiles/tl.ts
+++ b/packages/semantic/src/generators/profiles/tl.ts
@@ -153,6 +153,13 @@ export const tagalogProfile: LanguageProfile = {
     stream: { primary: 'i-stream', alternatives: ['stream', 'agos'], normalized: 'stream' },
     live: { primary: 'live', alternatives: ['tuwiran', 'direkta'], normalized: 'live' },
     socket: { primary: 'socket', alternatives: ['websocket'], normalized: 'socket' },
+    // Service-worker keyword (Filipino code-switches English heavily; English
+    // primary + native alternative, matching the socket/live entries above)
+    intercept: {
+      primary: 'intercept',
+      alternatives: ['harangin', 'humarang'],
+      normalized: 'intercept',
+    },
     // Reactive: bind (generated text keeps the English verb; native primary
     // for future i18n dictionary support)
     bind: { primary: 'itali', alternatives: ['iugnay', 'bind'], normalized: 'bind' },

--- a/packages/semantic/src/generators/profiles/ukrainian.ts
+++ b/packages/semantic/src/generators/profiles/ukrainian.ts
@@ -320,7 +320,11 @@ export const ukrainianProfile: LanguageProfile = {
       alternatives: ['у-прямому-ефірі', 'в-режимі-реального-часу'],
       normalized: 'live',
     },
-    socket: { primary: 'сокет', alternatives: ['гніздо', 'websocket'], normalized: 'socket' },
+    socket: {
+      primary: 'сокет',
+      alternatives: ['гніздо', 'websocket', 'socket'],
+      normalized: 'socket',
+    },
     // Reactive / realtime commands
     // ASCII apostrophe (U+0027) — the Ukrainian tokenizer's letter class
     // whitelists U+0027, not the typographic ʼ (U+02BC); `приєднати` is an

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-07T01:09:13.663Z",
-  "commit": "147ac2d",
+  "timestamp": "2026-06-07T02:37:49.391Z",
+  "commit": "3a60707",
   "languages": {
     "ar": {
       "parseSuccess": 132,
       "parseFailure": 22,
       "parseRate": 0.8571428571428571,
       "avgConfidence": 0.9052167331579098,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -610,7 +610,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7943001443001443,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1235,7 +1235,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9367465504720396,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1859,7 +1859,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2484,7 +2484,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3108,7 +3108,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.9888888888888889,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3726,11 +3726,11 @@
       }
     },
     "he": {
-      "parseSuccess": 132,
-      "parseFailure": 22,
-      "parseRate": 0.8571428571428571,
-      "avgConfidence": 0.8443482443482448,
-      "bundleSize": 395292,
+      "parseSuccess": 133,
+      "parseFailure": 21,
+      "parseRate": 0.8636363636363636,
+      "avgConfidence": 0.8455185583005137,
+      "bundleSize": 395301,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -3753,6 +3753,10 @@
           "confidence": 1
         },
         "eventsource-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-basic": {
           "success": true,
           "confidence": 1
         },
@@ -4299,9 +4303,6 @@
         "focus-trap": {
           "success": false
         },
-        "socket-basic": {
-          "success": false
-        },
         "keydown-key-is-syntax": {
           "success": false
         },
@@ -4333,7 +4334,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 1,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -4957,7 +4958,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5581,7 +5582,7 @@
       "parseFailure": 6,
       "parseRate": 0.961038961038961,
       "avgConfidence": 0.9975975975975976,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6200,7 +6201,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.793957671957672,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6821,7 +6822,7 @@
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.5570015220700152,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7438,7 +7439,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9988455988455989,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8063,7 +8064,7 @@
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.8331811263318118,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8680,7 +8681,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.838198983297023,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "blur-element": {
           "success": true,
@@ -9304,7 +9305,7 @@
       "parseFailure": 7,
       "parseRate": 0.9545454545454546,
       "avgConfidence": 0.6972789115646258,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -9918,11 +9919,11 @@
       }
     },
     "ru": {
-      "parseSuccess": 151,
-      "parseFailure": 3,
-      "parseRate": 0.9805194805194806,
-      "avgConfidence": 0.8842005676442766,
-      "bundleSize": 395292,
+      "parseSuccess": 152,
+      "parseFailure": 2,
+      "parseRate": 0.987012987012987,
+      "avgConfidence": 0.884962406015038,
+      "bundleSize": 395301,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -9977,6 +9978,10 @@
           "confidence": 1
         },
         "eventsource-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-basic": {
           "success": true,
           "confidence": 1
         },
@@ -10528,9 +10533,6 @@
           "success": true,
           "confidence": 0.5555555555555556
         },
-        "socket-basic": {
-          "success": false
-        },
         "live-derived-value": {
           "success": false
         },
@@ -10544,7 +10546,7 @@
       "parseFailure": 9,
       "parseRate": 0.9415584415584416,
       "avgConfidence": 0.8682211275314727,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11156,11 +11158,11 @@
       }
     },
     "th": {
-      "parseSuccess": 150,
-      "parseFailure": 4,
-      "parseRate": 0.974025974025974,
-      "avgConfidence": 0.9386243386243376,
-      "bundleSize": 395292,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.9402185116470816,
+      "bundleSize": 395301,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11362,7 +11364,19 @@
           "success": true,
           "confidence": 1
         },
+        "eventsource-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-basic": {
+          "success": true,
+          "confidence": 1
+        },
         "socket-send": {
+          "success": true,
+          "confidence": 1
+        },
+        "worker-basic": {
           "success": true,
           "confidence": 1
         },
@@ -11423,6 +11437,10 @@
           "confidence": 1
         },
         "caret-var-on-target": {
+          "success": true,
+          "confidence": 1
+        },
+        "intercept-cache-strategies": {
           "success": true,
           "confidence": 1
         },
@@ -11761,27 +11779,15 @@
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
-        },
-        "eventsource-basic": {
-          "success": false
-        },
-        "socket-basic": {
-          "success": false
-        },
-        "worker-basic": {
-          "success": false
-        },
-        "intercept-cache-strategies": {
-          "success": false
         }
       }
     },
     "tl": {
-      "parseSuccess": 129,
-      "parseFailure": 25,
-      "parseRate": 0.8376623376623377,
-      "avgConfidence": 0.8771849825201401,
-      "bundleSize": 395292,
+      "parseSuccess": 130,
+      "parseFailure": 24,
+      "parseRate": 0.8441558441558441,
+      "avgConfidence": 0.8781297134238313,
+      "bundleSize": 395301,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11984,6 +11990,10 @@
           "confidence": 1
         },
         "reactive-array-push": {
+          "success": true,
+          "confidence": 1
+        },
+        "intercept-cache-strategies": {
           "success": true,
           "confidence": 1
         },
@@ -12370,9 +12380,6 @@
         },
         "caret-var-on-target": {
           "success": false
-        },
-        "intercept-cache-strategies": {
-          "success": false
         }
       }
     },
@@ -12381,7 +12388,7 @@
       "parseFailure": 6,
       "parseRate": 0.961038961038961,
       "avgConfidence": 0.7927177177177177,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -12996,11 +13003,11 @@
       }
     },
     "uk": {
-      "parseSuccess": 151,
-      "parseFailure": 3,
-      "parseRate": 0.9805194805194806,
-      "avgConfidence": 0.8826868495742671,
-      "bundleSize": 395292,
+      "parseSuccess": 152,
+      "parseFailure": 2,
+      "parseRate": 0.987012987012987,
+      "avgConfidence": 0.8834586466165417,
+      "bundleSize": 395301,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13051,6 +13058,10 @@
           "confidence": 1
         },
         "eventsource-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-basic": {
           "success": true,
           "confidence": 1
         },
@@ -13606,9 +13617,6 @@
           "success": true,
           "confidence": 0.5555555555555556
         },
-        "socket-basic": {
-          "success": false
-        },
         "live-derived-value": {
           "success": false
         },
@@ -13622,7 +13630,7 @@
       "parseFailure": 2,
       "parseRate": 0.987012987012987,
       "avgConfidence": 0.8872180451127823,
-      "bundleSize": 395292,
+      "bundleSize": 395301,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14241,11 +14249,11 @@
       }
     },
     "zh": {
-      "parseSuccess": 149,
-      "parseFailure": 5,
-      "parseRate": 0.9675324675324676,
-      "avgConfidence": 0.998806860551827,
-      "bundleSize": 395292,
+      "parseSuccess": 150,
+      "parseFailure": 4,
+      "parseRate": 0.974025974025974,
+      "avgConfidence": 0.9988148148148148,
+      "bundleSize": 395301,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -14731,6 +14739,10 @@
           "success": true,
           "confidence": 1
         },
+        "socket-basic": {
+          "success": true,
+          "confidence": 1
+        },
         "socket-send": {
           "success": true,
           "confidence": 1
@@ -14843,9 +14855,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "socket-basic": {
-          "success": false
-        },
         "behavior-removable": {
           "success": false
         },
@@ -14863,7 +14872,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 395292,
+      "size": 395301,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
Implements the **Track 1 quick wins** from `docs-internal/MULTILINGUAL_ROADMAP.md` (the roadmap landed in #268). Clears **9 failing pattern-instances**; priority-bundle cross-language average **96.2% → 96.4%**, with **zero regressions**.

## What changed

**th/tl reactive keyword wiring** (mirrors the #262 ja/he pattern — #262 only covered the 8 Class-B langs, leaving th/tl behind):
- `th`: added `intercept` / `worker` / `eventsource` keywords → fixes `intercept-cache-strategies`, `worker-basic`, `eventsource-basic`.
- `tl`: added `intercept` keyword → fixes `intercept-cache-strategies`.

**`socket-basic` (he / ru / th / uk / zh):** the i18n `GrammarTransformer` emits `socket` in **English** (there's no i18n-dictionary entry for it), but these five profiles registered only the *native* form (`сокет`, `套接字`, `שקע`, `ซ็อกเก็ต`), so the tokenizer didn't recognize the emitted keyword. Added English `socket` as an alternative in each — consistent with how `eventsource`/`worker`/`intercept` already accept their English forms. (`zh`'s `把` object-marker insertion is handled fine by the `bareKeyword` parser once the keyword resolves.)

All five commands are `bareKeyword` (no source-marker alignment needed, unlike `bind`).

## Verification (per the roadmap playbook)
- Probed each pattern via `MultilingualHyperscript.parse()` (the harness's success criterion) after rebuilding semantic + core.
- Repopulated the DB (`db:init:force` + `sync:translations`) and regenerated the `browser-priority` baseline.
- Baseline diff: **exactly 9 fail→pass flips, 0 pass→fail** —
  `th`: intercept-cache-strategies, worker-basic, eventsource-basic, socket-basic ·
  `tl`: intercept-cache-strategies ·
  `he`/`ru`/`uk`/`zh`: socket-basic.
- `keyword-collisions.test.ts` passes (25/25). i18n suite green (623/623). Semantic suite green except the known-environmental `build-artifacts.test.ts` `.d.ts` checks (pass in CI).
- Binary `patterns.db` restored (not committed); the regenerated baseline JSON **is** committed.

## Not included
`socket-basic` turned out to be a clean shared keyword-alias fix (not deep block grammar). The remaining Track 1 work — `live` blocks (14) and `when` blocks (12) — is genuine block-grammar design and is scoped as separate follow-up PRs in the roadmap.

https://claude.ai/code/session_01TdYeGo5Yxrvit2Xdtar1BM

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdYeGo5Yxrvit2Xdtar1BM)_