### PR TITLE
fix(multilingual): wrap trailing-event block bodies (clears unless-condition ar+tl)

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,7 +5,7 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after custom-event SOV slot (`on-custom-event-receive` ko+qu, `window-resize` qu+tr). Property-path patient, Tier 1, Track 4, Track 1 (reactive) complete._
+_Last updated: after trailing-event block-wrap (`unless-condition` ar+tl). Custom-event SOV, property-path patient, Tier 1, Track 4, Track 1 (reactive) complete._
 
 ---
 
@@ -14,25 +14,25 @@ _Last updated: after custom-event SOV slot (`on-custom-event-receive` ko+qu, `wi
 Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
 (generated with `--bundle browser-priority`). Cross-language average **99.05%**
 (up from 97.5% before Phase 1; Phases 1–4 + Track 4 + qu `install` + passthrough
-batch + Tier 1 + property-path patient + custom-event SOV: +62 instances).
-**31 failing pattern-instances** remain (24 are Bucket B behaviors).
+batch + Tier 1 + property-path patient + custom-event SOV + trailing-event
+block-wrap: +64 instances). **29 failing pattern-instances** remain (24 are
+Bucket B behaviors).
 
-| Rate   | Languages                                   |
-| ------ | ------------------------------------------- |
-| 100%   | en, bn, hi, ja, ko, ms, qu, ru, th, uk, vi  |
-| 99%    | de/es/fr/id/pt (99.4), sw (98.7), tr (99.4) |
-| 98–99% | tl (98.1)                                   |
-| 96–98% | it/pl/zh (97.4), ar (97.4), he (97.4)       |
+| Rate   | Languages                                              |
+| ------ | ------------------------------------------------------ |
+| 100%   | en, bn, hi, ja, ko, ms, qu, ru, th, uk, vi             |
+| 99%    | de/es/fr/id/pt (99.4), sw (98.7), tr (99.4), tl (98.7) |
+| 96–98% | it/pl/zh (97.4), ar (98.1), he (97.4)                  |
 
-**7 non-behavior failing pattern-instances** remain (plus 24 Bucket B behaviors):
+**5 non-behavior failing pattern-instances** remain (plus 24 Bucket B behaviors):
 
-| Track                         | Instances | Nature                                                                                               |
-| ----------------------------- | --------- | ---------------------------------------------------------------------------------------------------- |
-| **Bucket B — behaviors**      | 24        | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`)                     |
-| **Deep per-language grammar** | 7         | compound/`in me` splits, condition i18n + VSO block-wrap, caret destination reorder, event modifiers |
+| Track                         | Instances | Nature                                                                                |
+| ----------------------------- | --------- | ------------------------------------------------------------------------------------- |
+| **Bucket B — behaviors**      | 24        | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`)      |
+| **Deep per-language grammar** | 5         | compound/`in me` splits, caret destination reorder, event-modifier + VSO source-block |
 
-The 7 non-behavior remainders: `form-disable-on-submit`, `unless-condition`,
-`caret-var-on-target` (each **ar+tl**); `focus-trap` (tr).
+The 5 non-behavior remainders: `form-disable-on-submit`, `caret-var-on-target`
+(each **ar+tl**); `focus-trap` (tr).
 
 > **Custom-event SOV cleared `on-custom-event-receive` (ko+qu) and, as a side
 > effect, `window-resize` (qu+tr).** The SOV event extractor now accepts a bare
@@ -51,6 +51,34 @@ The 7 non-behavior remainders: `form-disable-on-submit`, `unless-condition`,
 ---
 
 ## Shipped
+
+### Trailing-event block-wrap — `unless-condition` ar+tl (+2)
+
+- **2 instances, 0 regressions, avg 99.05% (full `browser-priority` regen: exactly
+  ar/tl `unless-condition` flip `↑`, zero `↓`).** ar 97.4→98.1, tl 98.1→98.7.
+- **Root cause.** SVO/VSO transforms put the event clause at the very end
+  (`<body> عند <event>` / `<body> kapag <event>`). The per-command _fused_ event
+  patterns (`toggle-event-ar-vso-…`) only cover simple bodies, so a **block** body
+  (`unless <cond> toggle …`) wasn't wrapped and degraded to a hollow standalone
+  command. Two gaps: ar/tl didn't recognize `unless` at all (ar `إلا إذا`
+  **splits**, with `إذا`→`if`; tl `maliban_kung` was an unrecognized identifier),
+  and there was no generic block+trailing-event wrapper.
+- **Fix (two parts).**
+  1. **Keyword.** Added `unless` to the ar/tl semantic profiles as a single token
+     (`إلا` / `maliban_kung`); the i18n ar dict now emits single-token `إلا` (the
+     two-word `إلا إذا` is split by the tokenizer). `keyword-collisions.test.ts`
+     clean.
+  2. **Parser — `tryTrailingEventExtraction` (new stage 1.5).** Recognizes a
+     trailing `<on-marker> <event>` (gated to a recognized event keyword in the
+     final position, so a trailing destination selector like `على #button` is
+     never mistaken for an event), strips it, and parses the preceding tokens as
+     the handler body. It runs only after the dedicated event patterns fail and
+     returns null (falling through to the command stage unchanged) unless it finds
+     a genuine trailing event whose body parses — so structurally it can only add
+     parses, never break one. Result is en-parity: `on { unless(…) ; toggle(…) }`.
+- Locked by `semantic/test/multilingual-roadmap-fixes.test.ts` (ar+tl block-wrap
+  asserting the body keeps both `unless` and `toggle`, plus guards that a trailing
+  destination selector and a plain command are left untouched).
 
 ### Custom-event SOV slot — `on-custom-event-receive` ko+qu (+ window-resize qu+tr) (+4)
 
