### PR TITLE
fix(multilingual): Track 5 Async Tier 1 — async modifier transparency

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,7 +5,8 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after Track 5 **Tier 1 — if/else block-body in event handlers** (degenerate passes **219 → 181**, −38 degenerate→faithful, 0 fidelity regressions, parse rate unchanged 3672/3696). Cleared `if-exists` entirely (ar+it flipped, the named Tier 1 target) and lifted `if-empty`/`input-validation`/`unless-condition` across 13 languages — the parser fix generalizes the whole if-block cluster. Earlier: German `fetch` keyword alignment, caret-scope masking, @attr-in-selector-role, trailing-event block-wrap, custom-event SOV, property-path patient, (parse-rate) Tier 1, Track 4, Track 1 (reactive) complete._
+_Last updated: after Track 5 **Async Tier 1 — `async` modifier transparency** (degenerate passes **181 → 176**, −5 degenerate→faithful: `async-block` ar/de/it/th/tl, 0 regressions, parse rate unchanged 3672/3696). The parser now strips the transparent `async` command-prefix before parsing (mirroring English), so the real command anchors instead of `async` being captured as the handler action. SOV (ja/ko/bn/qu/tr), zh, fr/pt (separate fetch-in-event gap), ms remain — Async Tier 2._
+_Earlier: after Track 5 **Tier 1 — if/else block-body in event handlers** (degenerate passes **219 → 181**, −38 degenerate→faithful, 0 fidelity regressions). Cleared `if-exists` entirely (ar+it flipped, the named Tier 1 target) and lifted `if-empty`/`input-validation`/`unless-condition` across 13 languages. Before that: German `fetch` keyword alignment, caret-scope masking, @attr-in-selector-role, trailing-event block-wrap, custom-event SOV, property-path patient, (parse-rate) Tier 1, Track 4, Track 1 (reactive) complete._
 
 ---
 
@@ -57,6 +58,39 @@ behaviors), not a parsing/i18n track. See Track 2.
 ---
 
 ## Shipped
+
+### Track 5 Async Tier 1 — `async` modifier transparency (−5 degenerate)
+
+- **Fidelity, not parse rate**: degenerate passes **181 → 176** (−5 degenerate→faithful:
+  `async-block` **ar, de, it, th, tl**), **0 regressions, parse rate unchanged** (3672/3696).
+  Confirmed by a full `browser-priority` regen + `--regression` gate (every flip is
+  degenerate→faithful; zero parse-success ↑/↓; zero faithful→degenerate).
+- **Root cause.** `async` is a command **modifier** (`async fetch … then …` runs the
+  following command asynchronously), not a verb — English never surfaces it as an action.
+  But the i18n transformer treats it as a verb and reorders it by word order (leading in
+  VSO, after the event in SVO, verb-final in SOV). A fused event pattern then captured
+  `async` as the handler **action**, and the real command + the `then`-chain collapsed to
+  a degenerate parse (`async-block` was degenerate in 13 langs).
+- **Fix (parser, additive).** `parse()` strips the transparent `async` keyword before
+  tokenizing (a new `stripAsyncModifier`, mirroring the existing `extractStandaloneModifiers`
+  for once/debounce/throttle), so the following command anchors as the action. Matched
+  against the profile's `async` form (primary + alternatives) + the English literal the
+  transformer passes through; gated to the async token, so non-async inputs are
+  byte-identical. tl needed a one-line passthrough-alignment (`sabay` added as a tl semantic
+  `async` alternative — the i18n tl dict emits `sabay`).
+- **Honest scope — fragments by word order, like the if-block arc.** This clears the
+  **VSO/SVO/V2** slice only. Still degenerate (Async Tier 2): **SOV** (ja*, ko, bn, qu, tr)
+  — the event sits mid-stream and the then-chain isn't recovered even with `async` gone;
+  **zh** (deeper block-body gap, same one blocking the deferred zh fetch fix); **fr/pt**
+  (a separate fetch-in-event gap — `récupérer`/`buscar` drop even *without* `async`, despite
+  being registered fetch keywords); **ms** (no grammar profile, English passthrough doesn't
+  parse). `async` execution semantics are **not yet preserved** (stripped, English-parity) —
+  re-surfacing them is Tier 2. (*ja `async-block` was already faithful at 0.67.)
+- **Unblocks** the deferred **ja/zh `fetch` keyword alignment** (correcting ja's dict
+  regressed `async-block`/ja before this) — now a clean follow-up once the SOV then-chain
+  is handled.
+- Locked by `multilingual-roadmap-fixes.test.ts` ("async modifier transparency": ar/tl keep
+  fetch+put, it recovers the real command, `async` never an action, non-async unaffected).
 
 ### Track 5 Tier 1 — if/else block-body in event handlers (−38 degenerate)
 
