### PR TITLE
fix(i18n,semantic): align focus command keyword — clears first-in-parent degenerate cluster (de/fr/pl/pt/sw)

### DIFF
--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -5,7 +5,9 @@
 > breakdown predates the 8 PRs below and no longer matches the baseline).
 > Source of truth for "what's left" is the regenerated baseline, not #259.
 
-_Last updated: after Track 5 **VSO (ar/tl) mid-stream event after a plain leading command** — a single language-agnostic-but-VSO-gated parser fix clearing a whole cluster. Verb-initial languages front the verb, so the i18n transformer renders an `on click` handler as `<command> … on click then <body>` — the event clause sits **mid-stream after the first command**, e.g. ar `احذف .active من .tab عند نقر ثم أضف …` / tl `alisin .active mula sa .tab kapag click pagkatapos …` (= `remove .active from .tab on click then add …`). The parser matched the leading command as a bare standalone and dropped the event + then-chain body (only `{remove}`). The existing `tryMidStreamEventExtraction` (already used for the VSO **loop** path) now also fires on a **plain leading command**, gated to `wordOrder === 'VSO'` (ar, tl) — in event-first SVO/SOV languages a plain command is never an event-mid-stream form, and running the extractor there mis-fires on incidental `on`+event token pairs (an un-gated first cut regressed ja/bn/he/de). Cleared the ar/tl cluster: `accordion-exclusive`, `tabs-basic`, `tabs-content`, `copy-to-clipboard`, `form-submit-prevent`, `halt-propagation`, `take-class-from-siblings`, + ar/tl from `modal-close-escape`. **Degenerate total 112 → 97 (−15), 0 regressions, no over-generation** (the with/without diff is all deletions); ar/tl avgFidelity 0.888 → 0.934 / 0.896 → 0.937; baseline regenerated. Locked by `multilingual-roadmap-fixes.test.ts` ("VSO (ar/tl) mid-stream event after a plain leading command")._
+_Last updated: Track 5 **`focus` command keyword alignment (de/fr/pl/pt/sw)** — the shared root cause behind the `first-in-parent` degenerate cluster. `on click focus first <input/> in closest <form/>` parsed degenerate `{on}` (fid 0.33) in all 5. Root cause: the i18n **`commands` dictionaries were missing a `focus` entry**, so the transformer fell back to the event-noun form (de `fokus`, fr `focus`, pt `foco`, sw `zingatia`, pl `fokus`) — which the semantic command parser does not recognize (the profile primaries are verbs: `fokussieren` / `focaliser` / `focar` / `lenga` / `skup`). The whole `focus …` body dropped. Spanish was unaffected only because its event-focus word (`enfocar`) coincidentally equals its profile primary; `focus-element` (`on click focus #input`, 2-action EN reference) hid the same drop under the 0.50 fidelity floor. Fix: add `focus` = the profile-primary verb to each of the 5 `commands` dicts, so the transformer emits a word the parser parses. **Degenerate total 97 → 92 (−5), `--regression` gate green, 0 regressions** (the baseline degenerate diff is 5 removals + 0 additions); `first-in-parent` degenerate→faithful (0.33 → 0.67) in all 5, focus un-masked in `focus-element`, avgFidelity ↑ de 0.911→0.917 / fr 0.888→0.893 / pl 0.896→0.901 / pt 0.873→0.879 / sw 0.909→0.914; baseline regenerated. The paired probe target **`if-empty` is a DIFFERENT root cause** — not a keyword gap (its `on/if/add/put` verbs are all present in the dicts) but the documented hard block-body cluster (`put`+positional-destination drop after a non-`into` marker, the `is empty` predicate, SOV `on blur` collapse in ja/ko) — left tracked, not force-unified. Locked by `multilingual-roadmap-fixes.test.ts` ("focus command keyword alignment")._
+
+_Earlier: Track 5 **VSO (ar/tl) mid-stream event after a plain leading command** — a single language-agnostic-but-VSO-gated parser fix clearing a whole cluster. Verb-initial languages front the verb, so the i18n transformer renders an `on click` handler as `<command> … on click then <body>` — the event clause sits **mid-stream after the first command**, e.g. ar `احذف .active من .tab عند نقر ثم أضف …` / tl `alisin .active mula sa .tab kapag click pagkatapos …` (= `remove .active from .tab on click then add …`). The parser matched the leading command as a bare standalone and dropped the event + then-chain body (only `{remove}`). The existing `tryMidStreamEventExtraction` (already used for the VSO **loop** path) now also fires on a **plain leading command**, gated to `wordOrder === 'VSO'` (ar, tl) — in event-first SVO/SOV languages a plain command is never an event-mid-stream form, and running the extractor there mis-fires on incidental `on`+event token pairs (an un-gated first cut regressed ja/bn/he/de). Cleared the ar/tl cluster: `accordion-exclusive`, `tabs-basic`, `tabs-content`, `copy-to-clipboard`, `form-submit-prevent`, `halt-propagation`, `take-class-from-siblings`, + ar/tl from `modal-close-escape`. **Degenerate total 112 → 97 (−15), 0 regressions, no over-generation** (the with/without diff is all deletions); ar/tl avgFidelity 0.888 → 0.934 / 0.896 → 0.937; baseline regenerated. Locked by `multilingual-roadmap-fixes.test.ts` ("VSO (ar/tl) mid-stream event after a plain leading command")._
 
 _Earlier: Track 5 **`ms` (Malay) grammar profile** — ms had no i18n grammar profile (`Unknown target locale: ms`), so its baseline 100% parse rate was an English-fallback artifact. Added `malayProfile` (mirrors Indonesian, but the event head is `apabila` not `pada`) + handcrafted ms `set`/`fetch`; real ms 37% → 97% (149/154), 0 degenerate; baseline regenerated. See [ZH_BLOCK_BODY_SCOPE.md](ZH_BLOCK_BODY_SCOPE.md)._
 
