### PR TITLE
fix(i18n,semantic): recover qu/sw 'set' via keyword realign + sw pattern

### DIFF
--- a/docs-internal/ZH_BLOCK_BODY_SCOPE.md
+++ b/docs-internal/ZH_BLOCK_BODY_SCOPE.md
@@ -222,10 +222,28 @@ degenerate, not a faithful→degenerate regression; it also makes he consistent 
 the already-degenerate `behavior-draggable`/`-resizable`). Locked by
 `multilingual-roadmap-fixes.test.ts` ("he set: accusative-fronted form").
 
-The remaining `template-literal-list-build` languages (ms, qu, sw, vi) and the
-`for`-loop structural gap stay in the block-body roadmap arc. `ms` additionally has
-**no i18n grammar profile** (`Unknown target locale: ms`), so its translations can't
-be generated at all — a separate transformer-coverage gap.
+### #2 sweep — per-language follow-on: `qu` / `sw` set keyword realign (shipped)
+
+A different flavour of the same family: the **i18n dicts mapped `set` to the _put_
+verb** (qu `churay`, sw `weka`) — both of which the semantic profiles read as `put`
+(set is qu `churanay` / sw `seti`). So a transformed `set` parsed as `put` (with a
+selector arg) or dropped (with a literal). Realigning the dicts (`set` → `churanay` /
+`seti`, same shape as the zh `fetch` 获取→抓取 realign) fixed **qu** outright — it
+then parses via its generated SOV pattern (`{destination} ta {patient} man churanay`).
+**sw** also needed a handcrafted `set-sw-kwa` pattern (`seti {destination} kwa
+{patient}`, canonical roles), since the generated arrangement didn't match the
+transform. Cleared `template-literal-list-build` for both (faithful `{on,set}`);
+degenerate total 122 → 121, gate green, 0 regressions. (`sw` joins `behavior-sortable`
+in the list — but that pattern's body holds a real `seti … kwa …` that sw now
+correctly parses as `set`; the EN reference only recovers `{behavior}` for behavior
+definitions, so recall-based fidelity scores it 0 — a metric artifact, not over-
+generation.) Locked by `multilingual-roadmap-fixes.test.ts` ("qu / sw set: keyword
+realignment").
+
+The remaining `template-literal-list-build` language is `ms`, plus the `for`-loop
+structural gap — both stay in the block-body roadmap arc. `ms` has **no i18n grammar
+profile** (`Unknown target locale: ms`), so its translations can't be generated at
+all — a separate transformer-coverage gap (the next planned item).
 
 ## Probe
 

--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -11,7 +11,10 @@ export const qu: Dictionary = {
     send: 'kachay',
     take: 'hurquy',
     put: 'churay',
-    set: 'churay',
+    // churay is the semantic qu profile's `put` primary; `set` is churanay. Emitting
+    // churay for set made the semantic parser read a transformed `set` as `put`.
+    // See ZH_BLOCK_BODY_SCOPE.md (#2 sweep — keyword realignment, cf. zh fetch).
+    set: 'churanay',
     get: 'chaskiy',
     add: 'yapay',
     remove: 'qichuy',

--- a/packages/i18n/src/dictionaries/sw.ts
+++ b/packages/i18n/src/dictionaries/sw.ts
@@ -11,7 +11,10 @@ export const sw: Dictionary = {
     send: 'tuma',
     take: 'chukua',
     put: 'weka',
-    set: 'weka',
+    // weka is the semantic sw profile's `put` primary; `set` is seti. Emitting weka
+    // for set made the semantic parser read a transformed `set` as `put`.
+    // See ZH_BLOCK_BODY_SCOPE.md (#2 sweep — keyword realignment, cf. zh fetch).
+    set: 'seti',
     get: 'pata',
     add: 'ongeza',
     remove: 'ondoa',

--- a/packages/semantic/src/patterns/set.ts
+++ b/packages/semantic/src/patterns/set.ts
@@ -619,6 +619,44 @@ function getSetPatternsRu(): LanguagePattern[] {
   ];
 }
 
+function getSetPatternsSw(): LanguagePattern[] {
+  return [
+    {
+      // After the i18n dict realign (set → `seti`, was the put verb `weka`), the
+      // transformer emits `seti {destination} kwa {patient}` for `set X to Y` — the
+      // variable being set leads (unmarked), and `kwa` ("to"/"with") introduces the
+      // value. The generated pattern arranged the markers differently, so the
+      // transformed `set` dropped. This maps the transform to the canonical set roles
+      // (destination = the var, patient = the value). See ZH_BLOCK_BODY_SCOPE.md (#2).
+      id: 'set-sw-kwa',
+      language: 'sw',
+      command: 'set',
+      priority: 100,
+      template: {
+        format: 'seti {destination} kwa {patient}',
+        tokens: [
+          { type: 'literal', value: 'seti', alternatives: ['weka thamani'] },
+          {
+            type: 'role',
+            role: 'destination',
+            expectedTypes: ['property-path', 'selector', 'reference', 'expression'],
+          },
+          { type: 'literal', value: 'kwa', alternatives: ['kwenye'] },
+          {
+            type: 'role',
+            role: 'patient',
+            expectedTypes: ['literal', 'expression', 'reference', 'selector'],
+          },
+        ],
+      },
+      extraction: {
+        destination: { position: 1 },
+        patient: { marker: 'kwa', markerAlternatives: ['kwenye'] },
+      },
+    },
+  ];
+}
+
 function getSetPatternsTh(): LanguagePattern[] {
   return [
     // Simple pattern: ตั้ง :x 5
@@ -889,6 +927,8 @@ export function getSetPatternsForLanguage(language: string): LanguagePattern[] {
       return getSetPatternsPt();
     case 'ru':
       return getSetPatternsRu();
+    case 'sw':
+      return getSetPatternsSw();
     case 'th':
       return getSetPatternsTh();
     case 'uk':

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1248,3 +1248,49 @@ describe('he set: accusative-fronted form (קבע את {destination} על {patie
     expect(a.has('set')).toBe(true);
   });
 });
+
+describe('qu / sw set: keyword realignment (set verb ≠ put verb)', () => {
+  // The i18n dicts mapped `set` to the *put* verb (qu churay, sw weka), which the
+  // semantic profiles read as `put` — so a transformed `set` parsed as `put` (or
+  // dropped). Realigned to the real set verbs (qu churanay, sw seti). qu then parses
+  // via its generated SOV pattern (`{dest} ta {patient} man churanay`); sw needs a
+  // handcrafted `seti {dest} kwa {patient}` (canonical roles). Same family as the zh
+  // fetch keyword realign. See ZH_BLOCK_BODY_SCOPE.md (#2 sweep).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+  function roles(node: unknown): Record<string, unknown> {
+    const rec = (node as Record<string, unknown>) ?? {};
+    const r = rec.roles;
+    if (r instanceof Map) return Object.fromEntries(r);
+    return (r as Record<string, unknown>) ?? {};
+  }
+
+  it('[qu] parses `$html ta "" man churanay` as set (not put) with canonical roles', () => {
+    const node = parse('$html ta "" man churanay', 'qu');
+    expect(actions(node).has('set')).toBe(true);
+    const r = roles(node);
+    expect((r.destination as { value?: string })?.value).toBe('$html');
+    expect((r.patient as { value?: string })?.value).toBe('');
+  });
+  it('[sw] parses `seti $html kwa ""` as set (not put) with canonical roles', () => {
+    const node = parse('seti $html kwa ""', 'sw');
+    expect(actions(node).has('set')).toBe(true);
+    const r = roles(node);
+    expect((r.destination as { value?: string })?.value).toBe('$html');
+    expect((r.patient as { value?: string })?.value).toBe('');
+  });
+  it('[sw] handles a property-path target `seti #list.innerHTML kwa $html`', () => {
+    const node = parse('seti #list.innerHTML kwa $html', 'sw');
+    expect(actions(node).has('set')).toBe(true);
+    expect((roles(node).destination as { type?: string })?.type).toBe('property-path');
+  });
+});


### PR DESCRIPTION
## Summary

Continues the per-language `set` sweep (after `zh`, `he`, `vi`). **`qu` and `sw`** had a different flavour of the family — a **keyword misalignment** (same shape as the zh `fetch` 获取→抓取 fix): the i18n dicts mapped `set` to the *put* verb.

- **qu**: dict `set: 'churay'` — but `churay` is the semantic profile's *put* primary (set is `churanay`).
- **sw**: dict `set: 'weka'` — but `weka` is the semantic profile's *put* primary (set is `seti`).

So a transformed `set` parsed as `put` (with a selector arg) or dropped (with a literal). Realigning the dicts (`set` → `churanay` / `seti`) fixes **qu outright** — it then parses via its generated SOV pattern (`{destination} ta {patient} man churanay`). **sw** also needed a handcrafted `set-sw-kwa` pattern (`seti {destination} kwa {patient}`, canonical roles).

## Impact (clean A/B, with vs without, same DB)

- Cleared `template-literal-list-build` for **both qu and sw** (faithful `{on,set}`, fidelity 0.67 each).
- Degenerate total **122 → 121**, `--regression --full` gate **green, 0 regressions**.
- Roles verified canonical (`destination` = var, `patient` = value); property-path targets handled.
- semantic suite 5428 pass, i18n suite 662 pass (dict change clean); lock tests added.

## Investigated transparency note (not over-generation)

`sw` joins `behavior-sortable` in the degenerate list. I traced it: that pattern's `raw_code` is a **full behavior definition** whose body contains a real `seti dragClass kwa "sorting"` — sw now **correctly** parses that as `set`. The EN reference only recovers `{behavior}` (the parser doesn't descend behavior bodies in *any* language), so recall-based fidelity scores sw 0 — a **metric artifact**, not over-generation or a regression. sw is arguably better (recovers a real command). The gate's faithful→degenerate ratchet stays green.

## Remaining (tracked)

`template-literal-list-build` now lists only `ms` — which has **no i18n grammar profile** (`Unknown target locale: ms`), the next planned item. The `for`-loop structural gap stays in the block-body roadmap arc.

https://claude.ai/code/session_01VLQjtgwkjcwyKvHYY6utZz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLQjtgwkjcwyKvHYY6utZz)_