### PR TITLE
feat(patterns-reference): DB provenance stamp to guard the multilingual gate against stale patterns.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ lerna-debug.log*
 *.sqlite
 *.sqlite3
 !packages/patterns-reference/data/patterns.db
+# Local DB provenance stamp (freshness guard) — records what source produced the
+# local patterns.db; not committed (it's machine/working-tree local).
+packages/patterns-reference/data/patterns.db.stamp
 
 # Generated files
 /src/generated/

--- a/packages/patterns-reference/CLAUDE.md
+++ b/packages/patterns-reference/CLAUDE.md
@@ -179,6 +179,24 @@ src/api/llm.test.ts           # 16 tests
 src/database/connection.test.ts # 11 tests
 ```
 
+## DB freshness guard (provenance stamp)
+
+`sync:translations` writes a `data/patterns.db.stamp` sidecar — a SHA-256 of the
+**source** that determines the DB's content (the i18n + semantic `src` trees, the
+seed `init-db.ts`, and `sync-translations.ts`). The multilingual `--regression` gate
+checks it before comparing against the committed baseline:
+
+- **stale** (source changed since the last sync) → the gate **refuses to run** and
+  tells you to re-sync. This prevents the cross-branch "phantom regression" footgun:
+  a `patterns.db` synced on one branch, then used on another, silently mis-compares
+  against that branch's baseline.
+- **unstamped** (DB predates the guard, e.g. a fresh checkout of the committed DB) →
+  the gate warns once; re-sync to get a stamp.
+
+The stamp is **local** (gitignored) — it records "what source produced _my_ DB". CI
+re-syncs (`npm run populate`) before gating, so it always sees a fresh stamp.
+Util: `src/sync/db-stamp.ts` (`writeDbStamp` / `checkDbStamp`).
+
 ## Common Issues
 
 ### Database not found

--- a/packages/patterns-reference/scripts/sync-translations.ts
+++ b/packages/patterns-reference/scripts/sync-translations.ts
@@ -26,6 +26,7 @@ import {
   getProfile as getGrammarProfile,
 } from '@lokascript/i18n';
 import { maskSpans, unmaskSpans } from '../src/sync/span-mask';
+import { writeDbStamp } from '../src/sync/db-stamp';
 
 // =============================================================================
 // Configuration
@@ -390,6 +391,11 @@ async function syncTranslations() {
     // Calculate overall average
     const overallAvg = stats.reduce((sum, row) => sum + row.avg_confidence, 0) / stats.length;
     console.log(`\nOverall average confidence: ${overallAvg.toFixed(2)}`);
+
+    // Stamp the DB with the provenance of its source inputs, so the multilingual
+    // gate can detect a stale (cross-branch) DB before trusting a baseline compare.
+    writeDbStamp(dbPath);
+    console.log(`Wrote DB provenance stamp: ${dbPath}.stamp`);
   } finally {
     db.close();
   }

--- a/packages/patterns-reference/src/database/connection.ts
+++ b/packages/patterns-reference/src/database/connection.ts
@@ -25,6 +25,15 @@ let dbInstance: InstanceType<typeof Database> | null = null;
 let currentDbPath: string | null = null;
 
 /**
+ * The resolved default DB path (honouring `LSP_DB_PATH` / `HYPERSCRIPT_LSP_DB`).
+ * Exposed so callers (e.g. the multilingual gate's freshness check) can target the
+ * exact DB that `getDatabase()` opens.
+ */
+export function getDefaultDbPath(): string {
+  return DEFAULT_DB_PATH;
+}
+
+/**
  * Get database connection (lazy singleton).
  */
 export function getDatabase(options: ConnectionOptions = {}): InstanceType<typeof Database> {

--- a/packages/patterns-reference/src/index.ts
+++ b/packages/patterns-reference/src/index.ts
@@ -83,6 +83,7 @@ export {
   resetConnection,
   isConnected,
   getCurrentDbPath,
+  getDefaultDbPath,
 } from './database/connection';
 
 // =============================================================================
@@ -166,6 +167,11 @@ export {
   validateAllTranslations,
   discoverPatterns,
   seedLLMExamples,
+  computeDbInputHash,
+  dbStampPath,
+  writeDbStamp,
+  checkDbStamp,
+  type DbStampStatus,
 } from './sync';
 
 // =============================================================================

--- a/packages/patterns-reference/src/sync/db-stamp.test.ts
+++ b/packages/patterns-reference/src/sync/db-stamp.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { computeDbInputHash, dbStampPath, writeDbStamp, checkDbStamp } from './db-stamp';
+
+/**
+ * Build a throwaway monorepo-shaped tree so the stamp's source-hashing has real
+ * files to read, then exercise the ok / stale / unstamped transitions.
+ *
+ * Layout: <root>/packages/{i18n,semantic}/src/*.ts +
+ *         <root>/packages/patterns-reference/{scripts,src/sync,data}
+ */
+function makeFakeRepo(): { root: string; dbPath: string } {
+  const root = mkdtempSync(join(tmpdir(), 'db-stamp-'));
+  const mk = (p: string) => mkdirSync(join(root, p), { recursive: true });
+  mk('packages/i18n/src');
+  mk('packages/semantic/src/parser');
+  mk('packages/patterns-reference/scripts');
+  mk('packages/patterns-reference/src/sync');
+  mk('packages/patterns-reference/data');
+  writeFileSync(join(root, 'packages/i18n/src/transformer.ts'), 'export const x = 1;\n');
+  writeFileSync(join(root, 'packages/semantic/src/parser/p.ts'), 'export const y = 2;\n');
+  writeFileSync(join(root, 'packages/patterns-reference/scripts/init-db.ts'), '// seed\n');
+  writeFileSync(
+    join(root, 'packages/patterns-reference/scripts/sync-translations.ts'),
+    '// sync\n'
+  );
+  writeFileSync(join(root, 'packages/patterns-reference/src/sync/span-mask.ts'), '// mask\n');
+  const dbPath = join(root, 'packages/patterns-reference/data/patterns.db');
+  writeFileSync(dbPath, '');
+  return { root, dbPath };
+}
+
+describe('db-stamp provenance guard', () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const r of roots.splice(0)) rmSync(r, { recursive: true, force: true });
+  });
+
+  it('reports `unstamped` when no stamp sidecar exists', () => {
+    const { root, dbPath } = makeFakeRepo();
+    roots.push(root);
+    expect(checkDbStamp(dbPath).status).toBe('unstamped');
+  });
+
+  it('writes a stamp and reports `ok` against unchanged source', () => {
+    const { root, dbPath } = makeFakeRepo();
+    roots.push(root);
+    writeDbStamp(dbPath);
+    expect(existsSync(dbStampPath(dbPath))).toBe(true);
+    expect(checkDbStamp(dbPath).status).toBe('ok');
+  });
+
+  it('reports `stale` after a source input changes (the cross-branch footgun)', () => {
+    const { root, dbPath } = makeFakeRepo();
+    roots.push(root);
+    writeDbStamp(dbPath);
+    // Simulate switching to a branch with different parser source.
+    writeFileSync(join(root, 'packages/semantic/src/parser/p.ts'), 'export const y = 999;\n');
+    const res = checkDbStamp(dbPath);
+    expect(res.status).toBe('stale');
+    if (res.status === 'stale') expect(res.actual).not.toBe(res.expected);
+  });
+
+  it('hash is stable for identical source and changes when a new source file appears', () => {
+    const { root, dbPath } = makeFakeRepo();
+    roots.push(root);
+    const h1 = computeDbInputHash(dbPath);
+    expect(computeDbInputHash(dbPath)).toBe(h1); // deterministic
+    writeFileSync(join(root, 'packages/i18n/src/dictionaries.ts'), '// new file\n');
+    expect(computeDbInputHash(dbPath)).not.toBe(h1);
+  });
+
+  it('ignores .test.ts / .d.ts files (test churn must not flip freshness)', () => {
+    const { root, dbPath } = makeFakeRepo();
+    roots.push(root);
+    const h1 = computeDbInputHash(dbPath);
+    writeFileSync(join(root, 'packages/semantic/src/parser/p.test.ts'), 'it("x", () => {});\n');
+    writeFileSync(join(root, 'packages/semantic/src/parser/p.d.ts'), 'export const y: number;\n');
+    expect(computeDbInputHash(dbPath)).toBe(h1);
+  });
+});

--- a/packages/patterns-reference/src/sync/db-stamp.ts
+++ b/packages/patterns-reference/src/sync/db-stamp.ts
@@ -1,0 +1,108 @@
+/**
+ * DB provenance stamp — guards against running the multilingual gate against a
+ * `patterns.db` that was generated from *different* source than is currently checked
+ * out (the cross-branch "phantom regression" footgun).
+ *
+ * The DB's content (transformer translation text + stored parser confidence /
+ * verified_parses) is determined by the i18n + semantic **source**, plus the seed and
+ * sync scripts. We hash that source (not the gitignored, build-non-deterministic
+ * `dist/`) so the stamp catches a branch / source change regardless of whether `dist`
+ * happened to be rebuilt. `sync-translations` writes the stamp next to the DB; the
+ * gate verifies it before trusting a comparison against the committed baseline.
+ *
+ * The stamp file (`patterns.db.stamp`) is a **local** artifact (gitignored) — it
+ * records "what source produced *my* local DB", which is exactly what the gate needs
+ * to confirm the DB is fresh for the current working tree.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+
+/**
+ * Resolve the monorepo root from a `patterns.db` path. Standard layout:
+ * `<root>/packages/patterns-reference/data/patterns.db` → up 3 from `data/`.
+ */
+function repoRootFromDbPath(dbPath: string): string {
+  return resolve(dirname(dbPath), '..', '..', '..');
+}
+
+/** Recursively collect non-test `.ts` source files under `dir`. */
+function walkTsFiles(dir: string, acc: string[]): void {
+  if (!existsSync(dir)) return;
+  for (const name of readdirSync(dir).sort()) {
+    if (name === 'node_modules' || name === 'dist' || name === '__tests__') continue;
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walkTsFiles(full, acc);
+    } else if (name.endsWith('.ts') && !name.endsWith('.test.ts') && !name.endsWith('.d.ts')) {
+      acc.push(full);
+    }
+  }
+}
+
+/**
+ * The source files whose content determines `patterns.db`: the i18n transformer +
+ * dictionaries + grammar profiles (translation text), the semantic parser + profiles
+ * (stored confidence + the language set), and the seed / sync scripts.
+ */
+function dbInputFiles(dbPath: string): string[] {
+  const root = repoRootFromDbPath(dbPath);
+  const files: string[] = [];
+  walkTsFiles(join(root, 'packages', 'i18n', 'src'), files);
+  walkTsFiles(join(root, 'packages', 'semantic', 'src'), files);
+  const pr = join(root, 'packages', 'patterns-reference');
+  for (const f of [
+    join(pr, 'scripts', 'init-db.ts'),
+    join(pr, 'scripts', 'sync-translations.ts'),
+    join(pr, 'src', 'sync', 'span-mask.ts'),
+  ]) {
+    if (existsSync(f)) files.push(f);
+  }
+  return files.sort();
+}
+
+/**
+ * Compute the provenance hash of the DB's source inputs. Stable across machines (it
+ * hashes committed source, keyed by repo-relative path).
+ */
+export function computeDbInputHash(dbPath: string): string {
+  const root = repoRootFromDbPath(dbPath);
+  const files = dbInputFiles(dbPath);
+  const h = createHash('sha256');
+  h.update(`files:${files.length}\0`);
+  for (const f of files) {
+    h.update(relative(root, f).split(sep).join('/'));
+    h.update('\0');
+    h.update(readFileSync(f));
+    h.update('\0');
+  }
+  return h.digest('hex');
+}
+
+export function dbStampPath(dbPath: string): string {
+  return `${dbPath}.stamp`;
+}
+
+/** Write the provenance stamp next to the DB (called at the end of sync). */
+export function writeDbStamp(dbPath: string): void {
+  writeFileSync(dbStampPath(dbPath), `${computeDbInputHash(dbPath)}\n`, 'utf8');
+}
+
+export type DbStampStatus =
+  | { status: 'ok' }
+  | { status: 'unstamped' }
+  | { status: 'stale'; expected: string; actual: string };
+
+/**
+ * Verify the DB's stamp against the current source. `unstamped` (no sidecar) is
+ * returned when the DB predates this guard — callers should warn, not hard-fail.
+ */
+export function checkDbStamp(dbPath: string): DbStampStatus {
+  const sp = dbStampPath(dbPath);
+  if (!existsSync(sp)) return { status: 'unstamped' };
+  const expected = readFileSync(sp, 'utf8').trim();
+  const actual = computeDbInputHash(dbPath);
+  return actual === expected ? { status: 'ok' } : { status: 'stale', expected, actual };
+}

--- a/packages/patterns-reference/src/sync/index.ts
+++ b/packages/patterns-reference/src/sync/index.ts
@@ -68,3 +68,12 @@ export async function seedLLMExamples(_dryRun: boolean = false): Promise<{ count
     'seedLLMExamples should be run via: bun run packages/semantic/scripts/seed-llm-examples.ts'
   );
 }
+
+// DB provenance stamp — freshness guard for the multilingual gate.
+export {
+  computeDbInputHash,
+  dbStampPath,
+  writeDbStamp,
+  checkDbStamp,
+  type DbStampStatus,
+} from './db-stamp';

--- a/packages/testing-framework/src/multilingual/cli.ts
+++ b/packages/testing-framework/src/multilingual/cli.ts
@@ -5,6 +5,7 @@
  * Command-line interface for running multilingual tests.
  */
 
+import { checkDbStamp, getDefaultDbPath } from '@hyperfixi/patterns-reference';
 import { TestOrchestrator } from './orchestrator';
 import type { TestConfig, LanguageCode } from './types';
 
@@ -203,6 +204,32 @@ async function main(): Promise<void> {
 
     // --save-baseline needs the regression reporter wired so it can persist.
     if (config.saveBaseline) config.regression = true;
+
+    // DB freshness guard: refuse to run a regression/baseline compare against a
+    // patterns.db generated from *different* source than is currently checked out
+    // (the cross-branch "phantom regression" footgun). The committed baseline only
+    // pairs with a DB synced from the matching source. CI re-syncs before the gate,
+    // so it always passes; locally this catches a stale DB after a branch switch or
+    // an un-re-synced source edit.
+    if (config.regression) {
+      const dbPath = getDefaultDbPath();
+      const stamp = checkDbStamp(dbPath);
+      if (stamp.status === 'stale') {
+        console.error(
+          '\n✗ patterns.db is STALE — it was generated from different source than is currently\n' +
+            '  checked out, so a comparison against the committed baseline would report phantom\n' +
+            '  regressions. Re-sync it before running the gate:\n\n' +
+            '    npm run db:init:force --prefix packages/patterns-reference\n' +
+            '    npm run sync:translations --prefix packages/patterns-reference\n'
+        );
+        process.exit(1);
+      } else if (stamp.status === 'unstamped') {
+        console.warn(
+          '⚠ patterns.db has no provenance stamp (generated before the freshness guard); ' +
+            'cannot verify it is fresh. Re-sync if results look surprising.'
+        );
+      }
+    }
 
     const orchestrator = new TestOrchestrator(config);
     const results = await orchestrator.run();


### PR DESCRIPTION
## Summary

Implements the recommended mitigation for the **DB/baseline drift footgun** we hit during the ar/tl work (where a stale `patterns.db` produced phantom regressions).

### The problem

The multilingual `--regression` gate compares *(current parser parsing the DB's translations)* vs the **committed baseline**. But `patterns.db` is regenerated by `db:init:force && sync:translations` from i18n + semantic source, and **nothing checked that the DB matched the currently-checked-out source**. Sync the DB on branch A, switch to branch B, run the gate without re-syncing → it silently mis-compares branch-A data against branch-B's baseline. The deeper hazard isn't the wasted cycle — it's getting *desensitized* and waving off a **real** regression as "probably DB drift."

### The fix — a content-hash provenance stamp

- `sync-translations` now writes a **`data/patterns.db.stamp`** sidecar: a SHA-256 of the **source** that determines the DB's content (the i18n + semantic `src` trees, `init-db.ts`, `sync-translations.ts`, `span-mask`).
- The gate calls `checkDbStamp()` before a `--regression` run:
  - **`stale`** (source changed since the last sync) → **refuses to run**, with the exact re-sync command.
  - **`unstamped`** (committed DB on a fresh checkout) → **warns once** (back-compat).
  - **`ok`** → silent.
- We hash **source, not the gitignored/non-deterministic `dist`**, so the stamp catches branch/source changes regardless of whether `dist` happened to be rebuilt. The stamp itself is **local** (gitignored) — it records "what source produced *my* DB."

### Why this is the right design

- `.gitignore` un-ignores `patterns.db` (it's **committed**) and pairs with the committed baseline. The drift is purely a local working-tree hazard, which a source-hash stamp catches precisely.
- Conservative on purpose: it hashes both i18n and semantic src (the DB stores transformer translations *and* parser confidence/verified_parses, and `--verified-only`/`--confidence` modes read those), so it can never *miss* a real drift. Cost is an occasional extra re-sync.

### CI is unaffected

The multilingual job runs `npm run populate` (re-syncs → fresh stamp → `ok`) before gating, and its gate command uses `--bundle`/`--quick`, not `--regression`. The guard can't wrongly fire in CI.

### Validation

- End-to-end: fresh sync → gate runs `ok` + green (97 degenerate, no regression); a simulated source edit → gate prints **STALE** and exits 1 with the fix command.
- `db-stamp.test.ts` covers the ok/stale/unstamped transitions, determinism, and that `.test.ts`/`.d.ts` churn doesn't flip freshness. patterns-reference suite 114 pass (+5 new); typecheck clean.

https://claude.ai/code/session_01VLQjtgwkjcwyKvHYY6utZz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLQjtgwkjcwyKvHYY6utZz)_