### PR TITLE
feat(multilingual): property-path patient clears announce-screen-reader (he+sw)

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,35 +5,35 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after the Tier 1 parser-feature batch (tag-less `<.class/>` selectors, positional `last/first <sel> in <src>`, `of`-possessive `set`, member-access on queried elements). Track 4 and Track 1 (reactive) complete._
+_Last updated: after property-path patient (Tier 2; `announce-screen-reader` he+sw). Tier 1, Track 4, Track 1 (reactive) complete._
 
 ---
 
 ## Current state
 
 Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
-(generated with `--bundle browser-priority`). Cross-language average **99.00%**
+(generated with `--bundle browser-priority`). Cross-language average **99.05%**
 (up from 97.5% before Phase 1; Phases 1–4 + Track 4 + qu `install` + passthrough
-batch + Tier 1: +56 instances).
-**37 failing pattern-instances** remain (24 are Bucket B behaviors).
+batch + Tier 1 + property-path patient: +58 instances).
+**35 failing pattern-instances** remain (24 are Bucket B behaviors).
 
-| Rate   | Languages                                  |
-| ------ | ------------------------------------------ |
-| 100%   | en, bn, hi, ja, ms, ru, th, uk, vi         |
-| 99%    | de/es/fr/id/pt/ko (99.4)                   |
-| 98–99% | qu (98.7), tr (98.7), sw (98.1), tl (98.1) |
-| 96–98% | it/pl/zh (97.4), ar (97.4), he (96.8)      |
+| Rate   | Languages                             |
+| ------ | ------------------------------------- |
+| 100%   | en, bn, hi, ja, ms, ru, th, uk, vi    |
+| 99%    | de/es/fr/id/pt/ko (99.4), sw (98.7)   |
+| 98–99% | qu (98.7), tr (98.7), tl (98.1)       |
+| 96–98% | it/pl/zh (97.4), ar (97.4), he (97.4) |
 
-**13 non-behavior failing pattern-instances** remain (plus 24 Bucket B behaviors):
+**11 non-behavior failing pattern-instances** remain (plus 24 Bucket B behaviors):
 
 | Track                         | Instances | Nature                                                                           |
 | ----------------------------- | --------- | -------------------------------------------------------------------------------- |
 | **Bucket B — behaviors**      | 24        | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`) |
-| **Deep per-language grammar** | 13        | compound/`in me` splits, condition i18n, custom-event SOV slot, event modifiers  |
+| **Deep per-language grammar** | 11        | compound/`in me` splits, condition i18n, custom-event SOV slot, event modifiers  |
 
-The 13 non-behavior remainders: `form-disable-on-submit`, `unless-condition`,
-`caret-var-on-target` (each **ar+tl**); `announce-screen-reader` (he+sw);
-`on-custom-event-receive` (ko+qu); `window-resize` (qu+tr); `focus-trap` (tr).
+The 11 non-behavior remainders: `form-disable-on-submit`, `unless-condition`,
+`caret-var-on-target` (each **ar+tl**); `on-custom-event-receive` (ko+qu);
+`window-resize` (qu+tr); `focus-trap` (tr).
 
 > **The clean tokenizer token-split vein is now largely worked out** (Phases 1 & 4
 > cleared `@`/`*`/`^`; Tier 1 the tag-less `<.class/>` selector). Every remaining
@@ -44,6 +44,29 @@ The 13 non-behavior remainders: `form-disable-on-submit`, `unless-condition`,
 ---
 
 ## Shipped
+
+### Property-path patient — fused-dot member access (+2)
+
+- **2 instances, 0 regressions, avg 99.00% → 99.05%.** he 97.4→97.4 (announce was
+  he's last non-behavior; he/sw both clear it). Cleared `announce-screen-reader`
+  (he+sw). Confirmed by a full `browser-priority` baseline regen (exactly these 2
+  flip `↑`, zero `↓`).
+- **Root cause.** `put event.detail.message into #x` fails even in **English** at
+  the bare-command level: the tokenizer fuses the dotted path into a base token +
+  `.`-prefixed _selector_ tokens (`event` + `.detail` + `.message`, since `.foo`
+  looks like a class selector), and `tryMatchPropertyAccessExpression` only knew the
+  un-fused `base . identifier` operator form. Added a fused-dot branch that folds a
+  chain of `.prop` selectors into the property path.
+- **The lever was NOT he/sw `set`.** Investigation found announce's `set …` clause
+  and the `set … on <target>` mis-split are both _tolerated_ inside the event-handler
+  compound (like `toggle .active on #host`, which already passes in he despite the
+  split). The only hard blocker was the property-path patient in the `put` clause —
+  so the he/sw `set`-marker alignment originally scoped for this item was unnecessary
+  and was dropped (no baseline impact, avoids the `weka`=put verb-collision risk).
+- **Regression guard.** The fused-dot branch is gated to identifier/reference bases
+  (`PROPERTY_ACCESS_BASES`) so a command verb + class selector (`toggle .active`,
+  AR `بدل .active`, the proclitic `وبدل .active`) is never swallowed as a property
+  path. Locked by `semantic/test/multilingual-property-path-patient.test.ts`.
 
 ### Tier 1 parser features — positional / of-possessive / member-access (+6)
 
