### PR TITLE
fix(multilingual): VSO/Austronesian repeat-* mid-stream event reorder (ar/tl)

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,7 +5,8 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after Track 5 **SOV `repeat-*` loop-body reorder** — for SOV languages the i18n transformer surfaces a block loop's keyword (반복/পুনরাবৃত্তি/kutipay) — or a leading `while`/`for` clause — ahead of its body, so the parser matched the bare loop keyword as a standalone command (Stage 2) and dropped the event + variant + body (degenerate). Korean (no event-marker particle) was hit hardest. The Stage-2 gate now prefers SOV event extraction (Stage 3) when the matched action is a block/loop action, recovering the event + loop body; and the qu `repeat` dict keyword was realigned (`kutichiy`→`kutipay`; `kutichiy` is the profile's `return` primary). **Degenerate passes 148 → 141 (−7), 0 regressions, parse rate unchanged** (3678/3696). Cleared `repeat-forever`/`repeat-while`/`repeat-for-each` for ko (+ `stagger-animation` bonus), `repeat-while` for bn, `repeat-while`/`repeat-for-each` for qu. avgFidelity ko 0.889→0.903, bn 0.952→0.956, qu 0.782→0.794. See [SOV_REPEAT_SCOPE.md](SOV_REPEAT_SCOPE.md)._
+_Last updated: after Track 5 **VSO/Austronesian `repeat-*` mid-stream event reorder** — the non-SOV sibling of the SOV repeat-\* fix. For VSO/Austronesian the i18n transformer surfaces the loop keyword first and places the event clause mid-stream, marked by an `on`-marker (`كرر عند نقر …` / `ulitin kapag click …` = `repeat on click …`). The trailing-event extractor (Stage 1.5) can't see it (the event isn't last), so the bare loop keyword won Stage 2 and the event + body dropped (degenerate). `tryMidStreamEventExtraction` strips the `<on-marker> <event>` pair and re-parses the rest as the loop body; the block/loop gate now tries it after SOV extraction. **Degenerate passes 141 → 135 (−6), 0 regressions, parse rate unchanged** (3678/3696). Cleared `repeat-for-each`/`repeat-while` (ar+tl) + bonus `focus-trap`/`window-keydown` (ar — same mid-stream-event shape). avgFidelity ar 0.866→0.883, tl 0.884→0.894. Remaining repeat residue (zh circumfix block-body, the `for`-binding `repeat`-keyword drop, the `wait`-after-`end` tail) scoped in [NON_SOV_REPEAT_SCOPE.md](NON_SOV_REPEAT_SCOPE.md)._
+_Earlier: Track 5 **SOV `repeat-*` loop-body reorder** — for SOV languages the i18n transformer surfaces a block loop's keyword (반복/পুনরাবৃত্তি/kutipay) — or a leading `while`/`for` clause — ahead of its body, so the parser matched the bare loop keyword as a standalone command (Stage 2) and dropped the event + variant + body (degenerate). Korean (no event-marker particle) was hit hardest. The Stage-2 gate now prefers SOV event extraction (Stage 3) when the matched action is a block/loop action, recovering the event + loop body; and the qu `repeat` dict keyword was realigned (`kutichiy`→`kutipay`; `kutichiy` is the profile's `return` primary). **Degenerate passes 148 → 141 (−7), 0 regressions, parse rate unchanged** (3678/3696). Cleared `repeat-forever`/`repeat-while`/`repeat-for-each` for ko (+ `stagger-animation` bonus), `repeat-while` for bn, `repeat-while`/`repeat-for-each` for qu. avgFidelity ko 0.889→0.903, bn 0.952→0.956, qu 0.782→0.794. See [SOV_REPEAT_SCOPE.md](SOV_REPEAT_SCOPE.md)._
 _Earlier: Track 5 **juxtaposed multi-command event bodies** — a fused event pattern captured only the FIRST body command as the action; a then-chain/block continued, but a **juxtaposed** body (`halt the event call validateForm() if … end` — no `then` between commands) was dropped. `buildEventHandler` now re-parses any trailing non-`end` tokens as body commands (additive; `parseBodyWithGrammarPatterns` only appends matched commands). **Degenerate passes 179 → 159 (−20), 0 regressions, parse rate unchanged** (3679/3696). Cleared `form-submit-prevent` (de/it/ru/sw/th/uk/vi), `fetch-loading-state` (bn/hi/it/ja/tr), plus `fetch-error-handling`/`fetch-with-headers` (ja), `render-template-with-data` (qu/tl/vi), `repeat-forever`/`stagger-animation` (qu), `window-scroll` (th)._
 _Earlier: Track 5 **then/end keyword recognition for 9 profile-only languages** (it, ru, th, vi, he, hi, ms, pl, uk). `isThenKeyword`/`isEndKeyword` were hardcoded maps covering only 15 langs; the other 9 fell back to the English literal, so their native then/end (`allora`, `затем`, …) weren't recognized — multi-command then-chains collapsed to the first command and `end`-blocks didn't close. Both now fall back to the profile's form. **Parse rate +7** (he/it/pl behaviors now parse — `end` recognized; he/it/pl jump toward 100%), **+4 fidelity** (`fetch-loading-state` ru/th/vi/uk degenerate→faithful), **0 regressions** (gate green). Degenerate nets 176 → 179 (−4 fetch-loading-state, +7 newly-parsing Bucket B behaviors)._
 _Earlier: Track 5 **Async Tier 1 — `async` modifier transparency** (degenerate **181 → 176**, −5: `async-block` ar/de/it/th/tl)._
