### PR TITLE
feat(testing-framework): multilingual parse-fidelity signal + CI ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -745,7 +745,10 @@ jobs:
       # (HE/TL/AR/KO are the laggards — tracked for language-coverage work). This
       # step gates on REGRESSION vs the committed baseline: a language fails CI if
       # its parse rate drops >2pts below baseline (per-pattern flips on borderline-
-      # confidence patterns are reported but don't fail the gate). Regenerate the
+      # confidence patterns are reported but don't fail the gate). It ALSO ratchets
+      # parse *fidelity*: if >3 faithful baseline passes become degenerate (parse
+      # non-null but lose >50% of the English command structure) the gate fails —
+      # see the "Multilingual parse rate ≠ fidelity" note in CLAUDE.md. Regenerate the
       # baseline after an INTENTIONAL coverage change — IMPORTANT: populate first
       # so the DB matches CI:
       #   npm run populate --prefix packages/patterns-reference

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,28 @@ The four PR-only jobs already ran against the merged-as-PR code, so re-running t
 - Behavior tests: Draggable, Sortable, Resizable not fully implemented (continue-on-error)
 - SOV/VSO languages: Japanese, Korean, Turkish have lower pass rates than SVO languages (continue-on-error)
 
+### Multilingual parse rate ≠ fidelity
+
+The `multilingual-validation` parse rate counts a translation as passing when the
+semantic parser returns a **non-null** node — **not** when that node is a faithful
+translation. A complex pattern can parse non-null while dropping most of the
+source's commands (e.g. an `if/focus/halt` body collapsing to a bare `if`). So a
+"100% / 99%" parse rate means "parses", not "parses correctly".
+
+The harness computes a structural **fidelity** signal (`packages/testing-framework/src/multilingual/fidelity.ts`):
+the fraction of the English reference parse's command actions present in each
+translation. Passes below 50% fidelity are reported as **degenerate passes** (the
+console run prints a `⚠ Degenerate passes` section), and per-language
+`avgFidelity` / `degeneratePasses` are tracked in the committed baseline.
+
+The `--regression` gate ratchets on this: a **faithful** baseline pass that becomes
+a **degenerate** pass fails CI (tolerance 3, to absorb baseline noise — same spirit
+as the parse-rate ±2pt tolerance). This prevents fidelity backsliding without
+demanding the ~232 existing degenerate passes be fixed at once. After an
+_intentional_ fidelity change, regenerate the baseline (`--save-baseline`). The
+remaining degenerate passes (mostly block-body translation — `if-*`, `fetch-*`
+states, `async-block`) are tracked in `docs-internal/MULTILINGUAL_ROADMAP.md`.
+
 **Other Workflows:**
 
 - `.github/workflows/publish.yml` - Manual npm publishing (workflow_dispatch)

--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -492,6 +492,58 @@ own transformer/parser project (no shared lever remains):
 
 ## Remaining work
 
+### Track 5 — Parse fidelity (parse rate ≠ faithful) — NEW, tracked
+
+The non-behavior parse rate hit 100% (all 24 priority languages), but that metric
+counts a **non-null** parse, not a **faithful** one. A complex pattern can parse
+non-null while dropping most of the source's commands. The clearest example is
+`focus-trap`: nominally green in 24 languages, but the `if/focus/halt` body
+collapses to a bare `if` / stray `from` in most — faithfully parsed in ~1 (English).
+
+A structural **fidelity** signal now makes this visible
+(`packages/testing-framework/src/multilingual/fidelity.ts`): for each translation,
+the fraction of the English reference parse's command actions that survive (recall,
+word-order agnostic). Passes below 50% fidelity are **degenerate passes**.
+
+**Current state (committed baseline carries `avgFidelity` / `degeneratePasses`):**
+~**232 degenerate-pass instances across ~51 patterns**. The clusters are dominated
+by **block-body translation** — the i18n transformer mishandling the body of
+control-flow / async / fetch constructs:
+
+| Cluster                     | Examples (langs)                                                                          |
+| --------------------------- | ----------------------------------------------------------------------------------------- |
+| control-flow blocks         | `if-empty` (16), `if-exists` (13), `unless-condition` (4)                                 |
+| fetch lifecycle / state     | `fetch-loading-state` (14), `fetch-with-headers` (6), `fetch-json` (5), `fetch-basic` (4) |
+| async / streaming           | `async-block` (13), `socket-basic` (9), `eventsource`/`worker`                            |
+| validation / forms          | `input-validation` (14), `form-submit-prevent` (9)                                        |
+| positional / possessive-dot | `first-in-parent` (5), `its-value-possessive-dot` (4)                                     |
+| event modifiers / behaviors | `event-debounce`/`event-once`, `behavior-*` (degenerate in the langs where they parse)    |
+
+**How it's tracked (ratchet, not crash-project).** The `--regression` CI gate fails
+when a **faithful** baseline pass becomes a **degenerate** pass (tolerance 3, mirroring
+the parse-rate ±2pt tolerance). This prevents backsliding without demanding the 232 be
+fixed at once. Improvements (fail → degenerate-pass, or degenerate → faithful) never
+fail the gate. After an _intentional_ fidelity change, regenerate the baseline.
+
+**How to resolve (gradually, after triage).**
+
+1. **Validate the signal first.** Fidelity is a heuristic (action-set recall). Before
+   "fixing" a cluster, confirm low scores mean genuinely lost commands, not a metric
+   artifact (a language that legitimately uses fewer command nodes, or an English
+   reference that itself parses oddly). Spot-check a sample per cluster.
+2. **Highest leverage = block-body transform.** Most degenerate clusters share one
+   root: the i18n transformer shreds/mistranslates a block body (the same class of bug
+   the trailing-event wrapper #283, caret-mask #285, and focus-trap from-source #286
+   each chipped at). A general "faithful block-body transform" (mask block → reorder
+   head → transform body as a unit → translate inner keywords) would lift many clusters
+   at once. Validate with the fidelity signal + a full regen (watch for the usual
+   stale-DB / flaky-harness traps — see Gotchas).
+3. **Prioritize by language-count × value.** `if-empty`/16, `fetch-loading-state`/14,
+   `input-validation`/14, `async-block`/13 are the biggest.
+
+Definition of done for this track: degenerate-pass count trends toward 0 with avg
+fidelity → 1.0, gated by the ratchet so it never grows.
+
 ### Track 2 — Bucket B behaviors (24)
 
 `behavior-removable` (11), `behavior-sortable` (5), `behavior-draggable` (4),

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -624,7 +624,31 @@
           "success": true,
           "confidence": 0.5
         }