@@ -635,9 +669,9 @@ the fraction of the English reference parse's command actions that survive (reca
 word-order agnostic). Passes below 50% fidelity are **degenerate passes**.
 
 **Current state (committed baseline carries `avgFidelity` / `degeneratePasses`):**
-~**181 degenerate-pass instances across ~50 patterns** (was 232; −9 from the
+~**176 degenerate-pass instances across ~50 patterns** (was 232; −9 from the
 post-event then-chain fix, −4 from the de fetch keyword alignment, −38 from the
-Tier 1 if/else block-body fix — all below).
+Tier 1 if/else block-body fix, −5 from the Async Tier 1 `async`-modifier fix — all below).
 Triage (`packages/testing-framework/tools/fidelity-triage.ts`)
 confirmed the signal is **real** — these are genuinely dropped commands, not a
 metric artifact — and isolated **two roots**: (A) the i18n **transformer** scrambles
@@ -664,14 +698,14 @@ alignment, below) but the bulk remains. The remaining clusters:
 
 The remaining clusters:
 
-| Cluster                     | Examples (langs)                                                                                                |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| control-flow blocks         | `if-empty` (5), `unless-condition` (2) — `if-exists` (0) + most `if-empty`/`input-validation` cleared by Tier 1 |
-| fetch lifecycle / state     | `fetch-loading-state` (9), `fetch-with-headers` (5), `fetch-json` (4), `fetch-do-not-throw` (3)                 |
-| async / streaming           | `async-block` (13), `socket-basic` (9), `eventsource`/`worker`                                                  |
-| validation / forms          | `input-validation` (2 — was 14, cleared by Tier 1), `form-submit-prevent` (9)                                   |
-| positional / possessive-dot | `first-in-parent` (5), `its-value-possessive-dot` (4)                                                           |
-| event modifiers / behaviors | `event-debounce`/`event-once`, `behavior-*` (degenerate in the langs where they parse)                          |
+| Cluster                     | Examples (langs)                                                                                                                       |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| control-flow blocks         | `if-empty` (5), `unless-condition` (2) — `if-exists` (0) + most `if-empty`/`input-validation` cleared by Tier 1                        |
+| fetch lifecycle / state     | `fetch-loading-state` (9), `fetch-with-headers` (5), `fetch-json` (4), `fetch-do-not-throw` (3)                                        |
+| async / streaming           | `async-block` (8 — was 13, ar/de/it/th/tl cleared by Async Tier 1; SOV+zh+fr/pt+ms remain), `socket-basic` (9), `eventsource`/`worker` |
+| validation / forms          | `input-validation` (2 — was 14, cleared by Tier 1), `form-submit-prevent` (9)                                                          |
+| positional / possessive-dot | `first-in-parent` (5), `its-value-possessive-dot` (4)                                                                                  |
+| event modifiers / behaviors | `event-debounce`/`event-once`, `behavior-*` (degenerate in the langs where they parse)                                                 |
 
 **How it's tracked (ratchet, not crash-project).** The `--regression` CI gate fails
 when a **faithful** baseline pass becomes a **degenerate** pass (tolerance 3, mirroring
@@ -693,10 +727,11 @@ fail the gate. After an _intentional_ fidelity change, regenerate the baseline.
    at once. Validate with the fidelity signal + a full regen (watch for the usual
    stale-DB / flaky-harness traps — see Gotchas). **See the validated spike below —
    the hypothesis holds structurally but lands in tiers, not one PR.**
-3. **Prioritize by language-count × value.** After Tier 1, `async-block`/13 is now
-   the biggest remaining (a separate command-first root, not an if-block); the
-   if-block cluster (`if-empty`/16, `if-exists`/13, `input-validation`/14) is mostly
-   cleared — residue is the SOV `is <pred>` / ja-ko `if`-wrapper class (Tier 2).
+3. **Prioritize by language-count × value.** After Tier 1 + Async Tier 1, the biggest
+   remaining are `socket-basic`/9, `form-submit-prevent`/9, and `fetch-loading-state`/9.
+   `async-block` is down to 8 (Async Tier 1 cleared the VSO/SVO/V2 slice; SOV+zh+fr/pt
+   are Async Tier 2). The if-block cluster is mostly cleared — residue is the SOV
+   `is <pred>` / ja-ko `if`-wrapper class (Tier 2).
 
 **Spike finding (validated, this session) — the if-block shred is one root but**
 **fragments by word order + condition shape; build it in tiers.** A controlled
@@ -730,8 +765,11 @@ so a single transform won't clear all conditional clusters cleanly:
   not pushed past the verb), the ja/ko `if`-wrapper recovery, and per-language keyword
   fixes (de `wenn`/`when`; the `is empty` adjective — partially shipped). Remaining
   degenerate: `if-empty` (de,he,ja,ko,sw), `input-validation` (ja,ko).
