### PR TITLE
fix(semantic): accept @attr in selector roles (clears form-disable ar+tl)

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,7 +5,7 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after trailing-event block-wrap (`unless-condition` ar+tl). Custom-event SOV, property-path patient, Tier 1, Track 4, Track 1 (reactive) complete._
+_Last updated: after @attr-in-selector-role (`form-disable-on-submit` ar+tl). Trailing-event block-wrap, custom-event SOV, property-path patient, Tier 1, Track 4, Track 1 (reactive) complete._
 
 ---
 
@@ -15,24 +15,23 @@ Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
 (generated with `--bundle browser-priority`). Cross-language average **99.05%**
 (up from 97.5% before Phase 1; Phases 1–4 + Track 4 + qu `install` + passthrough
 batch + Tier 1 + property-path patient + custom-event SOV + trailing-event
-block-wrap: +64 instances). **29 failing pattern-instances** remain (24 are
-Bucket B behaviors).
+block-wrap + @attr-in-selector-role: +66 instances). **27 failing
+pattern-instances** remain (24 are Bucket B behaviors).
 
 | Rate   | Languages                                              |
 | ------ | ------------------------------------------------------ |
 | 100%   | en, bn, hi, ja, ko, ms, qu, ru, th, uk, vi             |
-| 99%    | de/es/fr/id/pt (99.4), sw (98.7), tr (99.4), tl (98.7) |
-| 96–98% | it/pl/zh (97.4), ar (98.1), he (97.4)                  |
+| 99%    | de/es/fr/id/pt (99.4), sw (98.7), tr (99.4), tl (99.4) |
+| 96–98% | it/pl/zh (97.4), ar (98.7), he (97.4)                  |
 
-**5 non-behavior failing pattern-instances** remain (plus 24 Bucket B behaviors):
+**3 non-behavior failing pattern-instances** remain (plus 24 Bucket B behaviors):
 
-| Track                         | Instances | Nature                                                                                |
-| ----------------------------- | --------- | ------------------------------------------------------------------------------------- |
-| **Bucket B — behaviors**      | 24        | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`)      |
-| **Deep per-language grammar** | 5         | compound/`in me` splits, caret destination reorder, event-modifier + VSO source-block |
+| Track                         | Instances | Nature                                                                           |
+| ----------------------------- | --------- | -------------------------------------------------------------------------------- |
+| **Bucket B — behaviors**      | 24        | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`) |
+| **Deep per-language grammar** | 3         | caret destination reorder (ar+tl), event-modifier + VSO source-block (tr)        |
 
-The 5 non-behavior remainders: `form-disable-on-submit`, `caret-var-on-target`
-(each **ar+tl**); `focus-trap` (tr).
+The 3 non-behavior remainders: `caret-var-on-target` (**ar+tl**); `focus-trap` (tr).
 
 > **Custom-event SOV cleared `on-custom-event-receive` (ko+qu) and, as a side
 > effect, `window-resize` (qu+tr).** The SOV event extractor now accepts a bare
@@ -51,6 +50,36 @@ The 5 non-behavior remainders: `form-disable-on-submit`, `caret-var-on-target`
 ---
 
 ## Shipped