@@ -73,6 +75,40 @@ behaviors), not a parsing/i18n track. See Track 2.
 ---
 
 ## Shipped
+
+### Track 5 — `focus` command keyword alignment (first-in-parent → faithful, de/fr/pl/pt/sw)
+
+- **`first-in-parent` 0.33 → 0.67** (degenerate → faithful) in de, fr, pl, pt, sw;
+  **degenerate total 97 → 92 (−5)**; `--regression` gate green, **0 regressions**
+  (baseline degenerate diff = 5 removals, 0 additions); avgFidelity ↑ in all 5
+  (de 0.911→0.917, fr 0.888→0.893, pl 0.896→0.901, pt 0.873→0.879, sw 0.909→0.914);
+  baseline regenerated.
+- **Root cause.** The i18n `commands` dictionaries
+  (`packages/i18n/src/dictionaries/{de,fr,pl,pt,sw}.ts`) had **no `focus` entry**.
+  The grammar transformer therefore fell back to the event-noun form (de `fokus`,
+  fr `focus`, pt `foco`, sw `zingatia`, pl `fokus`) for the `focus` _command_ —
+  none of which the semantic command parser recognizes, since the profile primaries
+  are verbs (`fokussieren` / `focaliser` / `focar` / `lenga` / `skup`). So
+  `on click focus first <input/> in closest <form/>` dropped its entire `focus …`
+  body, parsing degenerate `{on}`. Spanish was unaffected only because its
+  event-focus word `enfocar` coincidentally equals its profile primary; the same
+  drop was present-but-masked in `focus-element` (2-action EN reference → 0.50,
+  exactly at the fidelity floor).
+- **Fix.** Add `focus` = the profile-primary verb to each of the 5 `commands`
+  dicts. The transformer now emits a verb the parser parses; the trailing
+  `first … in closest …` positional/scope is gracefully ignored (the EN reference
+  itself only yields `{focus, on, wait}`, so `{on, focus}` clears the 0.50 floor).
+  Same root-cause family as the qu/sw `increment` and zh `fetch` keyword
+  alignments. Locked by `multilingual-roadmap-fixes.test.ts`
+  ("focus command keyword alignment").
+- **Paired probe — `if-empty` is NOT the same root cause.** `if-empty`
+  (`on blur if my value is empty add .error to me put "Required" into next
+.error-message end`) is degenerate in de/he/ja/ko/sw, but its command verbs
+  (`on/if/add/put`) are all present in the dicts — it is the documented hard
+  block-body cluster, not a keyword gap: `put`+positional-destination drops after
+  the non-`into` marker (de `setzen … zu nächste …`), the `is empty` predicate, and
+  the SOV `on blur` collapse to a bare `blur` in ja/ko. Left tracked under the
+  block-body arc; deliberately not force-unified with the focus fix.
 
 ### Track 5 — zh `wait` BA-marked duration (zh repeat-forever → 1.0)
 

