### PR TITLE
fix(multilingual): recognize then/end keywords for 9 profile-only languages

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,7 +5,8 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after Track 5 **Async Tier 1 — `async` modifier transparency** (degenerate passes **181 → 176**, −5 degenerate→faithful: `async-block` ar/de/it/th/tl, 0 regressions, parse rate unchanged 3672/3696). The parser now strips the transparent `async` command-prefix before parsing (mirroring English), so the real command anchors instead of `async` being captured as the handler action. SOV (ja/ko/bn/qu/tr), zh, fr/pt (separate fetch-in-event gap), ms remain — Async Tier 2._
+_Last updated: after Track 5 **then/end keyword recognition for 9 profile-only languages** (it, ru, th, vi, he, hi, ms, pl, uk). `isThenKeyword`/`isEndKeyword` were hardcoded maps covering only 15 langs; the other 9 fell back to the English literal, so their native then/end (`allora`, `затем`, …) weren't recognized — multi-command then-chains collapsed to the first command and `end`-blocks didn't close. Both now fall back to the profile's form. **Parse rate +7** (he/it/pl behaviors now parse — `end` recognized; he/it/pl jump toward 100%), **+4 fidelity** (`fetch-loading-state` ru/th/vi/uk degenerate→faithful), **0 regressions** (gate green). Degenerate nets 176 → 179 (−4 fetch-loading-state, +7 newly-parsing Bucket B behaviors)._
+_Earlier: Track 5 **Async Tier 1 — `async` modifier transparency** (degenerate **181 → 176**, −5: `async-block` ar/de/it/th/tl)._
 _Earlier: after Track 5 **Tier 1 — if/else block-body in event handlers** (degenerate passes **219 → 181**, −38 degenerate→faithful, 0 fidelity regressions). Cleared `if-exists` entirely (ar+it flipped, the named Tier 1 target) and lifted `if-empty`/`input-validation`/`unless-condition` across 13 languages. Before that: German `fetch` keyword alignment, caret-scope masking, @attr-in-selector-role, trailing-event block-wrap, custom-event SOV, property-path patient, (parse-rate) Tier 1, Track 4, Track 1 (reactive) complete._
 
 ---
@@ -58,6 +59,32 @@ behaviors), not a parsing/i18n track. See Track 2.
 ---
 
 ## Shipped
+
+### Track 5 — then/end keyword recognition for 9 profile-only languages
+
+- **Parse rate +7, fidelity +4, 0 regressions** (full `browser-priority` regen + `--regression`
+  gate green). `isThenKeyword`/`isEndKeyword` were hardcoded `Record<lang, Set>` maps covering
+  only **15** languages (en, ja, ar, es, ko, zh, tr, pt, fr, de, id, tl, bn, qu, sw); the other
+  **9** (it, ru, th, vi, he, hi, ms, pl, uk) hit the `|| en` fallback, so their native then/end
+  (`allora`/`затем`/`แล้ว`/`rồi`/`fine`/`koniec`/…) were never recognized.
+- **Two consequences, both fixed.** (1) Multi-command **then-chains collapsed to the first
+  command** (`fetch-loading-state` parsed as `{add, on}` in it/ru/th/vi/…). (2) `end`-terminated
+  **blocks didn't close** in those langs, so e.g. behavior definitions failed to parse outright.
+- **Fix (parser, additive, conservative).** A shared `profileKeywordMatches(lang, key, value)`
+  helper checks the language profile's keyword (primary + alternatives). `isThenKeyword`/
+  `isEndKeyword` now: keep the curated map verbatim for the 15 mapped langs (**byte-identical**),
+  and for the rest fall back to the profile's `then`/`end` form + the English literal. `isElseKeyword`
+  refactored onto the same helper. Every profile carries `then`/`end`/`else`, so this generalizes
+  to all 24 langs without hand-maintaining each map.
+- **Impact.** Fidelity: `fetch-loading-state` **ru/th/vi/uk** degenerate→faithful (+4). Parse rate:
+  **he/it/pl** behaviors (`behavior-draggable`/`-sortable`/`-resizable`) now parse — he +0.6%,
+  it +1.9%, pl +1.9% (it/pl cross ~99%). Those 7 are Bucket B (degenerate by nature — a separate
+  runtime track), so they're fail→degenerate **parse-rate wins**, not fidelity regressions; the
+  degenerate count nets 176 → 179. **Zero faithful→degenerate, zero parse-down.**
+- **Honest scope.** `fetch-loading-state` it/ja/bn/hi/tr stay degenerate for _other_ reasons (it's
+  fused `event-handler-it-full` quirk; SOV event-mid then-chain for ja/bn/hi/tr) — separate work.
+- Locked by `multilingual-roadmap-fixes.test.ts` ("then/end keyword recognition": ru/th/uk recover
+  the multi-command chain; ja curated chain unchanged).
 
 ### Track 5 Async Tier 1 — `async` modifier transparency (−5 degenerate)
 
