### PR TITLE
fix(multilingual): caret-scoped variable reads (clears caret-var-on-target ar+tl)

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,7 +5,7 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after @attr-in-selector-role (`form-disable-on-submit` ar+tl). Trailing-event block-wrap, custom-event SOV, property-path patient, Tier 1, Track 4, Track 1 (reactive) complete._
+_Last updated: after caret-scope masking (`caret-var-on-target` ar+tl). @attr-in-selector-role, trailing-event block-wrap, custom-event SOV, property-path patient, Tier 1, Track 4, Track 1 (reactive) complete._
 
 ---
 
@@ -15,23 +15,23 @@ Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
 (generated with `--bundle browser-priority`). Cross-language average **99.05%**
 (up from 97.5% before Phase 1; Phases 1–4 + Track 4 + qu `install` + passthrough
 batch + Tier 1 + property-path patient + custom-event SOV + trailing-event
-block-wrap + @attr-in-selector-role: +66 instances). **27 failing
-pattern-instances** remain (24 are Bucket B behaviors).
+block-wrap + @attr-in-selector-role + caret-scope masking: +68 instances).
+**25 failing pattern-instances** remain (24 are Bucket B behaviors).
 
 | Rate   | Languages                                              |
 | ------ | ------------------------------------------------------ |
-| 100%   | en, bn, hi, ja, ko, ms, qu, ru, th, uk, vi             |
-| 99%    | de/es/fr/id/pt (99.4), sw (98.7), tr (99.4), tl (99.4) |
-| 96–98% | it/pl/zh (97.4), ar (98.7), he (97.4)                  |
+| 100%   | en, bn, hi, ja, ko, ms, qu, ru, th, tl, uk, vi         |
+| 99%    | de/es/fr/id/pt (99.4), sw (98.7), tr (99.4), ar (99.4) |
+| 96–98% | it/pl/zh (97.4), he (97.4)                             |
 
-**3 non-behavior failing pattern-instances** remain (plus 24 Bucket B behaviors):
+**1 non-behavior failing pattern-instance** remains (plus 24 Bucket B behaviors):
 
 | Track                         | Instances | Nature                                                                           |
 | ----------------------------- | --------- | -------------------------------------------------------------------------------- |
 | **Bucket B — behaviors**      | 24        | Draggable/Sortable/Resizable/Removable defs don't parse (CI `continue-on-error`) |
-| **Deep per-language grammar** | 3         | caret destination reorder (ar+tl), event-modifier + VSO source-block (tr)        |
+| **Deep per-language grammar** | 1         | `focus-trap` (tr) — event-modifier guard + `from <source>` + VSO if-block        |
 
-The 3 non-behavior remainders: `caret-var-on-target` (**ar+tl**); `focus-trap` (tr).
+The sole non-behavior remainder: `focus-trap` (tr).
 
 > **Custom-event SOV cleared `on-custom-event-receive` (ko+qu) and, as a side
 > effect, `window-resize` (qu+tr).** The SOV event extractor now accepts a bare
