### PR TITLE
Track 4: method-call possessive-dot parsing (+5)

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,30 +5,31 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after Phases 1–4 + Track 4 method-call possessive-dot. Track 1 (reactive) complete._
+_Last updated: after Track 4 (method-call possessive-dot + event-body block masking). Track 1 (reactive) complete._
 
 ---
 
 ## Current state
 
 Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
-(generated with `--bundle browser-priority`). Cross-language average **98.3%**
-(up from 97.5% before Phase 1; Phases 1–4 + Track 4 method-call: +31 instances).
+(generated with `--bundle browser-priority`). Cross-language average **98.5%**
+(up from 97.5% before Phase 1; Phases 1–4 + Track 4: +36 instances).
 
-| Rate         | Languages                                              |
-| ------------ | ------------------------------------------------------ |
-| 100%         | en, bn, ms, ru, th, uk, vi                             |
-| 99.4%        | de, es, fr, hi, id, pt                                 |
-| 97–99%       | ja (99.4), tr/zh (98.1), it/pl/qu/zh (97.4), he (96.8) |
-| 95–96%       | sw (96.8), ko (95.5)                                   |
-| **laggards** | **ar (94.8), tl (91.6)**                               |
+| Rate         | Languages                             |
+| ------------ | ------------------------------------- |
+| 100%         | en, bn, ms, ru, th, uk, vi            |
+| 98–99%       | ja (99.4), qu (98.1), tr/zh (98.1)    |
+| 99.4%        | de, es, fr, hi, id, pt                |
+| 96–97%       | it/pl/zh (97.4), he (96.8), ko (96.1) |
+| 95–96%       | sw (96.8)                             |
+| **laggards** | **ar (94.8), tl (91.6)**              |
 
-**~45 failing pattern-instances** remain after Phases 1–4 + Track 4 method-call, in two tracks (Track 1 reactive done):
+**~40 failing pattern-instances** remain after Phases 1–4 + Track 4, in two tracks (Track 1 reactive done):
 
-| Track                         | Instances | Nature                                                                                |
-| ----------------------------- | --------- | ------------------------------------------------------------------------------------- |
-| **Bucket B — behaviors**      | ~26       | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`)      |
-| **Deep per-language grammar** | ~19       | Heterogeneous transformer/parser gaps (VSO event-at-end reorder, modifiers) — Track 4 |
+| Track                         | Instances | Nature                                                                           |
+| ----------------------------- | --------- | -------------------------------------------------------------------------------- |
+| **Bucket B — behaviors**      | ~26       | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`) |
+| **Deep per-language grammar** | ~14       | VSO event-at-end + `from`-source reorder, command modifiers, condition i18n      |
 
 > **The clean tokenizer token-split vein is now largely worked out** (Phases 1 & 4
 > cleared `@`/`*`/`^`; Phase 3a the English DOM events). Every remaining
@@ -166,6 +167,19 @@ own transformer/parser project (no shared lever remains):
   (`on input …`) whose body path parses it — so en passed all along and the fix
   was purely making ar/sw/tl's possessive path consume the split parens. Locked by
   possessive-value-fillers.test.ts.
+- **event-handler block body — DONE (+5).** `event-key-combo` (ja/ko/qu/tr) +
+  `repeat-until-event` (hi). `on <event> {if|repeat|…} … end` had its block body
+  shredded across the event handler's roles by `parseEventHandler`. Added
+  `tryTransformEventWithBlockBody` (i18n): mask the block, reorder the event head,
+  transform the block as a self-contained unit (`transformBlockBody`), and emit
+  **event-clause first, then block** — even in verb-first (VSO) languages, since
+  the semantic parser only matches a block body after the event. Event heads with
+  a `from <source>` modifier are excluded (the source/event ordering differs by
+  word order and the existing path already parses them) — this keeps
+  `window-keydown` / `focus-trap` unregressed. Locked by a grammar.test.ts case.
+- **Still open here:** `focus-trap` (tr), `window-resize` (qu/tr) — event-block
+  bodies _with_ a `from <source>` clause; need event-first + source ordering for
+  VSO. `multiple-events` (ar) needs `or`-conjoined events.
 - **`transition-*` `over <dur>` modifier** (ko/tl) — `over 500ms` modifier is
   dropped/misplaced in word-order reorder.
 - **`scroll to last <sel> in …`** (last-in-collection; ar/tl) — `scroll to` +

--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,30 +5,30 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after Phases 1–4 (tokenizer token-split fixes + js/guard masking + English DOM events). Track 1 (reactive) complete._
+_Last updated: after Phases 1–4 + Track 4 method-call possessive-dot. Track 1 (reactive) complete._
 
 ---
 
 ## Current state
 
 Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
-(generated with `--bundle browser-priority`). Cross-language average **98.2%**
-(up from 97.5% before Phase 1; Phases 1, 2, 3a, 4 shipped: +26 instances).
+(generated with `--bundle browser-priority`). Cross-language average **98.3%**
+(up from 97.5% before Phase 1; Phases 1–4 + Track 4 method-call: +31 instances).
 
