### PR TITLE
fix(multilingual): Track 5 Tier 1 — faithful if/else block-body in event handlers

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,7 +5,7 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after German `fetch` keyword alignment (de fetch cluster, −4 degenerate→faithful, fidelity Track 5). Parse rate unchanged (all non-behavior failures already cleared). Caret-scope masking, @attr-in-selector-role, trailing-event block-wrap, custom-event SOV, property-path patient, Tier 1, Track 4, Track 1 (reactive) complete._
+_Last updated: after Track 5 **Tier 1 — if/else block-body in event handlers** (degenerate passes **219 → 181**, −38 degenerate→faithful, 0 fidelity regressions, parse rate unchanged 3672/3696). Cleared `if-exists` entirely (ar+it flipped, the named Tier 1 target) and lifted `if-empty`/`input-validation`/`unless-condition` across 13 languages — the parser fix generalizes the whole if-block cluster. Earlier: German `fetch` keyword alignment, caret-scope masking, @attr-in-selector-role, trailing-event block-wrap, custom-event SOV, property-path patient, (parse-rate) Tier 1, Track 4, Track 1 (reactive) complete._
 
 ---
 
@@ -57,6 +57,50 @@ behaviors), not a parsing/i18n track. See Track 2.
 ---
 
 ## Shipped
+
+### Track 5 Tier 1 — if/else block-body in event handlers (−38 degenerate)
+
+- **Fidelity, not parse rate**: degenerate passes **219 → 181** (−38 degenerate→faithful),
+  **0 fidelity regressions, parse rate unchanged** (3672/3696). Confirmed by a full
+  `browser-priority` regen + the `--regression` gate (every flip is degenerate→faithful;
+  zero faithful→degenerate; zero parse-success ↑/↓). avgFidelity rose for
+  ar/bn/he/hi/it/qu/ru/sw/th/tl/tr/uk/vi, none fell.
+- **Named target cleared.** `if-exists` (the Tier 1 target — ar+it fully shredded to
+  `[on, if]` at 0.40) is now **gone from the degenerate list entirely**: ar → 0.80,
+  it → 1.0. Because the fix is at the parser/transform layer (not per-pattern), it also
+  lifted the rest of the if-block cluster — **`if-empty`, `input-validation`,
+  `unless-condition`** — from degenerate to faithful across 13 languages.
+- **Root cause (two layers).**
+  1. **Parser (`buildEventHandler`).** A fused VSO/SVO event pattern (`if-event-ar-vso`,
+     `event-handler-it-full`, …) captures a **block** command (`if`/`unless`/…) as the
+     handler _action_, but — unlike a simple command — the block's condition + branch body
+     are **not** bridged by a then-marker (`on click if <cond> show … else … end`). The
+     handler body collapsed to a bare `if` and every branch command was dropped (degenerate).
+  2. **Transformer (`transformConditionalBody`).** The if-block body was reordered as one
+     stream, so `else` rode along glued to a selector-led clause (`#modal else` → marked a
+     selector → left **untranslated**) with a spurious `then` inserted around it.
+- **Fix (three parts, all additive).**
+  1. **Parser** — when the fused action is a block keyword (`if`/`unless`/`while`/`repeat`/
+     `for`) and trailing non-`end` tokens remain, parse them as body commands and append as
+     siblings (mirrors how the English event-body path flattens an if/else block; the
+     condition tokens and `else` are skipped as non-commands). Gated to block actions, so
+     simple-command handlers are byte-identical.
+  2. **Transformer** — split the if-block body at a **top-level** (depth-aware) `else` into
+     a then-branch and an else-branch, transform each independently, and translate `else`
+     (ar `وإلا`, it `altrimenti`, ja `そうでなければ`, ko `아니면`, de `sonst`, …).
+  3. **Compound-fallback gate** — the Stage-4 fallback fired only on a then-keyword. The
+     else-split removed the `then` that some handlers leaned on when their **event isn't
+     recognized** (sw `blur`=`poteza_macho`, so `input-validation` only ever parsed via the
+     fallback). The gate now also fires on an `else` keyword (profile-derived
+     `isElseKeyword`), preventing a faithful→null regression there.
+- **Honest scope.** ar `if-exists` is 0.80 not 1.0: `put it into body` (`ضع هو إلى جسم`)
+  is a separate ar `put` gap. ja/ko if-exists stay 0.80 (they drop the `if` wrapper — an
+  SOV conditional-parse gap, untouched here). The `is <pred>` conditional class (Tier 2)
+  is still the bigger, per-language effort.
+- Locked by `multilingual-roadmap-fixes.test.ts` ("if/else block-body in event handlers":
+  ar/it if-exists keep the if + branch body; sw else-joined block still parses) and
+  `grammar.test.ts` ("if/else block-body — else split + translation": ar/it/ja translate
+  `else`, no English `else` leaks, else-less body unchanged).
 
 ### German `fetch` keyword alignment — fidelity (de fetch cluster, +4 faithful)
 
@@ -591,8 +635,9 @@ the fraction of the English reference parse's command actions that survive (reca
 word-order agnostic). Passes below 50% fidelity are **degenerate passes**.
 
 **Current state (committed baseline carries `avgFidelity` / `degeneratePasses`):**
-~**219 degenerate-pass instances across ~50 patterns** (was 232; −9 from the
-post-event then-chain fix, −4 from the de fetch keyword alignment — both below).
+~**181 degenerate-pass instances across ~50 patterns** (was 232; −9 from the
+post-event then-chain fix, −4 from the de fetch keyword alignment, −38 from the
+Tier 1 if/else block-body fix — all below).
 Triage (`packages/testing-framework/tools/fidelity-triage.ts`)
 confirmed the signal is **real** — these are genuinely dropped commands, not a
 metric artifact — and isolated **two roots**: (A) the i18n **transformer** scrambles
@@ -619,14 +664,14 @@ alignment, below) but the bulk remains. The remaining clusters:
 
 The remaining clusters:
 
-| Cluster                     | Examples (langs)                                                                                |
-| --------------------------- | ----------------------------------------------------------------------------------------------- |
-| control-flow blocks         | `if-empty` (16), `if-exists` (13), `unless-condition` (4)                                       |
-| fetch lifecycle / state     | `fetch-loading-state` (9), `fetch-with-headers` (5), `fetch-json` (4), `fetch-do-not-throw` (3) |
-| async / streaming           | `async-block` (13), `socket-basic` (9), `eventsource`/`worker`                                  |
-| validation / forms          | `input-validation` (14), `form-submit-prevent` (9)                                              |
-| positional / possessive-dot | `first-in-parent` (5), `its-value-possessive-dot` (4)                                           |
-| event modifiers / behaviors | `event-debounce`/`event-once`, `behavior-*` (degenerate in the langs where they parse)          |
+| Cluster                     | Examples (langs)                                                                                                |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| control-flow blocks         | `if-empty` (5), `unless-condition` (2) — `if-exists` (0) + most `if-empty`/`input-validation` cleared by Tier 1 |
+| fetch lifecycle / state     | `fetch-loading-state` (9), `fetch-with-headers` (5), `fetch-json` (4), `fetch-do-not-throw` (3)                 |
+| async / streaming           | `async-block` (13), `socket-basic` (9), `eventsource`/`worker`                                                  |
+| validation / forms          | `input-validation` (2 — was 14, cleared by Tier 1), `form-submit-prevent` (9)                                   |
+| positional / possessive-dot | `first-in-parent` (5), `its-value-possessive-dot` (4)                                                           |
+| event modifiers / behaviors | `event-debounce`/`event-once`, `behavior-*` (degenerate in the langs where they parse)                          |
 
 **How it's tracked (ratchet, not crash-project).** The `--regression` CI gate fails
 when a **faithful** baseline pass becomes a **degenerate** pass (tolerance 3, mirroring
@@ -648,8 +693,10 @@ fail the gate. After an _intentional_ fidelity change, regenerate the baseline.
    at once. Validate with the fidelity signal + a full regen (watch for the usual
    stale-DB / flaky-harness traps — see Gotchas). **See the validated spike below —
    the hypothesis holds structurally but lands in tiers, not one PR.**
-3. **Prioritize by language-count × value.** `if-empty`/16, `input-validation`/14,
-   `async-block`/13, `if-exists`/13 are the biggest.
+3. **Prioritize by language-count × value.** After Tier 1, `async-block`/13 is now
+   the biggest remaining (a separate command-first root, not an if-block); the
+   if-block cluster (`if-empty`/16, `if-exists`/13, `input-validation`/14) is mostly
+   cleared — residue is the SOV `is <pred>` / ja-ko `if`-wrapper class (Tier 2).
 
 **Spike finding (validated, this session) — the if-block shred is one root but**
 **fragments by word order + condition shape; build it in tiers.** A controlled
@@ -664,18 +711,25 @@ so a single transform won't clear all conditional clusters cleanly:
   VSO/SVO (ar, it) fully shred** to `[on, if]`. Also `else` leaks **untranslated**
   here (`#modal else を 表示`) even though it _is_ translated in input-validation
   (`そうでなければ`) — a structure-dependent else-handling inconsistency.
-  → **Tier 1 (most tractable):** an `if/else` block-mask + reorder (event-first,
-  block-after — mirrors #283/#286) that keeps the `if` wrapper and translates `else`,
-  validated on `if-exists` first. ar/it are the main beneficiaries.
+  → **Tier 1 — SHIPPED** (see Shipped → "Track 5 Tier 1"). The real blocker turned
+  out to be the **parser**, not just the transform: a fused event pattern captured
+  `if` as the action and dropped the whole block body. Fixed in `buildEventHandler`
+  (parse the trailing block body) + the i18n `else`-split/translation + an `else`-aware
+  compound-fallback gate. `if-exists` cleared (ar 0.40→0.80, it 0.40→1.0) and the fix
+  generalized to `if-empty`/`input-validation`/`unless-condition` across 13 langs
+  (−38 degenerate total).
 - **`if <subj> is <pred>` (if-empty 16, input-validation 14).** Harder. SOV ja/ko
   **fully collapse** (only the event leaks as a bare command) because the transformer
   strands the **predicate** (`空`/empty) _after_ the verb and interleaves the body
   into the condition; ar/it keep only `[on, if]`; de keeps `[on, add]` (drops
   `if`+`empty`, plus `wenn`→if collides with `when`, asserted by tests).
-  → **Tier 2:** requires the masked-block transform _and_ keeping the SOV
-  `<subj> is <pred>` condition **contiguous** (predicate not pushed past the verb),
-  _and_ per-language keyword fixes (de `wenn`/`when`; the `is empty` adjective —
-  partially shipped). Genuinely multi-PR, per-language.
+  → **Tier 2 (partially overtaken by Tier 1):** the if-block parser fix already
+  cleared the **SVO/VSO** slice (ar/it/ru/uk/… `if-empty`+`input-validation` flipped
+  to faithful), so the residue is the **SOV ja/ko fully-collapse** case + **de**. It
+  still needs keeping the SOV `<subj> is <pred>` condition **contiguous** (predicate
+  not pushed past the verb), the ja/ko `if`-wrapper recovery, and per-language keyword
+  fixes (de `wenn`/`when`; the `is empty` adjective — partially shipped). Remaining
+  degenerate: `if-empty` (de,he,ja,ko,sw), `input-validation` (ja,ko).
 - **`async-block` (13) is a separate root** — command-first verb ordering, not an
   if-block (see the ja fetch note below). Don't fold it into the if-block transform.
 

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -1450,3 +1450,38 @@ describe('Event-block body with `from <source>` (focus-trap)', () => {
     expect(t.transform(raw).length).toBeGreaterThan(0);
   });
 });
