### PR TITLE
feat(multilingual): Tier 1 parser features clear 6 non-behavior failures

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,48 +5,76 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after the passthrough-alignment batch (or-conjoined events ar/tl; ko `fetch`/`transition` and tl `transition` keyword alignment). Track 4 (method-call, event-body blocks, tl put before/after) and Track 1 (reactive) complete._
+_Last updated: after the Tier 1 parser-feature batch (tag-less `<.class/>` selectors, positional `last/first <sel> in <src>`, `of`-possessive `set`, member-access on queried elements). Track 4 and Track 1 (reactive) complete._
 
 ---
 
 ## Current state
 
 Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
-(generated with `--bundle browser-priority`). Cross-language average **98.84%**
+(generated with `--bundle browser-priority`). Cross-language average **99.00%**
 (up from 97.5% before Phase 1; Phases 1–4 + Track 4 + qu `install` + passthrough
-batch: +50 instances).
-**43 failing pattern-instances** remain (24 are Bucket B behaviors).
+batch + Tier 1: +56 instances).
+**37 failing pattern-instances** remain (24 are Bucket B behaviors).
 
-| Rate     | Languages                            |
-| -------- | ------------------------------------ |
-| 100%     | en, bn, hi, ja, ms, ru, th, uk, vi   |
-| 99%      | de/es/fr/id/pt (99.4), **ko (99.4)** |
-| 98–99%   | qu (98.7), tr (98.7), sw (98.1)      |
-| 96–98%   | it/pl/zh (97.4), he (96.8)           |
-| laggards | **ar (95.5), tl (96.1)**             |
+| Rate   | Languages                                  |
+| ------ | ------------------------------------------ |
+| 100%   | en, bn, hi, ja, ms, ru, th, uk, vi         |
+| 99%    | de/es/fr/id/pt/ko (99.4)                   |
+| 98–99% | qu (98.7), tr (98.7), sw (98.1), tl (98.1) |
+| 96–98% | it/pl/zh (97.4), ar (97.4), he (96.8)      |
 
