### PR TITLE
fix(testing-framework): --regression implies --full so the fidelity ratchet runs

### DIFF
--- a/packages/testing-framework/src/multilingual/cli.ts
+++ b/packages/testing-framework/src/multilingual/cli.ts
@@ -18,6 +18,11 @@ function parseArgs(): TestConfig {
     quickModeLimit: 10,
   };
 
+  // Track whether quick mode was explicitly requested, so --regression can safely
+  // upgrade the default-quick run to full (where the fidelity/degenerate ratchet
+  // actually runs) without overriding an explicit --quick.
+  let explicitQuick = false;
+
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
 
@@ -47,12 +52,16 @@ function parseArgs(): TestConfig {
         break;
 
       case '--mode':
-      case '-m':
-        config.mode = args[++i] as 'quick' | 'full';
+      case '-m': {
+        const mode = args[++i] as 'quick' | 'full';
+        config.mode = mode;
+        if (mode === 'quick') explicitQuick = true;
         break;
+      }
 
       case '--quick':
         config.mode = 'quick';
+        explicitQuick = true;
         break;
 
       case '--full':
@@ -119,6 +128,20 @@ function parseArgs(): TestConfig {
     }
   }
 
+  // The regression gate ratchets on degenerate/fidelity passes, which are only
+  // computed in full mode. A default-quick --regression run silently checks just
+  // parse rate — a much weaker gate. Upgrade to full unless the caller explicitly
+  // asked for quick (in which case warn that the fidelity ratchet is skipped).
+  if (config.regression && config.mode === 'quick') {
+    if (explicitQuick) {
+      console.warn(
+        '⚠ --regression in --quick mode only checks parse rate; the degenerate/fidelity ratchet requires --full.'
+      );
+    } else {
+      config.mode = 'full';
+    }
+  }
+
   return config;
 }
 
@@ -141,7 +164,10 @@ OPTIONS:
       --quick                  Quick mode (10 patterns per language)
       --full                   Full mode (all patterns)
   -v, --verbose                Enable verbose output
-  -r, --regression             Gate on regressions vs baseline (exit 1 if any)
+  -r, --regression             Gate on regressions vs baseline (exit 1 if any).
+                               Implies --full (the degenerate/fidelity ratchet
+                               needs full mode); pass --quick to force parse-rate-
+                               only and skip it.
       --baseline <path>        Baseline file (default: ./baselines/multilingual-priority.json)
   -c, --confidence <n>         Minimum confidence threshold (0-1)
       --verified-only          Only test verified translations


### PR DESCRIPTION
## Summary

Follow-up to the gate-hardening work (#310). While investigating the `for`-loop degenerate (see "Investigation findings" below), I confirmed a real trap: **`--regression` defaults to quick mode, which silently skips the degenerate/fidelity ratchet** — the documented purpose of the gate.

The regression gate is meant to ratchet on degenerate/fidelity passes (a faithful baseline pass becoming degenerate fails CI). But those are only computed in `--full` mode; the CLI defaults to quick (10 patterns/lang). So a plain `npm run test:multilingual:regression` checked only parse rate — a much weaker gate that misses exactly the fidelity backsliding the ratchet exists to catch.

## Change

- `--regression` now upgrades the default-quick run to **full mode**, so the fidelity ratchet actually runs.
- An explicit `--quick` is still honored, but now **warns** that the fidelity ratchet is skipped (parse-rate-only).
- Help text updated.

## Validation

- `--regression` alone → now reports `Mode: full mode`, prints the `⚠ Degenerate passes: 124` section, and runs the regression analysis (`✓ No regression vs baseline`).
- `--regression --quick` → prints `⚠ --regression in --quick mode only checks parse rate; the degenerate/fidelity ratchet requires --full.` and stays in quick mode.
- testing-framework multilingual unit tests pass (12/12); no new typecheck errors.

## Investigation findings (the `for`-loop "top pick" — not a contained fix)

I probed the `for`-loop degeneracy that remained in `template-literal-list-build` (he/ms/qu/sw/vi). Verdict: **it's not the lever, and not one root cause.** For-loop *bodies* already recover in event context when the header parses (EN `on click for … end` → `{on,for,append}`). The degeneracy is a **per-language constellation**:

- **`ms`**: the i18n transformer has **no Malay grammar profile** (`Unknown target locale: ms`) — the whole translation fails. Needs a new profile.
- **`he` / `vi`**: lose their `set` commands — but the fix is **not** a mirror of the zh `set` fix (Hebrew accusative-marks the set target, `קבע את DEST על VALUE`; Vietnamese has its own marker shape). Each is a genuine per-language pattern-authoring task.
- **`qu` / `sw`**: partial recovery; need deeper probing.

So this is exactly the "constellation of independent root causes" the roadmap anticipated — a series of small per-language efforts, not a single PR. I've left it unstarted rather than force it; happy to pick off individual languages (e.g. `he` `set`) as scoped follow-ups if you want.

https://claude.ai/code/session_01VLQjtgwkjcwyKvHYY6utZz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLQjtgwkjcwyKvHYY6utZz)_