-      }
+      },
+      "avgFidelity": 0.8009803921568631,
+      "degeneratePasses": [
+        "accordion-exclusive",
+        "async-block",
+        "behavior-draggable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "copy-to-clipboard",
+        "event-debounce",
+        "fetch-loading-state",
+        "focus-trap",
+        "form-submit-prevent",
+        "halt-propagation",
+        "if-empty",
+        "if-exists",
+        "input-validation",
+        "modal-close-escape",
+        "repeat-for-each",
+        "repeat-while",
+        "socket-basic",
+        "tabs-basic",
+        "tabs-content",
+        "window-keydown"
+      ]
     },
     "bn": {
       "parseSuccess": 154,
@@ -1249,7 +1273,18 @@
           "success": true,
           "confidence": 0.5
         }
-      }
+      },
+      "avgFidelity": 0.8792207792207795,
+      "degeneratePasses": [
+        "async-block",
+        "event-once",
+        "fetch-loading-state",
+        "if-empty",
+        "if-exists",
+        "input-validation",
+        "repeat-while",
+        "socket-basic"
+      ]
     },
     "de": {
       "parseSuccess": 153,
@@ -1873,7 +1908,24 @@
           "success": true,
           "confidence": 0.5
         }
-      }
+      },
+      "avgFidelity": 0.8157952069716776,
+      "degeneratePasses": [
+        "async-block",
+        "behavior-draggable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "fetch-basic",
+        "fetch-do-not-throw",
+        "fetch-error-handling",
+        "fetch-json",
+        "fetch-loading-state",
+        "fetch-with-headers",
+        "first-in-parent",
+        "form-submit-prevent",
+        "if-empty",
+        "its-value-possessive-dot"
+      ]
     },
     "en": {
       "parseSuccess": 154,
@@ -3122,7 +3174,9 @@
           "success": true,
           "confidence": 0.5
         }
-      }
+      },
+      "avgFidelity": 0.9089324618736385,
+      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"]
     },
     "fr": {
       "parseSuccess": 153,
@@ -3746,7 +3800,16 @@
           "success": true,
           "confidence": 0.5
         }
-      }
+      },
+      "avgFidelity": 0.8775599128540305,
+      "degeneratePasses": [
+        "async-block",
+        "behavior-draggable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "fetch-with-headers",
+        "first-in-parent"
+      ]
     },
     "he": {
       "parseSuccess": 150,
@@ -4367,7 +4430,17 @@
         "behavior-resizable": {
           "success": false
         }
-      }
+      },
+      "avgFidelity": 0.7901111111111112,
+      "degeneratePasses": [
+        "fetch-do-not-throw",
+        "fetch-json",
+        "if-empty",
+        "if-exists",
+        "input-validation",
+        "template-literal-list-build",
+        "unless-condition"
+      ]
     },
     "hi": {
       "parseSuccess": 154,
@@ -4992,7 +5065,25 @@
           "success": true,
           "confidence": 1
         }
-      }
+      },
+      "avgFidelity": 0.8169913419913423,
+      "degeneratePasses": [
+        "bind-auto-detect",
+        "bind-explicit-property",
+        "bind-non-form-display",
+        "bind-two-way",
+        "eventsource-basic",
+        "fetch-loading-state",
+        "if-empty",
+        "if-exists",
+        "input-validation",
+        "install-behavior",
+        "intercept-cache-strategies",
+        "live-derived-value",
+        "live-multiple-deps",
+        "socket-basic",
+        "worker-basic"
+      ]
     },
     "id": {
       "parseSuccess": 153,
@@ -5616,7 +5707,14 @@
           "success": true,
           "confidence": 0.5
         }
-      }
+      },
+      "avgFidelity": 0.8149237472766885,
+      "degeneratePasses": [
+        "behavior-draggable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "unless-condition"
+      ]
     },
     "it": {
       "parseSuccess": 150,
@@ -6237,7 +6335,16 @@
         "behavior-resizable": {
           "success": false
         }
-      }
+      },
+      "avgFidelity": 0.8700000000000003,
+      "degeneratePasses": [
+        "async-block",
+        "fetch-loading-state",
+        "form-submit-prevent",
+        "if-empty",
+        "if-exists",
+        "input-validation"
+      ]
     },
     "ja": {
       "parseSuccess": 154,
@@ -6862,7 +6969,26 @@
           "success": true,
           "confidence": 0.5
         }
-      }
+      },
+      "avgFidelity": 0.8062770562770563,
+      "degeneratePasses": [
+        "announce-screen-reader",
+        "behavior-draggable",
+        "behavior-removable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "event-once",
+        "fetch-basic",
+        "fetch-do-not-throw",
+        "fetch-error-handling",
+        "fetch-json",
+        "fetch-loading-state",
+        "fetch-with-headers",
+        "if-empty",
+        "input-validation",
+        "its-value-possessive-dot",
+        "socket-basic"
+      ]
     },
     "ko": {
       "parseSuccess": 154,
@@ -7487,7 +7613,24 @@
           "success": true,
           "confidence": 0.5
         }
