### PR TITLE
Track 4: Tagalog put before/after (+2)

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,7 +5,7 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after Track 4 (method-call possessive-dot + event-body block masking). Track 1 (reactive) complete._
+_Last updated: after Track 4 (method-call, event-body blocks, tl put before/after). Track 1 (reactive) complete._
 
 ---
 
@@ -13,7 +13,7 @@ _Last updated: after Track 4 (method-call possessive-dot + event-body block mask
 
 Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
 (generated with `--bundle browser-priority`). Cross-language average **98.5%**
-(up from 97.5% before Phase 1; Phases 1–4 + Track 4: +36 instances).
+(up from 97.5% before Phase 1; Phases 1–4 + Track 4: +38 instances).
 
 | Rate         | Languages                             |
 | ------------ | ------------------------------------- |
@@ -22,9 +22,9 @@ Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
 | 99.4%        | de, es, fr, hi, id, pt                |
 | 96–97%       | it/pl/zh (97.4), he (96.8), ko (96.1) |
 | 95–96%       | sw (96.8)                             |
-| **laggards** | **ar (94.8), tl (91.6)**              |
+| **laggards** | **ar (94.8), tl (92.9)**              |
 
-**~40 failing pattern-instances** remain after Phases 1–4 + Track 4, in two tracks (Track 1 reactive done):
+**~38 failing pattern-instances** remain after Phases 1–4 + Track 4, in two tracks (Track 1 reactive done):
 
 | Track                         | Instances | Nature                                                                           |
 | ----------------------------- | --------- | -------------------------------------------------------------------------------- |
@@ -180,6 +180,13 @@ own transformer/parser project (no shared lever remains):
 - **Still open here:** `focus-trap` (tr), `window-resize` (qu/tr) — event-block
   bodies _with_ a `from <source>` clause; need event-first + source ordering for
   VSO. `multiple-events` (ar) needs `or`-conjoined events.
+- **put before/after — DONE (+2, tl).** Only tl failed (ar/es/en parse). Two
+  causes: (1) tl's destination role-marker had no before/after alternatives, so
+  the generated put pattern couldn't match a before/after target — added `bago`
+  (before) / `matapos` (after) as destination alternatives, mirroring Arabic's
+  قبل/بعد. (2) the i18n tl dict emitted `pagkatapos` for positional "after", which
+  is _also_ tl "then" — switched it to the unambiguous `matapos` (matching the
+  semantic profile). Locked by tagalog-idioms.test.ts.
 - **`transition-*` `over <dur>` modifier** (ko/tl) — `over 500ms` modifier is
   dropped/misplaced in word-order reorder.
 - **`scroll to last <sel> in …`** (last-in-collection; ar/tl) — `scroll to` +

--- a/packages/i18n/src/dictionaries/tl.ts
+++ b/packages/i18n/src/dictionaries/tl.ts
@@ -80,7 +80,11 @@ export const tagalogDictionary: Dictionary = {
     as: 'bilang',
     by: 'sa_pamamagitan_ng',
     before: 'bago',
-    after: 'pagkatapos',
+    // `matapos` (not `pagkatapos`) for the positional "after": `pagkatapos` is
+    // also Tagalog "then", so emitting it for the position modifier collides with
+    // the sequence connector. `matapos` is the unambiguous positional form and
+    // matches the semantic tl profile's `after`.
+    after: 'matapos',
     over: 'sa_ibabaw',
     under: 'sa_ilalim',
     between: 'sa_pagitan',

--- a/packages/semantic/src/generators/profiles/tl.ts
+++ b/packages/semantic/src/generators/profiles/tl.ts
@@ -48,7 +48,11 @@ export const tagalogProfile: LanguageProfile = {
     },
   },
   roleMarkers: {
-    destination: { primary: 'sa', position: 'before' }, // "to/into"
+    // `bago` (before) / `matapos` (after) are positional destination markers for
+    // `put X before/after Y`, mirroring how Arabic lists قبل/بعد as destination
+    // alternatives. Without them the generated put pattern can't match a
+    // before/after target.
+    destination: { primary: 'sa', alternatives: ['bago', 'matapos'], position: 'before' }, // "to/into"
     source: { primary: 'mula_sa', position: 'before' }, // "from"
     patient: { primary: '', position: 'before' },
     style: { primary: 'nang', position: 'before' }, // manner marker

--- a/packages/semantic/test/tagalog-idioms.test.ts
+++ b/packages/semantic/test/tagalog-idioms.test.ts
@@ -567,4 +567,17 @@ describe('Tagalog Integration Tests', () => {
       expect(tokens.length).toBeGreaterThan(0);
     });
   });