@@ -61,6 +62,39 @@ behaviors), not a parsing/i18n track. See Track 2.
 ---
 
 ## Shipped
+
+### Track 5 — VSO/Austronesian `repeat-*` mid-stream event reorder (ar/tl, −6 degenerate)
+
+- **Degenerate passes 141 → 135 (−6), 0 regressions, parse rate unchanged**
+  (3678/3696). Full `browser-priority` regen + `--regression` gate green; every flip
+  is degenerate→faithful, zero faithful→degenerate. Cleared `repeat-for-each` and
+  `repeat-while` (ar+tl) **plus bonus `focus-trap` and `window-keydown` (ar)** — same
+  mid-stream-event shape. avgFidelity ar 0.866→0.883, tl 0.884→0.894; all other
+  languages byte-identical.
+- **Root cause (the non-SOV sibling of the SOV repeat-\* fix).** For VSO/Austronesian
+  the i18n transformer surfaces a block loop's keyword first and places the event
+  clause **mid-stream**, marked by an `on`-marker (`كرر عند نقر …` /
+  `ulitin kapag click …` = `repeat on click …`). Unlike SOV (no marker / event-marker
+  particle) and unlike the trailing-event SVO/VSO case (event last), the event sits
+  right after the leading loop keyword. `tryTrailingEventExtraction` (Stage 1.5)
+  requires the event to be the final token, so it missed it; the bare loop keyword won
+  Stage 2 and the event + variant + body dropped (degenerate). `repeat-forever` already
+  worked for ar/tl because _its_ event reorders to the **end** (caught by Stage 1.5).
+- **Fix (parser, additive).** New `tryMidStreamEventExtraction` scans for an
+  `on`-marker (`normalized === 'on'`) immediately followed by a known event keyword,
+  strips that pair, and parses everything else (leading loop keyword + for/while clause
+  - then-chain body) as the handler body. Wired into the same block/loop Stage-2 gate
+    added for the SOV fix, _after_ SOV extraction returns null — so it's reached only when
+    Stage 2 matched a bare block/loop action (already a degenerate parse) and only fires
+    on a real on-marked event whose body parses. Simple commands never reach it.
+- **Honest scope.** ar/tl `repeat-for-each` land at 0.67 (the `for <var> in <coll>`
+  binder doesn't re-yield a `repeat` action — a shared gap with ko, tracked as #2 in the
+  follow-up). The remaining degenerate `repeat-*` is **zh `repeat-forever`** (circumfix
+  `当…时` event + a zh block-body collapse — a different layer), plus the `wait`-after-`end`
+  tail residue across SOV. All scoped in [NON_SOV_REPEAT_SCOPE.md](NON_SOV_REPEAT_SCOPE.md).
+- Locked by `multilingual-roadmap-fixes.test.ts` ("VSO/Austronesian repeat-\* mid-stream
+  event reorder — ar/tl": ar/tl recover the event + loop body; a simple VSO command is
+  unaffected).
 
 ### Track 5 — SOV `repeat-*` loop-body reorder (ko/bn/qu, −7 degenerate)
 