@@ -50,6 +50,38 @@ The 3 non-behavior remainders: `caret-var-on-target` (**ar+tl**); `focus-trap` (
 ---
 
 ## Shipped
+
+### Caret-scope masking — `caret-var-on-target` ar+tl (+2)
+
+- **2 instances, 0 regressions, avg 99.05% (fix run vs committed baseline: exactly
+  ar/tl `caret-var-on-target` flip `↑`, zero `↓`; no stale-DB artifact this time).**
+  ar 98.7→99.4, tl 99.4→100.
+- **Root cause (two sides).** `on click put ^count on #host into me` failed even in
+  **English**: `^count on #host` reads a DOM-scoped `^count` variable from a
+  specific element, but the **overloaded `on`** broke both layers. (1) The semantic
+  `put` pattern had no notion of `^var on <selector>`, so the inner `on` left
+  `into me` unmatched → NULL (the full handler only "passed" with a hollow
+  empty body). (2) The i18n transformer's splitter/event-parser read the inner
+  `on` as an event/command boundary, mangling the output (`ضع ^count عند نقر ثم في
+أنا عند #host` — spurious `then`, scope stranded at the end, event lost).
+- **Fix (two parts).**
+  1. **Semantic matcher (`tryMatchCaretScopeExpression`).** Folds `^name on
+<selector>` into one expression value, gated to `^`-prefixed identifier tokens
+     followed by an `on`-marker (matched by raw value `on` or normalized
+     `destination`, cross-language) and a selector — so `toggle .active on #button`
+     (class-selector patient) is untouched. The trailing `into me` destination then
+     matches; the en handler gets a real body.
+  2. **Transformer masking.** `maskCaretScopes` hides the ` on <selector>` scope
+     behind an opaque sentinel attached to `^name` before any split/reorder (the
+     same shape as the js-block / string-literal masks), then `restoreCaretScopes`
+     puts it back verbatim. The command reorders as if the patient were a single
+     value; the event clause survives and `^count on #host` stays adjacent. `on`
+     is kept English (passthrough-alignment — the matcher accepts it everywhere).
+- Locked by `multilingual-roadmap-fixes.test.ts` (clean-en parse, real-body guard,
+  `toggle … on #button` + scope-less `put` guards, ar/tl transformed forms) and
+  `grammar.test.ts` (transform keeps the scope adjacent + event, no leftover
+  sentinel, normal commands undisturbed). Only one corpus pattern carries a
+  caret-scope, so the change is inherently narrow.
 
 ### `@attr` in selector roles — `form-disable-on-submit` ar+tl (+2)
 
@@ -136,25 +168,21 @@ The 3 non-behavior remainders: `caret-var-on-target` (**ar+tl**); `focus-trap` (
   the 클릭 control, and a guard that a plain command body never becomes a phantom
   event handler).
 
-### Investigated, deferred — `caret-var` (ar+tl), `focus-trap` (tr)
+### Investigated, deferred — `focus-trap` (tr)
 
-> `unless-condition` (ar+tl) and `form-disable-on-submit` (ar+tl) graduated from
-> this section — see Shipped → "Trailing-event block-wrap" and "@attr in selector
-> roles". The `<selector> in <scope>` matcher once scoped here turned out **not**
-> to be the form-disable blocker (`in me` was already tolerated; the real gate was
-> `@attr` patient classification), and `focus-trap`'s positional `<sel> in <scope>`
-> already parses in command context (`focus first <button/> in .modal` → OK). The
-> reusable trailing-event wrapper is the lever `focus-trap` still needs.
+> `unless-condition`, `form-disable-on-submit`, and `caret-var-on-target` (all
+> ar+tl) graduated from this section — see Shipped → "Trailing-event block-wrap",
+> "@attr in selector roles", and "Caret-scope masking". The `<selector> in <scope>`
+> matcher once scoped here turned out **not** to be the form-disable blocker (`in
+me` was already tolerated; the real gate was `@attr` patient classification), and
+> `focus-trap`'s positional `<sel> in <scope>` already parses in command context
+> (`focus first <button/> in .modal` → OK). The reusable trailing-event wrapper and
+> caret-scope masking are levers `focus-trap` can draw on.
 
-Probed faithfully (DB-stored translation → `parseSemantic`) and confirmed each needs
-deep transformer work — the achievable semantic-side result is a mangled parse, so
-they were **not** landed:
+Probed faithfully (DB-stored translation → `parseSemantic`); the sole remaining
+non-behavior failure needs deep transformer work — the achievable semantic-side
+result is a mangled parse, so it is **not** landed:
 
-- **`caret-var-on-target` (ar+tl).** The i18n transformer mangles
-  `put ^count on #host into me` → ar `ضع ^count عند نقر ثم في أنا عند #host` (spurious
-  `then` inserted, `on #host` scope split to the end, the event stranded mid-stream).
-  Needs transformer reorder surgery for the `^var on <elt> into me` scoped-destination
-  shape before the semantic side can see anything parseable.
 - **`focus-trap` (tr).** The i18n transformer mangles the event-block-with-source
   `on keydown[key=="Tab"] from .modal if … end` into a scrambled token stream
   (mixed untranslated `in`/`focus`/`first`, Turkish `içinde`/`eğer`/`durdur`, wrong

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -1387,3 +1387,24 @@ describe('Possessive Dot Notation Translation', () => {
     });
   });
 });
