### PR TITLE
fix(semantic): recognize the `is empty` adjective predicate in 5 languages (Root A, partial)

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -58,6 +58,29 @@ behaviors), not a parsing/i18n track. See Track 2.
 
 ## Shipped
 
+### `is empty` predicate alignment — fidelity Root A partial (avgFidelity, 5 langs)
+
+- **avgFidelity up for fr/id/pl/pt/zh (~+0.0026 each, +0.0006 cross-lang), 0 new
+  failures, 0 fidelity regressions, degenerate count unchanged (223).** Each `if …
+is empty …` handler in these languages now parses faithfully (`add,empty,if,on`)
+  instead of dropping the condition predicate (`add,if,on`).
+- **Root cause (recurring, per-language).** The semantic profile's `empty` keyword
+  primary is the **verb** ("to empty/clear" — `vider`/`esvaziar`/`清空`/…), but the
+  i18n transformer emits the **adjective** for the `is empty` emptiness check
+  (`vide`/`vazio`/`空的`/…). The adjective was unregistered, so the predicate was
+  dropped from the condition. Only `es` (`vacío`) was already aligned.
+- **Fix.** Add the adjective as an `alternatives` entry on each profile's `empty`
+  mapping (additive — the verb/clear-command still works; no collisions). 5 one-line
+  profile edits.
+- **Honest scope.** This is a **partial Root A** win and deliberately does **not**
+  move the degenerate-pass count: these patterns were already ≥0.5 fidelity (above
+  the degenerate threshold), so the fix lifts them 0.75→1.0 (avgFidelity) without
+  clearing a degenerate pass. See the Track-5 note below — the tracked degenerate
+  cases are the _fully-collapsed_ (<0.5) ones, which need deeper per-language work.
+  Languages it/ru/uk/vi/th/sw also drop `empty` but additionally lose the body
+  command, so the predicate alignment alone doesn't make them faithful (separate gap).
+- Locked by `multilingual-roadmap-fixes.test.ts` ("`is empty` predicate alignment").
+
 ### Post-event then-chain capture — fidelity Root B (+9 faithful, first Track-5 fix)
 
 - **Fidelity, not parse rate**: degenerate passes **232 → 223** (−9 degenerate→faithful),
@@ -540,8 +563,24 @@ SOV `if <subj> is <pred>` conditions, interleaving the following command into th
 condition so the translated _text_ is broken (`if-empty`/ja, `input-validation`/ko
 → 0.00); (B) the semantic **parser** drops the post-event `then`-chain in
 command-first (VSO/SOV) event bodies (`fetch-loading-state`/ar → 0.40). Root B is
