### PR TITLE
fix(i18n): it focus verb + pt halt/break cross-map (pt +4 patterns lossy→faithful)

### DIFF
--- a/packages/i18n/src/dictionaries/it.ts
+++ b/packages/i18n/src/dictionaries/it.ts
@@ -62,6 +62,9 @@ export const it: Dictionary = {
     select: 'selezionare',
     clone: 'clonare',
     prepend: 'anteporre',
+    // profile primary; without a commands entry the transformer fell back to
+    // the EVENTS noun 'fuoco', which generated focus patterns can't match
+    focus: 'focalizzare',
   },
 
   modifiers: {

--- a/packages/i18n/src/dictionaries/pt.ts
+++ b/packages/i18n/src/dictionaries/pt.ts
@@ -25,8 +25,9 @@ export const pt: Dictionary = {
     while: 'enquanto',
     until: 'até',
     continue: 'continuar',
-    break: 'parar',
-    halt: 'interromper',
+    // un-crossed: the profile/tokenizer read parar=halt, interromper=break
+    break: 'interromper',
+    halt: 'parar',
     wait: 'esperar',
     fetch: 'buscar',
     call: 'chamar',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -2327,3 +2327,64 @@ describe('bn/hi single-word append + hi swap vocabulary (B2c)', () => {
     expect(actions(parse('.active को क्लिक पर टॉगल', 'hi')).has('toggle')).toBe(true);
   });
 });
+
+describe('it focus verb + pt halt/break cross-map (focus-trap residuals)', () => {
+  // Two dict-side residuals surfaced by the #349 span-mask fix (which exposed
+  // the focus-trap body to translation for the first time):
+  // - it: the dict's COMMANDS section had no focus verb, so the transformer
+  //   fell back to the EVENTS noun (fuoco) — the #321/#344 noun-where-verb
+  //   family. The generated focus patterns match the profile primary literal
+  //   (focalizzare), so the command dropped. Added commands focus: focalizzare.
+  // - pt: halt/break were CROSS-MAPPED (dict break: parar / halt: interromper,
+  //   while profile+tokenizer read parar=halt, interromper=break). Every halt
+  //   emission parsed as break — poisoning dropdown-toggle, halt-propagation,
+  //   if-matches, window-keydown (all lossy → faithful, pt avgFidelity
+  //   0.9300 → 0.9411) plus the focus-trap tail.
+  // it/pt focus-trap 0.5 → 0.75 (the remaining 0.25 is the dropped `if`, the
+  // M2 body-parse mechanism — tracked separately).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('[it] the transformed focus-trap body keeps focus + halt', () => {
+    const a = actions(
+      parse(
+        'su keydown[key=="Tab"] da .modal se obiettivo corrisponde ultimo <button/> in .modal focalizzare primo <button/> in .modal allora fermare fine',
+        'it'
+      )
+    );
+    expect(a.has('focus')).toBe(true);
+    expect(a.has('halt')).toBe(true);
+  });
+
+  it('[pt] the transformed focus-trap body keeps focus + halt (parar)', () => {
+    const a = actions(
+      parse(
+        'em keydown[key=="Tab"] de .modal se alvo corresponde último <button/> dentro .modal focar primeiro <button/> dentro .modal então parar fim',
+        'pt'
+      )
+    );
+    expect(a.has('focus')).toBe(true);
+    expect(a.has('halt')).toBe(true);
+  });
+
+  it('[pt] halt-propagation shape parses parar as halt (was break)', () => {
+    const a = actions(parse('em clique parar the evento', 'pt'));
+    expect(a.has('halt')).toBe(true);
+    expect(a.has('break')).toBe(false);
+  });
+
+  it('[it] the focus EVENT still works via the noun (fuoco unchanged in events)', () => {
+    const a = actions(parse('su fuoco aggiungere .active a io', 'it'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('add')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T00:51:22.119Z",
-  "commit": "e00b75ae",
+  "timestamp": "2026-06-12T01:20:43.490Z",
+  "commit": "f4c727c8",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -5799,7 +5799,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9878721859114016,
-      "avgFidelity": 0.9604575163398692,
+      "avgFidelity": 0.9620915032679738,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "blur-element",
@@ -9043,20 +9043,17 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8344952795933194,
-      "avgFidelity": 0.9299564270152505,
+      "avgFidelity": 0.9410675381263616,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "async-block",
         "blur-element",
         "caret-var-on-target",
-        "dropdown-toggle",
         "fetch-do-not-throw",
         "fetch-with-headers",
         "focus-trap",
         "form-submit-prevent",
-        "halt-propagation",
         "if-exists",
-        "if-matches",
         "modal-close-backdrop",
         "put-after",
         "put-before",
@@ -9064,8 +9061,7 @@
         "tell-other-element",
         "template-literal-list-build",
         "unless-condition",
-        "when-value-changes",
-        "window-keydown"
+        "when-value-changes"
       ],
       "bundleSize": 405912,
       "patterns": {


### PR DESCRIPTION
## Two dict residuals exposed by #349

The span-mask fix let the focus-trap body reach the transformer for the first time — and two languages still dropped commands for dictionary reasons:

**it — no focus verb in the commands section.** The transformer fell back to the EVENTS noun (`fuoco`) — the #321/#344 noun-where-verb family. Generated focus patterns match the profile primary literal (`focalizzare`), so the command dropped. Added `focus: 'focalizzare'` to commands; the focus *event* keeps `fuoco`.

**pt — halt/break cross-mapped.** The dict had `break: 'parar'` / `halt: 'interromper'`, exactly backwards vs the profile and tokenizer (`parar`=halt, `interromper`=break). Every pt halt emission parsed as break — poisoning **dropdown-toggle, halt-propagation, if-matches, window-keydown** and the focus-trap tail. Un-crossed.

## A/B (same DB, full browser-priority bundle)

- pt 0.9300 → **0.9411** — 4 patterns lossy → faithful, the largest per-language jump of the campaign
- it 0.9605 → 0.9621 (focus-trap 0.5 → 0.75)
- 0 drops, 0 flips, gate green
- Guards: pt `parar` standalone halts; it `su fuoco …` event handlers unchanged

Remaining focus-trap blockers (separate mechanisms, future PRs): the dropped `if` (M2 body-parse), sw/tr tail-drop after the if-condition, ar VSO reorder path, he/bn untranslated matches-segment.

semantic 5572 + i18n 837 passed; lock test added; baseline regenerated; patterns.db not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)