### PR TITLE
fix(multilingual): clear 11 non-behavior parse failures via passthrough-alignment

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,31 +5,38 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after the qu `install` keyword-collision fix (`install-behavior` qu). Track 4 (method-call, event-body blocks, tl put before/after) and Track 1 (reactive) complete._
+_Last updated: after the passthrough-alignment batch (or-conjoined events ar/tl; ko `fetch`/`transition` and tl `transition` keyword alignment). Track 4 (method-call, event-body blocks, tl put before/after) and Track 1 (reactive) complete._
 
 ---
 
 ## Current state
 
 Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
-(generated with `--bundle browser-priority`). Cross-language average **98.54%**
-(up from 97.5% before Phase 1; Phases 1–4 + Track 4 + qu `install`: +39 instances).
-**54 failing pattern-instances** remain (24 are Bucket B behaviors).
+(generated with `--bundle browser-priority`). Cross-language average **98.84%**
+(up from 97.5% before Phase 1; Phases 1–4 + Track 4 + qu `install` + passthrough
+batch: +50 instances).
+**43 failing pattern-instances** remain (24 are Bucket B behaviors).
 
-| Rate     | Languages                                   |
-| -------- | ------------------------------------------- |
-| 100%     | en, bn, hi, ja, ms, ru, th, uk, vi          |
-| 98–99%   | qu (98.7), de/es/fr/id/pt (99.4), tr (98.7) |
-| 96–98%   | it/pl/zh (97.4), ko (96.1), he/sw (96.8)    |
-| laggards | **ar (94.8), tl (92.9)**                    |
+| Rate     | Languages                            |
+| -------- | ------------------------------------ |
+| 100%     | en, bn, hi, ja, ms, ru, th, uk, vi   |
+| 99%      | de/es/fr/id/pt (99.4), **ko (99.4)** |
+| 98–99%   | qu (98.7), tr (98.7), sw (98.1)      |
+| 96–98%   | it/pl/zh (97.4), he (96.8)           |
+| laggards | **ar (95.5), tl (96.1)**             |
 
