### PR TITLE
fix(multilingual): parse juxtaposed multi-command event bodies (−20 degenerate)

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,7 +5,8 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after Track 5 **then/end keyword recognition for 9 profile-only languages** (it, ru, th, vi, he, hi, ms, pl, uk). `isThenKeyword`/`isEndKeyword` were hardcoded maps covering only 15 langs; the other 9 fell back to the English literal, so their native then/end (`allora`, `затем`, …) weren't recognized — multi-command then-chains collapsed to the first command and `end`-blocks didn't close. Both now fall back to the profile's form. **Parse rate +7** (he/it/pl behaviors now parse — `end` recognized; he/it/pl jump toward 100%), **+4 fidelity** (`fetch-loading-state` ru/th/vi/uk degenerate→faithful), **0 regressions** (gate green). Degenerate nets 176 → 179 (−4 fetch-loading-state, +7 newly-parsing Bucket B behaviors)._
+_Last updated: after Track 5 **juxtaposed multi-command event bodies** — a fused event pattern captured only the FIRST body command as the action; a then-chain/block continued, but a **juxtaposed** body (`halt the event call validateForm() if … end` — no `then` between commands) was dropped. `buildEventHandler` now re-parses any trailing non-`end` tokens as body commands (additive; `parseBodyWithGrammarPatterns` only appends matched commands). **Degenerate passes 179 → 159 (−20), 0 regressions, parse rate unchanged** (3679/3696). Cleared `form-submit-prevent` (de/it/ru/sw/th/uk/vi), `fetch-loading-state` (bn/hi/it/ja/tr), plus `fetch-error-handling`/`fetch-with-headers` (ja), `render-template-with-data` (qu/tl/vi), `repeat-forever`/`stagger-animation` (qu), `window-scroll` (th)._
+_Earlier: Track 5 **then/end keyword recognition for 9 profile-only languages** (it, ru, th, vi, he, hi, ms, pl, uk). `isThenKeyword`/`isEndKeyword` were hardcoded maps covering only 15 langs; the other 9 fell back to the English literal, so their native then/end (`allora`, `затем`, …) weren't recognized — multi-command then-chains collapsed to the first command and `end`-blocks didn't close. Both now fall back to the profile's form. **Parse rate +7** (he/it/pl behaviors now parse — `end` recognized; he/it/pl jump toward 100%), **+4 fidelity** (`fetch-loading-state` ru/th/vi/uk degenerate→faithful), **0 regressions** (gate green). Degenerate nets 176 → 179 (−4 fetch-loading-state, +7 newly-parsing Bucket B behaviors)._
 _Earlier: Track 5 **Async Tier 1 — `async` modifier transparency** (degenerate **181 → 176**, −5: `async-block` ar/de/it/th/tl)._
 _Earlier: after Track 5 **Tier 1 — if/else block-body in event handlers** (degenerate passes **219 → 181**, −38 degenerate→faithful, 0 fidelity regressions). Cleared `if-exists` entirely (ar+it flipped, the named Tier 1 target) and lifted `if-empty`/`input-validation`/`unless-condition` across 13 languages. Before that: German `fetch` keyword alignment, caret-scope masking, @attr-in-selector-role, trailing-event block-wrap, custom-event SOV, property-path patient, (parse-rate) Tier 1, Track 4, Track 1 (reactive) complete._
 
@@ -59,6 +60,32 @@ behaviors), not a parsing/i18n track. See Track 2.
 ---
 
 ## Shipped
