### PR TITLE
fix(multilingual): zh wait BA-marked duration (等待 把 {duration})

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,7 +5,8 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after Track 5 **qu/sw `increment` keyword alignment** — the i18n dictionaries collapsed `add` and `increment` onto one word (qu `yapay`, sw `ongeza`), so the transformer emitted the add-word for increment and the parser read it as `add` (capping qu/sw `repeat-while` at 0.75). The dicts now emit the profile's distinct increment primary (qu `yapachiy`, sw `ongezeko`); qu additionally needed a handcrafted SOV pattern (`{patient} ta yapachiy`) mirroring `add-qu-sov`, since the generated SOV pattern didn't anchor the verb-final order. **qu/sw `repeat-while` 0.75 → 1.0**, avgFidelity qu 0.796→0.809, sw 0.843→0.856, parse rate unchanged (3679/3696), 0 regressions (zero faithful→degenerate flips). Locked by `multilingual-roadmap-fixes.test.ts` ("qu/sw increment keyword alignment"). The other deferred residue (zh `wait` SVO pattern gap, `等待 1s`) remains — see [NON_SOV_REPEAT_SCOPE.md](NON_SOV_REPEAT_SCOPE.md)._
+_Last updated: after Track 5 **zh `wait` BA-marked duration** — the last zh `repeat-*` residue. The i18n transformer emits `等待 把 1s` for `wait 1s`: its generic argument parser defaults the first argument to the `patient` role, and zh marks `patient` with the BA particle `把`. The generated `等待 {duration}` pattern has no `把`, so the marked form didn't parse and the trailing `wait` dropped (zh `repeat-forever` body `… 那么 等待 把 1s 结束`). A handcrafted `wait-zh-ba` pattern (`packages/semantic/src/patterns/wait.ts`) now tolerates the optional `把`, mirroring `toggle-zh-ba`. **zh `repeat-forever` 0.67 → 1.0** (full `{on,repeat,toggle,wait}` body); avgFidelity zh 0.794 → 0.808; parse rate unchanged (3679/3696), 0 regressions. (Earlier notes called this a "zh SVO pattern gap / `等待 1s`" — that was a probe artifact; bare `等待 1s` always parsed, the `把` was the real blocker.) The deeper root cause — the transformer marking a duration as a fronted patient — plus the `那么`/`然后` then-keyword mismatch are scoped in [ZH_BLOCK_BODY_SCOPE.md](ZH_BLOCK_BODY_SCOPE.md). Locked by `multilingual-roadmap-fixes.test.ts` ("zh wait BA-marked duration")._
+_Earlier: Track 5 **qu/sw `increment` keyword alignment** — the i18n dictionaries collapsed `add` and `increment` onto one word (qu `yapay`, sw `ongeza`), so the transformer emitted the add-word for increment and the parser read it as `add` (capping qu/sw `repeat-while` at 0.75). The dicts now emit the profile's distinct increment primary (qu `yapachiy`, sw `ongezeko`); qu additionally needed a handcrafted SOV pattern (`{patient} ta yapachiy`) mirroring `add-qu-sov`, since the generated SOV pattern didn't anchor the verb-final order. **qu/sw `repeat-while` 0.75 → 1.0**, avgFidelity qu 0.796→0.809, sw 0.843→0.856, parse rate unchanged (3679/3696), 0 regressions (zero faithful→degenerate flips). Locked by `multilingual-roadmap-fixes.test.ts` ("qu/sw increment keyword alignment")._
 _Earlier: Track 5 **Non-SOV `repeat-*` loop-body + tail residue** — two parser-side fixes closed the structural remainder scoped in [NON_SOV_REPEAT_SCOPE.md](NON_SOV_REPEAT_SCOPE.md). (1) The **`end`-mid-stream tail merge** (`parseBodyWithClauses`): the verb-final SOV reorder strands a trailing command's argument before `end` and its verb after (`… 200ms 終わり を 待つ`), so the `end`-break dropped the trailing `wait`; `end` now tolerates a single trailing clause (collect to the next then/end boundary, merge with the stranded pre-`end` argument). (2) The **`for`-binding `repeat`-keyword recovery** (`parseClause`): the transformer drops the `for` binder (`repeat for x in y` → `repeat x in y`) so the bare `repeat` has no matchable variant; when matchBest fails on a `repeat`-normalized token the clause now emits the `repeat` action directly. **Degenerate passes 135 → 132 (−3), parse rate 3678 → 3679 (+1 he), 0 regressions** (gate green; zero faithful→degenerate flips). Cleared the last degenerate `repeat-*` (zh `repeat-forever`, deg→0.67 faithful) + sw `repeat-until-event` + bonus `focus-trap` (sw/tr); for-each ar/tl/zh 0.67→1.0; while ja/ko/tr 0.75→1.0, qu 0.50→0.75; sw while 0.50→0.75. Deferred residue (separate keyword tracks): zh `wait` SVO pattern gap (`等待 1s`), qu/sw `add`-vs-`increment` overlap. See [NON_SOV_REPEAT_SCOPE.md](NON_SOV_REPEAT_SCOPE.md)._
 _Earlier: Track 5 **VSO/Austronesian `repeat-*` mid-stream event reorder** — the non-SOV sibling of the SOV repeat-\* fix. For VSO/Austronesian the i18n transformer surfaces the loop keyword first and places the event clause mid-stream, marked by an `on`-marker (`كرر عند نقر …` / `ulitin kapag click …` = `repeat on click …`). The trailing-event extractor (Stage 1.5) can't see it (the event isn't last), so the bare loop keyword won Stage 2 and the event + body dropped (degenerate). `tryMidStreamEventExtraction` strips the `<on-marker> <event>` pair and re-parses the rest as the loop body; the block/loop gate now tries it after SOV extraction. **Degenerate passes 141 → 135 (−6), 0 regressions, parse rate unchanged** (3678/3696). Cleared `repeat-for-each`/`repeat-while` (ar+tl) + bonus `focus-trap`/`window-keydown` (ar — same mid-stream-event shape). avgFidelity ar 0.866→0.883, tl 0.884→0.894. Remaining repeat residue (zh circumfix block-body, the `for`-binding `repeat`-keyword drop, the `wait`-after-`end` tail) scoped in [NON_SOV_REPEAT_SCOPE.md](NON_SOV_REPEAT_SCOPE.md)._
 _Earlier: Track 5 **SOV `repeat-*` loop-body reorder** — for SOV languages the i18n transformer surfaces a block loop's keyword (반복/পুনরাবৃত্তি/kutipay) — or a leading `while`/`for` clause — ahead of its body, so the parser matched the bare loop keyword as a standalone command (Stage 2) and dropped the event + variant + body (degenerate). Korean (no event-marker particle) was hit hardest. The Stage-2 gate now prefers SOV event extraction (Stage 3) when the matched action is a block/loop action, recovering the event + loop body; and the qu `repeat` dict keyword was realigned (`kutichiy`→`kutipay`; `kutichiy` is the profile's `return` primary). **Degenerate passes 148 → 141 (−7), 0 regressions, parse rate unchanged** (3678/3696). Cleared `repeat-forever`/`repeat-while`/`repeat-for-each` for ko (+ `stagger-animation` bonus), `repeat-while` for bn, `repeat-while`/`repeat-for-each` for qu. avgFidelity ko 0.889→0.903, bn 0.952→0.956, qu 0.782→0.794. See [SOV_REPEAT_SCOPE.md](SOV_REPEAT_SCOPE.md)._
