### PR TITLE
fix(semantic,i18n): Track 1 live blocks — fr/it/pl/ru/sw/uk/vi (14 instances)

### DIFF
--- a/packages/i18n/src/dictionaries/sw.ts
+++ b/packages/i18n/src/dictionaries/sw.ts
@@ -130,7 +130,7 @@ export const sw: Dictionary = {
     else: 'sivyo',
     otherwise: 'vinginevyo',
     end: 'mwisho',
-    live: 'moja_kwa_moja',
+    live: 'mubashara',
     changes: 'inabadilika',
   },
 

--- a/packages/i18n/src/dictionaries/vi.ts
+++ b/packages/i18n/src/dictionaries/vi.ts
@@ -130,7 +130,7 @@ export const vi: Dictionary = {
     else: 'không thì',
     end: 'kết thúc',
     then: 'rồi',
-    live: 'trực tiếp',
+    live: 'live',
     changes: 'thay đổi',
   },
 

--- a/packages/semantic/src/generators/profiles/french.ts
+++ b/packages/semantic/src/generators/profiles/french.ts
@@ -146,7 +146,7 @@ export const frenchProfile: LanguageProfile = {
     // used by the vocab generator — `sse-connecter`, `hx-en-direct`, etc.
     connect: { primary: 'connecter', alternatives: ['connexion'], normalized: 'connect' },
     stream: { primary: 'flux', alternatives: ['streaming'], normalized: 'stream' },
-    live: { primary: 'en-direct', alternatives: ['direct'], normalized: 'live' },
+    live: { primary: 'en-direct', alternatives: ['direct', 'vif'], normalized: 'live' },
     socket: { primary: 'socket', alternatives: ['websocket'], normalized: 'socket' },
     // Reactive / realtime commands
     bind: { primary: 'lier', alternatives: ['relier', 'bind'], normalized: 'bind' },

--- a/packages/semantic/src/generators/profiles/italian.ts
+++ b/packages/semantic/src/generators/profiles/italian.ts
@@ -169,7 +169,11 @@ export const italianProfile: LanguageProfile = {
       normalized: 'connect',
     },
     stream: { primary: 'trasmettere', alternatives: ['flusso', 'streaming'], normalized: 'stream' },
-    live: { primary: 'in-diretta', alternatives: ['diretta', 'dal-vivo'], normalized: 'live' },
+    live: {
+      primary: 'in-diretta',
+      alternatives: ['diretta', 'dal-vivo', 'vivo'],
+      normalized: 'live',
+    },
     socket: { primary: 'socket', alternatives: ['presa', 'websocket'], normalized: 'socket' },
     // Reactive / realtime commands
     bind: { primary: 'vincolare', alternatives: ['legare', 'bind'], normalized: 'bind' },

--- a/packages/semantic/src/generators/profiles/polish.ts
+++ b/packages/semantic/src/generators/profiles/polish.ts
@@ -288,7 +288,7 @@ export const polishProfile: LanguageProfile = {
     // used by the vocab generator — `sse-połącz`, `hx-na-żywo`, etc.
     connect: { primary: 'połącz', alternatives: ['podłącz'], normalized: 'connect' },
     stream: { primary: 'transmituj', alternatives: ['strumień', 'streamuj'], normalized: 'stream' },
-    live: { primary: 'na-żywo', alternatives: ['na-bieżąco', 'live'], normalized: 'live' },
+    live: { primary: 'na-żywo', alternatives: ['na-bieżąco', 'live', 'żywy'], normalized: 'live' },
     socket: { primary: 'gniazdo', alternatives: ['socket', 'websocket'], normalized: 'socket' },
     // Reactive / realtime commands
     bind: { primary: 'powiąż', alternatives: ['związać', 'bind'], normalized: 'bind' },

--- a/packages/semantic/src/generators/profiles/russian.ts
+++ b/packages/semantic/src/generators/profiles/russian.ts
@@ -307,7 +307,7 @@ export const russianProfile: LanguageProfile = {
     stream: { primary: 'транслировать', alternatives: ['поток', 'стрим'], normalized: 'stream' },
     live: {
       primary: 'в-прямом-эфире',
-      alternatives: ['прямой-эфир', 'вживую'],
+      alternatives: ['прямой-эфир', 'вживую', 'живой'],
       normalized: 'live',
     },
     socket: {

--- a/packages/semantic/src/generators/profiles/ukrainian.ts
+++ b/packages/semantic/src/generators/profiles/ukrainian.ts
@@ -317,7 +317,7 @@ export const ukrainianProfile: LanguageProfile = {
     stream: { primary: 'транслювати', alternatives: ['потік', 'стрім'], normalized: 'stream' },
     live: {
       primary: 'наживо',
-      alternatives: ['у-прямому-ефірі', 'в-режимі-реального-часу'],
+      alternatives: ['у-прямому-ефірі', 'в-режимі-реального-часу', 'живий'],
       normalized: 'live',
     },
     socket: {

--- a/packages/semantic/src/generators/profiles/vietnamese.ts
+++ b/packages/semantic/src/generators/profiles/vietnamese.ts
@@ -157,7 +157,7 @@ export const vietnameseProfile: LanguageProfile = {
     // `nối` is reserved as `append` primary — connect uses the compound form only.
     connect: { primary: 'kết-nối', alternatives: ['kết-nối-tới'], normalized: 'connect' },
     stream: { primary: 'truyền-phát', alternatives: ['phát', 'luồng'], normalized: 'stream' },
-    live: { primary: 'trực-tiếp', alternatives: ['phát-trực-tiếp'], normalized: 'live' },
+    live: { primary: 'trực-tiếp', alternatives: ['phát-trực-tiếp', 'live'], normalized: 'live' },
     socket: { primary: 'socket', alternatives: ['ổ-cắm', 'websocket'], normalized: 'socket' },
     // Reactive / realtime commands
     bind: { primary: 'ràng buộc', alternatives: ['liên kết', 'bind'], normalized: 'bind' },

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-07T02:37:49.391Z",
-  "commit": "3a60707",
+  "timestamp": "2026-06-07T03:27:28.400Z",
+  "commit": "4b8878a",
   "languages": {
     "ar": {
       "parseSuccess": 132,
       "parseFailure": 22,
       "parseRate": 0.8571428571428571,
       "avgConfidence": 0.9052167331579098,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -610,7 +610,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7943001443001443,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1235,7 +1235,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9367465504720396,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1859,7 +1859,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2484,7 +2484,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3104,11 +3104,11 @@
       }
     },
     "fr": {
-      "parseSuccess": 151,
-      "parseFailure": 3,
-      "parseRate": 0.9805194805194806,
-      "avgConfidence": 0.9888888888888889,
-      "bundleSize": 395301,
+      "parseSuccess": 153,
+      "parseFailure": 1,
+      "parseRate": 0.9935064935064936,
+      "avgConfidence": 0.989034132171387,
+      "bundleSize": 395307,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3654,6 +3654,14 @@
           "success": true,
           "confidence": 1
         },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-multiple-deps": {
+          "success": true,
+          "confidence": 1
+        },
         "when-value-changes": {
           "success": true,
           "confidence": 1
@@ -3702,12 +3710,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "live-derived-value": {
-          "success": false
-        },
-        "live-multiple-deps": {
-          "success": false
-        },
         "behavior-removable": {
           "success": false
         },
@@ -3730,7 +3732,7 @@
       "parseFailure": 21,
       "parseRate": 0.8636363636363636,
       "avgConfidence": 0.8455185583005137,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4334,7 +4336,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 1,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -4958,7 +4960,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5578,11 +5580,11 @@
       }
     },
     "it": {
-      "parseSuccess": 148,
-      "parseFailure": 6,
-      "parseRate": 0.961038961038961,
-      "avgConfidence": 0.9975975975975976,
-      "bundleSize": 395301,
+      "parseSuccess": 150,
+      "parseFailure": 4,
+      "parseRate": 0.974025974025974,
+      "avgConfidence": 0.9976296296296296,
+      "bundleSize": 395307,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6124,6 +6126,14 @@
           "success": true,
           "confidence": 1
         },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-multiple-deps": {
+          "success": true,
+          "confidence": 1
+        },
         "when-value-changes": {
           "success": true,
           "confidence": 1
@@ -6176,12 +6186,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "live-derived-value": {
-          "success": false
-        },
-        "live-multiple-deps": {
-          "success": false
-        },
         "behavior-removable": {
           "success": false
         },
@@ -6201,7 +6205,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.793957671957672,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6822,7 +6826,7 @@
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.5570015220700152,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7439,7 +7443,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9988455988455989,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8060,11 +8064,11 @@
       }
     },
     "pl": {
-      "parseSuccess": 146,
-      "parseFailure": 8,
-      "parseRate": 0.948051948051948,
-      "avgConfidence": 0.8331811263318118,
-      "bundleSize": 395301,
+      "parseSuccess": 148,
+      "parseFailure": 6,
+      "parseRate": 0.961038961038961,
+      "avgConfidence": 0.835435435435436,
+      "bundleSize": 395307,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8079,6 +8083,14 @@
           "confidence": 1
         },
         "worker-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-multiple-deps": {
           "success": true,
           "confidence": 1
         },
@@ -8650,12 +8662,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "live-derived-value": {
-          "success": false
-        },
-        "live-multiple-deps": {
-          "success": false
-        },
         "when-value-changes": {
           "success": false
         },
@@ -8681,7 +8687,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.838198983297023,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "blur-element": {
           "success": true,
@@ -9305,7 +9311,7 @@
       "parseFailure": 7,
       "parseRate": 0.9545454545454546,
       "avgConfidence": 0.6972789115646258,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -9919,11 +9925,11 @@
       }
     },
     "ru": {
-      "parseSuccess": 152,
-      "parseFailure": 2,
-      "parseRate": 0.987012987012987,
-      "avgConfidence": 0.884962406015038,
-      "bundleSize": 395301,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.8864564007421153,
+      "bundleSize": 395307,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -9998,6 +10004,14 @@
           "confidence": 1
         },
         "on-custom-event-receive": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-multiple-deps": {
           "success": true,
           "confidence": 1
         },
@@ -10532,21 +10546,15 @@
         "install-behavior": {
           "success": true,
           "confidence": 0.5555555555555556
-        },
-        "live-derived-value": {
-          "success": false
-        },
-        "live-multiple-deps": {
-          "success": false
         }
       }
     },
     "sw": {
-      "parseSuccess": 145,
-      "parseFailure": 9,
-      "parseRate": 0.9415584415584416,
-      "avgConfidence": 0.8682211275314727,
-      "bundleSize": 395301,
+      "parseSuccess": 147,
+      "parseFailure": 7,
+      "parseRate": 0.9545454545454546,
+      "avgConfidence": 0.8700140373609765,
+      "bundleSize": 395307,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10641,6 +10649,14 @@
           "confidence": 1
         },
         "beep-debug-expression": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-multiple-deps": {
           "success": true,
           "confidence": 1
         },
