### PR TITLE
fix(semantic): Hebrew DOM event-name recognition (14 instances)

### DIFF
--- a/packages/semantic/src/tokenizers/he.ts
+++ b/packages/semantic/src/tokenizers/he.ts
@@ -88,6 +88,17 @@ const HEBREW_EXTRAS: KeywordEntry[] = [
   { native: 'שחרור מקש', normalized: 'keyup' },
   { native: 'מעבר עכבר', normalized: 'mouseover' },
   { native: 'יציאת עכבר', normalized: 'mouseout' },
+  // Standard DOM event names commonly written in English even in Hebrew code.
+  // The i18n dictionary has no Hebrew form for these, so the grammar
+  // transformer passes them through verbatim — register them so the emitted
+  // `ב load …` / `ב scroll …` handlers tokenize the event token.
+  { native: 'load', normalized: 'load' },
+  { native: 'resize', normalized: 'resize' },
+  { native: 'scroll', normalized: 'scroll' },
+  { native: 'keydown', normalized: 'keydown' },
+  { native: 'keyup', normalized: 'keyup' },
+  { native: 'mousedown', normalized: 'mousedown' },
+  { native: 'mouseup', normalized: 'mouseup' },
   { native: 'טעינה', normalized: 'load' },
   { native: 'גלילה', normalized: 'scroll' },
 

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-07T03:56:37.550Z",
-  "commit": "0210ab7",
+  "timestamp": "2026-06-07T04:13:48.288Z",
+  "commit": "c5485a3",
   "languages": {
     "ar": {
       "parseSuccess": 134,
@@ -3730,10 +3730,10 @@
       }
     },
     "he": {
-      "parseSuccess": 135,
-      "parseFailure": 19,
-      "parseRate": 0.8766233766233766,
-      "avgConfidence": 0.8478071722516173,
+      "parseSuccess": 149,
+      "parseFailure": 5,
+      "parseRate": 0.9675324675324676,
+      "avgConfidence": 0.8454032172152983,
       "bundleSize": 396800,
       "patterns": {
         "put-content-basic": {
@@ -3924,6 +3924,10 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "trigger-event": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "multiple-events": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -3973,6 +3977,10 @@
           "confidence": 0.8222222222222222
         },
         "focus-element": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "blur-element": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -4028,6 +4036,10 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "modal-close-backdrop": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -4068,6 +4080,22 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "set-opacity": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -4100,6 +4128,14 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "repeat-while": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -4112,7 +4148,15 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "event-throttle": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "event-key-combo": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -4161,6 +4205,10 @@
           "confidence": 0.8222222222222222
         },
         "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "focus-trap": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -4248,6 +4296,10 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "breakpoint-command": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -4264,6 +4316,10 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "caret-var-increment": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -4276,49 +4332,7 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "trigger-event": {
-          "success": false
-        },
-        "blur-element": {
-          "success": false
-        },
-        "modal-close-escape": {
-          "success": false
-        },
-        "window-keydown": {
-          "success": false
-        },
-        "window-scroll": {
-          "success": false
-        },
-        "window-resize": {
-          "success": false
-        },
-        "document-ready": {
-          "success": false
-        },
-        "repeat-until-event": {
-          "success": false
-        },
-        "repeat-forever": {
-          "success": false
-        },
-        "event-throttle": {
-          "success": false
-        },
-        "event-key-combo": {
-          "success": false
-        },
         "announce-screen-reader": {
-          "success": false
-        },
-        "focus-trap": {
-          "success": false
-        },
-        "keydown-key-is-syntax": {
-          "success": false
-        },
-        "caret-var-write": {
           "success": false
         },
         "behavior-removable": {


### PR DESCRIPTION
Pivot from the deep tl/ar Bucket C clusters to **Hebrew**, which had one high-leverage root cause. Clears **14 failing pattern-instances** with a single tokenizer change. he **85.7% → 94.8%**, priority average **97.1% → 97.5%**, **zero regressions**.

## Root cause
The Hebrew tokenizer registers Hebrew event names (`טעינה`=load, `גלילה`=scroll, `לחיצת מקש`=keydown, …), but the he i18n **dictionary** has no Hebrew form for `load`/`resize`/`scroll`/`keydown`/`mousedown`/`mouseup`. So the grammar transformer passes those through **verbatim in English** (`on load …` → `ב load …`), and the he tokenizer didn't recognize the English tokens — every window-/keydown-/load-driven handler failed to parse.

Fix: register the English DOM event names as he tokenizer extras — the same passthrough-alignment used for `socket-basic` (#269). The emitted handlers now tokenize their event token.

## Unlocked (14)
`window-resize`, `window-scroll`, `window-keydown`, `document-ready`, `repeat-forever`, `repeat-until-event`, `blur-element`, `event-throttle`, `event-key-combo`, `keydown-key-is-syntax`, `modal-close-escape`, `trigger-event`, `caret-var-write`, `focus-trap`.

## Verification
- Probed each via `MultilingualHyperscript.parse()`; regenerated the `browser-priority` baseline.
- Baseline diff: **exactly 14 fail→pass flips, 0 regressions** across all 24 languages.
- Collision guard green (25). Semantic suite green except the known-environmental `build-artifacts.test.ts` `.d.ts` checks (5260 passing, unchanged).
- Binary `patterns.db` restored (not committed); regenerated baseline committed.

## Note on remaining Bucket C
This was the cleanest remaining win. The other laggards need deeper, per-pattern work (confirmed by investigation): tl has transformer mangling + keyword collisions (`after`→`pagkatapos` = `then`); tl/ar's `set-@`/`*` family isn't parsed bare even in English. he's residual 5 are 4 Bucket B behaviors + `announce-screen-reader`.

https://claude.ai/code/session_01TdYeGo5Yxrvit2Xdtar1BM

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdYeGo5Yxrvit2Xdtar1BM)_