-      }
+      },
+      "avgFidelity": 0.8799783549783553,
+      "degeneratePasses": [
+        "async-block",
+        "behavior-draggable",
+        "behavior-removable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "event-once",
+        "if-empty",
+        "input-validation",
+        "repeat-for-each",
+        "repeat-forever",
+        "repeat-while",
+        "socket-basic",
+        "stagger-animation",
+        "window-scroll"
+      ]
     },
     "ms": {
       "parseSuccess": 154,
@@ -8112,7 +8255,18 @@
           "success": true,
           "confidence": 0.8222222222222222
         }
-      }
+      },
+      "avgFidelity": 0.7876623376623375,
+      "degeneratePasses": [
+        "announce-screen-reader",
+        "async-block",
+        "event-debounce",
+        "fetch-basic",
+        "fetch-json",
+        "fetch-with-headers",
+        "its-value-possessive-dot",
+        "template-literal-list-build"
+      ]
     },
     "pl": {
       "parseSuccess": 150,
@@ -8733,7 +8887,9 @@
         "behavior-resizable": {
           "success": false
         }
-      }
+      },
+      "avgFidelity": 0.905,
+      "degeneratePasses": ["first-in-parent"]
     },
     "pt": {
       "parseSuccess": 153,
@@ -9357,7 +9513,18 @@
           "success": true,
           "confidence": 0.5
         }
-      }
+      },
+      "avgFidelity": 0.8631808278867102,
+      "degeneratePasses": [
+        "async-block",
+        "behavior-draggable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "fetch-with-headers",
+        "first-in-parent",
+        "focus-trap",
+        "socket-basic"
+      ]
     },
     "qu": {
       "parseSuccess": 154,
@@ -9982,7 +10149,29 @@
           "success": true,
           "confidence": 0.5
         }
-      }
+      },
+      "avgFidelity": 0.7296536796536797,
+      "degeneratePasses": [
+        "async-block",
+        "behavior-draggable",
+        "behavior-removable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "event-once",
+        "fetch-loading-state",
+        "get-value",
+        "if-empty",
+        "if-exists",
+        "input-validation",
+        "modal-close-escape",
+        "render-template-with-data",
+        "repeat-for-each",
+        "repeat-forever",
+        "repeat-while",
+        "socket-basic",
+        "stagger-animation",
+        "template-literal-list-build"
+      ]
     },
     "ru": {
       "parseSuccess": 154,
@@ -10607,7 +10796,17 @@
           "success": true,
           "confidence": 0.5555555555555556
         }
-      }
+      },
+      "avgFidelity": 0.8733766233766237,
+      "degeneratePasses": [
+        "fetch-loading-state",
+        "form-submit-prevent",
+        "if-empty",
+        "if-exists",
+        "input-validation",
+        "install-behavior",
+        "unless-condition"
+      ]
     },
     "sw": {
       "parseSuccess": 152,
@@ -11230,7 +11429,22 @@
           "success": true,
           "confidence": 0.5
         }
-      }
+      },
+      "avgFidelity": 0.7716008771929828,
+      "degeneratePasses": [
+        "behavior-draggable",
+        "behavior-resizable",
+        "event-debounce",
+        "fetch-loading-state",
+        "first-in-parent",
+        "focus-trap",
+        "form-submit-prevent",
+        "if-empty",
+        "if-exists",
+        "repeat-until-event",
+        "socket-basic",
+        "template-literal-list-build"
+      ]
     },
     "th": {
       "parseSuccess": 154,
@@ -11855,7 +12069,17 @@
           "success": true,
           "confidence": 0.8222222222222222
         }
-      }
+      },
+      "avgFidelity": 0.8750000000000006,
+      "degeneratePasses": [
+        "async-block",
+        "fetch-loading-state",
+        "form-submit-prevent",
+        "if-empty",
+        "if-exists",
+        "input-validation",
+        "window-scroll"
+      ]
     },
     "tl": {
       "parseSuccess": 154,
@@ -12480,7 +12704,30 @@
           "success": true,
           "confidence": 1
         }
-      }
+      },
+      "avgFidelity": 0.8195887445887448,
+      "degeneratePasses": [
+        "accordion-exclusive",
+        "async-block",
+        "copy-to-clipboard",
+        "event-debounce",
+        "eventsource-basic",
+        "fetch-loading-state",
+        "form-submit-prevent",
+        "get-value",
+        "halt-propagation",
+        "if-empty",
+        "if-exists",
+        "input-validation",
+        "modal-close-escape",
+        "render-template-with-data",
+        "repeat-for-each",
+        "repeat-while",
+        "tabs-basic",
+        "tabs-content",
+        "take-class-from-siblings",
+        "worker-basic"
+      ]
     },
     "tr": {
       "parseSuccess": 154,
@@ -13105,7 +13352,23 @@
           "success": true,
           "confidence": 0.5
         }
-      }
+      },
+      "avgFidelity": 0.8532467532467535,
+      "degeneratePasses": [
+        "async-block",
+        "behavior-draggable",
+        "behavior-removable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "default-value",
+        "event-once",
+        "fetch-loading-state",
+        "focus-trap",
+        "if-empty",
+        "if-exists",
+        "input-validation",
+        "socket-basic"
+      ]
     },
     "uk": {
       "parseSuccess": 154,
@@ -13730,7 +13993,17 @@
           "success": true,
           "confidence": 0.5555555555555556
         }
-      }
+      },
+      "avgFidelity": 0.8733766233766237,
+      "degeneratePasses": [
+        "fetch-loading-state",
+        "form-submit-prevent",
+        "if-empty",
+        "if-exists",
+        "input-validation",
+        "install-behavior",
+        "unless-condition"
+      ]
     },
     "vi": {
       "parseSuccess": 154,
@@ -14355,7 +14628,17 @@
           "success": true,
           "confidence": 0.8222222222222222
         }
