### PR TITLE
fix(semantic): de nächste→next + sw ijayo positional keywords (B1, put-positional tail)

### DIFF
--- a/packages/semantic/src/tokenizers/german.ts
+++ b/packages/semantic/src/tokenizers/german.ts
@@ -50,10 +50,14 @@ const GERMAN_EXTRAS: KeywordEntry[] = [
   { native: 'letzte', normalized: 'last' },
   { native: 'letzter', normalized: 'last' },
   { native: 'letztes', normalized: 'last' },
+  // 'nächste' means both "next" and "closest"; keyword-map insertion is last-wins,
+  // so a second 'closest' entry here would shadow 'next' and break positional
+  // expressions (`put X into next .y` — `next` is positional-capable, `closest`
+  // is not). The locative `in nächste <form/>` scope guard accepts 'next' too
+  // (POSITIONAL_OR_SCOPE_KEYWORDS), so normalizing to 'next' serves both readings.
   { native: 'nächste', normalized: 'next' },
   { native: 'nachste', normalized: 'next' },
   { native: 'vorherige', normalized: 'previous' },
-  { native: 'nächste', normalized: 'closest' },
   { native: 'eltern', normalized: 'parent' },
 
   // Events

--- a/packages/semantic/src/tokenizers/swahili.ts
+++ b/packages/semantic/src/tokenizers/swahili.ts
@@ -76,6 +76,7 @@ const SWAHILI_EXTRAS: KeywordEntry[] = [
   { native: 'wa kwanza', normalized: 'first' },
   { native: 'wa mwisho', normalized: 'last' },
   { native: 'ifuatayo', normalized: 'next' },
+  { native: 'ijayo', normalized: 'next' }, // i18n dict emits 'ijayo' for next
   { native: 'iliyotangulia', normalized: 'previous' },
   { native: 'karibu', normalized: 'closest' },
   { native: 'mzazi', normalized: 'parent' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1874,8 +1874,8 @@ describe('positional destination — `put X into next <sel>` (B1)', () => {
   // and handcrafted put patterns) rejected it, so `put X into next .y` dropped the
   // command. Making `expression` type-compatible with selector/reference (like
   // `property-path`) recovers it — fr/pt/id flip if-empty lossy→faithful; +9 langs
-  // avgFidelity, 0 regressions. (de `nächste`→`closest` and sw `ijayo` need separate
-  // positional-keyword fixes.)
+  // avgFidelity, 0 regressions. (de `nächste`→`closest` and sw `ijayo` were separate
+  // positional-keyword bugs — fixed and locked in the next describe block.)
   function actions(node: unknown, acc = new Set<string>()): Set<string> {
     if (!node || typeof node !== 'object') return acc;
     const rec = node as Record<string, unknown>;
@@ -1902,5 +1902,70 @@ describe('positional destination — `put X into next <sel>` (B1)', () => {
 
   it('[en] a positional destination still works (regression guard)', () => {
     expect(actions(parse('put "X" into next .y', 'en')).has('put')).toBe(true);
+  });
+});
+
+describe('de/sw positional keywords — nächste→next, ijayo (B1)', () => {
+  // The de/sw tail of the put-positional cluster (#337). Two tokenizer bugs made
+  // `put X into next <sel>` fail to parse at all (not just drop the command):
+  // - de: GERMAN_EXTRAS listed `nächste` twice (next, then closest). The keyword
+  //   map is keyed by native word and insertion is last-wins, so `closest`
+  //   shadowed `next` — and `closest` is not in POSITIONAL_KEYWORDS, so
+  //   tryMatchPositionalExpression never fired. Removing the duplicate restores
+  //   `nächste`→`next`; the locative `in nächste <form/>` scope guard accepts
+  //   `next` too (POSITIONAL_OR_SCOPE_KEYWORDS), so first-in-parent is unaffected.
+  // - sw: the i18n dict emits `ijayo` for `next` but the tokenizer only knew
+  //   `ifuatayo` — `ijayo` is now an additional native variant.
+  // de if-empty flips lossy→faithful (avgFid 0.9408→0.9422); sw if-empty recovers
+  // `put` (avgFid 0.9339→0.9352); all other languages byte-identical, gate green.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('[de] put with a nächste (next) destination keeps put', () => {
+    expect(actions(parse('setzen "X" zu nächste .y', 'de')).has('put')).toBe(true);
+  });
+
+  it('[sw] put with an ijayo (next) destination keeps put', () => {
+    expect(actions(parse('weka "X" kwa ijayo .y', 'sw')).has('put')).toBe(true);
+  });
+
+  it('[sw] the previously-known ifuatayo variant still works', () => {
+    expect(actions(parse('weka "X" kwa ifuatayo .y', 'sw')).has('put')).toBe(true);
+  });
+
+  it('[de] locative scope `in nächste <form/>` still parses (first-in-parent guard)', () => {
+    const a = actions(parse('bei klick fokussieren erste <input/> in nächste <form/>', 'de'));
+    expect(a.has('focus')).toBe(true);
+    expect(a.has('on')).toBe(true);
+    expect(a.has('wait')).toBe(false);
+  });
+
+  it('[de] if-empty then-chain recovers put (corpus-shaped)', () => {
+    const a = actions(
+      parse(
+        'bei unscharf wenn mein wert ist leer hinzufügen .error zu ich dann setzen "Required" zu nächste .error-message ende',
+        'de'
+      )
+    );
+    expect(a.has('put')).toBe(true);
+  });
+
+  it('[sw] if-empty then-chain recovers put (corpus-shaped)', () => {
+    const a = actions(
+      parse(
+        'kwenye poteza_macho kama yangu thamani ni tupu ongeza .error kwa mimi kisha weka "Required" kwa ijayo .error-message mwisho',
+        'sw'
+      )
+    );
+    expect(a.has('put')).toBe(true);
   });
 });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-11T17:46:55.350Z",
-  "commit": "15e39d8",
+  "timestamp": "2026-06-11T18:56:40.822Z",
+  "commit": "f671ba69",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -30,7 +30,7 @@
         "template-literal-list-build",
         "window-scroll"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -673,7 +673,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1298,7 +1298,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9359995850191917,
-      "avgFidelity": 0.9408496732026141,
+      "avgFidelity": 0.9421568627450979,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "async-block",
@@ -1311,7 +1311,6 @@
         "form-disable-on-submit",
         "form-submit-prevent",
         "get-value",
-        "if-empty",
         "if-exists",
         "keydown-key-is-syntax",
         "put-after",
@@ -1319,7 +1318,7 @@
         "template-literal-list-build",
         "when-value-changes"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1943,7 +1942,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2583,7 +2582,7 @@
         "tell-other-element",
         "template-literal-list-build"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3229,7 +3228,7 @@
         "template-literal-list-build",
         "when-value-changes"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3884,7 +3883,7 @@
         "trigger-event",
         "wait-then"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4536,7 +4535,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5194,7 +5193,7 @@
         "template-literal-interpolation",
         "template-literal-list-build"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5833,7 +5832,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6491,7 +6490,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7143,7 +7142,7 @@
         "unless-condition",
         "wait-for-event"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7804,7 +7803,7 @@
         "template-literal-interpolation",
         "template-literal-list-build"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8446,7 +8445,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -9100,7 +9099,7 @@
         "when-value-changes",
         "window-keydown"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "window-resize": {
           "success": true,
@@ -9769,7 +9768,7 @@
         "unless-condition",
         "window-scroll"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10411,7 +10410,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11036,7 +11035,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.8749947089947094,
-      "avgFidelity": 0.9338888888888888,
+      "avgFidelity": 0.9352222222222222,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "append-content",
@@ -11058,7 +11057,7 @@
         "set-color-variable",
         "template-literal-list-build"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11693,7 +11692,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12339,7 +12338,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12986,7 +12985,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13627,7 +13626,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14273,7 +14272,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14938,7 +14937,7 @@
         "two-way-binding",
         "unless-condition"
       ],
-      "bundleSize": 405573,
+      "bundleSize": 405530,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15557,7 +15556,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 405573,
+      "size": 405530,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Finishes the put-positional cluster from #337, which made positional expressions type-compatible with selector/reference destinations but deferred two per-language tokenizer bugs that made `put X into next <sel>` **fail to parse entirely** (not just drop the command):

- **de**: `GERMAN_EXTRAS` listed `nächste` twice — `next`, then `closest`. The tokenizer keyword map is keyed by native word and insertion is last-wins, so `closest` shadowed `next`; `closest` is not in `POSITIONAL_KEYWORDS`, so `tryMatchPositionalExpression` never fired and the whole put pattern failed. Removing the duplicate restores `nächste`→`next`. The locative `in nächste <form/>` scope (first-in-parent) is unaffected — the #336 duration guard accepts `next` via `POSITIONAL_OR_SCOPE_KEYWORDS` (verified by lock test).
- **sw**: the i18n dict emits `ijayo` for `next` but the tokenizer only knew `ifuatayo`, so the positional never formed. `ijayo` is now an additional native variant.

## Probe (measure-first)

| Input | Before | After |
| --- | --- | --- |
| de `setzen "X" zu nächste .y` | parse **failure** | `{put}` with positional destination |
| sw `weka "X" kwa ijayo .y` | parse **failure** | `{put}` with positional destination |
| de if-empty corpus emission | `{add, empty, on}` | `{add, empty, on, put}` |
| sw if-empty corpus emission | `{add, empty, if}` | `{add, empty, if, put}` |
| de first-in-parent (locative `in nächste <form/>`) | `{focus, on}` | `{focus, on}` (unchanged) |

## Results (full browser-priority A/B)

- **de** avgFidelity 0.9408 → 0.9422, `if-empty` **lossy → faithful**
- **sw** avgFidelity 0.9339 → 0.9352 (`if-empty` recovers the dropped `put`)
- All 21 other languages byte-identical; **0 parse-rate changes, 0 degenerate changes**; `--regression` gate green (parse-rate + fidelity + correctness ratchets)
- Baseline regenerated against a fresh `populate`; patterns.db not committed per convention
- Full semantic suite: 74 files, 5496 passed

## Lock test

`multilingual-roadmap-fixes.test.ts` → "de/sw positional keywords — nächste→next, ijayo (B1)": minimal puts for both languages, the sw `ifuatayo` variant, the de locative-scope regression guard, and both corpus-shaped if-empty emissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)