-**19 non-behavior failing pattern-instances** remain (plus 24 Bucket B behaviors),
-in two tracks (Track 1 reactive done):
+**13 non-behavior failing pattern-instances** remain (plus 24 Bucket B behaviors):
 
 | Track                         | Instances | Nature                                                                           |
 | ----------------------------- | --------- | -------------------------------------------------------------------------------- |
 | **Bucket B — behaviors**      | 24        | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`) |
-| **Deep per-language grammar** | 19        | VSO event-at-end + `from`-source reorder, command modifiers, condition i18n      |
+| **Deep per-language grammar** | 13        | compound/`in me` splits, condition i18n, custom-event SOV slot, event modifiers  |
 
-The 19 non-behavior remainders: `input-clear`, `form-disable-on-submit`,
-`set-color-variable`, `last-in-collection`, `unless-condition`,
+The 13 non-behavior remainders: `form-disable-on-submit`, `unless-condition`,
 `caret-var-on-target` (each **ar+tl**); `announce-screen-reader` (he+sw);
 `on-custom-event-receive` (ko+qu); `window-resize` (qu+tr); `focus-trap` (tr).
 
 > **The clean tokenizer token-split vein is now largely worked out** (Phases 1 & 4
-> cleared `@`/`*`/`^`; Phase 3a the English DOM events). Every remaining
+> cleared `@`/`*`/`^`; Tier 1 the tag-less `<.class/>` selector). Every remaining
 > non-behavior failure needs per-pattern transformer/parser/grammar work (see
-> Track 4 and "Why the rest is hard"). There is no longer a uniform fix that
-> clears a whole cluster.
+> "Why the rest is hard"). There is no longer a uniform fix that clears a whole
+> cluster.
 
 ---
 
 ## Shipped
+
+### Tier 1 parser features — positional / of-possessive / member-access (+6)
+
+- **6 instances, 0 regressions, avg 98.84% → 99.00%.** ar 95.5→97.4, tl 96.1→98.1.
+  Confirmed by a full `browser-priority` baseline regen (exactly these 6 flip `↑`,
+  zero `↓`). Cleared `last-in-collection`, `set-color-variable`, `input-clear` (all ar+tl).
+- **Unlike the passthrough batch, these are genuine parser features** — each fails
+  even in English at the bare-command level (English only "passed" them via the
+  degenerate empty-body event-handler match). VSO langs (ar/tl) require a parseable
+  body, so the features had to be built for real; English gains real parsing too.
+- **Tag-less query selector tokenization** (`css-selector.ts`). `<.message/>` /
+  `<#id/>` / `<[attr]/>` split into `<` + `.message` + `/>`; the tag name is now
+  optional in the extractor regex (lookahead still rejects `a < b`). Shared across
+  all 24 languages.
+- **Positional query expression** (`pattern-matcher.ts` `tryMatchPositionalExpression`).
+  Matches `<positional> <selector> [<marker> <source>]` (`last <.message/> in #chat`,
+  AR `آخر <.message/> في #chat`, TL `huli <.message/> sa_loob #chat`) as a single
+  expression. Triggered only when the role starts with a positional keyword
+  (first/last/next/previous/random), so other roles are untouched. `scroll`'s
+  destination role gained `expression` in its expected types. Also folds a trailing
+  `.prop` member access (`previous <input/>.value`).
+- **`of`-possessive `set`** (`pattern-matcher.ts` `tryMatchOfPossessiveExpression`).
+  `set <prop> of <owner> to <value>` (`*--primary-color of #theme`, AR `… من …`,
+  TL `… ng …`) → property-path. **Gated to roles that opt into `property-path`** —
+  only `set`'s destination does — so the `of`/source marker can never shadow a real
+  source role on other commands (`get data from #input` is unaffected). The leaked
+  untranslated `the` is absorbed by the existing `skipNoiseWords`.
+- **tl `scroll` keyword alignment.** Transformer emits English `scroll`; semantic tl
+  primary is `iscroll`. Added `scroll` as a tl alternative (passthrough-alignment).
+- Locked by `semantic/test/multilingual-tier1-features.test.ts` (16 cases across
+  en/ar/tl + regression guards).
 
 ### Passthrough-alignment batch — or-events + fetch/transition keywords (+11)
 
@@ -279,17 +307,18 @@ fix. Largest single pattern is `behavior-removable` (fails in 11 langs incl.
 high-rate de/es/fr/it/pt) — worth checking whether it's a _parse_ issue (the
 `install … removable` syntax) separable from the unimplemented-runtime issue.
 
-### Track 3 — Deep per-language grammar (~52 remaining)
+### Track 3 — Deep per-language grammar
 
-Concentrated in **tl (16)** and **ar (11)**; the rest scattered (ko 8, sw 7,
-qu 5, he/qu 5, ja/tr 3–4, zh/it/pl 1–4). Recurring themes:
+> **Historical analysis below; the live remainder is the 13 in "Current state".**
+> The Tier 1 batch cleared `last-in-collection`, `set-color-variable`, and
+> `input-clear` (ar+tl); the passthrough batch cleared `multiple-events`,
+> `fetch`, and `transition`. The notes here are kept as a record of approaches.
 
