### PR TITLE
fix(multilingual): non-SOV repeat-* loop-body + tail residue (zh/ar/tl/ja/ko/qu/sw)

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,7 +5,8 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after Track 5 **VSO/Austronesian `repeat-*` mid-stream event reorder** — the non-SOV sibling of the SOV repeat-\* fix. For VSO/Austronesian the i18n transformer surfaces the loop keyword first and places the event clause mid-stream, marked by an `on`-marker (`كرر عند نقر …` / `ulitin kapag click …` = `repeat on click …`). The trailing-event extractor (Stage 1.5) can't see it (the event isn't last), so the bare loop keyword won Stage 2 and the event + body dropped (degenerate). `tryMidStreamEventExtraction` strips the `<on-marker> <event>` pair and re-parses the rest as the loop body; the block/loop gate now tries it after SOV extraction. **Degenerate passes 141 → 135 (−6), 0 regressions, parse rate unchanged** (3678/3696). Cleared `repeat-for-each`/`repeat-while` (ar+tl) + bonus `focus-trap`/`window-keydown` (ar — same mid-stream-event shape). avgFidelity ar 0.866→0.883, tl 0.884→0.894. Remaining repeat residue (zh circumfix block-body, the `for`-binding `repeat`-keyword drop, the `wait`-after-`end` tail) scoped in [NON_SOV_REPEAT_SCOPE.md](NON_SOV_REPEAT_SCOPE.md)._
+_Last updated: after Track 5 **Non-SOV `repeat-*` loop-body + tail residue** — two parser-side fixes closed the structural remainder scoped in [NON_SOV_REPEAT_SCOPE.md](NON_SOV_REPEAT_SCOPE.md). (1) The **`end`-mid-stream tail merge** (`parseBodyWithClauses`): the verb-final SOV reorder strands a trailing command's argument before `end` and its verb after (`… 200ms 終わり を 待つ`), so the `end`-break dropped the trailing `wait`; `end` now tolerates a single trailing clause (collect to the next then/end boundary, merge with the stranded pre-`end` argument). (2) The **`for`-binding `repeat`-keyword recovery** (`parseClause`): the transformer drops the `for` binder (`repeat for x in y` → `repeat x in y`) so the bare `repeat` has no matchable variant; when matchBest fails on a `repeat`-normalized token the clause now emits the `repeat` action directly. **Degenerate passes 135 → 132 (−3), parse rate 3678 → 3679 (+1 he), 0 regressions** (gate green; zero faithful→degenerate flips). Cleared the last degenerate `repeat-*` (zh `repeat-forever`, deg→0.67 faithful) + sw `repeat-until-event` + bonus `focus-trap` (sw/tr); for-each ar/tl/zh 0.67→1.0; while ja/ko/tr 0.75→1.0, qu 0.50→0.75; sw while 0.50→0.75. Deferred residue (separate keyword tracks): zh `wait` SVO pattern gap (`等待 1s`), qu/sw `add`-vs-`increment` overlap. See [NON_SOV_REPEAT_SCOPE.md](NON_SOV_REPEAT_SCOPE.md)._
+_Earlier: Track 5 **VSO/Austronesian `repeat-*` mid-stream event reorder** — the non-SOV sibling of the SOV repeat-\* fix. For VSO/Austronesian the i18n transformer surfaces the loop keyword first and places the event clause mid-stream, marked by an `on`-marker (`كرر عند نقر …` / `ulitin kapag click …` = `repeat on click …`). The trailing-event extractor (Stage 1.5) can't see it (the event isn't last), so the bare loop keyword won Stage 2 and the event + body dropped (degenerate). `tryMidStreamEventExtraction` strips the `<on-marker> <event>` pair and re-parses the rest as the loop body; the block/loop gate now tries it after SOV extraction. **Degenerate passes 141 → 135 (−6), 0 regressions, parse rate unchanged** (3678/3696). Cleared `repeat-for-each`/`repeat-while` (ar+tl) + bonus `focus-trap`/`window-keydown` (ar — same mid-stream-event shape). avgFidelity ar 0.866→0.883, tl 0.884→0.894. Remaining repeat residue (zh circumfix block-body, the `for`-binding `repeat`-keyword drop, the `wait`-after-`end` tail) scoped in [NON_SOV_REPEAT_SCOPE.md](NON_SOV_REPEAT_SCOPE.md)._
 _Earlier: Track 5 **SOV `repeat-*` loop-body reorder** — for SOV languages the i18n transformer surfaces a block loop's keyword (반복/পুনরাবৃত্তি/kutipay) — or a leading `while`/`for` clause — ahead of its body, so the parser matched the bare loop keyword as a standalone command (Stage 2) and dropped the event + variant + body (degenerate). Korean (no event-marker particle) was hit hardest. The Stage-2 gate now prefers SOV event extraction (Stage 3) when the matched action is a block/loop action, recovering the event + loop body; and the qu `repeat` dict keyword was realigned (`kutichiy`→`kutipay`; `kutichiy` is the profile's `return` primary). **Degenerate passes 148 → 141 (−7), 0 regressions, parse rate unchanged** (3678/3696). Cleared `repeat-forever`/`repeat-while`/`repeat-for-each` for ko (+ `stagger-animation` bonus), `repeat-while` for bn, `repeat-while`/`repeat-for-each` for qu. avgFidelity ko 0.889→0.903, bn 0.952→0.956, qu 0.782→0.794. See [SOV_REPEAT_SCOPE.md](SOV_REPEAT_SCOPE.md)._
 _Earlier: Track 5 **juxtaposed multi-command event bodies** — a fused event pattern captured only the FIRST body command as the action; a then-chain/block continued, but a **juxtaposed** body (`halt the event call validateForm() if … end` — no `then` between commands) was dropped. `buildEventHandler` now re-parses any trailing non-`end` tokens as body commands (additive; `parseBodyWithGrammarPatterns` only appends matched commands). **Degenerate passes 179 → 159 (−20), 0 regressions, parse rate unchanged** (3679/3696). Cleared `form-submit-prevent` (de/it/ru/sw/th/uk/vi), `fetch-loading-state` (bn/hi/it/ja/tr), plus `fetch-error-handling`/`fetch-with-headers` (ja), `render-template-with-data` (qu/tl/vi), `repeat-forever`/`stagger-animation` (qu), `window-scroll` (th)._
 _Earlier: Track 5 **then/end keyword recognition for 9 profile-only languages** (it, ru, th, vi, he, hi, ms, pl, uk). `isThenKeyword`/`isEndKeyword` were hardcoded maps covering only 15 langs; the other 9 fell back to the English literal, so their native then/end (`allora`, `затем`, …) weren't recognized — multi-command then-chains collapsed to the first command and `end`-blocks didn't close. Both now fall back to the profile's form. **Parse rate +7** (he/it/pl behaviors now parse — `end` recognized; he/it/pl jump toward 100%), **+4 fidelity** (`fetch-loading-state` ru/th/vi/uk degenerate→faithful), **0 regressions** (gate green). Degenerate nets 176 → 179 (−4 fetch-loading-state, +7 newly-parsing Bucket B behaviors)._