-      }
+      },
+      "avgFidelity": 0.80952380952381,
+      "degeneratePasses": [
+        "fetch-loading-state",
+        "form-submit-prevent",
+        "if-empty",
+        "if-exists",
+        "input-validation",
+        "render-template-with-data",
+        "template-literal-list-build"
+      ]
     },
     "zh": {
       "parseSuccess": 150,
@@ -14976,7 +15259,19 @@
         "behavior-resizable": {
           "success": false
         }
-      }
+      },
+      "avgFidelity": 0.7818888888888886,
+      "degeneratePasses": [
+        "async-block",
+        "event-debounce",
+        "fetch-basic",
+        "fetch-do-not-throw",
+        "fetch-json",
+        "fetch-with-headers",
+        "its-value-possessive-dot",
+        "repeat-forever",
+        "template-literal-list-build"
+      ]
     }
   },
   "bundles": {

--- a/packages/testing-framework/src/multilingual/cli.ts
+++ b/packages/testing-framework/src/multilingual/cli.ts
@@ -217,9 +217,20 @@ async function main(): Promise<void> {
         );
         exitCode = 1;
       } else {
-        const regressed = reporter
-          .getRegressionResults()
-          .filter(r => r.parseRateDelta < -REGRESSION_TOLERANCE_PTS);
+        const allResults = reporter.getRegressionResults();
+        const regressed = allResults.filter(r => r.parseRateDelta < -REGRESSION_TOLERANCE_PTS);
+
+        // Fidelity ratchet: faithful baseline passes that became degenerate
+        // (parse non-null but lost most of the English command structure). A
+        // small tolerance absorbs residual baseline/DB noise — consistent with
+        // the parse-rate tolerance above — while catching real backsliding (a
+        // transformer change that degrades a whole cluster). Regenerate the
+        // baseline (with --save-baseline) after an intentional fidelity change.
+        const FIDELITY_REGRESSION_TOLERANCE = 3;
+        const fidelityRegressions = allResults.flatMap(r =>
+          r.newDegeneratePasses.map(id => `${r.language}/${id}`)
+        );
+
         if (regressed.length > 0) {
           console.error(
             `\n✗ Regression vs baseline in ${regressed.length} language(s) ` +
@@ -232,7 +243,24 @@ async function main(): Promise<void> {
             console.error(`   ${r.language}: ΔparseRate ${r.parseRateDelta.toFixed(1)}pts${fails}`);
           }
           exitCode = 1;
+        } else if (fidelityRegressions.length > FIDELITY_REGRESSION_TOLERANCE) {
+          console.error(
+            `\n✗ Fidelity regression vs baseline: ${fidelityRegressions.length} faithful pass(es) ` +
+              `became degenerate (tolerance ${FIDELITY_REGRESSION_TOLERANCE}):`
+          );
+          for (const id of fidelityRegressions) console.error(`   ${id}`);
+          console.error(
+            `   (parse non-null but lost >50% of the English command structure — ` +
+              `if intentional, regenerate the baseline with --save-baseline)`
+          );
+          exitCode = 1;
         } else {
+          if (fidelityRegressions.length > 0) {
+            console.warn(
+              `\n⚠ ${fidelityRegressions.length} fidelity regression(s) within tolerance ` +
+                `(${FIDELITY_REGRESSION_TOLERANCE}): ${fidelityRegressions.join(', ')}`
+            );
+          }
           console.log(`\n✓ No regression vs baseline (tolerance ${REGRESSION_TOLERANCE_PTS}pts).`);
           exitCode = 0;
         }

--- a/packages/testing-framework/src/multilingual/fidelity.test.ts
+++ b/packages/testing-framework/src/multilingual/fidelity.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { collectActions, computeFidelity, FIDELITY_THRESHOLD } from './fidelity';
+
+describe('collectActions', () => {
+  it('collects distinct actions across a nested event-handler tree', () => {
+    // Shape of the English `focus-trap` parse: on { if ; focus ; halt }.
+    const node = {
+      kind: 'event-handler',
+      action: 'on',
+      body: [
+        {
+          kind: 'compound',
+          action: 'compound',
+          statements: [
+            { kind: 'command', action: 'if' },
+            { kind: 'command', action: 'focus' },
+            { kind: 'command', action: 'halt' },
+          ],
+        },
+      ],
+    };
+    expect(collectActions(node)).toEqual(['focus', 'halt', 'if', 'on']);
+  });
+
+  it('excludes the structural `compound` wrapper', () => {
+    const node = { action: 'compound', statements: [{ action: 'toggle' }] };
+    expect(collectActions(node)).toEqual(['toggle']);
+  });
+
+  it('handles a flat command and non-object input', () => {
+    expect(collectActions({ kind: 'command', action: 'toggle' })).toEqual(['toggle']);
+    expect(collectActions(null)).toEqual([]);
+    expect(collectActions(undefined)).toEqual([]);
+  });
+});
+
+describe('computeFidelity', () => {
+  const en = ['focus', 'halt', 'if', 'on'];
+
+  it('scores a faithful (reordered) parse 1.0', () => {
+    // SOV/VSO reorder keeps the same command set → full fidelity.
+    expect(computeFidelity(en, ['on', 'if', 'halt', 'focus'])).toBe(1);
+  });
+
+  it('scores a degenerate parse low (focus-trap dropping commands)', () => {
+    // ja `focus-trap` parsed as `on { from }` — only `on` survives of 4.
+    const score = computeFidelity(en, ['on', 'from']);
+    expect(score).toBeCloseTo(0.25);
+    expect(score! < FIDELITY_THRESHOLD).toBe(true);
+  });
+
+  it('is recall, not precision — extra candidate actions do not lower it', () => {
+    expect(computeFidelity(['toggle'], ['toggle', 'add', 'remove'])).toBe(1);
+  });
+
+  it('returns undefined when there is no reference to score against', () => {
+    expect(computeFidelity([], ['on'])).toBeUndefined();
+  });
+});

--- a/packages/testing-framework/src/multilingual/fidelity.ts
+++ b/packages/testing-framework/src/multilingual/fidelity.ts
@@ -1,0 +1,73 @@
+/**
+ * Structural fidelity for multilingual parses.
+ *
+ * The parse-validator's success metric is "the parser returned a non-null node".
+ * That conflates a faithful parse with a *degenerate* one — a translated pattern
+ * can parse non-null while silently dropping most of the source's commands (e.g.
+ * `focus-trap` parses as a bare `if` or a stray `from` in several languages, with
+ * the `focus`/`halt`/condition lost). This module derives a lightweight
+ * structural signature from a parsed node and scores a translation's parse against
+ * the English reference parse, so those degenerate passes are visible.
+ *
+ * The signature is intentionally word-order agnostic: it is the *set* of command
+ * actions in the node tree, so a faithful SOV/VSO reorder scores 1.0 while a parse
+ * that loses commands scores low.
+ */
+
+/** Passes scoring below this are flagged as degenerate (lost >half the structure). */
+export const FIDELITY_THRESHOLD = 0.5;
+
+/** The structural `compound` wrapper is not a command; never counts as an action. */
+const STRUCTURAL_ACTIONS = new Set(['compound']);
+
+/** Node-array fields the walk recurses into (event/loop/conditional bodies). */
+const CHILD_FIELDS = ['body', 'statements', 'thenBranch', 'elseBranch', 'branches'] as const;
+
+/**
+ * Collect the distinct command actions anywhere in a parsed semantic node tree
+ * (top-level action + nested body/statements/branches), excluding the structural
+ * `compound` wrapper. Returns a sorted array for stable comparison/serialization.
+ */
+export function collectActions(node: unknown): string[] {
+  const acc = new Set<string>();
+  walk(node, acc, 0);
+  return [...acc].sort();
+}
+
+function walk(node: unknown, acc: Set<string>, depth: number): void {
+  // Guard against pathological/cyclic structures.
+  if (depth > 64 || node === null || typeof node !== 'object') return;
+
+  const rec = node as Record<string, unknown>;
+  const action = rec.action;
+  if (typeof action === 'string' && !STRUCTURAL_ACTIONS.has(action)) {
+    acc.add(action);
+  }
+
+  for (const field of CHILD_FIELDS) {
+    const child = rec[field];
+    if (Array.isArray(child)) {
+      for (const c of child) walk(c, acc, depth + 1);
+    } else if (child && typeof child === 'object') {
+      walk(child, acc, depth + 1);
+    }
+  }
+}
+
+/**
+ * Structural fidelity in [0, 1]: the fraction of the reference (English) actions
+ * also present in the candidate (recall). Returns `undefined` when the reference
+ * has no actions to compare against.
+ */
+export function computeFidelity(
+  reference: readonly string[],
+  candidate: readonly string[]
+): number | undefined {
+  if (reference.length === 0) return undefined;
+  const cand = new Set(candidate);
+  let hits = 0;
+  for (const a of reference) {
+    if (cand.has(a)) hits++;
+  }
+  return hits / reference.length;
+}

--- a/packages/testing-framework/src/multilingual/orchestrator.ts
+++ b/packages/testing-framework/src/multilingual/orchestrator.ts
@@ -12,6 +12,7 @@ import { ConsoleReporter } from './reporters/console-reporter';
 import { JSONReporter } from './reporters/json-reporter';
 import { RegressionReporter } from './reporters/regression-reporter';
 import type { TestConfig, TestResults, LanguageResults, LanguageCode, Reporter } from './types';
+import { computeFidelity, FIDELITY_THRESHOLD } from './fidelity';
 
 const execAsync = promisify(exec);
 
@@ -90,6 +91,11 @@ export class TestOrchestrator {
         const result = await this.testLanguage(language as LanguageCode, langPatterns);
         languageResults.push(result);
       }
+
+      // Score structural fidelity against the English reference parse. This
+      // surfaces *degenerate* passes — patterns that parse non-null but drop most
+      // of the source's commands — which the parse-rate metric alone can't see.
+      this.scoreFidelity(languageResults);
 
       // Collect bundle information
       const bundles: TestResults['bundles'] = {};
@@ -210,6 +216,49 @@ export class TestOrchestrator {
     }
 
     return result;
+  }
+
+  /**
+   * Score structural fidelity of every parse against the English reference parse
+   * of the same pattern, in-place. Fills `ParseResult.fidelity` plus per-language
+   * `avgFidelity` / `degeneratePasses`. English is the reference, so its own
+   * results are left unscored. No-op when English wasn't part of the run.
+   */
+  private scoreFidelity(languageResults: LanguageResults[]): void {
+    const en = languageResults.find(r => r.language === 'en');
+    if (!en) return;
+
+    // codeExampleId -> English action signature (only successful en parses).
+    const reference = new Map<string, string[]>();
+    for (const r of en.parseResults) {
+      if (r.success && r.actionSignature && r.actionSignature.length > 0) {
+        reference.set(r.pattern.codeExampleId, r.actionSignature);
+      }
+    }
+
+    for (const lang of languageResults) {
+      if (lang.language === 'en') continue;
+
+      const degenerate: string[] = [];
+      const scores: number[] = [];
+
+      for (const result of lang.parseResults) {
+        if (!result.success || !result.actionSignature) continue;
+        const ref = reference.get(result.pattern.codeExampleId);
+        if (!ref) continue;
+
+        const fidelity = computeFidelity(ref, result.actionSignature);
+        if (fidelity === undefined) continue;
+
+        result.fidelity = fidelity;
+        scores.push(fidelity);
+        if (fidelity < FIDELITY_THRESHOLD) degenerate.push(result.pattern.codeExampleId);
+      }
+
+      lang.avgFidelity =
+        scores.length > 0 ? scores.reduce((a, b) => a + b, 0) / scores.length : undefined;
+      lang.degeneratePasses = degenerate.sort();
+    }
   }
 
   /**

--- a/packages/testing-framework/src/multilingual/reporters/console-reporter.ts
+++ b/packages/testing-framework/src/multilingual/reporters/console-reporter.ts
@@ -157,7 +157,47 @@ export class ConsoleReporter implements Reporter {
       }
     }
 
+    this.reportDegeneratePasses(results);
+
     this.log('');
+  }
+
+  /**
+   * Surface *degenerate* passes — patterns that parse non-null but drop most of
+   * the English reference's command structure (structural fidelity below the
+   * threshold). These pass the parse-rate gate yet aren't faithful translations,
+   * so they're reported separately rather than silently counted as green.
+   */
+  private reportDegeneratePasses(results: TestResults): void {
+    // pattern id -> languages where it's a degenerate pass
+    const byPattern = new Map<string, string[]>();
+    for (const lang of results.languageResults) {
+      for (const id of lang.degeneratePasses ?? []) {
+        let langs = byPattern.get(id);
+        if (!langs) {
+          langs = [];
+          byPattern.set(id, langs);
+        }
+        langs.push(lang.language);
+      }
+    }
+    if (byPattern.size === 0) return;
+
+    const totalInstances = [...byPattern.values()].reduce((n, langs) => n + langs.length, 0);
+    this.log('');
+    this.log(
+      this.yellow(
+        `⚠ Degenerate passes: ${totalInstances} instance(s) across ${byPattern.size} pattern(s)`
+      )
+    );
+    this.log(
+      this.dim('  (parse non-null but lost >50% of the English command structure — not failures)')
+    );
+    for (const [id, langs] of [...byPattern.entries()].sort((a, b) => b[1].length - a[1].length)) {
+      this.log(
+        `  ${this.dim('-')} ${id} ${this.dim(`(${langs.length}: ${langs.sort().join(',')})`)}`
+      );
+    }
   }
 
   /**

--- a/packages/testing-framework/src/multilingual/reporters/console-reporter.ts
+++ b/packages/testing-framework/src/multilingual/reporters/console-reporter.ts
@@ -251,6 +251,14 @@ export class ConsoleReporter implements Reporter {
         this.log(`  ${this.green('New Successes:')} ${result.newSuccesses.length}`);
       }
 
+      // Fidelity regressions (faithful pass → degenerate pass)
+      if (result.newDegeneratePasses.length > 0) {
+        this.log(
+          `  ${this.yellow('Fidelity Regressions:')} ${result.newDegeneratePasses.length}` +
+            ` ${this.dim(`(${result.newDegeneratePasses.join(', ')})`)}`
+        );
+      }
+
       this.log('');
     }
   }

--- a/packages/testing-framework/src/multilingual/reporters/regression-reporter.test.ts
+++ b/packages/testing-framework/src/multilingual/reporters/regression-reporter.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { writeFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { RegressionReporter } from './regression-reporter';
+import type { TestResults, LanguageResults, ParseResult, Baseline } from '../types';
+
+/** Minimal ParseResult for a successful pattern. */
+function pass(id: string): ParseResult {
+  return {
+    pattern: {
+      codeExampleId: id,
+      language: 'ja',
+      hyperscript: '',
+      wordOrder: 'SOV',
+      confidence: 1,
+      verifiedParses: 0,
+      roleAlignmentScore: 0,
+    },
+    success: true,
+    duration: 0,
+  };
+}
+
+function lang(parseResults: ParseResult[], degeneratePasses: string[]): LanguageResults {
+  const parseSuccess = parseResults.filter(r => r.success).length;
+  return {
+    language: 'ja',
+    bundle: 'browser-priority',
+    parseResults,
+    parseSuccess,
+    parseFailure: parseResults.length - parseSuccess,
+    parseRate: parseSuccess / parseResults.length,
+    avgConfidence: 1,
+    degeneratePasses,
+    duration: 0,
+    status: 'pass',
+  };
+}
+
+function results(language: LanguageResults): TestResults {
+  return {
+    timestamp: '',
+    commit: 'test',
+    config: {} as TestResults['config'],
+    languageResults: [language],
+    bundles: {},
+    summary: {
+      totalPatterns: language.parseResults.length,
+      totalSuccess: language.parseSuccess,
+      totalFailure: language.parseFailure,
+      totalDuration: 0,
+      overallStatus: 'pass',
+    },
+  };
+}
+
+describe('RegressionReporter fidelity ratchet', () => {
+  let dir: string;
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function reporterWith(baseline: Baseline): RegressionReporter {
+    dir = mkdtempSync(join(tmpdir(), 'fidelity-'));
+    const path = join(dir, 'baseline.json');
+    writeFileSync(path, JSON.stringify(baseline));
+    return new RegressionReporter(path);
+  }
+
+  const baseline: Baseline = {
+    timestamp: '',
+    commit: 'base',
+    languages: {
+      ja: {
+        parseSuccess: 3,
+        parseFailure: 1,
+        parseRate: 0.75,
+        avgConfidence: 1,
+        avgFidelity: 0.9,
+        // `was-degenerate` already degenerate; `was-faithful` is a clean pass;
+        // `was-fail` failed in baseline.
+        degeneratePasses: ['was-degenerate'],
+        bundleSize: undefined,
+        patterns: {
+          'was-faithful': { success: true, confidence: 1 },
+          'was-degenerate': { success: true, confidence: 1 },
+          stable: { success: true, confidence: 1 },
+          'was-fail': { success: false, confidence: undefined },
+        },
+      },
+    },
+    bundles: {},
+  };
+
+  it('flags a faithful baseline pass that became degenerate', () => {
+    const reporter = reporterWith(baseline);
+    // `was-faithful` is now degenerate; `was-fail` now parses degenerately (improvement).
+    reporter.reportComplete(
+      results(
+        lang(
+          [pass('was-faithful'), pass('was-degenerate'), pass('stable'), pass('was-fail')],
+          ['was-faithful', 'was-degenerate', 'was-fail']
+        )
+      )
+    );
+    const r = reporter.getRegressionResults().find(x => x.language === 'ja')!;
+    // Only the faithful→degenerate transition is a regression.
+    expect(r.newDegeneratePasses).toEqual(['was-faithful']);
+    // `was-degenerate` (already degenerate) and `was-fail` (was failing) are excluded.
+    expect(r.newDegeneratePasses).not.toContain('was-degenerate');
+    expect(r.newDegeneratePasses).not.toContain('was-fail');
+    expect(r.status).toBe('regressed');
+  });
+
+  it('does not flag anything when fidelity is unchanged', () => {
+    const reporter = reporterWith(baseline);
+    reporter.reportComplete(
+      results(
+        lang([pass('was-faithful'), pass('was-degenerate'), pass('stable')], ['was-degenerate'])
+      )
+    );
+    const r = reporter.getRegressionResults().find(x => x.language === 'ja')!;
+    expect(r.newDegeneratePasses).toEqual([]);
+  });
+
+  it('never retro-flags when the baseline has no fidelity data', () => {
+    const noFidelity: Baseline = structuredClone(baseline);
+    delete noFidelity.languages.ja!.degeneratePasses;
+    const reporter = reporterWith(noFidelity);
+    reporter.reportComplete(
+      results(lang([pass('was-faithful'), pass('stable')], ['was-faithful', 'stable']))
+    );
+    const r = reporter.getRegressionResults().find(x => x.language === 'ja')!;
+    expect(r.newDegeneratePasses).toEqual([]);
+  });
+});

--- a/packages/testing-framework/src/multilingual/reporters/regression-reporter.ts
+++ b/packages/testing-framework/src/multilingual/reporters/regression-reporter.ts
@@ -116,10 +116,12 @@ export class RegressionReporter implements Reporter {
       // Identify new failures and successes
       const newFailures = this.findNewFailures(langResult, baselineLang);
       const newSuccesses = this.findNewSuccesses(langResult, baselineLang);
+      // Fidelity ratchet: faithful pass in baseline → degenerate pass now.
+      const newDegeneratePasses = this.findNewDegeneratePasses(langResult, baselineLang);
 
       // Determine status
       let status: 'improved' | 'regressed' | 'unchanged' = 'unchanged';
-      if (parseRateDelta < -5 || newFailures.length > 0) {
+      if (parseRateDelta < -5 || newFailures.length > 0 || newDegeneratePasses.length > 0) {
         status = 'regressed';
       } else if (parseRateDelta > 5 || newSuccesses.length > 0) {
         status = 'improved';
@@ -132,6 +134,7 @@ export class RegressionReporter implements Reporter {
         bundleSizeDelta: bundleSizeDelta !== undefined ? bundleSizeDelta : undefined,
         newFailures,
         newSuccesses,
+        newDegeneratePasses,
         status,
       });
     }
@@ -198,6 +201,36 @@ export class RegressionReporter implements Reporter {
     }
 
     return newSuccesses.slice(0, 10); // Limit to 10 for reporting
+  }
+
+  /**
+   * Find patterns that *regressed in fidelity*: a faithful (non-degenerate) pass
+   * in the baseline that is now a degenerate pass (still parses, but lost most of
+   * the English command structure). This is the fidelity ratchet's signal.
+   *
+   * Returns [] when the baseline carries no fidelity data yet (`degeneratePasses`
+   * undefined) so adopting the signal never retro-flags the whole corpus. A
+   * pattern that went FAIL → degenerate-pass is an improvement (it now parses),
+   * not a regression, and is excluded because it wasn't a baseline pass.
+   */
+  private findNewDegeneratePasses(
+    current: LanguageResults,
+    baseline: {
+      patterns: Record<string, { success: boolean; confidence: number | undefined }> | undefined;
+      degeneratePasses?: string[] | undefined;
+    }
+  ): string[] {
+    if (!baseline.degeneratePasses || !baseline.patterns) return [];
+    const baselineDegenerate = new Set(baseline.degeneratePasses);
+    const currentDegenerate = new Set(current.degeneratePasses ?? []);
+
+    const regressed: string[] = [];
+    for (const id of currentDegenerate) {
+      const wasPass = baseline.patterns[id]?.success === true;
+      // Faithful baseline pass (passed, not already degenerate) that is now degenerate.
+      if (wasPass && !baselineDegenerate.has(id)) regressed.push(id);
+    }
+    return regressed.sort();
   }
 
   /**

--- a/packages/testing-framework/src/multilingual/reporters/regression-reporter.ts
+++ b/packages/testing-framework/src/multilingual/reporters/regression-reporter.ts
@@ -238,6 +238,10 @@ export class RegressionReporter implements Reporter {
         parseFailure: langResult.parseFailure,
         parseRate: langResult.parseRate,
         avgConfidence: langResult.avgConfidence,
+        // Structural fidelity vs the English reference parse — tracks degenerate
+        // (non-null but shallow) passes that the parse rate alone can't surface.
+        avgFidelity: langResult.avgFidelity ?? undefined,
+        degeneratePasses: langResult.degeneratePasses ?? undefined,
         bundleSize: langResult.bundleSize ?? undefined,
         patterns,
       };

--- a/packages/testing-framework/src/multilingual/types.ts
+++ b/packages/testing-framework/src/multilingual/types.ts
@@ -255,6 +255,12 @@ export interface RegressionResult {
   bundleSizeDelta: number | undefined; // % change
   newFailures: string[]; // pattern IDs
   newSuccesses: string[]; // pattern IDs
+  /**
+   * Patterns that were a *faithful* pass in the baseline but are now a
+   * *degenerate* pass (fidelity dropped below threshold) — a fidelity
+   * regression. Empty when the baseline has no fidelity data yet.
+   */
+  newDegeneratePasses: string[];
   status: 'improved' | 'regressed' | 'unchanged';
 }
 

