### PR TITLE
fix(semantic): capture post-event then-chain in command-first event bodies (fidelity Root B)

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -58,6 +58,32 @@ behaviors), not a parsing/i18n track. See Track 2.
 
 ## Shipped
 
+### Post-event then-chain capture — fidelity Root B (+9 faithful, first Track-5 fix)
+
+- **Fidelity, not parse rate**: degenerate passes **232 → 223** (−9 degenerate→faithful),
+  **0 new failures, 0 fidelity regressions, parse rate unchanged** (3672/3696). Locked
+  by the fidelity ratchet (`--regression`). The 9: `fetch-loading-state` (ar, de, qu,
+  sw, tl), `fetch-basic` (de, ja), `its-value-possessive-dot` (de, ja).
+- **Root cause (semantic parser).** A fused VSO/SOV event pattern matches a
+  command-first handler (`<cmd> on <event> then <cmd>…` — e.g. ar `أضف .loading …
+عند نقر ثم احذف … ثم ضع …`) and captures the _first_ command, but the trailing
+  `then`-chain is left unconsumed _without_ a `continues` marker. `buildEventHandler`
+  only parsed the remainder when `continues:'then'` was captured, so the body
+  collapsed to that first command and **every post-event command was silently dropped**
+  — a non-null but degenerate parse.
+- **Fix.** In `buildEventHandler`'s grammar-transformed branch, also parse the
+  remainder when the next unconsumed token is a then-keyword (`hasTrailingThenChain`),
+  not only when `continues` was captured. Additive and tightly gated: a lone
+  command-first event (no trailing `then`) is unchanged, and only successfully-parsed
+  commands are appended, so it can lift fidelity but never break an existing parse
+  (confirmed: 0 regressions across the full 24-language corpus + 5313 semantic tests).
+- **Honest caveat.** This is Root B only. Root A (the i18n transformer scrambling SOV
+  `if … is …` conditions — `if-empty`/`input-validation`, the largest cluster) is
+  untouched and is the next Track-5 target. `fetch-loading-state`/ar is now 0.80 not
+  1.0 (its inner `fetch` body command is a separate AR-pattern gap).
+- Locked by `multilingual-roadmap-fixes.test.ts` ("Post-event then-chain capture":
+  ar body keeps remove/put; a lone command-first event keeps just its command).
+
 ### Event-block `from`-source routing — `focus-trap` tr (+1, completes the non-behavior track)
 
 - **1 instance, 0 regressions, avg 99.05% (fix run vs committed baseline: exactly
@@ -506,9 +532,16 @@ the fraction of the English reference parse's command actions that survive (reca
 word-order agnostic). Passes below 50% fidelity are **degenerate passes**.
 
 **Current state (committed baseline carries `avgFidelity` / `degeneratePasses`):**
-~**232 degenerate-pass instances across ~51 patterns**. The clusters are dominated
-by **block-body translation** — the i18n transformer mishandling the body of
-control-flow / async / fetch constructs:
+~**223 degenerate-pass instances across ~51 patterns** (was 232; −9 from the
+post-event then-chain fix below). Triage (`packages/testing-framework/tools/fidelity-triage.ts`)
+confirmed the signal is **real** — these are genuinely dropped commands, not a
+metric artifact — and isolated **two roots**: (A) the i18n **transformer** scrambles
+SOV `if <subj> is <pred>` conditions, interleaving the following command into the
+condition so the translated _text_ is broken (`if-empty`/ja, `input-validation`/ko
+→ 0.00); (B) the semantic **parser** drops the post-event `then`-chain in
+command-first (VSO/SOV) event bodies (`fetch-loading-state`/ar → 0.40). Root B is
+**fixed** (below); Root A (the biggest cluster) is the next target. The remaining
+clusters:
 
 | Cluster                     | Examples (langs)                                                                          |
 | --------------------------- | ----------------------------------------------------------------------------------------- |

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -327,9 +327,20 @@ export class SemanticParserImpl implements ISemanticParser {
         confidence: match.confidence,
       });
 
-      // Check if pattern has continuation marker (then-chains)
+      // Check if pattern has continuation marker (then-chains).
       const continuesValue = match.captured.get('continues');