@@ -65,6 +66,29 @@ behaviors), not a parsing/i18n track. See Track 2.
 
 ## Shipped
 
+### Track 5 — zh `wait` BA-marked duration (zh repeat-forever → 1.0)
+
+- **zh `repeat-forever` 0.67 → 1.0** (now recovers the full `{on, repeat, toggle, wait}`
+  body); avgFidelity zh 0.794 → 0.808; parse rate unchanged (3679/3696), 0 regressions
+  (full `browser-priority` regen + `--regression` gate green; zh the only language moved).
+- **Root cause.** The i18n transformer emits `等待 把 1s` for `wait 1s`: its generic
+  argument parser (`transformer.ts` ~L910/973) defaults the first argument to the
+  `patient` role, and zh marks `patient` with the BA particle `把`
+  (`profiles/index.ts`). The generated semantic pattern is `等待 {duration}` (no `把`),
+  so the marked form didn't match — the trailing `wait` in
+  `… 那么 等待 把 1s 结束` was dropped.
+- **Fix.** Handcrafted `wait-zh-ba` pattern (`packages/semantic/src/patterns/wait.ts`,
+  registered in `builders.ts`) tolerating the optional `把` before the duration —
+  mirrors the existing `toggle-zh-ba` convention and the qu increment handcrafted fix.
+  Contained and low-risk; the unmarked `等待 1s` keeps using the generated pattern.
+- **Deeper follow-up (deferred).** The transformer over-applies `把` to non-patient
+  arguments (a duration is not a BA object — `等待 把 1s` is ungrammatical zh; the
+  transformer's own example table lists `等待 2秒`). Teaching it to honor the schema
+  `primaryRole` is an architecturally significant change to the i18n role model;
+  plus the `那么`/`然后` then-keyword mismatch. Both scoped in
+  [ZH_BLOCK_BODY_SCOPE.md](ZH_BLOCK_BODY_SCOPE.md). Locked by
+  `multilingual-roadmap-fixes.test.ts` ("zh wait BA-marked duration").
+
 ### Track 5 — qu/sw `increment` keyword alignment (yapachiy / ongezeko, qu/sw repeat-while → 1.0)
 
 - **qu/sw `repeat-while` 0.75 → 1.0**; avgFidelity qu 0.796 → 0.809, sw 0.843 → 0.856;
@@ -85,8 +109,6 @@ behaviors), not a parsing/i18n track. See Track 2.
   — the generated SOV pattern didn't anchor the `{patient} ta <verb>` order (which is
   why `add` already carried a handcrafted SOV pattern). Locked by
   `multilingual-roadmap-fixes.test.ts` ("qu/sw increment keyword alignment").
