### PR TITLE
docs: correctness & reliability assessment + roadmap reframe (fidelity over parse rate)

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -1,0 +1,146 @@
+# Multilingual correctness & reliability — assessment + plan
+
+> **Thesis:** the system **parses reliably** (~99.4% non-null) but does not always
+> parse **correctly**. The headline metrics (parse rate, degenerate count) hide a
+> ~7×-larger band of **lossy passes** — translations that parse and pass CI while
+> silently dropping commands. This plan reframes the work around **fidelity**
+> (avgFidelity 0.928 today) and prioritizes correctness/reliability **before**
+> behaviors (Track 2 runtime).
+
+## 1. The measurement (full fidelity distribution)
+
+A sweep of **24 languages × 154 gate patterns = 3696 instances** (each parsed via
+`@hyperfixi/core/multilingual`, fidelity = fraction of the English reference parse's
+command actions present — the same signal the gate ratchets on):
+
+| Bucket                                             | Count   | Share     |
+| -------------------------------------------------- | ------- | --------- |
+| **Faithful** (fidelity = 1.0)                      | 3133    | 84.8%     |
+| **Lossy** (0.5 ≤ fid < 1.0 — parses, drops ≥1 cmd) | **471** | **12.7%** |
+| **Degenerate** (fid < 0.5 — the tracked headline)  | 69      | 1.9%      |
+| **Failed** (null parse)                            | 23\*    | 0.6%      |
+
+\* In-scope null failures only; the 5 `component-*` HTML-template patterns (110
+instances) are markup, correctly excluded from the semantic-parse set.
+
+**Key point:** the **lossy bucket (471) is ~7× the degenerate bucket (69)** we've been
+optimizing. The degenerate ratchet only catches the worst ~13% of the incomplete-parse
+problem. The fetch-droppers fixed in #330 (es/pl/id/sw/he, sitting at 0.67) were all
+lossy — invisible to the degenerate metric until measured directly.
+
+### Per-language fidelity (avgFidelity, worst → best)
+
+```
+zh 0.865 | ms 0.879 | qu 0.882 | id 0.889 | ja 0.901 | he 0.904 | sw 0.905 | hi 0.908
+pt 0.913 | de 0.914 | ko 0.915 | fr 0.921 | tr 0.931 | ar 0.934 | es 0.944 | it 0.949
+tl 0.954 | vi 0.957 | ru 0.963 | uk 0.963 | bn 0.965 | th 0.979 | (en 1.000)
+```
+
+Cross-language avgFidelity **0.928**. Parse rate (~99.4%) overstates health by ~7pts of
+fidelity. The lowest-fidelity languages (zh, ms, qu, id, ja) carry the most lossy passes
+(zh 38, qu 36, ms 34, id 32, de 27).
+
+## 2. What's actually being dropped (leverage analysis)
+
+Across all lossy+degenerate instances, the most-dropped commands:
+
+| Dropped cmd    | Count | Cluster                                                              |
+| -------------- | ----- | -------------------------------------------------------------------- |
+| `if`           | 109   | **Control-flow conditions** — if/unless headers don't form           |
+| `put`          | 88    | Mostly **inside then-chain / block bodies** (`… then put it into Y`) |
+| `behavior`     | 60    | Track 2 (behaviors) — deferred                                       |
+| `set`          | 49    | then-chain / block bodies                                            |
+| `on`           | 36    | event head mangled (SOV/VSO reorder, modifiers)                      |
+| `empty`        | 30    | `is empty` predicate (condition vocab)                               |
+| `wait`         | 24    | block/loop tails                                                     |
+| `focus`        | 23    | `focus first <input/> in closest <form/>` positional                 |
+| `for`/`unless` | 23/21 | loops / conditionals                                                 |
+
+Top lossy patterns (instances across 23 non-en languages): `first-in-parent` (23),
+`focus-trap` (23), `template-literal-list-build` (23), `form-submit-prevent` (22),
+`form-disable-on-submit` (22), `fetch-do-not-throw` (22), `unless-condition` (21),
+`if-empty` (21), `input-validation` (17), `if-exists` (15), `append-content` (13),
+`swap-content` (11), `modal-close-backdrop` (10), `event-debounce` (10).
+
+**Diagnosis:** the single dominant correctness gap is **control-flow body parsing** —
+conditionals (`if`/`unless`, ~130 drops with `empty`) and the commands inside/after them
+(`put`/`set`, the then-chain bodies). `put`/`set` are not a simple keyword/marker issue
+(a bare `put X into Y` parses fine in 22/23 languages); they drop because the **enclosing
+block/then-chain** collapses. So conditionals and then-chain bodies are one campaign.
+
+A `put X into Y` spot-check (kept in 22/23, only zh drops) confirms the simple commands
+are fine — the loss is structural (the block/condition wrapper), not lexical.
+
+## 3. Reliability gap in the harness (fix first)
+
+The gate ratchets on **degenerate flips** (faithful→<0.5) and parse-rate (±2pt). It does
+**not** track the lossy band, so a faithful→lossy regression (a command silently dropped
+at, say, 0.8) **passes CI invisibly**. That is the reliability hole: the metric that
+would catch silent command-drops isn't enforced.
+
+**R0 (do first): add a per-language avgFidelity ratchet + lossy-pass count to the gate.**
+Record `avgFidelity` and `lossyPasses` per language in the baseline; fail CI on an
+avgFidelity drop beyond a small tolerance (mirroring the degenerate ratchet's spirit).
+This makes every command-drop visible and prevents correctness backsliding while we work
+the clusters below. (Low-risk harness change; the data is already computed per run.)
+
+## 4. Prioritized tracks (correctness before behaviors)
+
+### Track A — control-flow body parsing (biggest lever) — ~150–200 lossy/degen instances
+
+Conditionals and their bodies. Members: `if-empty`, `if-exists`, `unless-condition`,
+`input-validation`, `form-submit-prevent`, `form-disable-on-submit`, `modal-close-*`,
+and the `put`/`set` drops in `… then put …` tails. This is the B1 condition campaign
+(BLOCK_BODY_CONDITION_SCOPE.md §3.3) **re-scoped with the lossy data** — far larger than
+the degenerate count implied. Sub-mechanisms (each its own measure-first PR):
+
+- **A1 — predicate vocabulary** (`is empty`, `I match …`, `exists`): mirror the Spanish
+  profile's predicate keywords into more languages (de/sw shipped; he/ja/ko deferred for
+  reorder reasons). Recovers `if`/`unless`/`empty`/`matches`.
+- **A2 — then-chain / block-body attachment**: the `… then put it into Y` body after
+  `fetch`/`if`/`async` collapses (drops `put`/`set`). Generalize the event-body recovery
+  to then-chain positions (additive, guarded — the proven #329 shape).
+- **A3 — SOV/VSO event-head + condition reorder** (ja/ko/he/ar): the highest-risk slice;
+  the handler collapses to a bare event. Dedicated parser work, sequence last.
+
+### Track B — positional & content clusters — ~50–80 instances
+
+- **B1 — `focus first <input/> in closest <form/>`** (`first-in-parent`/`focus-trap`):
+  the positional `first … in …` query drops `focus` across ~all languages. One positional
+  fix clears two patterns ×23.
+- **B2 — `append`/`swap`/`prepend` content** (`append-content`, `swap-content`): content
+  commands drop in block/then contexts.
+- **B3 — long-tail**: `wait` tails, `event-debounce` (ar/tl `${…}`-in-URL tokenizer),
+  `keydown-key-is-syntax`.
+
+### Track C — low-fidelity language audits — zh / ms / qu / id / ja
+
+The bottom-5 by avgFidelity. After Tracks A/B land, sweep each for residual
+language-specific drops (zh has 4 hard nulls + 38 lossy; ms 34 lossy + 5 nulls). Some are
+keyword/marker alignments (the cheap id-toggle/get-value family), some are structural.
+
+### Deferred — Track 2 behaviors (60 `behavior` drops + the null behavior defs)
+
+`behavior … end` definitions don't parse/run — a **runtime** track, not parsing/i18n.
+Explicitly **after** correctness per the current priority. (Also out of scope: the
+`component-*` HTML templates.)
+
+## 5. Method (unchanged — it works)
+
+Every item: **measure-first probe** (confirm the mechanism and the dropped-command set
+before editing) → **one mechanism per PR** → **clean A/B** on the same DB (avgFidelity up,
+0 parse-rate drops, 0 faithful→degenerate flips) → **lock test** + **regenerate baseline**
+(patterns.db uncommitted). This session's 3 PRs (get-value −2, fr/pt fetch −4, es/pl/id/sw/he
+fetch +fidelity) validate the loop; the recurring lesson is that **the documented diagnosis
+is often wrong until probed** (hi `bind` → structural; B3 → fetch gap, not then-chain;
+`${…}`-in-URL → red herring that surfaced the broad fetch gap).
+
+## 6. Sequencing recommendation
+
+1. **R0** — avgFidelity ratchet in the gate (reliability floor; unblocks everything else).
+2. **Track A** (control-flow bodies) — biggest fidelity lever; multi-PR, A1 → A2 → A3.
+3. **Track B** (positional/content) — interleave the cheap ones (focus-first-in-parent).
+4. **Track C** (low-fidelity audits) — sweep zh/ms/qu/id/ja for residual cheap wins.
+5. **Then** behaviors (Track 2).
+
+Target: avgFidelity **0.928 → ~0.97+** (clearing the lossy bucket) before behaviors.