-- **`set-*` family (ar+tl): MOSTLY DONE in Phase 1.** The `@attr` / `*style`
-  token-splitting bug was fixed once in the shared `CssSelectorExtractor` (see
-  Shipped → Phase 1). Remaining `set-*` stragglers are `set-color-variable`
-  (article `the` + `of`-possessive) and `input-clear` (`<input/>.value` member
-  access) — both deferred to the scattered Phase 4 work below, not the `@`/`*`
-  token issue.
+- **`set-*` family (ar+tl): DONE.** Phase 1 fixed the `@attr` / `*style`
+  token-splitting in the shared `CssSelectorExtractor`; Tier 1 then cleared the two
+  stragglers — `set-color-variable` (the `of`-possessive `set` matcher, with the
+  leaked `the` absorbed by `skipNoiseWords`) and `input-clear` (member-access on a
+  queried element). See Shipped → Tier 1.
 - **possessive-dot (`.`):** `get-attribute-possessive-dot`,
   `method-call-possessive-dot` (ar/sw/tl) — member-access `.` chains.
 - **`caret`** (caret-var-write/on-target; ar/tl), **`transition-*`**

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -385,7 +385,9 @@ export const setSchema: CommandSchema = {
       role: 'destination',
       description: 'The property or variable to set',
       required: true,
-      expectedTypes: ['selector', 'reference', 'expression'],
+      // 'property-path' opts this role into the "of"-possessive matcher
+      // (`set *--x of #y to z`); see pattern-matcher tryMatchOfPossessiveExpression.
+      expectedTypes: ['selector', 'reference', 'expression', 'property-path'],
       svoPosition: 1,
       sovPosition: 1,
       // Override destination marker for English (remove 'on', use no marker)
@@ -2134,7 +2136,8 @@ export const scrollSchema: CommandSchema = {
       role: 'destination',
       description: 'The element to scroll to',
       required: true,
-      expectedTypes: ['selector', 'reference'],
+      // 'expression' admits positional queries (`last <.message/> in #chat`).
+      expectedTypes: ['selector', 'reference', 'expression'],
       svoPosition: 1,
       sovPosition: 1,
       markerOverride: { en: 'to' },

--- a/packages/semantic/src/generators/profiles/tl.ts
+++ b/packages/semantic/src/generators/profiles/tl.ts
@@ -98,7 +98,9 @@ export const tagalogProfile: LanguageProfile = {
     breakpoint: { primary: 'breakpoint', normalized: 'breakpoint' },
     // Navigation
     go: { primary: 'pumunta', alternatives: ['punta'], normalized: 'go' },
-    scroll: { primary: 'iscroll', alternatives: ['mag_scroll'], normalized: 'scroll' },
+    // 'scroll' (English loanword) is the form the i18n transformer emits;
+    // registered as an alternative for passthrough-alignment.
+    scroll: { primary: 'iscroll', alternatives: ['mag_scroll', 'scroll'], normalized: 'scroll' },
     push: { primary: 'itulak', alternatives: ['ipush'], normalized: 'push' },
     replace: { primary: 'palitan_url', alternatives: ['ireplace'], normalized: 'replace' },
     process: { primary: 'iproseso', alternatives: ['proseso'], normalized: 'process' },

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -264,6 +264,33 @@ export class PatternMatcher {
       return patternToken.optional || false;
     }
 
+    // Check for a positional query expression (e.g., 'last <.message/> in #chat',
+    // 'first <button/> in .modal'). Triggered only when the role starts with a
+    // positional keyword, so non-positional roles are unaffected.
+    const positionalValue = this.tryMatchPositionalExpression(tokens);
+    if (positionalValue) {
+      if (patternToken.expectedTypes && patternToken.expectedTypes.length > 0) {
+        if (!isTypeCompatible(positionalValue.type, patternToken.expectedTypes)) {
+          return patternToken.optional || false;
+        }
+      }
+      captured.set(patternToken.role, positionalValue);
+      return true;
+    }
+
+    // Check for an "of"-possessive expression (e.g. "*--primary-color of #theme",
+    // AR "*--primary-color من #theme", TL "*--primary-color ng #theme"). Gated to
+    // roles that opt into property-path (currently `set`'s destination), so the
+    // "of"/source marker can't be confused with a real source role on other
+    // commands (e.g. `get data from #input`).
+    if (patternToken.expectedTypes?.includes('property-path')) {
+      const ofPossessive = this.tryMatchOfPossessiveExpression(tokens);
+      if (ofPossessive) {
+        captured.set(patternToken.role, ofPossessive);
+        return true;
+      }
+    }
+
     // Check for possessive expression (e.g., 'my value', 'its innerHTML')
     const possessiveValue = this.tryMatchPossessiveExpression(tokens);
     if (possessiveValue) {
@@ -352,6 +379,137 @@ export class PatternMatcher {
     captured.set(patternToken.role, value);
     tokens.advance();
     return true;
+  }
+
+  /**
+   * Positional query keywords (English + normalized forms produced by the
+   * tokenizers for every language, e.g. AR آخر→last, TL huli→last).
+   */
+  private static readonly POSITIONAL_KEYWORDS = new Set([
+    'first',
+    'last',
+    'next',
+    'previous',
+    'random',
+  ]);
+
+  /**
+   * Try to match a positional query expression:
+   *   <positional> <selector> [<in/from-marker> <source-selector>]
+   * e.g. "last <.message/> in #chat", "first <button/> in .modal", "آخر <.message/> في #chat".
+   *
+   * Only fires when the role begins with a positional keyword, so ordinary
+   * roles are untouched. The whole construct is captured as a single
+   * expression value (the harness/AST treats positional queries as
+   * expressions). The optional source clause consumes exactly one
+   * `<marker> <selector>` pair, which is safe because positional queries are
+   * terminal in their role (e.g. scroll's only role is the destination).
+   */
+  private tryMatchPositionalExpression(tokens: TokenStream): SemanticValue | null {
+    const token = tokens.peek();
+    if (!token) return null;
+
+    const norm = (token.normalized ?? token.value).toLowerCase();
+    if (
+      !PatternMatcher.POSITIONAL_KEYWORDS.has(norm) &&
+      !PatternMatcher.POSITIONAL_KEYWORDS.has(token.value.toLowerCase())
+    ) {
+      return null;
+    }
+
+    const mark = tokens.mark();
+    const parts: string[] = [token.value];
+    tokens.advance();
+
+    // Required: the queried selector (e.g. <.message/>, .message, <button/>).
+    const sel = tokens.peek();
+    if (!sel || sel.kind !== 'selector') {
+      tokens.reset(mark);
+      return null;
+    }
+    parts.push(sel.value);
+    tokens.advance();
+
+    // Optional member access on the queried element: `.value`, `.textContent`
+    // (`previous <input/>.value`). The tokenizer emits these as `.`-prefixed
+    // selector tokens; fold them into the expression so the whole lvalue is one
+    // value.
+    let memberGuard = 0;
+    while (memberGuard++ < 8) {
+      const member = tokens.peek();
+      if (member && member.kind === 'selector' && member.value.startsWith('.')) {
+        parts.push(member.value);
+        tokens.advance();
+      } else {
+        break;
+      }
+    }
+
+    // Optional source clause: <marker> <source-selector> (in #chat / في #chat /
+    // sa_loob #chat). The marker may be a keyword, particle, or (TL) identifier;
+    // we only consume it when a selector follows, so a trailing command keyword
+    // is never swallowed.
+    const marker = tokens.peek();
+    const source = tokens.peek(1);
+    if (
+      marker &&
+      source &&
+      source.kind === 'selector' &&
+      (marker.kind === 'keyword' || marker.kind === 'particle' || marker.kind === 'identifier') &&
+      !PatternMatcher.POSITIONAL_KEYWORDS.has((marker.normalized ?? marker.value).toLowerCase())
+    ) {
+      parts.push(marker.value, source.value);
+      tokens.advance();
+      tokens.advance();
+    }
+
+    return { type: 'expression', raw: parts.join(' ') } as SemanticValue;
+  }
+
+  /**
+   * Markers that introduce the owner in a prepositional ("of") possessive:
+   * EN `of`; AR من / others that tokenize with a `source`/`of` normalized form;
+   * TL genitive linker `ng`. Kept narrow and only consulted for property-path
+   * roles, so it never shadows a real source role.
+   */
+  private isOfPossessiveMarker(token: LanguageToken): boolean {
+    const value = token.value.toLowerCase();
+    const normalized = (token.normalized ?? '').toLowerCase();
+    return value === 'of' || value === 'ng' || normalized === 'of' || normalized === 'source';
+  }
+
+  /**
+   * Try to match a prepositional "of" possessive:
+   *   <property-selector> <of-marker> <owner-selector>
+   * e.g. "*--primary-color of #theme" → property-path(#theme, *--primary-color).
+   *
+   * This is the surface the i18n transformer emits for "set the X of #y to Z"
+   * across languages (`set #y's X` would be the alternative, but the transformer
+   * uses the `of` form). Only called for property-path roles (see matchRoleToken).
+   */
+  private tryMatchOfPossessiveExpression(tokens: TokenStream): SemanticValue | null {
+    const property = tokens.peek();
+    if (!property || property.kind !== 'selector') return null;
+
+    const mark = tokens.mark();
+    tokens.advance();
+
+    const marker = tokens.peek();
+    if (!marker || !this.isOfPossessiveMarker(marker)) {
+      tokens.reset(mark);
+      return null;
+    }
+    tokens.advance();
+
+    const owner = tokens.peek();
+    if (!owner || owner.kind !== 'selector') {
+      tokens.reset(mark);
+      return null;
+    }
+    tokens.advance();
+
+    // "X of #y" means the X property of #y → property-path(object: #y, property: X).
+    return createPropertyPath(createSelector(owner.value), property.value);
   }
 
   /**

--- a/packages/semantic/src/tokenizers/extractors/css-selector.ts
+++ b/packages/semantic/src/tokenizers/extractors/css-selector.ts
@@ -60,9 +60,15 @@ export function extractCssSelector(input: string, position: number): string | nu
     return null; // Unclosed bracket
   }
 
-  // HTML tag selector: <tag/> or <tag#id.class[attr]/> or <tag[attr=value]/>
+  // HTML tag selector: <tag/>, <tag#id.class[attr]/>, <tag[attr=value]/>, and
+  // tag-less query selectors <.class/>, <#id/>, <[attr]/> (hyperscript treats
+  // `<.message/>` as "all .message elements"). The tag name is optional, but the
+  // lookahead requires the char after `<` to start a tag/`#`/`.`/`[` clause — so
+  // a less-than comparison (`a < b`) is never mis-extracted (the space fails it).
   if (char === '<') {
-    const match = input.slice(position).match(/^<[\w-]+(?:[#.][\w-]+|\[[^\]]+\])*\s*\/>/);
+    const match = input
+      .slice(position)
+      .match(/^<(?=[\w.#[])[\w-]*(?:[#.][\w-]+|\[[^\]]+\])*\s*\/>/);
     return match ? match[0] : null;
   }
 

--- a/packages/semantic/test/multilingual-tier1-features.test.ts
+++ b/packages/semantic/test/multilingual-tier1-features.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Multilingual roadmap — Tier 1 parser features.
+ *
+ * Regression guards for the structural parser work that cleared the
+ * `last-in-collection`, `set-color-variable`, and `input-clear` failures in
+ * ar+tl (see docs-internal/MULTILINGUAL_ROADMAP.md). Each fails even in English
+ * at the bare-command level today, so these tests assert genuine parsing rather
+ * than the degenerate event-handler match.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse, canParse, tokenize } from '../src';
+
+function tokens(input: string, language = 'en') {
+  return tokenize(input, language).tokens;
+}
+
+describe('Tag-less query selector tokenization (<.class/>, <#id/>, <[attr]/>)', () => {
+  it('keeps <.message/> as a single selector token', () => {
+    const t = tokens('scroll to last <.message/> in #chat');
+    expect(t.some(tk => tk.kind === 'selector' && tk.value === '<.message/>')).toBe(true);
+  });
+
+  it('keeps <#id/> and <[attr]/> whole', () => {
+    expect(tokens('<#main/>').some(tk => tk.value === '<#main/>')).toBe(true);
+    expect(tokens('<[data-x=1]/>').some(tk => tk.value === '<[data-x=1]/>')).toBe(true);
+  });
+
+  it('does not mis-extract a less-than comparison (a < b)', () => {
+    // The lone "<" must not swallow " b" as a tag-less selector.
+    const t = tokens('a < b');
+    expect(t.some(tk => tk.kind === 'selector' && tk.value.includes('b'))).toBe(false);
+  });
+
+  it('still tokenizes a normal tag selector <button/>', () => {
+    expect(tokens('toggle .active on <button/>').some(tk => tk.value === '<button/>')).toBe(true);
+  });
+});
+
+describe('Positional query expressions (last/first <sel> in <src>)', () => {
+  const cases: [string, string][] = [
+    ['scroll to last <.message/> in #chat', 'en'],
+    ['scroll to first <.message/> in #chat', 'en'],
+    ['تمرير إلى آخر <.message/> في #chat', 'ar'],
+    ['iscroll sa huli <.message/> sa_loob #chat', 'tl'],
+  ];
+  for (const [input, lang] of cases) {
+    it(`parses "${input}" (${lang})`, () => {
+      expect(canParse(input, lang)).toBe(true);
+      expect(parse(input, lang).action).toBe('scroll');
+    });
+  }
+
+  it('does not consume a trailing command after the positional query', () => {
+    // The optional source clause must not swallow the next selector if no marker
+    // precedes it; plain scroll still works.
+    expect(parse('scroll to #chat', 'en').action).toBe('scroll');
+  });
+});
+
+describe('"of"-possessive set (set <prop> of <owner> to <value>)', () => {
+  const cases: [string, string][] = [
+    ['set the *--primary-color of #theme to "#ff6600"', 'en'],
+    ['اضبط the *--primary-color من #theme إلى "#ff6600"', 'ar'],
+    ['itakda the *--primary-color ng #theme sa "#ff6600"', 'tl'],
+  ];
+  for (const [input, lang] of cases) {
+    it(`parses "${input}" (${lang})`, () => {
+      expect(canParse(input, lang)).toBe(true);
+      expect(parse(input, lang).action).toBe('set');
+    });
+  }
+
+  it('does not regress simple set or source extraction', () => {
+    expect(parse('set x to 5', 'en').action).toBe('set');
+    expect(parse('set my innerHTML to "hi"', 'en').action).toBe('set');
+    // The "of"-matcher is gated to property-path roles (set), so get's source
+    // role is unaffected.
+    expect(parse('get data from #input', 'en').action).toBe('get');
+  });
+});
+
+describe('Member access on a queried element (previous <input/>.value)', () => {
+  const cases: [string, string][] = [
+    ['set previous <input/>.value to ""', 'en'],
+    ['اضبط السابق <input/>.value إلى "" عند نقر', 'ar'],
+    ['itakda nakaraan <input/>.value sa "" kapag click', 'tl'],
+  ];
+  for (const [input, lang] of cases) {
+    it(`parses "${input}" (${lang})`, () => {
+      expect(canParse(input, lang)).toBe(true);
+    });
+  }
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-07T14:45:18.932Z",
-  "commit": "9373801",
+  "timestamp": "2026-06-07T17:20:18.817Z",
+  "commit": "5dc3d86",
   "languages": {
     "ar": {
-      "parseSuccess": 147,
-      "parseFailure": 7,
-      "parseRate": 0.9545454545454546,
-      "avgConfidence": 0.9168292713910963,
-      "bundleSize": 397515,
+      "parseSuccess": 150,
+      "parseFailure": 4,
+      "parseRate": 0.974025974025974,
+      "avgConfidence": 0.9186778711484593,
+      "bundleSize": 399097,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -213,6 +213,10 @@
           "success": true,
           "confidence": 1
         },
+        "input-clear": {
+          "success": true,
+          "confidence": 1
+        },
         "form-submit-prevent": {
           "success": true,
           "confidence": 1
@@ -233,11 +237,23 @@
           "success": true,
           "confidence": 1
         },
+        "set-color-variable": {
+          "success": true,
+          "confidence": 1
+        },
         "transition-color": {
           "success": true,
           "confidence": 1
         },
+        "next-element": {
+          "success": true,
+          "confidence": 1
+        },
         "closest-ancestor": {
+          "success": true,
+          "confidence": 1
+        },
+        "last-in-collection": {
           "success": true,
           "confidence": 1
         },
@@ -398,10 +414,6 @@
           "confidence": 1
         },
         "send-with-detail": {
-          "success": true,
-          "confidence": 0.9722222222222222
-        },
-        "next-element": {
           "success": true,
           "confidence": 0.9722222222222222
         },
@@ -549,9 +561,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "input-clear": {
-          "success": false
-        },
         "form-disable-on-submit": {
           "success": false
         },
@@ -562,12 +571,6 @@
         "window-scroll": {
           "success": true,
           "confidence": 0.5
-        },
-        "set-color-variable": {
-          "success": false
-        },
-        "last-in-collection": {
-          "success": false
         },
         "repeat-until-event": {
           "success": true,
@@ -624,8 +627,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.868975468975469,
-      "bundleSize": 397515,
+      "avgConfidence": 0.8722222222222222,
+      "bundleSize": 399097,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -840,6 +843,10 @@
           "confidence": 1
         },
         "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-clear": {
           "success": true,
           "confidence": 1
         },
@@ -1131,10 +1138,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "input-clear": {
-          "success": true,
-          "confidence": 0.5
-        },
         "form-submit-prevent": {
           "success": true,
           "confidence": 0.5
@@ -1250,7 +1253,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9367465504720396,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1874,7 +1877,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2499,7 +2502,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3123,7 +3126,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3747,7 +3750,7 @@
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.8500053265153942,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4367,7 +4370,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -4992,7 +4995,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5616,7 +5619,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9976296296296296,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6236,8 +6239,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8378066378066378,
-      "bundleSize": 397515,
+      "avgConfidence": 0.8410533910533909,
+      "bundleSize": 399097,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6436,6 +6439,10 @@
           "confidence": 1
         },
         "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-clear": {
           "success": true,
           "confidence": 1
         },
@@ -6723,10 +6730,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "input-clear": {
-          "success": true,
-          "confidence": 0.5
-        },
         "form-submit-prevent": {
           "success": true,
           "confidence": 0.5
@@ -6861,8 +6864,8 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.5655047204066812,
-      "bundleSize": 397515,
+      "avgConfidence": 0.5687726942628903,
+      "bundleSize": 399097,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -6885,6 +6888,10 @@
           "confidence": 1
         },
         "async-block": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-scroll": {
           "success": true,
           "confidence": 1
         },
@@ -7201,10 +7208,6 @@
           "confidence": 0.5
         },
         "window-keydown": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "window-scroll": {
           "success": true,
           "confidence": 0.5
         },
@@ -7486,7 +7489,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9988455988455989,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8111,7 +8114,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.8352592592592598,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8732,7 +8735,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8312273057371102,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "window-resize": {
           "success": true,
@@ -9356,7 +9359,7 @@
       "parseFailure": 2,
       "parseRate": 0.987012987012987,
       "avgConfidence": 0.735672514619883,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -9979,7 +9982,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8871985157699446,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10604,7 +10607,7 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.8849048670240726,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11226,7 +11229,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9402185116470816,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11847,11 +11850,11 @@
       }
     },
     "tl": {
-      "parseSuccess": 148,
-      "parseFailure": 6,
-      "parseRate": 0.961038961038961,
-      "avgConfidence": 0.8898547707371238,
-      "bundleSize": 397515,
+      "parseSuccess": 151,
+      "parseFailure": 3,
+      "parseRate": 0.9805194805194806,
+      "avgConfidence": 0.8932204228269676,
+      "bundleSize": 399097,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11941,6 +11944,10 @@
           "success": true,
           "confidence": 1
         },
+        "input-clear": {
+          "success": true,
+          "confidence": 1
+        },
         "form-submit-prevent": {
           "success": true,
           "confidence": 1
@@ -11965,7 +11972,19 @@
           "success": true,
           "confidence": 1
         },
+        "set-color-variable": {
+          "success": true,
+          "confidence": 1
+        },
         "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
+        "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "last-in-collection": {
           "success": true,
           "confidence": 1
         },
@@ -12361,10 +12380,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "next-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "previous-element": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -12413,21 +12428,12 @@
           "success": true,
           "confidence": 0.5
         },
-        "input-clear": {
-          "success": false
-        },
         "form-disable-on-submit": {
           "success": false
         },
         "window-scroll": {
           "success": true,
           "confidence": 0.5
-        },
-        "set-color-variable": {
-          "success": false
-        },
-        "last-in-collection": {
-          "success": false
         },
         "event-once": {
           "success": true,
@@ -12469,8 +12475,8 @@
       "parseSuccess": 152,
       "parseFailure": 2,
       "parseRate": 0.987012987012987,
-      "avgConfidence": 0.860672514619883,
-      "bundleSize": 397515,
+      "avgConfidence": 0.8639619883040935,
+      "bundleSize": 399097,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -12689,6 +12695,10 @@
           "confidence": 1
         },
         "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-clear": {
           "success": true,
           "confidence": 1
         },
@@ -12953,10 +12963,6 @@
           "confidence": 0.5
         },
         "modal-close-escape": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "input-clear": {
           "success": true,
           "confidence": 0.5
         },
@@ -13093,7 +13099,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8864564007421153,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13718,7 +13724,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8894248608534325,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14343,7 +14349,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9988148148148148,
-      "bundleSize": 397515,
+      "bundleSize": 399097,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -14962,7 +14968,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 397515,
+      "size": 399097,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Implements the **Tier 1** parser features from the post-#279 roadmap recommendation, clearing **6 non-behavior multilingual parse failures**. Cross-language average **98.84% → 99.00%**; non-behavior failures **19 → 13** (Bucket B behaviors unchanged at 24).

Verified by a full `--bundle browser-priority` baseline regeneration: **exactly these 6 patterns flip to passing, zero regressions** (`↓`).

| Lang | before | after |
| ---- | ------ | ----- |
| ar   | 95.5%  | 97.4% |
| tl   | 96.1%  | 98.1% |

Cleared: `last-in-collection`, `set-color-variable`, `input-clear` (all ar+tl).

## Why these are different from the #279 batch

Unlike the passthrough-alignment fixes in #279, these are **genuine parser features** — each fails even in **English** at the bare-command level. English only "passed" them via the *degenerate empty-body event-handler match* (the harness scores non-null parse; the body silently parsed to nothing). VSO languages (ar/tl) require a genuinely parseable body, which forced building the features for real — so English now gets real parsing too.

## Changes

- **Tag-less query selector tokenization** (`css-selector.ts`) — `<.message/>`, `<#id/>`, `<[attr]/>` were split into `<` + `.message` + `/>`. The tag name is now optional in the extractor regex; a lookahead still rejects the `a < b` comparison. Shared across all 24 languages.
- **Positional query expression** (`pattern-matcher.ts` `tryMatchPositionalExpression`) — `last/first <sel> in <src>` (+ ar `آخر … في`, tl `huli … sa_loob`) captured as one expression. Triggered **only** when the role starts with a positional keyword, so other roles are untouched. Also folds a trailing `.prop` member access (`previous <input/>.value`). `scroll`'s destination role gained `expression`.
- **`of`-possessive `set`** (`pattern-matcher.ts` `tryMatchOfPossessiveExpression`) — `set <prop> of <owner> to <value>` → property-path. **Gated to roles opting into `property-path`** (only `set`'s destination), so the `of`/source marker can never shadow a real source role on other commands (`get data from #input` is unaffected). The leaked untranslated `the` is absorbed by the existing `skipNoiseWords`.
- **tl `scroll` keyword alignment** — transformer emits English `scroll`; added as a tl alternative (semantic primary is `iscroll`).

## Tests

`packages/semantic/test/multilingual-tier1-features.test.ts` (16 cases across en/ar/tl): tokenizer, positional, of-possessive, member access, plus regression guards (`a < b`, `set x to 5`, `get … from #x`, plain `scroll to #chat`).

Full semantic suite: 5272 pass (only the environmental `build-artifacts.test.ts` dist/`.d.ts` checks fail, as documented in the roadmap — they pass in CI). The of-matcher is gated to `set` only (the sole schema/pattern with `property-path` in its role types).

## Remaining (13 non-behavior, in roadmap)

`form-disable-on-submit`, `unless-condition`, `caret-var-on-target` (ar+tl); `announce-screen-reader` (he+sw); `on-custom-event-receive` (ko+qu); `window-resize` (qu+tr); `focus-trap` (tr). These need compound/`in me` split handling, condition i18n (expression-operator territory), the SOV custom-event slot, and event-modifier parsing.

Note: the binary `patterns.db` was regenerated locally for verification then restored (CI repopulates from source); only source + regenerated baseline JSON are committed.

https://claude.ai/code/session_01JjcXVHhpn5oQkAS9CrUugm

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjcXVHhpn5oQkAS9CrUugm)_