### PR TITLE
fix(semantic): emission-shaped generated swap patterns — flips swap-content lossy→faithful ×8

### DIFF
--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -1950,7 +1950,30 @@ export const swapSchema: CommandSchema = {
       expectedTypes: ['selector', 'reference'],
       svoPosition: 2,
       sovPosition: 1,
-      markerOverride: { en: 'of' }, // "swap innerHTML of #target"
+      // The i18n transformer emits the element-swap shape `swap X with Y` with
+      // an UNMARKED destination right after the verb (`intercambiar #a con #b`),
+      // not the profile's destination preposition (`intercambiar en #a`), so the
+      // generated patterns never matched any transformer output. SVO languages
+      // override to the emission shape: bare destination (he marks it with the
+      // direct-object particle את, zh with 把).
+      markerOverride: {
+        en: 'of', // "swap innerHTML of #target"
+        es: '',
+        fr: '',
+        pt: '',
+        it: '',
+        de: '',
+        pl: '',
+        ru: '',
+        uk: '',
+        id: '',
+        ms: '',
+        sw: '',
+        th: '',
+        vi: '',
+        he: 'את', // "החלף את #a עם #b" — direct-object particle
+        zh: '把', // "交换 把 #a 用 #b" — BA object marker
+      },
     },
     {
       role: 'patient',
@@ -1959,7 +1982,26 @@ export const swapSchema: CommandSchema = {
       expectedTypes: ['literal', 'expression', 'selector'],
       svoPosition: 3,
       sovPosition: 2,
-      markerOverride: { en: 'with' }, // "swap innerHTML of #target with <html>"
+      // Patient takes each language's with-word (matching the i18n dicts'
+      // `with` emission), so `swap {destination} with {patient}` parses.
+      markerOverride: {
+        en: 'with', // "swap innerHTML of #target with <html>"
+        es: 'con',
+        fr: 'avec',
+        pt: 'com',
+        it: 'con',
+        de: 'mit',
+        pl: 'z',
+        ru: 'с',
+        uk: 'з',
+        id: 'dengan',
+        ms: 'dengan',
+        sw: 'na',
+        th: 'ด้วย',
+        vi: 'với',
+        he: 'עם',
+        zh: '用',
+      },
     },
   ],
 };

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -2174,3 +2174,100 @@ describe('compound-split append — ru/uk dict realign + pl handcrafted collisio
     expect(actions(parse('dodaj .highlight do #item', 'pl')).has('add')).toBe(true);
   });
 });
+
+describe('Generated swap patterns match the transformer emission shape (swap pattern gap)', () => {
+  // The swap-content mystery: NO generated swap pattern matched any transformer
+  // output, in any language. swapSchema's destination carried the profile's
+  // destination preposition (es `intercambiar en #a`), but the i18n transformer
+  // emits the element-swap shape with an UNMARKED destination and a with-marked
+  // patient (`intercambiar #a con #b` — en source `swap #a with #b`). The
+  // faithful languages only survived via side paths: de/ru/sw/th/uk/vi through
+  // the fused `swap-event-*-vso` pattern (their event-marker emission happens to
+  // match the pattern's primary), it through event-handler-it-full's {action}
+  // role (the captured verb becomes the command node directly). Languages whose
+  // handcrafted event pattern captures only {event} (es/fr/pl/id/ms/zh) or whose
+  // generic on-pattern wins (pt/he) re-parse the body with command patterns —
+  // where the dead generated swap pattern failed, silently dropping `swap`.
+  //
+  // Fix: swapSchema destination/patient markerOverride now mirror the emission
+  // shape for SVO languages — bare destination after the verb (he marks it את,
+  // zh 把) and the language's with-word before the patient. Flips swap-content
+  // lossy → faithful in es/fr/he/id/ms/pl/pt/zh (8 instances, avgFidelity
+  // +0.0033 each); 0 regressions. Deferred (separate mechanisms): hi (dict emits
+  // बदलें, which parses as toggle — keyword-collision family), SOV/VSO languages
+  // (already faithful via fused event patterns; sovPosition order unchanged).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Standalone bodies (then-chain / event-body re-parse shape). These parsed as
+  // NOTHING before the fix — the generated pattern could never match.
+  const standalone: Array<[string, string]> = [
+    ['es', 'intercambiar #a con #b'],
+    ['fr', 'échanger #a avec #b'],
+    ['pt', 'trocar #a com #b'],
+    ['pl', 'zamień #a z #b'],
+    ['id', 'tukar #a dengan #b'],
+    ['ms', 'tukar_tempat #a dengan #b'],
+    ['he', 'החלף את #a עם #b'],
+    ['zh', '交换 把 #a 用 #b'],
+  ];
+  for (const [lang, input] of standalone) {
+    it(`[${lang}] standalone "swap X with Y" parses as swap`, () => {
+      expect(parse(input, lang as 'es').action).toBe('swap');
+    });
+  }
+
+  // Full corpus emissions (en: `on click swap #a with #b`) — the handler body
+  // must keep the swap action (this is the lossy→faithful flip).
+  const fullHandlers: Array<[string, string]> = [
+    ['es', 'en clic intercambiar #a con #b'],
+    ['fr', 'sur clic échanger #a avec #b'],
+    ['pt', 'em clique trocar #a com #b'],
+    ['pl', 'gdy kliknięcie zamień #a z #b'],
+    ['id', 'pada klik tukar #a dengan #b'],
+    ['ms', 'apabila click tukar_tempat #a dengan #b'],
+    ['he', 'ב לחיצה החלף את #a עם #b'],
+    ['zh', '当 点击 时 交换 把 #a 用 #b'],
+  ];
+  for (const [lang, input] of fullHandlers) {
+    it(`[${lang}] swap-content handler keeps the swap action`, () => {
+      const a = actions(parse(input, lang as 'es'));
+      expect(a.has('on')).toBe(true);
+      expect(a.has('swap')).toBe(true);
+    });
+  }
+
+  // Regression guards.
+  it('[pt] alternar still parses as toggle (trocar belongs to swap now)', () => {
+    expect(parse('alternar .active', 'pt').action).toBe('toggle');
+    // trocar is the pt profile/dict swap primary — the stale toggle reading is gone.
+    expect(parse('trocar .visible', 'pt').action).toBe('swap');
+  });
+
+  it('[en] the en swap forms are unchanged', () => {
+    expect(parse('swap #a with #b', 'en').action).toBe('swap');
+    const a = actions(parse('on click swap #a with #b', 'en'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('swap')).toBe(true);
+  });
+
+  it('[de/ru] previously-faithful fused-event languages stay faithful', () => {
+    for (const [lang, input] of [
+      ['de', 'bei klick tauschen #a mit #b'],
+      ['ru', 'при клик поменять #a с #b'],
+    ] as Array<[string, string]>) {
+      const a = actions(parse(input, lang as 'de'));
+      expect(a.has('on')).toBe(true);
+      expect(a.has('swap')).toBe(true);
+    }
+  });
+});

--- a/packages/semantic/test/portuguese-idioms.test.ts
+++ b/packages/semantic/test/portuguese-idioms.test.ts
@@ -296,11 +296,14 @@ describe('Portuguese Command Patterns', () => {
       }
     });
 