-**fixed** (below); Root A (the biggest cluster) is the next target. The remaining
-clusters:
+**fixed** (below); Root A is partially addressed (the `is empty` predicate
+alignment, below) but the bulk remains. The remaining clusters:
+
+> **Key triage insight (don't expect quick degenerate-count wins from Root A).**
+> Root A is **not one fix** — conditional parsing breaks _differently per language_
+> and across three layers (i18n transformer / semantic profile keywords / parser
+> condition-boundary), e.g. **de** `wenn`→`if` collides with `when` (and tests assert
+> `wenn`); **fr/pt/id/zh/pl** drop the `empty` adjective predicate (fixed); **ar/ja/ko**
+> fully collapse (transformer scrambles SOV `if <subj> is <pred>` _and_ the parser
+> doesn't parse SOV conditional bodies). Crucially, the **degenerate-pass count only
+> moves on the fully-collapsed (<0.5) cases** (ar/ja/ko/de) — the "close" cases
+> (fr/pt/… at 0.75) lift avgFidelity but stay above the 0.5 threshold. And part of
+> the `if-*` signal is **metric-entangled**: even the English reference shallow-parses
+> `is empty` as the `empty` _command_, so the predicate match is convention, not deep
+> fidelity. Net: Root A is a sustained, multi-PR, per-language effort; the big
+> degenerate-count wins require the hard SOV transformer + parser conditional work.
+
+The remaining clusters:
 
 | Cluster                     | Examples (langs)                                                                          |
 | --------------------------- | ----------------------------------------------------------------------------------------- |

--- a/packages/semantic/src/generators/profiles/chinese.ts
+++ b/packages/semantic/src/generators/profiles/chinese.ts
@@ -81,7 +81,7 @@ export const chineseProfile: LanguageProfile = {
     focus: { primary: '聚焦', normalized: 'focus' },
     blur: { primary: '失焦', normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: '清空', normalized: 'empty' },
+    empty: { primary: '清空', alternatives: ['空的'], normalized: 'empty' },
     open: { primary: '打开', normalized: 'open' },
     close: { primary: '关闭', normalized: 'close' },
     select: { primary: '选择', normalized: 'select' },

--- a/packages/semantic/src/generators/profiles/french.ts
+++ b/packages/semantic/src/generators/profiles/french.ts
@@ -85,7 +85,10 @@ export const frenchProfile: LanguageProfile = {
     focus: { primary: 'focaliser', alternatives: ['concentrer'], normalized: 'focus' },
     blur: { primary: 'défocaliser', normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: 'vider', normalized: 'empty' },
+    // `vide` (adjective, "empty") is the i18n transformer's `is empty` predicate
+    // form; `vider` is the verb ("to empty"). Accept both so the emptiness check
+    // in conditions is recognized, not just the clear-element command.
+    empty: { primary: 'vider', alternatives: ['vide'], normalized: 'empty' },
     open: { primary: 'ouvrir', normalized: 'open' },
     close: { primary: 'fermer', normalized: 'close' },
     select: { primary: 'sélectionner', alternatives: ['selectionner'], normalized: 'select' },

--- a/packages/semantic/src/generators/profiles/indonesian.ts
+++ b/packages/semantic/src/generators/profiles/indonesian.ts
@@ -85,7 +85,7 @@ export const indonesianProfile: LanguageProfile = {
     focus: { primary: 'fokus', alternatives: ['fokuskan'], normalized: 'focus' },
     blur: { primary: 'blur', normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: 'kosongkan', normalized: 'empty' },
+    empty: { primary: 'kosongkan', alternatives: ['kosong'], normalized: 'empty' },
     open: { primary: 'buka', normalized: 'open' },
     close: { primary: 'tutupkan', normalized: 'close' },
     select: { primary: 'tandai', normalized: 'select' },

--- a/packages/semantic/src/generators/profiles/polish.ts
+++ b/packages/semantic/src/generators/profiles/polish.ts
@@ -173,7 +173,7 @@ export const polishProfile: LanguageProfile = {
     },
     blur: { primary: 'rozmyj', alternatives: ['odskup'], normalized: 'blur', form: 'imperative' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: 'opróżnij', alternatives: ['oproznij'], normalized: 'empty' },
+    empty: { primary: 'opróżnij', alternatives: ['oproznij', 'pusty'], normalized: 'empty' },
     open: { primary: 'otwórz', alternatives: ['otworz'], normalized: 'open' },
     close: { primary: 'zamknij', normalized: 'close' },
     select: { primary: 'zaznacz', normalized: 'select' },

--- a/packages/semantic/src/generators/profiles/portuguese.ts
+++ b/packages/semantic/src/generators/profiles/portuguese.ts
@@ -80,7 +80,7 @@ export const portugueseProfile: LanguageProfile = {
     focus: { primary: 'focar', normalized: 'focus' },
     blur: { primary: 'desfocar', normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: 'esvaziar', normalized: 'empty' },
+    empty: { primary: 'esvaziar', alternatives: ['vazio'], normalized: 'empty' },
     open: { primary: 'abrir', normalized: 'open' },
     close: { primary: 'fechar', normalized: 'close' },
     select: { primary: 'selecionar', normalized: 'select' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -228,3 +228,38 @@ describe('Post-event then-chain capture (command-first VSO/SOV event bodies)', (
     expect([...actions(node)].sort()).toEqual(['on', 'toggle']);
   });
 });
+
+describe('`is empty` predicate alignment (verb vs adjective)', () => {
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // The semantic profile's `empty` primary is the *verb* (vider/esvaziar/清空/…),
+  // but the i18n transformer emits the *adjective* for the `is empty` emptiness
+  // check (vide/vazio/空的/…). Without the adjective registered, the condition
+  // predicate was silently dropped. These corpus-shaped `if … is empty …` handlers
+  // must now retain the `empty` action (alongside if + body).
+  const cases: Array<[string, string]> = [
+    ['fr', 'sur flou si mon valeur est vide ajouter .error à moi fin'],
+    ['pt', 'em desfoque se meu valor é vazio adicionar .error para eu fim'],
+    ['id', 'pada blur jika saya punya nilai adalah kosong tambah .error ke saya akhir'],
+    ['zh', '当 失焦 时 如果 我的 值 是 空的 把 添加 .error 到 我 结束'],
+    ['pl', 'gdy rozmycie jeśli mój wartość jest pusty dodaj .error do ja koniec'],
+  ];
+  for (const [lang, input] of cases) {
+    it(`[${lang}] recognizes the empty predicate in a conditional`, () => {
+      const a = actions(parse(input, lang));
+      expect(a.has('empty')).toBe(true);
+      expect(a.has('if')).toBe(true);
+      expect(a.has('add')).toBe(true);
+    });
+  }
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -3797,7 +3797,7 @@
           "confidence": 0.5
         }
       },
-      "avgFidelity": 0.8775599128540305,
+      "avgFidelity": 0.880174291938998,
       "degeneratePasses": [
         "async-block",
         "behavior-draggable",
@@ -5704,7 +5704,7 @@
           "confidence": 0.5
         }
       },
-      "avgFidelity": 0.8149237472766885,
+      "avgFidelity": 0.8175381263616558,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
@@ -8882,7 +8882,7 @@
           "success": false
         }
       },
-      "avgFidelity": 0.905,
+      "avgFidelity": 0.9076666666666667,
       "degeneratePasses": ["first-in-parent"]
     },
     "pt": {
@@ -9508,7 +9508,7 @@
           "confidence": 0.5
         }
       },