-**~30 non-behavior failing pattern-instances** remain (plus 24 Bucket B behaviors),
+**19 non-behavior failing pattern-instances** remain (plus 24 Bucket B behaviors),
 in two tracks (Track 1 reactive done):
 
 | Track                         | Instances | Nature                                                                           |
 | ----------------------------- | --------- | -------------------------------------------------------------------------------- |
 | **Bucket B — behaviors**      | 24        | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`) |
-| **Deep per-language grammar** | ~30       | VSO event-at-end + `from`-source reorder, command modifiers, condition i18n      |
+| **Deep per-language grammar** | 19        | VSO event-at-end + `from`-source reorder, command modifiers, condition i18n      |
+
+The 19 non-behavior remainders: `input-clear`, `form-disable-on-submit`,
+`set-color-variable`, `last-in-collection`, `unless-condition`,
+`caret-var-on-target` (each **ar+tl**); `announce-screen-reader` (he+sw);
+`on-custom-event-receive` (ko+qu); `window-resize` (qu+tr); `focus-trap` (tr).
 
 > **The clean tokenizer token-split vein is now largely worked out** (Phases 1 & 4
 > cleared `@`/`*`/`^`; Phase 3a the English DOM events). Every remaining
@@ -40,6 +47,39 @@ in two tracks (Track 1 reactive done):
 ---
 
 ## Shipped
+
+### Passthrough-alignment batch — or-events + fetch/transition keywords (+11)
+
+- **11 instances, 0 regressions, avg 98.54% → 98.84%.** ar 94.8→95.5, tl 92.9→96.1,
+  ko 96.1→99.4. Confirmed by a full `browser-priority` baseline regen (exactly these
+  11 patterns flip `↑`, zero `↓`).
+- **`multiple-events` (ar, tl) — transformer fix.** `on click or keypress[…] toggle .active`
+  hoisted `or keypress` ahead of the command because `parseEventHandler` read `or` as the
+  action verb. Fixed by folding `or`-conjoined events into the event role value
+  (`EVENT_CONJUNCTIONS`) so `<event1> or <event2>` translates and reorders as one event
+  clause that lands at the end (VSO). The semantic parser already accepted the event-or
+  clause at the end — only the i18n transformer needed the fix.
+- **`fetch` (ko ×3) — keyword alignment.** The i18n ko dict emits `가져오기` for `fetch`,
+  but the semantic ko profile's primary is the loanword `패치` (chosen to avoid colliding
+  with `get`=얻다). `가져오기` ("bring/fetch") doesn't collide with `얻다`, so it's now a
+  semantic `fetch` alternative. Cleared `fetch-with-method`, `fetch-with-method-body`,
+  `fetch-formdata`.
+- **`transition` (ko ×2, tl ×4) — keyword alignment.** ko: profile primary is loanword
+  `트랜지션`; transformer emits `전환` ("switch/transition") — added as a semantic
+  alternative (toggle uses `토글`, no collision). tl: transformer emitted `baguhin`, which
+  is the semantic tl verb for **morph**; the semantic tl `transition` verb is `lumipat`,
+  so the i18n tl dict now emits `lumipat` (morph keeps `baguhin_hugis`). Cleared
+  `transition-color`/`transition-transform` (both), plus tl `transition-opacity` and
+  `fade-out-remove`.
+- **Why this batch and not the rest.** These were the failures where either the i18n
+  transformer leaked the wrong token (the recurring **passthrough-alignment** lever) or a
+  pure structural reorder bug existed — verifiable as single keyword/transformer edits with
+  zero parser-surface change. The remaining 19 each need genuine parser/profile structure
+  work (VSO requires a _parseable_ body — unlike en/ko, which pass via degenerate empty-body
+  matches — so `set`-of-possessive, positional `last … in`, member-access, `unless` blocks,
+  custom-event SOV slots, event modifiers, and he/sw `set`-pattern gaps must each be built
+  out). Locked by `grammar.test.ts` (or-events + tl transition) and
+  `semantic/test/multilingual-roadmap-fixes.test.ts` (ko fetch + transition).
 
 ### qu `install` keyword-collision fix — `install-behavior` (+1)
 

--- a/packages/i18n/src/dictionaries/tl.ts
+++ b/packages/i18n/src/dictionaries/tl.ts
@@ -36,7 +36,7 @@ export const tagalogDictionary: Dictionary = {
     throw: 'ihagis',
     catch: 'hulihin',
     measure: 'sukatin',
-    transition: 'baguhin',
+    transition: 'lumipat',
     increment: 'dagdagan',
     decrement: 'bawasan',
     default: 'pamantayan',

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -849,6 +849,36 @@ describe('Word Order Integration Tests', () => {
       expect(result).toContain('.active');
     });
   });
+
+  // Regression guards for the multilingual parse-rate roadmap (see
+  // docs-internal/MULTILINGUAL_ROADMAP.md).
+  describe('Multi-event handlers (or-conjoined events)', () => {
+    it('keeps "or"-conjoined events together as a single event clause (ar)', () => {
+      const transformer = new GrammarTransformer('en', 'ar');
+      const result = transformer.transform('on click or keypress[key=="Enter"] toggle .active');
+      // The toggle action must lead (VSO); the event clause "<click> or keypress"
+      // stays together at the end, rather than "or keypress" being hoisted ahead
+      // of the command (the old bug, which read "or" as the action verb).
+      expect(result.indexOf('بدل')).toBeLessThan(result.indexOf('أو'));
+      expect(result).toContain('أو keypress[key=="Enter"]');
+    });
+
+    it('keeps "or"-conjoined events together as a single event clause (tl)', () => {
+      const transformer = new GrammarTransformer('en', 'tl');
+      const result = transformer.transform('on click or keypress[key=="Enter"] toggle .active');
+      expect(result).toContain('o keypress[key=="Enter"]');
+      expect(result.indexOf('palitan')).toBeLessThan(result.indexOf(' o '));
+    });
+  });
+
+  describe('Tagalog transition keyword alignment', () => {
+    it('emits the semantic transition verb "lumipat" (not "baguhin"=morph)', () => {
+      const transformer = new GrammarTransformer('en', 'tl');
+      const result = transformer.transform('on click transition opacity to 0 over 300ms');
+      expect(result).toContain('lumipat');
+      expect(result).not.toContain('baguhin');
+    });
+  });
 });
 
 // =============================================================================

--- a/packages/i18n/src/grammar/transformer.ts
+++ b/packages/i18n/src/grammar/transformer.ts
@@ -571,6 +571,14 @@ function deriveEventKeywordsFromProfiles(): Set<string> {
 /** Event keywords derived from language profiles */
 const EVENT_KEYWORDS = deriveEventKeywordsFromProfiles();
 
+/**
+ * Conjunctions that join multiple events in an event handler head
+ * (`on click or keypress ...`). Source hyperscript is English, so the
+ * canonical form is `or`; localized equivalents are added defensively for
+ * non-English sources.
+ */
+const EVENT_CONJUNCTIONS = new Set(['or']);
+
 // =============================================================================
 // Helper: Dynamic Modifier Map
 // =============================================================================
@@ -814,11 +822,30 @@ function parseEventHandler(tokens: string[], profile: LanguageProfile): ParsedSt
 
   // Next token is the event
   if (tokens[startIndex]) {
+    const eventTokens: string[] = [tokens[startIndex]];
+    startIndex++;
+
+    // Fold "or"-conjoined events into the event value (e.g.
+    // "on click or keypress[...] toggle .active"). Without this, "or" would be
+    // read as the action verb and the second event swept into role values,
+    // hoisting "or <event2>" ahead of the command on reorder. Keeping the whole
+    // "<event1> or <event2>" string in the event role lets it translate and
+    // reorder as a single event clause. Only consumes "or" that immediately
+    // follows the event, before any source/action — so a later "or" in a guard
+    // or value is untouched.
+    while (
+      tokens[startIndex] &&
+      EVENT_CONJUNCTIONS.has(tokens[startIndex].toLowerCase()) &&
+      tokens[startIndex + 1]
+    ) {
+      eventTokens.push(tokens[startIndex], tokens[startIndex + 1]);
+      startIndex += 2;
+    }
+
     roles.set('event', {
       role: 'event',
-      value: tokens[startIndex],
+      value: eventTokens.join(' '),
     });
-    startIndex++;
   }
 
   // Check for event source modifier before the action (e.g., "from #source" in "on input from #firstName set ...")

--- a/packages/semantic/src/generators/profiles/korean.ts
+++ b/packages/semantic/src/generators/profiles/korean.ts
@@ -75,7 +75,10 @@ export const koreanProfile: LanguageProfile = {
     // Visibility
     show: { primary: '보이다', alternatives: ['표시', '보이기'], normalized: 'show' },
     hide: { primary: '숨기다', alternatives: ['숨기기'], normalized: 'hide' },
-    transition: { primary: '트랜지션', normalized: 'transition' }, // loanword to avoid collision with toggle alt 전환
+    // primary is the loanword 트랜지션; 전환 ("switch/transition") is the form the
+    // i18n transformer emits — registered as an alternative (passthrough-alignment).
+    // toggle uses 토글, so 전환 carries no collision.
+    transition: { primary: '트랜지션', alternatives: ['전환'], normalized: 'transition' },
     // Events
     on: { primary: '에', alternatives: ['시', '할 때'], normalized: 'on' },
     trigger: { primary: '트리거', normalized: 'trigger' },
@@ -105,7 +108,10 @@ export const koreanProfile: LanguageProfile = {
     process: { primary: '처리', normalized: 'process' },
     // Async
     wait: { primary: '대기', normalized: 'wait' },
-    fetch: { primary: '패치', normalized: 'fetch' }, // loanword to avoid collision with get
+    // primary is the loanword 패치 (avoids collision with get 얻다); 가져오기
+    // ("bring/fetch") is the form the i18n transformer emits, registered here so
+    // transformed fetch patterns parse (passthrough-alignment).
+    fetch: { primary: '패치', alternatives: ['가져오기'], normalized: 'fetch' },
     settle: { primary: '안정', normalized: 'settle' },
     // Control flow
     if: { primary: '만약', normalized: 'if' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Multilingual roadmap — passthrough-alignment regression guards.
+ *
+ * The i18n grammar transformer emits certain command verbs as forms the
+ * semantic profile didn't originally list. These tests lock in the alignments
+ * that cleared the corresponding failing pattern-instances (see
+ * docs-internal/MULTILINGUAL_ROADMAP.md):
+ *
+ * - Korean `fetch`: transformer emits 가져오기 ("bring/fetch"), profile primary
+ *   is the loanword 패치. 가져오기 is registered as an alternative.
+ * - Korean `transition`: transformer emits 전환 ("switch/transition"), profile
+ *   primary is the loanword 트랜지션. 전환 is registered as an alternative
+ *   (toggle uses 토글, so no collision).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse, canParse } from '../src';
+
+describe('Korean fetch keyword alignment (가져오기)', () => {
+  // Corpus-shaped event handlers from the multilingual baseline.
+  const cases = [
+    '/api/form 를 제출 가져오기 method:"POST" body:form 로',
+    '/api/users 를 클릭 가져오기 method:"POST", body:"name=Joe" 로',
+  ];
+
+  for (const input of cases) {
+    it(`parses "${input}"`, () => {
+      expect(canParse(input, 'ko')).toBe(true);
+      expect(parse(input, 'ko').action).toBe('on');
+    });
+  }
+});
+
+describe('Korean transition keyword alignment (전환)', () => {
+  const cases = [
+    'transform 를 클릭 전환 "scale(1.2)" 에 300ms',
+    '*background-color 를 클릭 전환 "blue" 에 500ms',
+  ];
+
+  for (const input of cases) {
+    it(`parses "${input}"`, () => {
+      expect(canParse(input, 'ko')).toBe(true);
+      expect(parse(input, 'ko').action).toBe('on');
+    });
+  }
+
+  it('does not break toggle (토글) in Korean', () => {
+    expect(parse('.active 를 클릭 토글', 'ko').action).toBe('on');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-07T13:46:12.307Z",
-  "commit": "a8fcca2",
+  "timestamp": "2026-06-07T14:45:18.932Z",
+  "commit": "9373801",
   "languages": {
     "ar": {
-      "parseSuccess": 146,
-      "parseFailure": 8,
-      "parseRate": 0.948051948051948,
-      "avgConfidence": 0.9162596088663778,
-      "bundleSize": 397467,
+      "parseSuccess": 147,
+      "parseFailure": 7,
+      "parseRate": 0.9545454545454546,
+      "avgConfidence": 0.9168292713910963,
+      "bundleSize": 397515,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -114,6 +114,10 @@
           "confidence": 1
         },
         "send-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "multiple-events": {
           "success": true,
           "confidence": 1
         },
@@ -537,9 +541,6 @@
           "success": true,
           "confidence": 0.5294117647058824
         },
-        "multiple-events": {
-          "success": false
-        },
         "async-block": {
           "success": true,
           "confidence": 0.5
@@ -624,7 +625,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.868975468975469,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1249,7 +1250,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9367465504720396,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1873,7 +1874,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2498,7 +2499,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3122,7 +3123,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3746,7 +3747,7 @@
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.8500053265153942,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4366,7 +4367,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -4991,7 +4992,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5615,7 +5616,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9976296296296296,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6236,7 +6237,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8378066378066378,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6857,11 +6858,11 @@
       }
     },
     "ko": {
-      "parseSuccess": 148,
-      "parseFailure": 6,
-      "parseRate": 0.961038961038961,
-      "avgConfidence": 0.5643393393393393,
-      "bundleSize": 397467,
+      "parseSuccess": 153,
+      "parseFailure": 1,
+      "parseRate": 0.9935064935064936,
+      "avgConfidence": 0.5655047204066812,
+      "bundleSize": 397515,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -6880,6 +6881,10 @@
           "confidence": 1
         },
         "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "async-block": {
           "success": true,
           "confidence": 1
         },
@@ -7040,7 +7045,8 @@
           "confidence": 0.5
         },
         "transition-transform": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "settle-animations": {
           "success": true,
@@ -7071,7 +7077,8 @@
           "confidence": 0.5
         },
         "fetch-with-method": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "if-condition": {
           "success": true,
@@ -7122,10 +7129,6 @@
           "confidence": 0.5
         },
         "call-function": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "async-block": {
           "success": true,
           "confidence": 0.5
         },
@@ -7226,7 +7229,8 @@
           "confidence": 0.5
         },
         "transition-color": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "next-element": {
           "success": true,
@@ -7393,10 +7397,12 @@
           "confidence": 0.5
         },
         "fetch-with-method-body": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "fetch-formdata": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "fetch-do-not-throw": {
           "success": true,
@@ -7480,7 +7486,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9988455988455989,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8105,7 +8111,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.8352592592592598,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8726,7 +8732,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8312273057371102,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "window-resize": {
           "success": true,
@@ -9350,7 +9356,7 @@
       "parseFailure": 2,
       "parseRate": 0.987012987012987,
       "avgConfidence": 0.735672514619883,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -9973,7 +9979,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8871985157699446,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10598,7 +10604,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.8849048670240726,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11220,7 +11226,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9402185116470816,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11841,11 +11847,11 @@
       }
     },
     "tl": {
-      "parseSuccess": 143,
-      "parseFailure": 11,
-      "parseRate": 0.9285714285714286,
-      "avgConfidence": 0.8868027397439164,
-      "bundleSize": 397467,
+      "parseSuccess": 148,
+      "parseFailure": 6,
+      "parseRate": 0.961038961038961,
+      "avgConfidence": 0.8898547707371238,
+      "bundleSize": 397515,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11884,6 +11890,14 @@
           "confidence": 1
         },
         "wait-for-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
           "success": true,
           "confidence": 1
         },
@@ -11951,6 +11965,10 @@
           "success": true,
           "confidence": 1
         },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
         "event-key-combo": {
           "success": true,
           "confidence": 1
@@ -11960,6 +11978,10 @@
           "confidence": 1
         },
         "copy-to-clipboard": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
           "success": true,
           "confidence": 1
         },
@@ -12140,6 +12162,10 @@
           "confidence": 0.8857142857142858
         },
         "trigger-event": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "multiple-events": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -12375,15 +12401,6 @@
           "success": true,
           "confidence": 0.5294117647058824
         },
-        "transition-opacity": {
-          "success": false
-        },
-        "transition-transform": {
-          "success": false
-        },
-        "multiple-events": {
-          "success": false
-        },
         "get-value": {
           "success": true,
           "confidence": 0.5
@@ -12409,9 +12426,6 @@
         "set-color-variable": {
           "success": false
         },
-        "transition-color": {
-          "success": false
-        },
         "last-in-collection": {
           "success": false
         },
@@ -12428,9 +12442,6 @@
           "confidence": 0.5
         },
         "unless-condition": {
-          "success": false
-        },
-        "fade-out-remove": {
           "success": false
         },
         "announce-screen-reader": {
@@ -12459,7 +12470,7 @@
       "parseFailure": 2,
       "parseRate": 0.987012987012987,
       "avgConfidence": 0.860672514619883,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13082,7 +13093,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8864564007421153,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13707,7 +13718,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8894248608534325,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14332,7 +14343,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9988148148148148,
-      "bundleSize": 397467,
+      "bundleSize": 397515,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -14951,7 +14962,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 397467,
+      "size": 397515,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Clears **11 of the ~30 non-behavior multilingual parse failures** tracked in `docs-internal/MULTILINGUAL_ROADMAP.md`. Cross-language average **98.54% → 98.84%**; non-behavior failures **30 → 19** (Bucket B behaviors unchanged at 24).

Verified by a full `--bundle browser-priority` baseline regeneration: **exactly these 11 patterns flip to passing, zero regressions** (`↓`).

| Lang | before | after |
| ---- | ------ | ----- |
| ko   | 96.1%  | 99.4% |
| ar   | 94.8%  | 95.5% |
| tl   | 92.9%  | 96.1% |

## Changes

All four fixes are either a pure transformer reorder bug or the recurring **passthrough-alignment** lever (register the exact token the i18n transformer emits on the semantic side, rather than reshaping the parser):

- **`multiple-events` (ar, tl)** — `on click or keypress[…] toggle .active` hoisted `or keypress` ahead of the command because `parseEventHandler` read `or` as the action verb. Now folds `or`-conjoined events into the event role (`EVENT_CONJUNCTIONS`) so `<event1> or <event2>` reorders as one event clause. *(transformer only — the semantic parser already accepted the clause at the end)*
- **`fetch` (ko ×3)** — transformer emits `가져오기`; semantic primary is the loanword `패치`. Registered `가져오기` ("bring/fetch") as a `fetch` alternative (no collision with `get`=`얻다`). Cleared `fetch-with-method`, `fetch-with-method-body`, `fetch-formdata`.
- **`transition` (ko ×2)** — transformer emits `전환`; primary is loanword `트랜지션`. Added `전환` as a `transition` alternative (toggle uses `토글`, no collision).
- **`transition` (tl ×4)** — transformer emitted `baguhin`, which is the semantic tl verb for **morph**; the real tl `transition` verb is `lumipat`. The i18n tl dict now emits `lumipat` (morph keeps `baguhin_hugis`). Cleared `transition-color`, `transition-transform`, `transition-opacity`, `fade-out-remove`.

## Tests

- `packages/i18n/src/grammar/grammar.test.ts` — or-conjoined events (ar/tl) + tl transition→`lumipat`
- `packages/semantic/test/multilingual-roadmap-fixes.test.ts` (new) — ko `fetch`/`transition` parse + toggle non-regression

Full suites pass: i18n (630), semantic (5272; only the environmental `build-artifacts.test.ts` dist/`.d.ts` checks fail, as documented in the roadmap — they pass in CI).

## Remaining (19 non-behavior, documented in roadmap)

`input-clear`, `form-disable-on-submit`, `set-color-variable`, `last-in-collection`, `unless-condition`, `caret-var-on-target` (ar+tl); `announce-screen-reader` (he+sw); `on-custom-event-receive` (ko+qu); `window-resize` (qu+tr); `focus-trap` (tr). Each needs genuine parser/profile structure work — VSO requires a *parseable* body (unlike en/ko, which pass via degenerate empty-body matches), so `set`-of-possessive, positional `last … in`, member-access, `unless` blocks, custom-event SOV slots, event modifiers, and he/sw `set`-pattern gaps must each be built out.

Note: the committed binary `patterns.db` was regenerated locally for verification then restored (CI repopulates from source); only the source + regenerated baseline JSON are committed.

https://claude.ai/code/session_01JjcXVHhpn5oQkAS9CrUugm

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjcXVHhpn5oQkAS9CrUugm)_