### PR TITLE
Multilingual roadmap: Track 3 deep grammar fixes (Phases 1–4)

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,15 +5,15 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after #272 (Hebrew DOM event-name recognition). Track 1 (reactive) complete._
+_Last updated: after Phase 1 `@attr`/`*style` tokenizer fix (ar/tl set-\* family). Track 1 (reactive) complete._
 
 ---
 
 ## Current state
 
 Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
-(generated with `--bundle browser-priority`). Cross-language average **97.5%**
-(up from 96.2% at #267).
+(generated with `--bundle browser-priority`). Cross-language average **97.9%**
+(up from 97.5% before Phase 1).
 
 | Rate         | Languages                                   |
 | ------------ | ------------------------------------------- |
@@ -21,14 +21,14 @@ Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
 | 99.4%        | de, es, fr, hi, id, pt                      |
 | 97–99%       | ja (98.7), it/pl/tr/zh (97.4), he/qu (96.8) |
 | 94–96%       | sw (95.5), ko (94.8)                        |
-| **laggards** | **ar (87.0), tl (84.4)**                    |
+| **laggards** | **ar (92.9), tl (89.6)**                    |
 
-**93 failing pattern-instances** remain, now in two tracks (Track 1 reactive is done):
+**~76 failing pattern-instances** remain, now in two tracks (Track 1 reactive is done):
 
 | Track                         | Instances | Nature                                                                          |
 | ----------------------------- | --------- | ------------------------------------------------------------------------------- |
 | **Bucket B — behaviors**      | 24        | Draggable/Sortable/Resizable/Removable not implemented (CI `continue-on-error`) |
-| **Deep per-language grammar** | 69        | Heterogeneous transformer/parser gaps, concentrated in tl (24) / ar (20)        |
+| **Deep per-language grammar** | ~52       | Heterogeneous transformer/parser gaps, concentrated in tl / ar / ko             |
 
 > **The clean keyword/marker-alignment vein is exhausted.** Every remaining
 > non-behavior failure needs per-pattern transformer/parser/grammar work (see
@@ -75,6 +75,30 @@ move was **passthrough-alignment**: when the i18n transformer emits a token verb
 (English, or a form not in the profile), register that exact token on the semantic
 side rather than "fixing" the transformer.
 
+### Phase 1 — `@attr` / `*style` tokenizer fix (ar/tl `set-*` family)
+
+- **17 instances, 0 regressions, avg 97.5% → 97.9%.** ar 87.0% → 92.9%, tl 84.4% → 89.6%.
+- **One-line root cause, shared fix.** The semantic tokenizer's `CssSelectorExtractor`
+  (`packages/semantic/src/tokenizers/extractors/css-selector.ts`) handled `# . [ <`
+  but not `@` or `*`, so `@disabled` / `*opacity` / `*--primary-color` split into
+  `@`+`disabled` etc. and never filled a role (exactly the bug the `$greeting`
+  `variable-ref` extractor was written to avoid). Extended the extractor to keep
+  `@[a-zA-Z_][\w-]*` and `*(?:--)?[a-zA-Z_][\w-]*` as single selector tokens.
+  The `*` regex requires a letter/`_`/`--` immediately after `*`, so multiplication
+  (`a * b`, `2 * 3`) and globs (`*.css`, `/api/*`) — always space/`.`-delimited in the
+  corpus — are never mis-extracted.
+- This is shared across all 24 languages but only flips ar/tl (every other language
+  either passed already or routes `set` through a hand-crafted pattern / a different
+  command). Cleared: `set-attribute`, `set-style`, `set-opacity`, `set-transform`,
+  `default-value`, `tabs-aria`, `toggle-visibility`, `announce-screen-reader` (both
+  ar/tl), plus a bonus ar `transition-color` (uses `*background-color`).
+- **Roadmap note corrected:** the earlier "degenerate empty-body match" / "needs
+  per-language @attr handling" framing was wrong. en parses the body fine; the bug was
+  purely tokenizer-level token-splitting, fixable once in the shared extractor.
+- **Still failing (→ Phase 4):** `set-color-variable` (`set the *--x of #y …` —
+  untranslated article `the` + `of`-possessive) and `input-clear`
+  (`<input/>.value` member access on a selector).
+
 ---
 
 ## Remaining work
@@ -89,15 +113,17 @@ fix. Largest single pattern is `behavior-removable` (fails in 11 langs incl.
 high-rate de/es/fr/it/pt) — worth checking whether it's a _parse_ issue (the
 `install … removable` syntax) separable from the unimplemented-runtime issue.
 
-### Track 3 — Deep per-language grammar (69)
+### Track 3 — Deep per-language grammar (~52 remaining)
 
-Concentrated in **tl (24)** and **ar (20)**; the rest scattered (sw 7, ko 6,
-qu 5, ja/tr 3, zh/it/pl 1–2). Recurring themes — **all confirmed deep** (see below):
+Concentrated in **tl (16)** and **ar (11)**; the rest scattered (ko 8, sw 7,
+qu 5, he/qu 5, ja/tr 3–4, zh/it/pl 1–4). Recurring themes:
 
-- **`set-*` family (ar+tl):** `set-attribute`, `set-style`, `set-opacity`,
-  `set-transform`, `set-color-variable`. The `@attr` / `*style` tokens break
-  tokenization; even in **English** `set @disabled to true` only "passes" via a
-  **degenerate empty-body event-handler match** (the body isn't really parsed).
+- **`set-*` family (ar+tl): MOSTLY DONE in Phase 1.** The `@attr` / `*style`
+  token-splitting bug was fixed once in the shared `CssSelectorExtractor` (see
+  Shipped → Phase 1). Remaining `set-*` stragglers are `set-color-variable`
+  (article `the` + `of`-possessive) and `input-clear` (`<input/>.value` member
+  access) — both deferred to the scattered Phase 4 work below, not the `@`/`*`
+  token issue.
 - **possessive-dot (`.`):** `get-attribute-possessive-dot`,
   `method-call-possessive-dot` (ar/sw/tl) — member-access `.` chains.
 - **`caret`** (caret-var-write/on-target; ar/tl), **`transition-*`**

--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -114,6 +114,33 @@ side rather than "fixing" the transformer.
   handled with the Phase 5 behavior work). Locked in by a grammar.test.ts case.
 - Correct output, e.g. ja: `クリック で JS実行 console.log("from js") 終わり`.
 
+### Phase 3a — event guards + English DOM event passthrough
+
+- **3 instances, 0 regressions, avg 98.05% → 98.13%.** sw `blur-element`,
+  `focus-trap`, `keydown-key-is-syntax`.
+- **Two coordinated fixes:**
+  1. **i18n transformer** — the tokenizer split event guards on internal spaces
+     (`keyup[key is 'Escape']` → `keyup[key` / `is` / `'Escape']`, mis-reading
+     `is` as the action verb), and `translateMultiWordValue` translated keywords
+     _inside_ `[...]` (`is` → sw `ni`). Made `tokenize()` bracket-aware and mask
+     `[...]` guard spans from translation (verbatim, private-use sentinels).
+  2. **framework base tokenizer** — registered the standard English DOM event
+     names (`keyup`/`keydown`/`resize`/…) as universal `!has`-guarded fallbacks in
+     `initializeKeywordsFromProfile`. The transformer passes these through
+     verbatim (no native dictionary form), so non-English token streams treated
+     them as bare identifiers and guarded handlers failed. Generalizes the
+     per-language Hebrew registration from #272 to all 24 languages at once.
+- **Verified safe:** full semantic suite (5260 pass; only the environmental
+  `build-artifacts` `.d.ts` checks fail) and all 759 framework tests pass.
+- **Remaining Phase 3 (deferred — genuinely deep, heterogeneous):**
+  `event-key-combo` (ja/ko/qu/tr) and `repeat-until-event` (hi) need
+  **event-handler-body block masking** (`if…end` / `repeat…end` inside a handler
+  reorder into the role soup); `window-resize` (qu/tr) needs **event-modifier**
+  handling (`from window debounced at 200ms`); `multiple-events` (ar) needs
+  **`or`-conjoined events** in VSO; `on-custom-event-receive` (ko/qu) needs
+  custom-event + `put…into me` reorder; `focus-trap` (tr) needs the body-block
+  work too. Each is a separate transformer enhancement, not a shared fix.
+
 ---
 
 ## Remaining work

--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -99,6 +99,21 @@ side rather than "fixing" the transformer.
   untranslated article `the` + `of`-possessive) and `input-clear`
   (`<input/>.value` member access on a selector).
 
