### PR TITLE
fix(semantic): ru/uk positional base forms (drift burn-down, -14 entries)

### DIFF
--- a/packages/i18n/src/positional-keyword-drift.test.ts
+++ b/packages/i18n/src/positional-keyword-drift.test.ts
@@ -43,7 +43,8 @@ const POSITIONAL_CONCEPTS = [
  * - The `closest` superlatives/compounds (es máscercano, fr plusproche,
  *   it piùvicino, pt mais_próximo, tr en_yakın, qu aswan_kaylla) split or
  *   miss entirely.
- * - ru/uk tokenizers carry no positional extras at all (all 7 concepts).
+ * - ru/uk tokenizers carried only the feminine/neuter gendered variants — the
+ *   masculine nominative forms the dict emits were never listed; fixed.
  * - qu next/previous were CROSS-MAPPED (qhipantin→last, ñawpaqnin→first —
  *   morphology bound the prefixes); fixed with exact tokenizer entries.
  * - de closest→nächste normalizes to `next` by design (one word covers both
@@ -77,13 +78,6 @@ const KNOWN_DRIFT = new Set<string>([
   'qu:closest',
   'qu:parent',
   'qu:random',
-  'ru:first',
-  'ru:last',
-  'ru:next',
-  'ru:previous',
-  'ru:closest',
-  'ru:parent',
-  'ru:random',
   'sw:first',
   'sw:last',
   'sw:previous',
@@ -91,13 +85,6 @@ const KNOWN_DRIFT = new Set<string>([
   'th:random',
   'tr:closest',
   'tr:random',
-  'uk:first',
-  'uk:last',
-  'uk:next',
-  'uk:previous',
-  'uk:closest',
-  'uk:parent',
-  'uk:random',
   'zh:random',
 ]);
 

--- a/packages/semantic/src/tokenizers/russian.ts
+++ b/packages/semantic/src/tokenizers/russian.ts
@@ -103,6 +103,18 @@ const RUSSIAN_EXTRAS: KeywordEntry[] = [
   { native: 'часа', normalized: 'h' },
   { native: 'часов', normalized: 'h' },
 
+  // Positional (masculine nominative — the forms the i18n dict emits; the
+  // gendered variants below predate these but the base forms were never
+  // listed, so `последний <.message/> в #chat` never formed a positional
+  // query — see positional-keyword-drift.test.ts)
+  { native: 'первый', normalized: 'first' },
+  { native: 'последний', normalized: 'last' },
+  { native: 'следующий', normalized: 'next' },
+  { native: 'предыдущий', normalized: 'previous' },
+  { native: 'ближайший', normalized: 'closest' },
+  { native: 'родитель', normalized: 'parent' },
+  { native: 'случайный', normalized: 'random' },
+
   // Gendered forms (additional variants)
   { native: 'первая', normalized: 'first' }, // feminine
   { native: 'первое', normalized: 'first' }, // neuter

--- a/packages/semantic/src/tokenizers/ukrainian.ts
+++ b/packages/semantic/src/tokenizers/ukrainian.ts
@@ -99,6 +99,18 @@ const UKRAINIAN_EXTRAS: KeywordEntry[] = [
   { native: 'години', normalized: 'h' },
   { native: 'годин', normalized: 'h' },
 
+  // Positional (masculine nominative — the forms the i18n dict emits; the
+  // gendered variants below predate these but the base forms were never
+  // listed, so `останній <.message/> в #chat` never formed a positional
+  // query — see positional-keyword-drift.test.ts)
+  { native: 'перший', normalized: 'first' },
+  { native: 'останній', normalized: 'last' },
+  { native: 'наступний', normalized: 'next' },
+  { native: 'попередній', normalized: 'previous' },
+  { native: 'найближчий', normalized: 'closest' },
+  { native: 'батьківський', normalized: 'parent' },
+  { native: 'випадковий', normalized: 'random' },
+
   // Gendered forms (additional variants)
   { native: 'перша', normalized: 'first' }, // feminine
   { native: 'перше', normalized: 'first' }, // neuter

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-11T21:58:05.244Z",
-  "commit": "f36f8163",
+  "timestamp": "2026-06-11T22:11:36.266Z",
+  "commit": "051c7154",
   "languages": {
     "ar": {
       "parseSuccess": 153,


### PR DESCRIPTION
## Summary

Second burn-down of the `KNOWN_DRIFT` list from #340 — the largest block: all 14 ru/uk entries.

The ru/uk tokenizer EXTRAS carried only the feminine/neuter **gendered variants** of the positional adjectives (`первая`/`первое`, `перша`/`перше`, …) — but the masculine nominative **base forms the i18n dict actually emits** (`первый`, `последний`, `следующий`, `предыдущий` / `перший`, `останній`, `наступний`, `попередній`) were never listed. Whoever added the variants evidently assumed the base forms came from the profile; profiles carry no positionals. Result: no ru/uk positional query could ever form.

## Fix

The 7 base forms per language (first/last/next/previous/closest/parent/random) added to RUSSIAN_EXTRAS / UKRAINIAN_EXTRAS; all 14 ru/uk entries removed from `KNOWN_DRIFT`, so the drift test now enforces the alignment permanently.

## Honest scope

**No corpus-visible fidelity change yet** — gate green with a byte-identical baseline. The affected corpus patterns carry a second blocker: the ru/uk dict emits the scroll **noun** (`прокрутка`) where the profile primary is the **verb** (`прокрутить`/`прокрутити`) — the same noun/verb dict gap as the #321 focus fix. That realign is the immediate follow-up; with both in place `last-in-collection` (ru/uk) should flip.

Probe evidence this layer is fixed: `tokenize('последний')` now yields `normalized: 'last', kind: 'keyword'` (was a bare identifier).

## Validation

- i18n 837 passed (drift suite green with the shrunken list), semantic 5538 passed
- Multilingual `--regression` gate green; baseline byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)