+
+### Track 5 — juxtaposed multi-command event bodies (−20 degenerate)
+
+- **Degenerate passes 179 → 159 (−20), 0 regressions, parse rate unchanged** (3679/3696).
+  Full `browser-priority` regen + `--regression` gate green; 20 degenerate→faithful, 0
+  faithful→degenerate, 0 parse-down. The semantic role-extraction suite passes (fidelity is
+  recall-based and wouldn't catch _over_-generation; the suite confirms none).
+- **Root cause.** When a fused event pattern captures the first body command as the action,
+  the remaining body commands may be then-chained (`… then …` — Root B, shipped), a block
+  (if/else — Tier 1, shipped), or simply **juxtaposed** (`on submit halt the event call
+validateForm() if … end` — no `then` between `halt`/`call`/`if`). The action-branch only
+  continued on a then-chain or block, so juxtaposed commands were dropped and the handler
+  collapsed to `{halt, on}` (degenerate). English handles juxtaposed bodies because it goes
+  through `parseBodyWithClauses` (a matchBest loop), not the fused action-branch.
+- **Fix (one line, generalizing).** The three prior special cases (`hasContinuesMarker`,
+  `hasTrailingThenChain`, `hasBlockBody`) are subsumed by `hasTrailingBody` = any non-`end`
+  token trails the captured action. `parseBodyWithGrammarPatterns` then appends every command
+  it matches and skips the rest, so an already-consumed simple handler is unchanged and stray
+  role words never become spurious commands (verified: a single-command handler still yields
+  exactly `{on, toggle}`).
+- **Impact.** Cleared `form-submit-prevent` (de/it/ru/sw/th/uk/vi — ar/tl stay 0.20, VSO
+  event-mid), `fetch-loading-state` (bn/hi/it/ja/tr), `fetch-error-handling`/`fetch-with-headers`
+  (ja), `render-template-with-data` (qu/tl/vi), `repeat-forever`/`stagger-animation` (qu),
+  `window-scroll` (th).
+- Locked by `multilingual-roadmap-fixes.test.ts` ("Juxtaposed multi-command event bodies":
+  de/sw/vi recover halt+call+log; a simple handler doesn't over-generate).
 
 ### Track 5 — then/end keyword recognition for 9 profile-only languages
 
@@ -696,11 +723,12 @@ the fraction of the English reference parse's command actions that survive (reca
 word-order agnostic). Passes below 50% fidelity are **degenerate passes**.
 
 **Current state (committed baseline carries `avgFidelity` / `degeneratePasses`):**
-~**179 degenerate-pass instances across ~50 patterns** (was 232; −9 from the
+~**159 degenerate-pass instances across ~47 patterns** (was 232; −9 from the
 post-event then-chain fix, −4 from the de fetch keyword alignment, −38 from the
-Tier 1 if/else block-body fix, −5 from the Async Tier 1 `async`-modifier fix, then
-−4/+7 from the then/end keyword fix — −4 `fetch-loading-state` faithful, +7
-Bucket B behaviors that now _parse_ (degenerate by nature, a parse-rate win) — all below).
+Tier 1 if/else block-body fix, −5 from the Async Tier 1 `async`-modifier fix,
+−4/+7 from the then/end keyword fix (−4 `fetch-loading-state` faithful, +7 Bucket B
+behaviors that now _parse_ — a parse-rate win), −20 from the juxtaposed
+multi-command body fix — all below).
 Triage (`packages/testing-framework/tools/fidelity-triage.ts`)
 confirmed the signal is **real** — these are genuinely dropped commands, not a
 metric artifact — and isolated **two roots**: (A) the i18n **transformer** scrambles

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -365,17 +365,23 @@ export class SemanticParserImpl implements ISemanticParser {
       // while/repeat/for) as the action but leave the block's condition and branch
       // body unconsumed — and, unlike a simple command, those trailing tokens are
       // *not* bridged by a then-marker (`on click if <cond> show … else … end`).
-      // Without this, the whole block body is dropped and the handler collapses to
-      // a bare `if` (a degenerate parse — see fidelity ratchet). Parse the remainder
-      // as body commands and append them as siblings (the condition tokens and
-      // `else` are skipped as non-commands), mirroring how the English event-body
-      // path flattens an if/else block. Gated to a trailing token that isn't the
-      // block's own `end`, so an empty block is left untouched.
       const isBlockBodyAction = BLOCK_BODY_ACTIONS.has(actionName);
       const hasBlockBody =
         isBlockBodyAction && !!nextToken && !this.isEndKeyword(nextToken.value, language);
 
-      if (hasContinuesMarker || hasTrailingThenChain || hasBlockBody) {
+      // General case: a fused event pattern captured the *first* body command as the
+      // action and left the rest unconsumed. The body's remaining commands may be
+      // then-chained (`… then …`), block bodies (if/else), OR simply *juxtaposed*
+      // (`halt the event call validateForm() if … end` — no `then` between them).
+      // Whenever any non-`end` token trails the captured action, re-parse it as body
+      // commands. This is safe and additive: `parseBodyWithGrammarPatterns` only
+      // appends tokens that match a command pattern and skips everything else, so an
+      // already-consumed simple handler (no remainder) is unchanged, and stray role
+      // words can never become spurious commands. Subsumes the then-chain and
+      // block-body cases above; both are kept named for documentation.
+      const hasTrailingBody = !!nextToken && !this.isEndKeyword(nextToken.value, language);
+
+      if (hasContinuesMarker || hasTrailingThenChain || hasBlockBody || hasTrailingBody) {
         // Parse remaining tokens as additional commands
         const commandPatterns = getPatternsForLanguage(language)
           .filter(p => p.command !== 'on')

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -450,3 +450,47 @@ describe('then/end keyword recognition for profile-only languages — Track 5', 
     expect(a.has('remove')).toBe(true);
   });
 });
+
+describe('Juxtaposed multi-command event bodies — Track 5', () => {
+  // A fused event pattern captures the FIRST body command as the action; the rest
+  // of the body may be then-chained, a block, OR simply juxtaposed (no `then`
+  // between commands — `halt the event call validateForm() if … end`). The fused
+  // branch previously only continued on a then-chain/block, dropping juxtaposed
+  // commands. It now re-parses any trailing non-`end` tokens as body commands
+  // (additive: parseBodyWithGrammarPatterns only appends matched commands). Flips
+  // form-submit-prevent (de/it/ru/sw/th/uk/vi) + fetch-loading-state (bn/hi/it/ja/tr)
+  // + others degenerate→faithful. See docs-internal/MULTILINGUAL_ROADMAP.md.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const n = node as Record<string, unknown>;
+    if (typeof n.action === 'string') acc.add(n.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = n[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // form-submit-prevent corpus transforms — the juxtaposed `halt … call … log …`
+  // body must survive instead of collapsing to the first command (`halt`).
+  const cases: Array<[string, string]> = [
+    ['de', 'bei absenden anhalten the ereignis aufrufen validateForm() wenn ergebnis ist falsch protokollieren "Invalid form" ende'],
+    ['sw', 'kwenye wasilisha simama the tukio ita validateForm() kama matokeo ni uongo andika "Invalid form" mwisho'],
+    ['vi', 'khi gửi dừng lại the sự kiện gọi validateForm() nếu kết quả là sai in ra "Invalid form" kết thúc'],
+  ];
+  for (const [lang, input] of cases) {
+    it(`[${lang}] recovers a juxtaposed multi-command body`, () => {
+      const a = actions(parse(input, lang));
+      expect(a.has('on')).toBe(true);
+      expect(a.has('halt')).toBe(true);
+      expect(a.has('call')).toBe(true);
+      expect(a.has('log')).toBe(true);
+    });
+  }
+
+  it('does not over-generate on a simple single-command handler (en)', () => {
+    const a = actions(parse('on click toggle .active', 'en'));
+    expect([...a].sort()).toEqual(['on', 'toggle']);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-08T18:56:53.148Z",
-  "commit": "51d7108",
+  "timestamp": "2026-06-08T19:42:11.255Z",
+  "commit": "fe49e10",
   "languages": {
     "ar": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9268083704069859,
-      "avgFidelity": 0.8547930283224401,
+      "avgFidelity": 0.8662309368191721,
       "degeneratePasses": [
         "accordion-exclusive",
         "behavior-draggable",
@@ -26,7 +26,7 @@
         "tabs-content",
         "window-keydown"
       ],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -650,15 +650,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8754689754689755,
-      "avgFidelity": 0.916883116883117,
-      "degeneratePasses": [
-        "async-block",
-        "event-once",
-        "fetch-loading-state",
-        "repeat-while",
-        "socket-basic"
-      ],
-      "bundleSize": 402789,
+      "avgFidelity": 0.9286796536796538,
+      "degeneratePasses": ["async-block", "event-once", "repeat-while", "socket-basic"],
+      "bundleSize": 402829,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1283,16 +1277,15 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9367465504720396,
-      "avgFidelity": 0.8848583877995644,
+      "avgFidelity": 0.9114379084967318,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
         "behavior-sortable",
         "first-in-parent",
-        "form-submit-prevent",
         "if-empty"
       ],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1916,7 +1909,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2543,7 +2536,7 @@
       "avgConfidence": 0.989034132171387,
       "avgFidelity": 0.9089324618736385,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3176,7 +3169,7 @@
         "fetch-with-headers",
         "first-in-parent"
       ],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3809,7 +3802,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,14 +4424,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "avgFidelity": 0.8639610389610393,
+      "avgFidelity": 0.8830086580086581,
       "degeneratePasses": [
         "bind-auto-detect",
         "bind-explicit-property",
         "bind-non-form-display",
         "bind-two-way",
         "eventsource-basic",
-        "fetch-loading-state",
         "install-behavior",
         "intercept-cache-strategies",
         "live-derived-value",
@@ -4446,7 +4438,7 @@
         "socket-basic",
         "worker-basic"
       ],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5078,7 +5070,7 @@
         "behavior-sortable",
         "unless-condition"
       ],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5702,15 +5694,9 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9878721859114016,
-      "avgFidelity": 0.8871459694989108,
-      "degeneratePasses": [
-        "behavior-draggable",
-        "behavior-resizable",
-        "behavior-sortable",
-        "fetch-loading-state",
-        "form-submit-prevent"
-      ],
-      "bundleSize": 402789,
+      "avgFidelity": 0.9550108932461874,
+      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
+      "bundleSize": 402829,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6334,7 +6320,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8475468975468975,
-      "avgFidelity": 0.8387445887445889,
+      "avgFidelity": 0.8548701298701301,
       "degeneratePasses": [
         "announce-screen-reader",
         "behavior-draggable",
@@ -6343,15 +6329,12 @@
         "behavior-sortable",
         "event-once",
         "fetch-do-not-throw",
-        "fetch-error-handling",
         "fetch-json",
-        "fetch-loading-state",
-        "fetch-with-headers",
         "if-empty",
         "input-validation",
         "socket-basic"
       ],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6993,7 +6976,7 @@
         "stagger-animation",
         "window-scroll"
       ],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7629,7 +7612,7 @@
         "its-value-possessive-dot",
         "template-literal-list-build"
       ],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8261,7 +8244,7 @@
         "behavior-sortable",
         "first-in-parent"
       ],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8896,7 +8879,7 @@
         "focus-trap",
         "socket-basic"
       ],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "window-resize": {
           "success": true,
@@ -9520,7 +9503,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7326118326118326,
-      "avgFidelity": 0.7660173160173162,
+      "avgFidelity": 0.7752164502164502,
       "degeneratePasses": [
         "async-block",
         "behavior-draggable",
@@ -9530,15 +9513,12 @@
         "event-once",
         "get-value",
         "modal-close-escape",
-        "render-template-with-data",
         "repeat-for-each",
-        "repeat-forever",
         "repeat-while",
         "socket-basic",
-        "stagger-animation",
         "template-literal-list-build"
       ],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10163,9 +10143,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8895073180787468,
-      "avgFidelity": 0.9326839826839828,
-      "degeneratePasses": ["form-submit-prevent", "install-behavior"],
-      "bundleSize": 402789,
+      "avgFidelity": 0.9596320346320344,
+      "degeneratePasses": ["install-behavior"],
+      "bundleSize": 402829,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10790,20 +10770,19 @@
       "parseFailure": 2,
       "parseRate": 0.987012987012987,
       "avgConfidence": 0.8868316624895575,
-      "avgFidelity": 0.8075657894736844,
+      "avgFidelity": 0.8326754385964912,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
         "event-debounce",
         "first-in-parent",
         "focus-trap",
-        "form-submit-prevent",
         "if-empty",
         "repeat-until-event",
         "socket-basic",
         "template-literal-list-build"
       ],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11426,9 +11405,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9402185116470816,
-      "avgFidelity": 0.9408008658008657,
-      "degeneratePasses": ["form-submit-prevent", "window-scroll"],
-      "bundleSize": 402789,
+      "avgFidelity": 0.9791125541125543,
+      "degeneratePasses": [],
+      "bundleSize": 402829,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12053,7 +12032,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8985472977069613,
-      "avgFidelity": 0.8725108225108226,
+      "avgFidelity": 0.8838744588744591,
       "degeneratePasses": [
         "accordion-exclusive",
         "copy-to-clipboard",
@@ -12063,7 +12042,6 @@
         "get-value",
         "halt-propagation",
         "modal-close-escape",
-        "render-template-with-data",
         "repeat-for-each",
         "repeat-while",
         "tabs-basic",
@@ -12071,7 +12049,7 @@
         "take-class-from-siblings",
         "worker-basic"
       ],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12696,7 +12674,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8657287157287157,
-      "avgFidelity": 0.8889610389610392,
+      "avgFidelity": 0.9023809523809526,
       "degeneratePasses": [
         "async-block",
         "behavior-draggable",
@@ -12705,11 +12683,10 @@
         "behavior-sortable",
         "default-value",
         "event-once",
-        "fetch-loading-state",
         "focus-trap",
         "socket-basic"
       ],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13334,9 +13311,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8887652030509177,
-      "avgFidelity": 0.9326839826839828,
-      "degeneratePasses": ["form-submit-prevent", "install-behavior"],
-      "bundleSize": 402789,
+      "avgFidelity": 0.9596320346320344,
+      "degeneratePasses": ["install-behavior"],
+      "bundleSize": 402829,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13961,13 +13938,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.892888064316636,
-      "avgFidelity": 0.8677489177489179,
-      "degeneratePasses": [
-        "form-submit-prevent",
-        "render-template-with-data",
-        "template-literal-list-build"
-      ],
-      "bundleSize": 402789,
+      "avgFidelity": 0.894155844155844,
+      "degeneratePasses": ["template-literal-list-build"],
+      "bundleSize": 402829,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14604,7 +14577,7 @@
         "repeat-forever",
         "template-literal-list-build"
       ],