+
+describe('if/else block-body — else split + translation (Track 5 Tier 1)', () => {
+  // The if-block body was reordered as one stream, so `else` rode along glued to a
+  // selector-led clause (marked a selector → left UNTRANSLATED) with a spurious
+  // `then` inserted around it. The body is now split at a top-level `else` into a
+  // then-branch and an else-branch, each transformed independently, and `else` is
+  // translated. See docs-internal/MULTILINGUAL_ROADMAP.md (Track 5 Tier 1).
+  const raw = 'on click if #modal exists show #modal else make a <div#modal/> put it into body end';
+
+  it('[ar] translates else to وإلا (no English else leaks)', () => {
+    const result = new GrammarTransformer('en', 'ar').transform(raw);
+    expect(result).toContain('وإلا');
+    expect(result).not.toMatch(/\belse\b/);
+  });
+
+  it('[it] translates else to altrimenti (no English else leaks)', () => {
+    const result = new GrammarTransformer('en', 'it').transform(raw);
+    expect(result).toContain('altrimenti');
+    expect(result).not.toMatch(/\belse\b/);
+  });
+
+  it('[ja] translates else to そうでなければ (no English else leaks)', () => {
+    const result = new GrammarTransformer('en', 'ja').transform(raw);
+    expect(result).toContain('そうでなければ');
+    expect(result).not.toMatch(/\belse\b/);
+  });
+
+  it('leaves an else-less if-block body unchanged in shape', () => {
+    // No `else` → single body transform path, no spurious split.
+    const noElse = 'on click if #modal exists show #modal end';
+    const result = new GrammarTransformer('en', 'ar').transform(noElse);
+    expect(result).not.toMatch(/\belse\b/);
+    expect(result).toContain('اظهر'); // show translated
+  });
+});