+### Phase 2 — `js-inline` block masking (ja/ko/qu/tr)
+
+- **4 instances, 0 regressions, avg 97.9% → 98.05%.**
+- **Root cause:** the i18n transformer parsed `on click js console.log("from js") end`
+  as one statement with action `js` and the JS body + `end` as the patient role, then
+  reordered it — hoisting the raw JS ahead of the event
+  (`console.log(...) 終わり を クリック で JS実行`).
+- **Fix (`transformer.ts` → `tryTransformJsBlock`):** intercept `[on <event>] js <raw js> end`
+  at the top of `transform()`, before any splitting. The raw JS body is masked behind an
+  opaque placeholder so the surrounding event-handler head reorders normally; the
+  placeholder is then replaced with `<translated js> <verbatim body> <translated end>`.
+  Single-line only for now (multi-line js bodies — e.g. behavior `js(me) … end` — are
+  handled with the Phase 5 behavior work). Locked in by a grammar.test.ts case.
+- Correct output, e.g. ja: `クリック で JS実行 console.log("from js") 終わり`.
+
 ---
 
 ## Remaining work

--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,7 +5,7 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after Phase 1 `@attr`/`*style` tokenizer fix (ar/tl set-\* family). Track 1 (reactive) complete._
+_Last updated: after Phases 1–4 (tokenizer token-split fixes + js/guard masking + English DOM events). Track 1 (reactive) complete._
 
 ---
 
@@ -23,17 +23,18 @@ Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
 | 95–96%       | sw (96.1), ko (95.5)                                |
 | **laggards** | **ar (93.5), tl (90.3)**                            |
 
-**~76 failing pattern-instances** remain, now in two tracks (Track 1 reactive is done):
+**~50 failing pattern-instances** remain after Phases 1–4, in two tracks (Track 1 reactive done):
 
-| Track                         | Instances | Nature                                                                          |
-| ----------------------------- | --------- | ------------------------------------------------------------------------------- |
-| **Bucket B — behaviors**      | 24        | Draggable/Sortable/Resizable/Removable not implemented (CI `continue-on-error`) |
-| **Deep per-language grammar** | ~52       | Heterogeneous transformer/parser gaps, concentrated in tl / ar / ko             |
+| Track                         | Instances | Nature                                                                                 |
+| ----------------------------- | --------- | -------------------------------------------------------------------------------------- |
+| **Bucket B — behaviors**      | ~26       | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`)       |
+| **Deep per-language grammar** | ~24       | Heterogeneous transformer/parser gaps (method-calls, modifiers, reorder) — see Track 4 |
 
-> **The clean keyword/marker-alignment vein is exhausted.** Every remaining
+> **The clean tokenizer token-split vein is now largely worked out** (Phases 1 & 4
+> cleared `@`/`*`/`^`; Phase 3a the English DOM events). Every remaining
 > non-behavior failure needs per-pattern transformer/parser/grammar work (see
-> "Why the rest is hard"). There is no longer a uniform fix that clears a whole
-> cluster the way #269–#272 did.
+> Track 4 and "Why the rest is hard"). There is no longer a uniform fix that
+> clears a whole cluster.
 
 ---
 

--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -12,16 +12,16 @@ _Last updated: after Phase 1 `@attr`/`*style` tokenizer fix (ar/tl set-\* family
 ## Current state
 
 Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
-(generated with `--bundle browser-priority`). Cross-language average **97.9%**
-(up from 97.5% before Phase 1).
+(generated with `--bundle browser-priority`). Cross-language average **98.2%**
+(up from 97.5% before Phase 1; Phases 1, 2, 3a, 4 shipped: +26 instances).
 
-| Rate         | Languages                                   |
-| ------------ | ------------------------------------------- |
-| 100%         | en, bn, ms, ru, th, uk, vi                  |
-| 99.4%        | de, es, fr, hi, id, pt                      |
-| 97–99%       | ja (98.7), it/pl/tr/zh (97.4), he/qu (96.8) |
-| 94–96%       | sw (95.5), ko (94.8)                        |
-| **laggards** | **ar (92.9), tl (89.6)**                    |
+| Rate         | Languages                                           |
+| ------------ | --------------------------------------------------- |
+| 100%         | en, bn, ms, ru, th, uk, vi                          |
+| 99.4%        | de, es, fr, hi, id, pt                              |
+| 97–99%       | ja (99.4), tr/zh (98.1), it/pl (97.4), he/qu (96.8) |
+| 95–96%       | sw (96.1), ko (95.5)                                |
+| **laggards** | **ar (93.5), tl (90.3)**                            |
 
 **~76 failing pattern-instances** remain, now in two tracks (Track 1 reactive is done):
 
@@ -140,6 +140,36 @@ side rather than "fixing" the transformer.
   **`or`-conjoined events** in VSO; `on-custom-event-receive` (ko/qu) needs
   custom-event + `put…into me` reorder; `focus-trap` (tr) needs the body-block
   work too. Each is a separate transformer enhancement, not a shared fix.
+
+### Phase 4 — caret variable token-split (ar/tl)
+
+- **2 instances, 0 regressions, avg 98.13% → 98.19%.** ar/tl `caret-var-write`.
+- **Root cause:** the `variable-ref` extractor kept `:local` / `$global` together
+  but not `^caret`, so `^count` split into `^` + `count` and never filled a role
+  (same class as Phase 1's `@`/`*`). Added `^` (identifier-start required, so the
+  XOR operator `a ^ b` is never mis-extracted). Locked by a variable-ref.test.ts
+  case. `caret-var-on-target` still fails — its `… on #host into me` destination
+  reorders (separate issue, below).
+
+### Track 4 — Scattered per-language remainder (deferred, ~deep)
+
+After Phases 1–4 the non-behavior failures left are all genuinely deep, each its
+own transformer/parser project (no shared lever remains):
+
+- **method-call / member-access** (`my.value.toUpperCase()`, `my.getAttribute(…)`;
+  ar/sw/tl) — the trailing `()` method call splits into `(`/`)` tokens and isn't
+  parsed; fails even in en via the raw semantic path. Needs method-call parsing.
+- **`transition-*` `over <dur>` modifier** (ko/tl) — `over 500ms` modifier is
+  dropped/misplaced in word-order reorder.
+- **`scroll to last <sel> in …`** (last-in-collection; ar/tl) — `scroll to` +
+  positional `last` + `in` source structure. (Tag-less `<.class/>` query selectors
+  also tokenize whole now would help, but the structure is the real blocker.)
+- **`unless <cond>`** (ar/tl) — the condition (`I match .disabled`) keeps English
+  `I`/`match` and the `unless` block isn't reassembled.
+- **`put … before/after`** (tl) — `after` → `pagkatapos` collides with `then`.
+- **caret-var-on-target, announce-screen-reader (he/sw), set-color-variable,
+  input-clear, form-disable-on-submit, multiple-events** — destination/compound
+  reorder + article/`of`-possessive + `or`-events (see Phase 3 notes).
 
 ---
 

--- a/packages/framework/src/core/tokenization/base-tokenizer.ts
+++ b/packages/framework/src/core/tokenization/base-tokenizer.ts
@@ -41,6 +41,39 @@ const SIMPLE_TOKENIZER_OPERATOR_SET = new Set(DEFAULT_OPERATORS);
 export type { KeywordEntry };
 
 /**
+ * Standard DOM event names recognized in every language as universal fallbacks.
+ * The i18n grammar transformer emits these verbatim (no native dictionary form),
+ * so each tokenizer must accept them or English-named event handlers won't parse.
+ * Kept to genuine DOM event names (not command verbs) to minimize collisions; the
+ * registration is `!has`-guarded so any native keyword of the same spelling wins.
+ */
+const ENGLISH_DOM_EVENT_NAMES: readonly string[] = [
+  'click',
+  'dblclick',
+  'input',
+  'change',
+  'submit',
+  'keydown',
+  'keyup',
+  'keypress',
+  'mousedown',
+  'mouseup',
+  'mouseover',
+  'mouseout',
+  'mouseenter',
+  'mouseleave',
+  'mousemove',
+  'pointerdown',
+  'pointerup',
+  'pointermove',
+  'focus',
+  'blur',
+  'load',
+  'resize',
+  'scroll',
+];
+
+/**
  * Profile interface for keyword derivation.
  * Matches the structure of LanguageProfile but only includes fields needed for tokenization.
  */