-- **Still deferred:** the zh `wait` SVO pattern gap (`等待 1s` parses to nothing — zh
-  `repeat-forever` stays faithful at 0.67 but not 1.0). See [NON_SOV_REPEAT_SCOPE.md](NON_SOV_REPEAT_SCOPE.md).
 
 ### Track 5 — Non-SOV `repeat-*` loop-body + tail residue (zh/ar/tl/ja/ko/qu/sw, −3 degenerate)
 

--- a/docs-internal/NON_SOV_REPEAT_SCOPE.md
+++ b/docs-internal/NON_SOV_REPEAT_SCOPE.md
@@ -10,12 +10,14 @@
 > `repeat-until-event` + bonus `focus-trap` (sw/tr); for-each ar/tl/zh 0.67→1.0;
 > while ja/ko/tr 0.75→1.0, qu 0.50→0.75; sw while 0.50→0.75. Locked by
 > `multilingual-roadmap-fixes.test.ts` ("Non-SOV repeat-\* loop-body + tail
-> residue"). **Follow-up keyword tracks:** the qu/sw `add`-vs-`increment` overlap is
-> now **✅ SHIPPED** (qu `yapachiy` / sw `ongezeko` dict alignment + a handcrafted
-> qu SOV increment pattern; qu/sw `repeat-while` 0.75→1.0 — see
-> `MULTILINGUAL_ROADMAP.md` → Shipped). **Still deferred:** the zh `wait` SVO pattern
-> gap (`等待 1s` parses to nothing — zh `repeat-forever` sits at 0.67, faithful but
-> not 1.0), a zh block-body parser track, not a dictionary fix.
+> residue"). **Follow-up keyword tracks (both now ✅ SHIPPED):** the qu/sw
+> `add`-vs-`increment` overlap (qu `yapachiy` / sw `ongezeko` dict alignment + a
+> handcrafted qu SOV increment pattern; qu/sw `repeat-while` → 1.0), and the zh
+> `wait` BA-marked duration (`等待 把 1s` — a handcrafted `wait-zh-ba` pattern;
+> zh `repeat-forever` 0.67 → 1.0). The "zh `wait` SVO gap / `等待 1s`" framing was a
+> probe artifact — bare `等待 1s` always parsed; the `把` object-marker on the
+> duration was the real blocker. The deeper transformer root cause is scoped in
+> [ZH_BLOCK_BODY_SCOPE.md](ZH_BLOCK_BODY_SCOPE.md). See `MULTILINGUAL_ROADMAP.md` → Shipped.
 > **Prereq reading:** `SOV_REPEAT_SCOPE.md` (the SOV sibling, SHIPPED) and
 > `MULTILINGUAL_ROADMAP.md` → Shipped (SOV repeat-\* loop-body reorder; VSO
 > mid-stream event reorder).

--- a/docs-internal/ZH_BLOCK_BODY_SCOPE.md
+++ b/docs-internal/ZH_BLOCK_BODY_SCOPE.md
@@ -1,0 +1,101 @@
+# Chinese (zh) Block-Body / BA-Marking Residue — Project Scope
+
+> **Status:** Partially shipped. The **zh `wait` BA-marked duration** slice is
+> **✅ DONE** (the last zh `repeat-*` residue — `repeat-forever` 0.67 → 1.0; see
+> below + `MULTILINGUAL_ROADMAP.md` → Shipped). This file scopes the **deeper
+> root cause** behind it (the i18n transformer's generic patient-marking) and the
+> related zh then-keyword mismatch, both of which the shipped slice worked around
+> at the parser rather than fixing at the source.
+> **Prereq reading:** `NON_SOV_REPEAT_SCOPE.md` (the arc this fell out of) and
+> `MULTILINGUAL_ROADMAP.md` → Shipped.
+
+## Shipped (the contained slice)
+
+**zh `wait` BA-marked duration.** The i18n transformer emits `等待 把 1s` for
+`wait 1s` — it runs the argument through a generic parser that defaults the first
+argument to the `patient` role (`transformer.ts` ~L910/973: `let currentRole = 'patient'`),
+and zh marks `patient` with the BA particle `把` (`profiles/index.ts`:
+`{ form: '把', role: 'patient' }`). The generated semantic pattern is
+`等待 {duration}` (no `把`), so `等待 把 1s` didn't match and the trailing `wait`
+dropped (the zh `repeat-forever` body `… 那么 等待 把 1s 结束` lost its `wait`).
+
+A handcrafted `wait-zh-ba` pattern (`packages/semantic/src/patterns/wait.ts`) now
+tolerates the optional `把` before the duration, mirroring the existing
+`toggle-zh-ba` convention. **zh `repeat-forever` 0.67 → 1.0** (now recovers the
+full `{on, repeat, toggle, wait}` body); avgFidelity zh 0.794 → 0.808; parse rate
+unchanged (3679/3696), 0 regressions. Locked by `multilingual-roadmap-fixes.test.ts`
+("zh wait BA-marked duration").
+
+This is the same shape as the qu increment fix — a contained, per-command
+handcrafted pattern that absorbs a transformer/parser keyword-or-marker mismatch.
+
+## What's left (the root causes the slice worked around)
+
+### #1 — Transformer over-applies `把` to non-patient arguments
+
+`等待 把 1s` is **ungrammatical zh** (a duration is not a BA-construction object;
+natural zh is `等待 1s` / `等待 2秒` — which the transformer's own example table at
+`transformer.ts` ~L2009 already lists as the intended form). The generic argument
+parser assigns every leading argument the `patient` role, so any command whose
+primary argument is a **duration / literal / measure** — not a fronted object —
+gets a spurious `把`:
+
+- `wait <duration>` → `等待 把 <dur>` (worked around here)
+- likely also `settle`, `transition` durations, and other literal-primary commands
+  (unverified — probe before assuming).
+
+**Root-cause fix:** teach the transformer that a command's primary role can be a
+non-patient (the semantic command schemas already carry `primaryRole` — e.g.
+`wait.primaryRole = 'duration'`). The transformer's role model is independent of
+the semantic schemas, so this is an **architecturally significant** change to how
+i18n assigns/marks roles — it affects every zh patient-marked command and the
+display-quality of translated output, not just parsing. Validate against the full
+zh grammar test suite (`packages/i18n/src/grammar/grammar.test.ts`) and the
+multilingual `--regression` gate. Until then, the per-command handcrafted patterns
+(toggle/add/wait …) absorb the mismatch on the parse side.
+
+### #2 — zh then-keyword mismatch (`那么` vs `然后`)
+
+The i18n dictionary maps `then` → `那么` (`dictionaries/zh.ts`), but the semantic
+zh profile's `then` is `然后` / `接着`. The semantic tokenizer has a `那么`→then
+entry, but a particle extractor (`tokenizers/extractors/chinese-particle.ts` maps
+`那么` to role `consequence`) shadows it, so `那么` surfaces with an empty
+`normalized` and `isThenKeyword` doesn't recognize it. In the shipped slice this
+didn't block recovery (the clause parser's matchBest loop still found `等待` after
+the unrecognized `那么`), but it means **zh then-chains split on the wrong keyword
+wherever the transformer is the source** — a latent correctness gap for multi-clause
+zh bodies.
+
+**Fix:** reconcile the i18n dict (`那么`) and the semantic profile (`然后`) on one
+canonical `then`, and resolve the tokenizer's particle-vs-keyword precedence for
+`那么` so it normalizes to `then`. Smaller and more isolated than #1; do it first.
+
+### #3 — zh `fetch`-in-event-block (deferred elsewhere)
+
+The roadmap notes a deferred zh `fetch` keyword/block-body gap in event handlers.
+It is the same family as #1 (zh block-body parsing through the BA/marker layer); a
+real #1 fix may unblock it. Cross-reference when picking #1 up.
+
+## Suggested sequencing
+
+1. **#2 (then-keyword reconciliation)** — small, isolated, fixes a latent
+   multi-clause zh correctness gap. Probe `a 那么 b 那么 c` round-trips first.
+2. **#1 (transformer role model)** — the big one. Scope a controlled change to
+   honor `primaryRole` when marking, A/B against the gate + zh grammar suite, and
+   retire the per-command handcrafted `把` patterns it makes redundant.
+3. **#3 (zh fetch block-body)** — re-probe after #1; likely partially unblocked.
+
+## Probe
+
+Use the probe at the bottom of `NON_SOV_REPEAT_SCOPE.md`. **Caveat learned the hard
+way:** the probe transforms its input `en → lang`, so pass **English** source
+(`wait 1s`), not pre-transformed zh — feeding raw zh re-transforms it into garbage
+and produces false negatives. To test a raw zh string directly, call
+`parseSemantic('等待 把 1s', 'zh')` instead of going through the probe's transform.
+
+## Definition of done (for the remaining work)
+
+`那么` recognized as `then` (zh multi-clause bodies split correctly); the transformer
+emits grammatical zh for duration/literal-primary commands (no spurious `把`); the
+per-command `把` workaround patterns retired where the transformer fix subsumes them;
+`--regression` gate green; zh grammar suite clean.

--- a/packages/semantic/src/patterns/builders.ts
+++ b/packages/semantic/src/patterns/builders.ts
@@ -21,6 +21,7 @@ import { getSetPatternsForLanguage } from './set';
 import { getGetPatternsForLanguage } from './get';
 import { getIncrementPatternsForLanguage } from './increment';
 import { getDecrementPatternsForLanguage } from './decrement';
+import { getWaitPatternsForLanguage } from './wait';
 import { getAppendPatternsForLanguage } from './append';
 import { getPrependPatternsForLanguage } from './prepend';
 import { getTriggerPatternsForLanguage } from './trigger';
@@ -65,6 +66,7 @@ const PATTERN_LOADERS: PatternLoader[] = [
   getGetPatternsForLanguage,
   getIncrementPatternsForLanguage,
   getDecrementPatternsForLanguage,
+  getWaitPatternsForLanguage,
   getAppendPatternsForLanguage,
   getPrependPatternsForLanguage,
   getTriggerPatternsForLanguage,

--- a/packages/semantic/src/patterns/wait.ts
+++ b/packages/semantic/src/patterns/wait.ts
@@ -1,0 +1,56 @@
+/**
+ * Wait Command Patterns (hand-crafted)
+ *
+ * Most languages parse `wait <duration>` via the auto-generated
+ * `wait-{lang}-generated` pattern (`<verb> {duration}`). Chinese is the
+ * exception: the i18n grammar transformer runs `wait 1s` through its generic
+ * argument parser, which defaults the first argument to the `patient` role and
+ * therefore marks it with the BA-construction particle `把` — emitting
+ * `等待 把 1s`. The generated pattern is `等待 {duration}` (no `把`), so the
+ * marked form doesn't match and the trailing `wait` is dropped (e.g. the zh
+ * `repeat-forever` body `… 那么 等待 把 1s 结束`).
+ *
+ * This adds a zh pattern that tolerates the optional `把` before the duration,
+ * mirroring the existing `toggle-zh-ba` convention. (The cleaner root-cause fix
+ * — teaching the i18n transformer that `wait` takes a `duration`, not a fronted
+ * patient, so it never emits `把 1s` — is a broader change to the transformer's
+ * role model; see docs-internal/ZH_BLOCK_BODY_SCOPE.md.)
+ */
+
+import type { LanguagePattern } from '../types';
+
+function getWaitPatternsZh(): LanguagePattern[] {
+  return [
+    // BA-marked duration: 等待 把 1s (transformer output). The generated
+    // `等待 {duration}` already covers the unmarked `等待 1s` form.
+    {
+      id: 'wait-zh-ba',
+      language: 'zh',
+      command: 'wait',
+      priority: 105,
+      template: {
+        format: '等待 把 {duration}',
+        tokens: [
+          { type: 'literal', value: '等待', alternatives: ['等', '稍候'] },
+          { type: 'literal', value: '把' },
+          { type: 'role', role: 'duration', expectedTypes: ['literal', 'expression'] },
+        ],
+      },
+      extraction: {
+        duration: { position: 2 },
+      },
+    },
+  ];
+}
+
+/**
+ * Get wait patterns for a specific language.
+ */
+export function getWaitPatternsForLanguage(language: string): LanguagePattern[] {
+  switch (language) {
+    case 'zh':
+      return getWaitPatternsZh();
+    default:
+      return [];
+  }
+}

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1054,3 +1054,42 @@ describe('qu/sw increment keyword alignment (yapachiy / ongezeko)', () => {
     expect(a.has('wait')).toBe(true);
   });
 });