+
+describe('Caret-scoped variable read masking (`^name on <selector>`)', () => {
+  // `put ^count on #host into me` carries a second, overloaded `on` (the caret
+  // scope). The transformer masks ` on <selector>` so the splitter/event parser
+  // doesn't mistake it for an event/command boundary: the event clause survives
+  // and `^count on #host` stays adjacent. See caret-var-on-target in the roadmap.
+  it('keeps `^count on #host` together and preserves the event (ar)', () => {
+    const t = new GrammarTransformer('en', 'ar');
+    const result = t.transform('on click put ^count on #host into me');
+    expect(result).toContain('^count on #host'); // scope kept adjacent
+    expect(result).toContain('نقر'); // event (click) preserved
+    expect(result).not.toContain(''); // no leftover mask sentinel
+  });
+
+  it('does not disturb a normal command without a caret scope (ar)', () => {
+    const t = new GrammarTransformer('en', 'ar');
+    const result = t.transform('on click toggle .active on #button');
+    expect(result).not.toContain('');
+    expect(result).toMatch(/بدل|بدّل/);
+  });
+});

--- a/packages/i18n/src/grammar/transformer.ts
+++ b/packages/i18n/src/grammar/transformer.ts
@@ -1335,6 +1335,43 @@ function translateElements(
 }
 
 // =============================================================================