-| Rate         | Languages                                           |
-| ------------ | --------------------------------------------------- |
-| 100%         | en, bn, ms, ru, th, uk, vi                          |
-| 99.4%        | de, es, fr, hi, id, pt                              |
-| 97–99%       | ja (99.4), tr/zh (98.1), it/pl (97.4), he/qu (96.8) |
-| 95–96%       | sw (96.1), ko (95.5)                                |
-| **laggards** | **ar (93.5), tl (90.3)**                            |
+| Rate         | Languages                                              |
+| ------------ | ------------------------------------------------------ |
+| 100%         | en, bn, ms, ru, th, uk, vi                             |
+| 99.4%        | de, es, fr, hi, id, pt                                 |
+| 97–99%       | ja (99.4), tr/zh (98.1), it/pl/qu/zh (97.4), he (96.8) |
+| 95–96%       | sw (96.8), ko (95.5)                                   |
+| **laggards** | **ar (94.8), tl (91.6)**                               |
 
-**~50 failing pattern-instances** remain after Phases 1–4, in two tracks (Track 1 reactive done):
+**~45 failing pattern-instances** remain after Phases 1–4 + Track 4 method-call, in two tracks (Track 1 reactive done):
 
-| Track                         | Instances | Nature                                                                                 |
-| ----------------------------- | --------- | -------------------------------------------------------------------------------------- |
-| **Bucket B — behaviors**      | ~26       | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`)       |
-| **Deep per-language grammar** | ~24       | Heterogeneous transformer/parser gaps (method-calls, modifiers, reorder) — see Track 4 |
+| Track                         | Instances | Nature                                                                                |
+| ----------------------------- | --------- | ------------------------------------------------------------------------------------- |
+| **Bucket B — behaviors**      | ~26       | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`)      |
+| **Deep per-language grammar** | ~19       | Heterogeneous transformer/parser gaps (VSO event-at-end reorder, modifiers) — Track 4 |
 
 > **The clean tokenizer token-split vein is now largely worked out** (Phases 1 & 4
 > cleared `@`/`*`/`^`; Phase 3a the English DOM events). Every remaining
@@ -157,9 +157,15 @@ side rather than "fixing" the transformer.
 After Phases 1–4 the non-behavior failures left are all genuinely deep, each its
 own transformer/parser project (no shared lever remains):
 
-- **method-call / member-access** (`my.value.toUpperCase()`, `my.getAttribute(…)`;
-  ar/sw/tl) — the trailing `()` method call splits into `(`/`)` tokens and isn't
-  parsed; fails even in en via the raw semantic path. Needs method-call parsing.
+- **method-call / member-access — DONE (+5).** `my.value.toUpperCase()` /
+  `my.getAttribute("data-id")` (ar/sw/tl). The possessive-dot matcher
+  (`tryMatchPossessiveExpression`) expected the trailing call as a single `(...)`
+  token, but the tokenizer splits it into `(` / args / `)`. Changed it to consume
+  the call by balanced-paren count. The diagnostic detour: the bare semantic
+  `parse()` fails this even in en, but the harness wraps in an event handler
+  (`on input …`) whose body path parses it — so en passed all along and the fix
+  was purely making ar/sw/tl's possessive path consume the split parens. Locked by
+  possessive-value-fillers.test.ts.
 - **`transition-*` `over <dur>` modifier** (ko/tl) — `over 500ms` modifier is
   dropped/misplaced in word-order reorder.
 - **`scroll to last <sel> in …`** (last-in-collection; ar/tl) — `scroll to` +

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -408,6 +408,20 @@ describe('GrammarTransformer', () => {
       expect(result).toContain("keyup[key is 'Escape']");
     });
 
