### PR TITLE
fix(multilingual): SOV repeat-* loop-body reorder for ko/bn/qu

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,7 +5,8 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after Track 5 **juxtaposed multi-command event bodies** — a fused event pattern captured only the FIRST body command as the action; a then-chain/block continued, but a **juxtaposed** body (`halt the event call validateForm() if … end` — no `then` between commands) was dropped. `buildEventHandler` now re-parses any trailing non-`end` tokens as body commands (additive; `parseBodyWithGrammarPatterns` only appends matched commands). **Degenerate passes 179 → 159 (−20), 0 regressions, parse rate unchanged** (3679/3696). Cleared `form-submit-prevent` (de/it/ru/sw/th/uk/vi), `fetch-loading-state` (bn/hi/it/ja/tr), plus `fetch-error-handling`/`fetch-with-headers` (ja), `render-template-with-data` (qu/tl/vi), `repeat-forever`/`stagger-animation` (qu), `window-scroll` (th)._
+_Last updated: after Track 5 **SOV `repeat-*` loop-body reorder** — for SOV languages the i18n transformer surfaces a block loop's keyword (반복/পুনরাবৃত্তি/kutipay) — or a leading `while`/`for` clause — ahead of its body, so the parser matched the bare loop keyword as a standalone command (Stage 2) and dropped the event + variant + body (degenerate). Korean (no event-marker particle) was hit hardest. The Stage-2 gate now prefers SOV event extraction (Stage 3) when the matched action is a block/loop action, recovering the event + loop body; and the qu `repeat` dict keyword was realigned (`kutichiy`→`kutipay`; `kutichiy` is the profile's `return` primary). **Degenerate passes 148 → 141 (−7), 0 regressions, parse rate unchanged** (3678/3696). Cleared `repeat-forever`/`repeat-while`/`repeat-for-each` for ko (+ `stagger-animation` bonus), `repeat-while` for bn, `repeat-while`/`repeat-for-each` for qu. avgFidelity ko 0.889→0.903, bn 0.952→0.956, qu 0.782→0.794. See [SOV_REPEAT_SCOPE.md](SOV_REPEAT_SCOPE.md)._
+_Earlier: Track 5 **juxtaposed multi-command event bodies** — a fused event pattern captured only the FIRST body command as the action; a then-chain/block continued, but a **juxtaposed** body (`halt the event call validateForm() if … end` — no `then` between commands) was dropped. `buildEventHandler` now re-parses any trailing non-`end` tokens as body commands (additive; `parseBodyWithGrammarPatterns` only appends matched commands). **Degenerate passes 179 → 159 (−20), 0 regressions, parse rate unchanged** (3679/3696). Cleared `form-submit-prevent` (de/it/ru/sw/th/uk/vi), `fetch-loading-state` (bn/hi/it/ja/tr), plus `fetch-error-handling`/`fetch-with-headers` (ja), `render-template-with-data` (qu/tl/vi), `repeat-forever`/`stagger-animation` (qu), `window-scroll` (th)._
 _Earlier: Track 5 **then/end keyword recognition for 9 profile-only languages** (it, ru, th, vi, he, hi, ms, pl, uk). `isThenKeyword`/`isEndKeyword` were hardcoded maps covering only 15 langs; the other 9 fell back to the English literal, so their native then/end (`allora`, `затем`, …) weren't recognized — multi-command then-chains collapsed to the first command and `end`-blocks didn't close. Both now fall back to the profile's form. **Parse rate +7** (he/it/pl behaviors now parse — `end` recognized; he/it/pl jump toward 100%), **+4 fidelity** (`fetch-loading-state` ru/th/vi/uk degenerate→faithful), **0 regressions** (gate green). Degenerate nets 176 → 179 (−4 fetch-loading-state, +7 newly-parsing Bucket B behaviors)._
 _Earlier: Track 5 **Async Tier 1 — `async` modifier transparency** (degenerate **181 → 176**, −5: `async-block` ar/de/it/th/tl)._
 _Earlier: after Track 5 **Tier 1 — if/else block-body in event handlers** (degenerate passes **219 → 181**, −38 degenerate→faithful, 0 fidelity regressions). Cleared `if-exists` entirely (ar+it flipped, the named Tier 1 target) and lifted `if-empty`/`input-validation`/`unless-condition` across 13 languages. Before that: German `fetch` keyword alignment, caret-scope masking, @attr-in-selector-role, trailing-event block-wrap, custom-event SOV, property-path patient, (parse-rate) Tier 1, Track 4, Track 1 (reactive) complete._