@@ -62,6 +63,41 @@ behaviors), not a parsing/i18n track. See Track 2.
 ---
 
 ## Shipped
+
+### Track 5 — Non-SOV `repeat-*` loop-body + tail residue (zh/ar/tl/ja/ko/qu/sw, −3 degenerate)
+
+- **Degenerate passes 135 → 132 (−3), parse rate 3678 → 3679 (+1 he), 0 regressions.**
+  Full `browser-priority` regen + `--regression` gate green; zero faithful→degenerate
+  flips, every avgFidelity delta non-negative. Cleared the last degenerate `repeat-*`
+  (zh `repeat-forever`, 0.33→0.67 faithful) + sw `repeat-until-event` + bonus
+  `focus-trap` (sw/tr). avgFidelity up across the touched langs (e.g. ja 0.909→0.917,
+  ko 0.833→0.843, ar 0.883→0.888, tl 0.880→0.888, zh 0.785→0.794, sw 0.866→0.873).
+- **Two parser-side fixes** (`packages/semantic/src/parser/semantic-parser.ts`; no
+  transformer change — the transforms were already in a recoverable order):
+  1. **`end`-mid-stream tail merge** (`parseBodyWithClauses`). The verb-final SOV
+     reorder places the block-terminating `end` _between_ a trailing command's
+     argument and its verb (`… それから 200ms 終わり を 待つ` =
+     `… then 200ms end ‹patient› wait`); the naive `end`-break discarded the post-`end`
+     `を 待つ`, dropping the trailing `wait`. The break now tolerates a single trailing
+     clause: collect the post-`end` tokens up to the next then/end boundary and parse
+     them, merging with the pre-`end` tokens when those parsed to nothing on their own
+     (the stranded-argument case). Gated to one trailing clause so a genuine
+     nested-block close can't swallow arbitrary following content. Recovered the
+     trailing `wait` for ja/ko/tr (→1.0) and qu (→0.75); cleared `focus-trap` (tr).
+  2. **`for`-binding `repeat`-keyword recovery** (`parseClause`). The transformer drops
+     the `for` binder keyword (`repeat for x in y` → `repeat x in y`), leaving the bare
+     `repeat` with no matchable variant so matchBest can't anchor it (the `repeat`
+     action was silently dropped — ar/tl/zh `repeat-for-each`; ko escaped only because
+     SOV puts the keyword last). When matchBest fails on a token whose normalized form
+     is `repeat`, the clause parser now emits the `repeat` action directly. Lifted
+     for-each ar/tl/zh to 1.0, cleared the zh `repeat-forever` degenerate, and recovered
+     sw's leading `rudia`(repeat) clause (sw while 0.50→0.75).
+- **Deferred (separate keyword-alignment tracks):** the zh `wait` SVO pattern gap
+  (`等待 1s` parses to nothing — zh `repeat-forever` is faithful at 0.67 but not 1.0),
+  and the qu/sw `add`-vs-`increment` keyword overlap. Both are dictionary work, not
+  the structural reorder. Locked by `multilingual-roadmap-fixes.test.ts`
+  ("Non-SOV repeat-\* loop-body + tail residue — zh/ar/tl/ja/ko/sw"). See
+  [NON_SOV_REPEAT_SCOPE.md](NON_SOV_REPEAT_SCOPE.md).
 
 ### Track 5 — VSO/Austronesian `repeat-*` mid-stream event reorder (ar/tl, −6 degenerate)
 

--- a/docs-internal/NON_SOV_REPEAT_SCOPE.md
+++ b/docs-internal/NON_SOV_REPEAT_SCOPE.md
@@ -1,14 +1,43 @@
 # Non-SOV `repeat-*` Loop-Body + Tail Residue — Project Scope
 
