### PR TITLE
fix(i18n): align de `if` keyword (wenn→falls) — forms the conditional wrapper (A1)

### DIFF
--- a/packages/i18n/src/dictionaries/de.ts
+++ b/packages/i18n/src/dictionaries/de.ts
@@ -18,7 +18,12 @@ export const de: Dictionary = {
     toggle: 'umschalten',
     hide: 'verstecken',
     show: 'zeigen',
-    if: 'wenn',
+    // Align with the semantic German profile's `if` primary (`falls`). The previous
+    // `wenn` collides with the profile's `when` keyword (German `wenn` = both
+    // "if" and "when"), so a transformed `if` resolved to `when` and the conditional
+    // wrapper never formed (`if`/`put` dropped). Same dict↔profile alignment as id
+    // `toggle` / get-value. `when` is unaffected (separate dict entry).
+    if: 'falls',
     unless: 'wennnicht',
     repeat: 'wiederholen',
     for: 'für',

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -1456,7 +1456,10 @@ describe('Possessive Dot Notation Translation', () => {
       // parseConditional already handle it. Verify we didn't regress.
       const t = new GrammarTransformer('en', 'de');
       const result = t.transform('if $x then increment $count end');
-      expect(result).toMatch(/wenn|if/i);
+      // de `if` emits `falls` (the profile's `if` primary). `wenn` was the old dict
+      // value but collides with the profile's `when` keyword, so the conditional
+      // never formed — aligned to `falls` (see de dict if-keyword alignment, A1).
+      expect(result).toMatch(/falls|wenn|if/i);
       expect(result).toMatch(/dann|then/i);
       expect(result).toMatch(/erhöh|increment/i);
     });

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1755,3 +1755,50 @@ describe('marker-less fetch fidelity (es/pl/id/sw/he) — recover dropped fetch'
     });
   }
 });
+
+describe('de `if` keyword alignment (wenn→falls) — conditional wrapper (A1)', () => {
+  // The biggest correctness gap is control-flow body parsing; the first tractable
+  // slice is a dict↔profile mismatch (id-toggle family). The i18n de dict emitted
+  // `wenn` for `if`, but German `wenn` is the profile's `when` keyword (German `wenn`
+  // = both "if" and "when"), so a transformed `if` resolved to `when` and the `if`
+  // wrapper never formed (`if` + the conditional body dropped). Aligning the dict to
+  // the profile's `if` primary (`falls`) forms the conditional: 8 de patterns moved
+  // lossy → faithful (input-validation, if-condition, if-matches, event-key-combo,
+  // window-keydown, window-scroll, modal-close-backdrop, fetch-error-handling),
+  // avgFidelity +0.017, 0 regressions. The other if-dropping languages (reorder-split
+  // predicate, he English predicate) remain the deep structural track.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('[de] forms the if wrapper with `falls` (input-validation → faithful)', () => {
+    // Corpus-shaped transformer output (en → de), input-validation.
+    const a = actions(
+      parse(
+        'bei unscharf falls mein wert ist leer hinzufügen .error zu ich sonst entfernen .error von ich ende',
+        'de'
+      )
+    );
+    expect(a.has('if')).toBe(true);
+  });
+
+  it('[de] the colliding `wenn` resolves to `when`, not `if` (root-cause guard)', () => {
+    // `wenn` is the profile's `when` keyword, so the conditional does not form — this
+    // is why the dict had to emit `falls`.
+    const a = actions(
+      parse(
+        'bei unscharf wenn mein wert ist leer hinzufügen .error zu ich sonst entfernen .error von ich ende',
+        'de'
+      )
+    );
+    expect(a.has('if')).toBe(false);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-11T00:38:08.268Z",
-  "commit": "7b6eef2",
+  "timestamp": "2026-06-11T00:54:43.833Z",
+  "commit": "876a1a7",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -1299,16 +1299,14 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.9359995850191917,
-      "avgFidelity": 0.9194989106753811,
+      "avgConfidence": 0.9315177923021051,
+      "avgFidelity": 0.9364923747276689,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "async-block",
         "blur-element",
         "event-debounce",
-        "event-key-combo",
         "fetch-do-not-throw",
-        "fetch-error-handling",
         "fetch-loading-state",
         "fetch-with-headers",
         "first-in-parent",
@@ -1316,20 +1314,14 @@
         "form-disable-on-submit",
         "form-submit-prevent",
         "get-value",
-        "if-condition",
         "if-empty",
         "if-exists",
-        "if-matches",
-        "input-validation",
         "keydown-key-is-syntax",
-        "modal-close-backdrop",
         "put-after",
         "put-before",
         "template-literal-list-build",
         "unless-condition",
-        "when-value-changes",
-        "window-keydown",
-        "window-scroll"
+        "when-value-changes"
       ],
       "bundleSize": 405037,
       "patterns": {
@@ -1385,10 +1377,6 @@
           "success": true,
           "confidence": 1
         },
-        "if-condition": {
-          "success": true,
-          "confidence": 1
-        },
         "repeat-for-each": {
           "success": true,
           "confidence": 1
@@ -1421,19 +1409,11 @@
           "success": true,
           "confidence": 1
         },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 1
-        },
         "input-mirror": {
           "success": true,
           "confidence": 1
         },
         "input-char-count": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-validation": {
           "success": true,
           "confidence": 1
         },