-      if (continuesValue && continuesValue.type === 'literal' && continuesValue.value === 'then') {
+      const hasContinuesMarker =
+        continuesValue?.type === 'literal' && continuesValue.value === 'then';
+      // Some fused VSO/SOV event patterns capture only the *first* command and
+      // leave a trailing then-chain (`<cmd> on <event> then <cmd>…`) unconsumed
+      // *without* emitting a `continues` marker. Without this, the handler body
+      // silently collapses to that first command and every post-event command is
+      // dropped (a degenerate parse — see fidelity ratchet). Gate the extra parse
+      // on a leading then-keyword so we never sweep up unrelated trailing tokens.
+      const nextToken = tokens.peek();
+      const hasTrailingThenChain = !!nextToken && this.isThenKeyword(nextToken.value, language);
+
+      if (hasContinuesMarker || hasTrailingThenChain) {
         // Parse remaining tokens as additional commands
         const commandPatterns = getPatternsForLanguage(language)
           .filter(p => p.command !== 'on')

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -186,3 +186,45 @@ describe('Caret-scoped variable read `^name on <element>` (caret-var-on-target)'
     });
   }
 });
+
+describe('Post-event then-chain capture (command-first VSO/SOV event bodies)', () => {
+  // Distinct command actions anywhere in the parsed node tree (body/statements/
+  // branches), mirroring the harness fidelity signature — lets us assert that no
+  // body command was silently dropped.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // A fused VSO/SOV event pattern captures the first command (`add`) but left the
+  // post-event `then`-chain (`then fetch … then remove … then put …`) unconsumed
+  // without a `continues` marker — collapsing the body to just `add` (a degenerate
+  // parse). The body must now retain every then-chained command.
+  it('[ar] keeps remove/put after the event clause (fetch-loading-state shape)', () => {
+    const node = parse(
+      'أضف .loading إلى أنا عند نقر ثم احذف .loading من أنا ثم ضع هو إلى #result',
+      'ar'
+    );
+    expect(node.action).toBe('on');
+    const a = actions(node);
+    expect(a.has('add')).toBe(true);
+    expect(a.has('remove')).toBe(true);
+    expect(a.has('put')).toBe(true);
+  });
+
+  // No trailing then-chain → body is exactly the one captured command (unchanged
+  // behavior; guards against the gate over-reaching).
+  it('[ar] a lone command-first event keeps just its command', () => {
+    const node = parse('بدل .active عند نقر', 'ar');
+    expect(node.action).toBe('on');
+    // `on` is the handler's own action; `toggle` is the lone body command.
+    expect([...actions(node)].sort()).toEqual(['on', 'toggle']);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -625,7 +625,7 @@
           "confidence": 0.5
         }
       },
-      "avgFidelity": 0.8009803921568631,
+      "avgFidelity": 0.8297385620915034,
       "degeneratePasses": [
         "accordion-exclusive",
         "async-block",
@@ -634,7 +634,6 @@
         "behavior-sortable",
         "copy-to-clipboard",
         "event-debounce",
-        "fetch-loading-state",
         "focus-trap",
         "form-submit-prevent",
         "halt-propagation",
@@ -1274,7 +1273,7 @@
           "confidence": 0.5
         }
       },
-      "avgFidelity": 0.8792207792207795,
+      "avgFidelity": 0.8922077922077924,
       "degeneratePasses": [
         "async-block",
         "event-once",
@@ -1909,22 +1908,19 @@
           "confidence": 0.5
         }
       },
-      "avgFidelity": 0.8157952069716776,
+      "avgFidelity": 0.8423747276688455,
       "degeneratePasses": [
         "async-block",
         "behavior-draggable",
         "behavior-resizable",
         "behavior-sortable",
-        "fetch-basic",
         "fetch-do-not-throw",
         "fetch-error-handling",
         "fetch-json",
-        "fetch-loading-state",
         "fetch-with-headers",
         "first-in-parent",
         "form-submit-prevent",
-        "if-empty",
-        "its-value-possessive-dot"
+        "if-empty"
       ]
     },
     "en": {
@@ -6970,7 +6966,7 @@
           "confidence": 0.5
         }
       },