+// Caret-scope masking (`^name on <selector>`)
+// =============================================================================
+
+/** Private-use sentinels bracketing a masked caret-scope index. */
+const CARET_SCOPE_OPEN = '\uE000';
+const CARET_SCOPE_CLOSE = '\uE001';
+
+/**
+ * Match `^name on <selector>` and the scope's selector form (#id, .class,
+ * <tag/>, [attr]). The `^name` is kept; only the ` on <selector>` scope is masked.
+ */
+const CARET_SCOPE_RE = /(\^[A-Za-z_][\w-]*)(\s+on\s+(?:[#.][\w-]+|<[^>]*\/>|\[[^\]]+\]))/g;
+
+/**
+ * Mask the ` on <selector>` scope of every `^name on <selector>` read behind an
+ * opaque token attached to `^name`, so the overloaded `on` doesn't reach the
+ * splitter / event-handler parser. Returns null when there's nothing to mask.
+ */
+function maskCaretScopes(input: string): { masked: string; scopes: string[] } | null {
+  const scopes: string[] = [];
+  const masked = input.replace(CARET_SCOPE_RE, (_m, varTok: string, scope: string) => {
+    const idx = scopes.length;
+    scopes.push(scope);
+    return `${varTok}${CARET_SCOPE_OPEN}${idx}${CARET_SCOPE_CLOSE}`;
+  });
+  return scopes.length > 0 ? { masked, scopes } : null;
+}
+
+/** Restore masked caret-scope tokens to their verbatim ` on <selector>` form. */
+function restoreCaretScopes(input: string, scopes: string[]): string {
+  return input.replace(
+    new RegExp(`${CARET_SCOPE_OPEN}(\\d+)${CARET_SCOPE_CLOSE}`, 'g'),
+    (_m, n: string) => scopes[Number(n)] ?? ''
+  );
+}
+
+// =============================================================================
 // Main Transformer
 // =============================================================================
 
@@ -1361,6 +1398,18 @@ export class GrammarTransformer {
    * For multi-line input, preserves line structure (indentation, blank lines).
    */
   transform(input: string): string {
+    // Caret-scoped variable reads (`^name on <selector>`) carry a second,
+    // overloaded `on` that the splitter/event-parser would mistake for an event
+    // or command boundary — mangling `put ^count on #host into me`. Mask the
+    // ` on <selector>` scope behind an opaque token attached to `^name` so the
+    // command reorders as if the patient were a single value, then restore it.
+    // `on` is kept verbatim (the semantic caret-scope matcher accepts it by raw
+    // value across languages — passthrough-alignment).
+    const caret = maskCaretScopes(input);
+    if (caret) {
+      return restoreCaretScopes(this.transform(caret.masked), caret.scopes);
+    }
+
     const targetThen = getTargetThenKeyword(this.targetProfile.code);
 
     // Inline JS blocks (`... js <raw js> end`) must be masked BEFORE any

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -278,6 +278,23 @@ export class PatternMatcher {
       return true;
     }
 
+    // Check for a caret-scoped variable read (e.g. `^count on #host` — a
+    // DOM-scoped `^name` variable read from a specific element). The `^` prefix
+    // disambiguates this `on` from the event/destination `on`, so a normal
+    // `toggle .active on #button` (selector patient) is never affected. Folds
+    // `^name on <element>` into one expression value so a following destination
+    // (`into me`) still matches.
+    const caretScopeValue = this.tryMatchCaretScopeExpression(tokens);
+    if (caretScopeValue) {
+      if (patternToken.expectedTypes && patternToken.expectedTypes.length > 0) {
+        if (!isTypeCompatible(caretScopeValue.type, patternToken.expectedTypes)) {
+          return patternToken.optional || false;
+        }
+      }
+      captured.set(patternToken.role, caretScopeValue);
+      return true;
+    }
+
     // Check for an "of"-possessive expression (e.g. "*--primary-color of #theme",
     // AR "*--primary-color من #theme", TL "*--primary-color ng #theme"). Gated to
     // roles that opt into property-path (currently `set`'s destination), so the
@@ -506,6 +523,45 @@ export class PatternMatcher {
     }
 
     return { type: 'expression', raw: parts.join(' ') } as SemanticValue;
+  }
+
+  /**
+   * Match a caret-scoped variable read: `^name on <element>`.
+   *
+   * `^name` is a DOM-scoped variable; `^name on #host` reads it from a specific
+   * element rather than walking up from `me`. Gated to `^`-prefixed identifier
+   * tokens followed by an `on`-marker and a selector — so the overloaded `on`
+   * (event marker / destination marker) is never misread on ordinary commands
+   * like `toggle .active on #button` (whose patient is a class selector, not a
+   * caret variable). Works across languages: the `on` marker is matched by its
+   * normalized form (ar `عند`, tl `kapag`, …) and selectors aren't translated.
+   */
+  private tryMatchCaretScopeExpression(tokens: TokenStream): SemanticValue | null {
+    const token = tokens.peek();
+    if (!token || token.kind !== 'identifier' || !token.value.startsWith('^')) {
+      return null;
+    }
+
+    const onMarker = tokens.peek(1);
+    const scope = tokens.peek(2);
+    // The `on` marker is normalized to the `destination` role by the tokenizers
+    // (it is the destination marker for toggle/add), so accept it by raw value
+    // (`on`) or normalized role (`destination`/`on`). `into` normalizes
+    // elsewhere, so a `put ^x into #y` is never misread as a scoped read.
+    const markerForm = (onMarker?.normalized ?? '').toLowerCase();
+    const isOnMarker =
+      !!onMarker &&
+      (onMarker.value.toLowerCase() === 'on' ||
+        markerForm === 'destination' ||
+        markerForm === 'on');
+    if (!onMarker || !scope || scope.kind !== 'selector' || !isOnMarker) {
+      return null;
+    }
+
+    tokens.advance(); // ^name
+    tokens.advance(); // on-marker
+    tokens.advance(); // scope selector
+    return { type: 'expression', raw: `${token.value} on ${scope.value}` } as SemanticValue;
   }
 
   /**

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -146,3 +146,43 @@ describe('Attribute selectors (@attr) in selector-expecting roles (form-disable)
     });
   }
 });
+
+describe('Caret-scoped variable read `^name on <element>` (caret-var-on-target)', () => {
+  // `^name on #host` reads a DOM-scoped `^name` variable from a specific element.
+  // The overloaded `on` made `put ^count on #host into me` fail even in English;
+  // a caret-gated matcher now folds `^name on <selector>` into one expression so
+  // the trailing `into me` destination still matches. The i18n transformer masks
+  // the scope so the same `on` isn't mistaken for an event/command boundary.
+  // See docs-internal/MULTILINGUAL_ROADMAP.md (caret-var-on-target).
+  it('parses `put ^count on #host into me` (clean order, en)', () => {
+    expect(canParse('put ^count on #host into me', 'en')).toBe(true);
+    expect(parse('put ^count on #host into me', 'en').action).toBe('put');
+  });
+
+  it('gives the en event handler a real (non-empty) body', () => {
+    const node = parse('on click put ^count on #host into me', 'en');
+    expect(node.action).toBe('on');
+    expect(((node as { body?: unknown[] }).body ?? []).length).toBeGreaterThan(0);
+  });
+
+  it('does not affect a selector patient with `on` destination (toggle)', () => {
+    // `.active` is not a caret variable, so `on #button` stays the destination.
+    expect(parse('toggle .active on #button', 'en').action).toBe('toggle');
+  });
+
+  it('still parses a caret var without a scope (`put ^count into me`)', () => {
+    expect(parse('put ^count into me', 'en').action).toBe('put');
+  });
+
+  // Transformed (DB-shaped) ar/tl forms keep `^count on #host` adjacent and the
+  // event clause intact, so the handler parses (the body keeps the put).
+  const transformed: Array<[string, string]> = [
+    ['ar', 'ضع ^count on #host إلى أنا عند نقر'],
+    ['tl', 'ilagay ^count on #host sa ako kapag click'],
+  ];
+  for (const [lang, input] of transformed) {
+    it(`[${lang}] parses the transformed caret-scope handler`, () => {
+      expect(parse(input, lang).action).toBe('on');
+    });
+  }
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -3,10 +3,10 @@
   "commit": "9b34d38",
   "languages": {
     "ar": {
-      "parseSuccess": 152,
-      "parseFailure": 2,
-      "parseRate": 0.987012987012987,
-      "avgConfidence": 0.9263268465280847,
+      "parseSuccess": 153,
+      "parseFailure": 1,
+      "parseRate": 0.9935064935064936,
+      "avgConfidence": 0.926808370406986,
       "bundleSize": 399599,
       "patterns": {
         "toggle-class-basic": {
@@ -606,7 +606,8 @@
           "confidence": 0.5
         },
         "caret-var-on-target": {
-          "success": false
+          "success": true,
+          "confidence": 1
         },
         "behavior-removable": {
           "success": false
@@ -11857,10 +11858,10 @@
       }
     },
     "tl": {
-      "parseSuccess": 153,
-      "parseFailure": 1,
-      "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8978842081494907,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.8985472977069615,
       "bundleSize": 399599,
       "patterns": {
         "add-class-basic": {
@@ -12476,7 +12477,8 @@
           "confidence": 0.5
         },
         "caret-var-on-target": {
-          "success": false
+          "success": true,
+          "confidence": 1
         }
       }
     },


### PR DESCRIPTION
## Summary

Clears **`caret-var-on-target` (ar + tl)** — the last of the deep per-language grammar items besides `focus-trap` — with **zero regressions**. After this, **`tl` reaches 100%** and only **1 non-behavior failure** remains (`focus-trap` tr).

## Problem (both layers)

`on click put ^count on #host into me` failed **even in English**. `^count on #host` reads a DOM-scoped `^count` variable from a specific element, but the **overloaded `on`** broke both layers:

1. **Semantic** — the `put` pattern had no notion of `^var on <selector>`, so the inner `on` left `into me` unmatched → NULL (the full handler only "passed" with a hollow empty body).
2. **Transformer** — the splitter/event-parser read the inner `on` as an event/command boundary, mangling the output (ar `ضع ^count عند نقر ثم في أنا عند #host` — spurious `then`, scope stranded at the end, event lost).

The verification probe (run first, per plan) is what surfaced that this was **not** transformer-only.

## Fix (two parts)

1. **Semantic `tryMatchCaretScopeExpression`** (`pattern-matcher.ts`) — folds `^name on <selector>` into one expression value, gated to `^`-prefixed identifiers + an `on`-marker (matched by raw `on` or normalized `destination`, cross-language) + a selector. So `toggle .active on #button` (class patient) is untouched; the trailing `into me` then matches and the en handler gets a real body.
2. **Transformer masking** (`transformer.ts`) — `maskCaretScopes`/`restoreCaretScopes` hide the ` on <selector>` scope behind an opaque sentinel attached to `^name` before any split/reorder (same shape as the js-block / string-literal masks), then restore it verbatim. The event clause survives and `^count on #host` stays adjacent. `on` is kept English (passthrough-alignment — the matcher accepts it everywhere).

Only **one** corpus pattern carries a caret-scope, so the change is inherently narrow.

## Results

Fix run vs committed baseline: exactly `ar/caret-var-on-target` and `tl/caret-var-on-target` flip `↑`, **0 regressions** (no stale-DB artifact this time). ar 98.7→99.4, **tl 99.4→100**. Baseline updated surgically.

Roadmap: 3 → **1** non-behavior remainder (`focus-trap` tr).

## Tests
- `multilingual-roadmap-fixes.test.ts`: clean-en parse, real-body guard, `toggle … on #button` + scope-less `put` guards, ar/tl transformed forms.
- `grammar.test.ts`: transform keeps the scope adjacent + event preserved, no leftover sentinel, normal commands undisturbed.
- Full semantic (5343) and i18n (632) suites green; `tsc` clean for both packages.

https://claude.ai/code/session_01GJgn3E4wiAvKXwCnzCcQNM

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJgn3E4wiAvKXwCnzCcQNM)_