@@ -353,6 +386,20 @@ export abstract class BaseTokenizer implements LanguageTokenizer {
     if (profile.possessive?.keywords) {
       for (const [native, normalized] of Object.entries(profile.possessive.keywords)) {
         keywordMap.set(native, { native, normalized });
+      }
+    }
+
+    // Register English DOM event names as universal fallbacks. The i18n grammar
+    // transformer has no native form for most DOM events, so it passes them
+    // through verbatim (`on keyup …` → `<on-marker> keyup …`). Without these,
+    // non-English token streams treat `keyup`/`keydown`/`resize`/… as bare
+    // identifiers, and event handlers using them (often with `[key==…]` guards)
+    // fail to parse. Guarded by `!has` so any native mapping wins (same policy
+    // as the English-reference fallbacks above). Generalizes the per-language
+    // registration introduced for Hebrew in #272.
+    for (const evt of ENGLISH_DOM_EVENT_NAMES) {
+      if (!keywordMap.has(evt)) {
+        keywordMap.set(evt, { native: evt, normalized: evt });
       }
     }
 

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -399,6 +399,15 @@ describe('GrammarTransformer', () => {
       expect(result).toContain('#output');
     });
 
+    it('should keep event guards intact and untranslated', () => {
+      // `[key is 'Escape']` must stay one token with its contents verbatim —
+      // the spaces must not split it, and `is` must not be translated as a verb.
+      const result = transformer.transform("on keyup[key is 'Escape'] clear me");
+      // Guard stays one verbatim token attached to the event (not split on its
+      // internal spaces), and `is` inside it is not translated to a verb.
+      expect(result).toContain("keyup[key is 'Escape']");
+    });
+
     it('should mask inline js bodies from word-order reordering', () => {
       // The raw JS body must stay verbatim and immediately after the (translated)
       // `js` keyword — never reordered ahead of the event like other roles.

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -398,6 +398,17 @@ describe('GrammarTransformer', () => {
       const result = transformer.transform('on input put value into #output');
       expect(result).toContain('#output');
     });
+
+    it('should mask inline js bodies from word-order reordering', () => {
+      // The raw JS body must stay verbatim and immediately after the (translated)
+      // `js` keyword — never reordered ahead of the event like other roles.
+      const result = transformer.transform('on click js console.log("from js") end');
+      expect(result).toContain('console.log("from js")');
+      // js keyword precedes the raw body, which precedes the translated `end`.
+      expect(result).toMatch(/JS実行\s+console\.log\("from js"\)\s+終わり/);
+      // The body must not be split/reordered: no marker particle injected inside it.
+      expect(result).not.toMatch(/console\.log.*を.*from/);
+    });
   });
 
   describe('Arabic Transformation (VSO)', () => {

--- a/packages/i18n/src/grammar/transformer.ts
+++ b/packages/i18n/src/grammar/transformer.ts
@@ -1311,6 +1311,15 @@ export class GrammarTransformer {
   transform(input: string): string {
     const targetThen = getTargetThenKeyword(this.targetProfile.code);
 
+    // Inline JS blocks (`... js <raw js> end`) must be masked BEFORE any
+    // splitting/reordering: the body is raw JavaScript, not hyperscript, so it
+    // must never be tokenized, translated, or word-order reordered. (Single-line
+    // only here; multi-line js bodies are handled with the behavior work.)
+    if (!input.includes('\n')) {
+      const jsBlock = this.tryTransformJsBlock(input);
+      if (jsBlock !== null) return jsBlock;
+    }
+
     // Check if input has multi-line structure worth preserving
     const hasMultiLineStructure = input.includes('\n');
 
@@ -1391,6 +1400,68 @@ export class GrammarTransformer {
 
     // 7. Join without markers (still use joinTokens for consistency)
     return joinTokens(reordered.map(e => e.translated || e.value));
+  }
+
+  /**
+   * Detect and transform an inline JS block (`[on <event>] js <raw js> end`).
+   *
+   * The `js ... end` body is raw JavaScript: it must not be tokenized,
+   * translated, or word-order reordered. We mask the whole block with a single
+   * opaque placeholder, run the surrounding statement (the event-handler head,
+   * if any) through the normal reorder pipeline so the placeholder lands in the
+   * correct action position, then substitute the translated `js`/`end` keywords
+   * around the verbatim body.
+   *
+   * Returns `null` (fall through to the normal path) when there is no js block,
+   * no matching `end`, or trailing content after `end` (kept tight on purpose).
+   */
+  private tryTransformJsBlock(input: string): string | null {
+    const src = this.sourceProfile.code;
+    const dst = this.targetProfile.code;
+
+    // The `js` / `end` keyword forms in the SOURCE language.
+    const sourceJs = translateWord('js', 'en', src);
+    const sourceEnd = translateWord('end', 'en', src).toLowerCase();
+
+    const tokens = input.split(/\s+/).filter(t => t.length > 0);
+    // The js command token, optionally with a `(locals)` suffix: `js`, `js(me)`.
+    const escapedJs = sourceJs.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const jsRe = new RegExp(`^${escapedJs}(\\(.*\\))?$`, 'i');
+    const jsIdx = tokens.findIndex(t => jsRe.test(t));
+    if (jsIdx === -1) return null;
+
+    // First `end` after the js keyword closes the block (raw JS never contains a
+    // bare hyperscript `end` token).
+    let endIdx = -1;
+    for (let i = jsIdx + 1; i < tokens.length; i++) {
+      if (tokens[i].toLowerCase() === sourceEnd) {
+        endIdx = i;
+        break;
+      }
+    }
+    if (endIdx === -1) return null;
+    // Trailing content after `end` — leave for the normal path.
+    if (endIdx !== tokens.length - 1) return null;
+
+    const jsToken = tokens[jsIdx];
+    const jsParen = jsToken.match(jsRe)?.[1] ?? '';
+    const jsKeywordRaw = jsParen ? jsToken.slice(0, jsToken.length - jsParen.length) : jsToken;
+
+    const body = tokens.slice(jsIdx + 1, endIdx).join(' ');
+    const targetJs = translateWord(jsKeywordRaw, src, dst) + jsParen;
+    const targetEnd = translateWord(tokens[endIdx], src, dst);
+    const replacement = [targetJs, body, targetEnd].filter(s => s.length > 0).join(' ');
+
+    const before = tokens.slice(0, jsIdx);
+    // Bare `js ... end` with no leading event-handler head: emit directly.
+    if (before.length === 0) return replacement;
+
+    // Mask the block as one opaque action token, reorder the surrounding
+    // statement, then restore the verbatim block.
+    const placeholder = 'JSBLOCKPLACEHOLDER';
+    const reordered = this.transformSingle([...before, placeholder].join(' '));
+    if (!reordered.includes(placeholder)) return null; // unexpected — fall through
+    return reordered.replace(placeholder, replacement);
   }
 
   /**

--- a/packages/i18n/src/grammar/transformer.ts
+++ b/packages/i18n/src/grammar/transformer.ts
@@ -728,6 +728,7 @@ function tokenize(input: string, profile: LanguageProfile): string[] {
   let current = '';
   let inSelector = false;
   let selectorDepth = 0;
+  let bracketDepth = 0;
 
   for (let i = 0; i < input.length; i++) {
     const char = input[i];
@@ -741,8 +742,17 @@ function tokenize(input: string, profile: LanguageProfile): string[] {
       if (selectorDepth === 0) inSelector = false;
     }
 
-    // Split on whitespace unless in selector
-    if (/\s/.test(char) && !inSelector) {
+    // Track event-guard / attribute brackets so `[key is 'Escape']` (which has
+    // internal spaces) stays a single token instead of splitting into
+    // `[key` / `is` / `'Escape']` — which mis-assigns `is` as the action verb.
+    if (char === '[') {
+      bracketDepth++;
+    } else if (char === ']' && bracketDepth > 0) {
+      bracketDepth--;
+    }
+
+    // Split on whitespace unless inside a selector or a bracket guard
+    if (/\s/.test(char) && !inSelector && bracketDepth === 0) {
       if (current) {
         tokens.push(current);
         current = '';
@@ -1180,6 +1190,21 @@ function translateMultiWordValue(
   sourceLocale: string,
   targetLocale: string
 ): string {
+  // Mask event-guard / attribute brackets (`[key is 'Escape']`): their contents
+  // are expression syntax, not translatable keywords — translating `is` -> `ni`
+  // etc. inside them breaks the guard. Restore verbatim after translation.
+  if (value.includes('[')) {
+    const guards: string[] = [];
+    const masked = value.replace(/\[[^\]]*\]/g, match => {
+      guards.push(match);
+      return `${guards.length - 1}`;
+    });
+    if (guards.length > 0) {
+      const translated = translateMultiWordValue(masked, sourceLocale, targetLocale);
+      return translated.replace(/(\d+)/g, (_, n) => guards[Number(n)]);
+    }
+  }
+
   // If it's a single word, check for possessive then translate
   if (!value.includes(' ')) {
     // Check for possessive 's

--- a/packages/semantic/src/tokenizers/extractors/css-selector.ts
+++ b/packages/semantic/src/tokenizers/extractors/css-selector.ts
@@ -1,7 +1,7 @@
 /**
  * CSS Selector Extractor
  *
- * Extracts CSS selectors: #id, .class, [attr], <tag/>
+ * Extracts CSS selectors: #id, .class, [attr], <tag/>, @attr, *style
  * This is hyperscript-specific syntax.
  */
 
@@ -23,6 +23,23 @@ export function extractCssSelector(input: string, position: number): string | nu
   // Class selector: .identifier
   if (char === '.') {
     const match = input.slice(position).match(/^\.[a-zA-Z_][\w-]*/);
+    return match ? match[0] : null;
+  }
+
+  // Attribute reference: @attr (@disabled, @aria-selected, @data-count, @role)
+  // hyperscript's possessive-free attribute syntax. Kept as a single token so
+  // it fills a role; otherwise `@disabled` splits into `@` + `disabled`.
+  if (char === '@') {
+    const match = input.slice(position).match(/^@[a-zA-Z_][\w-]*/);
+    return match ? match[0] : null;
+  }
+
+  // Style/CSS-property reference: *prop or *--custom-prop
+  // (*opacity, *background-color, *--primary-color). Requires a letter, `_`, or
+  // a `--` custom-property prefix immediately after `*`, so the multiplication
+  // operator (`a * b`, `2 * 3`) is never mis-extracted.
+  if (char === '*') {
+    const match = input.slice(position).match(/^\*(?:--)?[a-zA-Z_][\w-]*/);
     return match ? match[0] : null;
   }
 
@@ -60,7 +77,11 @@ export class CssSelectorExtractor implements ValueExtractor {
 
   canExtract(input: string, position: number): boolean {
     const char = input[position];
-    return char === '#' || char === '.' || char === '[' || char === '<';
+    if (char === '#' || char === '.' || char === '[' || char === '<') return true;
+    // @attr / *style only when a valid name (or *-- custom property) follows, so
+    // a bare `*` (multiplication) or stray `@` does not get swallowed.
+    if (char === '@' || char === '*') return extractCssSelector(input, position) !== null;
+    return false;
   }
 
   extract(input: string, position: number): ExtractionResult | null {

--- a/packages/semantic/src/tokenizers/extractors/variable-ref.ts
+++ b/packages/semantic/src/tokenizers/extractors/variable-ref.ts
@@ -4,13 +4,16 @@
  * Extracts variable references:
  * - `:varname` — element-scoped local variables (`:count`, `:x`)
  * - `$varname` — global variables (`$count`, `$greeting`)
+ * - `^varname` — caret/published variables (`^count`)
  *
- * This is hyperscript-specific syntax. Both prefixes are kept attached to the
+ * This is hyperscript-specific syntax. All prefixes are kept attached to the
  * name so the reference tokenizes as a single token (otherwise `$greeting`
  * would split into `$` + `greeting` and never fill a role).
  *
  * The `$` form deliberately does NOT match `${` (template-literal
- * interpolation): the char after `$` must be an identifier start.
+ * interpolation): the char after `$` must be an identifier start. The `^` form
+ * requires an identifier start too, so the XOR operator (`a ^ b`) — always
+ * space-delimited — is never mis-extracted.
  */
 
 import type { ValueExtractor, ExtractionResult } from '../value-extractor-types';
@@ -24,7 +27,7 @@ export class VariableRefExtractor implements ValueExtractor {
   canExtract(input: string, position: number): boolean {
     const ch = input[position];
     return (
-      (ch === ':' || ch === '$') &&
+      (ch === ':' || ch === '$' || ch === '^') &&
       position + 1 < input.length &&
       /[a-zA-Z_]/.test(input[position + 1])
     );

--- a/packages/semantic/test/extractors/variable-ref.test.ts
+++ b/packages/semantic/test/extractors/variable-ref.test.ts
@@ -21,6 +21,15 @@ describe('VariableRefExtractor', () => {
     expect(ex.extract('$x_1', 0)?.value).toBe('$x_1');
   });
 
+  it('extracts a ^caret variable whole', () => {
+    expect(ex.extract('^count', 0)?.value).toBe('^count');
+  });
+
+  it('does NOT match the bare `^` XOR operator', () => {
+    // `a ^ b` — space after `^`, so it is not a caret variable.
+    expect(ex.canExtract('^ b', 0)).toBe(false);
+  });
+
   it('stops at non-identifier characters', () => {
     // "$name to" → only "$name" is the variable token
     const r = ex.extract('$name to #x', 0);

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-07T04:13:48.288Z",
-  "commit": "c5485a3",
+  "timestamp": "2026-06-07T05:30:51.010Z",
+  "commit": "ec634dd",
   "languages": {
     "ar": {
-      "parseSuccess": 134,
-      "parseFailure": 20,
-      "parseRate": 0.8701298701298701,
-      "avgConfidence": 0.9066314087824187,
-      "bundleSize": 396800,
+      "parseSuccess": 143,
+      "parseFailure": 11,
+      "parseRate": 0.9285714285714286,
+      "avgConfidence": 0.9125077536842245,
+      "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -34,6 +34,14 @@
           "confidence": 1
         },
         "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
           "success": true,
           "confidence": 1
         },
@@ -78,6 +86,10 @@
           "confidence": 1
         },
         "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-visibility": {
           "success": true,
           "confidence": 1
         },
@@ -145,6 +157,10 @@
           "success": true,
           "confidence": 1
         },
+        "default-value": {
+          "success": true,
+          "confidence": 1
+        },
         "tell-command": {
           "success": true,
           "confidence": 1
@@ -162,6 +178,10 @@
           "confidence": 1
         },
         "tabs-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-aria": {
           "success": true,
           "confidence": 1
         },
@@ -213,6 +233,18 @@
           "success": true,
           "confidence": 1
         },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
         "closest-ancestor": {
           "success": true,
           "confidence": 1
@@ -250,6 +282,10 @@
           "confidence": 1
         },
         "computed-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-aria-expanded": {
           "success": true,
           "confidence": 1
         },
@@ -481,27 +517,12 @@
           "success": true,
           "confidence": 0.5294117647058824
         },
-        "set-attribute": {
-          "success": false
-        },
-        "set-style": {
-          "success": false
-        },
-        "toggle-visibility": {
-          "success": false
-        },
         "multiple-events": {
-          "success": false
-        },
-        "default-value": {
           "success": false
         },
         "async-block": {
           "success": true,
           "confidence": 0.5
-        },
-        "tabs-aria": {
-          "success": false
         },
         "modal-close-button": {
           "success": true,
@@ -521,16 +542,7 @@
           "success": true,
           "confidence": 0.5
         },
-        "set-opacity": {
-          "success": false
-        },
-        "set-transform": {
-          "success": false
-        },
         "set-color-variable": {
-          "success": false
-        },
-        "transition-color": {
           "success": false
         },
         "last-in-collection": {
@@ -563,12 +575,9 @@
         "unless-condition": {
           "success": false
         },
-        "toggle-aria-expanded": {
+        "announce-screen-reader": {
           "success": true,
           "confidence": 0.5
-        },
-        "announce-screen-reader": {
-          "success": false
         },
         "method-call-possessive-dot": {
           "success": false
@@ -611,8 +620,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7943001443001443,
-      "bundleSize": 396800,
+      "avgConfidence": 0.8267676767676768,
+      "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -642,6 +651,14 @@
           "success": true,
           "confidence": 1
         },
+        "set-attribute": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
+          "success": true,
+          "confidence": 1
+        },
         "put-content-basic": {
           "success": true,
           "confidence": 1
@@ -667,6 +684,10 @@
           "confidence": 1
         },
         "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-visibility": {
           "success": true,
           "confidence": 1
         },
@@ -750,6 +771,10 @@
           "success": true,
           "confidence": 1
         },
+        "default-value": {
+          "success": true,
+          "confidence": 1
+        },
         "tell-command": {
           "success": true,
           "confidence": 1
@@ -763,6 +788,10 @@
           "confidence": 1
         },
         "tabs-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-aria": {
           "success": true,
           "confidence": 1
         },
@@ -794,7 +823,23 @@
           "success": true,
           "confidence": 1
         },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
         "window-scroll": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-color": {
           "success": true,
           "confidence": 1
         },
@@ -855,6 +900,10 @@
           "confidence": 1
         },
         "stagger-animation": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-aria-expanded": {
           "success": true,
           "confidence": 1
         },
@@ -978,14 +1027,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "set-attribute": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-style": {
-          "success": true,
-          "confidence": 0.5
-        },
         "put-before": {
           "success": true,
           "confidence": 0.5
@@ -999,10 +1040,6 @@
           "confidence": 0.5
         },
         "make-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "toggle-visibility": {
           "success": true,
           "confidence": 0.5
         },