-    it('should parse "trocar .visible"', () => {
+    it('should parse "trocar .visible" as swap (trocar is the pt swap primary)', () => {
+      // The pt profile and i18n dict both assign trocar = swap (toggle is
+      // alternar, no alternatives). The old toggle expectation predated the
+      // emission-shaped generated swap patterns, which now claim the verb.
       const result = canParse('trocar .visible', 'pt');
       if (result) {
         const node = parse('trocar .visible', 'pt');
-        expect(node.action).toBe('toggle');
+        expect(node.action).toBe('swap');
       } else {
         const tokens = getTokens('trocar .visible', 'pt');
         expect(tokens.length).toBeGreaterThan(0);

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-11T22:52:57.504Z",
-  "commit": "b086e388",
+  "timestamp": "2026-06-11T23:39:10.944Z",
+  "commit": "23cf40b2",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -29,7 +29,7 @@
         "template-literal-list-build",
         "window-scroll"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -672,7 +672,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1317,7 +1317,7 @@
         "template-literal-list-build",
         "when-value-changes"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1941,7 +1941,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2566,7 +2566,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "avgFidelity": 0.9581699346405228,
+      "avgFidelity": 0.9614379084967319,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "fetch-do-not-throw",
@@ -2575,12 +2575,11 @@
         "form-submit-prevent",
         "if-exists",
         "modal-close-backdrop",
-        "swap-content",
         "tell-command",
         "tell-other-element",
         "template-literal-list-build"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3204,7 +3203,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "avgFidelity": 0.9361655773420481,
+      "avgFidelity": 0.9394335511982572,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "async-block",
@@ -3219,13 +3218,12 @@
         "modal-close-backdrop",
         "put-after",
         "put-before",
-        "swap-content",
         "tell-command",
         "tell-other-element",
         "template-literal-list-build",
         "when-value-changes"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -3849,7 +3847,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8452847805788988,
-      "avgFidelity": 0.9137254901960785,
+      "avgFidelity": 0.9169934640522877,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
@@ -3873,14 +3871,13 @@
         "send-event-to-form",
         "send-with-detail",
         "socket-send",
-        "swap-content",
         "tell-command",
         "tell-other-element",
         "template-literal-list-build",
         "trigger-event",
         "wait-then"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4532,7 +4529,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5157,7 +5154,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.989034132171387,
-      "avgFidelity": 0.9040305010893246,
+      "avgFidelity": 0.9072984749455337,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "caret-var-increment",
@@ -5183,13 +5180,12 @@
         "set-style",
         "set-transform",
         "settle-animations",
-        "swap-content",
         "tell-command",
         "tell-other-element",
         "template-literal-interpolation",
         "template-literal-list-build"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5827,7 +5823,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6485,7 +6481,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7136,7 +7132,7 @@
         "unless-condition",
         "wait-for-event"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7761,7 +7757,7 @@
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.998806860551827,
-      "avgFidelity": 0.9147651006711408,
+      "avgFidelity": 0.9181208053691274,
       "degeneratePasses": [],
       "lossyPasses": [
         "async-block",
@@ -7791,13 +7787,12 @@
         "set-opacity",
         "set-style",
         "set-transform",
-        "swap-content",
         "tell-command",
         "tell-other-element",
         "template-literal-interpolation",
         "template-literal-list-build"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -8417,7 +8412,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.828685548293392,
-      "avgFidelity": 0.9407407407407408,
+      "avgFidelity": 0.9440087145969499,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "blur-element",
@@ -8431,14 +8426,13 @@
         "if-matches",
         "keydown-key-is-syntax",
         "modal-close-backdrop",
-        "swap-content",
         "tell-command",
         "tell-other-element",
         "template-literal-list-build",
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "window-scroll": {
           "success": true,
@@ -9062,7 +9056,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8344952795933194,
-      "avgFidelity": 0.9228758169934642,
+      "avgFidelity": 0.9261437908496734,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
@@ -9084,7 +9078,6 @@
         "modal-close-backdrop",
         "put-after",
         "put-before",
-        "swap-content",
         "tell-command",
         "tell-other-element",
         "template-literal-list-build",
@@ -9092,7 +9085,7 @@
         "when-value-changes",
         "window-keydown"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "window-resize": {
           "success": true,
@@ -9760,7 +9753,7 @@
         "unless-condition",
         "window-scroll"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10400,7 +10393,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11046,7 +11039,7 @@
         "set-color-variable",
         "template-literal-list-build"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11681,7 +11674,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12327,7 +12320,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12973,7 +12966,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13612,7 +13605,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14258,7 +14251,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14883,7 +14876,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.9988148148148148,
-      "avgFidelity": 0.9582222222222223,
+      "avgFidelity": 0.9615555555555556,
       "degeneratePasses": [],
       "lossyPasses": [
         "fetch-do-not-throw",
@@ -14896,14 +14889,13 @@
         "put-after",
         "put-before",
         "set-color-variable",
-        "swap-content",
         "take-class-from-siblings",
         "tell-command",
         "tell-other-element",
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 405630,
+      "bundleSize": 405921,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15522,7 +15514,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 405630,
+      "size": 405921,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## The swap pattern gap (the open mystery, resolved)

No generated swap pattern matched any transformer output, **in any language**. The measure-first probe traced it to a shape mismatch:

- `swapSchema`'s destination role carried the profile's destination preposition, so generated patterns demanded e.g. es `intercambiar **en** #a`
- the i18n transformer emits the element-swap shape: **unmarked destination, with-marked patient** — `intercambiar #a **con** #b` (en source: `swap #a with #b`)

The two could never meet, so the standalone `swap X with Y` body parsed as nothing in all 23 languages.

### Why de/it/ru/sw still recovered (the recovery split)

- **de/ru/sw/th/uk/vi**: the fused `swap-event-*-vso` generated pattern matched — their event-marker emission happens to equal the pattern's primary (`bei`/`при`/…)
- **it**: `event-handler-it-full` captures an `{action}` role; the verb (`scambiare`, normalized → swap) becomes a command node directly — no body re-parse needed
- **es/fr/pl/id/ms/zh/pt/he**: their winning event pattern captures only `{event}` and re-parses the body with command patterns — where the dead generated swap pattern failed, silently dropping `swap` (lossy 0.5, invisible to the degenerate ratchet)

### Fix (one mechanism)

`swapSchema` destination/patient `markerOverride` now mirror the emission shape for SVO languages: bare destination after the verb (he marks it `את`, zh `把`), and each language's with-word before the patient (`con`/`avec`/`com`/`z`/`dengan`/`na`/`mit`/`с`/`з`/`עם`/`用`/`ด้วย`/`với`).

### A/B (same DB, full browser-priority bundle)

| | base | new |
|---|---|---|
| swap-content fid | 0.5 in es/fr/he/id/ms/pl/pt/zh | **1.0** |
| avgFidelity | — | **+0.0033** in each of the 8 |
| drops / flips | — | **0 / 0**, regression gate green |

pt idiom test updated: `trocar` is the pt profile **and** dict swap primary (toggle is `alternar`, no alternatives) — the old `trocar .visible → toggle` expectation predated the schema's swap vocabulary (same stale-shadow family as pl `dołącz`).

Deferred (separate mechanisms): **hi** swap (dict emits `बदलें` which parses as toggle — keyword-collision family, pairs with the bn/hi/ms append-vocabulary target); **SOV/VSO** languages unchanged (already faithful via fused event patterns; sovPosition untouched).

Lock test added in `multilingual-roadmap-fixes.test.ts` (8 standalone + 8 full-handler cases + en/pt/de/ru regression guards). Baseline regenerated; patterns.db not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)