### PR TITLE
docs: cold-start build order + multilingual gate runbook in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,36 @@ examples/
 
 ## Essential Commands
 
+### Cold start (fresh checkout / web session)
+
+A freshly-cloned container has no workspace symlinks or local bins yet, and the
+package `dist/` trees are unbuilt. Before anything else:
+
+```bash
+npm install          # alias: npm run bootstrap — links workspaces + installs bins (tsx, vitest…)
+```
+
+> **`npm run build` is NOT dependency-ordered.** It maps to
+> `build --workspaces --if-present`, which builds in `package.json` declaration
+> order, not topological order. So building a single deep package on a cold tree
+> (e.g. `npm run build --prefix packages/core`) fails with
+> `Cannot find module .../framework/dist/index.js` until its upstream deps are
+> built first. (`npm run rebuild:full` uses the same unordered command and only
+> _looks_ like it succeeds — it pipes through `grep … || true` and swallows the
+> errors.)
+>
+> The authoritative topological build order lives in the **`build` job of
+> `.github/workflows/ci.yml`** (guarded against drift by
+> `npm run check:ci-order` → `scripts/check-ci-build-order.cjs`). For the
+> multilingual stack specifically, the ready-made ordered chain is
+> `npm run test:multilingual:build-deps` (intent → framework → semantic → i18n →
+> patterns-reference → core's `build:multilingual-dist`).
+>
+> Some package builds print `DTS Build error` / `tsc --emitDeclarationOnly`
+> failures but **still emit usable JS** — the `.js` bundle is produced before the
+> declaration step. A DTS error alone does not mean the build you need failed;
+> check whether the `dist/` artifact you actually consume exists.
+
 ### Core Package (Primary Development)
 
 ```bash
@@ -244,6 +274,28 @@ demanding the ~232 existing degenerate passes be fixed at once. After an
 _intentional_ fidelity change, regenerate the baseline (`--save-baseline`). The
 remaining degenerate passes (mostly block-body translation — `if-*`, `fetch-*`
 states, `async-block`) are tracked in `docs-internal/MULTILINGUAL_ROADMAP.md`.
+
+#### Running the multilingual `--regression` gate locally
+
+The CI `multilingual-validation` job is reproducible locally, but it needs the
+ordered build + a freshly synced patterns DB (the gate **refuses to run** against
+a stale/unstamped `patterns.db` — see the provenance-stamp note in
+`packages/patterns-reference/CLAUDE.md`). From a cold tree:
+
+```bash
+npm install                                              # if not already done
+npm run test:multilingual:build-deps                     # ordered build of the multilingual stack
+npm run populate --prefix packages/patterns-reference    # rebuild patterns.db + write its provenance stamp
+cd packages/testing-framework
+npx tsx src/multilingual/cli.ts --full --bundle browser-priority --regression
+```
+
+The gate exits non-zero on a parse-rate drop >2pts or >3 faithful→degenerate
+flips vs the committed baseline. After an _intentional_ fidelity change, re-run
+with `--save-baseline` (instead of `--regression`) to regenerate
+`packages/testing-framework/baselines/multilingual-priority.json`, and commit the
+new baseline. Per repo convention the regenerated `patterns.db` is **not**
+committed — CI re-populates it; only the dicts/profiles + baseline are tracked.
 
 **Other Workflows:**
 


### PR DESCRIPTION
## Summary

Docs-only follow-up capturing the setup friction hit early in the focus-keyword session (#321) when bringing up the multilingual stack from a fresh container. No code or script changes.

Adds two sections to `CLAUDE.md`:

### `## Essential Commands` → **Cold start (fresh checkout / web session)**
- `npm install` (≡ `npm run bootstrap`) is required first — a fresh container has no workspace symlinks or local bins (`tsx`, `vitest`).
- **`npm run build` is not dependency-ordered** — it's `build --workspaces --if-present` (declaration order), so building a deep package alone (`--prefix packages/core`) fails cold with `Cannot find module .../framework/dist/index.js`. `rebuild:full` uses the same unordered command and swallows the errors via `grep … || true`. Points at the authoritative order (the `build` job in `ci.yml`, drift-guarded by `check:ci-order`) and the ready-made `test:multilingual:build-deps` chain.
- DTS/`tsc --emitDeclarationOnly` errors still emit usable JS — not necessarily a real failure of the bundle you consume.

### `### Multilingual parse rate ≠ fidelity` → **Running the multilingual `--regression` gate locally**
- A reproducible runbook: `build-deps` → `populate` → `cli … --regression`, including the stale-`patterns.db` refusal (provenance stamp), the 2pt / 3-flip thresholds, `--save-baseline`, and the "don't commit `patterns.db`" convention.

## Why

Reconstructing the correct cold-tree build order cost several tool round-trips last session — the knowledge was split between `ci.yml` and an undocumented `test:multilingual:build-deps` script. Every claim here was verified against the live repo during that session (build failures, script definitions, gate thresholds in `cli.ts`).

The heavier options (a runnable ordered-build script, a SessionStart hook) were considered and deliberately deferred — docs-only was chosen as the lowest-risk, no-maintenance-surface fix.

https://claude.ai/code/session_019jBF2e4NGzhvU1nuVJqhv2

---
_Generated by [Claude Code](https://claude.ai/code/session_019jBF2e4NGzhvU1nuVJqhv2)_