### PR TITLE
fix(i18n,semantic): closest compound alignment — es/fr/it/pt/tr/qu (drift burn-down, -6 entries)

### DIFF
--- a/packages/i18n/src/dictionaries/es.ts
+++ b/packages/i18n/src/dictionaries/es.ts
@@ -192,7 +192,7 @@ export const es: Dictionary = {
     prev: 'ant',
     at: 'en',
     random: 'aleatorio',
-    closest: 'máscercano',
+    closest: 'cercano',
     parent: 'padre',
     children: 'hijos',
     within: 'dentro',

--- a/packages/i18n/src/dictionaries/fr.ts
+++ b/packages/i18n/src/dictionaries/fr.ts
@@ -193,7 +193,7 @@ export const fr: Dictionary = {
     prev: 'préc',
     at: 'à',
     random: 'aléatoire',
-    closest: 'plusproche',
+    closest: 'proche',
     parent: 'parent',
     children: 'enfants',
     within: 'dans',

--- a/packages/i18n/src/dictionaries/it.ts
+++ b/packages/i18n/src/dictionaries/it.ts
@@ -192,7 +192,7 @@ export const it: Dictionary = {
     prev: 'prec',
     at: 'a',
     random: 'casuale',
-    closest: 'piùvicino',
+    closest: 'vicino',
     parent: 'genitore',
     children: 'figli',
     within: 'dentro',

--- a/packages/i18n/src/dictionaries/pt.ts
+++ b/packages/i18n/src/dictionaries/pt.ts
@@ -194,7 +194,7 @@ export const pt: Dictionary = {
     prev: 'ant',
     at: 'em',
     random: 'aleatório',
-    closest: 'mais_próximo',
+    closest: 'maispróximo',
     parent: 'pai',
     children: 'filhos',
     within: 'dentro',

--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -199,7 +199,7 @@ export const qu: Dictionary = {
     prev: 'ñawpaq',
     at: 'pi',
     random: 'imaymanata',
-    closest: 'aswan_kaylla',
+    closest: 'kaylla',
     parent: 'mama_tayta',
     children: 'wawakuna',
     within: 'ukupi',

--- a/packages/i18n/src/dictionaries/tr.ts
+++ b/packages/i18n/src/dictionaries/tr.ts
@@ -193,7 +193,7 @@ export const tr: Dictionary = {
     prev: 'önc',
     at: 'de',
     random: 'rastgele',
-    closest: 'en_yakın',
+    closest: 'enyakın',
     parent: 'ebeveyn',
     children: 'çocuklar',
     within: 'içinde',

--- a/packages/i18n/src/examples/new-languages.ts
+++ b/packages/i18n/src/examples/new-languages.ts
@@ -100,7 +100,7 @@ export const quechuaExamples = {
 
   elements: {
     original: 'on mouseenter tell closest .card to add .highlight',
-    translated: 'rat_yaykuy kaqpi niy aswan_kaylla .card man yapay .highlight',
+    translated: 'rat_yaykuy kaqpi niy kaylla .card man yapay .highlight',
     description: 'Element communication',
   },
 

--- a/packages/i18n/src/new-languages.test.ts
+++ b/packages/i18n/src/new-languages.test.ts
@@ -154,7 +154,9 @@ describe('New Language Support', () => {
         to: 'qu',
       });
       expect(result).toContain('niy'); // tell → niy
-      expect(result).toContain('aswan_kaylla'); // closest → aswan_kaylla
+      // closest → kaylla (single token the qu tokenizer recognizes; the old
+      // aswan_kaylla compound split as as+wan+_+kaylla and never parsed)
+      expect(result).toContain('kaylla');
     });
 
     it('should support pluralization', () => {

--- a/packages/i18n/src/positional-keyword-drift.test.ts
+++ b/packages/i18n/src/positional-keyword-drift.test.ts
@@ -42,7 +42,10 @@ const POSITIONAL_CONCEPTS = [
  * - `random` is unrecognized by most tokenizers (no extras entry).
  * - The `closest` superlatives/compounds (es máscercano, fr plusproche,
  *   it piùvicino, pt mais_próximo, tr en_yakın, qu aswan_kaylla) split or
- *   miss entirely.
+ *   missed entirely — the tokenizer never matches multi-word/underscore
+ *   natives, so the old tokenizer entries were dead. Fixed by aligning each
+ *   dict to a single token the tokenizer recognizes (es cercano, fr proche,
+ *   it vicino, pt maispróximo, tr enyakın, qu kaylla).
  * - ru/uk tokenizers carried only the feminine/neuter gendered variants — the
  *   masculine nominative forms the dict emits were never listed; fixed.
  * - qu next/previous were CROSS-MAPPED (qhipantin→last, ñawpaqnin→first —
@@ -60,22 +63,17 @@ const KNOWN_DRIFT = new Set<string>([
   'de:closest',
   'de:parent',
   'de:random',
-  'es:closest',
   'es:random',
-  'fr:closest',
   'fr:random',
   'hi:random',
   'id:random',
-  'it:closest',
   'it:parent',
   'it:random',
   'ja:random',
   'ko:random',
   'ms:random',
   'pl:random',
-  'pt:closest',
   'pt:random',
-  'qu:closest',
   'qu:parent',
   'qu:random',
   'sw:first',
@@ -83,7 +81,6 @@ const KNOWN_DRIFT = new Set<string>([
   'sw:previous',
   'sw:random',
   'th:random',
-  'tr:closest',
   'tr:random',
   'zh:random',
 ]);

--- a/packages/semantic/src/tokenizers/french.ts
+++ b/packages/semantic/src/tokenizers/french.ts
@@ -52,7 +52,9 @@ const FRENCH_EXTRAS: KeywordEntry[] = [
   { native: 'suivant', normalized: 'next' },
   { native: 'précédent', normalized: 'previous' },
   { native: 'precedent', normalized: 'previous' },
-  { native: 'plus proche', normalized: 'closest' },
+  // Single token only — the tokenizer never matches multi-word natives, so the
+  // old 'plus proche' entry was dead. The i18n dict emits 'proche'.
+  { native: 'proche', normalized: 'closest' },
   { native: 'parent', normalized: 'parent' },
 
   // Events

--- a/packages/semantic/src/tokenizers/portuguese.ts
+++ b/packages/semantic/src/tokenizers/portuguese.ts
@@ -76,8 +76,11 @@ const PORTUGUESE_EXTRAS: KeywordEntry[] = [
   { native: 'próximo', normalized: 'next' },
   { native: 'proximo', normalized: 'next' },
   { native: 'anterior', normalized: 'previous' },
-  { native: 'mais próximo', normalized: 'closest' },
-  { native: 'mais proximo', normalized: 'closest' },
+  // Single token only — the tokenizer never matches multi-word natives, so the
+  // old 'mais próximo' entries were dead. Fused form matches the i18n dict
+  // ('próximo' alone is claimed by next).
+  { native: 'maispróximo', normalized: 'closest' },
+  { native: 'maisproximo', normalized: 'closest' },
   { native: 'pai', normalized: 'parent' },
 
   // Events

--- a/packages/semantic/src/tokenizers/quechua.ts
+++ b/packages/semantic/src/tokenizers/quechua.ts
@@ -120,7 +120,11 @@ const QUECHUA_EXTRAS: KeywordEntry[] = [
   { native: 'ñawpaqnin', normalized: 'previous' },
   { native: 'ñawpaq kaq', normalized: 'previous' },
   { native: 'ñawpaq_kaq', normalized: 'previous' },
-  { native: 'aswan qayllaqa', normalized: 'closest' },
+  // Single token only — 'aswan qayllaqa' (multi-word) was dead, and any
+  // aswan-prefixed compound splits (the suffix extractor strips -wan from
+  // 'aswan'). The i18n dict emits bare 'kaylla' (near/close).
+  { native: 'kaylla', normalized: 'closest' },
+  { native: 'qaylla', normalized: 'closest' },
   { native: 'tayta', normalized: 'parent' },
 
   // Events

--- a/packages/semantic/src/tokenizers/turkish.ts
+++ b/packages/semantic/src/tokenizers/turkish.ts
@@ -110,8 +110,10 @@ const TURKISH_EXTRAS: KeywordEntry[] = [
   { native: 'sonraki', normalized: 'next' },
   { native: 'önceki', normalized: 'previous' },
   { native: 'onceki', normalized: 'previous' },
-  { native: 'en_yakın', normalized: 'closest' },
-  { native: 'en_yakin', normalized: 'closest' },
+  // Fused single token — the tokenizer splits on '_', so the old 'en_yakın'
+  // entries were dead. The i18n dict emits the fused superlative.
+  { native: 'enyakın', normalized: 'closest' },
+  { native: 'enyakin', normalized: 'closest' },
   { native: 'ebeveyn', normalized: 'parent' },
 
   // Complex event names (multi-word events not in profile)


### PR DESCRIPTION
## Two-sided dead drift

The `closest` superlatives/compounds were misaligned on **both** sides:

- the dicts emitted fused/underscore compounds (`máscercano`, `plusproche`, `piùvicino`, `mais_próximo`, `en_yakın`, `aswan_kaylla`) that the tokenizers split or never recognized
- the tokenizers carried multi-word natives (`plus proche`, `mais próximo`, `aswan qayllaqa`, and tr's literal `en_yakın`) that the keyword matcher can **never** match — probed: the first token always comes back a bare identifier. (ms-style underscore compounds match only in tokenizers whose word-chars include `_`; pt/tr/qu split.)

qu was worst: `aswan` itself splits as `as`+`wan` (`wan` is the style particle suffix), so no aswan-prefixed compound can survive tokenization.

## Fix (one mechanism — the sw `ijayo` class, #338)

Align each dict to a single token and give the tokenizer the matching entry:

| lang | dict emission (old → new) | tokenizer |
|---|---|---|
| es | máscercano → **cercano** | already aligned (profile) |
| it | piùvicino → **vicino** | entry pre-existed |
| fr | plusproche → **proche** | added (replaced dead `plus proche`) |
| pt | mais_próximo → **maispróximo** | added ×2 (`próximo` is claimed by `next`) |
| tr | en_yakın → **enyakın** | added ×2 (replaced dead underscore entries) |
| qu | aswan_kaylla → **kaylla** | added `kaylla`/`qaylla` |

All 6 `lang:closest` entries removed from `KNOWN_DRIFT` — the drift test now enforces the alignment permanently (the list only shrinks).

## A/B

No corpus-visible fidelity change (results byte-identical to baseline, regression gate green) — the closest corpus patterns (`first-in-parent`, `focus-trap`) carry the **second blocker**, the B1 positional `first … in closest …` query structure. Same stacked-mechanism shape as #343 (ru/uk positional forms → scroll verb follow-up): this PR clears the lexical layer; B1 is the structural follow-up.

semantic 5563 + i18n 837 passed; drift suite green with the shrunken list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)