+
+### `@attr` in selector roles — `form-disable-on-submit` ar+tl (+2)
+
+- **2 instances, 0 regressions, avg 99.05% (fix run vs committed baseline: exactly
+  ar/tl `form-disable-on-submit` flip `↑`, zero `↓`).** ar 98.1→98.7, tl 98.7→99.4.
+- **Root cause.** `@disabled` tokenizes with kind **`identifier`**, not `selector`
+  — and that kind is **load-bearing**: roles like bind's `@property`
+  (expectedTypes `['reference','expression']`) rely on the identifier reading.
+  Phase 1 kept `@attr`/`*style` as one token (fixing the `set` family) but left
+  the kind as `identifier`, so `add`/`remove`/`toggle`, whose patient is
+  `expectedTypes: ['selector']`, reject it: `add @disabled` failed outright (and
+  `toggle @disabled` only "passed" via a permissive hand pattern that captured
+  nothing). That bad `add @disabled` clause gated the whole form-disable body.
+- **Fix.** In `matchRoleToken` (`pattern-matcher.ts`), when the candidate token is
+  an `@`-prefixed `identifier` **and the role explicitly expects a `selector`**,
+  convert it to an attribute selector. Gated on `expectedTypes.includes('selector')`
+  so non-selector `@`-roles (bind's `@property`, etc.) are untouched. Combined with
+  the trailing-event wrapper (below), the ar/tl form-disable body now parses.
+- **A global token-kind reclassification was tried first and rejected** — making
+  `@attr` a `selector` kind everywhere regressed 43 patterns (bind/js-inline/when/
+  live/transition families read `@x` as a non-selector). The role-gated value
+  conversion is the surgical version: provably additive (the new branch only fires
+  for `@`-identifiers in selector roles; every other input hits byte-identical
+  code), confirmed by an A/B probe (same DB, build toggled — flips only form-disable).
+- **Methodology note.** The committed baseline can disagree with a fresh-DB harness
+  run by tens of patterns (a flaky undercount surfaced here at 3624 vs 3669). Trust
+  a controlled A/B probe over a single full-suite run; verify regressions against
+  the committed baseline. Locked by `multilingual-roadmap-fixes.test.ts`
+  (`add @disabled`, `remove @disabled`, a bind non-regression guard, and the ar/tl
+  form-disable bodies).
 
 ### Trailing-event block-wrap — `unless-condition` ar+tl (+2)
 
@@ -107,27 +136,30 @@ The 5 non-behavior remainders: `form-disable-on-submit`, `caret-var-on-target`
   the 클릭 control, and a guard that a plain command body never becomes a phantom
   event handler).
 
-### Investigated, deferred — `caret-var` / `form-disable` (ar+tl)
+### Investigated, deferred — `caret-var` (ar+tl), `focus-trap` (tr)
 
-> `unless-condition` (ar+tl) graduated from this section — see Shipped →
-> "Trailing-event block-wrap". The generic trailing-event wrapper built there is
-> the reusable lever `focus-trap` (tr) will also need (event-at-end + block body),
-> once paired with a `from <source>` clause and a `<selector> in <scope>` matcher.
+> `unless-condition` (ar+tl) and `form-disable-on-submit` (ar+tl) graduated from
+> this section — see Shipped → "Trailing-event block-wrap" and "@attr in selector
+> roles". The `<selector> in <scope>` matcher once scoped here turned out **not**
+> to be the form-disable blocker (`in me` was already tolerated; the real gate was
+> `@attr` patient classification), and `focus-trap`'s positional `<sel> in <scope>`
+> already parses in command context (`focus first <button/> in .modal` → OK). The
+> reusable trailing-event wrapper is the lever `focus-trap` still needs.
 
 Probed faithfully (DB-stored translation → `parseSemantic`) and confirmed each needs
-deep, multi-session work; the only achievable result is a hollow / mangled parse, so
-they were **not** landed (avoids inflating the non-null metric with empty matches):
+deep transformer work — the achievable semantic-side result is a mangled parse, so
+they were **not** landed:
 
 - **`caret-var-on-target` (ar+tl).** The i18n transformer mangles
   `put ^count on #host into me` → ar `ضع ^count عند نقر ثم في أنا عند #host` (spurious
   `then` inserted, `on #host` scope split to the end, the event stranded mid-stream).
   Needs transformer reorder surgery for the `^var on <elt> into me` scoped-destination
   shape before the semantic side can see anything parseable.