--- a/packages/i18n/src/dictionaries/de.ts
+++ b/packages/i18n/src/dictionaries/de.ts
@@ -62,6 +62,7 @@ export const de: Dictionary = {
     select: 'auswählen',
     clone: 'klonen',
     prepend: 'voranstellen',
+    focus: 'fokussieren',
   },
 
   modifiers: {

--- a/packages/i18n/src/dictionaries/fr.ts
+++ b/packages/i18n/src/dictionaries/fr.ts
@@ -62,6 +62,7 @@ export const fr: Dictionary = {
     select: 'sélectionner',
     clone: 'cloner',
     prepend: 'préfixer',
+    focus: 'focaliser',
   },
 
   modifiers: {

--- a/packages/i18n/src/dictionaries/pl.ts
+++ b/packages/i18n/src/dictionaries/pl.ts
@@ -62,6 +62,7 @@ export const pl: Dictionary = {
     select: 'wybierz',
     clone: 'sklonuj',
     prepend: 'poprzedź',
+    focus: 'skup',
   },
 
   modifiers: {

--- a/packages/i18n/src/dictionaries/pt.ts
+++ b/packages/i18n/src/dictionaries/pt.ts
@@ -62,6 +62,7 @@ export const pt: Dictionary = {
     select: 'selecionar',
     clone: 'clonar',
     prepend: 'preceder',
+    focus: 'focar',
   },
 
   modifiers: {

--- a/packages/i18n/src/dictionaries/sw.ts
+++ b/packages/i18n/src/dictionaries/sw.ts
@@ -65,6 +65,7 @@ export const sw: Dictionary = {
     select: 'chagua',
     clone: 'nakili',
     prepend: 'tanguliza',
+    focus: 'lenga',
   },
 
   modifiers: {

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1422,3 +1422,46 @@ describe('VSO (ar/tl) mid-stream event after a plain leading command', () => {
     expect(a.has('toggle')).toBe(true);
   });
 });
+
+describe('focus command keyword alignment (de/fr/pl/pt/sw)', () => {
+  // first-in-parent (`on click focus first <input/> in closest <form/>`) was a
+  // degenerate pass in de/fr/pl/pt/sw. Root cause: the i18n `commands` dictionaries
+  // were MISSING a `focus` entry, so the transformer fell back to the event-noun
+  // form (de `fokus`, fr `focus`, pt `foco`, sw `zingatia`, pl `fokus`) — which the
+  // semantic command parser does not recognize (the profile primaries are verbs:
+  // fokussieren / focaliser / focar / lenga / skup). The whole `focus …` body
+  // dropped, leaving only `{on}` (fidelity 0.33). Spanish was unaffected only
+  // because its event-focus word (enfocar) happens to equal its profile primary.
+  // Fix: add `focus` to each `commands` dict = the profile primary verb, so the
+  // transformer emits a word the parser parses. Clears all 5 (degenerate→faithful,
+  // 0.33 → 0.67), un-masks focus in focus-element, and lifts avgFidelity in each.
+  // See docs-internal/MULTILINGUAL_ROADMAP.md ("focus keyword alignment").
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped transformer output (en → lang) for first-in-parent.
+  const cases: Array<[string, string]> = [
+    ['de', 'bei klick fokussieren erste <input/> in nächste <form/>'],
+    ['fr', 'sur clic focaliser premier <input/> en plusproche <form/>'],
+    ['pl', 'gdy kliknięcie skup pierwszy <input/> w najbliższy <form/>'],
+    ['pt', 'em clique focar primeiro <input/> dentro mais_próximo <form/>'],
+    ['sw', 'kwenye bonyeza lenga kwanza <input/> ndani karibu_zaidi <form/>'],
+  ];
+
+  for (const [lang, input] of cases) {
+    it(`[${lang}] recovers {on, focus} (first-in-parent)`, () => {
+      const a = actions(parse(input, lang as 'de'));
+      expect(a.has('on')).toBe(true);
+      expect(a.has('focus')).toBe(true);
+    });
+  }
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-10T04:46:19.594Z",
-  "commit": "526d20d",
+  "timestamp": "2026-06-10T06:00:27.968Z",
+  "commit": "dced86c",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -15,7 +15,7 @@
         "event-debounce",
         "socket-basic"
       ],
-      "bundleSize": 160454,
+      "bundleSize": 404980,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -641,7 +641,7 @@
       "avgConfidence": 0.8657287157287157,
       "avgFidelity": 0.9580086580086579,
       "degeneratePasses": ["socket-basic"],
-      "bundleSize": 155425,
+      "bundleSize": 404980,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1265,16 +1265,15 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.9367465504720396,
-      "avgFidelity": 0.9114379084967318,
+      "avgConfidence": 0.9359995850191917,
+      "avgFidelity": 0.9168845315904139,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
         "behavior-sortable",
-        "first-in-parent",
         "if-empty"
       ],
-      "bundleSize": 151501,
+      "bundleSize": 404980,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -1333,10 +1332,6 @@
           "confidence": 1
         },
         "repeat-for-each": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-element": {
           "success": true,
           "confidence": 1
         },
@@ -1700,6 +1695,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "log-value": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -1898,7 +1897,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 223757,
+      "bundleSize": 404980,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2525,7 +2524,7 @@
       "avgConfidence": 0.989034132171387,
       "avgFidelity": 0.9165577342047931,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 156407,
+      "bundleSize": 404980,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3149,16 +3148,15 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "avgFidelity": 0.8877995642701524,
+      "avgFidelity": 0.8932461873638345,
       "degeneratePasses": [
         "async-block",
         "behavior-draggable",
         "behavior-resizable",
         "behavior-sortable",
-        "fetch-with-headers",
-        "first-in-parent"
+        "fetch-with-headers"
       ],
-      "bundleSize": 153859,
+      "bundleSize": 404980,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3790,7 +3788,7 @@
         "if-empty",
         "unless-condition"
       ],