@@ -11135,12 +11151,6 @@
         "keydown-key-is-syntax": {
           "success": false
         },
-        "live-derived-value": {
-          "success": false
-        },
-        "live-multiple-deps": {
-          "success": false
-        },
         "behavior-removable": {
           "success": false
         },
@@ -11162,7 +11172,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9402185116470816,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11787,7 +11797,7 @@
       "parseFailure": 24,
       "parseRate": 0.8441558441558441,
       "avgConfidence": 0.8781297134238313,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12388,7 +12398,7 @@
       "parseFailure": 6,
       "parseRate": 0.961038961038961,
       "avgConfidence": 0.7927177177177177,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13003,11 +13013,11 @@
       }
     },
     "uk": {
-      "parseSuccess": 152,
-      "parseFailure": 2,
-      "parseRate": 0.987012987012987,
-      "avgConfidence": 0.8834586466165417,
-      "bundleSize": 395301,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.8849721706864567,
+      "bundleSize": 395307,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13074,6 +13084,14 @@
           "confidence": 1
         },
         "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-multiple-deps": {
           "success": true,
           "confidence": 1
         },
@@ -13616,21 +13634,15 @@
         "install-behavior": {
           "success": true,
           "confidence": 0.5555555555555556
-        },
-        "live-derived-value": {
-          "success": false
-        },
-        "live-multiple-deps": {
-          "success": false
         }
       }
     },
     "vi": {
-      "parseSuccess": 152,
-      "parseFailure": 2,
-      "parseRate": 0.987012987012987,
-      "avgConfidence": 0.8872180451127823,
-      "bundleSize": 395301,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.8886827458256034,
+      "bundleSize": 395307,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13701,6 +13713,14 @@
           "confidence": 1
         },
         "on-custom-event-receive": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-multiple-deps": {
           "success": true,
           "confidence": 1
         },