-- **`form-disable-on-submit` (ar+tl).** Compound (`add … <button/> in me  put "…" into
-<button/> in me`). The masked string literal defeats the transformer's compound split,
-  so the second clause stays fully English (`put "…" into <button/> in me`); separately,
-  `<button/> in me` (scoped query selector) isn't matched as one target. Needs both a
-  compound-split fix (mask-aware) and a `<selector> in <scope>` matcher.
+- **`focus-trap` (tr).** The i18n transformer mangles the event-block-with-source
+  `on keydown[key=="Tab"] from .modal if … end` into a scrambled token stream
+  (mixed untranslated `in`/`focus`/`first`, Turkish `içinde`/`eğer`/`durdur`, wrong
+  order). Needs the trailing-event wrapper (shipped) extended with a `from <source>`
+  clause plus transformer support for the SOV reorder of an event-block-with-source.
 
 ### Property-path patient — fused-dot member access (+2)
 

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -363,6 +363,23 @@ export class PatternMatcher {
       return true;
     }
 
+    // Attribute selectors (`@attr`) tokenize with kind `identifier`, not
+    // `selector` — and that kind is load-bearing: roles like bind's `@property`
+    // (expectedTypes ['reference','expression']) rely on the identifier reading.
+    // But when a role *explicitly expects a selector* (e.g. add/remove/toggle's
+    // patient), an `@`-identifier is an attribute selector — so convert it here,
+    // gated on the role opting into `selector`. This lets `add @disabled to
+    // <button/>` fill its patient without disturbing the non-selector @-roles.
+    if (
+      token.kind === 'identifier' &&
+      token.value.startsWith('@') &&
+      patternToken.expectedTypes?.includes('selector')
+    ) {
+      captured.set(patternToken.role, createSelector(token.value));
+      tokens.advance();
+      return true;
+    }
+
     // Try to extract a semantic value from the token
     const value = this.tokenToSemanticValue(token);
     if (!value) {

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -113,3 +113,36 @@ describe('Trailing event clause wraps a block body (unless-condition, ar+tl)', (
     expect(parse('بدل .selected', 'ar').action).toBe('toggle');
   });
 });