-      "bundleSize": 0,
+      "bundleSize": 404980,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4428,7 +4426,7 @@
         "socket-basic",
         "worker-basic"
       ],
-      "bundleSize": 157457,
+      "bundleSize": 404980,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5060,7 +5058,7 @@
         "behavior-sortable",
         "unless-condition"
       ],
-      "bundleSize": 147392,
+      "bundleSize": 404980,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5686,7 +5684,7 @@
       "avgConfidence": 0.9878721859114016,
       "avgFidelity": 0.9550108932461874,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 156391,
+      "bundleSize": 404980,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6321,7 +6319,7 @@
         "input-validation",
         "socket-basic"
       ],
-      "bundleSize": 158021,
+      "bundleSize": 404980,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6957,7 +6955,7 @@
         "socket-basic",
         "window-scroll"
       ],
-      "bundleSize": 164165,
+      "bundleSize": 404980,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7584,7 +7582,7 @@
       "avgConfidence": 0.998806860551827,
       "avgFidelity": 0.9089485458612976,
       "degeneratePasses": [],
-      "bundleSize": 145294,
+      "bundleSize": 404980,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8204,14 +8202,9 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.828685548293392,
-      "avgFidelity": 0.8958605664488017,
-      "degeneratePasses": [
-        "behavior-draggable",
-        "behavior-resizable",
-        "behavior-sortable",
-        "first-in-parent"
-      ],
-      "bundleSize": 154192,
+      "avgFidelity": 0.9013071895424839,
+      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
+      "bundleSize": 404980,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -8835,18 +8828,17 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8312273057371102,
-      "avgFidelity": 0.8734204793028322,
+      "avgFidelity": 0.8788671023965143,
       "degeneratePasses": [
         "async-block",
         "behavior-draggable",
         "behavior-resizable",
         "behavior-sortable",
         "fetch-with-headers",
-        "first-in-parent",
         "focus-trap",
         "socket-basic"
       ],