-> **Status:** Partially shipped. The VSO/Austronesian mid-stream-event slice (ar/tl)
-> is **DONE** (see below + `MULTILINGUAL_ROADMAP.md` → Shipped). This file scopes the
-> **remainder**: the zh circumfix block-body collapse, the shared `for`-binding
-> `repeat`-keyword drop, the then-chain tail drop, and sw `repeat-while`.
+> **Status:** ✅ SHIPPED (the structural slice). Two parser-side fixes —
+> the **`end`-mid-stream tail merge** (#3) and the **`for`-binding `repeat`-keyword
+> recovery** (#2) — together cleared the last degenerate `repeat-*` (zh
+> `repeat-forever`, #1) and lifted the `for`-binding (#2), `wait`-after-`end` (#3),
+> and sw leading-clause (#4) residues. **Degenerate passes 135 → 132 (−3), parse
+> rate 3678 → 3679 (+1, he), 0 regressions** (`--regression` gate green; zero
+> faithful→degenerate flips). Cleared zh `repeat-forever` (deg→faithful) + sw
+> `repeat-until-event` + bonus `focus-trap` (sw/tr); for-each ar/tl/zh 0.67→1.0;
+> while ja/ko/tr 0.75→1.0, qu 0.50→0.75; sw while 0.50→0.75. Locked by
+> `multilingual-roadmap-fixes.test.ts` ("Non-SOV repeat-\* loop-body + tail
+> residue"). **Deferred (separate keyword tracks, explicitly out of scope below):**
+> the zh `wait` SVO pattern gap (`等待 1s` parses to nothing — zh `repeat-forever`
+> sits at 0.67, faithful but not 1.0), and the qu/sw `add`-vs-`increment` keyword
+> overlap. Both are zh/qu/sw dictionary-alignment work, not the structural reorder.
 > **Prereq reading:** `SOV_REPEAT_SCOPE.md` (the SOV sibling, SHIPPED) and
 > `MULTILINGUAL_ROADMAP.md` → Shipped (SOV repeat-\* loop-body reorder; VSO
 > mid-stream event reorder).
 
-## Already shipped (this arc)
+## What shipped (this arc)
+
+Both fixes live in `packages/semantic/src/parser/semantic-parser.ts`, parser-side,
+no transformer change (as predicted below):
+
+1. **`end`-mid-stream tail merge** (`parseBodyWithClauses`). The verb-final SOV
+   reorder strands a trailing command's argument before `end` and its verb after
+   (`… 200ms 終わり を 待つ`). The `end`-break now tolerates a single trailing clause:
+   it collects the post-`end` tokens up to the next then/end boundary and parses
+   them — merging with the stranded pre-`end` argument when those tokens parsed to
+   nothing on their own. Recovered the trailing `wait` for ja/ko/tr (→1.0) and qu
+   (→0.75), and (bonus) cleared `focus-trap` for tr.
+2. **`for`-binding `repeat`-keyword recovery** (`parseClause`). The transformer
+   drops the `for` binder keyword (`repeat for x in y` → `repeat x in y`), so the
+   bare `repeat` carries no matchable variant and matchBest can't anchor it. When
+   matchBest fails on a token normalized to `repeat`, the clause parser now emits
+   the `repeat` action directly. Lifted for-each ar/tl/zh to 1.0, cleared the zh
+   `repeat-forever` degenerate, and recovered sw's leading `rudia`(repeat) clause.
+
+## Earlier in this arc (VSO/Austronesian slice)
 
 - **VSO/Austronesian mid-stream event (ar/tl).** For VSO the transformer surfaces the
   loop keyword first and the event clause mid-stream (`كرر عند نقر …` =
@@ -20,20 +49,24 @@
   148→135 cumulative with the SOV fix). Locked by `multilingual-roadmap-fixes.test.ts`
   ("VSO/Austronesian repeat-\* mid-stream event reorder — ar/tl").
 
-## TL;DR of what's left
+## TL;DR — what the four residues were (all now addressed)
 
-Four residues remain, in priority order:
+| #   | Issue                                         | Languages          | Was                             | Now                            |
+| --- | --------------------------------------------- | ------------------ | ------------------------------- | ------------------------------ |
+| 1   | **zh circumfix + block-body collapse**        | zh                 | `repeat-forever` 0.33 **DEGEN** | 0.67 faithful ✅ (deg cleared) |
+| 2   | **`for`-binding drops the `repeat` keyword**  | ar, tl, ko, zh     | `repeat-for-each` 0.67          | 1.0 ✅                         |
+| 3   | **then-chain tail drop (`wait` after `end`)** | ja, tr, ko, qu, zh | `repeat-while` 0.50–0.75        | ja/ko/tr 1.0, qu 0.75 ✅       |
+| 4   | **sw `repeat-while` leading clause drop**     | sw                 | `repeat-while` 0.50             | 0.75 ✅ (`rudia` recovered)    |
 
-| #   | Issue                                         | Languages          | Current                         | Target   |
-| --- | --------------------------------------------- | ------------------ | ------------------------------- | -------- |
-| 1   | **zh circumfix + block-body collapse**        | zh                 | `repeat-forever` 0.33 **DEGEN** | faithful |
-| 2   | **`for`-binding drops the `repeat` keyword**  | ar, tl, ko, zh     | `repeat-for-each` 0.67          | 1.0      |
-| 3   | **then-chain tail drop (`wait` after `end`)** | ja, tr, ko, qu, zh | `repeat-while` 0.50–0.75        | 1.0      |
-| 4   | **sw `repeat-while` leading clause drop**     | sw                 | `repeat-while` 0.50             | 1.0      |
+#1 was the only degenerate; recovering the bare `repeat` keyword (#2's fix) lifted it
+above the 0.5 threshold. The residual gaps to full 1.0 fidelity — zh `wait`
+(`等待 1s` doesn't parse, a zh SVO pattern gap), qu/sw `increment` (parsed as `add`,
+keyword overlap) — are **deferred keyword-alignment tracks**, called out below as
+out of scope for this structural arc.
 
-Only **#1 is degenerate** (the last degenerate `repeat-*` in the corpus); #2–#4 are
-faithful-but-lossy fidelity residues. Lower yield per unit effort than the shipped
-slices — multi-PR, per-issue.
+> The remainder of this file is the **original problem analysis** (probe evidence,
+> root causes, sequencing) kept for the record; the failure modes below describe the
+> pre-fix behavior.
 
 ## Failure modes (probe evidence)
 

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -526,12 +526,59 @@ export class SemanticParserImpl implements ISemanticParser {
       }
 
       if (isEnd) {
-        // End of block - parse final clause if any
-        if (currentClauseTokens.length > 0) {
+        tokens.advance(); // Consume 'end' token
+
+        // The verb-final SOV reorder can place the block-terminating `end`
+        // *between* a trailing command's argument and its verb:
+        //   ja: `… それから 200ms 終わり を 待つ`  (`… then 200ms end ‹patient› wait`)
+        //   ko: `… 그러면 200ms 끝 를 대기`         (`… then 200ms end ‹patient› wait`)
+        //   qu: `… chayqa 200ms tukuy ta suyay`     (`… then 200ms end ‹patient› wait`)
+        // A naive `end`-break discards the `を 待つ` / `를 대기` / `ta suyay` that
+        // follows, dropping the trailing `wait` (fidelity residue). Tolerate a
+        // single trailing command clause after `end`: collect the tokens up to the
+        // next then/end boundary (so a genuine nested-block close can't swallow
+        // arbitrary following content), then parse — merging with the pre-`end`
+        // tokens only when those tokens are a stranded fragment (the SOV
+        // verb-final split above), otherwise parsing the two as separate clauses.
+        const trailingTokens: LanguageToken[] = [];
+        while (!tokens.isAtEnd()) {
+          const t = tokens.peek();
+          if (!t) break;
+          const tIsBoundary =
+            t.kind === 'conjunction' ||
+            (t.kind === 'keyword' &&
+              (this.isThenKeyword(t.value, language) || this.isEndKeyword(t.value, language)));
+          if (tIsBoundary) break;
+          trailingTokens.push(t);
+          tokens.advance();
+        }
+
+        if (trailingTokens.length > 0) {
+          const preNodes =
+            currentClauseTokens.length > 0
+              ? this.parseClause(currentClauseTokens, commandPatterns, language)
+              : [];
+          if (preNodes.length === 0 && currentClauseTokens.length > 0) {
+            // Pre-`end` tokens parsed to nothing — a stranded argument (e.g. `200ms`)
+            // whose verb sits after `end`. Merge so the verb reclaims its argument.
+            clauses.push(
+              ...this.parseClause(
+                [...currentClauseTokens, ...trailingTokens],
+                commandPatterns,
+                language
+              )
+            );
+          } else {
+            // Pre-`end` tokens were already a complete clause (or empty); the
+            // trailing tokens are a distinct sibling command — parse separately.
+            clauses.push(...preNodes);
+            clauses.push(...this.parseClause(trailingTokens, commandPatterns, language));
+          }
+        } else if (currentClauseTokens.length > 0) {
           const clauseNodes = this.parseClause(currentClauseTokens, commandPatterns, language);
           clauses.push(...clauseNodes);
         }
-        tokens.advance(); // Consume 'end' token
+        currentClauseTokens.length = 0;
         break;
       }
 
@@ -577,6 +624,24 @@ export class SemanticParserImpl implements ISemanticParser {
       if (commandMatch) {
         commands.push(this.buildCommand(commandMatch, language));
       } else {
+        // A `for`-binding loop (`repeat for <var> in <coll>`) loses its `for`
+        // binder keyword in transit (the i18n transformer emits `repeat <var> in
+        // <coll>`), so the bare `repeat` keyword carries no matchable variant
+        // (`forever`/`while`/`N times`/`for`) and matchBest can't anchor it — the
+        // `repeat` action is silently dropped (ar/tl/zh `repeat-for-each` residue;
+        // ko escapes only because its SOV order puts the keyword last where it
+        // matches). When matchBest fails on a token whose normalized form is the
+        // `repeat` loop keyword, emit the loop action directly so it survives.
+        const tok = clauseStream.peek();
+        if (tok && tok.normalized?.toLowerCase() === 'repeat') {
+          commands.push(
+            createCommandNode(
+              'repeat' as ActionType,
+              {},
+              { sourceLanguage: language, confidence: 0.6 }
+            )
+          );
+        }
         // Skip unrecognized token
         clauseStream.advance();
       }

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -177,7 +177,10 @@ describe('Attribute selectors (@attr) in selector-expecting roles (form-disable)
 
   const formDisable: Array<[string, string]> = [
     ['ar', 'أضف @disabled إلى <button/> in me put "Submitting..." into <button/> in me عند إرسال'],
-    ['tl', 'idagdag @disabled sa <button/> in me put "Submitting..." into <button/> in me kapag submit'],
+    [
+      'tl',
+      'idagdag @disabled sa <button/> in me put "Submitting..." into <button/> in me kapag submit',
+    ],
   ];
   for (const [lang, input] of formDisable) {
     it(`[${lang}] parses the form-disable-on-submit body`, () => {
@@ -469,9 +472,18 @@ describe('then/end keyword recognition for profile-only languages — Track 5', 
   // fetch-loading-state corpus transforms — the then-chain (add → … → remove → put)
   // must survive instead of collapsing to the first command (`add`).
   const cases: Array<[string, string]> = [
-    ['ru', 'при клик добавить .loading в я затем загрузить /api/data затем удалить .loading из я затем положить это в #result'],
-    ['th', 'เมื่อ คลิก เพิ่ม .loading ใน ฉัน แล้ว ดึงข้อมูล /api/data แล้ว ลบ .loading จาก ฉัน แล้ว ใส่ มัน ใน #result'],
-    ['uk', 'при клік додати .loading в я тоді завантажити /api/data тоді видалити .loading з я тоді покласти це в #result'],
+    [
+      'ru',
+      'при клик добавить .loading в я затем загрузить /api/data затем удалить .loading из я затем положить это в #result',
+    ],
+    [
+      'th',
+      'เมื่อ คลิก เพิ่ม .loading ใน ฉัน แล้ว ดึงข้อมูล /api/data แล้ว ลบ .loading จาก ฉัน แล้ว ใส่ มัน ใน #result',
+    ],
+    [
+      'uk',
+      'при клік додати .loading в я тоді завантажити /api/data тоді видалити .loading з я тоді покласти це в #result',
+    ],
   ];
   for (const [lang, input] of cases) {
     it(`[${lang}] recovers a multi-command then-chain (was first-command-only)`, () => {
@@ -514,9 +526,18 @@ describe('Juxtaposed multi-command event bodies — Track 5', () => {
   // form-submit-prevent corpus transforms — the juxtaposed `halt … call … log …`
   // body must survive instead of collapsing to the first command (`halt`).
   const cases: Array<[string, string]> = [
-    ['de', 'bei absenden anhalten the ereignis aufrufen validateForm() wenn ergebnis ist falsch protokollieren "Invalid form" ende'],
-    ['sw', 'kwenye wasilisha simama the tukio ita validateForm() kama matokeo ni uongo andika "Invalid form" mwisho'],
-    ['vi', 'khi gửi dừng lại the sự kiện gọi validateForm() nếu kết quả là sai in ra "Invalid form" kết thúc'],
+    [
+      'de',
+      'bei absenden anhalten the ereignis aufrufen validateForm() wenn ergebnis ist falsch protokollieren "Invalid form" ende',
+    ],
+    [
+      'sw',
+      'kwenye wasilisha simama the tukio ita validateForm() kama matokeo ni uongo andika "Invalid form" mwisho',
+    ],
+    [
+      'vi',
+      'khi gửi dừng lại the sự kiện gọi validateForm() nếu kết quả là sai in ra "Invalid form" kết thúc',
+    ],
   ];
   for (const [lang, input] of cases) {
     it(`[${lang}] recovers a juxtaposed multi-command body`, () => {
@@ -695,7 +716,10 @@ describe('SOV repeat-* loop-body reorder — ko/bn/qu (Track 5)', () => {
   // repeat-while: `on click repeat while #x.innerText < 10 increment #x wait 200ms end`
   it('[ko] repeat-while recovers the event + repeat + increment body', () => {
     const a = actions(
-      parse('동안 #counter.innerText < 10 를 클릭 반복 그러면 #counter 를 증가 그러면 200ms 끝 를 대기', 'ko')
+      parse(
+        '동안 #counter.innerText < 10 를 클릭 반복 그러면 #counter 를 증가 그러면 200ms 끝 를 대기',
+        'ko'
+      )
     );
     expect(a.has('on')).toBe(true);
     expect(a.has('repeat')).toBe(true);
@@ -727,7 +751,9 @@ describe('SOV repeat-* loop-body reorder — ko/bn/qu (Track 5)', () => {
   // reads `kutichiy` as `return` (repeat primary is `kutipay`) — a keyword
   // collision that mis-parsed every qu repeat-*. The dict now emits `kutipay`.
   it('[qu] repeat-forever parses kutipay as repeat (not return)', () => {
-    const a = actions(parse('apakuy pi kutipay forever .pulse ta tikray chayqa 1s ta suyay tukuy', 'qu'));
+    const a = actions(
+      parse('apakuy pi kutipay forever .pulse ta tikray chayqa 1s ta suyay tukuy', 'qu')
+    );
     expect(a.has('on')).toBe(true);
     expect(a.has('repeat')).toBe(true);
     expect(a.has('return')).toBe(false);
@@ -743,7 +769,9 @@ describe('SOV repeat-* loop-body reorder — ko/bn/qu (Track 5)', () => {
     expect(a.has('repeat')).toBe(true);
   });
   it('[qu] repeat-for-each recovers the event + repeat', () => {
-    const a = actions(parse('ñitiy pi kutipay item ukupi .items chayqa .processed ta item man yapay', 'qu'));
+    const a = actions(
+      parse('ñitiy pi kutipay item ukupi .items chayqa .processed ta item man yapay', 'qu')
+    );
     expect(a.has('on')).toBe(true);
     expect(a.has('repeat')).toBe(true);
   });
@@ -791,7 +819,10 @@ describe('VSO/Austronesian repeat-* mid-stream event reorder — ar/tl (Track 5)
   // repeat-while: `on click repeat while #x.innerText < 10 increment #x wait 200ms end`
   it('[ar] repeat-while recovers the event + repeat + increment + wait body', () => {
     const a = actions(
-      parse('كرر بينما #counter.innerText < 10 عند نقر ثم زِد #counter ثم انتظر 200ms النهاية', 'ar')
+      parse(
+        'كرر بينما #counter.innerText < 10 عند نقر ثم زِد #counter ثم انتظر 200ms النهاية',
+        'ar'
+      )
     );
     expect(a.has('on')).toBe(true);
     expect(a.has('repeat')).toBe(true);
@@ -816,7 +847,9 @@ describe('VSO/Austronesian repeat-* mid-stream event reorder — ar/tl (Track 5)
     expect(a.has('add')).toBe(true);
   });
   it('[tl] repeat-for-each recovers the event + add body (not bare repeat)', () => {
-    const a = actions(parse('ulitin kapag click item sa_loob .items pagkatapos idagdag .processed sa item', 'tl'));
+    const a = actions(
+      parse('ulitin kapag click item sa_loob .items pagkatapos idagdag .processed sa item', 'tl')
+    );
     expect(a.has('on')).toBe(true);
     expect(a.has('add')).toBe(true);
   });
@@ -826,5 +859,123 @@ describe('VSO/Austronesian repeat-* mid-stream event reorder — ar/tl (Track 5)
   it('[ar] a simple toggle command is unaffected', () => {
     const a = actions(parse('بدل .active عند نقر', 'ar'));
     expect(a.has('toggle')).toBe(true);
+  });
+});
+
+describe('Non-SOV repeat-* loop-body + tail residue — zh/ar/tl/ja/ko/sw (Track 5)', () => {
+  // Two parser-side fixes that close the residues scoped in
+  // docs-internal/NON_SOV_REPEAT_SCOPE.md. Strings below are post-transform output
+  // (en → lang) from the harness pipeline (maskSpans → GrammarTransformer →
+  // unmaskSpans). Both fixes are additive — they only recover commands the parser
+  // previously dropped, never re-shape an already-faithful parse.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // ── Fix 1: `end`-mid-stream tail drop ────────────────────────────────────
+  // The verb-final SOV reorder puts the block-terminating `end` *between* a
+  // trailing command's argument and its verb (`… 200ms 終わり を 待つ` =
+  // `… 200ms end ‹patient› wait`). `parseBodyWithClauses` used to treat `end` as
+  // a hard terminator and discard the post-`end` `を 待つ` / `를 대기`, dropping
+  // the trailing `wait`. It now tolerates a single trailing clause after `end`,
+  // merging it with the stranded pre-`end` argument.
+  // repeat-while: `on click repeat while #x.innerText < 10 increment #x wait 200ms end`
+  it('[ja] repeat-while recovers the trailing wait after end', () => {
+    const a = actions(
+      parse(
+        'の間 #counter.innerText < 10 を クリック で 繰り返し それから #counter を 増加 それから 200ms 終わり を 待つ',
+        'ja'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+    expect(a.has('increment')).toBe(true);
+    expect(a.has('wait')).toBe(true); // was dropped by the `end`-break
+  });
+  it('[ko] repeat-while recovers the trailing wait after end', () => {
+    const a = actions(
+      parse(
+        '동안 #counter.innerText < 10 를 클릭 반복 그러면 #counter 를 증가 그러면 200ms 끝 를 대기',
+        'ko'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+    expect(a.has('increment')).toBe(true);
+    expect(a.has('wait')).toBe(true); // was dropped by the `end`-break
+  });
+
+  // ── Fix 2: `for`-binding drops the `repeat` keyword ──────────────────────
+  // `repeat for <var> in <coll>` loses its `for` binder keyword in transit, so
+  // the bare `repeat` keyword carries no matchable variant and matchBest can't
+  // anchor it. `parseClause` now emits the `repeat` action directly when matchBest
+  // fails on a token whose normalized form is the repeat loop keyword.
+  // repeat-for-each: `on click repeat for item in .items add .processed to item`
+  it('[ar] repeat-for-each recovers the repeat keyword (was dropped)', () => {
+    const a = actions(parse('كرر عند نقر item في .items ثم أضف .processed إلى item', 'ar'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true); // the `for`-binding repeat keyword
+    expect(a.has('add')).toBe(true);
+  });
+  it('[tl] repeat-for-each recovers the repeat keyword (was dropped)', () => {
+    const a = actions(
+      parse('ulitin kapag click item sa_loob .items pagkatapos idagdag .processed sa item', 'tl')
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+    expect(a.has('add')).toBe(true);
+  });
+  it('[zh] repeat-for-each recovers the repeat keyword (was dropped)', () => {
+    const a = actions(
+      parse('当 点击 时 重复 item 在 .items 那么 添加 把 .processed 到 item', 'zh')
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+    expect(a.has('add')).toBe(true);
+  });
+
+  // zh repeat-forever: the last degenerate repeat-* in the corpus. Recovering the
+  // leading `重复`(repeat) keyword lifts it above the 0.5 fidelity threshold
+  // (deg → faithful). `on load repeat forever toggle .pulse wait 1s end`
+  it('[zh] repeat-forever recovers repeat + toggle (no longer degenerate)', () => {
+    const a = actions(parse('当 加载 时 重复 forever 切换 把 .pulse 那么 等待 把 1s 结束', 'zh'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true); // cleared the last degenerate repeat-*
+    expect(a.has('toggle')).toBe(true);
+  });
+
+  // sw repeat-while: SVO event leads, then `rudia wakati <cond> kisha <body>`. The
+  // leading `rudia`(repeat) clause between the event and the first `kisha`(then)
+  // was dropped; the repeat-keyword recovery now keeps it.
+  it('[sw] repeat-while recovers the leading repeat keyword', () => {
+    const a = actions(
+      parse(
+        'kwenye bonyeza rudia wakati #counter.innerText < 10 kisha ongeza #counter kisha ngoja 200ms mwisho',
+        'sw'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true); // `rudia` was dropped before
+    expect(a.has('wait')).toBe(true);
+  });
+
+  // Regression guards: neither fix should over-generate on inputs that already
+  // parsed faithfully.
+  it('[en] a counted `repeat N times` body is unaffected (still parses as repeat)', () => {
+    const a = actions(parse('on click repeat 3 times add "<p>Line</p>" to me', 'en'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+  });
+  it('[en] a plain then-chain with a trailing end is unaffected', () => {
+    const a = actions(parse('on click toggle .active then add .b to me', 'en'));
+    expect([...a].sort()).toEqual(['add', 'on', 'toggle']);
   });
 });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-09T08:56:58.765Z",
-  "commit": "1d18bc2",
+  "timestamp": "2026-06-09T09:40:44.949Z",
+  "commit": "6fafe63",
   "languages": {
     "ar": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9268083704069859,
-      "avgFidelity": 0.8825708061002179,
+      "avgFidelity": 0.8880174291938998,
       "degeneratePasses": [
         "accordion-exclusive",
         "behavior-draggable",
@@ -22,7 +22,7 @@
         "tabs-basic",
         "tabs-content"
       ],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,9 +646,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8657287157287157,
-      "avgFidelity": 0.9563852813852812,
+      "avgFidelity": 0.9580086580086579,
       "degeneratePasses": ["socket-basic"],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1281,7 +1281,7 @@
         "first-in-parent",
         "if-empty"
       ],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1905,7 +1905,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,9 +2530,9 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "avgFidelity": 0.9089324618736385,
+      "avgFidelity": 0.9165577342047931,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3156,7 +3156,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "avgFidelity": 0.880174291938998,
+      "avgFidelity": 0.8877995642701524,
       "degeneratePasses": [
         "async-block",
         "behavior-draggable",
@@ -3165,7 +3165,7 @@
         "fetch-with-headers",
         "first-in-parent"
       ],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3785,12 +3785,13 @@
       }
     },
     "he": {
-      "parseSuccess": 151,
-      "parseFailure": 3,
-      "parseRate": 0.9805194805194806,
-      "avgConfidence": 0.8498580889309372,
-      "avgFidelity": 0.802869757174393,
+      "parseSuccess": 152,
+      "parseFailure": 2,
+      "parseRate": 0.987012987012987,
+      "avgConfidence": 0.8475563909774442,
+      "avgFidelity": 0.8041666666666668,
       "degeneratePasses": [
+        "behavior-draggable",
         "behavior-resizable",
         "fetch-do-not-throw",
         "fetch-json",
@@ -3798,7 +3799,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4404,7 +4405,8 @@
           "success": false
         },
         "behavior-draggable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-sortable": {
           "success": false
@@ -4434,7 +4436,7 @@
         "socket-basic",
         "worker-basic"
       ],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5059,14 +5061,14 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "avgFidelity": 0.8175381263616558,
+      "avgFidelity": 0.826797385620915,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
         "behavior-sortable",
         "unless-condition"
       ],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5692,7 +5694,7 @@
       "avgConfidence": 0.9878721859114016,
       "avgFidelity": 0.9550108932461874,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6316,7 +6318,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8410533910533909,
-      "avgFidelity": 0.8929653679653682,
+      "avgFidelity": 0.8945887445887448,
       "degeneratePasses": [
         "announce-screen-reader",
         "behavior-draggable",
@@ -6327,7 +6329,7 @@
         "input-validation",
         "socket-basic"
       ],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6952,7 +6954,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.5553391053391054,
-      "avgFidelity": 0.9032467532467534,
+      "avgFidelity": 0.9086580086580087,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -6963,7 +6965,7 @@
         "socket-basic",
         "window-scroll"
       ],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7588,7 +7590,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9988455988455989,
-      "avgFidelity": 0.7876623376623375,
+      "avgFidelity": 0.7898268398268397,
       "degeneratePasses": [
         "announce-screen-reader",
         "async-block",
@@ -7599,7 +7601,7 @@
         "its-value-possessive-dot",
         "template-literal-list-build"
       ],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8224,14 +8226,14 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.828685548293392,
-      "avgFidelity": 0.8898692810457517,
+      "avgFidelity": 0.8958605664488017,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
         "behavior-sortable",
         "first-in-parent"
       ],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8855,7 +8857,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8312273057371102,
-      "avgFidelity": 0.8657952069716778,
+      "avgFidelity": 0.8734204793028322,
       "degeneratePasses": [
         "async-block",
         "behavior-draggable",
@@ -8866,7 +8868,7 @@
         "focus-trap",
         "socket-basic"
       ],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "window-resize": {
           "success": true,
@@ -9490,7 +9492,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7293650793650793,
-      "avgFidelity": 0.7941558441558443,
+      "avgFidelity": 0.7957792207792208,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -9501,7 +9503,7 @@
         "socket-basic",
         "template-literal-list-build"
       ],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10126,9 +10128,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8895073180787468,
-      "avgFidelity": 0.9596320346320344,
+      "avgFidelity": 0.9628787878787877,
       "degeneratePasses": ["install-behavior"],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10753,19 +10755,17 @@
       "parseFailure": 2,
       "parseRate": 0.987012987012987,
       "avgConfidence": 0.8868316624895575,
-      "avgFidelity": 0.8326754385964912,
+      "avgFidelity": 0.8425438596491228,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
         "event-debounce",
         "first-in-parent",
-        "focus-trap",
         "if-empty",
-        "repeat-until-event",
         "socket-basic",
         "template-literal-list-build"
       ],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11390,7 +11390,7 @@
       "avgConfidence": 0.9402185116470816,
       "avgFidelity": 0.9791125541125543,
       "degeneratePasses": [],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8985472977069613,
-      "avgFidelity": 0.8941558441558443,
+      "avgFidelity": 0.8963203463203465,
       "degeneratePasses": [
         "accordion-exclusive",
         "copy-to-clipboard",
@@ -12030,7 +12030,7 @@
         "take-class-from-siblings",
         "worker-basic"
       ],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12655,17 +12655,16 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8648511256354393,
-      "avgFidelity": 0.9277777777777777,
+      "avgFidelity": 0.9310457516339868,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
         "behavior-resizable",
         "behavior-sortable",
         "default-value",
-        "focus-trap",
         "socket-basic"
       ],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13289,9 +13288,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8887652030509177,
-      "avgFidelity": 0.9596320346320344,
+      "avgFidelity": 0.9628787878787877,
       "degeneratePasses": ["install-behavior"],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13918,7 +13917,7 @@
       "avgConfidence": 0.892888064316636,
       "avgFidelity": 0.894155844155844,
       "degeneratePasses": ["template-literal-list-build"],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14543,7 +14542,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9988148148148148,
-      "avgFidelity": 0.7845555555555555,
+      "avgFidelity": 0.7939999999999998,
       "degeneratePasses": [
         "async-block",
         "event-debounce",
@@ -14552,10 +14551,9 @@
         "fetch-json",
         "fetch-with-headers",
         "its-value-possessive-dot",
-        "repeat-forever",
         "template-literal-list-build"
       ],
-      "bundleSize": 403997,
+      "bundleSize": 404501,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15174,7 +15172,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 403997,
+      "size": 404501,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
Implements the structural slice of `docs-internal/NON_SOV_REPEAT_SCOPE.md`.

## What

Two parser-side fixes in `packages/semantic/src/parser/semantic-parser.ts` (no transformer change — the transforms were already in a recoverable order, as the scope doc predicted):

1. **`end`-mid-stream tail merge** (`parseBodyWithClauses`). The verb-final SOV reorder places the block-terminating `end` *between* a trailing command's argument and its verb (`… 200ms 終わり を 待つ` = `… 200ms end ‹patient› wait`); the naive `end`-break discarded the post-`end` `を 待つ` / `를 대기` / `ta suyay`, dropping the trailing `wait`. The break now tolerates a **single** trailing clause — collected up to the next then/end boundary so a genuine nested-block close can't swallow arbitrary content — merging it with the stranded pre-`end` argument only when that argument parsed to nothing on its own.

2. **`for`-binding `repeat`-keyword recovery** (`parseClause`). The transformer drops the `for` binder keyword (`repeat for x in y` → `repeat x in y`), leaving the bare `repeat` with no matchable variant so matchBest can't anchor it (the `repeat` action was silently dropped; ko escaped only because SOV puts the keyword last). When matchBest fails on a token whose normalized form is `repeat`, the clause parser now emits the `repeat` action directly.

## Results

`--bundle browser-priority`, full regen + `--regression` gate:

- **Degenerate passes 135 → 132 (−3)**, **parse rate 3678 → 3679 (+1, he)**, **0 regressions** (zero faithful→degenerate flips; every avgFidelity delta non-negative).
- Cleared the **last degenerate `repeat-*`** (zh `repeat-forever`, 0.33 → 0.67 faithful) + sw `repeat-until-event` + bonus `focus-trap` (sw/tr).
- Fidelity sweep: for-each ar/tl/zh 0.67 → 1.0; while ja/ko/tr 0.75 → 1.0, qu 0.50 → 0.75; sw while 0.50 → 0.75.

## Maps to the scope doc

| # | Issue | Status |
| - | ----- | ------ |
| 1 | zh circumfix + block-body collapse | ✅ degenerate cleared (0.67 faithful) |
| 2 | `for`-binding drops the `repeat` keyword (ar/tl/zh) | ✅ 1.0 |
| 3 | then-chain tail drop (`wait` after `end`) | ✅ ja/ko/tr 1.0, qu 0.75 |
| 4 | sw `repeat-while` leading clause drop | ✅ 0.75 |

## Deferred (separate keyword-alignment tracks, called out in the scope doc)

- zh `wait` SVO pattern gap — `等待 1s` parses to nothing, so zh `repeat-forever` is faithful at 0.67 but not full 1.0.
- qu/sw `add`-vs-`increment` keyword overlap.

Both are dictionary work, not the structural reorder.

## Validation

- `--regression` gate green; baseline regenerated and prettier-formatted.
- Full `@lokascript/semantic` suite clean (the only failures observed were missing `.d.ts` artifacts before a full `build:types`; they pass after the declaration build — unrelated to the parser logic).
- New locking tests: `multilingual-roadmap-fixes.test.ts` → "Non-SOV repeat-* loop-body + tail residue — zh/ar/tl/ja/ko/sw" (incl. over-generation guards on en counted-repeat and a plain then-chain).

https://claude.ai/code/session_01KX9CNfC2XMgsiZyK8EkJva

---
_Generated by [Claude Code](https://claude.ai/code/session_01KX9CNfC2XMgsiZyK8EkJva)_