@@ -14239,12 +14259,6 @@
         "caret-var-on-target": {
           "success": true,
           "confidence": 0.8222222222222222
-        },
-        "live-derived-value": {
-          "success": false
-        },
-        "live-multiple-deps": {
-          "success": false
         }
       }
     },
@@ -14253,7 +14267,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9988148148148148,
-      "bundleSize": 395301,
+      "bundleSize": 395307,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -14872,7 +14886,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 395301,
+      "size": 395307,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
Implements the **`live` block grammar** track from `docs-internal/MULTILINGUAL_ROADMAP.md` (Track 1). Clears **14 failing pattern-instances** — `live-derived-value` + `live-multiple-deps` across fr/it/pl/ru/sw/uk/vi. Priority-bundle average **96.4% → 96.8%**, **zero regressions**.

## Root cause
The roadmap predicted "deep block-grammar work," but diagnosis showed it's the same **keyword-mismatch class** as `socket-basic` (#269): the i18n `GrammarTransformer` translates the `live` block keyword to a form the **semantic** profile didn't list, so the block *starter* wasn't recognized. The block body itself parsed fine; es/de/pt already passed precisely because their emitted forms (`vivo`/`live`) *were* in their semantic profiles.

## Fixes

**fr / it / pl / ru / uk** — add the transformer-emitted `live` form as a semantic alternative:
| lang | added alt |
|---|---|
| fr | `vif` |
| it | `vivo` |
| pl | `żywy` |
| ru | `живой` |
| uk | `живий` |