--- a/packages/testing-framework/src/multilingual/types.ts
+++ b/packages/testing-framework/src/multilingual/types.ts
@@ -114,6 +114,24 @@ export interface ParseResult {
   parser?: 'semantic' | 'traditional';
   error?: string;
   duration: number; // ms
+
+  /**
+   * Distinct command actions present anywhere in the parsed node tree
+   * (event-handler + nested body/statements), excluding the structural
+   * `compound` wrapper. Used to compute structural `fidelity` against the
+   * English reference parse. Set by the validator.
+   */
+  actionSignature?: string[];
+
+  /**
+   * Structural fidelity vs the English reference parse, in [0, 1]: the fraction
+   * of the English parse's distinct actions also present in this language's
+   * parse (recall). `1` = same command structure; low values flag a *degenerate*
+   * pass (parses non-null, but lost most of the source's commands). Computed
+   * cross-language after all parses complete; `undefined` when there is no
+   * usable English reference or this parse failed.
+   */
+  fidelity?: number;
 }
 
 /**
@@ -141,6 +159,19 @@ export interface LanguageResults {
   parseFailure: number;
   parseRate: number;
   avgConfidence: number;
+
+  /**
+   * Mean structural `fidelity` over successful parses that have an English
+   * reference (see ParseResult.fidelity). `undefined` for English itself.
+   */
+  avgFidelity?: number | undefined;
+
+  /**
+   * Pattern IDs that pass (non-null) but parse *degenerately* — fidelity below
+   * the harness threshold (lost most of the English command structure). These
+   * are real-but-shallow passes the parse-rate metric alone can't surface.
+   */
+  degeneratePasses?: string[] | undefined;
 
   /** Duration in ms */
   duration: number;
