### PR TITLE
fix(semantic): event-head source clause via profile markers, both orders (focus-trap pl/uk/zh/bn/hi lossy→faithful)

### DIFF
--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -167,9 +167,29 @@ export class PatternMatcher {
       }
     }
 
+    // Source-clause window: after the event role matches, the next 1–2 pattern
+    // tokens may be preceded in the stream by a source clause the fused
+    // patterns have no slot for — `gdy keydown[…] z .modal jeśli …` (marker
+    // BEFORE: pl z / uk з / zh 从) or `keydown[…] de .modal den eğer …`
+    // (marker AFTER: ja から / ko 에서 / bn থেকে / hi से / tr den). The window
+    // spans 2 pattern tokens because SOV emissions put the clause after the
+    // event-marker literal, not directly after the event. See
+    // tryConsumeEventSourceClause for the guards.
+    let sourceWindow = 0;
+
     for (let i = 0; i < patternTokens.length; i++) {
       const patternToken = patternTokens[i];
+
+      if (sourceWindow > 0 && patternToken.type === 'literal') {
+        this.tryConsumeEventSourceClause(tokens, captured, patternToken);
+      }
+
       const matched = this.matchPatternToken(tokens, patternToken, captured, patternTokens[i + 1]);
+
+      sourceWindow =
+        patternToken.type === 'role' && patternToken.role === 'event'
+          ? 2
+          : Math.max(0, sourceWindow - 1);
 
       if (!matched) {
         // If token is optional, continue
@@ -181,6 +201,54 @@ export class PatternMatcher {
     }
 
     return true;
+  }
+
+  /**
+   * Consume a source clause (`<marker> <selector>` or `<selector> <marker>`,
+   * per the profile's source-marker position) sitting between the event head
+   * and the next pattern literal. Fired only inside the post-event window and
+   * only when the upcoming literal does NOT match the stream position — a
+   * pattern that explicitly handles the marker (`bei {event} von {source}`)
+   * is left alone, and a failing consumption is harmless because matchPattern
+   * resets the stream on failure.
+   */
+  private tryConsumeEventSourceClause(
+    tokens: TokenStream,
+    captured: Map<SemanticRole, SemanticValue>,
+    upcoming: PatternToken & { type: 'literal' }
+  ): void {
+    if (captured.has('source')) return;
+    const tok0 = tokens.peek();
+    const tok1 = tokens.peek(1);
+    if (!tok0 || !tok1) return;
+    // The pattern explicitly expects this token next — leave it alone.
+    if (this.patternTokenWouldMatch(upcoming, tok0)) return;
+
+    const src = this.currentProfile?.roleMarkers?.source;
+    const isMarker = (t: LanguageToken): boolean => {
+      if (t.kind !== 'particle' && t.kind !== 'keyword') return false;
+      if ((t.normalized ?? '').toLowerCase() === 'source') return true;
+      if (!src) return false;
+      const v = t.value.toLowerCase();
+      if (src.primary?.toLowerCase() === v) return true;
+      return !!src.alternatives?.some(a => a.toLowerCase() === v);
+    };
+    const position = src?.position;
+
+    // Prepositional `from .modal` (pl z, uk з, zh 从, de von, sw kutoka).
+    if (position !== 'after' && isMarker(tok0) && tok1.kind === 'selector') {
+      tokens.advance();
+      const v = this.tokenToSemanticValue(tokens.advance());
+      if (v) captured.set('source', v);
+      return;
+    }
+    // Postpositional `.modal から` (ja から, ko 에서, bn থেকে, hi से, tr den).
+    if (position === 'after' && tok0.kind === 'selector' && isMarker(tok1)) {
+      const v = this.tokenToSemanticValue(tok0);
+      tokens.advance();
+      tokens.advance();
+      if (v) captured.set('source', v);
+    }
   }
 
   /**

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -2666,3 +2666,106 @@ describe('sw positional keywords — wamwisho (last) / kwanza / iliyopita', () =
     expect(a.has('focus')).toBe(true);
   });
 });
+
+describe('event-head source clause — profile markers, both orders (focus-trap pl/uk/zh/bn/hi)', () => {
+  // The #352 event-head tolerance recognized a source clause only by token
+  // normalization (`normalized === 'source'`) and only in the prepositional
+  // order directly after the event role. But the source markers normalize
+  // inconsistently across tokenizers (pl z / uk з → 'style'!; ja から, ko 에서,
+  // bn থেকে, hi से, zh 从 carry no normalization), and SOV emissions are
+  // postpositional AND put the clause after the event-marker literal
+  // (`keydown[…] de .modal den eğer …`), out of the event role's reach.
+  //
+  // matchTokenSequence now opens a 2-pattern-token window after the event role
+  // in which a source clause — recognized via the profile's roleMarkers.source
+  // (primary + alternatives, honoring its position) — is consumed before a
+  // literal the clause would otherwise block. Gated: only when the upcoming
+  // literal does NOT match the stream position (a pattern with an explicit
+  // `von {source}` slot is untouched), and a failed match still resets the
+  // stream. focus-trap flips lossy → faithful in pl/uk/zh/bn/hi (lossy
+  // 323 → 318, 0 regressions). tr's head now matches too (its remaining drop
+  // is the son/end polysemy — next PR); ja/ko have no fused if pattern to
+  // anchor (the A3 SOV slice); tl is the trailing-event path; ar is the VSO
+  // reorder. All tracked.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped transformer output (en → lang), focus-trap.
+  const corpus: Array<[string, string]> = [
+    [
+      'pl',
+      'gdy keydown[key=="Tab"] z .modal jeśli cel pasuje ostatni <button/> w .modal skup pierwszy <button/> w .modal wtedy zatrzymaj koniec',
+    ],
+    [
+      'uk',
+      'при keydown[key=="Tab"] з .modal якщо ціль відповідає останній <button/> у .modal сфокусувати перший <button/> у .modal тоді зупинити кінець',
+    ],
+    [
+      'zh',
+      '当 keydown[key=="Tab"] 从 .modal 如果 目标 匹配 最后一个 <button/> 在 .modal 聚焦 把 第一个 <button/> 在 .modal 那么 停止 结束',
+    ],
+    [
+      'bn',
+      'keydown[key=="Tab"] এ .modal থেকে যদি লক্ষ্য matches শেষ <button/> এ .modal প্রথম <button/> এ .modal কে ফোকাস তারপর থামুন শেষ',
+    ],
+    [
+      'hi',
+      'keydown[key=="Tab"] पर .modal से अगर लक्ष्य मेल_खाता अंतिम <button/> में .modal पहला <button/> में .modal को फोकस फिर रोकें समाप्त',
+    ],
+  ];
+  for (const [lang, input] of corpus) {
+    it(`[${lang}] focus-trap keeps the if wrapper (source clause consumed)`, () => {
+      const a = actions(parse(input, lang as 'pl'));
+      expect(a.has('on')).toBe(true);
+      expect(a.has('if')).toBe(true);
+      expect(a.has('focus')).toBe(true);
+      expect(a.has('halt')).toBe(true);
+    });
+  }
+
+  // tr: the postpositional clause after the event-marker literal now parses —
+  // the fused if pattern anchors (the body's son/end drop is a separate
+  // mechanism, locked when the dict realign lands).
+  it('[tr] the SOV head with postpositional source anchors the fused if pattern', () => {
+    const a = actions(
+      parse(
+        'keydown[key=="Tab"] de .modal den eğer hedef eşleşir ilk <button/> içinde .modal ilk <button/> içinde .modal i odak sonra durdur son',
+        'tr'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('if')).toBe(true);
+    expect(a.has('focus')).toBe(true);
+    expect(a.has('halt')).toBe(true);
+  });
+
+  // Regression guards.
+  it('[pl] a handler without a source clause is unchanged', () => {
+    const a = actions(parse('gdy kliknięcie przełącz .active', 'pl'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('toggle')).toBe(true);
+  });
+  it('[de] the explicit-source handcrafted pattern still parses', () => {
+    const a = actions(parse('bei klick von .modal umschalten .active', 'de'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('toggle')).toBe(true);
+  });
+  it('[en] the en reference parse is unchanged', () => {
+    const a = actions(
+      parse(
+        'on keydown[key=="Tab"] from .modal if target matches last <button/> in .modal focus first <button/> in .modal halt end',
+        'en'
+      )
+    );
+    expect([...a].sort()).toEqual(['focus', 'halt', 'if', 'on']);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T02:28:47.905Z",
-  "commit": "a2bcc18a",
+  "timestamp": "2026-06-12T02:41:24.115Z",
+  "commit": "229ba767",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -28,7 +28,7 @@
         "template-literal-list-build",
         "window-scroll"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -652,14 +652,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8884559884559885,
-      "avgFidelity": 0.9715367965367964,
+      "avgFidelity": 0.973160173160173,
       "degeneratePasses": [],
       "lossyPasses": [
         "announce-screen-reader",
         "breakpoint-command",
         "fetch-do-not-throw",
         "fetch-json",
-        "focus-trap",
         "form-disable-on-submit",
         "form-submit-prevent",
         "if-empty",
@@ -670,7 +669,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1313,7 +1312,7 @@
         "template-literal-list-build",
         "when-value-changes"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1937,7 +1936,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2565,7 +2564,7 @@
       "avgFidelity": 0.9752723311546839,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["fetch-do-not-throw", "form-submit-prevent", "template-literal-list-build"],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3203,7 +3202,7 @@
         "template-literal-list-build",
         "when-value-changes"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3855,7 +3854,7 @@
         "trigger-event",
         "wait-then"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4479,7 +4478,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "avgFidelity": 0.9208874458874459,
+      "avgFidelity": 0.9225108225108225,
       "degeneratePasses": [
         "bind-auto-detect",
         "bind-explicit-property",
@@ -4496,7 +4495,6 @@
         "event-throttle",
         "fetch-do-not-throw",
         "fetch-json",
-        "focus-trap",
         "form-submit-prevent",
         "if-empty",
         "input-validation",
@@ -4504,7 +4502,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5155,7 +5153,7 @@
         "template-literal-interpolation",
         "template-literal-list-build"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5791,7 +5789,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6449,7 +6447,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7099,7 +7097,7 @@
         "unless-condition",
         "wait-for-event"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7753,7 +7751,7 @@
         "template-literal-interpolation",
         "template-literal-list-build"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8372,13 +8370,12 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.891845627139745,
-      "avgFidelity": 0.9594771241830065,
+      "avgConfidence": 0.8910986616868973,
+      "avgFidelity": 0.961111111111111,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "blur-element",
         "fetch-do-not-throw",
-        "focus-trap",
         "form-submit-prevent",
         "get-value",
         "keydown-key-is-syntax",
@@ -8386,7 +8383,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8473,10 +8470,6 @@
           "confidence": 1
         },
         "announce-screen-reader": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-trap": {
           "success": true,
           "confidence": 1
         },
@@ -8764,6 +8757,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "optional-chaining-possessive": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -9025,7 +9022,7 @@
         "unless-condition",
         "when-value-changes"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9691,7 +9688,7 @@
         "unless-condition",
         "window-scroll"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10329,7 +10326,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10972,7 +10969,7 @@
         "set-color-variable",
         "template-literal-list-build"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11605,7 +11602,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12250,7 +12247,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12874,7 +12871,7 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8746550472040668,
+      "avgConfidence": 0.877923021060276,
       "avgFidelity": 0.9443355119825707,
       "degeneratePasses": [
         "behavior-draggable",
@@ -12896,7 +12893,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13214,6 +13211,10 @@
           "success": true,
           "confidence": 1
         },
+        "focus-trap": {
+          "success": true,
+          "confidence": 1
+        },
         "set-text-possessive-dot": {
           "success": true,
           "confidence": 1
@@ -13457,10 +13458,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.5
-        },
         "optional-chaining-possessive": {
           "success": true,
           "confidence": 0.5
@@ -13519,14 +13516,13 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8967635539064113,
-      "avgFidelity": 0.9753246753246753,
+      "avgConfidence": 0.896021438878582,
+      "avgFidelity": 0.9769480519480519,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [
         "event-debounce",
         "fetch-do-not-throw",
         "fetch-loading-state",
-        "focus-trap",
         "form-submit-prevent",
         "if-empty",
         "input-validation",
@@ -13534,7 +13530,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13609,10 +13605,6 @@
           "confidence": 1
         },
         "announce-screen-reader": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-trap": {
           "success": true,
           "confidence": 1
         },
@@ -13917,6 +13909,10 @@
           "confidence": 0.8857142857142858
         },
         "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "focus-trap": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -14178,7 +14174,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14802,12 +14798,11 @@
       "parseSuccess": 150,
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
-      "avgConfidence": 0.9988148148148148,
-      "avgFidelity": 0.9654444444444444,
+      "avgConfidence": 0.99805291005291,
+      "avgFidelity": 0.967111111111111,
       "degeneratePasses": [],
       "lossyPasses": [
         "fetch-do-not-throw",
-        "focus-trap",
         "form-submit-prevent",
         "get-value",
         "if-exists",
@@ -14821,7 +14816,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 406675,
+      "bundleSize": 407506,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15239,10 +15234,6 @@
           "success": true,
           "confidence": 1
         },
-        "focus-trap": {
-          "success": true,
-          "confidence": 1
-        },
         "set-text-possessive-dot": {
           "success": true,
           "confidence": 1
@@ -15419,6 +15410,10 @@
           "success": true,
           "confidence": 1
         },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -15440,7 +15435,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 406675,
+      "size": 407506,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Mechanism

Continuation of #352. Its source-clause tolerance recognized markers only by token normalization (`normalized === 'source'`) and only **prepositionally, directly after the event role**. The bisect showed two gaps:

1. **Marker recognition**: source markers normalize inconsistently — pl `z` / uk `з` normalize to `'style'`(!), and ja `から`, ko `에서`, bn `থেকে`, hi `से`, zh `从` carry no normalization at all. Only de/sw/tr happened to normalize to `'source'`.
2. **Position**: SOV emissions are postpositional **and** put the clause after the event-marker literal (`keydown[…] de .modal den eğer …`) — out of the event role's reach entirely.

## Fix (one mechanism, parser-side, additive)

`matchTokenSequence` opens a 2-pattern-token window after the event role matches. Inside it, before matching a literal, a source clause recognized via the **profile's `roleMarkers.source`** (primary + alternatives, honoring `position: before/after`) is consumed. Guards:

- only fires when the upcoming literal does NOT match the stream position — patterns with an explicit `von {source}` slot are untouched
- a pattern that still fails resets the stream as always (consumption is never observable on failure)

## A/B (same DB)

- focus-trap **lossy → faithful in pl/uk/zh/bn/hi**
- cross-lang avgFidelity **0.9489 → 0.9493**, lossy **323 → 318**, degenerate 67 (flat), gate green
- semantic 5607 tests pass; lock tests cover the 5 corpus shapes, the tr head anchor, and en/de/pl guards

## focus-trap campaign state

faithful in 18/23 now (#352: 11, #353: sw, here: 5). Remaining: **tr** (head anchors after this PR; the body drop is the `son`/end polysemy — next PR), **ja/ko** (no fused if pattern — the A3 SOV slice), **tl** (trailing-event path), **ar** (VSO reorder, deliberate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)