### PR TITLE
fix(multilingual): verb-final put-into reorder for ko/tr/bn SOV

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -61,6 +61,28 @@ behaviors), not a parsing/i18n track. See Track 2.
 
 ## Shipped
 
+### Track 5 — SOV put-into verb-final reorder (ko/tr/bn, +fidelity)
+
+- **tr `avgFidelity` 0.908 → 0.928, bn 0.935 → 0.952, 0 regressions, degenerate
+  count unchanged (148).** `--regression` gate green. ja had a `put-into` grammar
+  rule (`roleOrder: patient, destination, action` = verb-final); ko/tr/bn did not,
+  so `put X into Y` fell through to the generic reorder, which appends `destination`
+  **after** the verb (verb-middle `X i koy Y e`). The semantic parser only matches
+  verb-final put, so as a then-chain clause (`… then put it into me`) the `put`
+  silently dropped. Mirrored ja's rule into ko/tr/bn, **gated to standalone put via
+  a `predicate: parsed => !parsed.roles.has('event')`** so an event handler whose
+  action is `put` (`on success put …`) keeps the event mid-stream instead of being
+  verb-finalized (which would strand the event — caught as an
+  `announce-screen-reader` regression mid-implementation and fixed by the predicate).
+- The degenerate count is unchanged because the affected then-chain patterns were
+  already above the 50% threshold after the SOV reorder fix; this recovers the
+  dropped `put` (higher fidelity), it doesn't cross the degenerate line. ko is inert
+  for the current corpus (its body-clause parser already tolerated verb-middle put)
+  but the rule is kept for correctness/consistency. **qu** is excluded: it emits
+  verb-final already yet still fails to parse (a separate qu pattern/marker issue).
+- Locked by `multilingual-roadmap-fixes.test.ts` ("SOV put-into verb-final reorder")
+  - i18n `grammar.test.ts` ("SOV put-into verb-final reorder").
+
 ### Track 5 — SOV verb-first event-body reorder (−9 degenerate)
 
 - **Degenerate passes 159 → 150 (−9), 0 regressions, parse rate unchanged.** Full

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -1543,3 +1543,32 @@ describe('SOV modifier-prefixed event body reorder (Track 5)', () => {
     expect(out).toContain('.active');
   });
 });
+
+describe('SOV put-into verb-final reorder (Track 5)', () => {
+  // ko/tr/bn lacked ja's `put-into` rule, so `put X into Y` reordered to
+  // verb-middle (`X i koy Y e`) which the semantic parser can't match. The rule
+  // (gated to standalone put via a no-event predicate) emits verb-final order.
+  const verbFinal: Array<[string, string]> = [
+    ['tr', 'koy'],
+    ['ko', '넣다'],
+    ['bn', 'রাখুন'],
+  ];
+  for (const [lang, verb] of verbFinal) {
+    it(`[${lang}] standalone put is verb-final`, () => {
+      const out = new GrammarTransformer('en', lang).transform('put it into me');
+      // The verb is the last token (patient, destination, then verb).
+      expect(out.trim().endsWith(verb)).toBe(true);
+    });
+  }
+
+  it('[tr] event-handler `put` keeps the event before the verb (predicate gate)', () => {
+    // The no-event predicate excludes event handlers, so the event clause is not
+    // pushed past the verb (which would strand it from the parser).
+    const out = new GrammarTransformer('en', 'tr').transform(
+      'on success put event.detail.message into #sr-announce'
+    );
+    // `koy` (put) must not be verb-final here — the event (`success`) follows it.
+    expect(out.trim().endsWith('koy')).toBe(false);
+    expect(out).toMatch(/koy.*success|success.*koy/);
+  });
+});