@@ -1030,19 +1067,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "default-value": {
-          "success": true,
-          "confidence": 0.5
-        },
         "call-function": {
           "success": true,
           "confidence": 0.5
         },
         "js-inline": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "tabs-aria": {
           "success": true,
           "confidence": 0.5
         },
@@ -1070,10 +1099,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 0.5
-        },
         "window-keydown": {
           "success": true,
           "confidence": 0.5
@@ -1086,19 +1111,7 @@
           "success": true,
           "confidence": 0.5
         },
-        "set-opacity": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-transform": {
-          "success": true,
-          "confidence": 0.5
-        },
         "set-color-variable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "transition-color": {
           "success": true,
           "confidence": 0.5
         },
@@ -1139,10 +1152,6 @@
           "confidence": 0.5
         },
         "computed-value": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "toggle-aria-expanded": {
           "success": true,
           "confidence": 0.5
         },
@@ -1236,8 +1245,8 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.9367465504720396,
-      "bundleSize": 396800,
+      "avgConfidence": 0.9374935159248873,
+      "bundleSize": 396996,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1348,6 +1357,10 @@
           "confidence": 1
         },
         "input-clear": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
           "success": true,
           "confidence": 1
         },
@@ -1712,10 +1725,6 @@
           "confidence": 0.8857142857142858
         },
         "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-disable-on-submit": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -1861,7 +1870,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 396800,
