### PR TITLE
fix(multilingual): align ja fetch keyword to フェッチ (unblocked by SOV reorder)

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -61,6 +61,37 @@ behaviors), not a parsing/i18n track. See Track 2.
 
 ## Shipped
 
+### Track 5 — SOV verb-first event-body reorder (−9 degenerate)
+
+- **Degenerate passes 159 → 150 (−9), 0 regressions, parse rate unchanged.** Full
+  `browser-priority` regen + `--regression` gate green; the `event-once`,
+  `async-block`, and `event-debounce` SOV instances (ja/ko/tr/bn/qu) recover their
+  body commands instead of collapsing to a bare `*-generated-verb-first` command.
+- The i18n transformer (`tryTransformEventWithModifierBody`) lifts a leading body
+  modifier (`async`/`once`/`debounced`/`throttled`) out of the event handler so the
+  real verb isn't mis-rooted, keeps the body patient-first (recoverable by the
+  parser's SOV event-extraction), and re-emits the modifier as a leading literal the
+  parser strips pre-parse. **Gated to SOV** — SVO/VSO/V2/other are byte-identical.
+- See [SOV_REORDER_SCOPE.md](SOV_REORDER_SCOPE.md). Locked by
+  `multilingual-roadmap-fixes.test.ts` ("SOV verb-first event-body reorder") +
+  i18n `grammar.test.ts` ("SOV modifier-prefixed event body reorder").
+
+### Track 5 — fetch keyword alignment: ja (−2 degenerate, +fidelity)
+
+- **ja `取得`→`フェッチ` shipped.** Degenerate passes 150 → 148 (−2:
+  `fetch-do-not-throw`, `fetch-json`), ja `avgFidelity` 0.859 → 0.893, parse rate
+  unchanged, `--regression` gate green. The i18n dict emitted `取得` for both `get`
+  and `fetch`; the semantic ja profile reads `取得` as `get` (fetch primary is
+  `フェッチ`), so ja fetch-\* patterns parsed the wrong verb. The edit was blocked
+  until the SOV verb-first reorder fix (above): with `フェッチ` leading a verb-first
+  SOV body the event + then-chain used to drop; the body is now patient-first, so
+  `フェッチ` parses as `fetch` without losing the rest. Locked by
+  `multilingual-roadmap-fixes.test.ts` ("Japanese fetch keyword alignment").
+- **zh `获取`→`抓取` still deferred (inert).** Confirmed post-fix: `抓取` still drops
+  `fetch` inside the event-handler block body (`fetch-basic` stays degenerate
+  `{on}`), blocked behind the separate zh block-body parse gap. The dict edit is
+  inert for the metric until that gap is closed, so it was **not** shipped.
+
 ### Track 5 — juxtaposed multi-command event bodies (−20 degenerate)
 
 - **Degenerate passes 179 → 159 (−20), 0 regressions, parse rate unchanged** (3679/3696).
@@ -835,24 +866,19 @@ masking transform** delivered in two tiers (if-exists-class, then is-pred-class)
 not one sweep. Tier 1 (`if-exists` ar/it via if/else mask + `else` translation) is
 the recommended first PR of the arc.
 
-**fetch keyword alignment — ja/zh deferred (next session).** The de fetch fix
-(Shipped, above) found the same i18n-emits-the-get-word collision in **ja**
-(`取得`) and **zh** (`获取`). Both are blocked behind a deeper issue and were **not**
-shipped to keep the de win regression-free:
+**fetch keyword alignment — ja shipped, zh still deferred.** The de fetch fix
+found the same i18n-emits-the-get-word collision in **ja** (`取得`) and **zh**
+(`获取`).
 
-- **ja** — correcting the dict to `フェッチ` flips the 4 ja fetch-\* patterns
-  (`fetch-do-not-throw`/`-error-handling`/`-json`/`-with-headers`) **but regresses
-  `async-block`/ja 0.67→0.33**. Async Tier 1 (shipped) ruled out the `async` modifier
-  as the cause — the keyword is now stripped before parsing. The residual blocker is
-  the **SOV event-mid then-chain**: `フェッチ /api/data を クリック で … それから …`
-  parses to `{fetch}` only (the mid-stream event + `then`-chain are dropped), whereas
-  `取得`=get happens to anchor SOV verb-anchoring and recover on+put. So ja's fetch dict
-  edit is clean **only after Async Tier 2** (SOV event-mid then-chain recovery).
-- **zh** — `抓取` is the correct semantic fetch primary, but it still fails to parse
-  as `fetch` _inside the event-handler block body_ (zh fetch patterns drop `fetch`
-  even with the aligned keyword), so the dict edit is inert for the metric until the
-  zh block-body parse gap is closed. (`id` has an inert `ambil`/`muat` mismatch with
-  no corpus fetch patterns — latent, lowest priority.)
+- **ja — SHIPPED** (see Shipped → "fetch keyword alignment: ja"). The SOV
+  verb-first reorder fix removed the `async-block`/ja blocker (`フェッチ` now leads a
+  **patient-first** SOV body, not a verb-first one), so the `取得`→`フェッチ` dict edit
+  landed clean: −2 degenerate, ja `avgFidelity` 0.859→0.893, 0 regressions.
+- **zh — still deferred (inert).** `抓取` is the correct semantic fetch primary, but
+  it still fails to parse as `fetch` _inside the event-handler block body_ (confirmed
+  post-fix: `fetch-basic` stays degenerate `{on}`), so the dict edit is inert for the
+  metric until the zh block-body parse gap is closed. (`id` has an inert `ambil`/`muat`
+  mismatch with no corpus fetch patterns — latent, lowest priority.)
 
 Diagnostic for the next session: a 24-lang scan comparing each i18n `fetch`
 emission against the semantic profile's fetch primary/alternatives isolates these