--- a/packages/i18n/src/grammar/profiles/index.ts
+++ b/packages/i18n/src/grammar/profiles/index.ts
@@ -174,6 +174,23 @@ export const koreanProfile: LanguageProfile = {
       },
     },
     {
+      name: 'put-into',
+      description: 'Transform put X into Y to Korean verb-final order',
+      priority: 90,
+      match: {
+        commands: ['put', '넣다'],
+        requiredRoles: ['action', 'patient', 'destination'],
+        // Standalone put only (e.g. a then-chain clause): an event handler whose
+        // action is `put` must keep the event mid-stream, so don't verb-final it.
+        predicate: parsed => !parsed.roles.has('event'),
+      },
+      transform: {
+        // X 를 Y 에 넣다 (patient, destination, verb-last)
+        roleOrder: ['patient', 'destination', 'action'],
+        insertMarkers: true,
+      },
+    },
+    {
       name: 'bind-to',
       description: 'Transform bind $var to #el to Korean verb-final order',
       priority: 90,
@@ -402,6 +419,23 @@ export const turkishProfile: LanguageProfile = {
       },
       transform: {
         roleOrder: ['patient', 'event', 'action'],
+        insertMarkers: true,
+      },
+    },
+    {
+      name: 'put-into',
+      description: 'Transform put X into Y to Turkish verb-final order',
+      priority: 90,
+      match: {
+        commands: ['put', 'koy'],
+        requiredRoles: ['action', 'patient', 'destination'],
+        // Standalone put only (e.g. a then-chain clause): an event handler whose
+        // action is `put` must keep the event mid-stream, so don't verb-final it.
+        predicate: parsed => !parsed.roles.has('event'),
+      },
+      transform: {
+        // X i Y e koy (patient, destination, verb-last)
+        roleOrder: ['patient', 'destination', 'action'],
         insertMarkers: true,
       },
     },
@@ -645,6 +679,23 @@ export const bengaliProfile: LanguageProfile = {
       transform: {
         // #count কে ক্লিক এ বৃদ্ধি
         roleOrder: ['patient', 'event', 'action'],
+        insertMarkers: true,
+      },
+    },
+    {
+      name: 'put-into',
+      description: 'Transform put X into Y to Bengali verb-final order',
+      priority: 90,
+      match: {
+        commands: ['put', 'রাখুন'],
+        requiredRoles: ['action', 'patient', 'destination'],
+        // Standalone put only (e.g. a then-chain clause): an event handler whose
+        // action is `put` must keep the event mid-stream, so don't verb-final it.
+        predicate: parsed => !parsed.roles.has('event'),
+      },
+      transform: {
+        // X কে Y তে রাখুন (patient, destination, verb-last)
+        roleOrder: ['patient', 'destination', 'action'],
         insertMarkers: true,
       },
     },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -598,3 +598,65 @@ describe('SOV verb-first event-body reorder — modifier-prefixed bodies (Track 
     expect([...a].sort()).toEqual(['on', 'toggle']);
   });
 });
