### PR TITLE
fix(semantic): qu next/previous positional cross-map (drift burn-down, +2)

### DIFF
--- a/packages/i18n/src/positional-keyword-drift.test.ts
+++ b/packages/i18n/src/positional-keyword-drift.test.ts
@@ -44,8 +44,8 @@ const POSITIONAL_CONCEPTS = [
  *   it piùvicino, pt mais_próximo, tr en_yakın, qu aswan_kaylla) split or
  *   miss entirely.
  * - ru/uk tokenizers carry no positional extras at all (all 7 concepts).
- * - qu next/previous are CROSS-MAPPED (qhipantin→last, ñawpaqnin→first) —
- *   likely a real dict or tokenizer bug worth its own fix.
+ * - qu next/previous were CROSS-MAPPED (qhipantin→last, ñawpaqnin→first —
+ *   morphology bound the prefixes); fixed with exact tokenizer entries.
  * - de closest→nächste normalizes to `next` by design (one word covers both
  *   readings; POSITIONAL_OR_SCOPE_KEYWORDS accepts either) — expected to stay.
  * - bn/sw last (শেষ / mwisho) normalize to `end` (the block terminator) —
@@ -74,8 +74,6 @@ const KNOWN_DRIFT = new Set<string>([
   'pl:random',
   'pt:closest',
   'pt:random',
-  'qu:next',
-  'qu:previous',
   'qu:closest',
   'qu:parent',
   'qu:random',

--- a/packages/semantic/src/tokenizers/quechua.ts
+++ b/packages/semantic/src/tokenizers/quechua.ts
@@ -112,6 +112,12 @@ const QUECHUA_EXTRAS: KeywordEntry[] = [
   { native: 'nawpaq', normalized: 'first' },
   { native: 'qhipa', normalized: 'last' },
   { native: 'hamuq', normalized: 'next' },
+  // The i18n dict emits the -ntin/-nin derived forms ("the one after/before").
+  // Without exact entries the morphology binds their PREFIXES — qhipa(ntin)
+  // read as `last`, ñawpaq(nin) as `first` — cross-mapping next/previous.
+  // Longest-first matching makes the exact forms win.
+  { native: 'qhipantin', normalized: 'next' },
+  { native: 'ñawpaqnin', normalized: 'previous' },
   { native: 'ñawpaq kaq', normalized: 'previous' },
   { native: 'ñawpaq_kaq', normalized: 'previous' },
   { native: 'aswan qayllaqa', normalized: 'closest' },

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-11T21:44:39.585Z",
-  "commit": "fe0c1583",
+  "timestamp": "2026-06-11T21:58:05.244Z",
+  "commit": "f36f8163",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -29,7 +29,7 @@
         "template-literal-list-build",
         "window-scroll"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -672,7 +672,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1317,7 +1317,7 @@
         "template-literal-list-build",
         "when-value-changes"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1941,7 +1941,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2580,7 +2580,7 @@
         "tell-other-element",
         "template-literal-list-build"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3225,7 +3225,7 @@
         "template-literal-list-build",
         "when-value-changes"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3880,7 +3880,7 @@
         "trigger-event",
         "wait-then"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4532,7 +4532,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5189,7 +5189,7 @@
         "template-literal-interpolation",
         "template-literal-list-build"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5827,7 +5827,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6485,7 +6485,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7136,7 +7136,7 @@
         "unless-condition",
         "wait-for-event"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7797,7 +7797,7 @@
         "template-literal-interpolation",
         "template-literal-list-build"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8439,7 +8439,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -9093,7 +9093,7 @@
         "when-value-changes",
         "window-keydown"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "window-resize": {
           "success": true,
@@ -9716,8 +9716,8 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7228715728715729,
-      "avgFidelity": 0.8872294372294371,
+      "avgConfidence": 0.7326118326118326,
+      "avgFidelity": 0.8885281385281386,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -9761,7 +9761,7 @@
         "unless-condition",
         "window-scroll"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -9899,11 +9899,19 @@
           "success": true,
           "confidence": 1
         },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 1
+        },
         "input-validation": {
           "success": true,
           "confidence": 1
         },
         "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
+        "next-element": {
           "success": true,
           "confidence": 1
         },
@@ -9932,6 +9940,10 @@
           "confidence": 1
         },
         "if-empty": {
+          "success": true,
+          "confidence": 1
+        },
+        "slide-toggle": {
           "success": true,
           "confidence": 1
         },
@@ -10147,10 +10159,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "dropdown-toggle": {
-          "success": true,
-          "confidence": 0.5
-        },
         "dropdown-close-outside": {
           "success": true,
           "confidence": 0.5
@@ -10203,10 +10211,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "next-element": {
-          "success": true,
-          "confidence": 0.5
-        },
         "previous-element": {
           "success": true,
           "confidence": 0.5
@@ -10256,10 +10260,6 @@
           "confidence": 0.5
         },
         "fade-out-remove": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "slide-toggle": {
           "success": true,
           "confidence": 0.5
         },
@@ -10403,7 +10403,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11049,7 +11049,7 @@
         "set-color-variable",
         "template-literal-list-build"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11684,7 +11684,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12330,7 +12330,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12976,7 +12976,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13617,7 +13617,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14263,7 +14263,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14908,7 +14908,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405530,
+      "bundleSize": 405630,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15527,7 +15527,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 405530,
+      "size": 405630,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

First burn-down of the `KNOWN_DRIFT` list introduced in #340, fixing the entry flagged there as "likely a real bug": **qu next/previous were cross-mapped**.

The qu i18n dict emits the derived forms `qhipantin` ("the one after" = next) and `ñawpaqnin` ("the one before" = previous), but the tokenizer only knew the bare roots — morphological prefix-binding read `qhipa(ntin)` as `last` and `ñawpaq(nin)` as `first`, swapping the two positionals. Eight qu corpus patterns use these words (next-element, previous-element, input-clear, tabs-content, dropdown-toggle, if-empty, slide-toggle, toggle-aria-expanded).

## Fix

Exact tokenizer entries for both derived forms (longest-first matching prefers them over the prefix roots). `qu:next` and `qu:previous` are removed from `KNOWN_DRIFT`, so the drift test now **enforces** the alignment — that test is the lock.

## Results

- qu avgFidelity 0.8872 → 0.8885; all other languages byte-identical
- 0 parse-rate changes, 0 lossy/degenerate flips; `--regression` gate green
- Baseline regenerated against a fresh `populate`
- semantic 5538 passed, i18n 837 passed (drift test green with the shrunken list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)