-      "avgFidelity": 0.8062770562770563,
+      "avgFidelity": 0.8279220779220781,
       "degeneratePasses": [
         "announce-screen-reader",
         "behavior-draggable",
@@ -6978,7 +6974,6 @@
         "behavior-resizable",
         "behavior-sortable",
         "event-once",
-        "fetch-basic",
         "fetch-do-not-throw",
         "fetch-error-handling",
         "fetch-json",
@@ -6986,7 +6981,6 @@
         "fetch-with-headers",
         "if-empty",
         "input-validation",
-        "its-value-possessive-dot",
         "socket-basic"
       ]
     },
@@ -10150,7 +10144,7 @@
           "confidence": 0.5
         }
       },
-      "avgFidelity": 0.7296536796536797,
+      "avgFidelity": 0.7492424242424243,
       "degeneratePasses": [
         "async-block",
         "behavior-draggable",
@@ -10158,7 +10152,6 @@
         "behavior-resizable",
         "behavior-sortable",
         "event-once",
-        "fetch-loading-state",
         "get-value",
         "if-empty",
         "if-exists",
@@ -11430,12 +11423,11 @@
           "confidence": 0.5
         }
       },
-      "avgFidelity": 0.7716008771929828,
+      "avgFidelity": 0.791776315789474,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
         "event-debounce",
-        "fetch-loading-state",
         "first-in-parent",
         "focus-trap",
         "form-submit-prevent",
@@ -12705,14 +12697,13 @@
           "confidence": 1
         }
       },
-      "avgFidelity": 0.8195887445887448,
+      "avgFidelity": 0.8443722943722946,
       "degeneratePasses": [
         "accordion-exclusive",
         "async-block",
         "copy-to-clipboard",
         "event-debounce",
         "eventsource-basic",
-        "fetch-loading-state",
         "form-submit-prevent",
         "get-value",
         "halt-propagation",
@@ -13353,7 +13344,7 @@
           "confidence": 0.5
         }
       },