+
+describe('SOV put-into verb-final reorder — ko/tr/bn (Track 5)', () => {
+  // ja had a `put-into` grammar rule (roleOrder patient,destination,action =
+  // verb-final); ko/tr/bn did not, so `put X into Y` fell through to the generic
+  // reorder that appends `destination` AFTER the verb (verb-middle), which the
+  // semantic parser can't match. As a then-chain clause this silently dropped the
+  // `put`. Mirroring ja's rule (gated to standalone put via a no-event predicate)
+  // emits verb-final order so the clause parses. See
+  // docs-internal/MULTILINGUAL_ROADMAP.md (SOV put-into reorder).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Standalone verb-final `put it into me` (transformer output) now parses.
+  const standalone: Array<[string, string]> = [
+    ['tr', 'o i ben e koy'],
+    ['ko', '그것 를 나 에 넣다'],
+    ['bn', 'এটি কে আমি তে রাখুন'],
+  ];
+  for (const [lang, input] of standalone) {
+    it(`[${lang}] parses verb-final "put it into me"`, () => {
+      expect(parse(input, lang).action).toBe('put');
+    });
+  }
+
+  // Then-chain clause recovers `put` instead of dropping it.
+  const thenChain: Array<[string, string]> = [
+    ['tr', 'async /api/data i tıklama de getir sonra o i ben e koy'],
+    ['ko', 'async /api/data 를 클릭 가져오기 그러면 그것 를 나 에 넣다'],
+    ['bn', 'async /api/data কে ক্লিক এ আনুন তারপর এটি কে আমি তে রাখুন'],
+  ];
+  for (const [lang, input] of thenChain) {
+    it(`[${lang}] recovers fetch + put across the then-chain`, () => {
+      const a = actions(parse(input, lang));
+      expect(a.has('on')).toBe(true);
+      expect(a.has('fetch')).toBe(true);
+      expect(a.has('put')).toBe(true);
+    });
+  }
+
+  // Regression guard: an event handler whose action is `put` must keep the event
+  // mid-stream (the no-event predicate excludes it from the verb-final rule), so
+  // the event + body survive rather than collapsing to a bare `put`.
+  it('[tr] event handler `on success put …` keeps the event (not bare put)', () => {
+    const a = actions(
+      parse(
+        'event.detail.message i success de koy #sr-announce e sonra @role i ayarla "alert" e sonra #sr-announce de',
+        'tr'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('put')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-09T03:54:00.189Z",
-  "commit": "e1ca5df",
+  "timestamp": "2026-06-09T04:23:52.917Z",
+  "commit": "b20eba5",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -650,7 +650,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8657287157287157,
-      "avgFidelity": 0.9351731601731602,
+      "avgFidelity": 0.9515151515151513,
       "degeneratePasses": ["repeat-while", "socket-basic"],
       "bundleSize": 402829,
       "patterns": {
@@ -12667,7 +12667,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8648511256354393,
-      "avgFidelity": 0.9082788671023967,
+      "avgFidelity": 0.9277777777777777,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",


### PR DESCRIPTION
Third in the SOV multilingual-fidelity arc (follows #298 and #299, both merged). Target **#2** from the roadmap: SOV then-chain recovery for tr/bn.

## Root cause

Investigating the dropped then-chain `put` in tr/bn, the real gap turned out to be **word order, not then-keywords** (`sonra`/`তারপর` were already recognized). ja has a `put-into` grammar rule (`roleOrder: patient, destination, action` = verb-final); **ko/tr/bn lacked it**, so `put X into Y` fell through to the generic reorder that appends `destination` **after** the verb (verb-middle `X i koy Y e`). The semantic parser only matches **verb-final** put, so as a then-chain clause (`… then put it into me`) the `put` silently dropped.

## Fix

Mirror ja's `put-into` rule into ko/tr/bn, **gated to standalone put** via `predicate: parsed => !parsed.roles.has('event')`. The predicate is load-bearing: without it, an event handler whose action is `put` (`on success put …`) gets verb-finalized, pushing the event *past* the verb and stranding it (a degenerate `{put}`). I caught exactly this as an `announce-screen-reader` regression mid-implementation and the predicate resolves it — standalone then-chain clauses (no event role) still verb-finalize and parse.

## Validation

- **tr avgFidelity 0.908 → 0.928, bn 0.935 → 0.952**; **no language regressed**.
- **Degenerate count unchanged (148)** — honest framing: the affected then-chain patterns were already above the 50% threshold after #298, so this recovers the dropped `put` (higher fidelity) without crossing the degenerate line. The win is fidelity/correctness, not headline degenerate count.
- `--regression` gate **green**; full **i18n (650)** and **semantic (5382 pass / 9 skip)** suites pass; baseline regenerated.
- **ko** is inert for the current corpus (its body-clause parser already tolerated verb-middle put) but the rule is kept for correctness/consistency.
- **qu excluded**: it already emits verb-final yet still fails to parse — a separate qu pattern/marker issue, out of scope here.
- Locks added on both the transform (i18n) and parse-recovery (semantic) sides, including the `announce` event-handler regression guard.

https://claude.ai/code/session_01WfEQkGEywRhVkY8KFdhQQD