+      "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2486,7 +2495,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 396800,
+      "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3110,7 +3119,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 396800,
+      "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3733,8 +3742,8 @@
       "parseSuccess": 149,
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
-      "avgConfidence": 0.8454032172152983,
-      "bundleSize": 396800,
+      "avgConfidence": 0.8442100777671253,
+      "bundleSize": 396996,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -3745,10 +3754,6 @@
           "confidence": 1
         },
         "input-mirror": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-color": {
           "success": true,
           "confidence": 1
         },
@@ -4108,6 +4113,10 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "transition-color": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "next-element": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -4354,7 +4363,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 1,
-      "bundleSize": 396800,
+      "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -4978,7 +4987,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 396800,
+      "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5602,7 +5611,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9976296296296296,
-      "bundleSize": 396800,
+      "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6222,8 +6231,8 @@
       "parseSuccess": 152,
       "parseFailure": 2,
       "parseRate": 0.987012987012987,
-      "avgConfidence": 0.7966687552213868,
-      "bundleSize": 396800,
+      "avgConfidence": 0.8262740183792815,
+      "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6250,6 +6259,14 @@
           "confidence": 1
         },
         "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
           "success": true,
           "confidence": 1
         },
@@ -6282,6 +6299,10 @@
           "confidence": 1
         },
         "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-visibility": {
           "success": true,
           "confidence": 1
         },
@@ -6377,6 +6398,10 @@
           "success": true,
           "confidence": 1
         },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 1
+        },
         "modal-open": {
           "success": true,
           "confidence": 1
@@ -6402,6 +6427,22 @@
           "confidence": 1
         },
         "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-color": {
           "success": true,
           "confidence": 1
         },
@@ -6458,6 +6499,10 @@
           "confidence": 1
         },
         "stagger-animation": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-aria-expanded": {
           "success": true,
           "confidence": 1
         },
@@ -6589,14 +6634,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "set-attribute": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-style": {
-          "success": true,
-          "confidence": 0.5
-        },
         "put-before": {
           "success": true,
           "confidence": 0.5
@@ -6606,10 +6643,6 @@
           "confidence": 0.5
         },
         "append-content": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "toggle-visibility": {
           "success": true,
           "confidence": 0.5
         },
@@ -6652,10 +6685,6 @@
         "js-inline": {
           "success": false
         },
-        "tabs-aria": {
-          "success": true,
-          "confidence": 0.5
-        },
         "modal-close-button": {
           "success": true,
           "confidence": 0.5
@@ -6676,10 +6705,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 0.5
-        },
         "window-keydown": {
           "success": true,
           "confidence": 0.5
@@ -6696,19 +6721,7 @@
           "success": true,
           "confidence": 0.5
         },
-        "set-opacity": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-transform": {
-          "success": true,
-          "confidence": 0.5
-        },
         "set-color-variable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "transition-color": {
           "success": true,
           "confidence": 0.5
         },
@@ -6748,10 +6761,6 @@
           "confidence": 0.5
         },
         "computed-value": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "toggle-aria-expanded": {
           "success": true,
           "confidence": 0.5
         },
@@ -6846,7 +6855,7 @@
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.5570015220700152,
-      "bundleSize": 396800,
+      "bundleSize": 396996,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7463,7 +7472,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9988455988455989,
-      "bundleSize": 396800,
+      "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8088,7 +8097,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.8352592592592598,
-      "bundleSize": 396800,
+      "bundleSize": 396996,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8709,7 +8718,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.838198983297023,
-      "bundleSize": 396800,
+      "bundleSize": 396996,
       "patterns": {
         "blur-element": {
           "success": true,
@@ -9332,8 +9341,8 @@
       "parseSuccess": 149,
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
-      "avgConfidence": 0.7013422818791947,
-      "bundleSize": 396800,
+      "avgConfidence": 0.7114093959731543,
+      "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -9372,6 +9381,10 @@
           "confidence": 1
         },
         "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-visibility": {
           "success": true,
           "confidence": 1
         },
@@ -9459,6 +9472,10 @@
           "success": true,
           "confidence": 1
         },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
         "closest-ancestor": {
           "success": true,
           "confidence": 1
@@ -9484,6 +9501,10 @@
           "confidence": 1
         },
         "stagger-animation": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-aria-expanded": {
           "success": true,
           "confidence": 1
         },
@@ -9612,10 +9633,6 @@
           "confidence": 0.5
         },
         "swap-content": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "toggle-visibility": {
           "success": true,
           "confidence": 0.5
         },
@@ -9756,10 +9773,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "transition-color": {
-          "success": true,
-          "confidence": 0.5
-        },
         "next-element": {
           "success": true,
           "confidence": 0.5
@@ -9828,10 +9841,6 @@
           "confidence": 0.5
         },
         "computed-value": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "toggle-aria-expanded": {
           "success": true,
           "confidence": 0.5
         },
@@ -9952,8 +9961,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8864564007421153,
-      "bundleSize": 396800,
+      "avgConfidence": 0.8860441146155434,
+      "bundleSize": 396996,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -9987,7 +9996,7 @@
           "success": true,
           "confidence": 1
         },
-        "transition-color": {
+        "form-disable-on-submit": {
           "success": true,
           "confidence": 1
         },
@@ -10251,10 +10260,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "document-ready": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -10467,6 +10472,10 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "transition-color": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "last-in-collection": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -10577,8 +10586,8 @@
       "parseSuccess": 147,
       "parseFailure": 7,
       "parseRate": 0.9545454545454546,
-      "avgConfidence": 0.8700140373609765,
-      "bundleSize": 396800,
+      "avgConfidence": 0.8768383543893751,
+      "bundleSize": 396996,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10589,6 +10598,14 @@
           "confidence": 1
         },
         "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
           "success": true,
           "confidence": 1
         },
@@ -10604,11 +10621,27 @@
           "success": true,
           "confidence": 1
         },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 1
+        },
         "input-mirror": {
           "success": true,
           "confidence": 1
         },
         "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
           "success": true,
           "confidence": 1
         },
@@ -10876,10 +10909,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "document-ready": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -10988,14 +11017,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "set-attribute": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "set-style": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "put-before": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -11044,10 +11065,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "tabs-aria": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "modal-close-button": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -11061,14 +11078,6 @@
           "confidence": 0.8222222222222222
         },
         "window-resize": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "set-opacity": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "set-transform": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -11195,8 +11204,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.9402185116470816,