-      "avgFidelity": 0.8532467532467535,
+      "avgFidelity": 0.8662337662337665,
       "degeneratePasses": [
         "async-block",
         "behavior-draggable",

--- a/packages/testing-framework/tools/fidelity-triage.ts
+++ b/packages/testing-framework/tools/fidelity-triage.ts
@@ -1,0 +1,73 @@
+import { MultilingualHyperscript } from '@hyperfixi/core/multilingual';
+import { getTranslationsByLanguage } from '@hyperfixi/patterns-reference';
+import { collectActions } from '../src/multilingual/fidelity';
+
+// Representative degenerate cases spanning the dominant clusters + word orders.
+const CASES: Array<[string, string]> = [
+  ['if-empty', 'ja'],
+  ['fetch-loading-state', 'ar'],
+  ['async-block', 'tl'],
+  ['input-validation', 'ko'],
+  ['form-submit-prevent', 'tr'],
+];
+
+function tree(node: any, depth = 0): string {
+  if (!node || typeof node !== 'object') return '';
+  const pad = '  '.repeat(depth);
+  const lines: string[] = [];
+  const action = node.action;
+  if (typeof action === 'string') lines.push(`${pad}• ${action}`);
+  for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+    const c = node[f];
+    if (Array.isArray(c)) {
+      if (c.length) lines.push(`${pad}  [${f}]`);
+      for (const x of c) lines.push(tree(x, depth + 2));
+    } else if (c && typeof c === 'object') {
+      lines.push(`${pad}  {${f}}`);
+      lines.push(tree(c, depth + 2));
+    }
+  }
+  return lines.filter(Boolean).join('\n');
+}
+
+async function textOf(id: string, lang: string): Promise<string | undefined> {
+  const all = await getTranslationsByLanguage(lang as any, 1000);
+  return all.find((t: any) => t.codeExampleId === id)?.hyperscript;
+}
+
+async function main() {
+  const ml = new MultilingualHyperscript();
+  await ml.initialize();
+
+  for (const [id, lang] of CASES) {
+    const enText = await textOf(id, 'en');
+    const trText = await textOf(id, lang);
+    console.log('\n' + '='.repeat(78));
+    console.log(`PATTERN: ${id}   (${lang})`);
+    console.log('-'.repeat(78));
+    if (!enText || !trText) {
+      console.log(`  MISSING TEXT: en=${!!enText} ${lang}=${!!trText}`);
+      continue;
+    }
+    const enNode: any = await ml.parse(enText, 'en');
+    const trNode: any = await ml.parse(trText, lang);
+    const enA = collectActions(enNode);
+    const trA = collectActions(trNode);
+    const missing = enA.filter(a => !trA.includes(a));
+    const extra = trA.filter(a => !enA.includes(a));
+
+    console.log(`EN  src: ${enText}`);
+    console.log(`${lang.toUpperCase().padStart(3)} src: ${trText}`);
+    console.log(`\nEN  actions [${enA.length}]: ${enA.join(', ')}`);
+    console.log(`${lang.toUpperCase().padStart(3)} actions [${trA.length}]: ${trA.join(', ') || '(none)'}`);
+    console.log(`DROPPED: ${missing.join(', ') || '—'}    EXTRA: ${extra.join(', ') || '—'}`);
+    console.log(`fidelity(recall) = ${(enA.length ? (enA.length - missing.length) / enA.length : 1).toFixed(2)}`);
+    console.log(`\nEN parse tree:\n${tree(enNode) || '  (empty)'}`);
+    console.log(`\n${lang.toUpperCase()} parse tree:\n${tree(trNode) || '  (empty)'}`);
+  }
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

The **first Track-5 fidelity fix**, following the ratchet landed in #287. Triage of the degenerate-pass corpus confirmed the fidelity signal reflects **genuinely dropped commands** (not a metric artifact) and isolated two roots; this fixes **Root B**.

## Triage findings (validation step)

`tools/fidelity-triage.ts` (added here, reusable) dumps English-vs-translation parse trees + action diffs. It showed two distinct roots behind the ~232 degenerate passes:

- **Root A — i18n transformer (SOV):** scrambles `if <subj> is <pred>` conditions, interleaving the following command into the condition so the translated *text* is broken (`if-empty`/ja, `input-validation`/ko → fidelity **0.00**). The largest cluster. **Not addressed here** — next target.
- **Root B — semantic parser (command-first event bodies):** the text is correct, but the parser drops the post-event `then`-chain (`fetch-loading-state`/ar → **0.40**). **Fixed here.**

## The fix (Root B)

A fused VSO/SOV event pattern matches a command-first handler (`<cmd> on <event> then <cmd>…`, e.g. ar `أضف .loading … عند نقر ثم احذف … ثم ضع …`), captures the **first** command, but leaves the trailing `then`-chain unconsumed *without* a `continues` marker. `buildEventHandler` only parsed the remainder when `continues:'then'` was captured → the body collapsed to that first command and **every post-event command was silently dropped** (a non-null but degenerate parse).

**Fix:** also parse the remainder when the next unconsumed token is a then-keyword (`hasTrailingThenChain`), not only when `continues` was captured. Additive and tightly gated — a lone command-first event (no trailing `then`) is unchanged, and only successfully-parsed commands are appended, so it lifts fidelity **without breaking any existing parse**.

## Validation (full 24-language corpus + units)

| Metric | Result |
|---|---|
| Degenerate passes | **232 → 223** (−9 degenerate→faithful) |
| New failures | **0** |
| Fidelity regressions | **0** (confirmed by the #287 ratchet) |
| Parse rate | unchanged (3672/3696) |
| Semantic unit tests | 5313 pass (0 logic regressions) |

The 9 lifted: `fetch-loading-state` (ar, de, qu, sw, tl), `fetch-basic` (de, ja), `its-value-possessive-dot` (de, ja). Baseline updated (fidelity-only diff, zero success-flag drift) so the ratchet **protects these going forward**.

## Honest caveats
- Root B only. Root A (the SOV `if … is …` transformer scramble) is untouched and is the next Track-5 target (roadmap updated).
- `fetch-loading-state`/ar is now 0.80, not 1.0 — its inner `fetch` body command is a separate AR-pattern gap.

Locked by `multilingual-roadmap-fixes.test.ts` ("Post-event then-chain capture").

https://claude.ai/code/session_01GJgn3E4wiAvKXwCnzCcQNM

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJgn3E4wiAvKXwCnzCcQNM)_