--- a/packages/i18n/src/dictionaries/ja.ts
+++ b/packages/i18n/src/dictionaries/ja.ts
@@ -28,7 +28,7 @@ export const ja: Dictionary = {
     break: '中断',
     halt: '停止',
     wait: '待つ',
-    fetch: '取得',
+    fetch: 'フェッチ',
     call: '呼び出し',
     return: '戻る',
     make: '作る',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -31,6 +31,45 @@ describe('Korean fetch keyword alignment (가져오기)', () => {
   }
 });
 
+describe('Japanese fetch keyword alignment (フェッチ)', () => {
+  // The i18n dict previously emitted 取得 for both `get` and `fetch`; the semantic
+  // ja profile reads 取得 as `get` (fetch primary is フェッチ). Aligning the dict to
+  // フェッチ lets ja fetch-* corpus patterns parse the real `fetch` verb. This was
+  // blocked until the SOV verb-first reorder fix (PR #298): with フェッチ leading a
+  // verb-first SOV body, the event + then-chain used to drop; the body is now kept
+  // patient-first so フェッチ parses as fetch without losing the rest. See
+  // docs-internal/MULTILINGUAL_ROADMAP.md ("fetch keyword alignment — ja").
+  function bodyActions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => bodyActions(x, acc));
+      else if (c && typeof c === 'object') bodyActions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped transformer output (en → ja).
+  const cases: Array<[string, string[]]> = [
+    // fetch-basic: `on click fetch /api/data then put it into #result`
+    ['/api/data を クリック で フェッチ それから それ を #result に 置く', ['fetch', 'put']],
+    // fetch-with-method: `on submit fetch /api/form with method:"POST" body:form`
+    ['/api/form を 送信 で フェッチ method:"POST" body:form で', ['fetch']],
+  ];
+
+  for (const [input, expected] of cases) {
+    it(`parses フェッチ as fetch (not get): "${input}"`, () => {
+      const a = bodyActions(parse(input, 'ja'));
+      expect(a.has('on')).toBe(true);
+      for (const action of expected) expect(a.has(action)).toBe(true);
+      // The collision is resolved: フェッチ must not be read as `get`.
+      expect(a.has('get')).toBe(false);
+    });
+  }
+});
+
 describe('Korean transition keyword alignment (전환)', () => {
   const cases = [
     'transform 를 클릭 전환 "scale(1.2)" 에 300ms',

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-09T02:03:31.181Z",
-  "commit": "41b9c6f",
+  "timestamp": "2026-06-09T03:54:00.189Z",
+  "commit": "e1ca5df",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -6320,15 +6320,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8410533910533909,
-      "avgFidelity": 0.8591991341991345,
+      "avgFidelity": 0.8929653679653682,
       "degeneratePasses": [
         "announce-screen-reader",
         "behavior-draggable",
         "behavior-removable",
         "behavior-resizable",
         "behavior-sortable",
-        "fetch-do-not-throw",
-        "fetch-json",
         "if-empty",
         "input-validation",
         "socket-basic"


### PR DESCRIPTION
Follow-up to #298. Lands the **ja `fetch` keyword alignment** that #298 unblocked (per `MULTILINGUAL_ROADMAP.md` → "fetch keyword alignment — ja/zh deferred").

## Problem

The i18n ja dictionary emitted `取得` for **both** `get` and `fetch`, but the semantic ja profile reads `取得` as `get` (fetch primary is `フェッチ`). So ja `fetch-*` corpus patterns parsed the **wrong verb**.

The one-line dict edit (`取得`→`フェッチ`) was previously **blocked**: with `フェッチ` leading a verb-first SOV body, the mid-stream event + then-chain dropped (async-block/ja regressed 0.67→0.33). #298 fixed exactly that verb-first SOV reorder — the body is now **patient-first** (`/api/data を クリック で フェッチ それから …`), so `フェッチ` parses as `fetch` without losing the rest.

## Change

One line: `packages/i18n/src/dictionaries/ja.ts` — `fetch: '取得'` → `fetch: 'フェッチ'`.

## Validation

- **Degenerate passes 150 → 148 (−2:** ja `fetch-do-not-throw`, `fetch-json`).
- **ja `avgFidelity` 0.859 → 0.893** (fetch now parses as the correct verb across all ja fetch patterns).
- `--regression` gate **green**; parse rate unchanged; **no other language regressed** (verified avgFidelity delta across all 24).
- Full **i18n (650)** and **semantic (5375 pass / 9 skip)** suites green.
- Committed baseline regenerated; lock test added (`multilingual-roadmap-fixes.test.ts` → "Japanese fetch keyword alignment": asserts `フェッチ` parses as `fetch`, **not** `get`).

## zh deferred (confirmed inert)

I tested `zh 获取`→`抓取` and **reverted it**: confirmed still inert post-fix — `抓取` continues to drop `fetch` inside the event-handler block body (`fetch-basic` stays degenerate `{on}`), blocked behind a **separate zh block-body parse gap**. Documented in the roadmap; left for that follow-up.

https://claude.ai/code/session_01WfEQkGEywRhVkY8KFdhQQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfEQkGEywRhVkY8KFdhQQD)_