-      "bundleSize": 396800,
+      "avgConfidence": 0.940960626674911,
+      "bundleSize": 396996,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11287,6 +11296,10 @@
           "confidence": 1
         },
         "input-clear": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
           "success": true,
           "confidence": 1
         },
@@ -11671,10 +11684,6 @@
           "confidence": 0.8857142857142858
         },
         "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-disable-on-submit": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -11817,11 +11826,11 @@
       }
     },
     "tl": {
-      "parseSuccess": 130,
-      "parseFailure": 24,
-      "parseRate": 0.8441558441558441,
-      "avgConfidence": 0.8781297134238313,
-      "bundleSize": 396800,
+      "parseSuccess": 138,
+      "parseFailure": 16,
+      "parseRate": 0.8961038961038961,
+      "avgConfidence": 0.8835383428733814,
+      "bundleSize": 396996,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11832,6 +11841,14 @@
           "confidence": 1
         },
         "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
           "success": true,
           "confidence": 1
         },
@@ -11863,6 +11880,10 @@
           "success": true,
           "confidence": 1
         },
+        "default-value": {
+          "success": true,
+          "confidence": 1
+        },
         "tell-command": {
           "success": true,
           "confidence": 1
@@ -11872,6 +11893,10 @@
           "confidence": 1
         },
         "js-inline": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-aria": {
           "success": true,
           "confidence": 1
         },
@@ -11904,6 +11929,14 @@
           "confidence": 1
         },
         "document-ready": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
           "success": true,
           "confidence": 1
         },
@@ -12083,6 +12116,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "wait-then": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -12164,6 +12201,10 @@
           "confidence": 0.8857142857142858
         },
         "slide-toggle": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-aria-expanded": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -12295,19 +12336,10 @@
           "success": true,
           "confidence": 0.5294117647058824
         },
-        "set-attribute": {
-          "success": false
-        },
-        "set-style": {
-          "success": false
-        },
         "put-before": {
           "success": false
         },
         "put-after": {
-          "success": false
-        },
-        "toggle-visibility": {
           "success": false
         },
         "transition-opacity": {
@@ -12323,15 +12355,9 @@
           "success": true,
           "confidence": 0.5
         },
-        "default-value": {
-          "success": false
-        },
         "async-block": {
           "success": true,
           "confidence": 0.5
-        },
-        "tabs-aria": {
-          "success": false
         },
         "modal-close-button": {
           "success": true,
@@ -12346,12 +12372,6 @@
         "window-scroll": {
           "success": true,
           "confidence": 0.5
-        },
-        "set-opacity": {
-          "success": false
-        },
-        "set-transform": {
-          "success": false
         },
         "set-color-variable": {
           "success": false
@@ -12384,12 +12404,9 @@
         "fade-out-remove": {
           "success": false
         },
-        "toggle-aria-expanded": {
+        "announce-screen-reader": {
           "success": true,
           "confidence": 0.5
-        },
-        "announce-screen-reader": {
-          "success": false
         },
         "method-call-possessive-dot": {
           "success": false
@@ -12421,8 +12438,8 @@
       "parseSuccess": 150,
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
-      "avgConfidence": 0.7988148148148149,
-      "bundleSize": 396800,
+      "avgConfidence": 0.8288148148148148,
+      "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -12449,6 +12466,10 @@
           "confidence": 1
         },
         "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
           "success": true,
           "confidence": 1
         },
@@ -12485,6 +12506,10 @@
           "confidence": 1
         },
         "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-visibility": {
           "success": true,
           "confidence": 1
         },
@@ -12568,6 +12593,10 @@
           "success": true,
           "confidence": 1
         },
+        "default-value": {
+          "success": true,
+          "confidence": 1
+        },
         "tell-command": {
           "success": true,
           "confidence": 1
@@ -12581,6 +12610,10 @@
           "confidence": 1
         },
         "tabs-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-aria": {
           "success": true,
           "confidence": 1
         },
@@ -12609,6 +12642,22 @@
           "confidence": 1
         },
         "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-color": {
           "success": true,
           "confidence": 1
         },
@@ -12661,6 +12710,10 @@
           "confidence": 1
         },
         "stagger-animation": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-aria-expanded": {
           "success": true,
           "confidence": 1
         },
@@ -12788,19 +12841,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "set-style": {
-          "success": true,
-          "confidence": 0.5
-        },
         "put-before": {
           "success": true,
           "confidence": 0.5
         },
         "put-after": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "toggle-visibility": {
           "success": true,
           "confidence": 0.5
         },
@@ -12828,20 +12873,12 @@
           "success": true,
           "confidence": 0.5
         },
-        "default-value": {
-          "success": true,
-          "confidence": 0.5
-        },
         "call-function": {
           "success": true,
           "confidence": 0.5
         },
         "js-inline": {
           "success": false
-        },
-        "tabs-aria": {
-          "success": true,
-          "confidence": 0.5
         },
         "modal-close-button": {
           "success": true,
@@ -12867,10 +12904,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 0.5
-        },
         "window-keydown": {
           "success": true,
           "confidence": 0.5
@@ -12886,19 +12919,7 @@
           "success": true,
           "confidence": 0.5
         },
-        "set-opacity": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-transform": {
-          "success": true,
-          "confidence": 0.5
-        },
         "set-color-variable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "transition-color": {
           "success": true,
           "confidence": 0.5
         },
@@ -12946,10 +12967,6 @@
           "confidence": 0.5
         },
         "computed-value": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "toggle-aria-expanded": {
           "success": true,
           "confidence": 0.5
         },
@@ -13042,8 +13059,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8849721706864567,
-      "bundleSize": 396800,
+      "avgConfidence": 0.8845598845598848,
+      "bundleSize": 396996,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13077,7 +13094,7 @@
           "success": true,
           "confidence": 1
         },
-        "transition-color": {
+        "form-disable-on-submit": {
           "success": true,
           "confidence": 1
         },
@@ -13337,10 +13354,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "document-ready": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -13550,6 +13563,10 @@
           "confidence": 0.8222222222222222
         },
         "set-color-variable": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "transition-color": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -13667,8 +13684,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8886827458256034,
-      "bundleSize": 396800,
+      "avgConfidence": 0.8894248608534325,
+      "bundleSize": 396996,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13699,6 +13716,10 @@
           "confidence": 1
         },
         "tell-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
           "success": true,
           "confidence": 1
         },
@@ -13967,10 +13988,6 @@
           "confidence": 0.8857142857142858
         },
         "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-disable-on-submit": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -14293,7 +14310,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9988148148148148,
-      "bundleSize": 396800,
+      "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -14912,7 +14929,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 396800,
+      "size": 396996,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-07T05:39:38.282Z",
-  "commit": "c9f4611",
+  "timestamp": "2026-06-07T05:53:16.278Z",
+  "commit": "8d8d274",
   "languages": {
     "ar": {
       "parseSuccess": 143,
       "parseFailure": 11,
       "parseRate": 0.9285714285714286,
       "avgConfidence": 0.9125077536842245,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -621,7 +621,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.83001443001443,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1246,7 +1246,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9374935159248873,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1870,7 +1870,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2495,7 +2495,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3119,7 +3119,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3743,7 +3743,7 @@
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.8446361989986156,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4363,7 +4363,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 1,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -4987,7 +4987,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5611,7 +5611,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9976296296296296,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6232,7 +6232,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8274094823114431,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6856,7 +6856,7 @@
       "parseFailure": 7,
       "parseRate": 0.9545454545454546,
       "avgConfidence": 0.5566137566137567,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7474,7 +7474,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9988455988455989,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8099,7 +8099,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.8352592592592598,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8719,21 +8719,9 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.838198983297023,
-      "bundleSize": 396996,
+      "avgConfidence": 0.8312273057371102,
+      "bundleSize": 397297,
       "patterns": {
-        "blur-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 1
-        },
         "window-resize": {
           "success": true,
           "confidence": 1
@@ -8742,15 +8730,7 @@
           "success": true,
           "confidence": 1
         },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 1
-        },
         "announce-screen-reader": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-trap": {
           "success": true,
           "confidence": 1
         },
@@ -8763,10 +8743,6 @@
           "confidence": 1
         },
         "on-custom-event-receive": {
-          "success": true,
-          "confidence": 1
-        },
-        "keydown-key-is-syntax": {
           "success": true,
           "confidence": 1
         },
