### PR TITLE
fix(i18n): align qu `install` keyword to semantic profile (tarpuy)

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,31 +5,31 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after Track 4 (method-call, event-body blocks, tl put before/after). Track 1 (reactive) complete._
+_Last updated: after the qu `install` keyword-collision fix (`install-behavior` qu). Track 4 (method-call, event-body blocks, tl put before/after) and Track 1 (reactive) complete._
 
 ---
 
 ## Current state
 
 Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
-(generated with `--bundle browser-priority`). Cross-language average **98.5%**
-(up from 97.5% before Phase 1; Phases 1–4 + Track 4: +38 instances).
+(generated with `--bundle browser-priority`). Cross-language average **98.54%**
+(up from 97.5% before Phase 1; Phases 1–4 + Track 4 + qu `install`: +39 instances).
+**54 failing pattern-instances** remain (24 are Bucket B behaviors).
 
-| Rate         | Languages                             |
-| ------------ | ------------------------------------- |
-| 100%         | en, bn, ms, ru, th, uk, vi            |
-| 98–99%       | ja (99.4), qu (98.1), tr/zh (98.1)    |
-| 99.4%        | de, es, fr, hi, id, pt                |
-| 96–97%       | it/pl/zh (97.4), he (96.8), ko (96.1) |
-| 95–96%       | sw (96.8)                             |
-| **laggards** | **ar (94.8), tl (92.9)**              |
+| Rate     | Languages                                   |
+| -------- | ------------------------------------------- |
+| 100%     | en, bn, hi, ja, ms, ru, th, uk, vi          |
+| 98–99%   | qu (98.7), de/es/fr/id/pt (99.4), tr (98.7) |
+| 96–98%   | it/pl/zh (97.4), ko (96.1), he/sw (96.8)    |
+| laggards | **ar (94.8), tl (92.9)**                    |
 
-**~38 failing pattern-instances** remain after Phases 1–4 + Track 4, in two tracks (Track 1 reactive done):
+**~30 non-behavior failing pattern-instances** remain (plus 24 Bucket B behaviors),
+in two tracks (Track 1 reactive done):
 
 | Track                         | Instances | Nature                                                                           |
 | ----------------------------- | --------- | -------------------------------------------------------------------------------- |
-| **Bucket B — behaviors**      | ~26       | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`) |
-| **Deep per-language grammar** | ~14       | VSO event-at-end + `from`-source reorder, command modifiers, condition i18n      |
+| **Bucket B — behaviors**      | 24        | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`) |
+| **Deep per-language grammar** | ~30       | VSO event-at-end + `from`-source reorder, command modifiers, condition i18n      |
 
 > **The clean tokenizer token-split vein is now largely worked out** (Phases 1 & 4
 > cleared `@`/`*`/`^`; Phase 3a the English DOM events). Every remaining
@@ -40,6 +40,26 @@ Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
 ---
 
 ## Shipped
+
+### qu `install` keyword-collision fix — `install-behavior` (+1)
+
+- **1 instance, 0 regressions, avg 98.51% → 98.54%.** qu 98.1% → 98.7%.
+- **Root cause (passthrough-alignment).** The i18n qu dictionary mapped
+  `install` → `churay`, but `churay` is also qu for `put`/`set`, and the semantic
+  qu profile expects `install` = `tarpuy` (`churay` = `put` there). So
+  `install Draggable` transformed to `Draggable ta churay`, which the semantic
+  parser read as a malformed `put` (no destination) and rejected. Changed the
+  i18n qu dict to emit `tarpuy` (the specific "install/plant" verb already in the
+  semantic profile) — this both aligns the two systems and removes the
+  put/set/install overload. Verified `Draggable ta tarpuy` parses as `install`.
+  Locked by a Quechua case in `grammar.test.ts`.
+- **Reusable finding — the keyword-mismatch diagnostic.** A scan comparing each
+  i18n dict's command verbs against the semantic profile's primary+alternatives
+  surfaces many mismatches, but **most are latent** (the command isn't in the
+  test corpus, or the parse survives via normalization/word-order). The qu
+  `install` case was special: an _active collision_ (one i18n form, three
+  commands) **and** in the corpus **and** failing. When mining this list for more
+  wins, cross-reference against the actual failing patterns first.
 
 ### issue #259 lineage (pre-this-arc)
 
@@ -335,18 +355,41 @@ en-parity degenerate matching).
 
 ## Suggested sequencing for fresh sessions
 
