### PR TITLE
fix(i18n): tr positional last → sonuncu (son doubles as the end keyword; focus-trap lossy→faithful)

### DIFF
--- a/packages/i18n/src/dictionaries/tr.ts
+++ b/packages/i18n/src/dictionaries/tr.ts
@@ -187,7 +187,12 @@ export const tr: Dictionary = {
 
   expressions: {
     first: 'ilk',
-    last: 'son',
+    // 'son' is also the END keyword emission (block terminator), and the
+    // parser's end-recognizers match it by value — so a positional `last`
+    // emission of 'son' terminated the enclosing block mid-condition
+    // (focus-trap's `eşleşir son <button/>` dropped the branch body; the sw
+    // mwisho class). 'sonuncu' ("the last one") is unambiguous.
+    last: 'sonuncu',
     next: 'sonraki',
     previous: 'önceki',
     prev: 'önc',

--- a/packages/semantic/src/tokenizers/turkish.ts
+++ b/packages/semantic/src/tokenizers/turkish.ts
@@ -107,6 +107,7 @@ const TURKISH_EXTRAS: KeywordEntry[] = [
   // Positional (not in profile)
   { native: 'ilk', normalized: 'first' },
   { native: 'son', normalized: 'last' },
+  { native: 'sonuncu', normalized: 'last' }, // i18n dict emission ('son' doubles as end)
   { native: 'sonraki', normalized: 'next' },
   { native: 'önceki', normalized: 'previous' },
   { native: 'onceki', normalized: 'previous' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -2769,3 +2769,65 @@ describe('event-head source clause — profile markers, both orders (focus-trap 
     expect([...a].sort()).toEqual(['focus', 'halt', 'if', 'on']);
   });
 });
+
+describe('tr positional last — sonuncu (son doubles as the end keyword)', () => {
+  // The tr twin of the sw wamwisho fix. The tr dict emitted 'son' for BOTH the
+  // END keyword and positional `last`; the parser's end-recognizers match by
+  // value, so a positional condition (`eşleşir son <button/>`) terminated the
+  // enclosing block mid-condition and the branch body dropped (focus-trap
+  // stuck at {if,on} after #354 anchored the SOV head). The dict now emits
+  // 'sonuncu' ("the last one") for positional last; 'son' stays the block
+  // terminator. tr focus-trap flips lossy → faithful (0.9443 → 0.9476); every
+  // other language byte-identical.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('[tr] focus-trap keeps the full body (was {if,on} — son killed the branch)', () => {
+    // Corpus-shaped transformer output (en → tr) with the realigned emission.
+    const a = actions(
+      parse(
+        'keydown[key=="Tab"] de .modal den eğer hedef eşleşir sonuncu <button/> içinde .modal ilk <button/> içinde .modal i odak sonra durdur son',
+        'tr'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('if')).toBe(true);
+    expect(a.has('focus')).toBe(true);
+    expect(a.has('halt')).toBe(true);
+  });
+
+  it('[tr] the root cause stays locked: son in the condition kills the branch', () => {
+    // 'son' is matched by the end-recognizers by value — this is WHY the dict
+    // had to emit sonuncu for positional last.
+    const a = actions(
+      parse(
+        'keydown[key=="Tab"] de .modal den eğer hedef eşleşir son <button/> içinde .modal ilk <button/> içinde .modal i odak sonra durdur son',
+        'tr'
+      )
+    );
+    expect(a.has('focus')).toBe(false);
+  });
+
+  it('[tr] trailing then-chains with body verbs still parse (end reading unchanged)', () => {
+    // event-once shape from the SOV reorder lock tests — unchanged behavior.
+    const a = actions(
+      parse('once .initialized i tıklama de ekle ben e sonra setup() i çağır', 'tr')
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('add')).toBe(true);
+    expect(a.has('call')).toBe(true);
+  });
+
+  it('[tr] put into a sonuncu (last) destination keeps put', () => {
+    expect(actions(parse('o i sonuncu .y e koy', 'tr')).has('put')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T02:41:24.115Z",
-  "commit": "229ba767",
+  "timestamp": "2026-06-12T02:53:20.129Z",
+  "commit": "e41475c3",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -28,7 +28,7 @@
         "template-literal-list-build",
         "window-scroll"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -669,7 +669,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1312,7 +1312,7 @@
         "template-literal-list-build",
         "when-value-changes"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1936,7 +1936,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2564,7 +2564,7 @@
       "avgFidelity": 0.9752723311546839,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["fetch-do-not-throw", "form-submit-prevent", "template-literal-list-build"],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3202,7 +3202,7 @@
         "template-literal-list-build",
         "when-value-changes"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3854,7 +3854,7 @@
         "trigger-event",
         "wait-then"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4502,7 +4502,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5153,7 +5153,7 @@
         "template-literal-interpolation",
         "template-literal-list-build"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5789,7 +5789,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6447,7 +6447,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7097,7 +7097,7 @@
         "unless-condition",
         "wait-for-event"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7751,7 +7751,7 @@
         "template-literal-interpolation",
         "template-literal-list-build"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8383,7 +8383,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9022,7 +9022,7 @@
         "unless-condition",
         "when-value-changes"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9688,7 +9688,7 @@
         "unless-condition",
         "window-scroll"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10326,7 +10326,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10969,7 +10969,7 @@
         "set-color-variable",
         "template-literal-list-build"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11602,7 +11602,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12247,7 +12247,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12872,7 +12872,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.877923021060276,
-      "avgFidelity": 0.9443355119825707,
+      "avgFidelity": 0.9476034858387798,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -12884,7 +12884,6 @@
         "announce-screen-reader",
         "fetch-do-not-throw",
         "fetch-json",
-        "focus-trap",
         "form-disable-on-submit",
         "form-submit-prevent",
         "if-empty",
@@ -12893,7 +12892,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13530,7 +13529,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14174,7 +14173,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14816,7 +14815,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407506,
+      "bundleSize": 407543,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15435,7 +15434,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 407506,
+      "size": 407543,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Mechanism

The tr twin of #353 (sw `mwisho`). The tr dict emitted `son` for **both** the END keyword and positional `last`. The parser's end-recognizers match by value, so a positional condition (`eşleşir son <button/> içinde .modal`) read as a premature block-end and the branch body dropped — focus-trap stuck at `{if, on}` after #354 anchored the SOV event head.

Bisect proof: the same input with `ilk` (first) in the condition parses the full `{focus, halt, if, on}`.

## Fix

- dict `expressions.last: 'son' → 'sonuncu'` ("the last one" — a real, unambiguous Turkish word)
- tokenizer: `sonuncu → last` added; `son → last` kept (legacy inputs), `son` remains the block terminator

## A/B (same DB)

- tr **focus-trap lossy → faithful**, tr avgFidelity **0.9443 → 0.9476**
- every other language **byte-identical**; cross-lang 0.9493 → 0.9494, lossy 318 → 317, degenerate 67 (flat), gate green
- semantic 5611 + i18n 837 pass; lock tests: corpus shape, root-cause guard (`son`-in-condition still kills — documents why), end-reading guard, positional destination

## focus-trap campaign state

Faithful in **19/23** (#352: de/es/fr/he/id/it/ms/pt/ru/th/vi, #353: sw, #354: pl/uk/zh/bn/hi, here: tr). Remaining: ja/ko (no fused if pattern — A3 SOV slice), tl (trailing-event path), ar (VSO reorder, deliberate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)