--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -45,6 +45,19 @@ _Earlier: after Track 5 **Tier 1 — if/else block-body in event handlers** (deg
 
 ## Current state
 
+> **Focus shift (2026-06-11): from parse rate to _fidelity_.** Parse rate (~99.4%
+> non-null) is effectively maxed, but it overstates health: a full fidelity sweep
+> (24 langs × 154 patterns = 3696 instances) shows **84.8% faithful, 12.7% lossy,
+> 1.9% degenerate, 0.6% failed** — cross-language **avgFidelity 0.928**. The **lossy
+> band (471 instances that parse and pass CI while silently dropping ≥1 command) is
+> ~7× the tracked degenerate band (69)**. The next arc is **correctness & reliability
+> before behaviors**, organized around avgFidelity rather than the degenerate count.
+> Full assessment, leverage analysis (dominant gap: control-flow body parsing —
+> `if`/`unless` + then-chain `put`/`set`), and the prioritized tracks (R0 gate
+> avgFidelity ratchet → Track A conditions/bodies → Track B positional/content →
+> Track C low-fidelity audits → then behaviors) live in
+> [CORRECTNESS_RELIABILITY_PLAN.md](CORRECTNESS_RELIABILITY_PLAN.md).
+
 Baseline: `packages/testing-framework/baselines/multilingual-priority.json`
 (generated with `--bundle browser-priority`). Cross-language average **99.05%**
 (up from 97.5% before Phase 1; Phases 1–4 + Track 4 + qu `install` + passthrough


### PR DESCRIPTION
## Summary

Assesses the multilingual system from a **correctness/reliability** lens and reframes the roadmap to prioritize correctness **before behaviors** (Track 2 runtime), per the stated goal. Docs-only — no code change.

## The finding (full fidelity sweep: 24 langs × 154 patterns = 3696 instances)

Parse rate (~99.4% non-null) is effectively maxed but **overstates health**:

| Bucket | Count | Share |
| --- | --- | --- |
| Faithful (fid = 1.0) | 3133 | 84.8% |
| **Lossy** (0.5–1.0, parses but silently drops ≥1 command) | **471** | **12.7%** |
| Degenerate (<0.5, the tracked headline) | 69 | 1.9% |
| Failed (null) | 23 | 0.6% |

Cross-language **avgFidelity 0.928**. The **lossy band (471) is ~7× the degenerate band (69)** we've been optimizing — these pass CI as "faithful" while dropping commands. (The #330 fetch-droppers were all lossy, invisible to the degenerate metric until measured.)

## Leverage analysis (most-dropped commands)

`if` (109) / `unless` (21) / `empty` (30) = **control-flow conditions**; `put` (88) / `set` (49) = **then-chain & block bodies**; `focus` (23) = positional. The dominant gap is **control-flow body parsing**. `put`/`set` are structural (block collapse), not lexical — a bare `put X into Y` parses in 22/23 languages.

## Plan (new `CORRECTNESS_RELIABILITY_PLAN.md`)

1. **R0 — gate avgFidelity ratchet** (reliability floor): the gate currently only catches faithful→degenerate flips, so a faithful→lossy regression passes CI invisibly. Track per-language avgFidelity + lossy count and fail on a drop. Do first.
2. **Track A — conditions + then-chain bodies** (biggest lever, ~150–200 instances): A1 predicate vocab → A2 then-chain attachment → A3 SOV/VSO reorder.
3. **Track B — positional/content** (focus-first-in-parent, append/swap).
4. **Track C — low-fidelity audits** (zh/ms/qu/id/ja).
5. **Then behaviors** (Track 2).

Target: avgFidelity **0.928 → ~0.97+** before behaviors.

`MULTILINGUAL_ROADMAP.md` Current state updated to adopt the fidelity lens and link the plan.

## Test plan

Docs-only; no code/baseline change. Methodology and numbers are reproducible via `@hyperfixi/core/multilingual` + the patterns DB (fidelity = fraction of the EN reference parse's command actions present, matching the gate's `computeFidelity`).

https://claude.ai/code/session_01SFozasxEjZ2tmw5jR5QZuk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFozasxEjZ2tmw5jR5QZuk)_