### PR TITLE
fix(semantic,i18n): eventMarker emission alignment — fused event patterns come alive in es/fr/it/pt/pl/id/ms (26 patterns lossy→faithful)

### DIFF
--- a/packages/i18n/src/dictionaries/id.ts
+++ b/packages/i18n/src/dictionaries/id.ts
@@ -28,7 +28,10 @@ export const id: Dictionary = {
     break: 'hentikan',
     halt: 'berhenti',
     wait: 'tunggu',
-    fetch: 'ambil',
+    // profile primary; 'ambil' is take's word — emitting it for fetch made every
+    // fetch parse as take once the fused take-event pattern came alive (the de
+    // holen/abrufen bug class)
+    fetch: 'muat',
     call: 'panggil',
     return: 'kembali',
     make: 'buat',

--- a/packages/i18n/src/new-languages.test.ts
+++ b/packages/i18n/src/new-languages.test.ts
@@ -98,7 +98,9 @@ describe('New Language Support', () => {
         from: 'en',
         to: 'id',
       });
-      expect(result).toContain('ambil'); // fetch → ambil
+      // fetch → muat (profile primary; 'ambil' is take's word — the old
+      // emission made every id fetch parse as take)
+      expect(result).toContain('muat');
       expect(result).toContain('taruh'); // put → taruh
       expect(result).toContain('hasil'); // result → hasil
     });

--- a/packages/semantic/src/generators/profiles/french.ts
+++ b/packages/semantic/src/generators/profiles/french.ts
@@ -169,7 +169,10 @@ export const frenchProfile: LanguageProfile = {
     // Event marker: au (at/upon), used in SVO pattern
     // Pattern: au [event] [verb] [patient] sur [destination?]
     // Example: au clic basculer .active sur #button
-    eventMarker: { primary: 'au', alternatives: ['lors du', 'lors de'], position: 'before' },
+    // + the eventHandler.keyword word the i18n transformer actually emits —
+    // without it every generated fused `<cmd>-event-*-vso` pattern was dead
+    // (the swap/if recovery split, #346/#351)
+    eventMarker: { primary: 'au', alternatives: ['lors du', 'lors de', 'sur'], position: 'before' },
     temporalMarkers: ['quand', 'lorsque'], // temporal conjunctions (when)
   },
 };

--- a/packages/semantic/src/generators/profiles/indonesian.ts
+++ b/packages/semantic/src/generators/profiles/indonesian.ts
@@ -174,7 +174,10 @@ export const indonesianProfile: LanguageProfile = {
     // Event marker: saat (when), used in SVO pattern
     // Pattern: saat [event] [verb] [patient] pada [destination?]
     // Example: saat klik alihkan .active pada #button
-    eventMarker: { primary: 'saat', alternatives: ['ketika'], position: 'before' },
+    // + the eventHandler.keyword word the i18n transformer actually emits —
+    // without it every generated fused `<cmd>-event-*-vso` pattern was dead
+    // (the swap/if recovery split, #346/#351)
+    eventMarker: { primary: 'saat', alternatives: ['ketika', 'pada'], position: 'before' },
     temporalMarkers: ['ketika', 'saat'], // temporal conjunctions (when)
   },
 };

--- a/packages/semantic/src/generators/profiles/italian.ts
+++ b/packages/semantic/src/generators/profiles/italian.ts
@@ -192,7 +192,10 @@ export const italianProfile: LanguageProfile = {
     // Event marker: al (at/upon), used in SVO pattern
     // Pattern: al [event] [verb] [patient] su [destination?]
     // Example: al clic commutare .active su #button
-    eventMarker: { primary: 'al', alternatives: ['allo', 'alla'], position: 'before' },
+    // + the eventHandler.keyword word the i18n transformer actually emits —
+    // without it every generated fused `<cmd>-event-*-vso` pattern was dead
+    // (the swap/if recovery split, #346/#351)
+    eventMarker: { primary: 'al', alternatives: ['allo', 'alla', 'su'], position: 'before' },
     temporalMarkers: ['quando', 'al'], // temporal conjunctions (when)
   },
 };

--- a/packages/semantic/src/generators/profiles/ms.ts
+++ b/packages/semantic/src/generators/profiles/ms.ts
@@ -161,5 +161,8 @@ export const malayProfile: LanguageProfile = {
   eventHandler: {
     keyword: { primary: 'apabila', alternatives: ['ketika'], normalized: 'on' },
     sourceMarker: { primary: 'dari', position: 'before' },
+    // Without an eventMarker ms generated NO fused event patterns at all —
+    // the only language besides en in that state (the swap/if recovery split).
+    eventMarker: { primary: 'apabila', alternatives: ['ketika'], position: 'before' },
   },
 };

--- a/packages/semantic/src/generators/profiles/polish.ts
+++ b/packages/semantic/src/generators/profiles/polish.ts
@@ -311,7 +311,10 @@ export const polishProfile: LanguageProfile = {
     // Event marker: przy (at/on), used in SVO pattern
     // Pattern: przy [event] [verb] [patient] na [destination?]
     // Example: przy kliknięciu przełącz .active na #button
-    eventMarker: { primary: 'przy', alternatives: ['na'], position: 'before' },
+    // + the eventHandler.keyword word the i18n transformer actually emits —
+    // without it every generated fused `<cmd>-event-*-vso` pattern was dead
+    // (the swap/if recovery split, #346/#351)
+    eventMarker: { primary: 'przy', alternatives: ['na', 'gdy'], position: 'before' },
     temporalMarkers: ['kiedy', 'gdy', 'przy'], // temporal conjunctions (when, at)
   },
 };

