### PR TITLE
fix(i18n,semantic): compound-split append — ru/uk dict realign + pl handcrafted collision (B2b, 3 langs lossy→faithful)

### DIFF
--- a/packages/i18n/src/dictionaries/ru.ts
+++ b/packages/i18n/src/dictionaries/ru.ts
@@ -56,7 +56,7 @@ export const russianDictionary: Dictionary = {
     swap: 'поменять',
     morph: 'трансформировать',
     settle: 'стабилизировать',
-    append: 'добавить_в_конец',
+    append: 'дописать', // profile alternative; the compound splits and добавить parses as add
     exit: 'выйти',
     else: 'иначе',
     install: 'установить',

--- a/packages/i18n/src/dictionaries/uk.ts
+++ b/packages/i18n/src/dictionaries/uk.ts
@@ -56,7 +56,7 @@ export const ukrainianDictionary: Dictionary = {
     swap: 'поміняти',
     morph: 'трансформувати',
     settle: 'стабілізувати',
-    append: 'додати_в_кінець',
+    append: 'дописати', // profile alternative; the compound splits and додати parses as add
     exit: 'вийти',
     else: 'інакше',
     install: 'встановити',

--- a/packages/semantic/src/patterns/add.ts
+++ b/packages/semantic/src/patterns/add.ts
@@ -195,7 +195,11 @@ function getAddPatternsPl(): LanguagePattern[] {
       template: {
         format: 'dodaj {patient} do {destination}',
         tokens: [
-          { type: 'literal', value: 'dodaj', alternatives: ['dołącz', 'dolacz'] },
+          // 'dołącz'/'dolacz' removed: the pl profile claims dołącz as APPEND's
+          // primary, but listing it here made the higher-priority handcrafted
+          // add pattern shadow the generated append pattern — append-content
+          // parsed as add. The tokenizer already normalizes dołącz → append.
+          { type: 'literal', value: 'dodaj' },
           { type: 'role', role: 'patient' },
           {
             type: 'group',
@@ -224,7 +228,8 @@ function getAddPatternsPl(): LanguagePattern[] {
       template: {
         format: 'dodaj {patient}',
         tokens: [
-          { type: 'literal', value: 'dodaj', alternatives: ['dołącz', 'dolacz'] },
+          // dołącz/dolacz removed — they are append's words (see add-pl-full).
+          { type: 'literal', value: 'dodaj' },
           { type: 'role', role: 'patient' },
         ],
       },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -2127,3 +2127,50 @@ describe('ru/uk scroll command verb + positional query (last-in-collection)', ()
     expect(a.has('on')).toBe(true);
   });
 });
+
+describe('compound-split append — ru/uk dict realign + pl handcrafted collision (B2b)', () => {
+  // The compound-split tail of the B2a append cluster. Three languages where
+  // append-content stayed lossy AFTER the B2a realigns, for two reasons:
+  // - ru/uk: dict and profile AGREED on an underscore compound
+  //   (добавить_в_конец / додати_в_кінець), but the tokenizer splits it and the
+  //   embedded add-verb wins — the same splitting that broke ms tambah_hujung.
+  //   Realigned the dicts to the profiles' single-word ALTERNATIVE
+  //   (дописать / дописати), which parses as append directly.
+  // - pl: dict, profile, and tokenizer all agree dołącz = append — but the
+  //   HANDCRAFTED add-pl-full/add-pl-simple patterns listed dołącz/dolacz as
+  //   add-verb alternatives (predating the profile's append entry), and the
+  //   higher-priority handcrafted match shadowed the generated append pattern.
+  //   Removed the stale alternatives.
+  // pl/ru/uk append-content lossy → faithful; cross-lang avgFidelity
+  // 0.9392 → 0.9397; 0 regressions. Remaining compound-split append languages
+  // (bn শেষে যোগ, hi जोड़ें_अंत, ms tambah_hujung) need NEW single-word native
+  // vocabulary in both profile and dict — deferred.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  const cases: Array<[string, string]> = [
+    ['ru', 'при клик дописать "<li>Item</li>" в #list'],
+    ['uk', 'при клік дописати "<li>Item</li>" в #list'],
+    ['pl', 'gdy kliknięcie dołącz "<li>Item</li>" do #list'],
+  ];
+  for (const [lang, input] of cases) {
+    it(`[${lang}] append-content parses the real append action`, () => {
+      const a = actions(parse(input, lang as 'ru'));
+      expect(a.has('append')).toBe(true);
+      expect(a.has('add')).toBe(false);
+    });
+  }
+
+  it('[pl] plain add still parses (regression guard)', () => {
+    expect(actions(parse('dodaj .highlight do #item', 'pl')).has('add')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-11T22:24:00.750Z",
-  "commit": "7db54611",
+  "timestamp": "2026-06-11T22:52:57.504Z",
+  "commit": "b086e388",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -8417,10 +8417,9 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.828685548293392,
-      "avgFidelity": 0.9374727668845316,
+      "avgFidelity": 0.9407407407407408,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
-        "append-content",
         "blur-element",
         "fetch-do-not-throw",
         "focus-trap",
@@ -10386,10 +10385,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8947021232735521,
-      "avgFidelity": 0.9682900432900432,
+      "avgFidelity": 0.9715367965367964,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [
-        "append-content",
         "event-debounce",
         "fetch-do-not-throw",
         "fetch-loading-state",
@@ -13599,10 +13597,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8939600082457227,
-      "avgFidelity": 0.9682900432900432,
+      "avgFidelity": 0.9715367965367964,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [
-        "append-content",
         "event-debounce",
         "fetch-do-not-throw",
         "fetch-loading-state",


### PR DESCRIPTION
## Summary

The compound-split tail of the B2a append cluster (#339): three more languages flip `append-content` lossy → faithful. Two distinct causes within the family, both probe-confirmed:

### ru/uk — compound splits, embedded add-verb wins

Dict and profile **agreed** on an underscore compound (`добавить_в_конец` / `додати_в_кінець`), but the tokenizer splits compounds and the embedded add-verb won — append parsed as `add`. Fixed by realigning the dicts to the profiles' existing single-word **alternative** (`дописать` / `дописати`), which parses as append directly.

### pl — handcrafted pattern collision

Dict, profile, and tokenizer all agree `dołącz` = append (the tokenizer even normalizes it correctly) — but the handcrafted `add-pl-full`/`add-pl-simple` patterns listed `dołącz`/`dolacz` as add-verb **alternatives** (predating the profile's append entry), so the higher-priority handcrafted match shadowed the generated append pattern. Removed the stale alternatives; plain `dodaj` add is regression-guarded.

## Results (full browser-priority A/B)

- pl avgFidelity 0.9375 → 0.9407, ru 0.9683 → 0.9715, uk 0.9683 → 0.9715 — `append-content` lossy → faithful in all three
- Cross-language avgFidelity **0.9392 → 0.9397**; baseline diff is removals only
- 0 parse-rate changes, 0 degenerate changes; `--regression` gate green
- semantic 5544 passed (+4 lock tests), i18n 837 passed; baseline regenerated against a fresh `populate`

## Deferred

bn (`শেষে যোগ`), hi (`जोड़ें_अंत`), ms (`tambah_hujung`) — the same compound-splitting, but no existing single-word alternative in their profiles; fixing them means choosing new native vocabulary for both profile and dict, a separate (judgment-heavier) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)