+
+describe('Attribute selectors (@attr) in selector-expecting roles (form-disable)', () => {
+  // `@disabled` tokenizes with kind `identifier` (load-bearing — bind's
+  // `@property` relies on the identifier reading, expectedTypes
+  // ['reference','expression']). When a role explicitly expects a `selector`
+  // (add/remove/toggle patient), an `@`-identifier is an attribute selector and
+  // is now accepted. This clears `add @disabled to <button/>`, which gated the
+  // form-disable-on-submit body. See docs-internal/MULTILINGUAL_ROADMAP.md.
+  it('parses `add @disabled to <button/>` (attribute patient)', () => {
+    expect(canParse('add @disabled to <button/>', 'en')).toBe(true);
+    expect(parse('add @disabled to <button/>', 'en').action).toBe('add');
+  });
+
+  it('parses `remove @disabled from me`', () => {
+    expect(parse('remove @disabled from me', 'en').action).toBe('remove');
+  });
+
+  it('does not change bind, whose @property is a non-selector role', () => {
+    // bind's destination is expectedTypes ['reference','expression'] — the @attr
+    // conversion is gated to selector-expecting roles, so bind is untouched.
+    expect(parse('$color を #pickerの 値 に バインド', 'ja').action).toBe('bind');
+  });
+
+  const formDisable: Array<[string, string]> = [
+    ['ar', 'أضف @disabled إلى <button/> in me put "Submitting..." into <button/> in me عند إرسال'],
+    ['tl', 'idagdag @disabled sa <button/> in me put "Submitting..." into <button/> in me kapag submit'],
+  ];
+  for (const [lang, input] of formDisable) {
+    it(`[${lang}] parses the form-disable-on-submit body`, () => {
+      expect(parse(input, lang).action).toBe('on');
+    });
+  }
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -3,10 +3,10 @@
   "commit": "9b34d38",
   "languages": {
     "ar": {
-      "parseSuccess": 151,
-      "parseFailure": 3,
-      "parseRate": 0.9805194805194806,
-      "avgConfidence": 0.9258389448494627,
+      "parseSuccess": 152,
+      "parseFailure": 2,
+      "parseRate": 0.987012987012987,
+      "avgConfidence": 0.9263268465280847,
       "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
@@ -570,7 +570,8 @@
           "confidence": 0.5
         },
         "form-disable-on-submit": {
-          "success": false
+          "success": true,
+          "confidence": 1
         },
         "window-scroll": {
           "success": true,
@@ -11856,10 +11857,10 @@
       }
     },
     "tl": {
-      "parseSuccess": 152,
-      "parseFailure": 2,
-      "parseRate": 0.987012987012987,
-      "avgConfidence": 0.8972123937294215,
+      "parseSuccess": 153,
+      "parseFailure": 1,
+      "parseRate": 0.9935064935064936,
+      "avgConfidence": 0.8978842081494907,
       "bundleSize": 399599,
       "patterns": {
         "add-class-basic": {
@@ -12439,7 +12440,8 @@
           "confidence": 0.5
         },
         "form-disable-on-submit": {
-          "success": false
+          "success": true,
+          "confidence": 1
         },
         "window-scroll": {
           "success": true,


### PR DESCRIPTION
## Summary

Clears **`form-disable-on-submit` (ar + tl)** — 2 more non-behavior failures — with **zero regressions**. Pursued under the "try the @attr-kind fix" direction; the investigation pivoted the root cause and the implementation away from the originally-recommended `<sel> in <scope>` matcher (which turned out not to be the blocker).

## Root cause

`@disabled` tokenizes with kind **`identifier`**, not `selector` — and that kind is **load-bearing**: roles like `bind`'s `@property` (`expectedTypes: ['reference','expression']`) depend on it. Phase 1 kept `@attr`/`*style` as a single token (fixing the `set` family) but left the kind as `identifier`, so `add`/`remove`/`toggle` — whose patient is `expectedTypes: ['selector']` — reject it. `add @disabled` failed outright (and `toggle @disabled` only "passed" via a permissive hand pattern capturing nothing), which gated the whole form-disable body.

## Fix

In `matchRoleToken` (`pattern-matcher.ts`): when the candidate token is an `@`-prefixed `identifier` **and the role explicitly expects a `selector`**, convert it to an attribute selector. Gated on `expectedTypes.includes('selector')`, so non-selector `@`-roles (bind's `@property`, etc.) are untouched. Combined with the trailing-event wrapper from #283, the ar/tl form-disable body now parses.

### Why not the global token-kind change

I tried reclassifying `@attr` as `selector` kind globally first — it **regressed 43 patterns** (bind/js-inline/when/live/transition families read `@x` as a non-selector). The role-gated value conversion is the surgical version: **provably additive** (the new branch only fires for `@`-identifiers in selector roles; every other input hits byte-identical code), confirmed by an A/B probe (same DB, build toggled — flips only form-disable).

### Methodology note

The committed baseline can disagree with a fresh-DB harness run by tens of patterns (a flaky undercount surfaced here at 3624 vs 3669). I trusted a controlled A/B probe over a single full-suite run, and verified regressions against the committed baseline.

## Results

Fix run vs committed baseline: exactly `ar/form-disable-on-submit` and `tl/form-disable-on-submit` flip `↑`, **0 regressions**. ar 98.1→98.7, tl 98.7→99.4. Baseline updated surgically (only those 2 success flags + the two languages' aggregates).

Roadmap: 5 → **3** non-behavior remainders (`caret-var-on-target` ar+tl; `focus-trap` tr) — both now documented as deep transformer work with precise diagnoses.

## Tests
- New cases in `multilingual-roadmap-fixes.test.ts`: `add @disabled`, `remove @disabled`, a **bind non-regression guard**, and the ar/tl form-disable bodies.
- Full semantic suite green (the 30 `build-artifacts.test.ts` `.d.ts` failures are the documented environmental ones). `tsc --emitDeclarationOnly` clean.

https://claude.ai/code/session_01GJgn3E4wiAvKXwCnzCcQNM

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJgn3E4wiAvKXwCnzCcQNM)_