+
+describe('zh wait BA-marked duration (等待 把 {duration})', () => {
+  // The i18n transformer runs `wait 1s` through its generic argument parser,
+  // which defaults the first argument to the `patient` role and so marks it with
+  // the BA particle `把` — emitting `等待 把 1s`. The generated `等待 {duration}`
+  // pattern has no `把`, so the marked form didn't parse and the trailing `wait`
+  // dropped (the last zh `repeat-forever` residue: 0.67 → 1.0). A handcrafted
+  // `wait-zh-ba` pattern now tolerates the `把`. The deeper transformer fix (don't
+  // mark a duration as a fronted patient) is scoped in docs-internal/ZH_BLOCK_BODY_SCOPE.md.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('[zh] parses the BA-marked duration `等待 把 1s` as wait', () => {
+    const a = actions(parse('等待 把 1s', 'zh'));
+    expect(a.has('wait')).toBe(true);
+  });
+  it('[zh] still parses the unmarked `等待 1s` as wait (generated pattern)', () => {
+    const a = actions(parse('等待 1s', 'zh'));
+    expect(a.has('wait')).toBe(true);
+  });
+  // repeat-forever: `on load repeat forever toggle .pulse wait 1s end` — the last
+  // zh repeat-* residue. Now recovers the full {on, repeat, toggle, wait} body.
+  it('[zh] repeat-forever recovers the trailing wait (was dropped)', () => {
+    const a = actions(parse('当 加载 时 重复 forever 切换 把 .pulse 那么 等待 把 1s 结束', 'zh'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+    expect(a.has('toggle')).toBe(true);
+    expect(a.has('wait')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-09T10:14:40.669Z",
-  "commit": "ba9c0b8",
+  "timestamp": "2026-06-09T10:42:13.471Z",
+  "commit": "0931188",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -14542,7 +14542,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9988148148148148,
-      "avgFidelity": 0.7939999999999998,
+      "avgFidelity": 0.8078888888888888,
       "degeneratePasses": [
         "async-block",
         "event-debounce",


### PR DESCRIPTION
Second of the two recommended follow-ups to #304. Closes the **zh `wait` residue** — the last zh `repeat-*` gap — and lands the investigation as a scope doc for the deeper root cause.

## Root cause

The i18n transformer emits `等待 把 1s` for `wait 1s`. Its generic argument parser defaults the first argument to the `patient` role (`transformer.ts` ~L910/973), and zh marks `patient` with the BA-construction particle `把` (`profiles/index.ts`). The generated semantic pattern is `等待 {duration}` (**no `把`**), so `等待 把 1s` didn't match and the trailing `wait` was dropped — e.g. the zh `repeat-forever` body `… 那么 等待 把 1s 结束`.

> **Note:** earlier notes (from #304) called this a "zh SVO pattern gap / `等待 1s` parses to nothing." That was a **probe artifact** — the probe transforms its input `en → lang`, so feeding it raw zh re-transformed it into garbage. Bare `等待 1s` always parsed fine; the `把` object-marker on the duration was the real blocker.

## Fix (contained, low-risk)

Handcrafted `wait-zh-ba` pattern (`packages/semantic/src/patterns/wait.ts`, registered in `builders.ts`) tolerating the optional `把` before the duration — mirrors the existing `toggle-zh-ba` convention and the qu-increment handcrafted fix from #305. The unmarked `等待 1s` keeps using the generated pattern.

## Results

`--bundle browser-priority`, full regen + `--regression` gate:

- **zh `repeat-forever` 0.67 → 1.0** — now recovers the full `{on, repeat, toggle, wait}` body (was 0.33 degenerate before the whole arc).
- avgFidelity **zh 0.794 → 0.808**; zh is the *only* language that moved.
- Parse rate unchanged (3679/3696), **0 regressions** (zero faithful→degenerate flips).

## Validation

- Full `@lokascript/semantic` suite green (5405 passed); typecheck clean.
- New locking tests: `multilingual-roadmap-fixes.test.ts` → "zh wait BA-marked duration" (`把`-marked + unmarked forms, plus the full repeat-forever body).
- Baseline regenerated + prettier-formatted; `patterns.db` restored.

## Deeper follow-up (deferred, scoped not fixed)

New `docs-internal/ZH_BLOCK_BODY_SCOPE.md` documents the **root cause** this PR works around at the parser:

1. The transformer over-applies `把` to non-patient arguments (a duration isn't a BA object — `等待 把 1s` is ungrammatical zh; the transformer's own example table lists `等待 2秒`). Teaching it to honor the schema `primaryRole` is an architecturally significant change to the i18n role model — deferred deliberately.
2. The `那么` / `然后` then-keyword mismatch between the i18n dict and the semantic profile (a latent multi-clause zh correctness gap).

## Note on stacking

Branched off `main`, independent of #305 (qu/sw increment). Both touch the baseline JSON; whichever merges second may need a trivial baseline regen/rebase. This PR's baseline diff is **zh-only**.

https://claude.ai/code/session_01KX9CNfC2XMgsiZyK8EkJva

---
_Generated by [Claude Code](https://claude.ai/code/session_01KX9CNfC2XMgsiZyK8EkJva)_