@@ -60,6 +61,53 @@ behaviors), not a parsing/i18n track. See Track 2.
 ---
 
 ## Shipped
+
+### Track 5 — SOV `repeat-*` loop-body reorder (ko/bn/qu, −7 degenerate)
+
+- **Degenerate passes 148 → 141 (−7), 0 regressions, parse rate unchanged**
+  (3678/3696). Full `browser-priority` regen + `--regression` gate green; every
+  flip is degenerate→faithful, zero faithful→degenerate, zero parse-success ↑/↓.
+  Cleared `repeat-forever`/`repeat-while`/`repeat-for-each` (ko) + the
+  `stagger-animation` repeat body (ko bonus), `repeat-while` (bn),
+  `repeat-while`/`repeat-for-each` (qu). avgFidelity ko 0.889→0.903, bn
+  0.952→0.956, qu 0.782→0.794; all other languages byte-identical.
+- **Root cause (two layers — parser was the real blocker, mirroring the if/else
+  fix).** (1) For SOV the i18n transformer surfaces a block loop's keyword
+  (`반복`/`পুনরাবৃত্তি`/`kutipay` = repeat) — or a leading `while <cond>` / `for <x> in
+<y>` clause — ahead of its body. The semantic parser matched the bare loop
+  keyword as a **standalone command** at Stage 2 (`{ action: 'repeat'/'while',
+roles: {} }`) and returned before the SOV event-extraction (Stage 3) could run,
+  dropping the event + variant + body. **Korean is hit hardest:** with no
+  event-marker particle the Stage-1 fused event pattern can't anchor, so the bare
+  loop keyword always won. bn/qu fail only on the `while`/`for` variants, where the
+  leading condition clause pushes the event mid-stream and breaks the Stage-1
+  match. (2) The qu i18n dict emitted `kutichiy` for `repeat`, but `kutichiy` is the
+  semantic qu profile's **`return`** primary (repeat = `kutipay`) — a keyword
+  collision that mis-parsed every qu `repeat-*` independent of the reorder.
+- **Fix (two parts, both additive).**
+  1. **Parser (`semantic-parser.ts`, Stage 2 gate).** When the Stage-2 command
+     match's action is a block/loop action (`BLOCK_BODY_ACTIONS` = if/unless/while/
+     repeat/for), try `trySOVEventExtraction` (Stage 3) first; use its event-handler
+     result when it finds a real event whose body parses, else fall back to the bare
+     command. Gated to block/loop actions and only taken when SOV extraction finds an
+     event, so the counted variant (`repeat N times`) and genuine standalone loops
+     (no event → SOV extraction returns null) are unaffected — no phantom event
+     handler is synthesized. ja/tr already recovered these via Stage-1 (their event
+     marker anchors the fused pattern) and are untouched.
+  2. **qu keyword alignment (passthrough).** i18n qu dict `repeat: 'kutichiy'` →
+     `'kutipay'` (the semantic repeat primary). Collision-free: `kutichiy` stays
+     `return`'s word. Mirrors the qu `install` and de `fetch` dict realignments.
+- **Honest scope.** ko `repeat-forever` lands at 0.67 (the `반복` keyword + English
+  `forever` don't re-assemble into a `repeat` node, but the event + body recover) and
+  qu `repeat-while` at 0.50 (the body `yapay`=add vs `increment`, and a `tukuy`=end
+  landing mid-stream drops the trailing `wait` — the same then-chain-tail residue
+  ja/tr show at 0.75). All are ≥0.5 (faithful). Non-SOV `repeat-*` degenerates
+  (`ar`/`tl` VSO, `zh` SVO, `sw`) are separate word-order issues, out of scope.
+- Locked by `multilingual-roadmap-fixes.test.ts` ("SOV repeat-\* loop-body reorder":
+  ko/bn/qu recover the event + loop body; counted variant unaffected; a no-event loop
+  never becomes an event handler; qu `kutipay` parses as `repeat` not `return`) and
+  `grammar.test.ts` (qu emits `kutipay`, not `kutichiy`). See
+  [SOV_REPEAT_SCOPE.md](SOV_REPEAT_SCOPE.md).
 
 ### Track 5 — SOV put-into verb-final reorder (ko/tr/bn, +fidelity)
 

--- a/docs-internal/SOV_REPEAT_SCOPE.md
+++ b/docs-internal/SOV_REPEAT_SCOPE.md
@@ -1,6 +1,10 @@
 # SOV `repeat-*` Loop-Body Reorder — Project Scope
 
-> **Status:** Scoped, not started. Handoff-ready for a fresh session.
+> **Status:** ✅ SHIPPED. Parser Stage-2 gate (prefer SOV event extraction over a
+> bare block/loop keyword) + qu `repeat` dict realignment (`kutichiy`→`kutipay`).
+> Degenerate passes **148 → 141 (−7)**, 0 regressions. Cleared ko
+> (repeat-forever/while/for-each + stagger-animation), bn (repeat-while), qu
+> (repeat-while/for-each). See `MULTILINGUAL_ROADMAP.md` → Shipped for the writeup.
 > **Track:** Multilingual parse-fidelity (Track 5 in `MULTILINGUAL_ROADMAP.md`).
 > **Prereq reading:** `SOV_REORDER_SCOPE.md` (the verb-first event-body reorder
 > project — SHIPPED in #298) and `MULTILINGUAL_ROADMAP.md` → Shipped (the if/else

--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -20,7 +20,7 @@ export const qu: Dictionary = {
     show: 'rikuchiy',
     if: 'sichus',
     unless: 'mana_sichus',
-    repeat: 'kutichiy',
+    repeat: 'kutipay',
     for: 'rayku',
     while: 'kay_kaq',
     until: 'hayk_akama',

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -488,6 +488,20 @@ describe('GrammarTransformer', () => {
       expect(result).not.toContain('churay');
       expect(result).toContain('Draggable');
     });
+
+    it('should emit the repeat verb (kutipay), not the return verb (kutichiy)', () => {
+      // Regression: the qu dictionary mapped `repeat` to `kutichiy`, which is the
+      // semantic qu profile's `return` primary (repeat = kutipay there). So every
+      // qu `repeat …` transformed to `kutichiy …` and the semantic parser read it
+      // as `return`, dropping the loop — degenerate parses for the qu repeat-*
+      // cluster (repeat-while, repeat-for-each). Align the emitted verb to the
+      // semantic repeat keyword. See docs-internal/SOV_REPEAT_SCOPE.md.
+      const result = transformer.transform(
+        'on click repeat for item in .items add .processed to item'
+      );
+      expect(result).toContain('kutipay');
+      expect(result).not.toContain('kutichiy');
+    });
   });
 
   describe('German Transformation (fetch/get disambiguation)', () => {

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -191,6 +191,37 @@ export class SemanticParserImpl implements ISemanticParser {
     const commandMatch = patternMatcher.matchBest(tokens, commandPatterns);
 
     if (commandMatch) {
+      // A bare block/loop keyword (if/unless/while/repeat/for) can shadow the SOV
+      // event + loop-body path. For SOV languages the grammar transformer surfaces
+      // the loop keyword (反復/반복/পুনরাবৃত্তি) — or a leading `while`/`for` clause —
+      // ahead of its body, so Stage 2 matches it as a *standalone* command and the
+      // event + loop variant + body are all dropped (a degenerate parse). Korean is
+      // hit hardest: with no event-marker particle, the Stage-1 fused event pattern
+      // can't anchor, so the bare loop keyword always wins here. When the matched
+      // action is a block/loop action, prefer the SOV event extraction (Stage 3),
+      // which finds the (possibly mid-stream) event, strips it, and re-parses the
+      // loop body — recovering the loop keyword + body commands. Gated to block/loop
+      // actions and only taken when SOV extraction actually finds an event whose
+      // body parses (it returns null otherwise — e.g. a genuine standalone loop with
+      // no event), so it can only add parses, never break the counted/standalone
+      // variants. Mirrors the if/else block-body fix (the parser was the real
+      // blocker, capturing the block keyword as the action and dropping the body).
+      if (BLOCK_BODY_ACTIONS.has(commandMatch.pattern.command)) {
+        const sovLoop = this.trySOVEventExtraction(parseInput, language, sortedPatterns);
+        if (sovLoop) {
+          diagnostics.push(
+            parseDiagnostic(
+              `SOV event extraction preferred over bare ${commandMatch.pattern.command} command`,
+              'info',
+              'stage-sov-loop'
+            )
+          );
+          const result = modifiers
+            ? this.applyModifiers(sovLoop as EventHandlerSemanticNode, modifiers)
+            : sovLoop;
+          return withDiagnostics(result, diagnostics);
+        }
+      }
       diagnostics.push(
         parseDiagnostic(
           `command pattern matched: ${commandMatch.pattern.id} (confidence: ${commandMatch.confidence.toFixed(2)})`,

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -660,3 +660,109 @@ describe('SOV put-into verb-final reorder — ko/tr/bn (Track 5)', () => {
     expect(a.has('put')).toBe(true);
   });
 });
+
+describe('SOV repeat-* loop-body reorder — ko/bn/qu (Track 5)', () => {
+  // For SOV languages the i18n transformer surfaces a block loop's keyword
+  // (반복/পুনরাবৃত্তি/kutipay = repeat) — or a leading `while`/`for` clause — ahead of
+  // its body, so the semantic parser used to match the bare loop keyword as a
+  // *standalone* command (Stage 2) and drop the event + loop variant + body
+  // (degenerate). Korean is hit hardest: with no event-marker particle the
+  // Stage-1 fused event pattern can't anchor. The Stage-2 gate now prefers the
+  // SOV event extraction when the matched action is a block/loop action, so the
+  // event is found, stripped, and the loop body re-parsed. See
+  // docs-internal/SOV_REPEAT_SCOPE.md. Strings below are post-transform output
+  // (en → lang); the parser must recover the event + body.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // repeat-forever: `on load repeat forever toggle .pulse wait 1s end`
+  it('[ko] repeat-forever recovers the event + loop body (not bare repeat)', () => {
+    const a = actions(parse('로드 반복 forever .pulse 를 토글 그러면 1s 를 대기 끝', 'ko'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('toggle')).toBe(true);
+    expect(a.has('wait')).toBe(true);
+  });
+
+  // repeat-while: `on click repeat while #x.innerText < 10 increment #x wait 200ms end`
+  it('[ko] repeat-while recovers the event + repeat + increment body', () => {
+    const a = actions(
+      parse('동안 #counter.innerText < 10 를 클릭 반복 그러면 #counter 를 증가 그러면 200ms 끝 를 대기', 'ko')
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+    expect(a.has('increment')).toBe(true);
+  });
+
+  // repeat-for-each: `on click repeat for item in .items add .processed to item`
+  it('[ko] repeat-for-each recovers the event + repeat + add body', () => {
+    const a = actions(parse('클릭 반복 item 안에 .items 그러면 .processed 를 추가 item 에', 'ko'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+    expect(a.has('add')).toBe(true);
+  });
+
+  // bn repeat-while: the leading `while`-condition broke the Stage-1 fused event
+  // match (the event sits after the condition), so the bare `while` won Stage 2.
+  it('[bn] repeat-while recovers the event + increment body (not bare while)', () => {
+    const a = actions(
+      parse(
+        'যতক্ষণ #counter.innerText < 10 কে ক্লিক এ পুনরাবৃত্তি তারপর #counter কে বৃদ্ধি তারপর 200ms শেষ কে অপেক্ষা',
+        'bn'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('increment')).toBe(true);
+  });
+
+  // qu: the i18n dict emitted `kutichiy` for `repeat`, but the semantic qu profile
+  // reads `kutichiy` as `return` (repeat primary is `kutipay`) — a keyword
+  // collision that mis-parsed every qu repeat-*. The dict now emits `kutipay`.
+  it('[qu] repeat-forever parses kutipay as repeat (not return)', () => {
+    const a = actions(parse('apakuy pi kutipay forever .pulse ta tikray chayqa 1s ta suyay tukuy', 'qu'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+    expect(a.has('return')).toBe(false);
+  });
+  it('[qu] repeat-while recovers the event + repeat', () => {
+    const a = actions(
+      parse(
+        'kay_kaq #counter.innerText < 10 ta ñitiy pi kutipay chayqa #counter ta yapay chayqa 200ms tukuy ta suyay',
+        'qu'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+  });
+  it('[qu] repeat-for-each recovers the event + repeat', () => {
+    const a = actions(parse('ñitiy pi kutipay item ukupi .items chayqa .processed ta item man yapay', 'qu'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+  });
+
+  // Regression guards. The gate is scoped to block/loop actions AND only taken
+  // when SOV extraction finds a real event, so the counted variant and genuine
+  // standalone loops are unaffected — no phantom event handler is synthesized.
+  it('[ko] counted `repeat N times` inside an event still parses faithfully', () => {
+    const a = actions(parse('3 times 를 클릭 반복 그러면 "<p>Line</p>" 를 추가 나 에', 'ko'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+    expect(a.has('add')).toBe(true);
+  });
+  it('[ko] a standalone loop (no event) is not turned into an event handler', () => {
+    // Transformer output for `repeat 3 times toggle .x end` (no `on …`). With no
+    // event keyword the gate's SOV extraction returns null, so the parse stays a
+    // bare repeat command — no phantom `on` is synthesized.
+    const a = actions(parse('3 times 를 반복 그러면 .x end 를 토글', 'ko'));
+    expect(a.has('on')).toBe(false);
+    expect(a.has('repeat')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-09T04:23:52.917Z",
-  "commit": "b20eba5",
+  "timestamp": "2026-06-09T05:54:45.528Z",
+  "commit": "b965f54",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -26,7 +26,7 @@
         "tabs-content",
         "window-keydown"
       ],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -650,9 +650,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8657287157287157,
-      "avgFidelity": 0.9515151515151513,
-      "degeneratePasses": ["repeat-while", "socket-basic"],
-      "bundleSize": 402829,
+      "avgFidelity": 0.9563852813852812,
+      "degeneratePasses": ["socket-basic"],
+      "bundleSize": 403064,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1285,7 +1285,7 @@
         "first-in-parent",
         "if-empty"
       ],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1909,7 +1909,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2536,7 +2536,7 @@
       "avgConfidence": 0.989034132171387,
       "avgFidelity": 0.9089324618736385,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3169,7 +3169,7 @@
         "fetch-with-headers",
         "first-in-parent"
       ],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3802,7 +3802,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4438,7 +4438,7 @@
         "socket-basic",
         "worker-basic"
       ],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5070,7 +5070,7 @@
         "behavior-sortable",
         "unless-condition"
       ],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5696,7 +5696,7 @@
       "avgConfidence": 0.9878721859114016,
       "avgFidelity": 0.9550108932461874,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6331,7 +6331,7 @@
         "input-validation",
         "socket-basic"
       ],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6956,7 +6956,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.5553391053391054,
-      "avgFidelity": 0.8886363636363638,
+      "avgFidelity": 0.9032467532467534,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -6964,14 +6964,10 @@
         "behavior-sortable",
         "if-empty",
         "input-validation",
-        "repeat-for-each",
-        "repeat-forever",
-        "repeat-while",
         "socket-basic",
-        "stagger-animation",
         "window-scroll"
       ],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7607,7 +7603,7 @@
         "its-value-possessive-dot",
         "template-literal-list-build"
       ],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8239,7 +8235,7 @@
         "behavior-sortable",
         "first-in-parent"
       ],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8874,7 +8870,7 @@
         "focus-trap",
         "socket-basic"
       ],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "window-resize": {
           "success": true,
@@ -9498,7 +9494,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7293650793650793,
-      "avgFidelity": 0.7817099567099568,
+      "avgFidelity": 0.7941558441558443,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -9506,12 +9502,10 @@
         "behavior-sortable",
         "get-value",
         "modal-close-escape",
-        "repeat-for-each",
-        "repeat-while",
         "socket-basic",
         "template-literal-list-build"
       ],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10138,7 +10132,7 @@
       "avgConfidence": 0.8895073180787468,
       "avgFidelity": 0.9596320346320344,
       "degeneratePasses": ["install-behavior"],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10775,7 +10769,7 @@
         "socket-basic",
         "template-literal-list-build"
       ],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11400,7 +11394,7 @@
       "avgConfidence": 0.9402185116470816,
       "avgFidelity": 0.9791125541125543,
       "degeneratePasses": [],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12042,7 +12036,7 @@
         "take-class-from-siblings",
         "worker-basic"
       ],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12677,7 +12671,7 @@
         "focus-trap",
         "socket-basic"
       ],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13303,7 +13297,7 @@
       "avgConfidence": 0.8887652030509177,
       "avgFidelity": 0.9596320346320344,
       "degeneratePasses": ["install-behavior"],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13930,7 +13924,7 @@
       "avgConfidence": 0.892888064316636,
       "avgFidelity": 0.894155844155844,
       "degeneratePasses": ["template-literal-list-build"],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14567,7 +14561,7 @@
         "repeat-forever",
         "template-literal-list-build"
       ],
-      "bundleSize": 402829,
+      "bundleSize": 403064,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15186,7 +15180,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 402829,
+      "size": 403064,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Implements `docs-internal/SOV_REPEAT_SCOPE.md` — the loop sibling of the shipped if/else and SOV verb-first event-body fixes.

For SOV languages the i18n transformer surfaces a block loop's keyword (`반복`/`পুনরাবৃত্তি`/`kutipay` = repeat) — or a leading `while <cond>` / `for <x> in <y>` clause — ahead of its body. The semantic parser then matched the bare loop keyword as a **standalone command** at Stage 2 (`{ action: 'repeat'/'while', roles: {} }`) and returned before SOV event-extraction (Stage 3) could run, dropping the event + variant + body (degenerate parse). **Korean is hit hardest**: with no event-marker particle the Stage-1 fused event pattern can't anchor, so the bare loop keyword always won.

## Changes

1. **Parser (`semantic-parser.ts`, Stage-2 gate).** When the Stage-2 command match's action is a block/loop action (`if`/`unless`/`while`/`repeat`/`for`), prefer `trySOVEventExtraction` (Stage 3) — which finds the mid-stream event, strips it, and re-parses the loop body. Gated to block/loop actions and only taken when SOV extraction finds a real event whose body parses, so the counted variant (`repeat N times`) and genuine standalone loops (no event → returns null) are unaffected; **no phantom event handler is synthesized**. ja/tr already recovered these via Stage-1 and are untouched.

2. **qu keyword alignment (passthrough).** The i18n qu dict emitted `kutichiy` for `repeat`, but `kutichiy` is the semantic qu profile's **`return`** primary (repeat = `kutipay`) — a keyword collision that mis-parsed every qu `repeat-*`. Realigned the dict to `kutipay` (collision-free). Mirrors the shipped qu `install` and de `fetch` dict realignments.

## Results

**Degenerate passes 148 → 141 (−7), 0 regressions, parse rate unchanged (3678/3696), `--regression` gate green.** Every flip is degenerate→faithful, zero faithful→degenerate, zero parse-success ↑/↓; all other languages byte-identical.

| Language | Cleared | avgFidelity |
| --- | --- | --- |
| ko | repeat-forever, repeat-while, repeat-for-each (+ stagger-animation bonus) | 0.889 → 0.903 |
| bn | repeat-while | 0.952 → 0.956 |
| qu | repeat-while, repeat-for-each | 0.782 → 0.794 |

Non-SOV `repeat-*` degenerates (`ar`/`tl` VSO, `zh` SVO, `sw`) are separate word-order issues, out of scope.

## Validation

- Full `browser-priority` regen + `--regression` gate green; baseline regenerated.
- Semantic role-extraction suite clean (5352 pass; the 30 `build-artifacts.test.ts` `.d.ts` failures are the known environmental ones).
- Locked by `multilingual-roadmap-fixes.test.ts` (ko/bn/qu recover the event + loop body; counted variant unaffected; a no-event loop never becomes an event handler; qu `kutipay` parses as `repeat` not `return`) and `grammar.test.ts` (qu emits `kutipay`).

https://claude.ai/code/session_01QyVxCJqsKiuyAWLo6G1gz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyVxCJqsKiuyAWLo6G1gz5)_