### PR TITLE
fix(semantic): possessive property is never a normalized structural keyword (ms make-toast lossy→faithful)

### DIFF
--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -812,9 +812,15 @@ export class PatternMatcher {
     // Property should be an identifier, keyword (not structural), or selector (for style/dot/attr)
     // Examples: "my value", "my innerHTML", "my *background", "my *opacity", "my @data-count"
     // Also handles dot-property access: "my.textContent" tokenized as "my" + ".textContent"
+    // Structural keywords are checked by NORMALIZED form too — non-English
+    // structural words (ms kemudian→then, tamat→end) otherwise read as a
+    // property ("its then"), forming a phantom property-path whose type check
+    // fails the whole pattern (ms `letak 'X' ke ia kemudian …` dropped the put).
     if (
       propertyToken.kind === 'identifier' ||
-      (propertyToken.kind === 'keyword' && !this.isStructuralKeyword(propertyToken.value)) ||
+      (propertyToken.kind === 'keyword' &&
+        !this.isStructuralKeyword(propertyToken.value) &&
+        !(propertyToken.normalized && this.isStructuralKeyword(propertyToken.normalized))) ||
       (propertyToken.kind === 'selector' && propertyToken.value.startsWith('*')) ||
       (propertyToken.kind === 'selector' && propertyToken.value.startsWith('@')) ||
       (propertyToken.kind === 'selector' &&

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -2831,3 +2831,63 @@ describe('tr positional last — sonuncu (son doubles as the end keyword)', () =
     expect(actions(parse('o i sonuncu .y e koy', 'tr')).has('put')).toBe(true);
   });
 });
+
+describe('possessive property is never a normalized structural keyword (ms make-toast)', () => {
+  // ms make-toast-element went faithful→0.67 in #351 (accepted within
+  // tolerance) — once ms had an eventMarker, the fused make pattern anchored
+  // and the body re-parse hit `letak 'Saved!' ke ia kemudian …`. The
+  // possessive matcher read `ia kemudian` as "its kemudian" (ms `ia` = it/its;
+  // `kemudian` passed the structural-keyword check because that check used the
+  // raw VALUE against an English set) — forming a phantom property-path whose
+  // destination type-check failed the whole put pattern. The body's put
+  // silently dropped whenever ANY clause followed it. The check now also
+  // rejects a property token whose NORMALIZED form is structural
+  // (kemudian→then, tamat→end). ms make-toast-element lossy → faithful
+  // (0.9357 → 0.9379); every other language byte-identical.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('[ms] make-toast-element keeps the put (was dropped by the phantom possessive)', () => {
+    // Corpus-shaped transformer output (en → ms).
+    const a = actions(
+      parse(
+        "apabila click buat a <div.toast/> kemudian letak 'Saved!' ke ia kemudian letak ia di tamat daripada badan",
+        'ms'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('make')).toBe(true);
+    expect(a.has('put')).toBe(true);
+  });
+
+  it('[ms] a then-chained put with an it-destination keeps later clauses', () => {
+    const a = actions(
+      parse(
+        "apabila click buat a <div.toast/> kemudian letak 'Saved!' ke ia kemudian togol .x",
+        'ms'
+      )
+    );
+    expect(a.has('put')).toBe(true);
+    expect(a.has('toggle')).toBe(true);
+  });
+
+  it('[en] a real possessive property still parses (my value)', () => {
+    const a = actions(parse('put my value into #out', 'en'));
+    expect(a.has('put')).toBe(true);
+  });
+
+  it('[ms] a real ia-possessive property still parses', () => {
+    // `ia innerHTML` — identifier property, unaffected by the structural gate.
+    const a = actions(parse('letak ia innerHTML ke #out', 'ms'));
+    expect(a.has('put')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T02:53:20.129Z",
-  "commit": "e41475c3",
+  "timestamp": "2026-06-12T03:09:26.094Z",
+  "commit": "8e35cd64",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -28,7 +28,7 @@
         "template-literal-list-build",
         "window-scroll"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -669,7 +669,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1312,7 +1312,7 @@
         "template-literal-list-build",
         "when-value-changes"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1936,7 +1936,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2564,7 +2564,7 @@
       "avgFidelity": 0.9752723311546839,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["fetch-do-not-throw", "form-submit-prevent", "template-literal-list-build"],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3202,7 +3202,7 @@
         "template-literal-list-build",
         "when-value-changes"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3854,7 +3854,7 @@
         "trigger-event",
         "wait-then"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4502,7 +4502,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5153,7 +5153,7 @@
         "template-literal-interpolation",
         "template-literal-list-build"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5789,7 +5789,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6447,7 +6447,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7097,7 +7097,7 @@
         "unless-condition",
         "wait-for-event"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7722,7 +7722,7 @@
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.9374454032172144,
-      "avgFidelity": 0.9356823266219241,
+      "avgFidelity": 0.9379194630872483,
       "degeneratePasses": [],
       "lossyPasses": [
         "async-block",
@@ -7739,7 +7739,6 @@
         "keydown-key-is-syntax",
         "last-in-collection",
         "make-element",
-        "make-toast-element",
         "method-call-possessive-dot",
         "put-after",
         "put-before",
@@ -7751,7 +7750,7 @@
         "template-literal-interpolation",
         "template-literal-list-build"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8383,7 +8382,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9022,7 +9021,7 @@
         "unless-condition",
         "when-value-changes"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9688,7 +9687,7 @@
         "unless-condition",
         "window-scroll"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10326,7 +10325,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10969,7 +10968,7 @@
         "set-color-variable",
         "template-literal-list-build"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11602,7 +11601,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12247,7 +12246,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12892,7 +12891,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13529,7 +13528,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14173,7 +14172,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14815,7 +14814,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407543,
+      "bundleSize": 407600,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15434,7 +15433,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 407543,
+      "size": 407600,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Mechanism (handoff target 2 — diagnosis revised by the probe)

The handoff guessed transformer-side; the probe showed parser-side. ms make-toast-element's body re-parse hits `letak 'Saved!' ke ia kemudian …`, and the possessive matcher reads `ia kemudian` as **"its kemudian"** — ms `ia` covers it/its, and `kemudian` passed `isStructuralKeyword` because that check tests the raw value against an **English-only** set. The phantom property-path then fails put's destination type-check, killing the whole pattern match — so the put dropped whenever *any* clause followed it (bisect: `c1+c2` keeps put; `c1+c2+<anything>` loses it).

## Fix

One line: the property-token check also rejects a keyword whose **normalized** form is structural (`kemudian`→then, `tamat`→end). Language-agnostic, additive.

## A/B (same DB)

- ms **make-toast-element lossy → faithful** (the #351 within-tolerance regression, repaid), ms avgFidelity **0.9357 → 0.9379**
- every other language **byte-identical**; cross-lang 0.9494 → 0.9495, lossy 317 → 316, degenerate 67 (flat), gate green
- semantic 5615 pass; lock tests: corpus shape, then-chained guard, en + ms real-possessive guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)