**sw / vi** — the transformer emitted a **multi-token** form (sw `moja_kwa_moja`, vi `trực tiếp`), and these tokenizers split on hyphen/space with no multi-word-keyword support — so the keyword fragmented (sw's middle `kwa` was even mis-read as the *destination* marker). Fixed at the i18n **dictionary** instead, to a single-token form:
- sw → `mubashara` (natural Swahili, already a semantic `live` alternative — no semantic change needed)
- vi → `live` (idiomatic loanword, single token; added `live` to the vi profile's alternatives)

## Verification (roadmap playbook)
- Probed each pattern via `MultilingualHyperscript.parse()` after rebuilding semantic + i18n + core.
- Repopulated the DB, regenerated the `browser-priority` baseline.
- Baseline diff: **exactly 14 fail→pass flips, 0 pass→fail** across the 7 languages.
- Keyword-collision guard green (25/25). i18n suite green (623/623). Semantic suite green except the known-environmental `build-artifacts.test.ts` `.d.ts` checks (pass in CI).
- Binary `patterns.db` restored (not committed); regenerated baseline JSON committed.

## Remaining Track 1
`when` blocks (12 — ar/he/ja/pl/qu/tr) — the hardest reactive set (possessive + arithmetic + `changes` trigger in the condition). Scoped as the next follow-up PR.

https://claude.ai/code/session_01TdYeGo5Yxrvit2Xdtar1BM

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdYeGo5Yxrvit2Xdtar1BM)_