@@ -1494,18 +1474,6 @@
           "confidence": 1
         },
         "fetch-loading-state": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 1
-        },
-        "if-empty": {
           "success": true,
           "confidence": 1
         },
@@ -1737,6 +1705,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "repeat-times": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -1789,6 +1761,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "accordion-toggle": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -1802,6 +1778,10 @@
           "confidence": 0.8857142857142858
         },
         "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "input-validation": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -1846,6 +1826,18 @@
           "confidence": 0.8857142857142858
         },
         "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "if-empty": {
           "success": true,
           "confidence": 0.8857142857142858
         },


### PR DESCRIPTION
## Summary

First tractable slice of the **control-flow correctness campaign** (Track A1 of `CORRECTNESS_RELIABILITY_PLAN.md`). Conditionals dropping `if`/`unless` are the biggest correctness gap (130 drops). Probing showed it's **not (only) a predicate-vocab gap** — for de it's a **dict↔profile mismatch** (the id-toggle family):

- The i18n de dict emitted `wenn` for `if`, but German `wenn` is the semantic profile's **`when`** keyword (German `wenn` = both "if" and "when"). So a transformed `if` resolved to `when`, the `if` wrapper never formed, and `if` + the conditional body dropped.
- Even with adjacent predicate vocab (de had `ist`/`leer` from Phase 1a) and no spurious-`then`, the wrapper still didn't form — because `wenn`→`when`. Spanish parses the same shape because its `if` keyword (`si`) doesn't collide.

## Fix

Align the dict to the profile's `if` primary: de `if: 'wenn' → 'falls'` (`when` untouched — separate dict entry).

## Result

**8 de patterns moved lossy → faithful**: input-validation, if-condition, if-matches, event-key-combo, window-keydown, window-scroll, modal-close-backdrop, fetch-error-handling. if-empty/if-exists went 0.6 → 0.8 (recover `if`; `put` still drops in the then-chain body — a separate Track A2 issue).

- **de avgFidelity +0.017**, gate green, **0 regressions** (only de moves, `when` patterns unaffected, 0 parse-rate drops).
- **Validated by R0's lossy ratchet** (this PR is stacked on #332): the ratchet reports **8 lossy removals, 0 additions** — the correctness gain is now machine-checked, not just asserted.

Baseline regenerated; 2 new lock tests (the `falls` fix + a `wenn`→`when` root-cause guard).

## Scope note

The other if-dropping languages need the **deep structural track**: their `if` keyword already matches, but the predicate is split by SOV/VSO reorder (hi/tl/qu/tr/ja/ko) or left English (he). Scoped in `CORRECTNESS_RELIABILITY_PLAN.md` Track A.

## Stacked PR

Based on **#332 (R0)** so the correctness gain is validated by the new lossy ratchet. Retarget to `main` once #332 merges.

## Test plan

- [x] `npx vitest run test/multilingual-roadmap-fixes.test.ts` (156 passed, incl. 2 new)
- [x] `cli.ts --full --bundle browser-priority --regression` → ✓ no regression (R0 ratchet: 8 lossy removals, 0 additions)
- [x] de `when` patterns unaffected (separate dict entry)

https://claude.ai/code/session_01SFozasxEjZ2tmw5jR5QZuk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFozasxEjZ2tmw5jR5QZuk)_