### PR TITLE
fix(semantic): recover he 'set' via accusative-fronted pattern

### DIFF
--- a/docs-internal/ZH_BLOCK_BODY_SCOPE.md
+++ b/docs-internal/ZH_BLOCK_BODY_SCOPE.md
@@ -199,9 +199,33 @@ The one residue left in that pattern (the `for item in $items … end` loop) is
 **structural, not zh-specific**: the transformer emits a mangled header
 (`为 把 item 在 $items 那么 …` — BA-marked loop variable + a spurious `那么` before
 the body), and zh `for`-loops don't parse at all (no handcrafted/generated zh
-loop-header pattern). It degrades `template-literal-list-build` for 5 other
-languages too (he, ms, qu, sw, vi), so it belongs in the block-body roadmap arc,
+loop-header pattern). It degrades `template-literal-list-build` for the other
+languages too (ms, qu, sw, vi), so it belongs in the block-body roadmap arc,
 not this zh slice.
+
+### #2 sweep — per-language follow-on: `he` set (shipped)
+
+The same constellation continues in other languages. **Hebrew** lost its `set`
+because the transformer fronts the accusative — `set X to Y` → `קבע את {destination}
+על {patient}` (`את` = direct-object marker on the variable being set, `על` = "on"/
+"to" before the value). The generated pattern arranged the bare profile markers the
+other way, so the transformed `set` didn't match. A handcrafted `set-he-full`
+pattern maps the accusative form to the correct set roles (destination = the var,
+patient = the value), `את` kept **required** (the transformer always fronts it;
+required avoids the matcher emitting an empty partial match on unrelated `…את…`
+inputs). This recovered `set` in **three** he patterns — `template-literal-list-build`,
+`fetch-json`, `fetch-do-not-throw` (all degenerate → faithful) — netting he degenerate
+−2 (124 → 122 total, gate green, 0 regressions). `he` `behavior-sortable` flips
+null-parse → empty-node (it newly appears in the degenerate list) but `he` never
+recovered the EN-only `behavior` keyword for it (0 fidelity either way — failure→
+degenerate, not a faithful→degenerate regression; it also makes he consistent with
+the already-degenerate `behavior-draggable`/`-resizable`). Locked by
+`multilingual-roadmap-fixes.test.ts` ("he set: accusative-fronted form").
+
+The remaining `template-literal-list-build` languages (ms, qu, sw, vi) and the
+`for`-loop structural gap stay in the block-body roadmap arc. `ms` additionally has
+**no i18n grammar profile** (`Unknown target locale: ms`), so its translations can't
+be generated at all — a separate transformer-coverage gap.
 
 ## Probe
 

--- a/packages/semantic/src/patterns/set.ts
+++ b/packages/semantic/src/patterns/set.ts
@@ -689,6 +689,49 @@ function getSetPatternsUk(): LanguagePattern[] {
   ];
 }
 