@@ -194,6 +225,10 @@ export interface Baseline {
         parseFailure: number;
         parseRate: number;
         avgConfidence: number;
+        /** Mean structural fidelity vs the English reference parse (see ParseResult.fidelity). */
+        avgFidelity?: number | undefined;
+        /** Pattern IDs that pass but parse degenerately (fidelity below threshold). */
+        degeneratePasses?: string[] | undefined;
         bundleSize: number | undefined;
         /** Pattern-level results for detailed tracking */
         patterns: Record<string, { success: boolean; confidence: number | undefined }> | undefined;

--- a/packages/testing-framework/src/multilingual/validators/parse-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/parse-validator.ts
@@ -5,6 +5,7 @@
 import { MultilingualHyperscript } from '@hyperfixi/core/multilingual';
 import type { SemanticNode } from '@lokascript/semantic';
 import type { PatternTranslation, ParseResult, Validator } from '../types';
+import { collectActions } from '../fidelity';
 
 /**
  * Parse Validator
@@ -84,6 +85,8 @@ export class ParseValidator implements Validator<ParseResult[]> {
         roles,
         confidence: pattern.confidence, // Use pattern confidence
         parser: 'semantic',
+        // Structural signature for cross-language fidelity scoring (see fidelity.ts).
+        actionSignature: collectActions(semanticNode),
         duration: performance.now() - startTime,
       };
     } catch (error) {


### PR DESCRIPTION
## Summary

Adds a **structural fidelity signal** to the multilingual harness and **ratchets it in CI**, so *degenerate* passes — patterns that parse non-null but drop most of the source's command structure — are surfaced, tracked, and prevented from growing. Also documents the `parse rate ≠ fidelity` distinction.

Prompted by `focus-trap`: nominally green in 24 languages, faithfully parsed in ~1 (English); the rest return a non-null shell with the real commands lost.

## What it does

**Signal** (`fidelity.ts`): `collectActions` derives the *set* of command actions in a parsed node tree (word-order agnostic, excludes the `compound` wrapper); `computeFidelity` scores a translation against the English reference parse (recall). `FIDELITY_THRESHOLD = 0.5` flags degenerate passes. The validator records `actionSignature`; the orchestrator scores every language vs English after all parses complete → `ParseResult.fidelity` + per-language `avgFidelity` / `degeneratePasses`. The console run prints a `⚠ Degenerate passes` section.

**Ratchet** (chosen over a hard gate / report-only): the committed baseline now carries `avgFidelity` / `degeneratePasses` (added surgically — **zero success-flag drift**), and the `--regression` CI gate fails when a **faithful** baseline pass becomes a **degenerate** one (tolerance 3, mirroring the existing parse-rate ±2pt tolerance). Improvements (fail→degenerate-pass, degenerate→faithful) never fail it; an empty-fidelity baseline never retro-flags the corpus. **The pass/fail success gate and all parser/transformer behavior are unchanged.**

**Docs**: `parse rate ≠ fidelity` note in `CLAUDE.md` (+ a line in the CI workflow comment), and a new **Track 5 — Parse fidelity** section in `MULTILINGUAL_ROADMAP.md` cataloguing the degenerate clusters and the triage-then-resolve plan.

## What it reveals

**~232 degenerate-pass instances across ~51 patterns** behind the 99%+ parse rate — dominated by **block-body translation**: `if-empty` (16), `fetch-loading-state` (14), `input-validation` (14), `async-block` (13), `if-exists` (13), … i.e. the same transformer weakness behind this session's deep grammar fixes.

## Verification
- Gate **passes** when current == baseline (0 fidelity regressions).
- Tampered baseline (4 faithful→degenerate) correctly **exits 1** with a clear message.
- `fidelity.test.ts` (7) + `regression-reporter.test.ts` (3) green; full `src/multilingual` suite green; `tsc` clean (only the pre-existing environmental `@hyperfixi/core/multilingual` `.d.ts`, resolved in CI build).

> Note: rebased on `main` (includes focus-trap #286), so the baseline reflects current state.

https://claude.ai/code/session_01GJgn3E4wiAvKXwCnzCcQNM