-      "bundleSize": 402789,
+      "bundleSize": 402829,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15223,7 +15196,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 402789,
+      "size": 402829,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Continuing the Track 5 fidelity arc. Investigating the SOV event-mid then-chain surfaced a **broader, cleaner root**: when a fused event pattern captures the first body command as the handler action, the remaining body commands may be then-chained (Root B, shipped), a block (if/else, Tier 1, shipped), **or simply juxtaposed** with no `then` between them (`on submit halt the event call validateForm() if result is false log "..." end`). The action-branch only continued on a then-chain or block, so juxtaposed commands were dropped and the handler collapsed to `{halt, on}` (degenerate). English avoids this because it goes through `parseBodyWithClauses` (a `matchBest` loop), not the fused action-branch.

## Fix (one line, generalizing)

The three prior special cases (`hasContinuesMarker` / `hasTrailingThenChain` / `hasBlockBody`) are subsumed by `hasTrailingBody` = any non-`end` token trails the captured action. `parseBodyWithGrammarPatterns` then appends every command it matches and skips the rest — so an already-consumed simple handler is unchanged, and stray role words never become spurious commands.

## Result (full `browser-priority` regen + `--regression` gate green)

- **Degenerate passes 179 → 159 (−20)**, **0 faithful→degenerate, 0 parse-down**, parse rate unchanged (3679/3696).
- Cleared: `form-submit-prevent` (de/it/ru/sw/th/uk/vi), `fetch-loading-state` (bn/hi/it/ja/tr), `fetch-error-handling`/`fetch-with-headers` (ja), `render-template-with-data` (qu/tl/vi), `repeat-forever`/`stagger-animation` (qu), `window-scroll` (th).
- The semantic role-extraction suite passes — fidelity is recall-based and wouldn't catch *over*-generation, but the suite confirms none (a single-command handler still yields exactly `{on, toggle}`).

## Honest scope

`form-submit-prevent` ar/tl stay degenerate (0.20) — they're VSO with the event mid-stream and parse as a bare command (Stage 2), never reaching `buildEventHandler`. That VSO event-mid case is separate, deeper work.

## Tests

- `packages/semantic/test/multilingual-roadmap-fixes.test.ts` — de/sw/vi recover the juxtaposed `halt`+`call`+`log` body; a simple handler doesn't over-generate.
- Semantic suite passes (only the known sandbox-only `build-artifacts` `.d.ts` failures).

## Validation

Rebuilt semantic, repopulated the DB (3936), regenerated the committed baseline, verified the gate green with the breakdown above, restored the binary DB (not committed).

https://claude.ai/code/session_01X8WsAtVfWsQfEAFWQXVxdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8WsAtVfWsQfEAFWQXVxdN)_