### PR TITLE
fix(i18n): align append/swap dict keywords to profile primaries (B2a, 9 langs lossy→faithful)

### DIFF
--- a/packages/i18n/src/dictionaries/ar.ts
+++ b/packages/i18n/src/dictionaries/ar.ts
@@ -52,7 +52,7 @@ export const ar: Dictionary = {
     js: 'جافاسكربت',
     async: 'متزامن',
     render: 'ارسم',
-    swap: 'بدّل',
+    swap: 'استبدل', // profile primary; 'بدّل' is toggle's word (parsed as toggle)
     morph: 'حوّل',
     settle: 'استقر',
     append: 'ألحق',

--- a/packages/i18n/src/dictionaries/es.ts
+++ b/packages/i18n/src/dictionaries/es.ts
@@ -52,7 +52,7 @@ export const es: Dictionary = {
     swap: 'intercambiar',
     morph: 'transformar',
     settle: 'estabilizar',
-    append: 'añadir',
+    append: 'anexar', // profile primary; 'añadir' is add's word (parsed as add)
     exit: 'salir',
     install: 'instalar',
     breakpoint: 'punto-interrupción',

--- a/packages/i18n/src/dictionaries/fr.ts
+++ b/packages/i18n/src/dictionaries/fr.ts
@@ -52,7 +52,7 @@ export const fr: Dictionary = {
     swap: 'échanger',
     morph: 'transformer',
     settle: 'stabiliser',
-    append: 'ajouter',
+    append: 'annexer', // profile primary; 'ajouter' is add's word (parsed as add)
     exit: 'sortir',
     install: 'installer',
     breakpoint: 'point-arrêt',

--- a/packages/i18n/src/dictionaries/id.ts
+++ b/packages/i18n/src/dictionaries/id.ts
@@ -52,7 +52,7 @@ export const id: Dictionary = {
     swap: 'tukar',
     morph: 'ubah_bentuk',
     settle: 'stabil',
-    append: 'tambah_akhir',
+    append: 'sisipkan', // profile primary; 'tambah_akhir' splits and is unrecognized
     exit: 'keluar',
     install: 'pasang',
     breakpoint: 'titik-henti',

--- a/packages/i18n/src/dictionaries/it.ts
+++ b/packages/i18n/src/dictionaries/it.ts
@@ -52,7 +52,7 @@ export const it: Dictionary = {
     swap: 'scambiare',
     morph: 'trasformare',
     settle: 'stabilizzare',
-    append: 'aggiungere',
+    append: 'accodare', // profile primary; 'aggiungere' is add's word (parsed as add)
     exit: 'uscire',
     install: 'installare',
     breakpoint: 'punto-interruzione',

--- a/packages/i18n/src/dictionaries/ko.ts
+++ b/packages/i18n/src/dictionaries/ko.ts
@@ -52,7 +52,7 @@ export const ko: Dictionary = {
     swap: '교환',
     morph: '변형',
     settle: '안정',
-    append: '추가',
+    append: '덧붙이다', // profile primary; '추가' is add's word (parsed as add)
     exit: '종료',
     install: '설치',
     breakpoint: '중단점',

--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -55,7 +55,7 @@ export const qu: Dictionary = {
     js: 'js',
     async: 'mana_suyaspa',
     render: 'rikuchiy',
-    swap: 'rantin_tikray',
+    swap: "t'inkuy", // profile primary; 'rantin_tikray' splits, 'tikray' is toggle's word
     morph: 'tikrachiy',
     settle: 'tiyay',
     append: 'qhipaman_yapay',

--- a/packages/i18n/src/dictionaries/sw.ts
+++ b/packages/i18n/src/dictionaries/sw.ts
@@ -55,7 +55,7 @@ export const sw: Dictionary = {
     swap: 'badilishana',
     morph: 'badilishaUmbo',
     settle: 'tulia',
-    append: 'ongezaMwisho',
+    append: 'ambatanisha', // profile primary; 'ongezaMwisho' is unrecognized
     exit: 'toka',
     install: 'sakinisha',
     breakpoint: 'nukta-simama',

--- a/packages/i18n/src/dictionaries/tr.ts
+++ b/packages/i18n/src/dictionaries/tr.ts
@@ -52,7 +52,7 @@ export const tr: Dictionary = {
     swap: 'takas',
     morph: 'dönüştür',
     settle: 'sabitlen',
-    append: 'ekle',
+    append: 'iliştir', // profile primary; 'ekle' is add's word (parsed as add)
     exit: 'çık',
     install: 'kur',
     breakpoint: 'kesme-noktası',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1969,3 +1969,63 @@ describe('de/sw positional keywords — nächste→next, ijayo (B1)', () => {
     expect(a.has('put')).toBe(true);
   });
 });
+
+describe('append/swap dict keyword alignment (B2a)', () => {
+  // The B2 content cluster's keyword-mismatch tail (same family as focus/socket/
+  // get/toggle): the i18n dicts emitted a word the semantic profile reads as a
+  // DIFFERENT action — or doesn't know at all — so `append`/`swap` dropped:
+  // - append parsed as `add` (the dict word IS the add-verb): es añadir,
+  //   fr ajouter, it aggiungere, ko 추가, tr ekle
+  // - append unrecognized (whole command dropped): id tambah_akhir (splits),
+  //   sw ongezaMwisho
+  // - swap parsed as `toggle`: ar بدّل; qu rantin_tikray (splits; tikray is
+  //   toggle's word)
+  // Realigning each dict to the profile primary recovers the true action; all 9
+  // flip append-/swap-content lossy → faithful (cross-lang avgFidelity
+  // 0.9347 → 0.9360), 0 regressions. Deferred (different mechanisms): the
+  // compound-split append group (bn/hi/ms/pl/ru/uk — underscore/space compounds
+  // tokenize apart and the embedded add-verb wins), the missing standalone
+  // `swap X with Y` pattern (event-body recovery is what parses it today),
+  // he `swap` (את particle), zh `swap` (把/用 markers).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped transformer emissions with the realigned dict words.
+  const appendCases: Array<[string, string]> = [
+    ['es', 'en clic anexar "<li>Item</li>" a #list'],
+    ['fr', 'sur clic annexer "<li>Item</li>" à #list'],
+    ['it', 'su clic accodare "<li>Item</li>" in #list'],
+    ['ko', '"<li>Item</li>" 를 클릭 덧붙이다 #list 에'],
+    ['tr', '"<li>Item</li>" i tıklama de iliştir #list e'],
+    ['id', 'pada klik sisipkan "<li>Item</li>" ke #list'],
+    ['sw', 'kwenye bonyeza ambatanisha "<li>Item</li>" kwa #list'],
+  ];
+  for (const [lang, input] of appendCases) {
+    it(`[${lang}] append-content parses the real append action`, () => {
+      const a = actions(parse(input, lang as 'es'));
+      expect(a.has('append')).toBe(true);
+      expect(a.has('add')).toBe(false);
+    });
+  }
+
+  const swapCases: Array<[string, string]> = [
+    ['ar', 'استبدل #a عند نقر بـ#b'],
+    ['qu', "#a ta ñitiy pi t'inkuy #b wan"],
+  ];
+  for (const [lang, input] of swapCases) {
+    it(`[${lang}] swap-content parses the real swap action`, () => {
+      const a = actions(parse(input, lang as 'ar'));
+      expect(a.has('swap')).toBe(true);
+      expect(a.has('toggle')).toBe(false);
+    });
+  }
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-11T18:56:40.822Z",
-  "commit": "f671ba69",
+  "timestamp": "2026-06-11T19:53:54.222Z",
+  "commit": "8ab00ddb",
   "languages": {
     "ar": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.9315287770881767,
-      "avgFidelity": 0.9435729847494552,
+      "avgConfidence": 0.930781811635329,
+      "avgFidelity": 0.9468409586056645,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
@@ -26,7 +26,6 @@
         "keydown-key-is-syntax",
         "modal-close-button",
         "repeat-until-event",
-        "swap-content",
         "template-literal-list-build",
         "window-scroll"
       ],
@@ -89,10 +88,6 @@
           "confidence": 1
         },
         "make-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "swap-content": {
           "success": true,
           "confidence": 1
         },
@@ -471,6 +466,10 @@
         "closest-ancestor": {
           "success": true,
           "confidence": 0.9722222222222222
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.8857142857142858
         },
         "trigger-event": {
           "success": true,
@@ -2567,10 +2566,9 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "avgFidelity": 0.9549019607843137,
+      "avgFidelity": 0.9581699346405228,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
-        "append-content",
         "fetch-do-not-throw",
         "focus-trap",
         "form-disable-on-submit",
@@ -3206,10 +3204,9 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "avgFidelity": 0.9328976034858388,
+      "avgFidelity": 0.9361655773420481,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
-        "append-content",
         "async-block",
         "blur-element",
         "caret-var-on-target",
@@ -5160,10 +5157,9 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "avgFidelity": 0.9007625272331155,
+      "avgFidelity": 0.9040305010893246,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
-        "append-content",
         "caret-var-increment",
         "fetch-do-not-throw",
         "focus-trap",
@@ -5817,10 +5813,9 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9878721859114016,
-      "avgFidelity": 0.9571895424836601,
+      "avgFidelity": 0.9604575163398692,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
-        "append-content",
         "blur-element",
         "event-debounce",
         "fetch-do-not-throw",
@@ -7115,7 +7110,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.5553391053391054,
-      "avgFidelity": 0.9173160173160174,
+      "avgFidelity": 0.9205627705627707,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -7126,7 +7121,6 @@
         "window-scroll"
       ],
       "lossyPasses": [
-        "append-content",
         "caret-var-increment",
         "decrement-counter",
         "fetch-do-not-throw",
@@ -9722,8 +9716,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7196248196248196,
-      "avgFidelity": 0.883982683982684,
+      "avgConfidence": 0.7228715728715729,
+      "avgFidelity": 0.8872294372294371,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -9760,7 +9754,6 @@
         "set-attribute",
         "set-text-basic",
         "settle-animations",
-        "swap-content",
         "tabs-basic",
         "tabs-content",
         "take-class-from-siblings",
@@ -9791,6 +9784,10 @@
           "confidence": 1
         },
         "make-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "swap-content": {
           "success": true,
           "confidence": 1
         },
@@ -10075,10 +10072,6 @@
           "confidence": 0.5
         },
         "append-content": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "swap-content": {
           "success": true,
           "confidence": 0.5
         },
@@ -11034,11 +11027,10 @@
       "parseSuccess": 150,
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
-      "avgConfidence": 0.8749947089947094,
-      "avgFidelity": 0.9352222222222222,
+      "avgConfidence": 0.8761798941798944,
+      "avgFidelity": 0.9385555555555556,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
-        "append-content",
         "blur-element",
         "event-debounce",
         "focus-trap",
@@ -11072,6 +11064,10 @@
           "confidence": 1
         },
         "put-content-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "append-content": {
           "success": true,
           "confidence": 1
         },
@@ -11472,10 +11468,6 @@
           "confidence": 0.8222222222222222
         },
         "put-after": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "append-content": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -12962,8 +12954,8 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8648511256354393,
-      "avgFidelity": 0.9410675381263616,
+      "avgConfidence": 0.8615831517792302,
+      "avgFidelity": 0.9443355119825707,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -12973,7 +12965,6 @@
       ],
       "lossyPasses": [
         "announce-screen-reader",
-        "append-content",
         "fetch-do-not-throw",
         "fetch-json",
         "focus-trap",
@@ -13020,10 +13011,6 @@
           "confidence": 1
         },
         "put-content-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "append-content": {
           "success": true,
           "confidence": 1
         },