@@ -309,7 +332,7 @@ high-rate de/es/fr/it/pt) — worth checking whether it's a _parse_ issue (the
 
 ### Track 3 — Deep per-language grammar
 
-> **Historical analysis below; the live remainder is the 13 in "Current state".**
+> **Historical analysis below; the live remainder is the 11 in "Current state".**
 > The Tier 1 batch cleared `last-in-collection`, `set-color-variable`, and
 > `input-clear` (ar+tl); the passthrough batch cleared `multiple-events`,
 > `fetch`, and `transition`. The notes here are kept as a record of approaches.

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -394,6 +394,31 @@ export class PatternMatcher {
   ]);
 
   /**
+   * Reference bases that can lead a fused-dot property access (`it.value`,
+   * `event.detail.message`, `my.innerHTML`). Command verbs are deliberately
+   * excluded so `<verb> .class` (toggle .active) is never read as a property
+   * path. The corpus uses the English reference forms (they pass through the
+   * transformer verbatim); plain identifiers are handled separately.
+   */
+  private static readonly PROPERTY_ACCESS_BASES = new Set([
+    'it',
+    'me',
+    'you',
+    'my',
+    'its',
+    'your',
+    'event',
+    'result',
+    'target',
+    'detail',
+    'body',
+    'window',
+    'document',
+    'self',
+    'this',
+  ]);
+
+  /**
    * Try to match a positional query expression:
    *   <positional> <selector> [<in/from-marker> <source-selector>]
    * e.g. "last <.message/> in #chat", "first <button/> in .modal", "آخر <.message/> في #chat".
@@ -742,6 +767,37 @@ export class PatternMatcher {
     // Look ahead for: . identifier
     const mark = tokens.mark();
     tokens.advance(); // consume first token
+
+    // Fused-dot form: the tokenizer emits `it.value` / `event.detail.message` as
+    // a base token + `.`-prefixed *selector* tokens (`.value`, `.detail`), since
+    // `.foo` looks like a class selector. Fold a chain of those into the property
+    // path (the `.` operator path below handles the rare un-fused form).
+    //
+    // Gated to identifiers and known reference bases so a command verb followed
+    // by a class selector (`بدل .active` = "toggle .active") is never swallowed as
+    // a property access — command verbs are never reference bases.
+    const baseLower = token.value.toLowerCase();
+    const fusedFirst = tokens.peek();
+    if (
+      (token.kind === 'identifier' || PatternMatcher.PROPERTY_ACCESS_BASES.has(baseLower)) &&
+      fusedFirst &&
+      fusedFirst.kind === 'selector' &&
+      /^\.[a-zA-Z_]/.test(fusedFirst.value)
+    ) {
+      let fusedChain = token.value;
+      let fusedDepth = 0;
+      while (fusedDepth < PatternMatcher.MAX_PROPERTY_DEPTH) {
+        const prop = tokens.peek();
+        if (prop && prop.kind === 'selector' && /^\.[a-zA-Z_]/.test(prop.value)) {
+          fusedChain += `.${prop.value.slice(1)}`;
+          tokens.advance();
+          fusedDepth++;
+        } else {
+          break;
+        }
+      }
+      return { type: 'expression', raw: fusedChain } as SemanticValue;
+    }
 
     const dotToken = tokens.peek();
     if (!dotToken || dotToken.kind !== 'operator' || dotToken.value !== '.') {

--- a/packages/semantic/test/multilingual-property-path-patient.test.ts
+++ b/packages/semantic/test/multilingual-property-path-patient.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Multilingual roadmap — property-path patient (Tier 2).
+ *
+ * Regression guard for the property-path patient feature that cleared
+ * `announce-screen-reader` (he+sw) — see docs-internal/MULTILINGUAL_ROADMAP.md.
+ *
+ * `put event.detail.message into #x` fails even in English at the bare-command
+ * level: the tokenizer fuses the dotted path into a base token + `.`-prefixed
+ * selector tokens (`event` + `.detail` + `.message`), which the property-access
+ * matcher previously didn't recognize. The fix is gated to reference/identifier
+ * bases so a command verb + class selector (`toggle .active`) is never consumed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse, canParse } from '../src';
+
+describe('Property-path patient (fused-dot member access)', () => {
+  const cases: [string, string][] = [
+    ['put event.detail.message into #x', 'en'],
+    ['put it.value into #x', 'en'],
+    ['put my.innerHTML into #x', 'en'],
+    ['שים את event.detail.message על #x', 'he'],
+    ['weka event.detail.message kwa #x', 'sw'],
+  ];
+  for (const [input, lang] of cases) {
+    it(`parses "${input}" (${lang})`, () => {
+      expect(canParse(input, lang)).toBe(true);
+      expect(parse(input, lang).action).toBe('put');
+    });
+  }
+
+  it('does not swallow a command verb + class selector as a property path', () => {
+    // The fused-dot branch is gated to reference bases; `toggle`/`بدل` are verbs.
+    expect(parse('toggle .active', 'en').action).toBe('toggle');
+    // Arabic proclitic conjunction form must still parse as toggle, not on.
+    expect(parse('وبدل .active على #button', 'ar').action).toBe('toggle');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-07T17:20:18.817Z",
-  "commit": "5dc3d86",
+  "timestamp": "2026-06-07T18:10:59.659Z",
+  "commit": "9b34d38",
   "languages": {
     "ar": {
       "parseSuccess": 150,
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
-      "avgConfidence": 0.9186778711484593,
-      "bundleSize": 399097,
+      "avgConfidence": 0.9253445378151258,
+      "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -221,6 +221,10 @@
           "success": true,
           "confidence": 1
         },
+        "window-keydown": {
+          "success": true,
+          "confidence": 1
+        },
         "window-resize": {
           "success": true,
           "confidence": 1
@@ -286,6 +290,10 @@
           "confidence": 1
         },
         "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
           "success": true,
           "confidence": 1
         },
@@ -564,10 +572,6 @@
         "form-disable-on-submit": {
           "success": false
         },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.5
-        },
         "window-scroll": {
           "success": true,
           "confidence": 0.5
@@ -590,10 +594,6 @@
         },
         "unless-condition": {
           "success": false
-        },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 0.5
         },
         "socket-basic": {
           "success": true,
@@ -627,8 +627,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8722222222222222,
-      "bundleSize": 399097,
+      "avgConfidence": 0.8754689754689755,
+      "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -950,6 +950,10 @@
           "success": true,
           "confidence": 1
         },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 1
+        },
         "set-text-possessive-dot": {
           "success": true,
           "confidence": 1
@@ -1182,10 +1186,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 0.5
-        },
         "focus-trap": {
           "success": true,
           "confidence": 0.5
@@ -1253,7 +1253,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9367465504720396,
-      "bundleSize": 399097,
+      "bundleSize": 399599,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1877,7 +1877,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 399097,
+      "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2502,7 +2502,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 399097,
+      "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3126,7 +3126,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 399097,
+      "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3746,11 +3746,11 @@
       }
     },
     "he": {
-      "parseSuccess": 149,
-      "parseFailure": 5,
-      "parseRate": 0.9675324675324676,
-      "avgConfidence": 0.8500053265153942,
-      "bundleSize": 399097,
+      "parseSuccess": 150,
+      "parseFailure": 4,
+      "parseRate": 0.974025974025974,
+      "avgConfidence": 0.8510052910052915,
+      "bundleSize": 399599,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -3761,6 +3761,10 @@
           "confidence": 1
         },
         "input-mirror": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
           "success": true,
           "confidence": 1
         },
@@ -4348,9 +4352,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "announce-screen-reader": {
-          "success": false
-        },
         "behavior-removable": {
           "success": false
         },
@@ -4370,7 +4371,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 399097,
+      "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -4995,7 +4996,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 399097,
+      "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5619,7 +5620,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9976296296296296,
-      "bundleSize": 399097,
+      "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6239,8 +6240,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8410533910533909,
-      "bundleSize": 399097,
+      "avgConfidence": 0.8443001443001442,
+      "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6526,6 +6527,10 @@
           "success": true,
           "confidence": 1
         },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 1
+        },
         "set-text-possessive-dot": {
           "success": true,
           "confidence": 1
@@ -6790,10 +6795,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 0.5
-        },
         "focus-trap": {
           "success": true,
           "confidence": 0.5
@@ -6865,7 +6866,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.5687726942628903,
-      "bundleSize": 399097,
+      "bundleSize": 399599,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7489,7 +7490,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9988455988455989,
-      "bundleSize": 399097,
+      "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8114,7 +8115,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.8352592592592598,
-      "bundleSize": 399097,
+      "bundleSize": 399599,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8735,7 +8736,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8312273057371102,
-      "bundleSize": 399097,
+      "bundleSize": 399599,
       "patterns": {
         "window-resize": {
           "success": true,
@@ -9359,7 +9360,7 @@
       "parseFailure": 2,
       "parseRate": 0.987012987012987,
       "avgConfidence": 0.735672514619883,
-      "bundleSize": 399097,
+      "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -9981,8 +9982,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8871985157699446,
-      "bundleSize": 399097,
+      "avgConfidence": 0.8883529169243457,
+      "bundleSize": 399599,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10025,6 +10026,10 @@
           "confidence": 1
         },
         "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
           "success": true,
           "confidence": 1
         },
@@ -10537,10 +10542,6 @@
           "confidence": 0.8222222222222222
         },
         "computed-value": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "announce-screen-reader": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -10603,11 +10604,11 @@
       }
     },
     "sw": {
-      "parseSuccess": 151,
-      "parseFailure": 3,
-      "parseRate": 0.9805194805194806,
-      "avgConfidence": 0.8849048670240726,
-      "bundleSize": 399097,
+      "parseSuccess": 152,
+      "parseFailure": 2,
+      "parseRate": 0.987012987012987,
+      "avgConfidence": 0.8856620718462827,
+      "bundleSize": 399599,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10678,6 +10679,10 @@
           "confidence": 1
         },
         "computed-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
           "success": true,
           "confidence": 1
         },
@@ -11201,9 +11206,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "announce-screen-reader": {
-          "success": false
-        },
         "socket-basic": {
           "success": true,
           "confidence": 0.5
@@ -11229,7 +11231,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9402185116470816,
-      "bundleSize": 399097,
+      "bundleSize": 399599,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11853,8 +11855,8 @@
       "parseSuccess": 151,
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
-      "avgConfidence": 0.8932204228269676,
-      "bundleSize": 399097,
+      "avgConfidence": 0.896531681105113,
+      "bundleSize": 399599,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12009,6 +12011,10 @@
           "confidence": 1
         },
         "computed-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
           "success": true,
           "confidence": 1
         },
@@ -12450,10 +12456,6 @@
         "unless-condition": {
           "success": false
         },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 0.5
-        },
         "eventsource-basic": {
           "success": true,
           "confidence": 0.5
@@ -12475,8 +12477,8 @@
       "parseSuccess": 152,
       "parseFailure": 2,
       "parseRate": 0.987012987012987,
-      "avgConfidence": 0.8639619883040935,
-      "bundleSize": 399097,
+      "avgConfidence": 0.867251461988304,
+      "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -12786,6 +12788,10 @@
           "success": true,
           "confidence": 1
         },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 1
+        },
         "set-text-possessive-dot": {
           "success": true,
           "confidence": 1
@@ -13022,10 +13028,6 @@
           "confidence": 0.5
         },
         "computed-value": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "announce-screen-reader": {
           "success": true,
           "confidence": 0.5
         },
@@ -13098,8 +13100,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8864564007421153,
-      "bundleSize": 399097,
+      "avgConfidence": 0.8876108018965165,
+      "bundleSize": 399599,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13142,6 +13144,10 @@
           "confidence": 1
         },
         "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
           "success": true,
           "confidence": 1
         },
@@ -13650,10 +13656,6 @@
           "confidence": 0.8222222222222222
         },
         "computed-value": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "announce-screen-reader": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -13723,8 +13725,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8894248608534325,
-      "bundleSize": 399097,
+      "avgConfidence": 0.8917336631622349,
+      "bundleSize": 399599,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13775,6 +13777,14 @@
           "confidence": 1
         },
         "fade-out-remove": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value-possessive-dot": {
           "success": true,
           "confidence": 1
         },
@@ -14274,10 +14284,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "focus-trap": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -14287,10 +14293,6 @@
           "confidence": 0.8222222222222222
         },
         "set-inner-html-possessive-dot": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "get-value-possessive-dot": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -14349,7 +14351,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9988148148148148,
-      "bundleSize": 399097,
+      "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -14968,7 +14970,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 399097,
+      "size": 399599,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Clears `announce-screen-reader` (**he + sw**) via **property-path patient support** — the actual lever for this pattern. Cross-language average **99.00% → 99.05%**; non-behavior failures **13 → 11** (Bucket B behaviors unchanged at 24).

Verified by a full `--bundle browser-priority` baseline regen: **exactly these 2 patterns flip to passing, zero regressions** (`↓`). he 96.8→97.4%, sw 98.1→98.7%.

## What I found (and why the plan changed)

This item was scoped as "he/sw `set` alignment," but investigation showed that was **not** the lever:

- `announce` = `on success put event.detail.message into #sr-announce set @role to "alert" on #sr-announce`.
- The `set …` clause and the `set … on <target>` mis-split are both **tolerated** inside the event-handler compound (exactly like `toggle .active on #host`, which already passes in he despite splitting into `toggle … then on #host`).
- The **only** hard blocker was the **property-path patient** `event.detail.message` in the `put` clause — which fails even in **English** at the bare-command level.

So the he/sw `set`-marker work was dropped (no baseline impact, and it would have risked the `weka`=put verb collision in sw).

## Change

`put event.detail.message into #x` fails because the tokenizer fuses the dotted path into a base token + `.`-prefixed **selector** tokens (`event` + `.detail` + `.message`, since `.foo` looks like a class selector), and `tryMatchPropertyAccessExpression` only knew the un-fused `base . identifier` operator form.

Added a **fused-dot branch** that folds a chain of `.prop` selectors into the property path. **Gated to identifier/reference bases** (`PROPERTY_ACCESS_BASES`) so a command verb + class selector (`toggle .active`, AR `بدل .active`, the proclitic `وبدل .active`) is never swallowed as a property path — caught and fixed a regression on `vso-arabic.test.ts` during development.

## Tests

`packages/semantic/test/multilingual-property-path-patient.test.ts` (6 cases): `put`-with-property-path across en/he/sw + the command-verb regression guards. Full semantic suite: 5288 pass (only the environmental `build-artifacts.test.ts` dist/`.d.ts` checks fail, as documented — they pass in CI).

## Remaining (11 non-behavior, in roadmap)

`form-disable-on-submit`, `unless-condition`, `caret-var-on-target` (ar+tl); `on-custom-event-receive` (ko+qu); `window-resize` (qu+tr); `focus-trap` (tr). These need compound/`in me` split handling, condition i18n (expression-operator territory), the SOV custom-event slot, and event-modifier parsing — recommended for a fresh session.

Note: the binary `patterns.db` was regenerated locally for verification then restored (CI repopulates from source); only source + regenerated baseline JSON are committed.

https://claude.ai/code/session_01JjcXVHhpn5oQkAS9CrUugm

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjcXVHhpn5oQkAS9CrUugm)_