### PR TITLE
fix(i18n): add ru/uk scroll command verb — flips last-in-collection (lossy→faithful ×2)

### DIFF
--- a/packages/i18n/src/dictionaries/ru.ts
+++ b/packages/i18n/src/dictionaries/ru.ts
@@ -18,6 +18,10 @@ export const russianDictionary: Dictionary = {
     toggle: 'переключить',
     hide: 'скрыть',
     show: 'показать',
+    // command verb; the events section keeps the noun прокрутка for `on scroll`.
+    // Without this entry the transformer fell back to the event noun, which the
+    // parser doesn't read as the scroll command (#321 focus family).
+    scroll: 'прокрутить',
     if: 'если',
     unless: 'если_не',
     repeat: 'повторить',

--- a/packages/i18n/src/dictionaries/uk.ts
+++ b/packages/i18n/src/dictionaries/uk.ts
@@ -18,6 +18,10 @@ export const ukrainianDictionary: Dictionary = {
     toggle: 'перемкнути',
     hide: 'сховати',
     show: 'показати',
+    // command verb; the events section keeps the noun прокрутка for `on scroll`.
+    // Without this entry the transformer fell back to the event noun, which the
+    // parser doesn't read as the scroll command (#321 focus family).
+    scroll: 'прокрутити',
     if: 'якщо',
     unless: 'якщо_не',
     repeat: 'повторити',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -2087,3 +2087,43 @@ describe('append/swap dict keyword alignment (B2a)', () => {
     });
   }
 });
+
+describe('ru/uk scroll command verb + positional query (last-in-collection)', () => {
+  // Two stacked gaps kept ru/uk last-in-collection lossy:
+  // 1. The dicts had `scroll` only in the EVENTS section (прокрутка — the noun,
+  //    correct for `on scroll`), no commands entry — so the transformer fell
+  //    back to the noun for the scroll COMMAND, which the parser doesn't read
+  //    as a verb (#321 focus family). Fixed by adding commands
+  //    scroll: прокрутить (ru) / прокрутити (uk).
+  // 2. The tokenizers carried only the feminine/neuter gendered positional
+  //    variants — the masculine nominative forms the dict emits (последний /
+  //    останній) were never listed, so `last <sel> in <scope>` couldn't form
+  //    (fixed in the ru/uk positional-extras PR; enforced by
+  //    positional-keyword-drift.test.ts).
+  // With both in place last-in-collection parses the full {on, scroll}
+  // reference in ru and uk (lossy → faithful, avgFidelity 0.9650 → 0.9683 each).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped transformer emissions with the realigned command verb.
+  it('[ru] last-in-collection recovers scroll', () => {
+    const a = actions(parse('при клик прокрутить в последний <.message/> в #chat', 'ru'));
+    expect(a.has('scroll')).toBe(true);
+    expect(a.has('on')).toBe(true);
+  });
+
+  it('[uk] last-in-collection recovers scroll', () => {
+    const a = actions(parse('при клік прокрутити в останній <.message/> у #chat', 'uk'));
+    expect(a.has('scroll')).toBe(true);
+    expect(a.has('on')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-11T22:11:36.266Z",
-  "commit": "051c7154",
+  "timestamp": "2026-06-11T22:24:00.750Z",
+  "commit": "7db54611",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -10386,7 +10386,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8947021232735521,
-      "avgFidelity": 0.9650432900432899,
+      "avgFidelity": 0.9682900432900432,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [
         "append-content",
@@ -10398,7 +10398,6 @@
         "form-submit-prevent",
         "if-empty",
         "input-validation",
-        "last-in-collection",
         "template-literal-list-build",
         "trigger-event",
         "unless-condition"
@@ -13600,7 +13599,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8939600082457227,
-      "avgFidelity": 0.9650432900432899,
+      "avgFidelity": 0.9682900432900432,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [
         "append-content",
@@ -13612,7 +13611,6 @@
         "form-submit-prevent",
         "if-empty",
         "input-validation",
-        "last-in-collection",
         "template-literal-list-build",
         "trigger-event",
         "unless-condition"


### PR DESCRIPTION
## Summary

Completes the two-layer fix started in #343. The ru/uk dicts had `scroll` only in the **events** section (`прокрутка` — the noun, correct for `on scroll`) and no **commands** entry, so the transformer fell back to the event noun for the scroll *command* — which the parser doesn't read as a verb (profile primaries are `прокрутить`/`прокрутити`). Same missing-commands-entry mechanism as the #321 focus fix.

## Fix

`commands.scroll: 'прокрутить'` (ru) / `'прокрутити'` (uk); the events noun stays untouched. Composes with #343's positional base forms: the `last <.message/> in #chat` query now forms **and** the verb parses.

## Results (full browser-priority A/B)

- `last-in-collection` **lossy → faithful in both ru and uk**; avgFidelity 0.9650 → 0.9683 each
- Baseline diff is removals only; all other languages byte-identical
- 0 parse-rate changes, 0 degenerate changes; `--regression` gate green
- semantic 5540 passed (+2 lock tests), i18n 837 passed; baseline regenerated against a fresh `populate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)