@@ -13444,6 +13431,10 @@
           "confidence": 0.5
         },
         "put-after": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "append-content": {
           "success": true,
           "confidence": 0.5
         },


### PR DESCRIPTION
## Summary

First increment of the **B2 content cluster** (`append-content` lossy in 13 languages, `swap-content` in 11). A measure-first probe of all 24 stored translations decomposed the cluster; this PR ships its keyword-mismatch tail — the same dict↔profile family as the focus/socket/get/toggle alignments. The i18n dicts emitted a word the semantic profile reads as a **different action** (or doesn't know at all), so `append`/`swap` silently dropped:

| Group | Languages | Mechanism |
| --- | --- | --- |
| append → parsed as `add` | es `añadir`, fr `ajouter`, it `aggiungere`, ko `추가`, tr `ekle` | dict word IS the add-verb |
| append → dropped entirely | id `tambah_akhir`, sw `ongezaMwisho` | compound splits / unknown |
| swap → parsed as `toggle` | ar `بدّل`, qu `rantin_tikray` | toggle's word (qu splits; `tikray` = toggle) |

**Fix:** realign each dict entry to the semantic profile primary (es `anexar`, fr `annexer`, it `accodare`, ko `덧붙이다`, tr `iliştir`, id `sisipkan`, sw `ambatanisha`; ar `استبدل`, qu `t'inkuy`). Every substitution was probe-verified to parse the true action in corpus context before editing; collision-checked against each dict.

## Results (full browser-priority A/B)

- **All 9 languages flip `append-content`/`swap-content` lossy → faithful** — baseline diff is lossy-list removals only
- Per-language avgFidelity +0.0032–0.0034; **cross-language 0.9347 → 0.9360**
- 0 parse-rate changes, 0 degenerate changes; `--regression` gate green (parse-rate + fidelity + correctness ratchets)
- Semantic suite 74 files / 5505 passed (+9 new lock tests); i18n suite 684 passed
- Baseline regenerated against a fresh `populate`; patterns.db not committed per convention

## Deferred (different mechanisms, documented in the lock test)

- **Compound-split append group** (bn/hi/ms/pl/ru/uk): dict and profile *agree* on an underscore/space compound (`добавить_в_конец`, `जोड़ें_अंत`, `শেষে যোগ`…) but the tokenizer splits it and the embedded add-verb wins — the documented install-behavior family (BLOCK_BODY_CONDITION_SCOPE.md §2c)
- **Standalone `swap X with Y` pattern gap**: fails in every language including en-adjacent it — event-body recovery is what parses swap today
- **he swap** (`את` particle), **zh swap** (`把`/`用` markers) — language-specific marker work

🤖 Generated with [Claude Code](https://claude.com/claude-code)