-Track 1 (reactive) is **done** (#269–#271); Hebrew events done (#272). What remains is
-**not** quick — pick deliberately:
+Track 1 (reactive) is **done** (#269–#271); Hebrew events done (#272); `js-inline`
+block masking is **done** (Phase 2 — the old item 1 here was stale). What remains is
+**not** quick — almost everything left is structural SOV/VSO body reordering. Pick
+deliberately:
 
-1. **`js-inline` block masking** (ja/ko/qu/tr, 4) — single transformer fix to mask the
-   `js … end` body from word-order reordering. Most tractable of the deep set; verify it
-   isn't a degenerate match first.
-2. **`set-*` family** (ar/tl, ~10) — biggest count but lowest value (en-parity degenerate
-   match) and needs `@attr`/`*style` token handling in event-handler bodies.
-3. **Bucket B behaviors** (24) — separate **runtime** track; implement
-   Draggable/Sortable/Resizable/Removable, then revisit the `install … <behavior>` parse.
-4. **Scattered per-language** (caret, transition-\*, possessive-dot, announce) — one
-   pattern at a time; expect tokenizer/transformer work per item.
+1. **Bucket B behaviors** (24, biggest lever) — separate **runtime** track. Note
+   `behavior-removable`'s `raw_code` is the behavior _definition source_, which
+   contains a **multi-line `js(me) … end`** block; Phase 2 only masked single-line
+   `js`, so this needs multi-line-js masking inside `behavior` defs (deferred
+   "Phase 5"). Not a cheap parse win.
+2. **`transition-*`** (ko/tl, ~6) — **deeper than the refactor plan claimed** (see
+   the ⚠️ update at the top of `TRANSITION_MODIFIER_REFACTOR_PLAN.md`): needs new
+   post-verb-role SOV/VSO event-handler pattern variants, not a marker tweak.
+   Multi-session, low ROI.
+3. **`set-*` family** (ar/tl, ~10) — biggest non-behavior count but lowest value
+   (en-parity degenerate match) and needs `@attr`/`*style` token handling in
+   event-handler bodies.
+4. **Scattered per-language** (caret, possessive-dot, announce, unless, multiple-events)
+   — one pattern at a time; expect tokenizer/transformer work per item.
+
+**Structural finding — custom events in SOV (`on-custom-event-receive`, ko/qu).**
+`on hello put X into me` parses in SVO (en/es) but fails in ko: `on click …` passes
+(`'Got it!' 를 클릭 넣다 나 에`) while `on hello …` fails (`… hello 넣다 …`) — the
+_only_ difference is the event token. The SOV event-handler pattern's `{event}` slot
+matches a **recognized event keyword** (클릭) but not an arbitrary identifier
+(`hello`); SVO works because the leading `on`/`en` marker disambiguates. Fixing it
+means letting the SOV `{event}` slot accept a bare identifier (over-match risk) — a
+parser change, not a keyword fix.
+
+**Keyword-mismatch mining (low-risk wins, mostly latent).** A diagnostic comparing
+each i18n dict verb to the semantic profile's primary+alternatives surfaces dozens
+of mismatches, but most are inert (untested command, or parse survives anyway). The
+qu `install` win was the rare case that was an _active collision_ AND in the corpus
+AND failing. Cross-reference any candidate against the live failing-pattern list
+before investing.
 
 Definition of done (unchanged from #259): all languages ≥ ~99% in the regenerated baseline.
 Realistically the next ~10–15 points of parse-rate require the deep work above, not

--- a/docs-internal/TRANSITION_MODIFIER_REFACTOR_PLAN.md
+++ b/docs-internal/TRANSITION_MODIFIER_REFACTOR_PLAN.md
@@ -10,6 +10,52 @@
 
 ---
 
+## ⚠️ Investigation update (supersedes "Root-cause findings" below)
+
+A hands-on probing session (via the real harness path: `maskSpans` →
+`GrammarTransformer` → `MultilingualHyperscript.parse`) found the original
+root-cause analysis **partly wrong** and the work **deeper than estimated**:
+
+1. **ko `opacity` (literal patient) does NOT parse standalone.** `transition-opacity`
+   / `fade-out-remove` "pass" in the baseline only because of the trailing
+   `then remove me` (a compound where `remove me` parses). Strip the `then` and
+   even the clean-literal ko transition is `null`. So the metric is hollow there.
+2. **The goal-marker mismatch is NOT "minor" — but fixing it doesn't help either.**
+   i18n maps the English `to` to the **`destination`** role globally
+   (`ENGLISH_MODIFIER_ROLES.to = 'destination'`), so for ko it emits the
+   destination particle `에`. The semantic transition schema calls that slot
+   **`goal`**. Aligning markers (schema `goal.markerOverride.ko`, or adding a
+   profile `goal` marker — only `transition` uses `goal`, so zero blast radius)
+   changes **nothing**, because of the real blocker:
+3. **THE REAL BLOCKER — structural.** The generated SOV/VSO event-handler pattern
+   (`generateSOVPatientFirstEventHandlerPattern` in
+   `packages/semantic/src/generators/event-handlers-sov.ts`) is
+   `{patient} {marker} {event} {marker} {verb}` — it **ends at the verb**. It has
+   no slots for transition's `goal` / `destination` / `duration`, which the i18n
+   transformer emits **after** the verb (`… 전환 0 에 500ms`) because those roles
+   aren't in the language's `canonicalOrder` (they land in the `remainingOrder`
+   tail, after the event clause). So those trailing tokens are always
+   unmatched leftovers; ko `으로`/`에서` only ever "matched" via a fragile
+   secondary path, never the transition pattern itself.
+4. **The patient-type widening (`expectedTypes: ['literal','selector','identifier']`)
+   is correct but inert for the metric.** It makes `transform`/`*background-color`
+   behave exactly like `opacity` in the SOV pattern's patient slot, but the
+   leftover-token problem above means no end-to-end outcome changes (verified:
+   broad 23-lang probe still fails exactly ko/tl color+transform).
+5. **i18n has no per-command role lever** — `to`→`destination` is global, so the
+   transition body can't be cleanly re-marked there without touching every
+   command that uses `to` for an element destination (`add .x to #el`).
+
+**Corrected scope:** landing `transition-*` requires **new post-verb-role
+SOV/VSO event-handler pattern variants** in the generator (emit
+`… {verb} {goal} {goal-marker} [{duration}]`) reconciled with the i18n output,
+verified for zero regression across all SOV/VSO languages — a genuine
+multi-session refactor, **not** the ~6-instance drive-by the metric implies.
+The June-2026 session deliberately **deferred** this (poor ROI vs. risk) after
+confirming the above, and instead shipped a tractable win elsewhere
+(qu `install` collision). The findings below (1–3) are the original, partly
+inaccurate analysis — kept for history; trust this block over them.
+
 ## Target failures
 
 | Pattern                | Langs  | raw_code                                                       |

--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -54,7 +54,7 @@ export const qu: Dictionary = {
     settle: 'tiyay',
     append: 'qhipaman_yapay',
     exit: 'lluqsiy',
-    install: 'churay',
+    install: 'tarpuy',
     breakpoint: 'sayachinay',
     clear: 'pichay',
     close: 'wichqay',

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -473,6 +473,22 @@ describe('GrammarTransformer', () => {
       expect(result).toContain('.menu');
     });
   });
+
+  describe('Quechua Transformation (SOV)', () => {
+    const transformer = new GrammarTransformer('en', 'qu');
+
+    it('should emit the install-specific verb (tarpuy), not the put/set verb (churay)', () => {
+      // Regression: the qu dictionary mapped `install` to `churay`, which is
+      // also `put`/`set`. The semantic qu profile expects `install` = `tarpuy`
+      // (churay = put), so `install Draggable` parsed as a malformed `put` and
+      // failed (`install-behavior` baseline failure). Align the emitted verb to
+      // the semantic profile's install keyword.
+      const result = transformer.transform('install Draggable');
+      expect(result).toContain('tarpuy');
+      expect(result).not.toContain('churay');
+      expect(result).toContain('Draggable');
+    });
+  });
 });
 
 // =============================================================================

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-07T12:05:29.954Z",
-  "commit": "4213edb",
+  "timestamp": "2026-06-07T13:46:12.307Z",
+  "commit": "a8fcca2",
   "languages": {
     "ar": {
       "parseSuccess": 146,
       "parseFailure": 8,
       "parseRate": 0.948051948051948,
       "avgConfidence": 0.9162596088663778,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -624,7 +624,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.868975468975469,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1249,7 +1249,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9367465504720396,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1873,7 +1873,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2498,7 +2498,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3122,7 +3122,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3746,7 +3746,7 @@
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.8500053265153942,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4366,7 +4366,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -4991,7 +4991,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5615,7 +5615,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9976296296296296,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6236,7 +6236,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8378066378066378,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6861,7 +6861,7 @@
       "parseFailure": 6,
       "parseRate": 0.961038961038961,
       "avgConfidence": 0.5643393393393393,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7480,7 +7480,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9988455988455989,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8105,7 +8105,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.8352592592592598,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8726,7 +8726,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8312273057371102,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "window-resize": {
           "success": true,
@@ -9346,11 +9346,11 @@
       }
     },
     "qu": {
-      "parseSuccess": 151,
-      "parseFailure": 3,
-      "parseRate": 0.9805194805194806,
-      "avgConfidence": 0.7350993377483444,
-      "bundleSize": 397443,
+      "parseSuccess": 152,
+      "parseFailure": 2,
+      "parseRate": 0.987012987012987,
+      "avgConfidence": 0.735672514619883,
+      "bundleSize": 397467,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -9636,6 +9636,10 @@
           "success": true,
           "confidence": 1
         },
+        "install-behavior": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
         "remove-class-basic": {
           "success": true,
           "confidence": 0.5
@@ -9715,9 +9719,6 @@
         "default-value": {
           "success": true,
           "confidence": 0.5
-        },
-        "install-behavior": {
-          "success": false
         },
         "call-function": {
           "success": true,
@@ -9972,7 +9973,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8871985157699446,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10597,7 +10598,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.8849048670240726,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11219,7 +11220,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9402185116470816,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11844,7 +11845,7 @@
       "parseFailure": 11,
       "parseRate": 0.9285714285714286,
       "avgConfidence": 0.8868027397439164,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12458,7 +12459,7 @@
       "parseFailure": 2,
       "parseRate": 0.987012987012987,
       "avgConfidence": 0.860672514619883,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13081,7 +13082,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8864564007421153,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13706,7 +13707,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8894248608534325,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14331,7 +14332,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9988148148148148,
-      "bundleSize": 397443,
+      "bundleSize": 397467,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -14950,7 +14951,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 397443,
+      "size": 397467,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Pivoted from the roadmap's nominal next item (`transition-*`) — confirmed by hands-on probing to be a multi-session structural refactor with poor ROI — to a clean, tractable win: the `install-behavior` Quechua failure.

**Root cause (passthrough-alignment).** The i18n qu dictionary mapped `install` → `churay`, but `churay` is also qu for `put`/`set`, and the semantic qu profile expects `install` = `tarpuy` (`churay` = `put` there). So `install Draggable` transformed to `Draggable ta churay`, which the semantic parser read as a malformed `put` (no destination) and rejected.

**Fix.** Emit `tarpuy` (the specific "install/plant" verb already in the semantic profile). This aligns the two systems *and* removes the put/set/install overload. Verified end-to-end via the harness path (`maskSpans` → `GrammarTransformer` → `MultilingualHyperscript.parse`): `Draggable ta tarpuy` now parses as `install`.

## Verification

- **627 i18n tests pass** (incl. a new Quechua regression case in `grammar.test.ts`).
- **Regenerated priority baseline:** the *only* flip is `qu install-behavior` (False→True), **zero regressions** across all 24 languages.
  - qu **98.05% → 98.70%**; cross-language avg **98.51% → 98.54%**.
- Restored the binary `patterns.db` (not committed; CI repopulates from source).

## Docs

- **Corrected `TRANSITION_MODIFIER_REFACTOR_PLAN.md`** — its original root-cause analysis was partly wrong. Probing showed: ko `opacity` doesn't actually parse standalone (baseline "pass" is hollow via `then remove me`); the goal-marker mismatch is real but fixing it changes nothing; the *real* blocker is structural — the generated SOV/VSO event-handler pattern ends at the verb and has no slots for transition's post-verb `goal`/`destination`/`duration` roles. That's a new-pattern-variant refactor, not a marker tweak. Deferred deliberately.
- **Refreshed the roadmap sequencing** (the stale `js-inline` item 1 was already shipped) and recorded the **custom-event-in-SOV** finding (`on hello …` fails in ko because the SOV `{event}` slot only matches recognized event keywords, not arbitrary identifiers) plus guidance on the keyword-mismatch diagnostic (mostly latent — cross-reference against live failures).

## Files

- `packages/i18n/src/dictionaries/qu.ts` — the one-line fix
- `packages/i18n/src/grammar/grammar.test.ts` — regression test
- `packages/testing-framework/baselines/multilingual-priority.json` — regenerated baseline
- `docs-internal/MULTILINGUAL_ROADMAP.md`, `docs-internal/TRANSITION_MODIFIER_REFACTOR_PLAN.md` — corrected/updated

https://claude.ai/code/session_01Wj56J7wx1Vu7nyv7Q8SByv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wj56J7wx1Vu7nyv7Q8SByv)_