@@ -79,23 +107,17 @@ The 7 non-behavior remainders: `form-disable-on-submit`, `unless-condition`,
   the 클릭 control, and a guard that a plain command body never becomes a phantom
   event handler).
 
-### Investigated, deferred — `unless` / `caret-var` / `form-disable` (ar+tl)
+### Investigated, deferred — `caret-var` / `form-disable` (ar+tl)
+
+> `unless-condition` (ar+tl) graduated from this section — see Shipped →
+> "Trailing-event block-wrap". The generic trailing-event wrapper built there is
+> the reusable lever `focus-trap` (tr) will also need (event-at-end + block body),
+> once paired with a `from <source>` clause and a `<selector> in <scope>` matcher.
 
 Probed faithfully (DB-stored translation → `parseSemantic`) and confirmed each needs
 deep, multi-session work; the only achievable result is a hollow / mangled parse, so
 they were **not** landed (avoids inflating the non-null metric with empty matches):
 
-- **`unless-condition` (ar+tl).** Isolated cleanly: ar/tl already handle event-at-end
-  (`بدل .selected عند نقر` → `on`) and en parses the `unless` block, but ar/tl don't
-  recognize the `unless` keyword (ar `إلا إذا` **splits**, with `إذا`→`if`; tl
-  `maliban_kung` is an unrecognized identifier). Adding `unless` to the ar/tl profiles
-  (single-token `إلا` / `maliban_kung`) makes the block parse — **but** the simple
-  event-at-end is a _command-specific_ fused pattern (`toggle-event-ar-vso-verb-first`);
-  there is no generic block+event-at-end wrapper, so `unless … عند نقر` falls through to
-  a standalone `unless` that captures **nothing** (empty roles — body _and_ event
-  dropped), below even en-parity. A real `on` parse needs a generated
-  `unless-event-{ar,tl}-vso` pattern (or a generic event-at-end block wrapper). The
-  profile additions are correct-but-insufficient and were reverted to avoid a hollow flip.
 - **`caret-var-on-target` (ar+tl).** The i18n transformer mangles
   `put ^count on #host into me` → ar `ضع ^count عند نقر ثم في أنا عند #host` (spurious
   `then` inserted, `on #host` scope split to the end, the event stranded mid-stream).

