### PR TITLE
fix(semantic): recover vi 'set' via vào-marked pattern

### DIFF
--- a/docs-internal/ZH_BLOCK_BODY_SCOPE.md
+++ b/docs-internal/ZH_BLOCK_BODY_SCOPE.md
@@ -222,7 +222,21 @@ degenerate, not a faithful→degenerate regression; it also makes he consistent 
 the already-degenerate `behavior-draggable`/`-resizable`). Locked by
 `multilingual-roadmap-fixes.test.ts` ("he set: accusative-fronted form").
 
-The remaining `template-literal-list-build` languages (ms, qu, sw, vi) and the
+### #2 sweep — per-language follow-on: `vi` set (shipped)
+
+Same family in **Vietnamese**: the transformer emits `gán {destination} vào {patient}`
+for `set X to Y` (`vào` = vi's destination/"into" marker; the variable being set leads,
+unmarked). The existing `set-vi-full` used a different marker (`thành`) and
+non-canonical roles (var → `patient`), so it never matched the transform output and
+the `set` dropped (degenerate vi in `template-literal-list-build`). A `set-vi-vao`
+pattern (priority 101, above `set-vi-full`) matches the transform and assigns the
+canonical set roles (destination = the var, patient = the value). **vi degenerate → 0**
+(cleared `template-literal-list-build`; degenerate total 122 → 121, gate green, 0
+regressions, **no side-effect additions** — cleaner than the he fix, which flipped a
+behavior pattern null→empty). Locked by `multilingual-roadmap-fixes.test.ts`
+("vi set: vào-marked form").
+
+The remaining `template-literal-list-build` languages (ms, qu, sw) and the
 `for`-loop structural gap stay in the block-body roadmap arc. `ms` additionally has
 **no i18n grammar profile** (`Unknown target locale: ms`), so its translations can't
 be generated at all — a separate transformer-coverage gap.

--- a/packages/semantic/src/patterns/set.ts
+++ b/packages/semantic/src/patterns/set.ts
@@ -735,6 +735,41 @@ function getSetPatternsHe(): LanguagePattern[] {
 function getSetPatternsVi(): LanguagePattern[] {
   return [
     {
+      // The i18n grammar transformer emits `gán {destination} vào {patient}` for
+      // `set X to Y` — `vào` is vi's destination/"into" marker, and the variable
+      // being set leads (unmarked). The existing `set-vi-full` below uses a
+      // different marker (`thành`) and non-canonical roles (var → `patient`), so it
+      // never matched the transform output and the `set` dropped (degenerate vi in
+      // template-literal-list-build etc.). This pattern matches the transform and
+      // assigns the canonical set roles (destination = the var, patient = the value)
+      // that the AST mapper reads. See ZH_BLOCK_BODY_SCOPE.md (#2 sweep).
+      id: 'set-vi-vao',
+      language: 'vi',
+      command: 'set',
+      priority: 101,
+      template: {
+        format: 'gán {destination} vào {patient}',
+        tokens: [
+          { type: 'literal', value: 'gán', alternatives: ['thiết lập', 'đặt giá trị'] },
+          {
+            type: 'role',
+            role: 'destination',
+            expectedTypes: ['property-path', 'selector', 'reference', 'expression'],
+          },
+          { type: 'literal', value: 'vào', alternatives: ['cho', 'đến'] },
+          {
+            type: 'role',
+            role: 'patient',
+            expectedTypes: ['literal', 'expression', 'reference', 'selector'],
+          },
+        ],
+      },
+      extraction: {
+        destination: { position: 1 },
+        patient: { marker: 'vào', markerAlternatives: ['cho', 'đến'] },
+      },
+    },
+    {
       id: 'set-vi-full',
       language: 'vi',
       command: 'set',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1248,3 +1248,47 @@ describe('he set: accusative-fronted form (קבע את {destination} על {patie
     expect(a.has('set')).toBe(true);
   });
 });
+
+describe('vi set: vào-marked form (gán {destination} vào {patient})', () => {
+  // The i18n transformer emits `gán {destination} vào {patient}` for `set X to Y`
+  // (`vào` is vi's destination/"into" marker; the variable being set leads). The
+  // existing set-vi-full used a different marker (`thành`) and non-canonical roles
+  // (var → `patient`), so the transformed `set` dropped (degenerate vi in
+  // template-literal-list-build). A set-vi-vao pattern matches the transform and
+  // assigns the canonical roles. See ZH_BLOCK_BODY_SCOPE.md (#2 sweep).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+  function roles(node: unknown): Record<string, unknown> {
+    const rec = (node as Record<string, unknown>) ?? {};
+    const r = rec.roles;
+    if (r instanceof Map) return Object.fromEntries(r);
+    return (r as Record<string, unknown>) ?? {};
+  }
+
+  it('[vi] parses `gán $html vào ""` as set with correct destination/patient', () => {
+    const node = parse('gán $html vào ""', 'vi');
+    expect(actions(node).has('set')).toBe(true);
+    const r = roles(node);
+    expect((r.destination as { value?: string })?.value).toBe('$html');
+    expect((r.patient as { value?: string })?.value).toBe('');
+  });
+  it('[vi] parses a property-path target `gán #list.innerHTML vào $html`', () => {
+    const node = parse('gán #list.innerHTML vào $html', 'vi');
+    expect(actions(node).has('set')).toBe(true);
+    expect((roles(node).destination as { type?: string })?.type).toBe('property-path');
+  });
+  it('[vi] event-block `set` recovers (was the degenerate template-literal residue)', () => {
+    const a = actions(parse('khi nhấp gán $x vào "" rồi gán #out vào $x', 'vi'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('set')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Next step in the per-language `set`/marker sweep (after `zh` and `he`). **Vietnamese** lost its `set` because the transformer emits `gán {destination} vào {patient}` for `set X to Y` (`vào` is vi's destination/"into" marker; the variable being set leads, unmarked) — but the existing `set-vi-full` pattern used a *different* marker (`thành`) and non-canonical roles (var → `patient`), so it never matched the transform output.

A `set-vi-vao` pattern (priority 101, above `set-vi-full`) matches the transform and assigns the **canonical** set roles (`destination` = the var, `patient` = the value) that the AST mapper reads.

## Impact (clean A/B, with vs without, same DB)

- **vi degenerate passes → 0** — cleared `template-literal-list-build` (the only pattern where vi was degenerate).
- Degenerate total **122 → 121**, `--regression --full` gate **green, 0 regressions**, and **no side-effect additions** (cleaner than the he fix, which flipped a behavior pattern null→empty-node — this one adds nothing).
- Roles verified correct: `gán $html vào ""` → `set` with `destination=$html`, `patient=""`; property-path targets (`#list.innerHTML`) handled.
- Lock tests added (`multilingual-roadmap-fixes.test.ts` → "vi set: vào-marked form"); full semantic suite 5431 pass.

## Remaining in this family (tracked)

`template-literal-list-build` now lists only `ms, qu, sw`. `ms` has **no i18n grammar profile** (`Unknown target locale: ms`) — a separate transformer-coverage gap (next planned item). `qu`/`sw` are further per-language set/marker probes. The `for`-loop structural gap stays in the block-body roadmap arc.

https://claude.ai/code/session_01VLQjtgwkjcwyKvHYY6utZz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLQjtgwkjcwyKvHYY6utZz)_