+
+  describe('Positional put (before/after)', () => {
+    // `bago` (before) / `matapos` (after) are destination markers for
+    // `put X before/after Y`. `matapos` — not `pagkatapos` (which is also "then")
+    // — is the unambiguous positional "after".
+    it('parses put … bago (before) …', () => {
+      expect(parse('ilagay "<p>New</p>" bago ako kapag click', 'tl')).toBeTruthy();
+    });
+
+    it('parses put … matapos (after) …', () => {
+      expect(parse('ilagay "<p>New</p>" matapos ako kapag click', 'tl')).toBeTruthy();
+    });
+  });
 });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-07T11:47:19.051Z",
-  "commit": "d5cfc3c",
+  "timestamp": "2026-06-07T12:05:29.954Z",
+  "commit": "4213edb",
   "languages": {
     "ar": {
       "parseSuccess": 146,
@@ -11840,10 +11840,10 @@
       }
     },
     "tl": {
-      "parseSuccess": 141,
-      "parseFailure": 13,
-      "parseRate": 0.9155844155844156,
-      "avgConfidence": 0.885197104846667,
+      "parseSuccess": 143,
+      "parseFailure": 11,
+      "parseRate": 0.9285714285714286,
+      "avgConfidence": 0.8868027397439164,
       "bundleSize": 397443,
       "patterns": {
         "add-class-basic": {
@@ -11867,6 +11867,14 @@
           "confidence": 1
         },
         "put-content-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-before": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-after": {
           "success": true,
           "confidence": 1
         },
@@ -12365,12 +12373,6 @@
         "repeat-while": {
           "success": true,
           "confidence": 0.5294117647058824
-        },
-        "put-before": {
-          "success": false
-        },
-        "put-after": {
-          "success": false
         },
         "transition-opacity": {
           "success": false


### PR DESCRIPTION
## Track 4 — Tagalog `put before/after` (+2)

Follow-up to #275 (merged). Continuing Track 4.

### ✅ `put X before/after Y` for Tagalog (+2)

Only **tl** failed this (ar/es/en already parse). Two causes, both fixed:
1. tl's `destination` role-marker had no before/after alternatives, so the generated `put` pattern couldn't match a positional target. Added `bago` (before) / `matapos` (after) as destination alternatives — mirroring how Arabic lists `قبل`/`بعد`.
2. the i18n tl dictionary emitted `pagkatapos` for positional "after", which is **also** Tagalog "then" — colliding with the sequence connector. Switched it to the unambiguous `matapos` (matching the semantic tl profile).

**Impact:** baseline avg **98.46% → 98.51%**, **+2 patterns** (tl put-before, put-after), **0 regressions**. tl 91.6% → 92.9%. Locked by `tagalog-idioms.test.ts`; semantic suite (5265) + i18n tests pass.

### Status of the rest of Track 4
This is where the cheap wins end — every remaining non-behavior item needs deep, per-pattern work or risky shared-config surgery (documented in `MULTILINGUAL_ROADMAP.md` → Track 4): `transition-*`/`window-resize` need profile `canonicalOrder` + duration-marker changes; `multiple-events` needs `or`-event grouping across word orders; `unless` needs condition i18n; `input-clear`/`set-color-variable` need selector-member / article+`of` parsing; `focus-trap`(tr)/`window-keydown` need VSO event+`from`-source ordering. **Phase 5 — behaviors** remains held.

🤖 Cumulative across #274 + #275 + this PR: avg 97.5% → 98.51%, +38 patterns, 0 regressions.

https://claude.ai/code/session_01Pa5hn9cm61cnPwwuAMiu49

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pa5hn9cm61cnPwwuAMiu49)_