--- a/packages/semantic/src/generators/profiles/portuguese.ts
+++ b/packages/semantic/src/generators/profiles/portuguese.ts
@@ -164,7 +164,10 @@ export const portugueseProfile: LanguageProfile = {
     // Event marker: ao (at/upon), used in SVO pattern
     // Pattern: ao [event] [verb] [patient] em [destination?]
     // Example: ao clique alternar .active em #button
-    eventMarker: { primary: 'ao', alternatives: ['no'], position: 'before' },
+    // + the eventHandler.keyword word the i18n transformer actually emits —
+    // without it every generated fused `<cmd>-event-*-vso` pattern was dead
+    // (the swap/if recovery split, #346/#351)
+    eventMarker: { primary: 'ao', alternatives: ['no', 'em'], position: 'before' },
     temporalMarkers: ['quando', 'ao'], // temporal conjunctions (when)
   },
 };

--- a/packages/semantic/src/generators/profiles/spanish.ts
+++ b/packages/semantic/src/generators/profiles/spanish.ts
@@ -200,7 +200,10 @@ export const spanishProfile: LanguageProfile = {
     // Event marker: al (when), used in SVO pattern
     // Pattern: al [event] [verb] [patient] en [destination?]
     // Example: al clic alternar .active en #button
-    eventMarker: { primary: 'al', alternatives: ['cuando'], position: 'before' },
+    // + the eventHandler.keyword word the i18n transformer actually emits —
+    // without it every generated fused `<cmd>-event-*-vso` pattern was dead
+    // (the swap/if recovery split, #346/#351)
+    eventMarker: { primary: 'al', alternatives: ['cuando', 'en'], position: 'before' },
     temporalMarkers: ['cuando', 'al'], // temporal conjunctions (when)
   },
 };

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1745,7 +1745,10 @@ describe('marker-less fetch fidelity (es/pl/id/sw/he) — recover dropped fetch'
   const cases: Array<[string, string]> = [
     ['es', 'en clic buscar /api/data entonces poner ello a #result'],
     ['pl', 'gdy kliknięcie pobierz /api/data wtedy umieść to do #result'],
-    ['id', 'pada klik ambil /api/data lalu taruh itu ke #result'],
+    // id dict realigned fetch ambil→muat (ambil is take's word; once the fused
+    // take-event pattern came alive it claimed every ambil-fetch — the de
+    // holen/abrufen class). The emission is now muat.
+    ['id', 'pada klik muat /api/data lalu taruh itu ke #result'],
     ['sw', 'kwenye bonyeza leta /api/data kisha weka hiyo kwa #result'],
     ['he', 'ב לחיצה הבא את /api/data אז שים את זה על #result'],
   ];


### PR DESCRIPTION
## The generalization of the #346 swap recovery split

The i18n transformer leads event handlers with the profile's `eventHandler.keyword` word (es `en`, fr `sur`, it `su`, pt `em`, pl `gdy`, id `pada`, ms `apabila`) — but the generated fused `<cmd>-event-<lang>-vso` patterns anchor on `eventHandler.eventMarker`, which didn't include that word. **Every fused event pattern was dead in 6 languages, and ms generated none at all** (no eventMarker). Bodies fell to handcrafted event patterns + body re-parse, which drops if-blocks and other structures the fused path keeps.

This is why de recovered `if` (via `if-event-de-vso`) while es dropped it; why de/ru/sw recovered swap in #346 while es/fr/pt didn't. One probe (`if-event-de-vso` vs `event-es-standard` on identical sentence shapes) exposed the whole family.

## Fix

Add the emission word as an `eventMarker` alternative in es/fr/it/pt/pl/id; give ms an eventMarker (`apabila`/`ketika`).

**Surfaced collision, bundled per #345 precedent:** the id dict emitted `ambil` for fetch, but `ambil` is take's word — harmless while the fused take pattern was dead, catastrophic once alive (the whole id fetch cluster flipped to take, −0.0221 in the first A/B). Realigned id dict fetch → `muat` (profile primary); `ambil` stays take. Stale `ambil` test expectations updated.

## A/B (same DB, post-#350 base)

| lang | Δ avgFidelity | flips |
|---|---|---|
| es | +0.0084 | if-exists, modal-close-backdrop, tell-command, tell-other-element |
| fr | +0.0117 | caret-var-on-target, modal-close-backdrop, tell ×2 |
| id | +0.0084 | modal-close-backdrop, tell ×2 (fetch cluster preserved via realign) |
| ms | +0.0120 | get-value, hide-with-transition, modal-close-backdrop, tell ×2 |
| pl | +0.0117 | if-condition, if-exists, if-matches, modal-close-backdrop, tell ×2 |
| pt | +0.0117 | caret-var-on-target, modal-close-backdrop, tell ×2 |

26 pattern-instances lossy → faithful; cross-lang avgFidelity **0.9444 → 0.9477**. One within-tolerance regression flagged by the gate: ms make-toast-element (the transformer emits a different shape for that one multi-command body now that ms has an eventMarker — follow-up).

semantic 5578 + i18n 837 + patterns-reference 117 passed; lock tests added; baseline regenerated; patterns.db not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)