-      "bundleSize": 154050,
+      "bundleSize": 404980,
       "patterns": {
         "window-resize": {
           "success": true,
@@ -9480,7 +9472,7 @@
         "modal-close-escape",
         "socket-basic"
       ],
-      "bundleSize": 153372,
+      "bundleSize": 404980,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10107,7 +10099,7 @@
       "avgConfidence": 0.8895073180787468,
       "avgFidelity": 0.9628787878787877,
       "degeneratePasses": ["install-behavior"],
-      "bundleSize": 166510,
+      "bundleSize": 404980,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10731,18 +10723,17 @@
       "parseSuccess": 150,
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
-      "avgConfidence": 0.866582010582011,
-      "avgFidelity": 0.9087777777777778,
+      "avgConfidence": 0.8674285714285717,
+      "avgFidelity": 0.9143333333333333,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
         "behavior-sortable",
         "event-debounce",
-        "first-in-parent",
         "if-empty",
         "socket-basic"
       ],
-      "bundleSize": 146988,
+      "bundleSize": 404980,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -10964,6 +10955,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "log-value": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -11029,6 +11024,10 @@
           "confidence": 0.8857142857142858
         },
         "closest-ancestor": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "first-in-parent": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -11168,10 +11167,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "blur-element": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -11229,10 +11224,6 @@
           "confidence": 0.8222222222222222
         },
         "transition-color": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "first-in-parent": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -11365,7 +11356,7 @@
       "avgConfidence": 0.9402185116470816,
       "avgFidelity": 0.9791125541125543,
       "degeneratePasses": [],
-      "bundleSize": 151330,
+      "bundleSize": 404980,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -11992,7 +11983,7 @@
       "avgConfidence": 0.8985472977069613,
       "avgFidelity": 0.9370129870129869,
       "degeneratePasses": ["event-debounce", "eventsource-basic", "get-value", "worker-basic"],
-      "bundleSize": 149005,
+      "bundleSize": 404980,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -12626,7 +12617,7 @@
         "default-value",
         "socket-basic"
       ],
-      "bundleSize": 164692,
+      "bundleSize": 404980,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13252,7 +13243,7 @@
       "avgConfidence": 0.8887652030509177,
       "avgFidelity": 0.9628787878787877,
       "degeneratePasses": ["install-behavior"],
-      "bundleSize": 166251,
+      "bundleSize": 404980,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -13879,7 +13870,7 @@
       "avgConfidence": 0.892888064316636,
       "avgFidelity": 0.9574675324675322,
       "degeneratePasses": [],