--- a/docs-internal/NON_SOV_REPEAT_SCOPE.md
+++ b/docs-internal/NON_SOV_REPEAT_SCOPE.md
@@ -1,0 +1,247 @@
+# Non-SOV `repeat-*` Loop-Body + Tail Residue — Project Scope
+
+> **Status:** Partially shipped. The VSO/Austronesian mid-stream-event slice (ar/tl)
+> is **DONE** (see below + `MULTILINGUAL_ROADMAP.md` → Shipped). This file scopes the
+> **remainder**: the zh circumfix block-body collapse, the shared `for`-binding
+> `repeat`-keyword drop, the then-chain tail drop, and sw `repeat-while`.
+> **Prereq reading:** `SOV_REPEAT_SCOPE.md` (the SOV sibling, SHIPPED) and
+> `MULTILINGUAL_ROADMAP.md` → Shipped (SOV repeat-\* loop-body reorder; VSO
+> mid-stream event reorder).
+
+## Already shipped (this arc)
+
+- **VSO/Austronesian mid-stream event (ar/tl).** For VSO the transformer surfaces the
+  loop keyword first and the event clause mid-stream (`كرر عند نقر …` =
+  `repeat on click …`); the trailing-event extractor couldn't see it, so the bare
+  loop keyword won Stage 2. `tryMidStreamEventExtraction` (parser) strips the
+  `<on-marker> <event>` pair and re-parses the rest as the loop body. Gated to
+  block/loop actions. **Cleared ar `repeat-for-each`/`repeat-while` + bonus
+  `focus-trap`/`window-keydown`, tl `repeat-for-each`/`repeat-while`** (−6 degenerate,
+  148→135 cumulative with the SOV fix). Locked by `multilingual-roadmap-fixes.test.ts`
+  ("VSO/Austronesian repeat-\* mid-stream event reorder — ar/tl").
+
+## TL;DR of what's left
+
+Four residues remain, in priority order:
+
+| #   | Issue                                         | Languages          | Current                         | Target   |
+| --- | --------------------------------------------- | ------------------ | ------------------------------- | -------- |
+| 1   | **zh circumfix + block-body collapse**        | zh                 | `repeat-forever` 0.33 **DEGEN** | faithful |
+| 2   | **`for`-binding drops the `repeat` keyword**  | ar, tl, ko, zh     | `repeat-for-each` 0.67          | 1.0      |
+| 3   | **then-chain tail drop (`wait` after `end`)** | ja, tr, ko, qu, zh | `repeat-while` 0.50–0.75        | 1.0      |
+| 4   | **sw `repeat-while` leading clause drop**     | sw                 | `repeat-while` 0.50             | 1.0      |
+
+Only **#1 is degenerate** (the last degenerate `repeat-*` in the corpus); #2–#4 are
+faithful-but-lossy fidelity residues. Lower yield per unit effort than the shipped
+slices — multi-PR, per-issue.
+
+## Failure modes (probe evidence)
+
+Probe = `maskSpans → GrammarTransformer('en',lang) → unmaskSpans → parseSemantic`.
+Reproduce with the probe script at the bottom.
+
+### #1 — zh circumfix event + block-body collapse (the only remaining degenerate)
+
+```
+on load repeat forever toggle .pulse wait 1s end
+  zh → 当 加载 时 重复 forever 切换 把 .pulse 那么 等待 把 1s 结束
+       parsed: {on,toggle}   fid 0.33 DEGEN  (drops repeat + wait)
+```
+
+zh wraps the event in a **circumfix** `当 … 时` (`on load` → `当 加载 时`), so the
+Stage-1 zh event pattern _does_ anchor (the `on` survives) — unlike the SOV/VSO cases,
+this is **not** an event-extraction problem. The body
+`重复 forever 切换 把 .pulse 那么 等待 把 1s 结束` collapses: only `切换`(toggle) is
+recovered; the leading `重复`(repeat) + English `forever`, and the trailing
+`等待 把 1s 结束`(wait … end), are dropped. This is a **zh block-body parse gap** — the
+same family as the deferred zh `fetch`-in-event-block gap noted in the roadmap (zh's
+block-body body parser is the recurring zh blocker). Likely needs the body re-parse to
+(a) tolerate the leading `重复 forever` as a repeat clause and (b) not let `结束`(end)
+mid-stream truncate the trailing `等待`(wait) — see #3.
+
+### #2 — `for`-binding drops the `repeat` keyword (shared, ar/tl/ko/zh)
+
+```
+on click repeat for item in .items add .processed to item
+  ar → كرر عند نقر item في .items ثم أضف .processed إلى item
+       {on,add}  fid 0.67   (event + add recovered; `repeat` dropped)
+  ko → 클릭 반복 item 안에 .items 그러면 .processed 를 추가 item 에
+       {on,repeat,add} fid 1.00   ← ko already recovers repeat here
+```
+
+After the event is stripped, the for-binding clause `كرر item في .items`
+(`repeat item in .items`) doesn't yield a `repeat` action — the generated `repeat`
+command pattern doesn't match `repeat <identifier> <in-marker> <selector>` (the
+`for <var> in <coll>` binder). ko happens to recover it (its clause parser tolerates
+the binder); ar/tl/zh don't. The EN reference is `{on,repeat,add}`, so the dropped
+`repeat` is the 0.67→1.0 gap. A `repeat`/`for` binder sub-pattern (or a `for`-binding
+branch in `parseClause`) would lift all three at once.
+
+### #3 — then-chain tail drop: `end` mid-stream truncates the trailing `wait`
+
+```
+on click repeat while #x.innerText < 10 increment #x wait 200ms end
+  ja → … それから #counter を 増加 それから 200ms 終わり を 待つ   {…,increment} 0.75 (drops wait)
+  ko → … 그러면 #counter 를 증가 그러면 200ms 끝 를 대기            {…,increment} 0.75 (drops wait)
+  qu → … chayqa #counter ta yapay chayqa 200ms tukuy ta suyay     {…,add}       0.50 (drops wait)
+```
+
+The verb-final SOV reorder places the block-terminating `end`
+(`終わり`/`끝`/`tukuy`/`结束`) **between** the trailing duration and its `wait` verb
+(`200ms 終わり を 待つ` = `200ms end ‹patient› wait`). `parseBodyWithClauses` treats
+`end` as a hard block terminator (`isEndKeyword` → break), discarding the
+`を 待つ`/`를 대기`/`ta suyay` that follows. Making the `end`-break tolerant of a
+trailing post-`end` clause (parse it, then stop) would recover the `wait` across
+ja/tr/ko/qu **and** zh — a single structural fix touching several patterns. **Higher
+leverage than #1/#2.** Watch for over-reach: `end` must still terminate a genuine
+nested block; gate the tolerance to "a single trailing command clause after `end`."
+
+### #4 — sw `repeat-while` leading clause drop
+
+```
+on click repeat while #x.innerText < 10 increment #x wait 200ms end
+  sw → kwenye bonyeza rudia wakati #counter.innerText < 10 kisha ongeza #counter kisha ngoja 200ms mwisho
+       {on,add,wait}  fid 0.50   (drops `rudia`=repeat + `wakati`=while)
+```
+
+sw is SVO, so the event leads (`kwenye bonyeza` = `on click`), then
+`rudia wakati <cond> kisha <body>`. The Stage-1 sw event pattern anchors the event and
+the then-chain body (`ongeza`/`ngoja`), but the **leading `rudia wakati`**(repeat
+while) clause between the event and the first `kisha`(then) is dropped. Likely the
+event-handler body parser starts at the first then-keyword and skips the pre-`then`
+loop head. (sw `ongeza` parses as `add` not `increment` — a separate sw
+add/increment keyword overlap; doesn't affect the degenerate line.)
+
+## Root-cause summary (where each lives)
+
+| #   | Layer                            | Hook                                                                            |
+| --- | -------------------------------- | ------------------------------------------------------------------------------- |
+| 1   | parser (zh block-body re-parse)  | the zh Stage-1 event body / `parseBodyWithClauses` for zh                       |
+| 2   | parser (for-binding sub-pattern) | `parseClause` / generated `repeat` pattern (add a `for <var> in <coll>` branch) |
+| 3   | parser (end-break tolerance)     | `parseBodyWithClauses` `isEndKeyword` break (allow one trailing clause)         |
+| 4   | parser (pre-then loop head)      | event-handler body parse start (capture the loop head before the first `then`)  |
+
+All four are **parser-side**; none needs a transformer change (the transforms are
+already in a recoverable order — they were for the shipped slices too).
+
+## Suggested sequencing
+
+1. **#3 first (highest leverage).** The `end`-mid-stream tail drop touches ja/tr/ko/qu
+   **and** zh `repeat-while`, and is a contained `parseBodyWithClauses` change. Do it
+   before #1 — it's likely _part_ of why zh `repeat-forever` drops its `wait`.
+2. **#1 next (clears the last degenerate `repeat-*`).** With #3 in place, re-probe zh
+   `repeat-forever`; what remains is the `重复 forever` leading-clause recovery (cf. #2).
+3. **#2 (fidelity sweep).** The `for`-binding `repeat`-keyword recovery lifts ar/tl/zh
+   (and is a clean win once #1's zh body parses). Mirror ko's working binder handling.
+4. **#4 (sw).** Smallest, most isolated; do last.
+
+## Risks / gotchas
+
+- **#3 over-reach.** `end` legitimately closes nested blocks. Gate the trailing-clause
+  tolerance tightly (one trailing command clause, not arbitrary re-parsing past `end`).
+  Run the full `parseBodyWithClauses` callers — it's shared by SOV/VSO/mid-stream paths.
+- **Fidelity is recall-based** — won't catch over-generation. After any parser change run
+  the semantic role-extraction suite (`npm test --prefix packages/semantic`) in addition
+  to the regen.
+- **zh is the recurring hard case.** The same zh block-body gap blocks the deferred zh
+  `fetch` keyword alignment (roadmap). A real fix here may unblock that too — worth a
+  combined zh block-body session.
+- **Validate with the `--regression` gate**, not raw counts; trust a controlled A/B
+  (same DB, build toggled). Restore the binary `patterns.db` before committing.
+
+## Affected patterns / expected yield
+
+| Pattern         | Lang               | Now            | After                    |
+| --------------- | ------------------ | -------------- | ------------------------ |
+| repeat-forever  | zh                 | 0.33 **DEGEN** | faithful (−1 degenerate) |
+| repeat-for-each | ar, tl, zh         | 0.67           | 1.0 (fidelity)           |
+| repeat-while    | ja, tr, ko, qu, zh | 0.50–0.75      | 1.0 (fidelity)           |
+| repeat-while    | sw                 | 0.50           | 1.0 (fidelity)           |
+
+Net: **−1 degenerate** (zh), plus a fidelity sweep across ~5 languages. Cross-check the
+live degenerate list at execution time — counts drift as other fixes land.
+
+## Validation playbook (same as the shipped fixes)
+
+1. Edit `packages/semantic/src/parser/semantic-parser.ts`.
+2. Rebuild: `cd packages/semantic && npx tsup`.
+3. Repopulate DB: `cd packages/patterns-reference && npm run db:init:force &&
+npm run sync:translations`.
+4. Regen + `--regression` gate:
+   `cd packages/testing-framework && LSP_DB_PATH=…/patterns.db npx tsx
+src/multilingual/cli.ts --full --bundle browser-priority --regression`. Must say
+   "No regression". (Core's dist imports `@lokascript/semantic` at runtime, so a
+   `tsup` rebuild of semantic is picked up without rebuilding core — but core's
+   `dist/multilingual/*.js` must already exist: `rollup -c` in `packages/core` once.)
+5. `--save-baseline` to the committed path, then `npx prettier --write` it (the
+   JSONReporter emits raw JSON; the committed baseline is prettier-formatted).
+6. Add locks in `packages/semantic/test/multilingual-roadmap-fixes.test.ts`.
+7. Restore `git checkout packages/patterns-reference/data/patterns.db`. Don't commit it.
+
+## Probe script (drop at repo root, `npx tsx probe.ts "<en code>" zh sw ar tl ja ko qu`)
+
+```ts
+/* eslint-disable no-console */
+import { GrammarTransformer } from './packages/i18n/src/grammar/transformer';
+import * as SpanMaskNS from './packages/patterns-reference/src/sync/span-mask';
+import { parseSemantic } from './packages/semantic/src/index';
+const SpanMask = (SpanMaskNS as any).default ?? SpanMaskNS;
+const { maskSpans, unmaskSpans } = SpanMask;
+const [, , code, ...langs] = process.argv;
+function transform(src: string, l: string): string {
+  if (l === 'en') return src;
+  const { masked, spans } = maskSpans(src);
+  return unmaskSpans(new GrammarTransformer('en', l).transform(masked), spans);
+}
+function collect(node: unknown, acc: Set<string>): void {
+  if (!node || typeof node !== 'object') return;
+  const n = node as Record<string, unknown>;
+  if (typeof n.action === 'string' && n.action !== 'compound') acc.add(n.action);
+  for (const k of [
+    'body',
+    'statements',
+    'commands',
+    'thenBranch',
+    'elseBranch',
+    'branches',
+    'value',
+    'node',
+  ]) {
+    const c = n[k];
+    if (Array.isArray(c)) c.forEach(x => collect(x, acc));
+    else if (c) collect(c, acc);
+  }
+}
+function act(src: string, l: string): string[] {
+  try {
+    const r = parseSemantic(src, l) as any;
+    const a = new Set<string>();
+    collect(r.node ?? r, a);
+    return [...a];
+  } catch {
+    return ['ERR'];
+  }
+}
+const ref = act(code, 'en');
+console.log(`EN ref {${ref.join(',')}}: ${code}`);
+for (const l of langs) {
+  const t = transform(code, l);
+  const a = act(t, l);
+  const fid = ref.length ? ref.filter(x => a.includes(x)).length / ref.length : 1;
+  console.log(
+    `  ${l} {${a.join(',')}} fid ${fid.toFixed(2)}${fid < 0.5 ? ' DEGEN' : ''}\n     ${t}`
+  );
+}
+```
+
+Corpus inputs to probe:
+`on load repeat forever toggle .pulse wait 1s end`,
+`on click repeat while #counter.innerText < 10 increment #counter wait 200ms end`,
+`on click repeat for item in .items add .processed to item`.
+
+## Definition of done
+
+zh `repeat-forever` parses faithfully (deg→faithful, the last degenerate `repeat-*`);
+the `for`-binding `repeat` keyword and the `wait`-after-`end` tail are recovered across
+the affected languages; `--regression` gate green; role-extraction suite clean;
+baseline regenerated; locking tests added.

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -221,6 +221,28 @@ export class SemanticParserImpl implements ISemanticParser {
             : sovLoop;
           return withDiagnostics(result, diagnostics);
         }
+        // VSO/SVO sibling: the event sits *mid-stream*, marked by an `on`-marker
+        // right after the leading loop keyword (`كرر عند نقر …` / `ulitin kapag
+        // click …` = `repeat on click …`). The trailing-event extractor (Stage 1.5)
+        // can't see it (the event isn't last), so the bare loop keyword wins Stage 2
+        // and the event + body drop. Strip the `<on-marker> <event>` pair and parse
+        // the remainder (leading loop keyword + for/while clause + then-chain body)
+        // as the loop body. Same guard shape as the SOV path: gated to block/loop
+        // actions, fires only on a real on-marked event whose body parses.
+        const midLoop = this.tryMidStreamEventExtraction(parseInput, language, sortedPatterns);
+        if (midLoop) {
+          diagnostics.push(
+            parseDiagnostic(
+              `mid-stream event extraction preferred over bare ${commandMatch.pattern.command} command`,
+              'info',
+              'stage-midstream-loop'
+            )
+          );
+          const result = modifiers
+            ? this.applyModifiers(midLoop as EventHandlerSemanticNode, modifiers)
+            : midLoop;
+          return withDiagnostics(result, diagnostics);
+        }
       }
       diagnostics.push(
         parseDiagnostic(
@@ -1163,6 +1185,75 @@ export class SemanticParserImpl implements ISemanticParser {
       sourceLanguage: language,
       confidence: 0.75,
     });
+  }
+
+  /**
+   * Try to extract a *mid-stream* `<on-marker> <event>` pair (VSO/SVO loops).
+   *
+   * For VSO/Austronesian the grammar transformer surfaces a block loop's keyword
+   * first and places the event clause right after it, marked by an `on`-marker:
+   *   AR: "كرر عند نقر item في .items ثم أضف …"   (repeat on click for … then add)
+   *   TL: "ulitin kapag click item sa_loob .items pagkatapos idagdag …"
+   *
+   * Because the event isn't the final token, `tryTrailingEventExtraction` (Stage
+   * 1.5) can't see it, so the bare loop keyword wins Stage 2 and the event + body
+   * drop (degenerate). This scans for an `on`-marker (`normalized === 'on'`)
+   * immediately followed by a known event keyword, strips that pair, and parses
+   * everything else (the leading loop keyword + for/while clause + then-chain body)
+   * as the handler body. Returns null when no on-marked event is found or the body
+   * doesn't parse, so the caller falls through to the bare command unchanged. The
+   * caller gates this to block/loop actions, so simple commands never reach it.
+   */
+  private tryMidStreamEventExtraction(
+    input: string,
+    language: string,
+    patterns: LanguagePattern[]
+  ): SemanticNode | null {
+    const tokens = tokenizeInternal(input, language).tokens;
+    if (tokens.length < 3) return null;
+
+    const langEvents = eventNameTranslations[language];
+    const nativeEventNames = new Set<string>();
+    if (langEvents) {
+      for (const native of Object.keys(langEvents)) nativeEventNames.add(native.toLowerCase());
+    }
+
+    // Find an `on`-marker whose next token is a known event keyword.
+    for (let i = 0; i < tokens.length - 1; i++) {
+      const marker = tokens[i];
+      const isOnMarker = marker.kind === 'keyword' && marker.normalized?.toLowerCase() === 'on';
+      if (!isOnMarker) continue;
+
+      const evtToken = tokens[i + 1];
+      const evtVal = evtToken.value.toLowerCase();
+      const evtNorm = evtToken.normalized?.toLowerCase();
+      const isKnownEvent =
+        (!!evtNorm && SemanticParserImpl.KNOWN_EVENTS.has(evtNorm)) ||
+        SemanticParserImpl.KNOWN_EVENTS.has(evtVal) ||
+        nativeEventNames.has(evtVal);
+      if (!isKnownEvent) continue;
+
+      const eventName =
+        evtNorm && SemanticParserImpl.KNOWN_EVENTS.has(evtNorm)
+          ? evtNorm
+          : (langEvents?.[evtVal] ?? evtVal);
+
+      // Body = every token except the on-marker + event pair, parsed as a block.
+      const bodyTokens = tokens.filter((_, idx) => idx !== i && idx !== i + 1);
+      if (bodyTokens.length === 0) return null;
+
+      const commandPatterns = patterns.filter(p => p.command !== 'on');
+      const bodyStream = new TokenStreamImpl(bodyTokens, language);
+      const body = this.parseBodyWithClauses(bodyStream, commandPatterns, language);
+      if (body.length === 0) return null;
+
+      return createEventHandler({ type: 'literal', value: eventName }, body, undefined, {
+        sourceLanguage: language,
+        confidence: 0.75,
+      });
+    }
+
+    return null;
   }
 
   /**

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -766,3 +766,65 @@ describe('SOV repeat-* loop-body reorder — ko/bn/qu (Track 5)', () => {
     expect(a.has('repeat')).toBe(true);
   });
 });
+
+describe('VSO/Austronesian repeat-* mid-stream event reorder — ar/tl (Track 5)', () => {
+  // The non-SOV sibling of the SOV repeat-* fix. For VSO/Austronesian the i18n
+  // transformer surfaces a block loop's keyword first and places the event clause
+  // right after it, marked by an `on`-marker (`كرر عند نقر …` / `ulitin kapag click
+  // …` = `repeat on click …`). The trailing-event extractor (Stage 1.5) can't see
+  // the event (it isn't last), so the bare loop keyword won Stage 2 and the event +
+  // body dropped (degenerate). `tryMidStreamEventExtraction` strips the `<on-marker>
+  // <event>` pair and parses the rest as the loop body. Strings below are
+  // post-transform output (en → lang). See docs-internal/NON_SOV_REPEAT_SCOPE.md.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // repeat-while: `on click repeat while #x.innerText < 10 increment #x wait 200ms end`
+  it('[ar] repeat-while recovers the event + repeat + increment + wait body', () => {
+    const a = actions(
+      parse('كرر بينما #counter.innerText < 10 عند نقر ثم زِد #counter ثم انتظر 200ms النهاية', 'ar')
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+    expect(a.has('increment')).toBe(true);
+  });
+  it('[tl] repeat-while recovers the event + repeat + increment body', () => {
+    const a = actions(
+      parse(
+        'ulitin habang #counter.innerText < 10 kapag click pagkatapos dagdagan #counter pagkatapos maghintay 200ms wakas',
+        'tl'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+    expect(a.has('increment')).toBe(true);
+  });
+
+  // repeat-for-each: `on click repeat for item in .items add .processed to item`
+  it('[ar] repeat-for-each recovers the event + add body (not bare repeat)', () => {
+    const a = actions(parse('كرر عند نقر item في .items ثم أضف .processed إلى item', 'ar'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('add')).toBe(true);
+  });
+  it('[tl] repeat-for-each recovers the event + add body (not bare repeat)', () => {
+    const a = actions(parse('ulitin kapag click item sa_loob .items pagkatapos idagdag .processed sa item', 'tl'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('add')).toBe(true);
+  });
+
+  // Regression guard: a simple VSO command (no leading block/loop keyword) doesn't
+  // reach the gate, so it parses normally and is not over-wrapped.
+  it('[ar] a simple toggle command is unaffected', () => {
+    const a = actions(parse('بدل .active عند نقر', 'ar'));
+    expect(a.has('toggle')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-09T05:54:45.528Z",
-  "commit": "b965f54",
+  "timestamp": "2026-06-09T08:56:58.765Z",
+  "commit": "1d18bc2",
   "languages": {
     "ar": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9268083704069859,
-      "avgFidelity": 0.8662309368191721,
+      "avgFidelity": 0.8825708061002179,
       "degeneratePasses": [
         "accordion-exclusive",
         "behavior-draggable",
@@ -15,18 +15,14 @@
         "behavior-sortable",
         "copy-to-clipboard",
         "event-debounce",
-        "focus-trap",
         "form-submit-prevent",
         "halt-propagation",
         "modal-close-escape",
-        "repeat-for-each",
-        "repeat-while",
         "socket-basic",
         "tabs-basic",
-        "tabs-content",
-        "window-keydown"
+        "tabs-content"
       ],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -652,7 +648,7 @@
       "avgConfidence": 0.8657287157287157,
       "avgFidelity": 0.9563852813852812,
       "degeneratePasses": ["socket-basic"],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1285,7 +1281,7 @@
         "first-in-parent",
         "if-empty"
       ],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1909,7 +1905,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2536,7 +2532,7 @@
       "avgConfidence": 0.989034132171387,
       "avgFidelity": 0.9089324618736385,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3169,7 +3165,7 @@
         "fetch-with-headers",
         "first-in-parent"
       ],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3802,7 +3798,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4438,7 +4434,7 @@
         "socket-basic",
         "worker-basic"
       ],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5070,7 +5066,7 @@
         "behavior-sortable",
         "unless-condition"
       ],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5696,7 +5692,7 @@
       "avgConfidence": 0.9878721859114016,
       "avgFidelity": 0.9550108932461874,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6331,7 +6327,7 @@
         "input-validation",
         "socket-basic"
       ],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6967,7 +6963,7 @@
         "socket-basic",
         "window-scroll"
       ],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7603,7 +7599,7 @@
         "its-value-possessive-dot",
         "template-literal-list-build"
       ],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8235,7 +8231,7 @@
         "behavior-sortable",
         "first-in-parent"
       ],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8870,7 +8866,7 @@
         "focus-trap",
         "socket-basic"
       ],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "window-resize": {
           "success": true,
@@ -9505,7 +9501,7 @@
         "socket-basic",
         "template-literal-list-build"
       ],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10132,7 +10128,7 @@
       "avgConfidence": 0.8895073180787468,
       "avgFidelity": 0.9596320346320344,
       "degeneratePasses": ["install-behavior"],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10769,7 +10765,7 @@
         "socket-basic",
         "template-literal-list-build"
       ],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11394,7 +11390,7 @@
       "avgConfidence": 0.9402185116470816,
       "avgFidelity": 0.9791125541125543,
       "degeneratePasses": [],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12019,7 +12015,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8985472977069613,
-      "avgFidelity": 0.8838744588744591,
+      "avgFidelity": 0.8941558441558443,
       "degeneratePasses": [
         "accordion-exclusive",
         "copy-to-clipboard",
@@ -12029,14 +12025,12 @@
         "get-value",
         "halt-propagation",
         "modal-close-escape",
-        "repeat-for-each",
-        "repeat-while",
         "tabs-basic",
         "tabs-content",
         "take-class-from-siblings",
         "worker-basic"
       ],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12671,7 +12665,7 @@
         "focus-trap",
         "socket-basic"
       ],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13297,7 +13291,7 @@
       "avgConfidence": 0.8887652030509177,
       "avgFidelity": 0.9596320346320344,
       "degeneratePasses": ["install-behavior"],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13924,7 +13918,7 @@
       "avgConfidence": 0.892888064316636,
       "avgFidelity": 0.894155844155844,
       "degeneratePasses": ["template-literal-list-build"],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14561,7 +14555,7 @@
         "repeat-forever",
         "template-literal-list-build"
       ],
-      "bundleSize": 403064,
+      "bundleSize": 403997,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15180,7 +15174,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 403064,
+      "size": 403997,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Picks up next step #1 from the post-merge recommendations: the **non-SOV `repeat-*`** sibling of the just-shipped SOV fix (#302).

For VSO/Austronesian languages the i18n transformer surfaces a block loop's keyword first and places the event clause **mid-stream**, marked by an `on`-marker (`كرر عند نقر …` / `ulitin kapag click …` = `repeat on click …`). The existing trailing-event extractor (Stage 1.5) requires the event to be the *last* token, so it missed the mid-stream event; the bare loop keyword won Stage 2 and the event + body dropped (degenerate). (`repeat-forever` already worked for ar/tl because *its* event reorders to the end.)

## Change

New `tryMidStreamEventExtraction` (parser): scans for an `on`-marker (`normalized === 'on'`) immediately followed by a known event keyword, strips that pair, and parses the rest (leading loop keyword + for/while clause + then-chain body) as the handler body. Wired into the **same block/loop Stage-2 gate** added for the SOV fix, *after* SOV extraction returns null — so it's reached only when Stage 2 matched a bare block/loop action (already degenerate) and only fires on a real on-marked event whose body parses. Simple commands never reach it.

## Results

**Degenerate passes 141 → 135 (−6), 0 regressions, parse rate unchanged (3678/3696), `--regression` gate green.**

| Language | Cleared | avgFidelity |
| --- | --- | --- |
| ar | repeat-for-each, repeat-while, **focus-trap**, **window-keydown** (bonus — same mid-stream-event shape) | 0.866 → 0.883 |
| tl | repeat-for-each, repeat-while | 0.884 → 0.894 |

All other languages byte-identical; SOV cases (ja/ko/qu/bn) unaffected.

## Follow-up planning

The remaining `repeat-*` residue is scoped in **`docs-internal/NON_SOV_REPEAT_SCOPE.md`** for a future session:
1. **zh `repeat-forever`** — the last degenerate `repeat-*` (circumfix `当…时` event + a zh block-body collapse, a different layer).
2. **`for`-binding drops `repeat`** (ar/tl/zh at 0.67 — shared gap; ko already recovers it).
3. **`wait`-after-`end` tail drop** (ja/tr/ko/qu/zh — highest-leverage `parseBodyWithClauses` fix).
4. **sw `repeat-while`** leading-clause drop.

## Validation

- Full `browser-priority` regen + `--regression` gate green; baseline regenerated (prettier).
- Semantic role-extraction suite clean (5361 pass; the 30 `build-artifacts.test.ts` `.d.ts` failures are the known environmental ones).
- Locked by `multilingual-roadmap-fixes.test.ts` ("VSO/Austronesian repeat-\* mid-stream event reorder — ar/tl": ar/tl recover the event + loop body; a simple VSO command is unaffected).

https://claude.ai/code/session_01QyVxCJqsKiuyAWLo6G1gz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyVxCJqsKiuyAWLo6G1gz5)_