### PR TITLE
fix(i18n): sw positional last → wamwisho (mwisho is the end keyword; focus-trap + input-clear lossy→faithful)

### DIFF
--- a/packages/i18n/src/dictionaries/sw.ts
+++ b/packages/i18n/src/dictionaries/sw.ts
@@ -191,7 +191,13 @@ export const sw: Dictionary = {
 
   expressions: {
     first: 'kwanza',
-    last: 'mwisho',
+    // 'mwisho' is the END keyword (block terminator) — the tokenizer's keyword
+    // map is last-wins, so a positional `last` emission of 'mwisho' reads as
+    // `end` and terminates the enclosing block mid-condition (focus-trap's
+    // `… inafanana mwisho <button/>` dropped the whole branch body). Emit the
+    // concatenated adjective form instead (wa mwisho — the saufsi/wennnicht/
+    // enyakın single-token class); the tokenizer reads it as `last`.
+    last: 'wamwisho',
     next: 'ijayo',
     previous: 'iliyopita',
     prev: 'awali',

--- a/packages/i18n/src/positional-keyword-drift.test.ts
+++ b/packages/i18n/src/positional-keyword-drift.test.ts
@@ -52,8 +52,10 @@ const POSITIONAL_CONCEPTS = [
  *   morphology bound the prefixes); fixed with exact tokenizer entries.
  * - de closest→nächste normalizes to `next` by design (one word covers both
  *   readings; POSITIONAL_OR_SCOPE_KEYWORDS accepts either) — expected to stay.
- * - bn/sw last (শেষ / mwisho) normalize to `end` (the block terminator) —
- *   polysemous words claimed by the structural keyword.
+ * - bn last (শেষ) normalizes to `end` (the block terminator) — a polysemous
+ *   word claimed by the structural keyword. (sw had the same collision via
+ *   mwisho; fixed by emitting the distinct concatenated adjective `wamwisho`,
+ *   which the tokenizer reads as `last` — the saufsi/wennnicht/enyakın class.)
  */
 const KNOWN_DRIFT = new Set<string>([
   'ar:parent',
@@ -76,9 +78,6 @@ const KNOWN_DRIFT = new Set<string>([
   'pt:random',
   'qu:parent',
   'qu:random',
-  'sw:first',
-  'sw:last',
-  'sw:previous',
   'sw:random',
   'th:random',
   'tr:random',

--- a/packages/semantic/src/tokenizers/swahili.ts
+++ b/packages/semantic/src/tokenizers/swahili.ts
@@ -75,12 +75,17 @@ const SWAHILI_EXTRAS: KeywordEntry[] = [
   // tokenizer-keyword-injectivity.test.ts.
   { native: 'haijafafanuliwa', normalized: 'undefined' },
 
-  // Positional
-  { native: 'wa kwanza', normalized: 'first' },
-  { native: 'wa mwisho', normalized: 'last' },
+  // Positional. The tokenizer matches single words only, so the multi-word
+  // adjective forms ('wa kwanza', 'wa mwisho') were dead entries — the i18n
+  // dict emissions are the single tokens below (kwanza, wamwisho, iliyopita).
+  // 'mwisho' itself is claimed by `end` (last-wins keyword map), which is why
+  // positional last needs the distinct concatenated form.
+  { native: 'kwanza', normalized: 'first' },
+  { native: 'wamwisho', normalized: 'last' },
   { native: 'ifuatayo', normalized: 'next' },
   { native: 'ijayo', normalized: 'next' }, // i18n dict emits 'ijayo' for next
   { native: 'iliyotangulia', normalized: 'previous' },
+  { native: 'iliyopita', normalized: 'previous' }, // i18n dict emission
   { native: 'karibu', normalized: 'closest' },
   { native: 'mzazi', normalized: 'parent' },
 

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -2584,3 +2584,85 @@ describe('event-head tolerance — bracket key-filter + source clause (focus-tra
     expect([...actions(parse('en clic alternar .active', 'es'))].sort()).toEqual(['on', 'toggle']);
   });
 });
+
+describe('sw positional keywords — wamwisho (last) / kwanza / iliyopita', () => {
+  // The sw tail of the focus-trap campaign. The i18n sw dict emitted 'mwisho'
+  // for positional `last`, but 'mwisho' is the END keyword (block terminator;
+  // the keyword map is last-wins), so `… inafanana mwisho <button/>` read as a
+  // premature block-end and the whole branch body dropped (focus-trap stuck at
+  // {if,on} after #352 fixed the event head). The dict now emits the distinct
+  // concatenated adjective 'wamwisho' (wa mwisho — the saufsi/wennnicht/enyakın
+  // single-token class), which the tokenizer reads as `last`. Bundled (same
+  // dict↔tokenizer realign mechanism, #338 ijayo class): 'kwanza' → first and
+  // 'iliyopita' → previous tokenizer entries replace the dead multi-word
+  // 'wa kwanza'/'wa mwisho' entries. sw focus-trap + input-clear flip
+  // lossy → faithful (sw avgFidelity 0.9408 → 0.9474); three KNOWN_DRIFT
+  // entries removed (sw:first, sw:last, sw:previous — the list only shrinks).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('[sw] focus-trap keeps the full body (was {if,on} — mwisho killed the branch)', () => {
+    // Corpus-shaped transformer output (en → sw) with the realigned emission.
+    const a = actions(
+      parse(
+        'kwenye keydown[key=="Tab"] kutoka .modal kama lengo inafanana wamwisho <button/> ndani .modal lenga kwanza <button/> ndani .modal kisha simama mwisho',
+        'sw'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('if')).toBe(true);
+    expect(a.has('focus')).toBe(true);
+    expect(a.has('halt')).toBe(true);
+  });
+
+  it('[sw] the root cause stays locked: mwisho in the condition kills the branch', () => {
+    // 'mwisho' is the block terminator — this is WHY the dict had to emit
+    // wamwisho. If this starts passing, the polysemy was resolved another way
+    // and the dict emission can be reconsidered.
+    const a = actions(
+      parse(
+        'kwenye bonyeza kama lengo inafanana mwisho <button/> ndani .modal lenga kwanza <button/> ndani .modal kisha simama mwisho',
+        'sw'
+      )
+    );
+    expect(a.has('focus')).toBe(false);
+  });
+
+  it('[sw] mwisho still terminates a block (end reading unchanged)', () => {
+    // repeat-while corpus shape — trailing mwisho is the real end.
+    const a = actions(
+      parse(
+        'kwenye bonyeza rudia wakati #counter.innerText < 10 kisha ongezeko #counter kisha ngoja 200ms mwisho',
+        'sw'
+      )
+    );
+    expect(a.has('repeat')).toBe(true);
+    expect(a.has('increment')).toBe(true);
+    expect(a.has('wait')).toBe(true);
+  });
+
+  it('[sw] put into a wamwisho (last) destination keeps put', () => {
+    expect(actions(parse('weka "X" kwa wamwisho .y', 'sw')).has('put')).toBe(true);
+  });
+
+  it('[sw] put into an iliyopita (previous) destination keeps put', () => {
+    expect(actions(parse('weka "X" kwa iliyopita .y', 'sw')).has('put')).toBe(true);
+  });
+
+  it('[sw] first-in-parent still parses (kwanza now a real positional)', () => {
+    const a = actions(
+      parse('kwenye bonyeza lenga kwanza <input/> ndani karibu_zaidi <form/>', 'sw')
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('focus')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T02:10:20.987Z",
-  "commit": "69e70840",
+  "timestamp": "2026-06-12T02:28:47.905Z",
+  "commit": "a2bcc18a",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -10954,16 +10954,14 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.878719576719577,
-      "avgFidelity": 0.9407777777777776,
+      "avgFidelity": 0.9474444444444443,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "blur-element",
         "event-debounce",
-        "focus-trap",
         "form-submit-prevent",
         "if-empty",
         "if-exists",
-        "input-clear",
         "input-validation",
         "keydown-key-is-syntax",
         "make-element",


### PR DESCRIPTION
## Mechanism

The sw dict emitted `mwisho` for positional `last`, but `mwisho` is the **end keyword** (block terminator; tokenizer keyword map is last-wins — it cannot carry both readings). So a positional condition (`… inafanana mwisho <button/> ndani .modal`) read as a premature block-end and the entire branch body dropped. focus-trap was stuck at `{if, on}` (0.5) even after #352 fixed the event head.

Bisect proof: substituting any *recognized* positional (`ijayo`, `kwanza`) for `mwisho` in the same condition parses the full `{focus, halt, if, on}`.

## Fix (one mechanism: dict↔tokenizer positional realign, the #338 `ijayo` class)

- dict `expressions.last: 'mwisho' → 'wamwisho'` — the concatenated adjective (*wa mwisho*), same single-token class as de `wennnicht` / fr `saufsi` / tr `enyakın`
- tokenizer: `wamwisho → last`, plus `kwanza → first` and `iliyopita → previous` replacing the dead multi-word `'wa kwanza'`/`'wa mwisho'` entries
- KNOWN_DRIFT shrinks by three: `sw:first`, `sw:last`, `sw:previous` (the drift test enforces removal)

## A/B (same DB)

- sw **focus-trap + input-clear lossy → faithful**, sw avgFidelity **0.9408 → 0.9474**
- every other language **byte-identical**; cross-lang avgFidelity 0.9486 → 0.9489, lossy 325 → 323, degenerate 67 (flat), gate green
- semantic 5598 + i18n 837 pass; lock tests cover the corpus shape, the root-cause guard (`mwisho`-in-condition still kills the branch — documents *why* the dict emission changed), the end-reading guard (repeat-while), and the new positional destinations

## Next (separate mechanisms)

- **tr**: postpositional source (`.modal den`) in the SOV event head + positional-condition span in `if-event-tr-sov-simple`
- **ms** make-toast-element emission shape; **ar** VSO if-before-event reorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)