-      "bundleSize": 150966,
+      "bundleSize": 404980,
       "patterns": {
         "add-class-basic": {
           "success": true,
@@ -14506,7 +14497,7 @@
       "avgConfidence": 0.9988148148148148,
       "avgFidelity": 0.8879999999999999,
       "degeneratePasses": [],
-      "bundleSize": 152564,
+      "bundleSize": 404980,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15124,97 +15115,9 @@
     }
   },
   "bundles": {
-    "browser-ar": {
-      "size": 160454,
-      "languages": ["ar"]
-    },
-    "browser-bn": {
-      "size": 155425,
-      "languages": ["bn"]
-    },
-    "browser-de": {
-      "size": 151501,
-      "languages": ["de"]
-    },
-    "browser-en": {
-      "size": 223757,
-      "languages": ["en"]
-    },
-    "browser-es": {
-      "size": 156407,
-      "languages": ["es"]
-    },
-    "browser-fr": {
-      "size": 153859,
-      "languages": ["fr"]
-    },
-    "browser-hi": {
-      "size": 157457,
-      "languages": ["hi"]
-    },
-    "browser-id": {
-      "size": 147392,
-      "languages": ["id"]
-    },
-    "browser-it": {
-      "size": 156391,
-      "languages": ["it"]
-    },
-    "browser-ja": {
-      "size": 158021,
-      "languages": ["ja"]
-    },
-    "browser-ko": {
-      "size": 164165,
-      "languages": ["ko"]
-    },
-    "browser-ms": {
-      "size": 145294,
-      "languages": ["ms"]
-    },
-    "browser-pl": {
-      "size": 154192,
-      "languages": ["pl"]
-    },
-    "browser-pt": {
-      "size": 154050,
-      "languages": ["pt"]
-    },
-    "browser-qu": {
-      "size": 153372,
-      "languages": ["qu"]
-    },
-    "browser-ru": {
-      "size": 166510,
-      "languages": ["ru"]
-    },
-    "browser-sw": {
-      "size": 146988,
-      "languages": ["sw"]
-    },
-    "browser-th": {
-      "size": 151330,
-      "languages": ["th"]
-    },
-    "browser-tl": {
-      "size": 149005,
-      "languages": ["tl"]
-    },
-    "browser-tr": {
-      "size": 164692,
-      "languages": ["tr"]
-    },
-    "browser-uk": {
-      "size": 166251,
-      "languages": ["uk"]
-    },
-    "browser-vi": {
-      "size": 150966,
-      "languages": ["vi"]
-    },
-    "browser-zh": {
-      "size": 152564,
-      "languages": ["zh"]
+    "browser-priority": {
+      "size": 404980,
+      "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Probed the `if-empty` and `first-in-parent` degenerate-pass clusters for a shared root cause, then fixed the clean one with the A/B + `--regression` discipline.

**Finding:** the two patterns do **not** share a single mechanistic root cause — but `first-in-parent` has one clean cause that explains all five of its degenerate languages.

### `first-in-parent` — shared root cause (fixed)

`on click focus first <input/> in closest <form/>` parsed degenerate `{on}` (fidelity 0.33) in **de, fr, pl, pt, sw**. Root cause: the i18n **`commands` dictionaries were missing a `focus` entry**, so the grammar transformer fell back to the event-noun form for the `focus` *command*:

| lang | transformer emitted | semantic profile primary (parser expects) |
| ---- | ------------------- | ----------------------------------------- |
| de   | `fokus`             | `fokussieren` |
| fr   | `focus`             | `focaliser` |
| pl   | `fokus`             | `skup` |
| pt   | `foco`              | `focar` |
| sw   | `zingatia`          | `lenga` |

The parser doesn't recognize the noun forms, so the whole `focus …` body dropped. Spanish was unaffected only because its event-focus word `enfocar` coincidentally equals its profile primary; the same drop was *present but masked* in `focus-element` (a 2-action EN reference sits exactly on the 0.50 fidelity floor).

**Fix:** add `focus` = the profile-primary verb to each of the 5 `commands` dicts. The transformer now emits a verb the parser parses; the trailing `first … in closest …` positional/scope is gracefully ignored (the EN reference itself only yields `{focus, on, wait}`, so `{on, focus}` = 0.67 clears the floor). Same root-cause family as the shipped qu/sw `increment` and zh `fetch` keyword alignments.

### `if-empty` — different root cause (probed, not force-fixed)

`if-empty` is degenerate in de/he/ja/ko/sw, but its command verbs (`on`/`if`/`add`/`put`) are **all present** in the dicts — it is **not** a keyword gap. It's the documented hard block-body cluster: `put`+positional-destination drops after the non-`into` marker (de `setzen … zu nächste …`), the `is empty` predicate, and the SOV `on blur` collapse to a bare `blur` in ja/ko. Left tracked under the block-body arc rather than force-unified.

## A/B result (`--full --bundle browser-priority --regression`)

- **Degenerate total 97 → 92 (−5)** — exactly the five `first-in-parent` instances.
- `--regression` gate **green, 0 regressions**; baseline degenerate diff = **5 removals, 0 additions**.
- `first-in-parent` degenerate → faithful (0.33 → 0.67) in all 5; avgFidelity ↑ de 0.911→0.917 / fr 0.888→0.893 / pl 0.896→0.901 / pt 0.873→0.879 / sw 0.909→0.914.
- No parse-rate change in any language; no other pattern flipped.
- Baseline regenerated (`--save-baseline`).

## Changes

- `packages/i18n/src/dictionaries/{de,fr,pl,pt,sw}.ts` — add `focus` command entry (= profile primary)
- `packages/testing-framework/baselines/multilingual-priority.json` — regenerated baseline
- `packages/semantic/test/multilingual-roadmap-fixes.test.ts` — lock test ("focus command keyword alignment", 5 cases)
- `docs-internal/MULTILINGUAL_ROADMAP.md` — shipped entry + the `if-empty` finding

## Validation

- i18n suite: 662/662 ✓
- `multilingual-roadmap-fixes.test.ts`: 127/127 ✓ (incl. 5 new)
- `typecheck` i18n + semantic ✓
- Multilingual `--regression` gate ✓

Per repo convention (matching prior dict-fix commits), `patterns.db` is left for CI to re-populate; only the dicts + committed baseline are changed.

https://claude.ai/code/session_019jBF2e4NGzhvU1nuVJqhv2

---
_Generated by [Claude Code](https://claude.ai/code/session_019jBF2e4NGzhvU1nuVJqhv2)_