### PR TITLE
fix(testing-framework): make the multilingual --regression gate runnable in a fresh container

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:multilingual:quick": "npm run test:multilingual:quick --workspace=@hyperfixi/testing-framework",
     "test:multilingual:full": "npm run test:multilingual:full --workspace=@hyperfixi/testing-framework",
     "test:multilingual:regression": "npm run test:multilingual:regression --workspace=@hyperfixi/testing-framework",
+    "test:multilingual:build-deps": "npm run build --prefix packages/intent && npm run build --prefix packages/framework && npm run build --prefix packages/semantic && npm run build --prefix packages/i18n && npm run build --prefix packages/patterns-reference && npm run build:multilingual-dist --prefix packages/core",
     "test:watch": "npm run test:watch --workspaces",
     "test:coverage": "npm run test:coverage --workspaces",
     "lint": "npm run lint --workspaces",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -167,6 +167,7 @@
   "scripts": {
     "build": "rollup -c && rollup -c rollup.parser-modules.config.mjs && tsc -p tsconfig.build.json",
     "build:types": "tsc -p tsconfig.build.json",
+    "build:multilingual-dist": "rollup -c",
     "build:browser": "node scripts/build-browser-bundles.mjs",
     "build:browser:main-only": "rollup -c rollup.browser.config.mjs",
     "postbuild:browser": "node scripts/create-bundle-aliases.mjs",

--- a/packages/testing-framework/src/multilingual/bundle-builder.ts
+++ b/packages/testing-framework/src/multilingual/bundle-builder.ts
@@ -121,6 +121,16 @@ export async function findBundleForLanguages(
   }
 
   if (!bestBundle) {
+    // Fallback: a per-language bundle `browser-{lang}.{lang}.global.js` may exist
+    // even when no predefined group covers the language (these are emitted by the
+    // semantic build for every individual language).
+    if (languages.length === 1) {
+      const name = `browser-${languages[0]}`;
+      const p = getBundlePath(name);
+      if (existsSync(p)) {
+        return { name, path: p, languages, size: statSync(p).size, exists: true };
+      }
+    }
     return null;
   }
 
@@ -163,8 +173,13 @@ export async function getBundleInfo(bundleName: string): Promise<BundleInfo | nu
 export async function buildBundle(options: BundleBuildOptions): Promise<BundleInfo> {
   const { languages, groupName } = options;
 
-  // Generate bundle using the generate-bundle.mjs script
-  const semanticRoot = join(process.cwd(), 'packages/semantic');
+  // Generate bundle using the generate-bundle.mjs script.
+  // Anchor to this file's location (not process.cwd()): when the gate runs via
+  // `npm run … --workspace=@hyperfixi/testing-framework`, cwd is the workspace
+  // package dir, so `cwd()/packages/semantic` resolves to a non-existent path and
+  // exec() fails with `spawn /bin/sh ENOENT`. getBundlePath() already resolves the
+  // semantic root this way — mirror it here.
+  const semanticRoot = join(__dirname, '../../..', 'semantic');
   const scriptPath = join(semanticRoot, 'scripts/generate-bundle.mjs');
 
   let bundleName: string;
@@ -210,32 +225,35 @@ export async function selectBundle(
   languages: LanguageCode[],
   build: boolean = false
 ): Promise<BundleInfo> {
-  // First, try to find existing bundle
-  let bundle = await findBundleForLanguages(languages);
+  // First, try to find an existing bundle
+  const bundle = await findBundleForLanguages(languages);
 
-  // If bundle exists and we don't need to build, use it
-  if (bundle && bundle.exists && !build) {
+  if (bundle && bundle.exists) {
     return bundle;
   }
 
-  // If build is requested or no bundle exists, build it
-  if (build || !bundle || !bundle.exists) {
-    // Determine if we can use a predefined group
+  // Build only on explicit request. The regression gate parses in-process (via
+  // parseSemantic), so the bundle is consumed only for size/existence reporting —
+  // a missing display bundle must NOT silently trigger a heavy on-demand semantic
+  // rebuild as a side effect of running tests.
+  if (build) {
     const groupName = findGroupForLanguages(languages);
-
-    bundle = await buildBundle({
+    const built = await buildBundle({
       languages,
       groupName: groupName !== null ? groupName : undefined,
       outputPath: undefined,
       updateConfig: false, // Don't modify configs during testing
     });
+    if (!built.exists) {
+      throw new Error(`Bundle not found: ${built.path}`);
+    }
+    return built;
   }
 
-  if (!bundle.exists) {
-    throw new Error(`Bundle not found: ${bundle.path}`);
-  }
-
-  return bundle;
+  // Not building: return what we know (possibly non-existent). The caller reports
+  // it as unavailable and continues with the in-process parse.
+  const name = `browser-${languages.join('-')}`;
+  return bundle ?? { name, path: getBundlePath(name), languages, size: 0, exists: false };
 }
 
 /**

--- a/packages/testing-framework/src/multilingual/orchestrator.ts
+++ b/packages/testing-framework/src/multilingual/orchestrator.ts
@@ -11,7 +11,14 @@ import { SizeValidator } from './validators/size-validator';
 import { ConsoleReporter } from './reporters/console-reporter';
 import { JSONReporter } from './reporters/json-reporter';
 import { RegressionReporter } from './reporters/regression-reporter';
-import type { TestConfig, TestResults, LanguageResults, LanguageCode, Reporter } from './types';
+import type {
+  TestConfig,
+  TestResults,
+  LanguageResults,
+  LanguageCode,
+  Reporter,
+  BundleInfo,
+} from './types';
 import { computeFidelity, FIDELITY_THRESHOLD } from './fidelity';
 
 const execAsync = promisify(exec);
@@ -167,13 +174,25 @@ export class TestOrchestrator {
   private async testLanguage(language: LanguageCode, patterns: any[]): Promise<LanguageResults> {
     const startTime = performance.now();
 
-    // Select bundle for this language
-    const bundle = this.config.bundle
+    // Select bundle for this language. The bundle is consumed only for size
+    // reporting — parse validation below runs in-process via parseSemantic — so a
+    // missing display bundle is a warning, not a fatal error that aborts the sweep.
+    const selected = this.config.bundle
       ? await getBundleInfo(this.config.bundle)
       : await selectBundle([language], this.config.build || false);
 
-    if (!bundle || !bundle.exists) {
-      throw new Error(`Bundle not found for language: ${language}`);
+    const bundle: BundleInfo = selected ?? {
+      name: `browser-${language}`,
+      path: '',
+      languages: [language],
+      size: 0,
+      exists: false,
+    };
+
+    if (!bundle.exists) {
+      console.warn(
+        `⚠ No display bundle for '${language}' (${bundle.name}); reporting size 0 and continuing with in-process parse.`
+      );
     }
 
     // Notify reporters


### PR DESCRIPTION
## Summary

Follow-up to #309. While validating the zh fetch fix I hit several layers of friction running the full `--regression` gate in a fresh-checkout container — it aborted partway through with `spawn /bin/sh ENOENT`, then `Bundle not found`, and I had to stub a bundle + patch the harness locally to finish. This PR fixes the underlying causes so the gate runs end-to-end without that dance.

## Root causes & fixes

**1. `buildBundle()` resolved `semanticRoot` from `process.cwd()` — wrong under npm workspaces.** The gate runs via `--workspace=@hyperfixi/testing-framework`, so cwd is the workspace dir → `cwd/packages/semantic` doesn't exist → `exec()` fails with `spawn /bin/sh ENOENT`. The sibling `getBundlePath()` right above it already resolves the semantic root from `__dirname`; `buildBundle` now mirrors that. (Latent in CI, which pre-builds all bundles, but it bites immediately in a fresh container.)

**2. A missing display bundle aborted the entire sweep** — even though parse validation runs **in-process** via `parseSemantic` and the bundle is consumed *only* for size reporting. Now:
- `selectBundle()` no longer auto-builds as a side effect of testing (builds only on explicit `--build`), so running the gate can't silently trigger a heavy on-demand semantic rebuild.
- `testLanguage()` warns and continues with size 0 instead of throwing. A language without a prebuilt bundle (e.g. `he`, which has no `PREDEFINED_BUNDLES` entry or artifact) now reports rather than halts.

**3. `findBundleForLanguages()` gains a per-language fallback** (`browser-{lang}.{lang}.global.js`) so individually-built language bundles are found even when no predefined group covers them.

**4. Added `npm run test:multilingual:build-deps`** to build the gate's import chain in dependency order (intent → framework → semantic → i18n → patterns-reference + `core` multilingual dist), so the otherwise-cryptic `Cannot find module .../core/dist/multilingual/index.js` is a one-command fix.

## Validation

- **Full `--regression --full` sweep now completes end-to-end** in this fresh container with no stub and no local patch: degenerate 124, `✓ No regression vs baseline`.
- The `he` graceful-degradation path is exercised: `⚠ No display bundle for 'he' (browser-he); reporting size 0 and continuing with in-process parse.` — and `he` still tests at **152/154 (99%) PASS**.
- testing-framework unit tests pass (158/159; the one failure is a pre-existing flaky timing test in `runner.test.ts` — passes in isolation, unrelated to `src/multilingual/`).

## Notes

- No behavior change for CI, which pre-builds bundles — `findBundleForLanguages` still finds them first. This only changes what happens when a bundle is *absent*: graceful report instead of abort.
- There's a pre-existing typecheck warning (`parse-validator.ts` missing a `.d.ts` for `@hyperfixi/core/multilingual`) that's independent of this change; the gate runs via tsx and CI's full core build emits the declaration. Left as-is to keep this PR focused.

https://claude.ai/code/session_01VLQjtgwkjcwyKvHYY6utZz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLQjtgwkjcwyKvHYY6utZz)_