-- **`async-block` (13) is a separate root** — command-first verb ordering, not an
-  if-block (see the ja fetch note below). Don't fold it into the if-block transform.
+- **`async-block` (13) is a separate root** — `async` is a command _modifier_ the
+  transformer mis-reorders as a verb, not an if-block. **Async Tier 1 SHIPPED**
+  (see Shipped): the parser now strips the transparent `async` keyword, clearing the
+  VSO/SVO/V2 slice (ar/de/it/th/tl, −5). SOV (ja/ko/bn/qu/tr) + zh + fr/pt remain
+  (Async Tier 2). Don't fold it into the if-block transform.
 
 Net: the block-body transform is worth building, but as an **if/else conditional
 masking transform** delivered in two tiers (if-exists-class, then is-pred-class),
@@ -745,11 +783,12 @@ shipped to keep the de win regression-free:
 
 - **ja** — correcting the dict to `フェッチ` flips the 4 ja fetch-\* patterns
   (`fetch-do-not-throw`/`-error-handling`/`-json`/`-with-headers`) **but regresses
-  `async-block`/ja 0.67→0.33**: the i18n transform puts the verb _first_ in an
-  async body (`フェッチ /api/data を クリック で 非同期 …`), and `フェッチ`
-  command-first drops the trailing event + `put` (where `取得`=get happened to
-  parse them). This is the **`async-block` command-first transform-ordering**
-  cluster — fix that first, then ja's fetch dict edit is a clean +4.
+  `async-block`/ja 0.67→0.33**. Async Tier 1 (shipped) ruled out the `async` modifier
+  as the cause — the keyword is now stripped before parsing. The residual blocker is
+  the **SOV event-mid then-chain**: `フェッチ /api/data を クリック で … それから …`
+  parses to `{fetch}` only (the mid-stream event + `then`-chain are dropped), whereas
+  `取得`=get happens to anchor SOV verb-anchoring and recover on+put. So ja's fetch dict
+  edit is clean **only after Async Tier 2** (SOV event-mid then-chain recovery).
 - **zh** — `抓取` is the correct semantic fetch primary, but it still fails to parse
   as `fetch` _inside the event-handler block body_ (zh fetch patterns drop `fetch`
   even with the aligned keyword), so the dict edit is inert for the metric until the