-      "avgFidelity": 0.8631808278867102,
+      "avgFidelity": 0.8657952069716778,
       "degeneratePasses": [
         "async-block",
         "behavior-draggable",
@@ -15251,7 +15251,7 @@
           "success": false
         }
       },
-      "avgFidelity": 0.7818888888888886,
+      "avgFidelity": 0.7845555555555555,
       "degeneratePasses": [
         "async-block",
         "event-debounce",


### PR DESCRIPTION
## Summary

A **partial Root A** fidelity fix, continuing the incremental Track-5 work after #287 (ratchet) and #289 (Root B). Validation of Root A revealed it's not one fix but a per-language, multi-layer effort — this lands the cleanest slice (a recurring keyword-alignment gap) and documents the rest.

## Root cause (recurring across languages)

The semantic profile's `empty` keyword primary is the **verb** ("to empty/clear" — `vider`/`esvaziar`/`清空`/`kosongkan`/`opróżnij`), but the i18n transformer emits the **adjective** for the `is empty` emptiness check (`vide`/`vazio`/`空的`/`kosong`/`pusty`). The adjective was unregistered, so the condition predicate was silently dropped: `if … is empty …` parsed as `add,if,on`, losing `empty`. Only `es` (`vacío`) was already aligned.

## Fix

Add the adjective as an `alternatives` entry on each profile's `empty` mapping — additive (the clear-element command still works; no collisions). 5 one-line profile edits (fr, pt, id, zh, pl).

## Validation (full 24-language corpus)

| Metric | Result |
|---|---|
| avgFidelity (fr/id/pl/pt/zh) | +~0.0026 each (+0.0006 cross-lang) |
| New failures / fidelity regressions | **0 / 0** |
| Parse rate | unchanged (3672/3696) |
| Semantic units | green (0 logic regressions) |

Baseline avgFidelity updated for the 5 languages; regression gate passes.

## Honest scope (important)

This **deliberately does not move the degenerate-pass count** (still 223). These patterns were already ≥0.5 fidelity, so the fix lifts them 0.75→1.0 (avgFidelity) without clearing a degenerate pass. Per the validation:

- **Root A is per-language and multi-layer** — conditional parsing breaks differently in each: `de` `wenn`→`if` collides with `when` (and tests assert `wenn`); `fr/pt/id/zh/pl` drop the `empty` adjective (this PR); `ar/ja/ko` fully collapse (transformer scrambles SOV `if <subj> is <pred>` *and* the parser can't parse SOV conditional bodies).
- **The tracked degenerate cases are the fully-collapsed (<0.5) SOV/V2 ones** — those need the harder transformer + parser work.
- Part of the `if-*` signal is **metric-entangled**: even English shallow-parses `is empty` as the `empty` *command*, so the predicate match is convention, not deep fidelity.

Roadmap (Track 5) updated with this decomposition. Locked by `multilingual-roadmap-fixes.test.ts` ("`is empty` predicate alignment").

https://claude.ai/code/session_01GJgn3E4wiAvKXwCnzCcQNM

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJgn3E4wiAvKXwCnzCcQNM)_