--- a/packages/i18n/src/grammar/transformer.ts
+++ b/packages/i18n/src/grammar/transformer.ts
@@ -410,6 +410,14 @@ function getBoundaryModifiersForLocale(locale: string): Set<string> {
  */
 const BLOCK_HEAD_KEYWORDS = new Set(['live', 'when', 'unless']);
 
+/**
+ * Source-language block-introducing command keywords whose body is a clause plus a
+ * branch/loop body (harness source is English, so these are English-keyed). Used to
+ * locate a block body inside an event handler and to track block depth when finding
+ * a top-level `else`.
+ */
+const BLOCK_BODY_KEYWORDS = new Set(['if', 'repeat', 'unless', 'while', 'for']);
+
 function splitOnCommandBoundaries(input: string, sourceLocale: string): string[] {
   const commandKeywords = getCommandKeywordsForLocale(sourceLocale);
   const boundaryModifiers = getBoundaryModifiersForLocale(sourceLocale);
@@ -1589,9 +1597,6 @@ export class GrammarTransformer {
     if (tokens.length === 0) return null;
     if (!EVENT_KEYWORDS.has(tokens[0]?.toLowerCase())) return null;
 
-    // Source-language block-head keywords (harness source is English; the
-    // existing BLOCK_HEAD_KEYWORDS set is likewise English-keyed).
-    const BLOCK_BODY_KEYWORDS = new Set(['if', 'repeat', 'unless', 'while', 'for']);
     let blockIdx = -1;
     for (let i = 1; i < tokens.length; i++) {
       if (BLOCK_BODY_KEYWORDS.has(tokens[i].toLowerCase())) {
@@ -1661,14 +1666,60 @@ export class GrammarTransformer {
     if (bodyStart < 0) bodyStart = inner.length;
 
     const clause = inner.slice(0, bodyStart).join(' ');
-    const body = inner.slice(bodyStart).join(' ');
+    const bodyTokens = inner.slice(bodyStart);
 
     const headT = translateWord(head, src, dst);
     const tailT = tail ? translateWord(tail, src, dst) : '';
     const clauseT = clause ? translateMultiWordValue(clause, src, dst) : '';
-    const bodyT = body ? this.transform(body) : '';
+    const bodyT = this.transformConditionalBody(bodyTokens);
 
     return [headT, clauseT, bodyT, tailT].filter(s => s.length > 0).join(' ');
+  }
+
+  /**
+   * Transform an `if`/`unless` block body, splitting it at a top-level `else` into
+   * a then-branch and an else-branch so each is reordered as a self-contained unit
+   * and the `else` keyword itself is translated. Without this, the body is reordered
+   * as one stream: `else` rides along glued to the preceding clause (and, when that
+   * clause begins with a selector, is marked a selector and left *untranslated*),
+   * and a spurious `then` is inserted around it — both of which break the target
+   * text and the downstream parse. The split is depth-aware so an `else` belonging
+   * to a nested block is not mistaken for this block's separator. Bodies without an
+   * `else` transform exactly as before.
+   */
+  private transformConditionalBody(bodyTokens: string[]): string {
+    const src = this.sourceProfile.code;
+    const dst = this.targetProfile.code;
+
+    const sourceElse = translateWord('else', 'en', src).toLowerCase();
+    let depth = 0;
+    let elseIdx = -1;
+    for (let i = 0; i < bodyTokens.length; i++) {
+      const t = bodyTokens[i].toLowerCase();
+      if (BLOCK_BODY_KEYWORDS.has(t)) depth++;
+      else if (t === 'end' && depth > 0) depth--;
+      else if (t === sourceElse && depth === 0) {
+        elseIdx = i;
+        break;
+      }
+    }
+
+    if (elseIdx === -1) {
+      const body = bodyTokens.join(' ');
+      return body ? this.transform(body) : '';
+    }
+
+    const thenBranch = bodyTokens.slice(0, elseIdx).join(' ');
+    const elseBranch = bodyTokens.slice(elseIdx + 1).join(' ');
+    const elseT = translateWord(bodyTokens[elseIdx], src, dst);
+
+    return [
+      thenBranch ? this.transform(thenBranch) : '',
+      elseT,
+      elseBranch ? this.transform(elseBranch) : '',
+    ]
+      .filter(s => s.length > 0)
+      .join(' ');
   }
 
   /**

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -36,6 +36,14 @@ import { eventNameTranslations } from '../patterns/event-handler';
 import { render as renderExplicitFn } from '../explicit/renderer';
 import { parseExplicit as parseExplicitFn } from '../explicit/parser';
 
+/**
+ * Block-introducing command actions: their tokens are a condition/clause plus a
+ * branch body, not a flat argument list. When a fused event pattern captures one
+ * of these as the handler action, the trailing body must be parsed separately
+ * (see `buildEventHandler`).
+ */
+const BLOCK_BODY_ACTIONS = new Set(['if', 'unless', 'while', 'repeat', 'for']);
+
 // =============================================================================
 // Parse Error with Diagnostics (Phase 3.4)
 // =============================================================================
@@ -340,7 +348,21 @@ export class SemanticParserImpl implements ISemanticParser {
       const nextToken = tokens.peek();
       const hasTrailingThenChain = !!nextToken && this.isThenKeyword(nextToken.value, language);
 
-      if (hasContinuesMarker || hasTrailingThenChain) {
+      // A fused VSO/SVO event pattern can capture a *block* command (if/unless/
+      // while/repeat/for) as the action but leave the block's condition and branch
+      // body unconsumed — and, unlike a simple command, those trailing tokens are
+      // *not* bridged by a then-marker (`on click if <cond> show … else … end`).
+      // Without this, the whole block body is dropped and the handler collapses to
+      // a bare `if` (a degenerate parse — see fidelity ratchet). Parse the remainder
+      // as body commands and append them as siblings (the condition tokens and
+      // `else` are skipped as non-commands), mirroring how the English event-body
+      // path flattens an if/else block. Gated to a trailing token that isn't the
+      // block's own `end`, so an empty block is left untouched.
+      const isBlockBodyAction = BLOCK_BODY_ACTIONS.has(actionName);
+      const hasBlockBody =
+        isBlockBodyAction && !!nextToken && !this.isEndKeyword(nextToken.value, language);
+
+      if (hasContinuesMarker || hasTrailingThenChain || hasBlockBody) {
         // Parse remaining tokens as additional commands
         const commandPatterns = getPatternsForLanguage(language)
           .filter(p => p.command !== 'on')
@@ -927,13 +949,19 @@ export class SemanticParserImpl implements ISemanticParser {
     commandPatterns: LanguagePattern[],
     language: string
   ): SemanticNode | null {
-    // Only try if the input contains then-keywords (otherwise single-command already tried)
+    // Only try if the input has a clause-joining keyword (otherwise single-command
+    // already tried). A then-keyword joins sequential commands; an else-keyword
+    // joins an `if … else …` block whose branches carry no `then` between them
+    // (the if/else block-mask transform emits `<thenBranch> else <elseBranch>`),
+    // which would otherwise leave the whole handler unparsed when the event itself
+    // isn't recognized.
     const allTokens = tokens.tokens;
     const hasThenKeyword = allTokens.some(
       t =>
         t.kind === 'conjunction' || (t.kind === 'keyword' && this.isThenKeyword(t.value, language))
     );
-    if (!hasThenKeyword) return null;
+    const hasElseKeyword = allTokens.some(t => this.isElseKeyword(t.value, language));
+    if (!hasThenKeyword && !hasElseKeyword) return null;
 
     // Reset token stream and parse using clause-based parsing
     const freshStream = new TokenStreamImpl(allTokens as LanguageToken[], language);
@@ -1339,6 +1367,22 @@ export class SemanticParserImpl implements ISemanticParser {
     };
     const keywords = thenKeywords[language] || thenKeywords.en;
     return keywords.has(value.toLowerCase());
+  }
+
+  /**
+   * Check if a token is an 'else' keyword in the given language. Derived from the
+   * language profile (primary + alternatives), with the English literal always
+   * accepted (the grammar transformer leaves `else` verbatim for profiles without
+   * an else form). Used to let the compound fallback recognize an `if … else …`
+   * block whose branches are joined by `else` rather than a then-keyword.
+   */
+  private isElseKeyword(value: string, language: string): boolean {
+    const v = value.toLowerCase();
+    if (v === 'else') return true;
+    const kw = tryGetProfile(language)?.keywords?.else;
+    if (!kw) return false;
+    if (kw.primary?.toLowerCase() === v) return true;
+    return !!kw.alternatives?.some(a => a.toLowerCase() === v);
   }
 
   /**

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -297,3 +297,62 @@ describe('German fetch keyword alignment (abrufen vs holen)', () => {
     expect(parse('holen #x', 'de').action).toBe('get');
   });
 });
+
+describe('if/else block-body in event handlers — Track 5 Tier 1', () => {
+  // A fused VSO/SVO event pattern captures a *block* command (if/unless/…) as the
+  // handler action but leaves the block's condition + branch body unconsumed — and
+  // those tokens are not bridged by a then-marker. Before the fix `buildEventHandler`
+  // dropped them, collapsing the handler to a bare `if` (degenerate parse). It now
+  // parses the remainder as body commands. Combined with the i18n `else`-split
+  // transform (`<thenBranch> else <elseBranch>`), this flips `if-exists` ar/it from
+  // degenerate to faithful. See docs-internal/MULTILINGUAL_ROADMAP.md (Track 5 Tier 1).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const n = node as Record<string, unknown>;
+    if (typeof n.action === 'string') acc.add(n.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = n[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('[ar] if-exists keeps the if + branch body (was bare if)', () => {
+    // i18n transform of `on click if #modal exists show #modal else make a
+    // <div#modal/> put it into body end` — `else` translated to وإلا, branches split.
+    const input =
+      'عند نقر إذا #modal موجود اظهر #modal وإلا اصنع a <div#modal/> ثم ضع هو إلى جسم النهاية';
+    const node = parse(input, 'ar');
+    expect(node.action).toBe('on');
+    const a = actions(node);
+    expect(a.has('if')).toBe(true);
+    expect(a.has('show')).toBe(true);
+    expect(a.has('make')).toBe(true);
+  });
+
+  it('[it] if-exists keeps the if + full branch body (was bare if)', () => {
+    const input =
+      'su clic se #modal esiste mostrare #modal altrimenti fare a <div#modal/> allora mettere esso in corpo fine';
+    const node = parse(input, 'it');
+    expect(node.action).toBe('on');
+    const a = actions(node);
+    expect(a.has('if')).toBe(true);
+    expect(a.has('show')).toBe(true);
+    expect(a.has('make')).toBe(true);
+    expect(a.has('put')).toBe(true);
+  });
+
+  it('[sw] an else-joined block still parses when the event is unrecognized', () => {
+    // sw `blur` (poteza_macho) isn't a recognized event, so input-validation only
+    // parses via the Stage-4 compound fallback. The else-split removed the `then`
+    // that used to trigger it, so the fallback now also fires on an `else` keyword —
+    // this guards against that regression (faithful → null).
+    const input =
+      'kwenye poteza_macho kama yangu thamani ni tupu ongeza .error kwa mimi sivyo ondoa .error kutoka mimi mwisho';
+    const a = actions(parse(input, 'sw'));
+    expect(a.has('if')).toBe(true);
+    expect(a.has('add')).toBe(true);
+    expect(a.has('remove')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,33 @@
 {
-  "timestamp": "2026-06-07T18:10:59.659Z",
-  "commit": "9b34d38",
+  "timestamp": "2026-06-08T16:50:58.630Z",
+  "commit": "33bdb08",
   "languages": {
     "ar": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.926808370406986,
-      "bundleSize": 399599,
+      "avgConfidence": 0.9268083704069859,
+      "avgFidelity": 0.8504357298474946,
+      "degeneratePasses": [
+        "accordion-exclusive",
+        "async-block",
+        "behavior-draggable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "copy-to-clipboard",
+        "event-debounce",
+        "focus-trap",
+        "form-submit-prevent",
+        "halt-propagation",
+        "modal-close-escape",
+        "repeat-for-each",
+        "repeat-while",
+        "socket-basic",
+        "tabs-basic",
+        "tabs-content",
+        "window-keydown"
+      ],
+      "bundleSize": 402145,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -221,6 +241,10 @@
           "success": true,
           "confidence": 1
         },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
         "window-keydown": {
           "success": true,
           "confidence": 1
@@ -266,6 +290,10 @@
           "confidence": 1
         },
         "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "unless-condition": {
           "success": true,
           "confidence": 1
         },
@@ -410,6 +438,10 @@
           "confidence": 1
         },
         "caret-var-increment": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
           "success": true,
           "confidence": 1
         },
@@ -569,10 +601,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 1
-        },
         "window-scroll": {
           "success": true,
           "confidence": 0.5
@@ -593,10 +621,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "unless-condition": {
-          "success": true,
-          "confidence": 1
-        },
         "socket-basic": {
           "success": true,
           "confidence": 0.5
@@ -604,10 +628,6 @@
         "breakpoint-command": {
           "success": true,
           "confidence": 0.5
-        },
-        "caret-var-on-target": {
-          "success": true,
-          "confidence": 1
         },
         "behavior-removable": {
           "success": false
@@ -624,37 +644,22 @@
           "success": true,
           "confidence": 0.5
         }
-      },
-      "avgFidelity": 0.8297385620915034,
-      "degeneratePasses": [
-        "accordion-exclusive",
-        "async-block",
-        "behavior-draggable",
-        "behavior-resizable",
-        "behavior-sortable",
-        "copy-to-clipboard",
-        "event-debounce",
-        "focus-trap",
-        "form-submit-prevent",
-        "halt-propagation",
-        "if-empty",
-        "if-exists",
-        "input-validation",
-        "modal-close-escape",
-        "repeat-for-each",
-        "repeat-while",
-        "socket-basic",
-        "tabs-basic",
-        "tabs-content",
-        "window-keydown"
-      ]
+      }
     },
     "bn": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8754689754689755,
-      "bundleSize": 399599,
+      "avgFidelity": 0.916883116883117,
+      "degeneratePasses": [
+        "async-block",
+        "event-once",
+        "fetch-loading-state",
+        "repeat-while",
+        "socket-basic"
+      ],
+      "bundleSize": 402145,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1272,643 +1277,14 @@
           "success": true,
           "confidence": 0.5
         }
-      },
-      "avgFidelity": 0.8922077922077924,
-      "degeneratePasses": [
-        "async-block",
-        "event-once",
-        "fetch-loading-state",
-        "if-empty",
-        "if-exists",
-        "input-validation",
-        "repeat-while",
-        "socket-basic"
-      ]
+      }
     },
     "de": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9367465504720396,
-      "bundleSize": 399599,
-      "patterns": {
-        "add-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "add-class-to-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-attribute": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-style": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-content-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-before": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-after": {
-          "success": true,
-          "confidence": 1
-        },
-        "append-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "multiple-events": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "default-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "async-block": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-aria": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-mirror": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-char-count": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-clear": {
-          "success": true,
-          "confidence": 1
-        },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-color-variable": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-color": {
-          "success": true,
-          "confidence": 1
-        },
-        "next-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-once": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-debounce": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-throttle": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-loading-state": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 1
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 1
-        },
-        "fade-out-remove": {
-          "success": true,
-          "confidence": 1
-        },
-        "two-way-binding": {
-          "success": true,
-          "confidence": 1
-        },
-        "computed-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-inner-html-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "chained-access-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-attribute-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-interpolation": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-list-build": {
-          "success": true,
-          "confidence": 1
-        },
-        "eventsource-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "socket-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "socket-send": {
-          "success": true,
-          "confidence": 1
-        },
-        "worker-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event-to-form": {
-          "success": true,
-          "confidence": 1
-        },
-        "on-custom-event-receive": {
-          "success": true,
-          "confidence": 1
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 1
-        },
-        "breakpoint-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-derived-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-multiple-deps": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-value-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-multiple-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-auto-detect": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-two-way": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-explicit-property": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-non-form-display": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-on-target": {
-          "success": true,
-          "confidence": 1
-        },
-        "intercept-cache-strategies": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "toggle-class-on-other": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "toggle-visibility": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "settle-animations": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "send-with-detail": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "trigger-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-url": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "last-in-collection": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "slide-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "toggle-aria-expanded": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "install-behavior": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "behavior-removable": {
-          "success": false
-        },
-        "behavior-draggable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-sortable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-resizable": {
-          "success": true,
-          "confidence": 0.5
-        }
-      },
-      "avgFidelity": 0.8706971677559915,
+      "avgFidelity": 0.8826797385620916,
       "degeneratePasses": [
         "async-block",
         "behavior-draggable",
@@ -1917,14 +1293,632 @@
         "first-in-parent",
         "form-submit-prevent",
         "if-empty"
-      ]
+      ],
+      "bundleSize": 402145,
+      "patterns": {
+        "add-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-to-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-content-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-before": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-after": {
+          "success": true,
+          "confidence": 1
+        },
+        "append-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "multiple-events": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "async-block": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-mirror": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-clear": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-color-variable": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
+        "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-once": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-debounce": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-throttle": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 1
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
+          "success": true,
+          "confidence": 1
+        },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 1
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-inner-html-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-interpolation": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-list-build": {
+          "success": true,
+          "confidence": 1
+        },
+        "eventsource-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-send": {
+          "success": true,
+          "confidence": 1
+        },
+        "worker-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "on-custom-event-receive": {
+          "success": true,
+          "confidence": 1
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 1
+        },
+        "breakpoint-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-multiple-deps": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-value-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-multiple-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-auto-detect": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-two-way": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
+          "success": true,
+          "confidence": 1
+        },
+        "intercept-cache-strategies": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-on-other": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "settle-animations": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "send-with-detail": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "trigger-event": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "closest-ancestor": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "slide-toggle": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "install-behavior": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "behavior-removable": {
+          "success": false
+        },
+        "behavior-draggable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-sortable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-resizable": {
+          "success": true,
+          "confidence": 0.5
+        }
+      }
     },
     "en": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 399599,
+      "bundleSize": 402145,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2549,7 +2543,9 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 399599,
+      "avgFidelity": 0.9089324618736385,
+      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
+      "bundleSize": 402145,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3166,633 +3162,13 @@
           "success": true,
           "confidence": 0.5
         }
-      },
-      "avgFidelity": 0.9089324618736385,
-      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"]
+      }
     },
     "fr": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 399599,
-      "patterns": {
-        "toggle-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-class-on-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "add-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "add-class-to-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-attribute": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-style": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-content-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-before": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-after": {
-          "success": true,
-          "confidence": 1
-        },
-        "append-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-visibility": {
-          "success": true,
-          "confidence": 1
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 1
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "settle-animations": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-with-detail": {
-          "success": true,
-          "confidence": 1
-        },
-        "trigger-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "multiple-events": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 1
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 1
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 1
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 1
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 1
-        },
-        "go-url": {
-          "success": true,
-          "confidence": 1
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "default-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 1
-        },
-        "async-block": {
-          "success": true,
-          "confidence": 1
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-aria": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 1
-        },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 1
-        },
-        "dropdown-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-mirror": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-char-count": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-clear": {
-          "success": true,
-          "confidence": 1
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 1
-        },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 1
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-color-variable": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-color": {
-          "success": true,
-          "confidence": 1
-        },
-        "next-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 1
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 1
-        },
-        "last-in-collection": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-once": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-debounce": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-throttle": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-loading-state": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 1
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 1
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 1
-        },
-        "fade-out-remove": {
-          "success": true,
-          "confidence": 1
-        },
-        "slide-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 1
-        },
-        "two-way-binding": {
-          "success": true,
-          "confidence": 1
-        },
-        "computed-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-aria-expanded": {
-          "success": true,
-          "confidence": 1
-        },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-inner-html-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "chained-access-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-attribute-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 1
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-interpolation": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-list-build": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 1
-        },
-        "eventsource-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "socket-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "socket-send": {
-          "success": true,
-          "confidence": 1
-        },
-        "worker-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event-to-form": {
-          "success": true,
-          "confidence": 1
-        },
-        "on-custom-event-receive": {
-          "success": true,
-          "confidence": 1
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 1
-        },
-        "breakpoint-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 1
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 1
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-derived-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-multiple-deps": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-value-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-multiple-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-auto-detect": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-two-way": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-explicit-property": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-non-form-display": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-on-target": {
-          "success": true,
-          "confidence": 1
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 1
-        },
-        "intercept-cache-strategies": {
-          "success": true,
-          "confidence": 1
-        },
-        "install-behavior": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "behavior-removable": {
-          "success": false
-        },
-        "behavior-draggable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-sortable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-resizable": {
-          "success": true,
-          "confidence": 0.5
-        }
-      },
       "avgFidelity": 0.880174291938998,
       "degeneratePasses": [
         "async-block",
@@ -3801,14 +3177,640 @@
         "behavior-sortable",
         "fetch-with-headers",
         "first-in-parent"
-      ]
+      ],
+      "bundleSize": 402145,
+      "patterns": {
+        "toggle-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-class-on-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-to-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-content-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-before": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-after": {
+          "success": true,
+          "confidence": 1
+        },
+        "append-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "settle-animations": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-with-detail": {
+          "success": true,
+          "confidence": 1
+        },
+        "trigger-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "multiple-events": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 1
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 1
+        },
+        "async-block": {
+          "success": true,
+          "confidence": 1
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-mirror": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-clear": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 1
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-color-variable": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
+        "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
+          "success": true,
+          "confidence": 1
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 1
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-once": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-debounce": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-throttle": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 1
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 1
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
+          "success": true,
+          "confidence": 1
+        },
+        "slide-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 1
+        },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 1
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-inner-html-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-interpolation": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-list-build": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 1
+        },
+        "eventsource-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-send": {
+          "success": true,
+          "confidence": 1
+        },
+        "worker-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "on-custom-event-receive": {
+          "success": true,
+          "confidence": 1
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 1
+        },
+        "breakpoint-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 1
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 1
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-multiple-deps": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-value-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-multiple-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-auto-detect": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-two-way": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
+          "success": true,
+          "confidence": 1
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 1
+        },
+        "intercept-cache-strategies": {
+          "success": true,
+          "confidence": 1
+        },
+        "install-behavior": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "behavior-removable": {
+          "success": false
+        },
+        "behavior-draggable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-sortable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-resizable": {
+          "success": true,
+          "confidence": 0.5
+        }
+      }
     },
     "he": {
       "parseSuccess": 150,
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
-      "avgConfidence": 0.8510052910052915,
-      "bundleSize": 399599,
+      "avgConfidence": 0.8521904761904767,
+      "avgFidelity": 0.8082222222222223,
+      "degeneratePasses": [
+        "fetch-do-not-throw",
+        "fetch-json",
+        "if-empty",
+        "template-literal-list-build",
+        "unless-condition"
+      ],
+      "bundleSize": 402145,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -3883,6 +3885,10 @@
           "confidence": 1
         },
         "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
           "success": true,
           "confidence": 1
         },
@@ -4402,10 +4408,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "caret-var-on-target": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "reactive-array-push": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -4422,643 +4424,14 @@
         "behavior-resizable": {
           "success": false
         }
-      },
-      "avgFidelity": 0.7901111111111112,
-      "degeneratePasses": [
-        "fetch-do-not-throw",
-        "fetch-json",
-        "if-empty",
-        "if-exists",
-        "input-validation",
-        "template-literal-list-build",
-        "unless-condition"
-      ]
+      }
     },
     "hi": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 399599,
-      "patterns": {
-        "toggle-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-class-on-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "add-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "add-class-to-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-attribute": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-style": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-content-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-before": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-after": {
-          "success": true,
-          "confidence": 1
-        },
-        "append-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-visibility": {
-          "success": true,
-          "confidence": 1
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 1
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "settle-animations": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-with-detail": {
-          "success": true,
-          "confidence": 1
-        },
-        "trigger-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "multiple-events": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 1
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 1
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 1
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 1
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 1
-        },
-        "go-url": {
-          "success": true,
-          "confidence": 1
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "default-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "install-behavior": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 1
-        },
-        "async-block": {
-          "success": true,
-          "confidence": 1
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-aria": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 1
-        },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 1
-        },
-        "dropdown-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-mirror": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-char-count": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-clear": {
-          "success": true,
-          "confidence": 1
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 1
-        },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 1
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-color-variable": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-color": {
-          "success": true,
-          "confidence": 1
-        },
-        "next-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 1
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 1
-        },
-        "last-in-collection": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-once": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-debounce": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-throttle": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-loading-state": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 1
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 1
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 1
-        },
-        "fade-out-remove": {
-          "success": true,
-          "confidence": 1
-        },
-        "slide-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 1
-        },
-        "two-way-binding": {
-          "success": true,
-          "confidence": 1
-        },
-        "computed-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-aria-expanded": {
-          "success": true,
-          "confidence": 1
-        },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-inner-html-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "chained-access-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-attribute-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 1
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-interpolation": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-list-build": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 1
-        },
-        "eventsource-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "socket-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "socket-send": {
-          "success": true,
-          "confidence": 1
-        },
-        "worker-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event-to-form": {
-          "success": true,
-          "confidence": 1
-        },
-        "on-custom-event-receive": {
-          "success": true,
-          "confidence": 1
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 1
-        },
-        "breakpoint-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 1
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 1
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-derived-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-multiple-deps": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-value-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-multiple-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-auto-detect": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-two-way": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-explicit-property": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-non-form-display": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-on-target": {
-          "success": true,
-          "confidence": 1
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 1
-        },
-        "intercept-cache-strategies": {
-          "success": true,
-          "confidence": 1
-        },
-        "behavior-removable": {
-          "success": true,
-          "confidence": 1
-        },
-        "behavior-draggable": {
-          "success": true,
-          "confidence": 1
-        },
-        "behavior-sortable": {
-          "success": true,
-          "confidence": 1
-        },
-        "behavior-resizable": {
-          "success": true,
-          "confidence": 1
-        }
-      },
-      "avgFidelity": 0.8169913419913423,
+      "avgFidelity": 0.8423160173160175,
       "degeneratePasses": [
         "bind-auto-detect",
         "bind-explicit-property",
@@ -5066,654 +4439,1272 @@
         "bind-two-way",
         "eventsource-basic",
         "fetch-loading-state",
-        "if-empty",
-        "if-exists",
-        "input-validation",
         "install-behavior",
         "intercept-cache-strategies",
         "live-derived-value",
         "live-multiple-deps",
         "socket-basic",
         "worker-basic"
-      ]
+      ],
+      "bundleSize": 402145,
+      "patterns": {
+        "toggle-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-class-on-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-to-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-content-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-before": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-after": {
+          "success": true,
+          "confidence": 1
+        },
+        "append-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "settle-animations": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-with-detail": {
+          "success": true,
+          "confidence": 1
+        },
+        "trigger-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "multiple-events": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 1
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "install-behavior": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 1
+        },
+        "async-block": {
+          "success": true,
+          "confidence": 1
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-mirror": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-clear": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 1
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-color-variable": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
+        "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
+          "success": true,
+          "confidence": 1
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 1
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-once": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-debounce": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-throttle": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 1
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 1
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
+          "success": true,
+          "confidence": 1
+        },
+        "slide-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 1
+        },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 1
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-inner-html-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-interpolation": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-list-build": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 1
+        },
+        "eventsource-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-send": {
+          "success": true,
+          "confidence": 1
+        },
+        "worker-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "on-custom-event-receive": {
+          "success": true,
+          "confidence": 1
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 1
+        },
+        "breakpoint-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 1
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 1
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-multiple-deps": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-value-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-multiple-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-auto-detect": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-two-way": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
+          "success": true,
+          "confidence": 1
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 1
+        },
+        "intercept-cache-strategies": {
+          "success": true,
+          "confidence": 1
+        },
+        "behavior-removable": {
+          "success": true,
+          "confidence": 1
+        },
+        "behavior-draggable": {
+          "success": true,
+          "confidence": 1
+        },
+        "behavior-sortable": {
+          "success": true,
+          "confidence": 1
+        },
+        "behavior-resizable": {
+          "success": true,
+          "confidence": 1
+        }
+      }
     },
     "id": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "bundleSize": 399599,
-      "patterns": {
-        "toggle-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-class-on-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "add-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "add-class-to-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-attribute": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-style": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-content-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-before": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-after": {
-          "success": true,
-          "confidence": 1
-        },
-        "append-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-visibility": {
-          "success": true,
-          "confidence": 1
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 1
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "settle-animations": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-with-detail": {
-          "success": true,
-          "confidence": 1
-        },
-        "trigger-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "multiple-events": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 1
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 1
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 1
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 1
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 1
-        },
-        "go-url": {
-          "success": true,
-          "confidence": 1
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "default-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 1
-        },
-        "async-block": {
-          "success": true,
-          "confidence": 1
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-aria": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 1
-        },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 1
-        },
-        "dropdown-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-mirror": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-char-count": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-clear": {
-          "success": true,
-          "confidence": 1
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 1
-        },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 1
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-color-variable": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-color": {
-          "success": true,
-          "confidence": 1
-        },
-        "next-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 1
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 1
-        },
-        "last-in-collection": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-once": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-debounce": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-throttle": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-loading-state": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 1
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 1
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 1
-        },
-        "fade-out-remove": {
-          "success": true,
-          "confidence": 1
-        },
-        "slide-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 1
-        },
-        "two-way-binding": {
-          "success": true,
-          "confidence": 1
-        },
-        "computed-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-aria-expanded": {
-          "success": true,
-          "confidence": 1
-        },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-inner-html-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "chained-access-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-attribute-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 1
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-interpolation": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-list-build": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 1
-        },
-        "eventsource-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "socket-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "socket-send": {
-          "success": true,
-          "confidence": 1
-        },
-        "worker-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event-to-form": {
-          "success": true,
-          "confidence": 1
-        },
-        "on-custom-event-receive": {
-          "success": true,
-          "confidence": 1
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 1
-        },
-        "breakpoint-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 1
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 1
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-derived-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-multiple-deps": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-value-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-multiple-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-auto-detect": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-two-way": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-explicit-property": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-non-form-display": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-on-target": {
-          "success": true,
-          "confidence": 1
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 1
-        },
-        "intercept-cache-strategies": {
-          "success": true,
-          "confidence": 1
-        },
-        "install-behavior": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "behavior-removable": {
-          "success": false
-        },
-        "behavior-draggable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-sortable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-resizable": {
-          "success": true,
-          "confidence": 0.5
-        }
-      },
       "avgFidelity": 0.8175381263616558,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
         "behavior-sortable",
         "unless-condition"
-      ]
+      ],
+      "bundleSize": 402145,
+      "patterns": {
+        "toggle-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-class-on-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-to-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-content-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-before": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-after": {
+          "success": true,
+          "confidence": 1
+        },
+        "append-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "settle-animations": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-with-detail": {
+          "success": true,
+          "confidence": 1
+        },
+        "trigger-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "multiple-events": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 1
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 1
+        },
+        "async-block": {
+          "success": true,
+          "confidence": 1
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-mirror": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-clear": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 1
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-color-variable": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
+        "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
+          "success": true,
+          "confidence": 1
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 1
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-once": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-debounce": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-throttle": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 1
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 1
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
+          "success": true,
+          "confidence": 1
+        },
+        "slide-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 1
+        },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 1
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-inner-html-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-interpolation": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-list-build": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 1
+        },
+        "eventsource-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-send": {
+          "success": true,
+          "confidence": 1
+        },
+        "worker-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "on-custom-event-receive": {
+          "success": true,
+          "confidence": 1
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 1
+        },
+        "breakpoint-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 1
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 1
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-multiple-deps": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-value-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-multiple-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-auto-detect": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-two-way": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
+          "success": true,
+          "confidence": 1
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 1
+        },
+        "intercept-cache-strategies": {
+          "success": true,
+          "confidence": 1
+        },
+        "install-behavior": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "behavior-removable": {
+          "success": false
+        },
+        "behavior-draggable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-sortable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-resizable": {
+          "success": true,
+          "confidence": 0.5
+        }
+      }
     },
     "it": {
       "parseSuccess": 150,
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9976296296296296,
-      "bundleSize": 399599,
+      "avgFidelity": 0.9026666666666668,
+      "degeneratePasses": ["async-block", "fetch-loading-state", "form-submit-prevent"],
+      "bundleSize": 402145,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6327,642 +6318,14 @@
         "behavior-resizable": {
           "success": false
         }
-      },
-      "avgFidelity": 0.8700000000000003,
-      "degeneratePasses": [
-        "async-block",
-        "fetch-loading-state",
-        "form-submit-prevent",
-        "if-empty",
-        "if-exists",
-        "input-validation"
-      ]
+      }
     },
     "ja": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8443001443001442,
-      "bundleSize": 399599,
-      "patterns": {
-        "toggle-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-class-on-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "add-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "add-class-to-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-attribute": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-style": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-content-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-visibility": {
-          "success": true,
-          "confidence": 1
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 1
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "settle-animations": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "trigger-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 1
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 1
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 1
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 1
-        },
-        "go-url": {
-          "success": true,
-          "confidence": 1
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-aria": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 1
-        },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 1
-        },
-        "dropdown-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-mirror": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-char-count": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-clear": {
-          "success": true,
-          "confidence": 1
-        },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-color": {
-          "success": true,
-          "confidence": 1
-        },
-        "next-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 1
-        },
-        "last-in-collection": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-once": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-debounce": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-throttle": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-loading-state": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 1
-        },
-        "fade-out-remove": {
-          "success": true,
-          "confidence": 1
-        },
-        "slide-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-aria-expanded": {
-          "success": true,
-          "confidence": 1
-        },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-inner-html-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "chained-access-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-attribute-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 1
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-interpolation": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-list-build": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 1
-        },
-        "socket-send": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event-to-form": {
-          "success": true,
-          "confidence": 1
-        },
-        "on-custom-event-receive": {
-          "success": true,
-          "confidence": 1
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-derived-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-multiple-deps": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-value-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-multiple-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-auto-detect": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-two-way": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-explicit-property": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-non-form-display": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 1
-        },
-        "install-behavior": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.6
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.6
-        },
-        "put-before": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "put-after": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "append-content": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "send-with-detail": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "multiple-events": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "default-value": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "async-block": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-color-variable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "two-way-binding": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "computed-value": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "eventsource-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "socket-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "worker-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "breakpoint-command": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "caret-var-on-target": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "intercept-cache-strategies": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-removable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-draggable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-sortable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-resizable": {
-          "success": true,
-          "confidence": 0.5
-        }
-      },
-      "avgFidelity": 0.8279220779220781,
+      "avgConfidence": 0.8475468975468975,
+      "avgFidelity": 0.8387445887445889,
       "degeneratePasses": [
         "announce-screen-reader",
         "behavior-draggable",
@@ -6978,16 +6341,118 @@
         "if-empty",
         "input-validation",
         "socket-basic"
-      ]
-    },
-    "ko": {
-      "parseSuccess": 154,
-      "parseFailure": 0,
-      "parseRate": 1,
-      "avgConfidence": 0.5683261183261183,
-      "bundleSize": 399599,
+      ],
+      "bundleSize": 402145,
       "patterns": {
+        "toggle-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-class-on-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-to-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-content-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 1
+        },
         "wait-for-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "settle-animations": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "trigger-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method": {
           "success": true,
           "confidence": 1
         },
@@ -7007,19 +6472,119 @@
           "success": true,
           "confidence": 1
         },
-        "async-block": {
+        "go-url": {
           "success": true,
           "confidence": 1
         },
-        "window-scroll": {
+        "go-back": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-mirror": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-clear": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
+        "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
+          "success": true,
+          "confidence": 1
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-until-event": {
           "success": true,
           "confidence": 1
         },
         "repeat-forever": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-while": {
           "success": true,
           "confidence": 1
         },
@@ -7035,7 +6600,127 @@
           "success": true,
           "confidence": 1
         },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
+          "success": true,
+          "confidence": 1
+        },
+        "slide-toggle": {
+          "success": true,
+          "confidence": 1
+        },
         "stagger-animation": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-inner-html-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-interpolation": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-list-build": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-send": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "on-custom-event-receive": {
+          "success": true,
+          "confidence": 1
+        },
+        "take-class-from-siblings": {
           "success": true,
           "confidence": 1
         },
@@ -7044,6 +6729,14 @@
           "confidence": 1
         },
         "live-multiple-deps": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-value-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-multiple-changes": {
           "success": true,
           "confidence": 1
         },
@@ -7063,7 +6756,15 @@
           "success": true,
           "confidence": 1
         },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 1
+        },
         "caret-var-increment": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
           "success": true,
           "confidence": 1
         },
@@ -7079,46 +6780,6 @@
           "success": true,
           "confidence": 0.6
         },
-        "toggle-class-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "toggle-class-on-other": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "add-class-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "add-class-to-other": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-text-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-attribute": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-style": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "put-content-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
         "put-before": {
           "success": true,
           "confidence": 0.5
@@ -7131,79 +6792,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "toggle-visibility": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "settle-animations": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "send-event": {
-          "success": true,
-          "confidence": 0.5
-        },
         "send-with-detail": {
           "success": true,
           "confidence": 0.5
         },
-        "trigger-event": {
-          "success": true,
-          "confidence": 0.5
-        },
         "multiple-events": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-with-method": {
           "success": true,
           "confidence": 0.5
         },
@@ -7219,31 +6812,7 @@
           "success": true,
           "confidence": 0.5
         },
-        "go-url": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.5
-        },
         "blur-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "get-value": {
           "success": true,
           "confidence": 0.5
         },
@@ -7251,31 +6820,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "tell-command": {
-          "success": true,
-          "confidence": 0.5
-        },
         "call-function": {
           "success": true,
           "confidence": 0.5
         },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "tabs-aria": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-open": {
+        "async-block": {
           "success": true,
           "confidence": 0.5
         },
@@ -7291,43 +6840,15 @@
           "success": true,
           "confidence": 0.5
         },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "dropdown-toggle": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "input-mirror": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "input-char-count": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "input-clear": {
-          "success": true,
-          "confidence": 0.5
-        },
         "form-submit-prevent": {
           "success": true,
           "confidence": 0.5
         },
-        "form-disable-on-submit": {
+        "window-keydown": {
           "success": true,
           "confidence": 0.5
         },
-        "window-keydown": {
+        "window-scroll": {
           "success": true,
           "confidence": 0.5
         },
@@ -7339,31 +6860,7 @@
           "success": true,
           "confidence": 0.5
         },
-        "set-opacity": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-transform": {
-          "success": true,
-          "confidence": 0.5
-        },
         "set-color-variable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "transition-color": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "next-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "closest-ancestor": {
           "success": true,
           "confidence": 0.5
         },
@@ -7371,27 +6868,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "last-in-collection": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "event-from-elsewhere": {
+        "repeat-while": {
           "success": true,
           "confidence": 0.5
         },
         "event-key-combo": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-loading-state": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-error-handling": {
           "success": true,
           "confidence": 0.5
         },
@@ -7411,14 +6892,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "fade-out-remove": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "slide-toggle": {
-          "success": true,
-          "confidence": 0.5
-        },
         "two-way-binding": {
           "success": true,
           "confidence": 0.5
@@ -7427,75 +6900,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "toggle-aria-expanded": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 0.5
-        },
         "focus-trap": {
           "success": true,
           "confidence": 0.5
         },
-        "set-text-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-inner-html-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "get-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "chained-access-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
         "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "get-attribute-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "template-literal-interpolation": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "template-literal-list-build": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "morph-form-update": {
           "success": true,
           "confidence": 0.5
         },
@@ -7507,39 +6916,7 @@
           "success": true,
           "confidence": 0.5
         },
-        "socket-send": {
-          "success": true,
-          "confidence": 0.5
-        },
         "worker-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "send-event-to-form": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "on-custom-event-receive": {
           "success": true,
           "confidence": 0.5
         },
@@ -7556,26 +6933,6 @@
           "confidence": 0.5
         },
         "pick-text-range": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "when-value-changes": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "when-multiple-changes": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "caret-var-on-target": {
           "success": true,
           "confidence": 0.5
         },
@@ -7603,7 +6960,13 @@
           "success": true,
           "confidence": 0.5
         }
-      },
+      }
+    },
+    "ko": {
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.5683261183261183,
       "avgFidelity": 0.8799783549783553,
       "degeneratePasses": [
         "async-block",
@@ -7620,144 +6983,10 @@
         "socket-basic",
         "stagger-animation",
         "window-scroll"
-      ]
-    },
-    "ms": {
-      "parseSuccess": 154,
-      "parseFailure": 0,
-      "parseRate": 1,
-      "avgConfidence": 0.9988455988455989,
-      "bundleSize": 399599,
+      ],
+      "bundleSize": 402145,
       "patterns": {
-        "toggle-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-class-on-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "add-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "add-class-to-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-attribute": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-style": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-content-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-before": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-after": {
-          "success": true,
-          "confidence": 1
-        },
-        "append-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-visibility": {
-          "success": true,
-          "confidence": 1
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 1
-        },
         "wait-for-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "settle-animations": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-with-detail": {
-          "success": true,
-          "confidence": 1
-        },
-        "trigger-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "multiple-events": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-method": {
           "success": true,
           "confidence": 1
         },
@@ -7773,59 +7002,7 @@
           "success": true,
           "confidence": 1
         },
-        "if-condition": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 1
-        },
         "repeat-for-each": {
-          "success": true,
-          "confidence": 1
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 1
-        },
-        "go-url": {
-          "success": true,
-          "confidence": 1
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "default-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "call-function": {
           "success": true,
           "confidence": 1
         },
@@ -7833,131 +7010,7 @@
           "success": true,
           "confidence": 1
         },
-        "js-inline": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-aria": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 1
-        },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 1
-        },
-        "dropdown-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-mirror": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-char-count": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-clear": {
-          "success": true,
-          "confidence": 1
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 1
-        },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 1
-        },
         "window-scroll": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 1
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-color-variable": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-color": {
-          "success": true,
-          "confidence": 1
-        },
-        "next-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 1
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 1
-        },
-        "last-in-collection": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-until-event": {
           "success": true,
           "confidence": 1
         },
@@ -7981,195 +7034,7 @@
           "success": true,
           "confidence": 1
         },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-loading-state": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 1
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 1
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 1
-        },
-        "fade-out-remove": {
-          "success": true,
-          "confidence": 1
-        },
-        "slide-toggle": {
-          "success": true,
-          "confidence": 1
-        },
         "stagger-animation": {
-          "success": true,
-          "confidence": 1
-        },
-        "two-way-binding": {
-          "success": true,
-          "confidence": 1
-        },
-        "computed-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-aria-expanded": {
-          "success": true,
-          "confidence": 1
-        },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-inner-html-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "chained-access-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-attribute-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 1
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-interpolation": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-list-build": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 1
-        },
-        "eventsource-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "socket-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "socket-send": {
-          "success": true,
-          "confidence": 1
-        },
-        "worker-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event-to-form": {
-          "success": true,
-          "confidence": 1
-        },
-        "on-custom-event-receive": {
-          "success": true,
-          "confidence": 1
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 1
-        },
-        "breakpoint-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 1
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 1
-        },
-        "take-class-from-siblings": {
           "success": true,
           "confidence": 1
         },
@@ -8178,14 +7043,6 @@
           "confidence": 1
         },
         "live-multiple-deps": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-value-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-multiple-changes": {
           "success": true,
           "confidence": 1
         },
@@ -8205,47 +7062,553 @@
           "success": true,
           "confidence": 1
         },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 1
-        },
         "caret-var-increment": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-on-target": {
-          "success": true,
-          "confidence": 1
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 1
-        },
-        "intercept-cache-strategies": {
-          "success": true,
-          "confidence": 1
-        },
-        "behavior-removable": {
-          "success": true,
-          "confidence": 1
-        },
-        "behavior-draggable": {
-          "success": true,
-          "confidence": 1
-        },
-        "behavior-sortable": {
-          "success": true,
-          "confidence": 1
-        },
-        "behavior-resizable": {
           "success": true,
           "confidence": 1
         },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.6
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.6
+        },
+        "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "toggle-class-on-other": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "add-class-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "add-class-to-other": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-text-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-style": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "put-content-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "put-before": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "put-after": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "append-content": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "settle-animations": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "send-event": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "send-with-detail": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "trigger-event": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "multiple-events": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "default-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "tell-command": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "input-mirror": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "input-char-count": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "input-clear": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-color-variable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "next-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "closest-ancestor": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "fetch-loading-state": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "fade-out-remove": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "slide-toggle": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-text-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-inner-html-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "get-attribute-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "template-literal-interpolation": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "template-literal-list-build": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "eventsource-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "socket-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "socket-send": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "worker-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "send-event-to-form": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "on-custom-event-receive": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "breakpoint-command": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "when-value-changes": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "when-multiple-changes": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "caret-var-on-target": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "intercept-cache-strategies": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-removable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-draggable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-sortable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-resizable": {
+          "success": true,
+          "confidence": 0.5
         }
-      },
+      }
+    },
+    "ms": {
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.9988455988455989,
       "avgFidelity": 0.7876623376623375,
       "degeneratePasses": [
         "announce-screen-reader",
@@ -8256,14 +7619,635 @@
         "fetch-with-headers",
         "its-value-possessive-dot",
         "template-literal-list-build"
-      ]
+      ],
+      "bundleSize": 402145,
+      "patterns": {
+        "toggle-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-class-on-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-to-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-content-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-before": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-after": {
+          "success": true,
+          "confidence": 1
+        },
+        "append-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "settle-animations": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-with-detail": {
+          "success": true,
+          "confidence": 1
+        },
+        "trigger-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "multiple-events": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 1
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 1
+        },
+        "async-block": {
+          "success": true,
+          "confidence": 1
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-mirror": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-clear": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 1
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-color-variable": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
+        "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
+          "success": true,
+          "confidence": 1
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 1
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-once": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-debounce": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-throttle": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 1
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 1
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
+          "success": true,
+          "confidence": 1
+        },
+        "slide-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 1
+        },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 1
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-inner-html-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-interpolation": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-list-build": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 1
+        },
+        "eventsource-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-send": {
+          "success": true,
+          "confidence": 1
+        },
+        "worker-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "on-custom-event-receive": {
+          "success": true,
+          "confidence": 1
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 1
+        },
+        "breakpoint-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 1
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 1
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-multiple-deps": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-value-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-multiple-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-auto-detect": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-two-way": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
+          "success": true,
+          "confidence": 1
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 1
+        },
+        "intercept-cache-strategies": {
+          "success": true,
+          "confidence": 1
+        },
+        "behavior-removable": {
+          "success": true,
+          "confidence": 1
+        },
+        "behavior-draggable": {
+          "success": true,
+          "confidence": 1
+        },
+        "behavior-sortable": {
+          "success": true,
+          "confidence": 1
+        },
+        "behavior-resizable": {
+          "success": true,
+          "confidence": 1
+        },
+        "install-behavior": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        }
+      }
     },
     "pl": {
       "parseSuccess": 150,
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.8352592592592598,
-      "bundleSize": 399599,
+      "avgFidelity": 0.9076666666666667,
+      "degeneratePasses": ["first-in-parent"],
+      "bundleSize": 402145,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8877,633 +8861,13 @@
         "behavior-resizable": {
           "success": false
         }
-      },
-      "avgFidelity": 0.9076666666666667,
-      "degeneratePasses": ["first-in-parent"]
+      }
     },
     "pt": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8312273057371102,
-      "bundleSize": 399599,
-      "patterns": {
-        "window-resize": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 1
-        },
-        "eventsource-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "worker-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "on-custom-event-receive": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-derived-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-multiple-deps": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-value-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-multiple-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-auto-detect": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-two-way": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-explicit-property": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-non-form-display": {
-          "success": true,
-          "confidence": 1
-        },
-        "intercept-cache-strategies": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-class-basic": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "toggle-class-on-other": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "add-class-basic": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "add-class-to-other": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "set-text-basic": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "set-attribute": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "set-style": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "put-content-basic": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "put-before": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "put-after": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "append-content": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "toggle-visibility": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "settle-animations": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "send-event": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "send-with-detail": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "trigger-event": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "multiple-events": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "go-url": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "default-value": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "install-behavior": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "tell-command": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "async-block": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "tabs-aria": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "dropdown-toggle": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "input-mirror": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "input-char-count": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "input-clear": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "set-opacity": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "set-transform": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "set-color-variable": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "transition-color": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "next-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "last-in-collection": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "event-once": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "event-debounce": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "event-throttle": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "fetch-loading-state": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "fade-out-remove": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "slide-toggle": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "two-way-binding": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "computed-value": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "toggle-aria-expanded": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "set-text-possessive-dot": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "set-inner-html-possessive-dot": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "get-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "chained-access-possessive-dot": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "get-attribute-possessive-dot": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "template-literal-interpolation": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "template-literal-list-build": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "socket-send": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "send-event-to-form": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "breakpoint-command": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "caret-var-on-target": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "socket-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-removable": {
-          "success": false
-        },
-        "behavior-draggable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-sortable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-resizable": {
-          "success": true,
-          "confidence": 0.5
-        }
-      },
       "avgFidelity": 0.8657952069716778,
       "degeneratePasses": [
         "async-block",
@@ -9514,260 +8878,30 @@
         "first-in-parent",
         "focus-trap",
         "socket-basic"
-      ]
-    },
-    "qu": {
-      "parseSuccess": 154,
-      "parseFailure": 0,
-      "parseRate": 1,
-      "avgConfidence": 0.7326118326118326,
-      "bundleSize": 399599,
+      ],
+      "bundleSize": 402145,
       "patterns": {
-        "toggle-class-basic": {
+        "window-resize": {
           "success": true,
           "confidence": 1
         },
-        "toggle-class-on-other": {
+        "repeat-until-event": {
           "success": true,
           "confidence": 1
         },
-        "add-class-basic": {
+        "announce-screen-reader": {
           "success": true,
           "confidence": 1
         },
-        "add-class-to-other": {
+        "eventsource-basic": {
           "success": true,
           "confidence": 1
         },
-        "remove-element": {
+        "worker-basic": {
           "success": true,
           "confidence": 1
         },
-        "make-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-visibility": {
-          "success": true,
-          "confidence": 1
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 1
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "settle-animations": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 1
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 1
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 1
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 1
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "async-block": {
-          "success": true,
-          "confidence": 1
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 1
-        },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "dropdown-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-color": {
-          "success": true,
-          "confidence": 1
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-once": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-loading-state": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 1
-        },
-        "slide-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-aria-expanded": {
-          "success": true,
-          "confidence": 1
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 1
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 1
-        },
-        "socket-send": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event-to-form": {
-          "success": true,
-          "confidence": 1
-        },
-        "breakpoint-command": {
+        "on-custom-event-receive": {
           "success": true,
           "confidence": 1
         },
@@ -9803,329 +8937,552 @@
           "success": true,
           "confidence": 1
         },
-        "caret-var-increment": {
+        "intercept-cache-strategies": {
           "success": true,
           "confidence": 1
         },
-        "install-behavior": {
+        "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "toggle-class-on-other": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "add-class-basic": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "add-class-to-other": {
           "success": true,
           "confidence": 0.8222222222222222
         },
         "remove-class-basic": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "remove-class-from-all": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "set-text-basic": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "set-attribute": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "set-style": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "put-content-basic": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "put-before": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "put-after": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "append-content": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "swap-content": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "transition-opacity": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "settle-animations": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "send-event": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "send-with-detail": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "trigger-event": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "multiple-events": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "repeat-times": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "halt-propagation": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "go-url": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "blur-element": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "get-value": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "default-value": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "install-behavior": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "tell-command": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "call-function": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "async-block": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "tabs-basic": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "tabs-content": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "tabs-aria": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "modal-close-button": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "modal-close-escape": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "accordion-exclusive": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "dropdown-close-outside": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "input-mirror": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "input-char-count": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "input-clear": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "form-submit-prevent": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "form-disable-on-submit": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "window-keydown": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "window-scroll": {
           "success": true,
-          "confidence": 0.5
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "document-ready": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "set-opacity": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "set-transform": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "set-color-variable": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "next-element": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "previous-element": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "closest-ancestor": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "first-in-parent": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "last-in-collection": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
-        "repeat-until-event": {
+        "repeat-forever": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "repeat-while": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "event-once": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "event-debounce": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "event-throttle": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "event-from-elsewhere": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "event-key-combo": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "fetch-loading-state": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "unless-condition": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "copy-to-clipboard": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "fade-out-remove": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "slide-toggle": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "two-way-binding": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "computed-value": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
-        "announce-screen-reader": {
+        "toggle-aria-expanded": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "focus-trap": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "set-text-possessive-dot": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "set-inner-html-possessive-dot": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "get-value-possessive-dot": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "method-call-possessive-dot": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "chained-access-possessive-dot": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "optional-chaining-possessive": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "get-attribute-possessive-dot": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "template-literal-interpolation": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
         "template-literal-list-build": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
         },
-        "eventsource-basic": {
+        "morph-fetch-result": {
           "success": true,
-          "confidence": 0.5
+          "confidence": 0.8222222222222222
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "socket-send": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "send-event-to-form": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "breakpoint-command": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "caret-var-on-target": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.8222222222222222
         },
         "socket-basic": {
           "success": true,
           "confidence": 0.5
         },
-        "worker-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "on-custom-event-receive": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "caret-var-on-target": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "intercept-cache-strategies": {
-          "success": true,
-          "confidence": 0.5
-        },
         "behavior-removable": {
-          "success": true,
-          "confidence": 0.5
+          "success": false
         },
         "behavior-draggable": {
           "success": true,
@@ -10139,8 +9496,14 @@
           "success": true,
           "confidence": 0.5
         }
-      },
-      "avgFidelity": 0.7492424242424243,
+      }
+    },
+    "qu": {
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.7326118326118326,
+      "avgFidelity": 0.7660173160173162,
       "degeneratePasses": [
         "async-block",
         "behavior-draggable",
@@ -10149,9 +9512,6 @@
         "behavior-sortable",
         "event-once",
         "get-value",
-        "if-empty",
-        "if-exists",
-        "input-validation",
         "modal-close-escape",
         "render-template-with-data",
         "repeat-for-each",
@@ -10160,14 +9520,635 @@
         "socket-basic",
         "stagger-animation",
         "template-literal-list-build"
-      ]
+      ],
+      "bundleSize": 402145,
+      "patterns": {
+        "toggle-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-class-on-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-to-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "settle-animations": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 1
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "async-block": {
+          "success": true,
+          "confidence": 1
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-once": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 1
+        },
+        "slide-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 1
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-send": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "breakpoint-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-multiple-deps": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-value-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-multiple-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-auto-detect": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-two-way": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 1
+        },
+        "install-behavior": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-text-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-style": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "put-content-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "put-before": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "put-after": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "append-content": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "send-with-detail": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "trigger-event": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "multiple-events": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "default-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "input-mirror": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "input-char-count": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "input-clear": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-color-variable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "next-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "event-debounce": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "event-throttle": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "fade-out-remove": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-text-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-inner-html-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "get-attribute-possessive-dot": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "template-literal-interpolation": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "template-literal-list-build": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "eventsource-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "socket-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "worker-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "on-custom-event-receive": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "caret-var-on-target": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "intercept-cache-strategies": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-removable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-draggable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-sortable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-resizable": {
+          "success": true,
+          "confidence": 0.5
+        }
+      }
     },
     "ru": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8883529169243457,
-      "bundleSize": 399599,
+      "avgConfidence": 0.8895073180787468,
+      "avgFidelity": 0.9008658008658009,
+      "degeneratePasses": ["fetch-loading-state", "form-submit-prevent", "install-behavior"],
+      "bundleSize": 402145,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10274,6 +10255,10 @@
           "confidence": 1
         },
         "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
           "success": true,
           "confidence": 1
         },
@@ -10774,10 +10759,6 @@
           "confidence": 0.8222222222222222
         },
         "caret-var-write": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "caret-var-on-target": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -10785,641 +10766,14 @@
           "success": true,
           "confidence": 0.5555555555555556
         }
-      },
-      "avgFidelity": 0.8733766233766237,
-      "degeneratePasses": [
-        "fetch-loading-state",
-        "form-submit-prevent",
-        "if-empty",
-        "if-exists",
-        "input-validation",
-        "install-behavior",
-        "unless-condition"
-      ]
+      }
     },
     "sw": {
       "parseSuccess": 152,
       "parseFailure": 2,
       "parseRate": 0.987012987012987,
-      "avgConfidence": 0.8856620718462827,
-      "bundleSize": 399599,
-      "patterns": {
-        "add-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "add-class-to-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-attribute": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-style": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-content-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-aria": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-mirror": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-char-count": {
-          "success": true,
-          "confidence": 1
-        },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "next-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-loading-state": {
-          "success": true,
-          "confidence": 1
-        },
-        "two-way-binding": {
-          "success": true,
-          "confidence": 1
-        },
-        "computed-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-inner-html-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "chained-access-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-attribute-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-interpolation": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-list-build": {
-          "success": true,
-          "confidence": 1
-        },
-        "eventsource-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "socket-send": {
-          "success": true,
-          "confidence": 1
-        },
-        "worker-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event-to-form": {
-          "success": true,
-          "confidence": 1
-        },
-        "on-custom-event-receive": {
-          "success": true,
-          "confidence": 1
-        },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-derived-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-multiple-deps": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-value-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-multiple-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-auto-detect": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-two-way": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-explicit-property": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-non-form-display": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 1
-        },
-        "intercept-cache-strategies": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "toggle-class-on-other": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "toggle-visibility": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "settle-animations": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "send-with-detail": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "trigger-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "slide-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "toggle-aria-expanded": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "put-before": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "put-after": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "append-content": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "multiple-events": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "go-url": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "default-value": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "install-behavior": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "async-block": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "input-clear": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "set-color-variable": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "transition-color": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "last-in-collection": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "event-once": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "event-throttle": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "fade-out-remove": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "breakpoint-command": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "caret-var-on-target": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "event-debounce": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "socket-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-removable": {
-          "success": false
-        },
-        "behavior-draggable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-sortable": {
-          "success": false
-        },
-        "behavior-resizable": {
-          "success": true,
-          "confidence": 0.5
-        }
-      },
-      "avgFidelity": 0.791776315789474,
+      "avgConfidence": 0.8868316624895575,
+      "avgFidelity": 0.8075657894736844,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
@@ -11428,18 +10782,641 @@
         "focus-trap",
         "form-submit-prevent",
         "if-empty",
-        "if-exists",
         "repeat-until-event",
         "socket-basic",
         "template-literal-list-build"
-      ]
+      ],
+      "bundleSize": 402145,
+      "patterns": {
+        "add-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-to-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-content-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-mirror": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 1
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-inner-html-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-interpolation": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-list-build": {
+          "success": true,
+          "confidence": 1
+        },
+        "eventsource-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-send": {
+          "success": true,
+          "confidence": 1
+        },
+        "worker-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "on-custom-event-receive": {
+          "success": true,
+          "confidence": 1
+        },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-multiple-deps": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-value-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-multiple-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-auto-detect": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-two-way": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
+          "success": true,
+          "confidence": 1
+        },
+        "intercept-cache-strategies": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-on-other": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "settle-animations": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "send-with-detail": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "trigger-event": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "closest-ancestor": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "slide-toggle": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "put-before": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "put-after": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "append-content": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "multiple-events": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "default-value": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "install-behavior": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "async-block": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "input-clear": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "set-color-variable": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "event-once": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "event-throttle": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "fade-out-remove": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "breakpoint-command": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "event-debounce": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "socket-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-removable": {
+          "success": false
+        },
+        "behavior-draggable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-sortable": {
+          "success": false
+        },
+        "behavior-resizable": {
+          "success": true,
+          "confidence": 0.5
+        }
+      }
     },
     "th": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9402185116470816,
-      "bundleSize": 399599,
+      "avgFidelity": 0.9068181818181822,
+      "degeneratePasses": [
+        "async-block",
+        "fetch-loading-state",
+        "form-submit-prevent",
+        "window-scroll"
+      ],
+      "bundleSize": 402145,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12057,24 +12034,33 @@
           "success": true,
           "confidence": 0.8222222222222222
         }
-      },
-      "avgFidelity": 0.8750000000000006,
-      "degeneratePasses": [
-        "async-block",
-        "fetch-loading-state",
-        "form-submit-prevent",
-        "if-empty",
-        "if-exists",
-        "input-validation",
-        "window-scroll"
-      ]
+      }
     },
     "tl": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8985472977069615,
-      "bundleSize": 399599,
+      "avgConfidence": 0.8985472977069613,
+      "avgFidelity": 0.8681818181818183,
+      "degeneratePasses": [
+        "accordion-exclusive",
+        "async-block",
+        "copy-to-clipboard",
+        "event-debounce",
+        "eventsource-basic",
+        "form-submit-prevent",
+        "get-value",
+        "halt-propagation",
+        "modal-close-escape",
+        "render-template-with-data",
+        "repeat-for-each",
+        "repeat-while",
+        "tabs-basic",
+        "tabs-content",
+        "take-class-from-siblings",
+        "worker-basic"
+      ],
+      "bundleSize": 402145,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12172,6 +12158,10 @@
           "success": true,
           "confidence": 1
         },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
         "window-keydown": {
           "success": true,
           "confidence": 1
@@ -12213,6 +12203,10 @@
           "confidence": 1
         },
         "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "unless-condition": {
           "success": true,
           "confidence": 1
         },
@@ -12329,6 +12323,10 @@
           "confidence": 1
         },
         "caret-var-write": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
           "success": true,
           "confidence": 1
         },
@@ -12652,10 +12650,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 1
-        },
         "window-scroll": {
           "success": true,
           "confidence": 0.5
@@ -12672,10 +12666,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "unless-condition": {
-          "success": true,
-          "confidence": 1
-        },
         "eventsource-basic": {
           "success": true,
           "confidence": 0.5
@@ -12687,660 +12677,15 @@
         "breakpoint-command": {
           "success": true,
           "confidence": 0.5
-        },
-        "caret-var-on-target": {
-          "success": true,
-          "confidence": 1
         }
-      },
-      "avgFidelity": 0.8443722943722946,
-      "degeneratePasses": [
-        "accordion-exclusive",
-        "async-block",
-        "copy-to-clipboard",
-        "event-debounce",
-        "eventsource-basic",
-        "form-submit-prevent",
-        "get-value",
-        "halt-propagation",
-        "if-empty",
-        "if-exists",
-        "input-validation",
-        "modal-close-escape",
-        "render-template-with-data",
-        "repeat-for-each",
-        "repeat-while",
-        "tabs-basic",
-        "tabs-content",
-        "take-class-from-siblings",
-        "worker-basic"
-      ]
+      }
     },
     "tr": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8624819624819625,
-      "bundleSize": 399599,
-      "patterns": {
-        "toggle-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-class-on-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "add-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "add-class-to-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-style": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-content-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "append-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-visibility": {
-          "success": true,
-          "confidence": 1
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 1
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "settle-animations": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "trigger-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 1
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 1
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 1
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 1
-        },
-        "go-url": {
-          "success": true,
-          "confidence": 1
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "default-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "async-block": {
-          "success": true,
-          "confidence": 1
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-aria": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 1
-        },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 1
-        },
-        "dropdown-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-mirror": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-char-count": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-clear": {
-          "success": true,
-          "confidence": 1
-        },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-color": {
-          "success": true,
-          "confidence": 1
-        },
-        "next-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 1
-        },
-        "last-in-collection": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-once": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-loading-state": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 1
-        },
-        "fade-out-remove": {
-          "success": true,
-          "confidence": 1
-        },
-        "slide-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-aria-expanded": {
-          "success": true,
-          "confidence": 1
-        },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-inner-html-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "chained-access-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-attribute-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 1
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-interpolation": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-list-build": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 1
-        },
-        "socket-send": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event-to-form": {
-          "success": true,
-          "confidence": 1
-        },
-        "on-custom-event-receive": {
-          "success": true,
-          "confidence": 1
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-derived-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-multiple-deps": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-value-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-multiple-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-auto-detect": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-two-way": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-explicit-property": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-non-form-display": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 1
-        },
-        "install-behavior": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "set-attribute": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "put-before": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "put-after": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "send-with-detail": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "multiple-events": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-color-variable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "event-debounce": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "event-throttle": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "two-way-binding": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "computed-value": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "eventsource-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "socket-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "worker-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "breakpoint-command": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "caret-var-on-target": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "intercept-cache-strategies": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-removable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-draggable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-sortable": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "behavior-resizable": {
-          "success": true,
-          "confidence": 0.5
-        }
-      },
-      "avgFidelity": 0.8662337662337665,
+      "avgConfidence": 0.8657287157287157,
+      "avgFidelity": 0.8889610389610392,
       "degeneratePasses": [
         "async-block",
         "behavior-draggable",
@@ -13351,18 +12696,636 @@
         "event-once",
         "fetch-loading-state",
         "focus-trap",
-        "if-empty",
-        "if-exists",
-        "input-validation",
         "socket-basic"
-      ]
+      ],
+      "bundleSize": 402145,
+      "patterns": {
+        "toggle-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-class-on-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-to-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-content-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "append-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "settle-animations": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "trigger-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 1
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "async-block": {
+          "success": true,
+          "confidence": 1
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-mirror": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-clear": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
+        "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
+          "success": true,
+          "confidence": 1
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-once": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
+          "success": true,
+          "confidence": 1
+        },
+        "slide-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-inner-html-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-interpolation": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-list-build": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-send": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "on-custom-event-receive": {
+          "success": true,
+          "confidence": 1
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-multiple-deps": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-value-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-multiple-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-auto-detect": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-two-way": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
+          "success": true,
+          "confidence": 1
+        },
+        "install-behavior": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "put-before": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "put-after": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "send-with-detail": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "multiple-events": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "set-color-variable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "event-debounce": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "event-throttle": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "eventsource-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "socket-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "worker-basic": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "breakpoint-command": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "intercept-cache-strategies": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-removable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-draggable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-sortable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "behavior-resizable": {
+          "success": true,
+          "confidence": 0.5
+        }
+      }
     },
     "uk": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8876108018965165,
-      "bundleSize": 399599,
+      "avgConfidence": 0.8887652030509177,
+      "avgFidelity": 0.9008658008658009,
+      "degeneratePasses": ["fetch-loading-state", "form-submit-prevent", "install-behavior"],
+      "bundleSize": 402145,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13465,6 +13428,10 @@
           "confidence": 1
         },
         "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
           "success": true,
           "confidence": 1
         },
@@ -13969,10 +13936,6 @@
           "confidence": 0.8222222222222222
         },
         "caret-var-write": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "caret-var-on-target": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -13980,24 +13943,21 @@
           "success": true,
           "confidence": 0.5555555555555556
         }
-      },
-      "avgFidelity": 0.8733766233766237,
-      "degeneratePasses": [
-        "fetch-loading-state",
-        "form-submit-prevent",
-        "if-empty",
-        "if-exists",
-        "input-validation",
-        "install-behavior",
-        "unless-condition"
-      ]
+      }
     },
     "vi": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8917336631622349,
-      "bundleSize": 399599,
+      "avgConfidence": 0.892888064316636,
+      "avgFidelity": 0.8413419913419917,
+      "degeneratePasses": [
+        "fetch-loading-state",
+        "form-submit-prevent",
+        "render-template-with-data",
+        "template-literal-list-build"
+      ],
+      "bundleSize": 402145,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14104,6 +14064,10 @@
           "confidence": 1
         },
         "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
           "success": true,
           "confidence": 1
         },
@@ -14610,643 +14574,14 @@
         "caret-var-write": {
           "success": true,
           "confidence": 0.8222222222222222
-        },
-        "caret-var-on-target": {
-          "success": true,
-          "confidence": 0.8222222222222222
         }
-      },
-      "avgFidelity": 0.80952380952381,
-      "degeneratePasses": [
-        "fetch-loading-state",
-        "form-submit-prevent",
-        "if-empty",
-        "if-exists",
-        "input-validation",
-        "render-template-with-data",
-        "template-literal-list-build"
-      ]
+      }
     },
     "zh": {
       "parseSuccess": 150,
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9988148148148148,
-      "bundleSize": 399599,
-      "patterns": {
-        "toggle-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-class-on-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "add-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "add-class-to-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-attribute": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-style": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-content-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-before": {
-          "success": true,
-          "confidence": 1
-        },
-        "put-after": {
-          "success": true,
-          "confidence": 1
-        },
-        "append-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-visibility": {
-          "success": true,
-          "confidence": 1
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 1
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "settle-animations": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-with-detail": {
-          "success": true,
-          "confidence": 1
-        },
-        "trigger-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "multiple-events": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 1
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 1
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 1
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 1
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 1
-        },
-        "go-url": {
-          "success": true,
-          "confidence": 1
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "default-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 1
-        },
-        "async-block": {
-          "success": true,
-          "confidence": 1
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 1
-        },
-        "tabs-aria": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 1
-        },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 1
-        },
-        "dropdown-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-mirror": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-char-count": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-clear": {
-          "success": true,
-          "confidence": 1
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 1
-        },
-        "form-disable-on-submit": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 1
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 1
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-transform": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-color-variable": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-color": {
-          "success": true,
-          "confidence": 1
-        },
-        "next-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 1
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 1
-        },
-        "last-in-collection": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-once": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-debounce": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-throttle": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 1
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-loading-state": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 1
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 1
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 1
-        },
-        "fade-out-remove": {
-          "success": true,
-          "confidence": 1
-        },
-        "slide-toggle": {
-          "success": true,
-          "confidence": 1
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 1
-        },
-        "two-way-binding": {
-          "success": true,
-          "confidence": 1
-        },
-        "computed-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "toggle-aria-expanded": {
-          "success": true,
-          "confidence": 1
-        },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-inner-html-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "chained-access-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 1
-        },
-        "get-attribute-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 1
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-interpolation": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-list-build": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 1
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 1
-        },
-        "eventsource-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "socket-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "socket-send": {
-          "success": true,
-          "confidence": 1
-        },
-        "worker-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 1
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "send-event-to-form": {
-          "success": true,
-          "confidence": 1
-        },
-        "on-custom-event-receive": {
-          "success": true,
-          "confidence": 1
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 1
-        },
-        "breakpoint-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 1
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 1
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-derived-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "live-multiple-deps": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-value-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "when-multiple-changes": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-auto-detect": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-two-way": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-explicit-property": {
-          "success": true,
-          "confidence": 1
-        },
-        "bind-non-form-display": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 1
-        },
-        "caret-var-on-target": {
-          "success": true,
-          "confidence": 1
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 1
-        },
-        "intercept-cache-strategies": {
-          "success": true,
-          "confidence": 1
-        },
-        "install-behavior": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "behavior-removable": {
-          "success": false
-        },
-        "behavior-draggable": {
-          "success": false
-        },
-        "behavior-sortable": {
-          "success": false
-        },
-        "behavior-resizable": {
-          "success": false
-        }
-      },
       "avgFidelity": 0.7845555555555555,
       "degeneratePasses": [
         "async-block",
@@ -15258,12 +14593,627 @@
         "its-value-possessive-dot",
         "repeat-forever",
         "template-literal-list-build"
-      ]
+      ],
+      "bundleSize": 402145,
+      "patterns": {
+        "toggle-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-class-on-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-to-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-content-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-before": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-after": {
+          "success": true,
+          "confidence": 1
+        },
+        "append-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "settle-animations": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-with-detail": {
+          "success": true,
+          "confidence": 1
+        },
+        "trigger-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "multiple-events": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 1
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 1
+        },
+        "async-block": {
+          "success": true,
+          "confidence": 1
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-mirror": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-clear": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 1
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 1
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-color-variable": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
+        "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
+          "success": true,
+          "confidence": 1
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 1
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-once": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-debounce": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-throttle": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 1
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 1
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
+          "success": true,
+          "confidence": 1
+        },
+        "slide-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 1
+        },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 1
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 1
+        },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-inner-html-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-interpolation": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-list-build": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 1
+        },
+        "eventsource-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-send": {
+          "success": true,
+          "confidence": 1
+        },
+        "worker-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "on-custom-event-receive": {
+          "success": true,
+          "confidence": 1
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 1
+        },
+        "breakpoint-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 1
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 1
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-derived-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "live-multiple-deps": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-value-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "when-multiple-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-auto-detect": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-two-way": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
+          "success": true,
+          "confidence": 1
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 1
+        },
+        "intercept-cache-strategies": {
+          "success": true,
+          "confidence": 1
+        },
+        "install-behavior": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "behavior-removable": {
+          "success": false
+        },
+        "behavior-draggable": {
+          "success": false
+        },
+        "behavior-sortable": {
+          "success": false
+        },
+        "behavior-resizable": {
+          "success": false
+        }
+      }
     }
   },
   "bundles": {
     "browser-priority": {
-      "size": 399599,
+      "size": 402145,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Implements **Track 5 Tier 1** of the if-block transform arc (`docs-internal/MULTILINGUAL_ROADMAP.md`): make `if-exists` parse **faithfully** in **ar** and **it**.

The named target is cleared — `if-exists` flips from a degenerate pass (ar/it shredded to `[on, if]`, fidelity 0.40) to faithful (**ar 0.40→0.80, it 0.40→1.0**) and leaves the degenerate-pass list entirely. Because the fix lives at the parser/transform layer rather than per-pattern, it generalizes the whole if-block cluster:

- **Degenerate passes: 219 → 181 (−38)**, with `if-empty`, `input-validation`, and `unless-condition` also lifted degenerate→faithful across 13 languages.
- **Parse rate unchanged** (3672/3696), **0 fidelity regressions**, **0 parse-success ↑/↓** — confirmed by a full `browser-priority` regen + the `--regression` gate. `avgFidelity` rose for ar/bn/he/hi/it/qu/ru/sw/th/tl/tr/uk/vi, none fell.

## Root cause (two layers)

1. **Parser (`buildEventHandler`).** A fused VSO/SVO event pattern (`if-event-ar-vso`, `event-handler-it-full`, …) captures a **block** command (`if`/`unless`/…) as the handler *action*, but the block's condition + branch body are **not** bridged by a then-marker (`on click if <cond> show … else … end`). They were dropped and the handler collapsed to a bare `if`.
2. **Transformer (`transformConditionalBody`).** The if-block body was reordered as one stream, so `else` rode along glued to a selector-led clause (marked a selector → left **untranslated**) with a spurious `then` inserted around it.

## Fixes (all additive)

1. **Parser** — when the fused action is a block keyword (`if`/`unless`/`while`/`repeat`/`for`) and trailing non-`end` tokens remain, parse them as body commands and append as siblings (mirrors the English event-body path; condition tokens and `else` are skipped as non-commands). Gated to block actions, so simple-command handlers are byte-identical.
2. **Transformer** — split the if-block body at a top-level (depth-aware) `else` into then/else branches, transform each independently, and translate `else` (ar `وإلا`, it `altrimenti`, ja `そうでなければ`, ko `아니면`, de `sonst`, …).
3. **Compound-fallback gate** — the Stage-4 fallback fired only on a then-keyword. The else-split removed the `then` that some handlers leaned on when their **event isn't recognized** (sw `blur`=`poteza_macho`, so `input-validation` only ever parsed via the fallback). The gate now also fires on an `else` keyword (profile-derived `isElseKeyword`), preventing a faithful→null regression.

## Honest scope

- ar `if-exists` is 0.80 not 1.0 — `put it into body` (`ضع هو إلى جسم`) is a separate ar `put` gap.
- ja/ko `if-exists` stay 0.80 (they drop the `if` wrapper — an SOV conditional-parse gap, untouched here).
- The SOV `is <pred>` conditional class (Tier 2) remains the bigger, per-language effort, though Tier 1 already cleared its SVO/VSO slice.

## Tests

- `packages/semantic/test/multilingual-roadmap-fixes.test.ts` — ar/it `if-exists` keep the if + branch body; sw else-joined block still parses.
- `packages/i18n/src/grammar/grammar.test.ts` — ar/it/ja translate `else` (no English `else` leaks); else-less body unchanged.
- Full i18n suite (635) and semantic suite pass (the 30 `build-artifacts.test.ts` `.d.ts` failures are the known sandbox-only environmental ones).

## Validation

Per the roadmap playbook: rebuilt i18n/semantic/core, repopulated the DB, regenerated the `browser-priority` baseline (committed), verified only intended patterns flip with zero `↓`, then restored the binary DB (not committed).

https://claude.ai/code/session_01X8WsAtVfWsQfEAFWQXVxdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8WsAtVfWsQfEAFWQXVxdN)_