### PR TITLE
fix(multilingual): accept custom events in SOV extraction (clears 4 non-behavior failures)

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,7 +5,7 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after property-path patient (Tier 2; `announce-screen-reader` he+sw). Tier 1, Track 4, Track 1 (reactive) complete._
+_Last updated: after custom-event SOV slot (`on-custom-event-receive` ko+qu, `window-resize` qu+tr). Property-path patient, Tier 1, Track 4, Track 1 (reactive) complete._
 
 ---
 
@@ -14,26 +14,33 @@ _Last updated: after property-path patient (Tier 2; `announce-screen-reader` he+
 Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
 (generated with `--bundle browser-priority`). Cross-language average **99.05%**
 (up from 97.5% before Phase 1; Phases 1–4 + Track 4 + qu `install` + passthrough
-batch + Tier 1 + property-path patient: +58 instances).
-**35 failing pattern-instances** remain (24 are Bucket B behaviors).
+batch + Tier 1 + property-path patient + custom-event SOV: +62 instances).
+**31 failing pattern-instances** remain (24 are Bucket B behaviors).
 
-| Rate   | Languages                             |
-| ------ | ------------------------------------- |
-| 100%   | en, bn, hi, ja, ms, ru, th, uk, vi    |
-| 99%    | de/es/fr/id/pt/ko (99.4), sw (98.7)   |
-| 98–99% | qu (98.7), tr (98.7), tl (98.1)       |
-| 96–98% | it/pl/zh (97.4), ar (97.4), he (97.4) |
+| Rate   | Languages                                   |
+| ------ | ------------------------------------------- |
+| 100%   | en, bn, hi, ja, ko, ms, qu, ru, th, uk, vi  |
+| 99%    | de/es/fr/id/pt (99.4), sw (98.7), tr (99.4) |
+| 98–99% | tl (98.1)                                   |
+| 96–98% | it/pl/zh (97.4), ar (97.4), he (97.4)       |
 
-**11 non-behavior failing pattern-instances** remain (plus 24 Bucket B behaviors):
+**7 non-behavior failing pattern-instances** remain (plus 24 Bucket B behaviors):
 
-| Track                         | Instances | Nature                                                                           |
-| ----------------------------- | --------- | -------------------------------------------------------------------------------- |
-| **Bucket B — behaviors**      | 24        | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`) |
-| **Deep per-language grammar** | 11        | compound/`in me` splits, condition i18n, custom-event SOV slot, event modifiers  |
+| Track                         | Instances | Nature                                                                                               |
+| ----------------------------- | --------- | ---------------------------------------------------------------------------------------------------- |
+| **Bucket B — behaviors**      | 24        | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`)                     |
+| **Deep per-language grammar** | 7         | compound/`in me` splits, condition i18n + VSO block-wrap, caret destination reorder, event modifiers |
 
-The 11 non-behavior remainders: `form-disable-on-submit`, `unless-condition`,
-`caret-var-on-target` (each **ar+tl**); `on-custom-event-receive` (ko+qu);
-`window-resize` (qu+tr); `focus-trap` (tr).
+The 7 non-behavior remainders: `form-disable-on-submit`, `unless-condition`,
+`caret-var-on-target` (each **ar+tl**); `focus-trap` (tr).
+
+> **Custom-event SOV cleared `on-custom-event-receive` (ko+qu) and, as a side
+> effect, `window-resize` (qu+tr).** The SOV event extractor now accepts a bare
+> (non-keyword) identifier in the event slot, gated by the event-marker particle
+> (ja/tr/qu/bn) or an immediately-following command verb (ko). The qu/tr resize
+> words (`hatun_kay` / `boyut_değiştir`) are real events absent from the native
+> event dictionary, so they fell out for free. **+4 instances, 0 regressions**
+> (full `browser-priority` regen). See Shipped → "Custom-event SOV slot".
 
 > **The clean tokenizer token-split vein is now largely worked out** (Phases 1 & 4
 > cleared `@`/`*`/`^`; Tier 1 the tag-less `<.class/>` selector). Every remaining
@@ -44,6 +51,61 @@ The 11 non-behavior remainders: `form-disable-on-submit`, `unless-condition`,
 ---
 
 ## Shipped