@@ -8978,6 +8954,10 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "log-value": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -9034,6 +9014,10 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "modal-close-backdrop": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -9075,6 +9059,10 @@
           "confidence": 0.8222222222222222
         },
         "form-disable-on-submit": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "window-keydown": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -9146,6 +9134,10 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "fetch-loading-state": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -9195,6 +9187,10 @@
           "confidence": 0.8222222222222222
         },
         "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "focus-trap": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -9286,6 +9282,10 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "breakpoint-command": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -9344,7 +9344,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.7133333333333334,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -9965,7 +9965,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8860441146155434,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10586,11 +10586,11 @@
       }
     },
     "sw": {
-      "parseSuccess": 147,
-      "parseFailure": 7,
-      "parseRate": 0.9545454545454546,
-      "avgConfidence": 0.8768383543893751,
-      "bundleSize": 396996,
+      "parseSuccess": 150,
+      "parseFailure": 4,
+      "parseRate": 0.974025974025974,
+      "avgConfidence": 0.8821904761904765,
+      "bundleSize": 397297,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11056,6 +11056,10 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "default-value": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -11072,7 +11076,15 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "input-clear": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "window-keydown": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -11112,6 +11124,10 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "unless-condition": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -11120,11 +11136,19 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 0.8222222222222222
         },
         "make-toast-element": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "keydown-key-is-syntax": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -11140,18 +11164,7 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "blur-element": {
-          "success": false
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.5
-        },
         "input-validation": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "window-keydown": {
           "success": true,
           "confidence": 0.5
         },
@@ -11163,18 +11176,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.5
-        },
         "if-empty": {
           "success": true,
           "confidence": 0.5
         },
         "announce-screen-reader": {
-          "success": false
-        },
-        "focus-trap": {
           "success": false
         },
         "method-call-possessive-dot": {
@@ -11183,9 +11189,6 @@
         "socket-basic": {
           "success": true,
           "confidence": 0.5
-        },
-        "keydown-key-is-syntax": {
-          "success": false
         },
         "behavior-removable": {
           "success": false
@@ -11208,7 +11211,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.940960626674911,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11833,7 +11836,7 @@
       "parseFailure": 16,
       "parseRate": 0.8961038961038961,
       "avgConfidence": 0.8835383428733814,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12442,7 +12445,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.8299484915378955,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13064,7 +13067,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8845598845598848,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13689,7 +13692,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8894248608534325,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14314,7 +14317,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9988148148148148,
-      "bundleSize": 396996,
+      "bundleSize": 397297,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -14933,7 +14936,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 396996,
+      "size": 397297,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-07T05:53:16.278Z",
-  "commit": "8d8d274",
+  "timestamp": "2026-06-07T06:05:38.263Z",
+  "commit": "9863a5d",
   "languages": {
     "ar": {
-      "parseSuccess": 143,
-      "parseFailure": 11,
-      "parseRate": 0.9285714285714286,
-      "avgConfidence": 0.9125077536842245,
-      "bundleSize": 397297,
+      "parseSuccess": 144,
+      "parseFailure": 10,
+      "parseRate": 0.935064935064935,
+      "avgConfidence": 0.9133082399626519,
+      "bundleSize": 397306,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -389,6 +389,14 @@
           "success": true,
           "confidence": 1
         },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 1
+        },
         "reactive-array-push": {
           "success": true,
           "confidence": 1
@@ -406,10 +414,6 @@
           "confidence": 0.9722222222222222
         },
         "previous-element": {
-          "success": true,
-          "confidence": 0.9722222222222222
-        },
-        "caret-var-increment": {
           "success": true,
           "confidence": 0.9722222222222222
         },
@@ -593,9 +597,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "caret-var-write": {
-          "success": false
-        },
         "caret-var-on-target": {
           "success": false
         },
@@ -620,8 +621,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.83001443001443,
-      "bundleSize": 397297,
+      "avgConfidence": 0.8397546897546898,
+      "bundleSize": 397306,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1027,6 +1028,18 @@
           "success": true,
           "confidence": 1
         },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
+          "success": true,
+          "confidence": 1
+        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -1203,18 +1216,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "caret-var-on-target": {
-          "success": true,
-          "confidence": 0.5
-        },
         "reactive-array-push": {
           "success": true,
           "confidence": 0.5
@@ -1246,7 +1247,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9374935159248873,
-      "bundleSize": 397297,
+      "bundleSize": 397306,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1870,7 +1871,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 397297,
+      "bundleSize": 397306,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2495,7 +2496,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 397297,
+      "bundleSize": 397306,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3119,7 +3120,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 397297,
+      "bundleSize": 397306,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3743,7 +3744,7 @@
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.8446361989986156,
-      "bundleSize": 397297,
+      "bundleSize": 397306,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4363,7 +4364,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 1,
-      "bundleSize": 397297,
+      "bundleSize": 397306,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -4987,7 +4988,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 397297,
+      "bundleSize": 397306,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5611,7 +5612,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9976296296296296,
-      "bundleSize": 397297,
+      "bundleSize": 397306,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6231,8 +6232,8 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8274094823114431,
-      "bundleSize": 397297,
+      "avgConfidence": 0.8339454300238615,
+      "bundleSize": 397306,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6626,6 +6627,14 @@
           "success": true,
           "confidence": 1
         },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 1
+        },
         "input-validation": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -6810,14 +6819,6 @@
           "confidence": 0.5
         },
         "pick-text-range": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "caret-var-increment": {
           "success": true,
           "confidence": 0.5
         },
@@ -6855,8 +6856,8 @@
       "parseSuccess": 147,
       "parseFailure": 7,
       "parseRate": 0.9545454545454546,
-      "avgConfidence": 0.5566137566137567,
-      "bundleSize": 397297,
+      "avgConfidence": 0.5600151171579743,
+      "bundleSize": 397306,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -6919,6 +6920,10 @@
           "confidence": 1
         },
         "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-increment": {
           "success": true,
           "confidence": 1
         },
@@ -7432,10 +7437,6 @@
           "confidence": 0.5
         },
         "caret-var-write": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "caret-var-increment": {
           "success": true,
           "confidence": 0.5
         },
@@ -7474,7 +7475,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9988455988455989,
-      "bundleSize": 397297,
+      "bundleSize": 397306,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8099,7 +8100,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.8352592592592598,
-      "bundleSize": 397297,
+      "bundleSize": 397306,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8720,7 +8721,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8312273057371102,
-      "bundleSize": 397297,
+      "bundleSize": 397306,
       "patterns": {
         "window-resize": {
           "success": true,
@@ -9343,8 +9344,8 @@
       "parseSuccess": 150,
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
-      "avgConfidence": 0.7133333333333334,
-      "bundleSize": 397297,
+      "avgConfidence": 0.7166666666666667,
+      "bundleSize": 397306,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -9599,6 +9600,10 @@
           "confidence": 1
         },
         "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-increment": {
           "success": true,
           "confidence": 1
         },
@@ -9926,10 +9931,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.5
-        },
         "caret-var-on-target": {
           "success": true,
           "confidence": 0.5
@@ -9965,7 +9966,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8860441146155434,
-      "bundleSize": 397297,
+      "bundleSize": 397306,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10589,8 +10590,8 @@
       "parseSuccess": 150,
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
-      "avgConfidence": 0.8821904761904765,
-      "bundleSize": 397297,
+      "avgConfidence": 0.8833756613756617,
+      "bundleSize": 397306,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10741,6 +10742,10 @@
           "confidence": 1
         },
         "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-write": {
           "success": true,
           "confidence": 1
         },
@@ -11156,10 +11161,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "caret-var-on-target": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -11211,7 +11212,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.940960626674911,
-      "bundleSize": 397297,
+      "bundleSize": 397306,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11832,11 +11833,11 @@
       }
     },
     "tl": {
-      "parseSuccess": 138,
-      "parseFailure": 16,
-      "parseRate": 0.8961038961038961,
-      "avgConfidence": 0.8835383428733814,
-      "bundleSize": 397297,
+      "parseSuccess": 139,
+      "parseFailure": 15,
+      "parseRate": 0.9025974025974026,
+      "avgConfidence": 0.8848329739569691,
+      "bundleSize": 397306,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12062,6 +12063,10 @@
           "success": true,
           "confidence": 1
         },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 1
+        },
         "reactive-array-push": {
           "success": true,
           "confidence": 1
@@ -12262,6 +12267,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "remove-class-basic": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -12303,10 +12312,6 @@
           "confidence": 0.8222222222222222
         },
         "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "caret-var-increment": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -12432,9 +12437,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "caret-var-write": {