+function getSetPatternsHe(): LanguagePattern[] {
+  return [
+    {
+      // Hebrew set. The i18n grammar transformer emits the accusative-fronted form
+      // `קבע את {destination} על {patient}` for `set X to Y` — `את` is the direct-
+      // object marker on the variable being set, and `על` ("on"/"to") introduces
+      // the value. The generated pattern used the bare profile markers (destination
+      // → על, patient → את) in the opposite arrangement, so the transformed form
+      // didn't match and the `set` dropped (degenerate `template-literal-list-build`
+      // in he). `את` is required: the transformer always fronts the accusative for
+      // set, and keeping it required (rather than an optional group) avoids the
+      // matcher producing an empty partial match on unrelated `…את…` inputs.
+      // See docs-internal/ZH_BLOCK_BODY_SCOPE.md (#2 sweep — per-language set marking).
+      id: 'set-he-full',
+      language: 'he',
+      command: 'set',
+      priority: 100,
+      template: {
+        format: 'קבע את {destination} על {patient}',
+        tokens: [
+          { type: 'literal', value: 'קבע', alternatives: ['הגדר'] },
+          { type: 'literal', value: 'את' },
+          {
+            type: 'role',
+            role: 'destination',
+            expectedTypes: ['property-path', 'selector', 'reference', 'expression'],
+          },
+          { type: 'literal', value: 'על', alternatives: ['ב', 'אל', 'ל', 'כ'] },
+          {
+            type: 'role',
+            role: 'patient',
+            expectedTypes: ['literal', 'expression', 'reference', 'selector'],
+          },
+        ],
+      },
+      extraction: {
+        destination: { marker: 'את' },
+        patient: { marker: 'על', markerAlternatives: ['ב', 'אל', 'ל', 'כ'] },
+      },
+    },
+  ];
+}
+
 function getSetPatternsVi(): LanguagePattern[] {
   return [
     {
@@ -832,6 +875,8 @@ export function getSetPatternsForLanguage(language: string): LanguagePattern[] {
       return getSetPatternsEs();
     case 'fr':
       return getSetPatternsFr();
+    case 'he':
+      return getSetPatternsHe();
     case 'hi':
       return getSetPatternsHi();
     case 'id':

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1202,3 +1202,49 @@ describe('zh fetch in event block (抓取 把 {source} [的 {responseType}])', (
     expect(actions(parse('设置 x 为 5', 'zh')).has('set')).toBe(true);
   });
 });
+
+describe('he set: accusative-fronted form (קבע את {destination} על {patient})', () => {
+  // The i18n grammar transformer emits `קבע את {destination} על {patient}` for
+  // `set X to Y` — `את` is the direct-object marker on the variable being set, and
+  // `על` ("on"/"to") introduces the value. The generated pattern used the bare
+  // profile markers in the opposite arrangement, so the transformed `set` dropped
+  // (degenerate he in template-literal-list-build / fetch-json / fetch-do-not-throw).
+  // A handcrafted set-he-full pattern maps the accusative form to the correct set
+  // roles (destination = the var, patient = the value). See ZH_BLOCK_BODY_SCOPE.md (#2).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+  function roles(node: unknown): Record<string, unknown> {
+    const rec = (node as Record<string, unknown>) ?? {};
+    const r = rec.roles;
+    if (r instanceof Map) return Object.fromEntries(r);
+    return (r as Record<string, unknown>) ?? {};
+  }
+
+  it('[he] parses `קבע את $html על ""` as set with correct destination/patient', () => {
+    const node = parse('קבע את $html על ""', 'he');
+    expect(actions(node).has('set')).toBe(true);
+    const r = roles(node);
+    expect((r.destination as { value?: string })?.value).toBe('$html');
+    expect((r.patient as { value?: string })?.value).toBe('');
+  });
+  it('[he] parses a property-path target `קבע את #list.innerHTML על $html`', () => {
+    const node = parse('קבע את #list.innerHTML על $html', 'he');
+    expect(actions(node).has('set')).toBe(true);
+    expect((roles(node).destination as { type?: string })?.type).toBe('property-path');
+  });
+  it('[he] event-block `set` recovers (was the degenerate template-literal residue)', () => {
+    // on click set $x to "" → כ-לחיצה ... קבע את $x על ""
+    const a = actions(parse('ב לחיצה קבע את $x על "" אז קבע את #out על $x', 'he'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('set')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The per-language follow-on from the `for`-loop investigation (see PR #313's investigation notes). **Hebrew** lost its `set` command in the multilingual sweep because the i18n transformer fronts the accusative:

`set X to Y` → `קבע את {destination} על {patient}` — `את` is the direct-object marker on the variable being set, and `על` ("on"/"to") introduces the value. The generated pattern arranged the bare profile markers in the opposite arrangement, so the transformed `set` didn't match and dropped.

A handcrafted `set-he-full` pattern maps the accusative-fronted form to the **correct** set roles (destination = the variable, patient = the value). `את` is kept **required** — the transformer always fronts it, and requiring it (vs. an optional group) avoids the matcher emitting an empty partial match on unrelated `…את…` inputs.

## Impact (clean A/B, with vs without the pattern, same DB)

Recovers `set` in **three** he patterns, all degenerate → **faithful**:
| pattern | EN ref | he (after) | fidelity |
| --- | --- | --- | --- |
| `template-literal-list-build` | `{on,set,for}` | `{on,set}` | 0.67 |
| `fetch-json` | `{on,fetch,set}` | `{on,set}` | 0.67 |
| `fetch-do-not-throw` | `{on,fetch,if,set}` | `{on,set}` | 0.50 |

- **Degenerate total 124 → 122**, `--regression --full` gate **green, 0 regressions**, HE parse rate **152 → 153/154**.
- New roles are correct: `קבע את $html על ""` → `set` with `destination=$html`, `patient=""`; property-path targets (`#list.innerHTML`) handled.
- Locked by `multilingual-roadmap-fixes.test.ts` ("he set: accusative-fronted form"); full semantic suite 5428 pass.

## One transparency note (investigated, not a regression)

`he`/`behavior-sortable` **newly appears** in the degenerate list with this change. I A/B-verified this is **not** a faithful→degenerate regression:
- `behavior-sortable` is `behavior Sortable(dragClass)`; EN ref is `{behavior}`. Hebrew has no `behavior` keyword, so `he` recovers **0** for it **with or without** this change.
- My set pattern provably can't match it (no `קבע`; zero patterns match the he transform). The change only flips the parse from `null` (parse failure, not listed) to a non-null empty node (degenerate, listed) — same 0 fidelity, no quality loss.
- It also makes `he` **consistent** with the already-degenerate `behavior-draggable`/`-resizable` (continue-on-error behaviors).

Net is still −2 degenerate and the gate's faithful→degenerate ratchet stays green.

## Out of scope (tracked)

The other `template-literal-list-build` languages (ms, qu, sw, vi) and the `for`-loop structural gap remain in the block-body roadmap arc. `ms` additionally has **no i18n grammar profile** (`Unknown target locale: ms`) — its translations can't be generated at all, a separate transformer-coverage gap.

https://claude.ai/code/session_01VLQjtgwkjcwyKvHYY6utZz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLQjtgwkjcwyKvHYY6utZz)_