+
+### Custom-event SOV slot — `on-custom-event-receive` ko+qu (+ window-resize qu+tr) (+4)
+
+- **4 instances, 0 regressions, avg 99.05% (full `browser-priority` regen: exactly
+  ko/qu `on-custom-event-receive` + qu/tr `window-resize` flip `↑`, zero `↓`).**
+  ko 99.4→100, qu 98.7→100, tr 98.7→99.4.
+- **Root cause.** `trySOVEventExtraction` (the stage-3 fallback in
+  `semantic-parser.ts`) only recognized built-in event keywords
+  (`click`/`submit`/…) in the event slot. A custom event keeps its untranslated
+  source identifier after the grammar transform — `on hello put 'Got it!' into me`
+  → ko `'Got it!' 를 hello 넣다 나 에`, qu `… hello pi churay` — so `hello`
+  surfaced as a bare `identifier` token and never filled the event slot; the whole
+  handler failed (stages 1 & 2 already can't anchor a mid-stream event).
+- **Fix.** A second pass accepts a bare identifier in the event slot, gated by the
+  same structural cue the built-in path uses so a stray content identifier is never
+  mistaken for an event: marker languages (ja/tr/qu/bn) require the event-marker
+  particle right after the identifier (`hello pi`); marker-less Korean requires the
+  identifier to sit immediately before the body's command verb (`hello 넣다`). The
+  existing body re-parse is the final guard. Runs only after the event- and
+  command-pattern stages already failed.
+- **Bonus.** `window-resize` (qu/tr) flipped too: the qu/tr resize words
+  (`hatun_kay` / `boyut_değiştir`) are the real event, just absent from the native
+  event dictionary — the same gate now accepts them. (The `debounced at 200ms`
+  modifier is still dropped, but the metric is non-null parse.)
+- Locked by `semantic/test/multilingual-roadmap-fixes.test.ts` (ko+qu custom event,
+  the 클릭 control, and a guard that a plain command body never becomes a phantom
+  event handler).
+
+### Investigated, deferred — `unless` / `caret-var` / `form-disable` (ar+tl)
+
+Probed faithfully (DB-stored translation → `parseSemantic`) and confirmed each needs
+deep, multi-session work; the only achievable result is a hollow / mangled parse, so
+they were **not** landed (avoids inflating the non-null metric with empty matches):
+
+- **`unless-condition` (ar+tl).** Isolated cleanly: ar/tl already handle event-at-end
+  (`بدل .selected عند نقر` → `on`) and en parses the `unless` block, but ar/tl don't
+  recognize the `unless` keyword (ar `إلا إذا` **splits**, with `إذا`→`if`; tl
+  `maliban_kung` is an unrecognized identifier). Adding `unless` to the ar/tl profiles
+  (single-token `إلا` / `maliban_kung`) makes the block parse — **but** the simple
+  event-at-end is a _command-specific_ fused pattern (`toggle-event-ar-vso-verb-first`);
+  there is no generic block+event-at-end wrapper, so `unless … عند نقر` falls through to
+  a standalone `unless` that captures **nothing** (empty roles — body _and_ event
+  dropped), below even en-parity. A real `on` parse needs a generated
+  `unless-event-{ar,tl}-vso` pattern (or a generic event-at-end block wrapper). The
+  profile additions are correct-but-insufficient and were reverted to avoid a hollow flip.
+- **`caret-var-on-target` (ar+tl).** The i18n transformer mangles
+  `put ^count on #host into me` → ar `ضع ^count عند نقر ثم في أنا عند #host` (spurious
+  `then` inserted, `on #host` scope split to the end, the event stranded mid-stream).
+  Needs transformer reorder surgery for the `^var on <elt> into me` scoped-destination
+  shape before the semantic side can see anything parseable.
+- **`form-disable-on-submit` (ar+tl).** Compound (`add … <button/> in me  put "…" into
+<button/> in me`). The masked string literal defeats the transformer's compound split,
+  so the second clause stays fully English (`put "…" into <button/> in me`); separately,
+  `<button/> in me` (scoped query selector) isn't matched as one target. Needs both a
+  compound-split fix (mask-aware) and a `<selector> in <scope>` matcher.
 
 ### Property-path patient — fused-dot member access (+2)
 

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1103,7 +1103,9 @@ export class SemanticParserImpl implements ISemanticParser {
     // body's command verb for marker-less Korean. The body re-parse further
     // below is the final guard — a wrong match yields no parseable body.
     if (eventIndex === -1) {
-      const commandActions = new Set(patterns.filter(p => p.command !== 'on').map(p => p.command));
+      const commandActions = new Set<string>(
+        patterns.filter(p => p.command !== 'on').map(p => p.command)
+      );
       for (let i = 0; i < allTokens.length; i++) {
         const token = allTokens[i];
         if (token.kind !== 'identifier') continue;

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1093,6 +1093,61 @@ export class SemanticParserImpl implements ISemanticParser {
       }
     }
 
+    // Second pass: custom (non-keyword) event identifiers, e.g. `on hello …`.
+    // Only runs when no built-in event keyword matched above. Custom events
+    // keep their untranslated source identifier (`hello`), so they surface as a
+    // bare `identifier` token rather than a normalized event keyword. To avoid
+    // mistaking a stray content identifier for an event, this is gated by the
+    // same structural cue the built-in path uses: the event-marker particle for
+    // marker languages (ja/tr/qu/bn), or being immediately followed by the
+    // body's command verb for marker-less Korean. The body re-parse further
+    // below is the final guard — a wrong match yields no parseable body.
+    if (eventIndex === -1) {
+      const commandActions = new Set(patterns.filter(p => p.command !== 'on').map(p => p.command));
+      for (let i = 0; i < allTokens.length; i++) {
+        const token = allTokens[i];
+        if (token.kind !== 'identifier') continue;
+
+        if (eventMarkers.size > 0) {
+          // Marker languages: the event-marker particle right after the
+          // identifier (modulo a bracket key-filter selector) confirms the role.
+          let markerOffset = 1;
+          const nextToken = allTokens[i + 1];
+          if (nextToken && nextToken.kind === 'selector' && nextToken.value.startsWith('[')) {
+            markerOffset = 2;
+          }
+          const markerToken = allTokens[i + markerOffset];
+          if (
+            markerToken &&
+            (markerToken.kind === 'particle' || markerToken.kind === 'keyword') &&
+            eventMarkers.has(markerToken.value)
+          ) {
+            eventIndex = i;
+            eventName = token.value;
+            keyFilter = markerOffset === 2 ? allTokens[i + 1].value : '';
+            tokensToRemove = markerOffset + 1;
+            break;
+          }
+        } else {
+          // Marker-less Korean: the event identifier sits immediately before the
+          // body's command verb (e.g. `… hello 넣다 …`).
+          const nextToken = allTokens[i + 1];
+          if (
+            nextToken &&
+            nextToken.kind === 'keyword' &&
+            nextToken.normalized != null &&
+            commandActions.has(nextToken.normalized)
+          ) {
+            eventIndex = i;
+            eventName = token.value;
+            keyFilter = '';
+            tokensToRemove = 1;
+            break;
+          }
+        }
+      }
+    }
+
     if (eventIndex === -1) return null;
 
     // Build the list of indices to remove: event keyword + marker

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -48,3 +48,34 @@ describe('Korean transition keyword alignment (전환)', () => {
     expect(parse('.active 를 클릭 토글', 'ko').action).toBe('on');
   });
 });
+
+describe('Custom (non-keyword) event identifiers in SOV languages', () => {
+  // `on hello put 'Got it!' into me` — the custom event `hello` keeps its
+  // untranslated identifier form, so the SOV event extractor must accept a bare
+  // identifier in the event slot (gated by the event-marker particle for marker
+  // languages, or by an immediately-following command verb for marker-less
+  // Korean). See docs-internal/MULTILINGUAL_ROADMAP.md (on-custom-event-receive).
+  const cases: Array<[string, string]> = [
+    // Korean (no event-marker particle): `… <event-id> <verb> …`.
+    ['ko', "'Got it!' 를 hello 넣다 나 에"],
+    // Quechua (event-marker particle `pi`): `… <event-id> pi <verb>`.
+    ['qu', "'Got it!' ta noqa man hello pi churay"],
+  ];
+
+  for (const [lang, input] of cases) {
+    it(`[${lang}] parses custom event "${input}"`, () => {
+      expect(canParse(input, lang)).toBe(true);
+      expect(parse(input, lang).action).toBe('on');
+    });
+  }
+
+  it('still parses the known-event (클릭) control in Korean', () => {
+    expect(parse("'Got it!' 를 클릭 넣다 나 에", 'ko').action).toBe('on');
+  });
+
+  it('does not treat a plain command body as an event handler (ko)', () => {
+    // `.active 를 토글` is a bare toggle command — no event identifier present,
+    // so it must remain a command, never become a phantom event handler.
+    expect(parse('.active 를 토글', 'ko').action).toBe('toggle');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -6862,10 +6862,10 @@
       }
     },
     "ko": {
-      "parseSuccess": 153,
-      "parseFailure": 1,
-      "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.5687726942628903,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.5683261183261183,
       "bundleSize": 399599,
       "patterns": {
         "wait-for-event": {
@@ -7421,7 +7421,8 @@
           "confidence": 0.5
         },
         "on-custom-event-receive": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "keydown-key-is-syntax": {
           "success": true,
@@ -9356,10 +9357,10 @@
       }
     },
     "qu": {
-      "parseSuccess": 152,
-      "parseFailure": 2,
-      "parseRate": 0.987012987012987,
-      "avgConfidence": 0.735672514619883,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.7326118326118326,
       "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
@@ -9791,7 +9792,8 @@
           "confidence": 0.5
         },
         "window-resize": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "document-ready": {
           "success": true,
@@ -9926,7 +9928,8 @@
           "confidence": 0.5
         },
         "on-custom-event-receive": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "keydown-key-is-syntax": {
           "success": true,
@@ -12474,10 +12477,10 @@
       }
     },
     "tr": {
-      "parseSuccess": 152,
-      "parseFailure": 2,
-      "parseRate": 0.987012987012987,
-      "avgConfidence": 0.867251461988304,
+      "parseSuccess": 153,
+      "parseFailure": 1,
+      "parseRate": 0.9935064935064936,
+      "avgConfidence": 0.8648511256354393,
       "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
@@ -12985,7 +12988,8 @@
           "confidence": 0.5
         },
         "window-resize": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "document-ready": {
           "success": true,


### PR DESCRIPTION
## Summary

Work toward the 11 non-behavior multilingual parse failures in `docs-internal/MULTILINGUAL_ROADMAP.md`. This PR lands one clean, well-gated parser fix that clears **4 of the 11** with **zero regressions**, and documents the deep investigation (with reproduction evidence) for three deferred items.

## What landed: custom-event SOV slot

`trySOVEventExtraction` (the stage-3 fallback in `packages/semantic/src/parser/semantic-parser.ts`) only recognized built-in event keywords (`click`/`submit`/…) in the event slot. A **custom** event keeps its untranslated source identifier after the grammar transform, e.g. `on hello put 'Got it!' into me`:

- ko → `'Got it!' 를 hello 넣다 나 에`
- qu → `'Got it!' ta noqa man hello pi churay`

So `hello` surfaced as a bare `identifier` and never filled the event slot — the whole handler failed.

**Fix:** a second pass accepts a bare identifier in the event slot, gated by the same structural cue the built-in path uses so a stray content identifier is never mistaken for an event:
- marker languages (ja/tr/qu/bn): the event-marker particle must immediately follow (`hello pi`);
- marker-less Korean: the identifier must sit immediately before the body's command verb (`hello 넣다`).

The existing body re-parse is the final guard, and the whole pass runs only after the event- and command-pattern stages already failed.

## Results (full `browser-priority` baseline regen)

**+4 instances, 0 regressions.** Exactly these flip `↑`:

| Pattern | Languages |
| --- | --- |
| `on-custom-event-receive` | ko, qu *(intended)* |
| `window-resize` | qu, tr *(bonus — the resize words `hatun_kay` / `boyut_değiştir` are the real event, just absent from the native event dictionary)* |

Rates: ko 99.4→100, qu 98.7→100, tr 98.7→99.4. Baseline updated surgically (only those 4 success flags + the three languages' aggregates).

## Deferred (investigated, not landed)

Probed faithfully (DB-stored translation → `parseSemantic`) and confirmed each only yields a hollow/mangled parse without deep multi-session work — not landed, to avoid inflating the non-null metric with empty matches. Full analysis in the roadmap's new "Investigated, deferred" section:

- **`unless-condition` (ar+tl)** — ar/tl don't recognize `unless` (`إلا إذا` splits with `إذا`→`if`; tl `maliban_kung` unrecognized). Adding the keyword parses the block, but there's no generic block+event-at-end wrapper (the simple case uses a *command-specific* fused VSO pattern), so it collapses to an empty `unless`. Needs a generated `unless-event-{ar,tl}-vso` pattern.
- **`caret-var-on-target` (ar+tl)** — the i18n transformer mangles `put ^count on #host into me` (spurious `then`, `on #host` split to the end, event stranded). Needs transformer reorder surgery.
- **`form-disable-on-submit` (ar+tl)** — masked string literal defeats compound splitting (2nd clause stays English) + `<button/> in me` scoped selector unhandled.

`focus-trap` (tr) remains; it was out of the agreed scope (Tranches A+B).

## Tests

- New regression cases in `packages/semantic/test/multilingual-roadmap-fixes.test.ts` (ko+qu custom event, the 클릭 control, and a guard that a plain command body never becomes a phantom event handler).
- Full semantic suite: 5298 pass (the 30 `build-artifacts.test.ts` `.d.ts` failures are the documented environmental ones — they pass in CI).

https://claude.ai/code/session_01GJgn3E4wiAvKXwCnzCcQNM

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJgn3E4wiAvKXwCnzCcQNM)_