@@ -669,9 +696,11 @@ the fraction of the English reference parse's command actions that survive (reca
 word-order agnostic). Passes below 50% fidelity are **degenerate passes**.
 
 **Current state (committed baseline carries `avgFidelity` / `degeneratePasses`):**
-~**176 degenerate-pass instances across ~50 patterns** (was 232; −9 from the
+~**179 degenerate-pass instances across ~50 patterns** (was 232; −9 from the
 post-event then-chain fix, −4 from the de fetch keyword alignment, −38 from the
-Tier 1 if/else block-body fix, −5 from the Async Tier 1 `async`-modifier fix — all below).
+Tier 1 if/else block-body fix, −5 from the Async Tier 1 `async`-modifier fix, then
+−4/+7 from the then/end keyword fix — −4 `fetch-loading-state` faithful, +7
+Bucket B behaviors that now _parse_ (degenerate by nature, a parse-rate win) — all below).
 Triage (`packages/testing-framework/tools/fidelity-triage.ts`)
 confirmed the signal is **real** — these are genuinely dropped commands, not a
 metric artifact — and isolated **two roots**: (A) the i18n **transformer** scrambles

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1358,9 +1358,28 @@ export class SemanticParserImpl implements ISemanticParser {
   }
 
   /**
+   * Match a token value against a language profile's keyword (primary +
+   * alternatives) for the given key. Used by the then/end/else recognizers to
+   * cover languages absent from their curated keyword maps — every profile
+   * carries `then`/`end`/`else`, so this generalizes recognition to all 24
+   * languages without hand-maintaining each map.
+   */
+  private profileKeywordMatches(language: string, key: string, value: string): boolean {
+    const kw = (
+      tryGetProfile(language)?.keywords as
+        | Record<string, { primary?: string; alternatives?: string[] }>
+        | undefined
+    )?.[key];
+    if (!kw) return false;
+    if (kw.primary?.toLowerCase() === value) return true;
+    return !!kw.alternatives?.some(a => a.toLowerCase() === value);
+  }
+
+  /**
    * Check if a token is a 'then' keyword in the given language.
    */
   private isThenKeyword(value: string, language: string): boolean {
+    const v = value.toLowerCase();
     const thenKeywords: Record<string, Set<string>> = {
       en: new Set(['then']),
       ja: new Set(['それから', '次に', 'そして']),
@@ -1378,8 +1397,13 @@ export class SemanticParserImpl implements ISemanticParser {
       qu: new Set(['chaymantataq', 'hinaspa', 'chaymanta', 'chayqa']),
       sw: new Set(['kisha', 'halafu', 'baadaye']),
     };
-    const keywords = thenKeywords[language] || thenKeywords.en;
-    return keywords.has(value.toLowerCase());
+    // Languages with a curated map keep their exact (colloquial-rich) behavior.
+    // Languages absent from it (it/ru/th/vi/he/hi/ms/pl/uk) fall back to the
+    // profile's `then` form + the English literal the transformer passes through —
+    // without this their multi-command then-chains collapsed to the first command.
+    const curated = thenKeywords[language];
+    if (curated) return curated.has(v);
+    return v === 'then' || this.profileKeywordMatches(language, 'then', v);
   }
 
   /**
@@ -1392,16 +1416,14 @@ export class SemanticParserImpl implements ISemanticParser {
   private isElseKeyword(value: string, language: string): boolean {
     const v = value.toLowerCase();
     if (v === 'else') return true;
-    const kw = tryGetProfile(language)?.keywords?.else;
-    if (!kw) return false;
-    if (kw.primary?.toLowerCase() === v) return true;
-    return !!kw.alternatives?.some(a => a.toLowerCase() === v);
+    return this.profileKeywordMatches(language, 'else', v);
   }
 
   /**
    * Check if a token is an 'end' keyword in the given language.
    */
   private isEndKeyword(value: string, language: string): boolean {
+    const v = value.toLowerCase();
     const endKeywords: Record<string, Set<string>> = {
       en: new Set(['end']),
       ja: new Set(['終わり', '終了', 'おわり']),
@@ -1419,8 +1441,11 @@ export class SemanticParserImpl implements ISemanticParser {
       qu: new Set(['tukukuy', 'tukuy', 'puchukay']),
       sw: new Set(['mwisho', 'maliza', 'tamati']),
     };
-    const keywords = endKeywords[language] || endKeywords.en;
-    return keywords.has(value.toLowerCase());
+    // See isThenKeyword: curated langs unchanged; the rest fall back to the
+    // profile's `end` form + the English literal.
+    const curated = endKeywords[language];
+    if (curated) return curated.has(v);
+    return v === 'end' || this.profileKeywordMatches(language, 'end', v);
   }
 
   /**

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -406,3 +406,47 @@ describe('async modifier transparency — Track 5 Async Tier 1', () => {
     expect(parse('toggle .active', 'en').action).toBe('toggle');
   });
 });
+
+describe('then/end keyword recognition for profile-only languages — Track 5', () => {
+  // isThenKeyword/isEndKeyword were hardcoded maps covering 15 languages; 9 others
+  // (it, ru, th, vi, he, hi, ms, pl, uk) fell back to the English literal, so their
+  // native then/end (`allora`, `затем`, `แล้ว`, `rồi`, …) weren't recognized — every
+  // multi-command then-chain collapsed to the first command and `end`-terminated
+  // blocks didn't close. Both recognizers now fall back to the language profile's
+  // then/end form for languages absent from the curated maps (curated langs stay
+  // byte-identical). See docs-internal/MULTILINGUAL_ROADMAP.md (then/end recognition).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const n = node as Record<string, unknown>;
+    if (typeof n.action === 'string') acc.add(n.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = n[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // fetch-loading-state corpus transforms — the then-chain (add → … → remove → put)
+  // must survive instead of collapsing to the first command (`add`).
+  const cases: Array<[string, string]> = [
+    ['ru', 'при клик добавить .loading в я затем загрузить /api/data затем удалить .loading из я затем положить это в #result'],
+    ['th', 'เมื่อ คลิก เพิ่ม .loading ใน ฉัน แล้ว ดึงข้อมูล /api/data แล้ว ลบ .loading จาก ฉัน แล้ว ใส่ มัน ใน #result'],
+    ['uk', 'при клік додати .loading в я тоді завантажити /api/data тоді видалити .loading з я тоді покласти це в #result'],
+  ];
+  for (const [lang, input] of cases) {
+    it(`[${lang}] recovers a multi-command then-chain (was first-command-only)`, () => {
+      const a = actions(parse(input, lang));
+      expect(a.has('add')).toBe(true);
+      expect(a.has('remove')).toBe(true);
+      expect(a.has('put')).toBe(true);
+    });
+  }
+
+  it('leaves a curated-map language (ja) then-chain unchanged', () => {
+    // ja is in the curated map; its then (それから) keeps working.
+    const a = actions(parse('.a を クリック で 追加 それから .b を 削除', 'ja'));
+    expect(a.has('add')).toBe(true);
+    expect(a.has('remove')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-08T18:08:25.748Z",
-  "commit": "be65843",
+  "timestamp": "2026-06-08T18:56:53.148Z",
+  "commit": "51d7108",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -26,7 +26,7 @@
         "tabs-content",
         "window-keydown"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -658,7 +658,7 @@
         "repeat-while",
         "socket-basic"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1292,7 +1292,7 @@
         "form-submit-prevent",
         "if-empty"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1916,7 +1916,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2543,7 +2543,7 @@
       "avgConfidence": 0.989034132171387,
       "avgFidelity": 0.9089324618736385,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3176,7 +3176,7 @@
         "fetch-with-headers",
         "first-in-parent"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3796,19 +3796,20 @@
       }
     },
     "he": {
-      "parseSuccess": 150,
-      "parseFailure": 4,
-      "parseRate": 0.974025974025974,
-      "avgConfidence": 0.8521904761904767,
-      "avgFidelity": 0.8082222222222223,
+      "parseSuccess": 151,
+      "parseFailure": 3,
+      "parseRate": 0.9805194805194806,
+      "avgConfidence": 0.8498580889309372,
+      "avgFidelity": 0.802869757174393,
       "degeneratePasses": [
+        "behavior-resizable",
         "fetch-do-not-throw",
         "fetch-json",
         "if-empty",
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4420,7 +4421,8 @@
           "success": false
         },
         "behavior-resizable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         }
       }
     },
@@ -4429,7 +4431,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "avgFidelity": 0.8423160173160175,
+      "avgFidelity": 0.8639610389610393,
       "degeneratePasses": [
         "bind-auto-detect",
         "bind-explicit-property",
@@ -4444,7 +4446,7 @@
         "socket-basic",
         "worker-basic"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5076,7 +5078,7 @@
         "behavior-sortable",
         "unless-condition"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5696,13 +5698,19 @@
       }
     },
     "it": {
-      "parseSuccess": 150,
-      "parseFailure": 4,
-      "parseRate": 0.974025974025974,
-      "avgConfidence": 0.9976296296296296,
-      "avgFidelity": 0.904888888888889,
-      "degeneratePasses": ["fetch-loading-state", "form-submit-prevent"],
-      "bundleSize": 402626,
+      "parseSuccess": 153,
+      "parseFailure": 1,
+      "parseRate": 0.9935064935064936,
+      "avgConfidence": 0.9878721859114016,
+      "avgFidelity": 0.8871459694989108,
+      "degeneratePasses": [
+        "behavior-draggable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "fetch-loading-state",
+        "form-submit-prevent"
+      ],
+      "bundleSize": 402789,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6308,13 +6316,16 @@
           "success": false
         },
         "behavior-draggable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-sortable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-resizable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         }
       }
     },
@@ -6340,7 +6351,7 @@
         "input-validation",
         "socket-basic"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6982,7 +6993,7 @@
         "stagger-animation",
         "window-scroll"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7618,7 +7629,7 @@
         "its-value-possessive-dot",
         "template-literal-list-build"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8239,13 +8250,18 @@
       }
     },
     "pl": {
-      "parseSuccess": 150,
-      "parseFailure": 4,
-      "parseRate": 0.974025974025974,
-      "avgConfidence": 0.8352592592592598,
-      "avgFidelity": 0.9076666666666667,
-      "degeneratePasses": ["first-in-parent"],
-      "bundleSize": 402626,
+      "parseSuccess": 153,
+      "parseFailure": 1,
+      "parseRate": 0.9935064935064936,
+      "avgConfidence": 0.828685548293392,
+      "avgFidelity": 0.8898692810457517,
+      "degeneratePasses": [
+        "behavior-draggable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "first-in-parent"
+      ],
+      "bundleSize": 402789,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8851,13 +8867,16 @@
           "success": false
         },
         "behavior-draggable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-sortable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-resizable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         }
       }
     },
@@ -8877,7 +8896,7 @@
         "focus-trap",
         "socket-basic"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "window-resize": {
           "success": true,
@@ -9519,7 +9538,7 @@
         "stagger-animation",
         "template-literal-list-build"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10144,9 +10163,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8895073180787468,
-      "avgFidelity": 0.9008658008658009,
-      "degeneratePasses": ["fetch-loading-state", "form-submit-prevent", "install-behavior"],
-      "bundleSize": 402626,
+      "avgFidelity": 0.9326839826839828,
+      "degeneratePasses": ["form-submit-prevent", "install-behavior"],
+      "bundleSize": 402789,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10784,7 +10803,7 @@
         "socket-basic",
         "template-literal-list-build"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11407,9 +11426,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9402185116470816,
-      "avgFidelity": 0.9089826839826842,
-      "degeneratePasses": ["fetch-loading-state", "form-submit-prevent", "window-scroll"],
-      "bundleSize": 402626,
+      "avgFidelity": 0.9408008658008657,
+      "degeneratePasses": ["form-submit-prevent", "window-scroll"],
+      "bundleSize": 402789,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12052,7 +12071,7 @@
         "take-class-from-siblings",
         "worker-basic"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12690,7 +12709,7 @@
         "focus-trap",
         "socket-basic"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13315,9 +13334,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8887652030509177,
-      "avgFidelity": 0.9008658008658009,
-      "degeneratePasses": ["fetch-loading-state", "form-submit-prevent", "install-behavior"],
-      "bundleSize": 402626,
+      "avgFidelity": 0.9326839826839828,
+      "degeneratePasses": ["form-submit-prevent", "install-behavior"],
+      "bundleSize": 402789,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13942,14 +13961,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.892888064316636,
-      "avgFidelity": 0.8413419913419917,
+      "avgFidelity": 0.8677489177489179,
       "degeneratePasses": [
-        "fetch-loading-state",
         "form-submit-prevent",
         "render-template-with-data",
         "template-literal-list-build"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14586,7 +14604,7 @@
         "repeat-forever",
         "template-literal-list-build"
       ],
-      "bundleSize": 402626,
+      "bundleSize": 402789,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15205,7 +15223,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 402626,
+      "size": 402789,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Continuing the Track 5 fidelity arc. While scoping Async Tier 2 (SOV event-mid then-chain), the probe surfaced a broader, higher-leverage root: **`isThenKeyword`/`isEndKeyword` were hardcoded maps covering only 15 of 24 languages.** The other 9 (**it, ru, th, vi, he, hi, ms, pl, uk**) hit the `|| en` fallback, so their native then/end (`allora`, `затем`, `แล้ว`, `rồi`, `fine`, `koniec`, …) were never recognized.

Two consequences, both fixed:
1. **Multi-command then-chains collapsed to the first command** — e.g. `fetch-loading-state` parsed as `{add, on}` in it/ru/th/vi/….
2. **`end`-terminated blocks didn't close** in those langs — so behavior definitions failed to parse outright.

## Fix (parser, additive, conservative)

A shared `profileKeywordMatches(lang, key, value)` helper checks the language profile's keyword (primary + alternatives). `isThenKeyword`/`isEndKeyword` now keep the curated map **verbatim for the 15 mapped langs (byte-identical)** and fall back to the profile's `then`/`end` form + the English literal for the rest. `isElseKeyword` refactored onto the same helper. Every profile carries `then`/`end`/`else`, so this generalizes to all 24 languages without hand-maintaining each map.

## Result (full `browser-priority` regen + `--regression` gate green)

- **Fidelity +4:** `fetch-loading-state` **ru/th/vi/uk** degenerate→faithful (the then-chain `add → fetch → remove → put` now survives).
- **Parse rate +7:** **he/it/pl** behaviors (`behavior-draggable`/`-sortable`/`-resizable`) now parse (`end` recognized) — he +0.6%, it +1.9%, pl +1.9% (it/pl cross ~99%).
- **Zero faithful→degenerate, zero parse-down.** The 7 newly-parsing behaviors are Bucket B (degenerate by nature — a separate runtime track), so they're **fail→degenerate parse-rate wins**, not fidelity regressions. Degenerate count nets 176 → 179.

## Honest scope

`fetch-loading-state` it/ja/bn/hi/tr stay degenerate for *other* reasons (it's fused `event-handler-it-full` quirk; SOV event-mid then-chain for ja/bn/hi/tr) — these are the deeper Async/SOV Tier 2 work, separate from keyword recognition.

## Tests

- `packages/semantic/test/multilingual-roadmap-fixes.test.ts` — ru/th/uk recover the multi-command then-chain; a curated-map language (ja) chain is unchanged.
- Semantic suite passes (only the known sandbox-only `build-artifacts` `.d.ts` failures); the 15 curated languages are byte-identical (5329 passing).

## Validation

Per the roadmap playbook: rebuilt semantic, repopulated the DB (3936 translations), regenerated the `browser-priority` baseline (committed), verified the gate is green with the breakdown above, then restored the binary DB (not committed).

https://claude.ai/code/session_01X8WsAtVfWsQfEAFWQXVxdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8WsAtVfWsQfEAFWQXVxdN)_