-          "success": false
-        },
         "caret-var-on-target": {
           "success": false
         }
@@ -12444,8 +12446,8 @@
       "parseSuccess": 151,
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
-      "avgConfidence": 0.8299484915378955,
-      "bundleSize": 397297,
+      "avgConfidence": 0.8365710080941869,
+      "bundleSize": 397306,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -12843,6 +12845,14 @@
           "success": true,
           "confidence": 1
         },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 1
+        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -13024,14 +13034,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.5
-        },
         "caret-var-on-target": {
           "success": true,
           "confidence": 0.5
@@ -13067,7 +13069,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8845598845598848,
-      "bundleSize": 397297,
+      "bundleSize": 397306,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13692,7 +13694,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8894248608534325,
-      "bundleSize": 397297,
+      "bundleSize": 397306,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14317,7 +14319,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9988148148148148,
-      "bundleSize": 397297,
+      "bundleSize": 397306,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -14936,7 +14938,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 397297,
+      "size": 397306,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-07T05:30:51.010Z",
-  "commit": "ec634dd",
+  "timestamp": "2026-06-07T05:39:38.282Z",
+  "commit": "c9f4611",
   "languages": {
     "ar": {
       "parseSuccess": 143,
@@ -620,7 +620,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8267676767676768,
+      "avgConfidence": 0.83001443001443,
       "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
@@ -780,6 +780,10 @@
           "confidence": 1
         },
         "async-block": {
+          "success": true,
+          "confidence": 1
+        },
+        "js-inline": {
           "success": true,
           "confidence": 1
         },
@@ -1068,10 +1072,6 @@
           "confidence": 0.5
         },
         "call-function": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "js-inline": {
           "success": true,
           "confidence": 0.5
         },
@@ -3742,7 +3742,7 @@
       "parseSuccess": 149,
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
-      "avgConfidence": 0.8442100777671253,
+      "avgConfidence": 0.8446361989986156,
       "bundleSize": 396996,
       "patterns": {
         "put-content-basic": {
@@ -3822,6 +3822,10 @@
           "confidence": 0.8857142857142858
         },
         "default-value": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "js-inline": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -4014,10 +4018,6 @@
           "confidence": 0.8222222222222222
         },
         "async-block": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "js-inline": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -6228,10 +6228,10 @@
       }
     },
     "ja": {
-      "parseSuccess": 152,
-      "parseFailure": 2,
-      "parseRate": 0.987012987012987,
-      "avgConfidence": 0.8262740183792815,
+      "parseSuccess": 153,
+      "parseFailure": 1,
+      "parseRate": 0.9935064935064936,
+      "avgConfidence": 0.8274094823114431,
       "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
@@ -6387,6 +6387,10 @@
           "confidence": 1
         },
         "tell-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "js-inline": {
           "success": true,
           "confidence": 1
         },
@@ -6682,9 +6686,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "js-inline": {
-          "success": false
-        },
         "modal-close-button": {
           "success": true,
           "confidence": 0.5
@@ -6851,10 +6852,10 @@
       }
     },
     "ko": {
-      "parseSuccess": 146,
-      "parseFailure": 8,
-      "parseRate": 0.948051948051948,
-      "avgConfidence": 0.5570015220700152,
+      "parseSuccess": 147,
+      "parseFailure": 7,
+      "parseRate": 0.9545454545454546,
+      "avgConfidence": 0.5566137566137567,
       "bundleSize": 396996,
       "patterns": {
         "wait-for-event": {
@@ -7108,7 +7109,8 @@
           "confidence": 0.5
         },
         "js-inline": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "tabs-basic": {
           "success": true,
@@ -9338,10 +9340,10 @@
       }
     },
     "qu": {
-      "parseSuccess": 149,
-      "parseFailure": 5,
-      "parseRate": 0.9675324675324676,
-      "avgConfidence": 0.7114093959731543,
+      "parseSuccess": 150,
+      "parseFailure": 4,
+      "parseRate": 0.974025974025974,
+      "avgConfidence": 0.7133333333333334,
       "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
@@ -9457,6 +9459,10 @@
           "confidence": 1
         },
         "async-block": {
+          "success": true,
+          "confidence": 1
+        },
+        "js-inline": {
           "success": true,
           "confidence": 1
         },
@@ -9686,9 +9692,6 @@
         "call-function": {
           "success": true,
           "confidence": 0.5
-        },
-        "js-inline": {
-          "success": false
         },
         "tabs-basic": {
           "success": true,
@@ -12435,10 +12438,10 @@
       }
     },
     "tr": {
-      "parseSuccess": 150,
-      "parseFailure": 4,
-      "parseRate": 0.974025974025974,
-      "avgConfidence": 0.8288148148148148,
+      "parseSuccess": 151,
+      "parseFailure": 3,
+      "parseRate": 0.9805194805194806,
+      "avgConfidence": 0.8299484915378955,
       "bundleSize": 396996,
       "patterns": {
         "toggle-class-basic": {
@@ -12602,6 +12605,10 @@
           "confidence": 1
         },
         "async-block": {
+          "success": true,
+          "confidence": 1
+        },
+        "js-inline": {
           "success": true,
           "confidence": 1
         },
@@ -12876,9 +12883,6 @@
         "call-function": {
           "success": true,
           "confidence": 0.5
-        },
-        "js-inline": {
-          "success": false
         },
         "modal-close-button": {
           "success": true,


### PR DESCRIPTION
## Multilingual parse-rate roadmap — Track 3 deep grammar (Phases 1–4)

Working through the remaining non-behavior failures in `docs-internal/MULTILINGUAL_ROADMAP.md`, sequenced by tractability × value. Behaviors (Track 2 / Phase 5) deliberately held for last.

**Net: avg 97.5% → 98.19%, +26 patterns, 0 regressions.** ar 87.0% → 93.5%, tl 84.4% → 90.3% (the two former deep laggards). Each phase is a separate commit; the binary `patterns.db` is intentionally not committed (CI repopulates from source).

### ✅ Phase 1 — `@attr` / `*style` tokenizer fix (+17, ar/tl)
Shared `CssSelectorExtractor` handled `# . [ <` but not `@`/`*`, so `@disabled` / `*opacity` / `*--primary-color` split into separate tokens and never filled a role. Extended it to keep them whole (the `*` form requires a letter/`_`/`--`, so multiplication and globs are untouched). Cleared the whole `set-*` family for ar/tl + bonus ar transition-color. Corrected a wrong roadmap note (it was never a "degenerate empty-body match").

### ✅ Phase 2 — `js-inline` block masking (+4, ja/ko/qu/tr)
`on click js <raw js> end` was reordered, hoisting the raw JS ahead of the event. Added `tryTransformJsBlock` to mask the `js … end` body (raw JavaScript — never tokenized/translated/reordered) behind a placeholder, reorder the surrounding handler, then restore `<translated js> <verbatim body> <translated end>`.

### ✅ Phase 3a — event guards + English DOM event passthrough (+3, sw)
Two coordinated fixes: (1) i18n transformer now keeps `[key is 'Escape']` guards whole (bracket-aware tokenize) and doesn't translate inside `[…]`; (2) framework base tokenizer registers the standard English DOM event names (`keyup`/`keydown`/`resize`/…) as universal `!has`-guarded fallbacks — generalizing the per-language Hebrew #272 fix to all 24 languages.

### ✅ Phase 4 — `^caret` variable token-split (+2, ar/tl)
`variable-ref` extractor kept `:local`/`$global` whole but not `^caret`; added `^` (same class as Phase 1).

### Remaining (documented in roadmap)
- **Phase 3 deep remainder:** event-body block masking (`event-key-combo`, `repeat-until-event`), event modifiers (`window-resize`), `or`-events (`multiple-events`), custom-event reorder (`on-custom-event-receive`), `focus-trap` tr.
- **Track 4 scattered:** method-call member access (`my.value.toUpperCase()`), `transition-* over <dur>`, `unless`, `put before/after` (tl `after`↔`then`), etc.
- **Phase 5 — behaviors** (held per request): the `behavior … end` definitions don't parse across languages (destructured event params, conditionals, inline `js(me)…end`); depends on Phase 2/3 block work.

**Verification:** full semantic suite (5260 pass — only the documented environmental `build-artifacts` `.d.ts` checks fail) + all 759 framework tests + all i18n grammar tests pass. New regression tests lock in each tokenizer/transformer fix.

🤖 Phases 2–4 are follow-up commits on this branch.

https://claude.ai/code/session_01Pa5hn9cm61cnPwwuAMiu49