--- a/packages/semantic/src/generators/profiles/tl.ts
+++ b/packages/semantic/src/generators/profiles/tl.ts
@@ -127,7 +127,9 @@ export const tagalogProfile: LanguageProfile = {
     end: { primary: 'wakas', alternatives: ['tapos'], normalized: 'end' },
     // Advanced
     js: { primary: 'js', normalized: 'js' },
-    async: { primary: 'async', normalized: 'async' },
+    // `sabay` is the form the i18n tl dictionary emits for async; register it so
+    // the async-modifier strip recognizes it (passthrough-alignment).
+    async: { primary: 'async', alternatives: ['sabay'], normalized: 'async' },
     tell: { primary: 'sabihin', alternatives: ['magsabi'], normalized: 'tell' },
     default: {
       primary: 'pamantayan',

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -98,7 +98,20 @@ export class SemanticParserImpl implements ISemanticParser {
   parse(input: string, language: string): SemanticNode {
     // Extract standalone event modifiers (once, debounced, throttled) from input
     const { modifiers, remainingInput } = this.extractStandaloneModifiers(input, language);
-    const parseInput = remainingInput || input;
+    const modInput = remainingInput || input;
+
+    // Strip a transparent `async` command prefix (`async fetch … then …`). `async`
+    // marks the *following* command for asynchronous execution — it's a modifier,
+    // not a command verb. The grammar transformer, treating it as a verb, reorders
+    // it (often verb-final SOV / event-mid VSO), so a fused event pattern captures
+    // `async` as the handler action and the real command + then-chain collapse to a
+    // degenerate parse. Removing the keyword and re-parsing the remainder mirrors
+    // English — whose body parser already skips `async`, so the action set is
+    // identical with or without it (async is not yet surfaced as a node; preserving
+    // its execution semantics across languages is Track 5 Tier 2). Gated to the
+    // async keyword token, so non-async inputs are byte-identical.
+    const asyncStrip = this.stripAsyncModifier(modInput, language);
+    const parseInput = asyncStrip.remainingInput ?? modInput;
 
     // Diagnostics accumulator (Phase 3.4)
     const diagnostics: Diagnostic[] = [];
@@ -1522,6 +1535,34 @@ export class SemanticParserImpl implements ISemanticParser {
     const remainingInput = input.slice(startPos);
 
     return { modifiers, remainingInput };
+  }
+
+  /**
+   * Remove a transparent `async` command-modifier keyword from the input so the
+   * following command (not `async`) is parsed as the action. The async keyword is
+   * found anywhere in the stream (the grammar transformer relocates it by word
+   * order — leading in VSO, after the event in SVO, verb-final in SOV) and matched
+   * against the language profile's `async` form (primary + alternatives) plus the
+   * English literal the transformer passes through for profiles without a native
+   * form. Returns `remainingInput: null` when there's no async keyword, so the
+   * normal path is byte-identical.
+   */
+  private stripAsyncModifier(input: string, language: string): { remainingInput: string | null } {
+    const kw = tryGetProfile(language)?.keywords?.async;
+    const forms = new Set<string>(['async']);
+    if (kw?.primary) forms.add(kw.primary.toLowerCase());
+    kw?.alternatives?.forEach(a => forms.add(a.toLowerCase()));
+
+    const allTokens = tokenizeInternal(input, language).tokens;
+    const idx = allTokens.findIndex(t => forms.has(t.value.toLowerCase()));
+    if (idx === -1) return { remainingInput: null };
+
+    const tok = allTokens[idx];
+    const stripped = (input.slice(0, tok.position.start) + input.slice(tok.position.end))
+      .replace(/\s{2,}/g, ' ')
+      .trim();
+    if (stripped.length === 0) return { remainingInput: null };
+    return { remainingInput: stripped };
   }
 
   /**

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -356,3 +356,53 @@ describe('if/else block-body in event handlers — Track 5 Tier 1', () => {
     expect(a.has('remove')).toBe(true);
   });
 });
+
+describe('async modifier transparency — Track 5 Async Tier 1', () => {
+  // `async` marks the *following* command for async execution — it is a modifier,
+  // not a command verb. The grammar transformer reorders it as a verb, so a fused
+  // event pattern captured `async` as the handler action and the real command +
+  // then-chain collapsed (degenerate). The parser now strips the async keyword
+  // before parsing (mirroring English, whose body parser already skips it), so the
+  // following command anchors. Flips async-block ar/de/it/th/tl degenerate→faithful.
+  // See docs-internal/MULTILINGUAL_ROADMAP.md (Track 5 Async Tier 1).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const n = node as Record<string, unknown>;
+    if (typeof n.action === 'string') acc.add(n.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = n[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('[ar] async-block keeps fetch + put (async not taken as the action)', () => {
+    // i18n transform of `on click async fetch /api/data then put it into me`.
+    const input = 'متزامن احضر /api/data عند نقر ثم ضع هو إلى أنا';
+    const a = actions(parse(input, 'ar'));
+    expect(a.has('fetch')).toBe(true);
+    expect(a.has('put')).toBe(true);
+    expect(a.has('async')).toBe(false); // stripped, never an action
+  });
+
+  it('[tl] async-block keeps fetch + put (sabay recognized as async)', () => {
+    const input = 'sabay kuhanin_mula /api/data kapag click pagkatapos ilagay ito sa ako';
+    const a = actions(parse(input, 'tl'));
+    expect(a.has('fetch')).toBe(true);
+    expect(a.has('put')).toBe(true);
+    expect(a.has('async')).toBe(false);
+  });
+
+  it('[it] async-block recovers the real command (was bare async)', () => {
+    const input = 'su clic asincrono recuperare /api/data allora mettere esso in io';
+    const a = actions(parse(input, 'it'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('fetch')).toBe(true);
+    expect(a.has('async')).toBe(false);
+  });
+
+  it('does not disturb a non-async command', () => {
+    expect(parse('toggle .active', 'en').action).toBe('toggle');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,16 +1,15 @@
 {
-  "timestamp": "2026-06-08T16:50:58.630Z",
-  "commit": "33bdb08",
+  "timestamp": "2026-06-08T18:08:25.748Z",
+  "commit": "be65843",
   "languages": {
     "ar": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9268083704069859,
-      "avgFidelity": 0.8504357298474946,
+      "avgFidelity": 0.8547930283224401,
       "degeneratePasses": [
         "accordion-exclusive",
-        "async-block",
         "behavior-draggable",
         "behavior-resizable",
         "behavior-sortable",
@@ -27,7 +26,7 @@
         "tabs-content",
         "window-keydown"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -659,7 +658,7 @@
         "repeat-while",
         "socket-basic"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1284,9 +1283,8 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9367465504720396,
-      "avgFidelity": 0.8826797385620916,
+      "avgFidelity": 0.8848583877995644,
       "degeneratePasses": [
-        "async-block",
         "behavior-draggable",
         "behavior-resizable",
         "behavior-sortable",
@@ -1294,7 +1292,7 @@
         "form-submit-prevent",
         "if-empty"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1918,7 +1916,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2545,7 +2543,7 @@
       "avgConfidence": 0.989034132171387,
       "avgFidelity": 0.9089324618736385,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3178,7 +3176,7 @@
         "fetch-with-headers",
         "first-in-parent"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3810,7 +3808,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4446,7 +4444,7 @@
         "socket-basic",
         "worker-basic"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5078,7 +5076,7 @@
         "behavior-sortable",
         "unless-condition"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5702,9 +5700,9 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9976296296296296,
-      "avgFidelity": 0.9026666666666668,
-      "degeneratePasses": ["async-block", "fetch-loading-state", "form-submit-prevent"],
-      "bundleSize": 402145,
+      "avgFidelity": 0.904888888888889,
+      "degeneratePasses": ["fetch-loading-state", "form-submit-prevent"],
+      "bundleSize": 402626,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6342,7 +6340,7 @@
         "input-validation",
         "socket-basic"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6984,7 +6982,7 @@
         "stagger-animation",
         "window-scroll"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7620,7 +7618,7 @@
         "its-value-possessive-dot",
         "template-literal-list-build"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8247,7 +8245,7 @@
       "avgConfidence": 0.8352592592592598,
       "avgFidelity": 0.9076666666666667,
       "degeneratePasses": ["first-in-parent"],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8879,7 +8877,7 @@
         "focus-trap",
         "socket-basic"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "window-resize": {
           "success": true,
@@ -9521,7 +9519,7 @@
         "stagger-animation",
         "template-literal-list-build"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10148,7 +10146,7 @@
       "avgConfidence": 0.8895073180787468,
       "avgFidelity": 0.9008658008658009,
       "degeneratePasses": ["fetch-loading-state", "form-submit-prevent", "install-behavior"],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10786,7 +10784,7 @@
         "socket-basic",
         "template-literal-list-build"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11409,14 +11407,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9402185116470816,
-      "avgFidelity": 0.9068181818181822,
-      "degeneratePasses": [
-        "async-block",
-        "fetch-loading-state",
-        "form-submit-prevent",
-        "window-scroll"
-      ],
-      "bundleSize": 402145,
+      "avgFidelity": 0.9089826839826842,
+      "degeneratePasses": ["fetch-loading-state", "form-submit-prevent", "window-scroll"],
+      "bundleSize": 402626,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12041,10 +12034,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8985472977069613,
-      "avgFidelity": 0.8681818181818183,
+      "avgFidelity": 0.8725108225108226,
       "degeneratePasses": [
         "accordion-exclusive",
-        "async-block",
         "copy-to-clipboard",
         "event-debounce",
         "eventsource-basic",
@@ -12060,7 +12052,7 @@
         "take-class-from-siblings",
         "worker-basic"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12698,7 +12690,7 @@
         "focus-trap",
         "socket-basic"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13325,7 +13317,7 @@
       "avgConfidence": 0.8887652030509177,
       "avgFidelity": 0.9008658008658009,
       "degeneratePasses": ["fetch-loading-state", "form-submit-prevent", "install-behavior"],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13957,7 +13949,7 @@
         "render-template-with-data",
         "template-literal-list-build"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14594,7 +14586,7 @@
         "repeat-forever",
         "template-literal-list-build"
       ],
-      "bundleSize": 402145,
+      "bundleSize": 402626,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15213,7 +15205,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 402145,
+      "size": 402626,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Next step in the Track 5 fidelity arc (`docs-internal/MULTILINGUAL_ROADMAP.md`): the `async-block` cluster. Flips `async-block` **degenerate→faithful for ar, de, it, th, tl** (+5).

- **Degenerate passes: 181 → 176 (−5)**, **0 regressions**, **parse rate unchanged** (3672/3696) — confirmed by a full `browser-priority` regen + the `--regression` gate (every flip degenerate→faithful; zero parse-success ↑/↓; zero faithful→degenerate).

## Root cause

`async` is a command **modifier** (`async fetch … then …` runs the following command asynchronously), not a verb — English never surfaces it as an action. But the i18n transformer treats it as a verb and reorders it by word order (leading in VSO, after the event in SVO, verb-final in SOV). A fused event pattern then captured `async` as the handler **action**, and the real command + the `then`-chain collapsed to a degenerate parse (`async-block` was degenerate in 13 langs).

## Fix (parser, additive)

`parse()` strips the transparent `async` keyword before tokenizing — a new `stripAsyncModifier` mirroring the existing `extractStandaloneModifiers` (once/debounce/throttle) — so the following command anchors as the action. Matched against the profile's `async` form (primary + alternatives) + the English literal the transformer passes through; gated to the async token, so non-async inputs are byte-identical. `tl` needed a one-line passthrough-alignment (`sabay` added as a tl semantic `async` alternative — the i18n tl dict emits `sabay`).

## Scope (fragments by word order, like the if-block arc)

Clears the **VSO/SVO/V2** slice only. Remaining (Async Tier 2):
- **SOV** (ja*, ko, bn, qu, tr) — the event sits mid-stream and the then-chain isn't recovered even with `async` gone.
- **zh** — deeper block-body gap (the same one blocking the deferred zh fetch fix).
- **fr/pt** — a *separate* fetch-in-event gap (`récupérer`/`buscar` drop even **without** `async`, despite being registered fetch keywords).
- **ms** — no grammar profile; English passthrough doesn't parse.

`async` execution semantics are **not yet preserved** (stripped, English-parity) — re-surfacing them is Tier 2. (*ja `async-block` was already faithful at 0.67.)

This also **unblocks the deferred ja/zh `fetch` keyword alignment**: Async Tier 1 ruled out the `async` modifier as the cause of the ja regression; the residual blocker is the SOV event-mid then-chain (Async Tier 2).

## Tests

- `packages/semantic/test/multilingual-roadmap-fixes.test.ts` — async-block ar/tl keep fetch+put, it recovers the real command, `async` is never an action, non-async commands unaffected.
- Semantic suite passes (only the known sandbox-only `build-artifacts` `.d.ts` failures remain); `keyword-collisions` clean.

## Validation

Per the roadmap playbook: rebuilt semantic, repopulated the DB, regenerated the `browser-priority` baseline (committed), verified only `async-block` ar/de/it/th/tl flip with zero `↓`, then restored the binary DB (not committed).

https://claude.ai/code/session_01X8WsAtVfWsQfEAFWQXVxdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8WsAtVfWsQfEAFWQXVxdN)_