### PR TITLE
test: positional-keyword guard tests — extras injectivity + dict↔tokenizer drift

### DIFF
--- a/packages/framework/src/core/tokenization/base-tokenizer.ts
+++ b/packages/framework/src/core/tokenization/base-tokenizer.ts
@@ -118,6 +118,21 @@ export abstract class BaseTokenizer implements LanguageTokenizer {
   protected profileKeywordMap: Map<string, KeywordEntry> = new Map();
 
   /**
+   * The raw EXTRAS list passed to initializeKeywordsFromProfile, kept pre-dedup.
+   * The keyword map is keyed by native word with last-wins insertion, so a
+   * duplicate native word inside the extras silently shadows the earlier entry
+   * (e.g. a `nächste→closest` entry shadowing `nächste→next` broke German
+   * positional expressions). Exposed so consistency tests can detect such
+   * intra-extras collisions, which are invisible in the deduplicated map.
+   */
+  private rawExtraEntries: KeywordEntry[] = [];
+
+  /** Raw extras as passed in, pre-dedup — for consistency tests. */
+  getExtraKeywordEntries(): readonly KeywordEntry[] {
+    return this.rawExtraEntries;
+  }
+
+  /**
    * Pluggable value extractors for domain-specific syntax.
    * When registered, BaseTokenizer will use extractor-based tokenization instead of legacy methods.
    */
@@ -330,6 +345,7 @@ export abstract class BaseTokenizer implements LanguageTokenizer {
   ): void {
     // Use a Map to deduplicate, with extras taking precedence
     const keywordMap = new Map<string, KeywordEntry>();
+    this.rawExtraEntries = extras;
 
     // Extract from keywords (command translations)
     if (profile.keywords) {

--- a/packages/i18n/src/positional-keyword-drift.test.ts
+++ b/packages/i18n/src/positional-keyword-drift.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Dict positional emissions ↔ tokenizer recognition.
+ *
+ * The i18n dictionaries' `expressions` section declares what the transformer
+ * EMITS for positional/scope concepts (first/last/next/previous/closest/
+ * parent/random); the semantic tokenizers declare what the parser RECOGNIZES.
+ * Nothing else keeps the two in sync — Swahili's dict emitted `ijayo` for
+ * `next` while the tokenizer only knew `ifuatayo`, so `put X into next <sel>`
+ * failed to parse outright (fixed in #338).
+ *
+ * For every language and concept this test tokenizes the dict emission and
+ * requires it to normalize back to that concept. Same convention as
+ * command-primary-roles.test.ts: the test imports @lokascript/semantic, but
+ * tests don't ship in the bundle.
+ *
+ * KNOWN_DRIFT below is a burn-down list of the misalignments that existed when
+ * the test was introduced (mostly `random`, the `closest` compounds, and the
+ * ru/uk positional sets — see the table in the PR that added this). Each entry
+ * suppresses the exact-match requirement for one lang:concept pair. The test
+ * also fails when an entry STARTS passing, so fixes must remove their entry —
+ * the list can only shrink. Do NOT add new entries to silence a regression;
+ * new drift means a dict emission and a tokenizer disagree and one of them is
+ * wrong.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getTokenizer } from '@lokascript/semantic';
+import { dictionaries } from './dictionaries';
+
+const POSITIONAL_CONCEPTS = [
+  'first',
+  'last',
+  'next',
+  'previous',
+  'closest',
+  'parent',
+  'random',
+] as const;
+
+/**
+ * Burn-down list (lang:concept). State as of introduction:
+ * - `random` is unrecognized by most tokenizers (no extras entry).
+ * - The `closest` superlatives/compounds (es máscercano, fr plusproche,
+ *   it piùvicino, pt mais_próximo, tr en_yakın, qu aswan_kaylla) split or
+ *   miss entirely.
+ * - ru/uk tokenizers carry no positional extras at all (all 7 concepts).
+ * - qu next/previous are CROSS-MAPPED (qhipantin→last, ñawpaqnin→first) —
+ *   likely a real dict or tokenizer bug worth its own fix.
+ * - de closest→nächste normalizes to `next` by design (one word covers both
+ *   readings; POSITIONAL_OR_SCOPE_KEYWORDS accepts either) — expected to stay.
+ * - bn/sw last (শেষ / mwisho) normalize to `end` (the block terminator) —
+ *   polysemous words claimed by the structural keyword.
+ */
+const KNOWN_DRIFT = new Set<string>([
+  'ar:parent',
+  'ar:random',
+  'bn:last',
+  'bn:random',
+  'de:closest',
+  'de:parent',
+  'de:random',
+  'es:closest',
+  'es:random',
+  'fr:closest',
+  'fr:random',
+  'hi:random',
+  'id:random',
+  'it:closest',
+  'it:parent',
+  'it:random',
+  'ja:random',
+  'ko:random',
+  'ms:random',
+  'pl:random',
+  'pt:closest',
+  'pt:random',
+  'qu:next',
+  'qu:previous',
+  'qu:closest',
+  'qu:parent',
+  'qu:random',
+  'ru:first',
+  'ru:last',
+  'ru:next',
+  'ru:previous',
+  'ru:closest',
+  'ru:parent',
+  'ru:random',
+  'sw:first',
+  'sw:last',
+  'sw:previous',
+  'sw:random',
+  'th:random',
+  'tr:closest',
+  'tr:random',
+  'uk:first',
+  'uk:last',
+  'uk:next',
+  'uk:previous',
+  'uk:closest',
+  'uk:parent',
+  'uk:random',
+  'zh:random',
+]);
+
+function normalizeEmission(lang: string, emission: string): string | null {
+  let tokenizer: ReturnType<typeof getTokenizer>;
+  try {
+    tokenizer = getTokenizer(lang);
+  } catch {
+    return null; // no tokenizer for this language — out of scope
+  }
+  try {
+    const stream = tokenizer.tokenize(emission);
+    const token = stream.peek() as { normalized?: string; value: string } | undefined | null;
+    if (!token) return '(no-token)';
+    return token.normalized ?? token.value;
+  } catch {
+    return '(tokenize-error)';
+  }
+}
+
+describe('dict positional emissions are recognized by the tokenizer', () => {
+  for (const [lang, dict] of Object.entries(dictionaries)) {
+    if (lang === 'en') continue;
+    const expressions = dict.expressions ?? {};
+    for (const concept of POSITIONAL_CONCEPTS) {
+      const emission = expressions[concept];
+      if (!emission) continue;
+      const key = `${lang}:${concept}`;
+      const expectedDrift = KNOWN_DRIFT.has(key);
+
+      it(`[${key}] '${emission}' ${expectedDrift ? 'is on the burn-down list' : `normalizes to '${concept}'`}`, () => {
+        const normalized = normalizeEmission(lang, emission);
+        if (normalized === null) return; // no tokenizer registered
+        const aligned = normalized === concept;
+        if (expectedDrift) {
+          expect(
+            aligned,
+            `[${key}] '${emission}' now normalizes to '${concept}' — the drift is fixed; ` +
+              `remove '${key}' from KNOWN_DRIFT in positional-keyword-drift.test.ts (the list only shrinks).`
+          ).toBe(false);
+        } else {
+          expect(
+            aligned,
+            `[${key}] dict emits '${emission}' but the ${lang} tokenizer normalizes it to ` +
+              `'${normalized}', not '${concept}'. The transformer emits words the parser can't ` +
+              `read as positionals (the sw 'ijayo' bug class, #338). Align the dict emission to ` +
+              `a word the tokenizer recognizes, or teach the tokenizer the dict's word.`
+          ).toBe(true);
+        }
+      });
+    }
+  }
+});

--- a/packages/semantic/src/tokenizers/swahili.ts
+++ b/packages/semantic/src/tokenizers/swahili.ts
@@ -69,7 +69,10 @@ const SWAHILI_EXTRAS: KeywordEntry[] = [
   { native: 'kweli', normalized: 'true' },
   { native: 'uongo', normalized: 'false' },
   { native: 'null', normalized: 'null' },
-  { native: 'tupu', normalized: 'null' },
+  // 'tupu' also means the null literal, but it is claimed by 'empty' below
+  // (the `ni tupu` is-empty predicate, #325). Keyword-map insertion is
+  // last-wins, so a second entry here would be dead code — see
+  // tokenizer-keyword-injectivity.test.ts.
   { native: 'haijafafanuliwa', normalized: 'undefined' },
 
   // Positional

--- a/packages/semantic/test/tokenizer-keyword-injectivity.test.ts
+++ b/packages/semantic/test/tokenizer-keyword-injectivity.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tokenizer EXTRAS injectivity guard.
+ *
+ * Each tokenizer passes a hand-maintained EXTRAS list (literals, positional
+ * words, event names, time units) to initializeKeywordsFromProfile. The
+ * combined keyword map is keyed by native word with LAST-WINS insertion, so a
+ * native word listed twice with different normalized values silently shadows
+ * the earlier entry — there is no error, no warning, and the loser is
+ * invisible in the deduplicated map.
+ *
+ * This bit us in German: GERMAN_EXTRAS carried both `nächste → next` and
+ * `nächste → closest`; `closest` won, `closest` is not positional-expression
+ * capable, and `put X into next <sel>` failed to parse outright (fixed in
+ * #338). This test makes any such intra-EXTRAS collision a hard failure.
+ *
+ * A word that legitimately covers two concepts must pick the one normalized
+ * form that serves both readings (de `nächste` → `next`: the locative scope
+ * guard accepts `next` via POSITIONAL_OR_SCOPE_KEYWORDS, so one mapping
+ * serves both) — see packages/semantic/src/tokenizers/german.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getTokenizer, getSupportedTokenizerLanguages } from '../src';
+
+interface KeywordEntryLike {
+  native: string;
+  normalized: string;
+}
+
+describe('tokenizer EXTRAS injectivity (no native word → two normalized values)', () => {
+  for (const lang of getSupportedTokenizerLanguages()) {
+    it(`[${lang}] extras map each native word to exactly one normalized value`, () => {
+      const tokenizer = getTokenizer(lang) as unknown as {
+        getExtraKeywordEntries?: () => readonly KeywordEntryLike[];
+      };
+      // Tokenizers predating initializeKeywordsFromProfile (or with no extras)
+      // simply have nothing to check.
+      const extras = tokenizer.getExtraKeywordEntries?.() ?? [];
+      const byNative = new Map<string, Set<string>>();
+      for (const e of extras) {
+        const key = e.native.toLowerCase();
+        if (!byNative.has(key)) byNative.set(key, new Set());
+        byNative.get(key)!.add(e.normalized);
+      }
+      const collisions = [...byNative.entries()]
+        .filter(([, norms]) => norms.size > 1)
+        .map(([native, norms]) => `'${native}' → {${[...norms].join(', ')}}`);
+      expect(
+        collisions,
+        `[${lang}] EXTRAS list maps one native word to multiple normalized values ` +
+          `(keyword-map insertion is last-wins, so the earlier mapping is silently dead):\n  ` +
+          collisions.join('\n  ')
+      ).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Two reliability guards for the vocabulary split-brain behind the #338 bugs. Positional words currently live in three places nothing keeps in sync — tokenizer EXTRAS lists, i18n dict `expressions`, and the matcher's normalized keyword sets — and both #338 bugs were silent drift between the first two.

### 1. EXTRAS injectivity (`packages/semantic/test/tokenizer-keyword-injectivity.test.ts`)

No tokenizer EXTRAS list may map one native word to two normalized values. Keyword-map insertion is last-wins, so the earlier entry silently dies — exactly how de `nächste→closest` shadowed `nächste→next`. `BaseTokenizer` now retains the raw pre-dedup extras (`getExtraKeywordEntries()`) so the test can see collisions the deduplicated map hides.

**It immediately caught a live one:** sw `tupu` was listed as both `null` (line 72, dead) and `empty` (line 114, live — the #325 `ni tupu` is-empty predicate depends on it). The dead entry is removed with a pointer comment; zero behavior change.

### 2. Dict↔tokenizer positional drift (`packages/i18n/src/positional-keyword-drift.test.ts`)

Every dict positional emission (first/last/next/previous/closest/parent/random) must normalize back to its concept through that language's tokenizer — the sw `ijayo` bug class. Follows the `command-primary-roles.test.ts` cross-package convention.

A dry-run revealed the latent drift is **much** larger than the two fixed bugs; it's captured in a `KNOWN_DRIFT` burn-down list (49 entries) rather than fixed here:

- `random` unrecognized in ~15 languages (no tokenizer entry)
- the `closest` superlative compounds split or miss (es `máscercano`, fr `plusproche`, it `piùvicino`, pt `mais_próximo`, tr `en_yakın`, qu `aswan_kaylla`)
- **ru/uk tokenizers carry no positional extras at all** (all 7 concepts drift)
- **qu next/previous are cross-mapped** (`qhipantin`→last, `ñawpaqnin`→first) — likely a real bug worth its own fix
- bn/sw `last` words are claimed by the `end` block terminator

The test fails on **new** drift and also fails when a listed entry **starts passing** (forcing removal), so the list can only shrink. Burning it down is follow-up fidelity work — several entries plausibly explain current lossy passes (qu `previous-element`, he `last-in-collection`).

## Validation

- i18n 837 passed (153 drift assertions), semantic 5529 passed (24 injectivity)
- Multilingual `--regression` gate green; **no baseline change** (the removed sw entry was unreachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)