--- a/packages/i18n/src/dictionaries/ar.ts
+++ b/packages/i18n/src/dictionaries/ar.ts
@@ -19,7 +19,10 @@ export const ar: Dictionary = {
     hide: 'اخف',
     show: 'اظهر',
     if: 'إذا',
-    unless: 'إلا إذا',
+    // Single-token form: the semantic ar tokenizer splits the two-word `إلا إذا`
+    // into `إلا` + `إذا`(if), which derails the `unless` block. `إلا` alone is the
+    // conventional Arabic shorthand and matches the ar profile's unless keyword.
+    unless: 'إلا',
     repeat: 'كرر',
     for: 'لكل',
     while: 'بينما',

--- a/packages/semantic/src/generators/profiles/arabic.ts
+++ b/packages/semantic/src/generators/profiles/arabic.ts
@@ -111,6 +111,7 @@ export const arabicProfile: LanguageProfile = {
     settle: { primary: 'استقر', normalized: 'settle' },
     // Control flow
     if: { primary: 'إذا', normalized: 'if' },
+    unless: { primary: 'إلا', normalized: 'unless' },
     when: { primary: 'عندما', normalized: 'when' },
     where: { primary: 'أين', normalized: 'where' },
     else: { primary: 'وإلا', alternatives: ['خلاف ذلك'], normalized: 'else' },

--- a/packages/semantic/src/generators/profiles/tl.ts
+++ b/packages/semantic/src/generators/profiles/tl.ts
@@ -110,6 +110,7 @@ export const tagalogProfile: LanguageProfile = {
     settle: { primary: 'magpatahimik', normalized: 'settle' },
     // Control flow
     if: { primary: 'kung', normalized: 'if' },
+    unless: { primary: 'maliban_kung', normalized: 'unless' },
     when: { primary: 'tuwing', normalized: 'when' },
     where: { primary: 'kung_saan', normalized: 'where' },
     else: { primary: 'kung_hindi', alternatives: ['kundi'], normalized: 'else' },

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -143,6 +143,28 @@ export class SemanticParserImpl implements ISemanticParser {
       )
     );
 
+    // Stage 1.5: Trailing event clause wrapping a block/command body.
+    // SVO/VSO grammar transforms put the event clause at the end
+    // (`<body> عند <event>` / `<body> kapag <event>`). The per-command fused
+    // event patterns (toggle-event-ar-vso-…) only cover simple bodies, so a
+    // block body (e.g. `unless <cond> toggle …`) falls through to a hollow
+    // standalone-command match. This generic wrapper recognizes the trailing
+    // event and parses everything before it as the handler body. It runs only
+    // after the dedicated event patterns failed, and returns null (falling
+    // through to the command stage unchanged) unless it finds a genuine trailing
+    // event whose preceding tokens parse as a body — so it can only add parses,
+    // never break an existing one.
+    const trailingResult = this.tryTrailingEventExtraction(parseInput, language, sortedPatterns);
+    if (trailingResult) {
+      diagnostics.push(
+        parseDiagnostic('trailing event extraction succeeded', 'info', 'stage-trailing-event')
+      );
+      const result = modifiers
+        ? this.applyModifiers(trailingResult as EventHandlerSemanticNode, modifiers)
+        : trailingResult;
+      return withDiagnostics(result, diagnostics);
+    }
+
     // Stage 2: Try command patterns
     const commandPatterns = sortedPatterns.filter(p => p.command !== 'on');
     const commandMatch = patternMatcher.matchBest(tokens, commandPatterns);
@@ -987,6 +1009,72 @@ export class SemanticParserImpl implements ISemanticParser {
       windowTokens: new Set(['k_iri', 'ventana', 'window', 'document']),
     },
   };
+
+  /**
+   * Try to extract a trailing event clause that wraps a block/command body.
+   *
+   * SVO/VSO grammar transforms emit the event clause at the very end:
+   *   AR: "<body> عند <event>"   (e.g. "إلا I match .disabled بدل .selected عند نقر")
+   *   TL: "<body> kapag <event>" (e.g. "maliban_kung … palitan .selected kapag click")
+   *
+   * The per-command fused event patterns only cover simple bodies, so a block
+   * body (unless/if/…) isn't wrapped and degrades to a hollow standalone match.
+   * This recognizes a trailing `<on-marker> <event>` (gated to a recognized
+   * event keyword in the final position, so a trailing destination selector like
+   * `على #button` is never mistaken for an event), strips it, and parses the
+   * preceding tokens as the handler body. Returns null when there is no such
+   * trailing event or the body doesn't parse — so the caller falls through to
+   * the command stage unchanged.
+   */
+  private tryTrailingEventExtraction(
+    input: string,
+    language: string,
+    patterns: LanguagePattern[]
+  ): SemanticNode | null {
+    const tokens = tokenizeInternal(input, language).tokens;
+    if (tokens.length < 3) return null;
+
+    // Native event names for this language (e.g. ar نقر→click, tl native forms).
+    const langEvents = eventNameTranslations[language];
+    const nativeEventNames = new Set<string>();
+    if (langEvents) {
+      for (const native of Object.keys(langEvents)) nativeEventNames.add(native.toLowerCase());
+    }
+
+    // The event must be the final token; the on-marker the one before it.
+    const markerIdx = tokens.length - 2;
+    const marker = tokens[markerIdx];
+    const isOnMarker = marker.kind === 'keyword' && marker.normalized?.toLowerCase() === 'on';
+    if (!isOnMarker) return null;
+
+    const evtToken = tokens[tokens.length - 1];
+    const evtVal = evtToken.value.toLowerCase();
+    const evtNorm = evtToken.normalized?.toLowerCase();
+    const isKnownEvent =
+      (!!evtNorm && SemanticParserImpl.KNOWN_EVENTS.has(evtNorm)) ||
+      SemanticParserImpl.KNOWN_EVENTS.has(evtVal) ||
+      nativeEventNames.has(evtVal);
+    if (!isKnownEvent) return null;
+
+    const eventName =
+      evtNorm && SemanticParserImpl.KNOWN_EVENTS.has(evtNorm)
+        ? evtNorm
+        : (langEvents?.[evtVal] ?? evtVal);
+
+    // Body = everything before the on-marker, parsed as command(s)/block.
+    const bodyTokens = tokens.slice(0, markerIdx);
+    if (bodyTokens.length === 0) return null;
+
+    const commandPatterns = patterns.filter(p => p.command !== 'on');
+    const bodyStream = new TokenStreamImpl(bodyTokens, language);
+    const body = this.parseBodyWithClauses(bodyStream, commandPatterns, language);
+    if (body.length === 0) return null;
+
+    return createEventHandler({ type: 'literal', value: eventName }, body, undefined, {
+      sourceLanguage: language,
+      confidence: 0.75,
+    });
+  }
 
   /**
    * Try to extract an embedded event trigger from SOV grammar-transformed text.

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -79,3 +79,37 @@ describe('Custom (non-keyword) event identifiers in SOV languages', () => {
     expect(parse('.active 를 토글', 'ko').action).toBe('toggle');
   });
 });
+
+describe('Trailing event clause wraps a block body (unless-condition, ar+tl)', () => {
+  // SVO/VSO transforms put the event clause last: `<body> عند <event>` /
+  // `<body> kapag <event>`. The per-command fused event patterns only cover
+  // simple bodies, so a block body (`unless <cond> toggle …`) used to degrade to
+  // a hollow standalone match. The trailing-event extractor now wraps it as a
+  // real `on` handler — en-parity: `on { unless(…) ; toggle(…) }`.
+  // See docs-internal/MULTILINGUAL_ROADMAP.md (unless-condition).
+  const cases: Array<[string, string]> = [
+    ['ar', 'إلا I match .disabled بدل .selected عند نقر'],
+    ['tl', 'maliban_kung I match .disabled palitan .selected kapag click'],
+  ];
+
+  for (const [lang, input] of cases) {
+    it(`[${lang}] wraps the unless block as an event handler`, () => {
+      const node = parse(input, lang);
+      expect(node.action).toBe('on');
+      // Body must contain both the unless block and the toggle, not drop either.
+      const body = (node as { body?: unknown[] }).body ?? [];
+      expect(JSON.stringify(body)).toContain('unless');
+      expect(JSON.stringify(body)).toContain('toggle');
+    });
+  }
+
+  it('does not mistake a trailing destination selector for an event (ar)', () => {
+    // `بدل .active على #button` ends in `<on-marker> <selector>` — the trailing
+    // extractor must not treat `#button` as an event; it stays a toggle command.
+    expect(parse('بدل .active على #button', 'ar').action).toBe('toggle');
+  });
+
+  it('leaves a plain command unchanged (ar)', () => {
+    expect(parse('بدل .selected', 'ar').action).toBe('toggle');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -3,10 +3,10 @@
   "commit": "9b34d38",
   "languages": {
     "ar": {
-      "parseSuccess": 150,
-      "parseFailure": 4,
-      "parseRate": 0.974025974025974,
-      "avgConfidence": 0.9253445378151258,
+      "parseSuccess": 151,
+      "parseFailure": 3,
+      "parseRate": 0.9805194805194806,
+      "avgConfidence": 0.9258389448494627,
       "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
@@ -593,7 +593,8 @@
           "confidence": 0.5
         },
         "unless-condition": {
-          "success": false
+          "success": true,
+          "confidence": 1
         },
         "socket-basic": {
           "success": true,
@@ -11855,10 +11856,10 @@
       }
     },
     "tl": {
-      "parseSuccess": 151,
-      "parseFailure": 3,
-      "parseRate": 0.9805194805194806,
-      "avgConfidence": 0.896531681105113,
+      "parseSuccess": 152,
+      "parseFailure": 2,
+      "parseRate": 0.987012987012987,
+      "avgConfidence": 0.8972123937294215,
       "bundleSize": 399599,
       "patterns": {
         "add-class-basic": {
@@ -12457,7 +12458,8 @@
           "confidence": 0.5
         },
         "unless-condition": {
-          "success": false
+          "success": true,
+          "confidence": 1
         },
         "eventsource-basic": {
           "success": true,


### PR DESCRIPTION
## Summary

Next step on the multilingual roadmap after #282: clears **`unless-condition` (ar + tl)** — 2 of the remaining non-behavior failures — with **zero regressions**, and builds the **generic trailing-event block-wrapper** that `focus-trap` (tr) will reuse.

## Problem

SVO/VSO grammar transforms put the event clause at the very end:
- ar → `إلا I match .disabled بدل .selected عند نقر`
- tl → `maliban_kung I match .disabled palitan .selected kapag click`

The per-command *fused* event patterns (`toggle-event-ar-vso-…`) only cover simple bodies, so a **block** body (`unless <cond> toggle …`) wasn't wrapped and degraded to a hollow standalone match. Two gaps: ar/tl didn't recognize `unless` at all (ar `إلا إذا` **splits** with `إذا`→`if`; tl `maliban_kung` was an unrecognized identifier), and there was no generic block + trailing-event wrapper.

## Fix (two parts)

1. **Keyword** — add `unless` to the ar/tl semantic profiles as a single token (`إلا` / `maliban_kung`); the i18n ar dict now emits single-token `إلا` (the two-word form is split by the tokenizer). `keyword-collisions.test.ts` clean.
2. **Parser** — new stage `tryTrailingEventExtraction` (between the event- and command-pattern stages). It recognizes a trailing `<on-marker> <event>`, **gated to a recognized event keyword in the final position** so a trailing destination selector like `على #button` is never mistaken for an event, strips it, and parses the preceding tokens as the handler body. It runs only after the dedicated event patterns fail and returns `null` (falling through unchanged) unless it finds a genuine trailing event whose body parses — so **structurally it can only add parses, never break one**.

Result is **en-parity**: `on { unless(…) ; toggle(…) }` (identical node structure to the English `on click unless …`).

## Results (full `browser-priority` baseline regen)

**+2 instances, 0 regressions.** Exactly `ar/unless-condition` and `tl/unless-condition` flip `↑`. ar 97.4→98.1, tl 98.1→98.7. Baseline updated surgically (only those 2 success flags + the two languages' aggregates).

Roadmap: 7 → **5** non-behavior remainders (`form-disable-on-submit`, `caret-var-on-target` ar+tl; `focus-trap` tr). The trailing-event wrapper here is the reusable lever noted for `focus-trap`.

## Tests
- New cases in `packages/semantic/test/multilingual-roadmap-fixes.test.ts`: ar+tl block-wrap asserting the body keeps **both** `unless` and `toggle`, plus guards that a trailing destination selector and a plain command are left untouched.
- Full semantic suite green (5328 passed); i18n suite green (630 passed); keyword-collisions green.

https://claude.ai/code/session_01GJgn3E4wiAvKXwCnzCcQNM

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJgn3E4wiAvKXwCnzCcQNM)_