+    it('should keep an event-handler block body intact (not shredded)', () => {
+      // `on <event> if … end` must keep the event clause first, then the whole
+      // `if … end` block as a self-contained unit — never reordered into the
+      // event handler's role soup.
+      const result = transformer.transform(
+        'on keydown[key=="Enter"] if event.shiftKey call submitAndContinue() end'
+      );
+      // Event leads; the if-block follows with its condition preserved.
+      expect(result).toMatch(/keydown\[key=="Enter"\].*もし.*event\.shiftKey/);
+      expect(result).toContain('submitAndContinue()');
+      // `end` keyword present (translated), block not dropped.
+      expect(result).toContain('終わり');
+    });
+
     it('should mask inline js bodies from word-order reordering', () => {
       // The raw JS body must stay verbatim and immediately after the (translated)
       // `js` keyword — never reordered ahead of the event like other roles.

--- a/packages/i18n/src/grammar/transformer.ts
+++ b/packages/i18n/src/grammar/transformer.ts
@@ -1343,6 +1343,12 @@ export class GrammarTransformer {
     if (!input.includes('\n')) {
       const jsBlock = this.tryTransformJsBlock(input);
       if (jsBlock !== null) return jsBlock;
+
+      // Event handler whose body is a block (`on <event> if/repeat/unless … end`):
+      // the block body must be reordered as a self-contained unit, not shredded
+      // across the event handler's role soup.
+      const eventBlock = this.tryTransformEventWithBlockBody(input);
+      if (eventBlock !== null) return eventBlock;
     }
 
     // Check if input has multi-line structure worth preserving
@@ -1487,6 +1493,96 @@ export class GrammarTransformer {
     const reordered = this.transformSingle([...before, placeholder].join(' '));
     if (!reordered.includes(placeholder)) return null; // unexpected — fall through
     return reordered.replace(placeholder, replacement);
+  }
+
+  /**
+   * Transform an event handler whose body is a block command
+   * (`on <event> [from <src>] {if|repeat|unless|while|for} … end`).
+   *
+   * `parseEventHandler` would treat the block keyword as the action and sweep the
+   * condition/body into role values, then reorder them — shredding the block
+   * (`if event.shiftKey call submitAndContinue() end` → scattered tokens). Instead
+   * we mask the whole block as an opaque action placeholder, reorder the event
+   * head normally, transform the block as a self-contained unit, and restitch.
+   *
+   * Returns `null` (fall through) when the input isn't an event handler, has no
+   * block-keyword body, or has no closing `end`.
+   */
+  private tryTransformEventWithBlockBody(input: string): string | null {
+    const tokens = tokenize(input, this.sourceProfile);
+    if (tokens.length === 0) return null;
+    if (!EVENT_KEYWORDS.has(tokens[0]?.toLowerCase())) return null;
+
+    // Source-language block-head keywords (harness source is English; the
+    // existing BLOCK_HEAD_KEYWORDS set is likewise English-keyed).
+    const BLOCK_BODY_KEYWORDS = new Set(['if', 'repeat', 'unless', 'while', 'for']);
+    let blockIdx = -1;
+    for (let i = 1; i < tokens.length; i++) {
+      if (BLOCK_BODY_KEYWORDS.has(tokens[i].toLowerCase())) {
+        blockIdx = i;
+        break;
+      }
+    }
+    if (blockIdx <= 0) return null;
+    // Only handle the explicitly-terminated form; un-terminated bodies
+    // (`on click unless X toggle Y`) keep the existing path.
+    if (tokens[tokens.length - 1].toLowerCase() !== 'end') return null;
+
+    const eventHead = tokens.slice(0, blockIdx);
+    const blockTokens = tokens.slice(blockIdx);
+
+    // Event heads carrying a `from <source>` modifier reorder the source relative
+    // to the event differently per word order; forcing event-first there breaks
+    // verb-first languages. Leave those on the existing path (they already parse)
+    // and only handle the plain `on <event> [guard]` head here.
+    if (eventHead.some(t => t.toLowerCase() === 'from')) return null;
+
+    const placeholder = 'EVENTBLOCKPLACEHOLDER';
+    const headOut = this.transformSingle([...eventHead, placeholder].join(' '));
+    if (!headOut.includes(placeholder)) return null;
+
+    const blockOut = this.transformBlockBody(blockTokens);
+
+    // Always emit the event clause first, then the block. An event handler's
+    // event is a leading delimiter, and the semantic parser only matches a
+    // block body when it follows the event — even in verb-first (VSO) languages
+    // whose normal command order would push the event to the end. So strip the
+    // placeholder out of the (possibly reordered) head and append the block,
+    // rather than substituting in place.
+    const eventClause = headOut.replace(placeholder, '').replace(/\s+/g, ' ').trim();
+    return [eventClause, blockOut].filter(s => s.length > 0).join(' ');
+  }
+
+  /**
+   * Transform a self-contained block command (`{head} {clause?} {body} {end}`),
+   * where head ∈ {if, repeat, unless, …}. The clause (condition / `until event …`)
+   * runs up to the first command verb and is translated word-by-word; the body is
+   * recursively transformed (so its inner commands reorder for the target); the
+   * head/tail keywords are translated. The block is never word-order reordered as
+   * a whole — delimiters stay at the edges regardless of target word order.
+   */
+  private transformBlockBody(blockTokens: string[]): string {
+    const src = this.sourceProfile.code;
+    const dst = this.targetProfile.code;
+
+    const head = blockTokens[0];
+    const hasEnd = blockTokens[blockTokens.length - 1]?.toLowerCase() === 'end';
+    const tail = hasEnd ? blockTokens[blockTokens.length - 1] : '';
+    const inner = blockTokens.slice(1, hasEnd ? -1 : undefined);
+
+    const commands = getCommandKeywordsForLocale(src);
+    let bodyStart = inner.findIndex(t => commands.has(t.toLowerCase()));
+    if (bodyStart < 0) bodyStart = inner.length;
+
+    const clause = inner.slice(0, bodyStart).join(' ');
+    const body = inner.slice(bodyStart).join(' ');
+
+    const headT = translateWord(head, src, dst);
+    const tailT = tail ? translateWord(tail, src, dst) : '';
+    const clauseT = clause ? translateMultiWordValue(clause, src, dst) : '';
+    const bodyT = body ? this.transform(body) : '';
+
+    return [headT, clauseT, bodyT, tailT].filter(s => s.length > 0).join(' ');
   }
 
   /**

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -429,12 +429,28 @@ export class PatternMatcher {
         tokens.advance();
       }
 
-      // Check for method call — next token is '(' in the value (e.g., .getAttribute("data-id"))
-      const nextPeek = tokens.peek();
-      if (nextPeek?.kind === 'literal' && nextPeek.value.startsWith('(')) {
-        // Consume method args
-        chainedProps += nextPeek.value;
-        tokens.advance();
+      // Check for a trailing method call: chain + '(' [args...] ')'
+      // (e.g., my.value.toUpperCase(), my.getAttribute("data-id")). The tokenizer
+      // may emit the call as one token (`("data-id")`) or split it into `(` / args
+      // / `)` (kinds vary: identifier/punctuation/literal), so consume by value
+      // until the parentheses balance rather than relying on a single-token form.
+      const afterChain = tokens.peek();
+      if (afterChain && afterChain.value.startsWith('(')) {
+        let call = '';
+        let depth = 0;
+        let guard = 0;
+        while (!tokens.isAtEnd() && guard++ < PatternMatcher.MAX_METHOD_ARGS + 2) {
+          const t = tokens.peek();
+          if (!t) break;
+          call += t.value;
+          tokens.advance();
+          for (const ch of t.value) {
+            if (ch === '(') depth++;
+            else if (ch === ')') depth--;
+          }
+          if (depth <= 0) break;
+        }
+        chainedProps += call;
       }
 
       // Create property-path: my value -> { object: me, property: 'value' }

--- a/packages/semantic/test/possessive-value-fillers.test.ts
+++ b/packages/semantic/test/possessive-value-fillers.test.ts
@@ -27,6 +27,12 @@ describe('Possessive value-fillers (cross-language)', () => {
     ['AR: set my value (لي قيمة)', 'اضبط لي قيمة إلى 0 عند تحميل', 'ar'],
     ['TL: put my value (aking halaga)', 'ilagay aking halaga sa #preview kapag input', 'tl'],
     ['ES: put my value (mi valor)', 'al hacer clic poner mi valor en #preview', 'es'],
+    // Possessive-dot member access with a trailing method call. The method-call
+    // parens may tokenize split (`(` / args / `)`), so the possessive matcher
+    // consumes them by balanced count rather than expecting a single token.
+    ['EN: my.value.toUpperCase()', 'on input put my.value.toUpperCase() into #preview', 'en'],
+    ['AR: my.value.toUpperCase()', 'ضع لي.value.toUpperCase() إلى #preview عند إدخال', 'ar'],
+    ['TL: my.getAttribute("data-id")', 'ilagay aking.getAttribute("data-id") sa #output kapag click', 'tl'],
   ];
 
   for (const [label, code, lang] of cases) {

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,12 +1,12 @@
 {
-  "timestamp": "2026-06-07T08:32:30.941Z",
-  "commit": "5c20e90",
+  "timestamp": "2026-06-07T11:47:19.051Z",
+  "commit": "d5cfc3c",
   "languages": {
     "ar": {
       "parseSuccess": 146,
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
-      "avgConfidence": 0.9144957983193279,
+      "avgConfidence": 0.9162596088663778,
       "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
@@ -129,10 +129,6 @@
           "success": true,
           "confidence": 1
         },
-        "if-condition": {
-          "success": true,
-          "confidence": 1
-        },
         "halt-propagation": {
           "success": true,
           "confidence": 1
@@ -189,10 +185,6 @@
           "success": true,
           "confidence": 1
         },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 1
-        },
         "accordion-toggle": {
           "success": true,
           "confidence": 1
@@ -214,10 +206,6 @@
           "confidence": 1
         },
         "input-char-count": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-validation": {
           "success": true,
           "confidence": 1
         },
@@ -254,14 +242,6 @@
           "confidence": 1
         },
         "fetch-loading-state": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-empty": {
           "success": true,
           "confidence": 1
         },
@@ -441,6 +421,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "go-back": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -449,11 +433,35 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "repeat-forever": {
           "success": true,
           "confidence": 0.8857142857142858
         },
         "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "stagger-animation": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -501,15 +509,15 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "repeat-times": {
           "success": true,
           "confidence": 0.7647058823529411
         },
         "repeat-for-each": {
-          "success": true,
-          "confidence": 0.7647058823529411
-        },
-        "stagger-animation": {
           "success": true,
           "confidence": 0.7647058823529411
         },
@@ -576,14 +584,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.5
-        },
         "unless-condition": {
           "success": false
         },
@@ -623,7 +623,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8462481962481962,
+      "avgConfidence": 0.868975468975469,
       "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
@@ -746,6 +746,10 @@
           "success": true,
           "confidence": 1
         },
+        "if-condition": {
+          "success": true,
+          "confidence": 1
+        },
         "repeat-for-each": {
           "success": true,
           "confidence": 1
@@ -806,6 +810,10 @@
           "success": true,
           "confidence": 1
         },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
         "accordion-toggle": {
           "success": true,
           "confidence": 1
@@ -827,6 +835,10 @@
           "confidence": 1
         },
         "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-validation": {
           "success": true,
           "confidence": 1
         },
@@ -866,6 +878,10 @@
           "success": true,
           "confidence": 1
         },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 1
+        },
         "repeat-forever": {
           "success": true,
           "confidence": 1
@@ -895,6 +911,18 @@
           "confidence": 1
         },
         "fetch-error-handling": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-empty": {
           "success": true,
           "confidence": 1
         },
@@ -1078,10 +1106,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.5
-        },
         "repeat-times": {
           "success": true,
           "confidence": 0.5
@@ -1103,14 +1127,6 @@
           "confidence": 0.5
         },
         "modal-close-escape": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "input-validation": {
           "success": true,
           "confidence": 0.5
         },
@@ -1142,23 +1158,7 @@
           "success": true,
           "confidence": 0.5
         },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.5
-        },
         "event-key-combo": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-empty": {
           "success": true,
           "confidence": 0.5
         },
@@ -1248,7 +1248,7 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.9374935159248873,
+      "avgConfidence": 0.9367465504720396,
       "bundleSize": 397443,
       "patterns": {
         "add-class-basic": {
@@ -1436,10 +1436,6 @@
           "confidence": 1
         },
         "fade-out-remove": {
-          "success": true,
-          "confidence": 1
-        },
-        "stagger-animation": {
           "success": true,
           "confidence": 1
         },
@@ -1776,6 +1772,10 @@
           "confidence": 0.8857142857142858
         },
         "slide-toggle": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "stagger-animation": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -3745,7 +3745,7 @@
       "parseSuccess": 149,
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
-      "avgConfidence": 0.8470224778949617,
+      "avgConfidence": 0.8500053265153942,
       "bundleSize": 397443,
       "patterns": {
         "put-content-basic": {
@@ -3828,6 +3828,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "repeat-for-each": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -3837,6 +3841,30 @@
           "confidence": 0.8857142857142858
         },
         "js-inline": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "if-empty": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -3976,10 +4004,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "repeat-times": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -4056,10 +4080,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "accordion-toggle": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -4077,10 +4097,6 @@
           "confidence": 0.8222222222222222
         },
         "input-char-count": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "input-validation": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -4152,10 +4168,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "repeat-while": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -4185,18 +4197,6 @@
           "confidence": 0.8222222222222222
         },
         "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "if-empty": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -4362,9 +4362,9 @@
       }
     },
     "hi": {
-      "parseSuccess": 153,
-      "parseFailure": 1,
-      "parseRate": 0.9935064935064936,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
       "avgConfidence": 1,
       "bundleSize": 397443,
       "patterns": {
@@ -4700,6 +4700,10 @@
           "success": true,
           "confidence": 1
         },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 1
+        },
         "repeat-forever": {
           "success": true,
           "confidence": 1
@@ -4979,9 +4983,6 @@
         "behavior-resizable": {
           "success": true,
           "confidence": 1
-        },
-        "repeat-until-event": {
-          "success": false
         }
       }
     },
@@ -6231,10 +6232,10 @@
       }
     },
     "ja": {
-      "parseSuccess": 153,
-      "parseFailure": 1,
-      "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8404813777362797,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.8378066378066378,
       "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
@@ -6466,6 +6467,10 @@
           "confidence": 1
         },
         "last-in-collection": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-until-event": {
           "success": true,
           "confidence": 1
         },
@@ -6645,17 +6650,17 @@
           "success": true,
           "confidence": 1
         },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.6
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.6
         },
         "put-before": {
           "success": true,
@@ -6749,16 +6754,13 @@
           "success": true,
           "confidence": 0.5
         },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.5
-        },
         "repeat-while": {
           "success": true,
           "confidence": 0.5
         },
         "event-key-combo": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "if-matches": {
           "success": true,
@@ -6855,10 +6857,10 @@
       }
     },
     "ko": {
-      "parseSuccess": 147,
-      "parseFailure": 7,
-      "parseRate": 0.9545454545454546,
-      "avgConfidence": 0.5600151171579743,
+      "parseSuccess": 148,
+      "parseFailure": 6,
+      "parseRate": 0.961038961038961,
+      "avgConfidence": 0.5643393393393393,
       "bundleSize": 397443,
       "patterns": {
         "wait-for-event": {
@@ -6878,6 +6880,10 @@
           "confidence": 1
         },
         "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-forever": {
           "success": true,
           "confidence": 1
         },
@@ -6932,6 +6938,14 @@
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.6
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.6
         },
         "toggle-class-basic": {
           "success": true,
@@ -7171,10 +7185,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.5
-        },
         "input-clear": {
           "success": true,
           "confidence": 0.5
@@ -7242,16 +7252,13 @@
           "success": true,
           "confidence": 0.5
         },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.5
-        },
         "event-from-elsewhere": {
           "success": true,
           "confidence": 0.5
         },
         "event-key-combo": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "fetch-loading-state": {
           "success": true,
@@ -7266,10 +7273,6 @@
           "confidence": 0.5
         },
         "if-exists": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-empty": {
           "success": true,
           "confidence": 0.5
         },
@@ -9343,10 +9346,10 @@
       }
     },
     "qu": {
-      "parseSuccess": 150,
-      "parseFailure": 4,
-      "parseRate": 0.974025974025974,
-      "avgConfidence": 0.7166666666666667,
+      "parseSuccess": 151,
+      "parseFailure": 3,
+      "parseRate": 0.9805194805194806,
+      "avgConfidence": 0.7350993377483444,
       "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
@@ -9437,6 +9440,10 @@
           "success": true,
           "confidence": 1
         },
+        "if-condition": {
+          "success": true,
+          "confidence": 1
+        },
         "repeat-for-each": {
           "success": true,
           "confidence": 1
@@ -9473,11 +9480,19 @@
           "success": true,
           "confidence": 1
         },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
         "accordion-toggle": {
           "success": true,
           "confidence": 1
         },
         "dropdown-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-validation": {
           "success": true,
           "confidence": 1
         },
@@ -9502,6 +9517,18 @@
           "confidence": 1
         },
         "fetch-error-handling": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-empty": {
           "success": true,
           "confidence": 1
         },
@@ -9665,10 +9692,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.5
-        },
         "repeat-times": {
           "success": true,
           "confidence": 0.5
@@ -9720,10 +9743,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.5
-        },
         "accordion-exclusive": {
           "success": true,
           "confidence": 0.5
@@ -9737,10 +9756,6 @@
           "confidence": 0.5
         },
         "input-char-count": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "input-validation": {
           "success": true,
           "confidence": 0.5
         },
@@ -9820,17 +9835,6 @@
           "confidence": 0.5
         },
         "event-key-combo": {
-          "success": false
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-empty": {
           "success": true,
           "confidence": 0.5
         },
@@ -9967,7 +9971,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8883529169243457,
+      "avgConfidence": 0.8871985157699446,
       "bundleSize": 397443,
       "patterns": {
         "add-class-basic": {
@@ -10011,10 +10015,6 @@
           "confidence": 1
         },
         "fetch-loading-state": {
-          "success": true,
-          "confidence": 1
-        },
-        "stagger-animation": {
           "success": true,
           "confidence": 1
         },
@@ -10515,6 +10515,10 @@
           "confidence": 0.8222222222222222
         },
         "fade-out-remove": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "stagger-animation": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -10592,7 +10596,7 @@
       "parseSuccess": 151,
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
-      "avgConfidence": 0.8853253442657419,
+      "avgConfidence": 0.8849048670240726,
       "bundleSize": 397443,
       "patterns": {
         "add-class-basic": {
@@ -10964,10 +10968,6 @@
           "confidence": 0.8857142857142858
         },
         "slide-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "stagger-animation": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -11151,6 +11151,10 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "focus-trap": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -11214,7 +11218,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.940960626674911,
+      "avgConfidence": 0.9402185116470816,
       "bundleSize": 397443,
       "patterns": {
         "add-class-basic": {
@@ -11366,10 +11370,6 @@
           "confidence": 1
         },
         "fade-out-remove": {
-          "success": true,
-          "confidence": 1
-        },
-        "stagger-animation": {
           "success": true,
           "confidence": 1
         },
@@ -11758,6 +11758,10 @@
           "confidence": 0.8857142857142858
         },
         "slide-toggle": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "stagger-animation": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -11839,7 +11843,7 @@
       "parseSuccess": 141,
       "parseFailure": 13,
       "parseRate": 0.9155844155844156,
-      "avgConfidence": 0.8864665487944589,
+      "avgConfidence": 0.885197104846667,
       "bundleSize": 397443,
       "patterns": {
         "add-class-basic": {
@@ -11878,10 +11882,6 @@
           "success": true,
           "confidence": 1
         },
-        "if-condition": {
-          "success": true,
-          "confidence": 1
-        },
         "halt-propagation": {
           "success": true,
           "confidence": 1
@@ -11910,19 +11910,11 @@
           "success": true,
           "confidence": 1
         },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 1
-        },
         "input-mirror": {
           "success": true,
           "confidence": 1
         },
         "input-char-count": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-validation": {
           "success": true,
           "confidence": 1
         },
@@ -11955,18 +11947,6 @@
           "confidence": 1
         },
         "fetch-loading-state": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-empty": {
           "success": true,
           "confidence": 1
         },
@@ -12178,6 +12158,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "go-back": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -12202,6 +12186,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "accordion-toggle": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -12210,7 +12198,15 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "closest-ancestor": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "repeat-until-event": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -12222,7 +12218,23 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "slide-toggle": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "stagger-animation": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -12334,10 +12346,6 @@
           "success": true,
           "confidence": 0.7647058823529411
         },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 0.7647058823529411
-        },
         "first-in-parent": {
           "success": true,
           "confidence": 0.6
@@ -12404,10 +12412,6 @@
         "last-in-collection": {
           "success": false
         },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.5
-        },
         "event-once": {
           "success": true,
           "confidence": 0.5
@@ -12448,10 +12452,10 @@
       }
     },
     "tr": {
-      "parseSuccess": 151,
-      "parseFailure": 3,
-      "parseRate": 0.9805194805194806,
-      "avgConfidence": 0.8431935246504783,
+      "parseSuccess": 152,
+      "parseFailure": 2,
+      "parseRate": 0.987012987012987,
+      "avgConfidence": 0.860672514619883,
       "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
@@ -12578,6 +12582,10 @@
           "success": true,
           "confidence": 1
         },
+        "if-condition": {
+          "success": true,
+          "confidence": 1
+        },
         "repeat-for-each": {
           "success": true,
           "confidence": 1
@@ -12638,6 +12646,10 @@
           "success": true,
           "confidence": 1
         },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
         "accordion-toggle": {
           "success": true,
           "confidence": 1
@@ -12659,6 +12671,10 @@
           "confidence": 1
         },
         "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-validation": {
           "success": true,
           "confidence": 1
         },
@@ -12715,6 +12731,18 @@
           "confidence": 1
         },
         "fetch-error-handling": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-empty": {
           "success": true,
           "confidence": 1
         },
@@ -12890,10 +12918,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.5
-        },
         "repeat-times": {
           "success": true,
           "confidence": 0.5
@@ -12915,14 +12939,6 @@
           "confidence": 0.5
         },
         "modal-close-escape": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "input-validation": {
           "success": true,
           "confidence": 0.5
         },
@@ -12970,17 +12986,6 @@
           "confidence": 0.5
         },
         "event-key-combo": {
-          "success": false
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-empty": {
           "success": true,
           "confidence": 0.5
         },
@@ -13073,7 +13078,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8868686868686871,
+      "avgConfidence": 0.8864564007421153,
       "bundleSize": 397443,
       "patterns": {
         "add-class-basic": {
@@ -13432,10 +13437,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "toggle-aria-expanded": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -13617,6 +13618,10 @@
           "confidence": 0.8222222222222222
         },
         "fade-out-remove": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "stagger-animation": {
           "success": true,
           "confidence": 0.8222222222222222
         },

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-07T06:05:38.263Z",
-  "commit": "9863a5d",
+  "timestamp": "2026-06-07T08:32:30.941Z",
+  "commit": "5c20e90",
   "languages": {
     "ar": {
-      "parseSuccess": 144,
-      "parseFailure": 10,
-      "parseRate": 0.935064935064935,
-      "avgConfidence": 0.9133082399626519,
-      "bundleSize": 397306,
+      "parseSuccess": 146,
+      "parseFailure": 8,
+      "parseRate": 0.948051948051948,
+      "avgConfidence": 0.9144957983193279,
+      "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -305,11 +305,19 @@
           "success": true,
           "confidence": 1
         },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
         "chained-access-possessive-dot": {
           "success": true,
           "confidence": 1
         },
         "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 1
         },
@@ -583,12 +591,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "method-call-possessive-dot": {
-          "success": false
-        },
-        "get-attribute-possessive-dot": {
-          "success": false
-        },
         "socket-basic": {
           "success": true,
           "confidence": 0.5
@@ -621,8 +623,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8397546897546898,
-      "bundleSize": 397306,
+      "avgConfidence": 0.8462481962481962,
+      "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -924,7 +926,15 @@
           "success": true,
           "confidence": 1
         },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
         "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 1
         },
@@ -1176,15 +1186,7 @@
           "success": true,
           "confidence": 0.5
         },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
         "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 0.5
         },
@@ -1247,7 +1249,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9374935159248873,
-      "bundleSize": 397306,
+      "bundleSize": 397443,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1871,7 +1873,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 397306,
+      "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2496,7 +2498,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 397306,
+      "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3120,7 +3122,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 397306,
+      "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3743,8 +3745,8 @@
       "parseSuccess": 149,
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
-      "avgConfidence": 0.8446361989986156,
-      "bundleSize": 397306,
+      "avgConfidence": 0.8470224778949617,
+      "bundleSize": 397443,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -3759,6 +3761,14 @@
           "confidence": 1
         },
         "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 1
         },
@@ -4230,19 +4240,11 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "chained-access-possessive-dot": {
           "success": true,
           "confidence": 0.8222222222222222
         },
         "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -4364,7 +4366,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 1,
-      "bundleSize": 397306,
+      "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -4988,7 +4990,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 397306,
+      "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5612,7 +5614,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9976296296296296,
-      "bundleSize": 397306,
+      "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6232,8 +6234,8 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8339454300238615,
-      "bundleSize": 397306,
+      "avgConfidence": 0.8404813777362797,
+      "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6523,7 +6525,15 @@
           "success": true,
           "confidence": 1
         },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
         "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 1
         },
@@ -6782,15 +6792,7 @@
           "success": true,
           "confidence": 0.5
         },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
         "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 0.5
         },
@@ -6857,7 +6859,7 @@
       "parseFailure": 7,
       "parseRate": 0.9545454545454546,
       "avgConfidence": 0.5600151171579743,
-      "bundleSize": 397306,
+      "bundleSize": 397443,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7475,7 +7477,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9988455988455989,
-      "bundleSize": 397306,
+      "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8100,7 +8102,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.8352592592592598,
-      "bundleSize": 397306,
+      "bundleSize": 397443,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8721,7 +8723,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8312273057371102,
-      "bundleSize": 397306,
+      "bundleSize": 397443,
       "patterns": {
         "window-resize": {
           "success": true,
@@ -9345,7 +9347,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.7166666666666667,
-      "bundleSize": 397306,
+      "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -9965,8 +9967,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8860441146155434,
-      "bundleSize": 397306,
+      "avgConfidence": 0.8883529169243457,
+      "bundleSize": 397443,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10017,6 +10019,14 @@
           "confidence": 1
         },
         "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 1
         },
@@ -10532,15 +10542,7 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "chained-access-possessive-dot": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -10587,11 +10589,11 @@
       }
     },
     "sw": {
-      "parseSuccess": 150,
-      "parseFailure": 4,
-      "parseRate": 0.974025974025974,
-      "avgConfidence": 0.8833756613756617,
-      "bundleSize": 397306,
+      "parseSuccess": 151,
+      "parseFailure": 3,
+      "parseRate": 0.9805194805194806,
+      "avgConfidence": 0.8853253442657419,
+      "bundleSize": 397443,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10677,7 +10679,15 @@
           "success": true,
           "confidence": 1
         },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
         "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 1
         },
@@ -11145,10 +11155,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "get-attribute-possessive-dot": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "make-toast-element": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -11184,9 +11190,6 @@
         "announce-screen-reader": {
           "success": false
         },
-        "method-call-possessive-dot": {
-          "success": false
-        },
         "socket-basic": {
           "success": true,
           "confidence": 0.5
@@ -11212,7 +11215,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.940960626674911,
-      "bundleSize": 397306,
+      "bundleSize": 397443,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11833,11 +11836,11 @@
       }
     },
     "tl": {
-      "parseSuccess": 139,
-      "parseFailure": 15,
-      "parseRate": 0.9025974025974026,
-      "avgConfidence": 0.8848329739569691,
-      "bundleSize": 397306,
+      "parseSuccess": 141,
+      "parseFailure": 13,
+      "parseRate": 0.9155844155844156,
+      "avgConfidence": 0.8864665487944589,
+      "bundleSize": 397443,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11995,11 +11998,19 @@
           "success": true,
           "confidence": 1
         },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
         "chained-access-possessive-dot": {
           "success": true,
           "confidence": 1
         },
         "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 1
         },
@@ -12419,12 +12430,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "method-call-possessive-dot": {
-          "success": false
-        },
-        "get-attribute-possessive-dot": {
-          "success": false
-        },
         "eventsource-basic": {
           "success": true,
           "confidence": 0.5
@@ -12446,8 +12451,8 @@
       "parseSuccess": 151,
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
-      "avgConfidence": 0.8365710080941869,
-      "bundleSize": 397306,
+      "avgConfidence": 0.8431935246504783,
+      "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -12741,7 +12746,15 @@
           "success": true,
           "confidence": 1
         },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
         "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 1
         },
@@ -12994,15 +13007,7 @@
         "focus-trap": {
           "success": false
         },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
         "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 0.5
         },
@@ -13068,8 +13073,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8845598845598848,
-      "bundleSize": 397306,
+      "avgConfidence": 0.8868686868686871,
+      "bundleSize": 397443,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13116,6 +13121,14 @@
           "confidence": 1
         },
         "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 1
         },
@@ -13631,15 +13644,7 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "chained-access-possessive-dot": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -13694,7 +13699,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8894248608534325,
-      "bundleSize": 397306,
+      "bundleSize": 397443,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14319,7 +14324,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9988148148148148,
-      "bundleSize": 397306,
+      "bundleSize": 397443,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -14938,7 +14943,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 397306,
+      "size": 397443,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Track 4 — deep per-language grammar (continuing after #274)

Follow-up to #274 (Phases 1–4, merged). Continuing into the deep Track 4 items documented in `docs-internal/MULTILINGUAL_ROADMAP.md`.

### ✅ Method calls on possessive-dot member access (+5)

`my.value.toUpperCase()` / `my.getAttribute("data-id")` failed to parse for **ar/sw/tl**. The possessive-dot matcher (`tryMatchPossessiveExpression`) expected the trailing method call as a single `(...)` literal token, but the tokenizer splits it into `(` / args / `)` (token kinds vary). Changed it to consume the call by **balanced-paren count**.

Diagnostic note: the bare semantic `parse()` fails this even in en — but the harness wraps every pattern in an event handler (`on input …`) whose body path parses it, so en passed all along; the fix only needed to make the non-English possessive path consume the split parens.

**Impact:** baseline avg **98.19% → 98.32%**, **+5 patterns, 0 regressions** (`method-call-possessive-dot` ar/sw/tl, `get-attribute-possessive-dot` ar/tl). ar 93.5% → 94.8%, tl 90.3% → 91.6%. Locked by `possessive-value-fillers.test.ts`; full semantic suite passes (5262 — only the documented environmental `build-artifacts` `.d.ts` checks fail).

### Remaining Track 4 (documented, genuinely deep)
Pinpointed precise blockers this session: the rest are **VSO event-at-end reorder robustness** (last-in-collection, multiple-events ar), **event-handler-body block masking** (event-key-combo, repeat-until-event), **event modifiers** (`over <dur>`, `from window debounced at`), condition translation (`unless I match …`), and tl `after`↔`then` collision (put-before/after). Each is its own transformer/parser project. **Phase 5 — behaviors** still held per request.

🤖 Cumulative across #274 + this PR: avg 97.5% → 98.32%, +31 patterns, 0 regressions.

https://claude.ai/code/session_01Pa5hn9cm61cnPwwuAMiu49

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pa5hn9cm61cnPwwuAMiu49)_