### PR TITLE
fix(semantic): empty-predicate adjective as profile keyword alternative (11 langs)

### DIFF
--- a/packages/semantic/src/generators/profiles/arabic.ts
+++ b/packages/semantic/src/generators/profiles/arabic.ts
@@ -92,7 +92,7 @@ export const arabicProfile: LanguageProfile = {
     focus: { primary: 'تركيز', alternatives: ['ركز'], normalized: 'focus' },
     blur: { primary: 'ضبابية', alternatives: ['شوش'], normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: 'إفراغ', normalized: 'empty' },
+    empty: { primary: 'إفراغ', alternatives: ['فارغ'], normalized: 'empty' },
     open: { primary: 'افتح', normalized: 'open' },
     close: { primary: 'أغلق', normalized: 'close' },
     select: { primary: 'ظلل', normalized: 'select' },

--- a/packages/semantic/src/generators/profiles/bengali.ts
+++ b/packages/semantic/src/generators/profiles/bengali.ts
@@ -87,7 +87,7 @@ export const bengaliProfile: LanguageProfile = {
     focus: { primary: 'ফোকাস', alternatives: ['মনোযোগ'], normalized: 'focus' },
     blur: { primary: 'ঝাপসা', alternatives: ['ফোকাস_সরান'], normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: 'খালি-করুন', normalized: 'empty' },
+    empty: { primary: 'খালি-করুন', alternatives: ['খালি'], normalized: 'empty' },
     open: { primary: 'খুলুন', normalized: 'open' },
     close: { primary: 'বন্ধ', normalized: 'close' },
     select: { primary: 'নির্বাচন', normalized: 'select' },

--- a/packages/semantic/src/generators/profiles/hindi.ts
+++ b/packages/semantic/src/generators/profiles/hindi.ts
@@ -105,7 +105,7 @@ export const hindiProfile: LanguageProfile = {
     focus: { primary: 'फोकस', alternatives: ['केंद्रित'], normalized: 'focus' },
     blur: { primary: 'धुंधला', alternatives: ['फोकस_हटाएं'], normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: 'खाली-करें', normalized: 'empty' },
+    empty: { primary: 'खाली-करें', alternatives: ['खाली'], normalized: 'empty' },
     open: { primary: 'खोलें', normalized: 'open' },
     close: { primary: 'बंद-करें', normalized: 'close' },
     select: { primary: 'चिह्नित-करें', normalized: 'select' },

--- a/packages/semantic/src/generators/profiles/italian.ts
+++ b/packages/semantic/src/generators/profiles/italian.ts
@@ -99,7 +99,7 @@ export const italianProfile: LanguageProfile = {
     focus: { primary: 'focalizzare', normalized: 'focus' },
     blur: { primary: 'sfuocare', normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: 'svuotare', normalized: 'empty' },
+    empty: { primary: 'svuotare', alternatives: ['vuoto'], normalized: 'empty' },
     open: { primary: 'aprire', normalized: 'open' },
     close: { primary: 'chiudere', normalized: 'close' },
     select: { primary: 'selezionare', normalized: 'select' },

--- a/packages/semantic/src/generators/profiles/ms.ts
+++ b/packages/semantic/src/generators/profiles/ms.ts
@@ -85,7 +85,7 @@ export const malayProfile: LanguageProfile = {
     focus: { primary: 'fokus', normalized: 'focus' },
     blur: { primary: 'kabur', normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: 'kosongkan', normalized: 'empty' },
+    empty: { primary: 'kosongkan', alternatives: ['kosong'], normalized: 'empty' },
     open: { primary: 'buka', normalized: 'open' },
     close: { primary: 'tutup', normalized: 'close' },
     select: { primary: 'tandai', normalized: 'select' },

--- a/packages/semantic/src/generators/profiles/russian.ts
+++ b/packages/semantic/src/generators/profiles/russian.ts
@@ -170,7 +170,7 @@ export const russianProfile: LanguageProfile = {
     },
     blur: { primary: 'размыть', alternatives: ['размой'], normalized: 'blur', form: 'infinitive' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: 'опустошить', normalized: 'empty' },
+    empty: { primary: 'опустошить', alternatives: ['пустой'], normalized: 'empty' },
     open: { primary: 'открыть', normalized: 'open' },
     close: { primary: 'закрыть', normalized: 'close' },
     select: { primary: 'выделить', normalized: 'select' },

--- a/packages/semantic/src/generators/profiles/thai.ts
+++ b/packages/semantic/src/generators/profiles/thai.ts
@@ -85,7 +85,7 @@ export const thaiProfile: LanguageProfile = {
     focus: { primary: 'โฟกัส', alternatives: [], normalized: 'focus' },
     blur: { primary: 'เบลอ', alternatives: [], normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: 'ล้าง', alternatives: ['ทำให้ว่าง'], normalized: 'empty' },
+    empty: { primary: 'ล้าง', alternatives: ['ทำให้ว่าง', 'ว่าง'], normalized: 'empty' },
     open: { primary: 'เปิด', normalized: 'open' },
     close: { primary: 'ปิด', normalized: 'close' },
     select: { primary: 'ทำเครื่องหมาย', normalized: 'select' },

--- a/packages/semantic/src/generators/profiles/tl.ts
+++ b/packages/semantic/src/generators/profiles/tl.ts
@@ -89,7 +89,11 @@ export const tagalogProfile: LanguageProfile = {
     focus: { primary: 'ituon', normalized: 'focus' },
     blur: { primary: 'alisin_tuon', normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: 'walang-laman', alternatives: ['alisin-laman'], normalized: 'empty' },
+    empty: {
+      primary: 'walang-laman',
+      alternatives: ['alisin-laman', 'walang_laman'],
+      normalized: 'empty',
+    },
     open: { primary: 'buksan', normalized: 'open' },
     close: { primary: 'isara', normalized: 'close' },
     select: { primary: 'piliin', normalized: 'select' },

--- a/packages/semantic/src/generators/profiles/turkish.ts
+++ b/packages/semantic/src/generators/profiles/turkish.ts
@@ -121,7 +121,7 @@ export const turkishProfile: LanguageProfile = {
     focus: { primary: 'odak', alternatives: ['odaklanma'], normalized: 'focus' },
     blur: { primary: 'bulanık', alternatives: ['bulanıklık', 'bulanik'], normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: 'boşalt', alternatives: ['bosalt'], normalized: 'empty' },
+    empty: { primary: 'boşalt', alternatives: ['bosalt', 'boş'], normalized: 'empty' },
     open: { primary: 'aç', alternatives: ['ac'], normalized: 'open' },
     close: { primary: 'kapat', normalized: 'close' },
     select: { primary: 'vurgula', normalized: 'select' },

--- a/packages/semantic/src/generators/profiles/ukrainian.ts
+++ b/packages/semantic/src/generators/profiles/ukrainian.ts
@@ -175,7 +175,7 @@ export const ukrainianProfile: LanguageProfile = {
       form: 'infinitive',
     },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: 'спорожнити', normalized: 'empty' },
+    empty: { primary: 'спорожнити', alternatives: ['порожній'], normalized: 'empty' },
     open: { primary: 'відкрити', normalized: 'open' },
     close: { primary: 'закрити', normalized: 'close' },
     select: { primary: 'виділити', normalized: 'select' },

--- a/packages/semantic/src/generators/profiles/vietnamese.ts
+++ b/packages/semantic/src/generators/profiles/vietnamese.ts
@@ -88,7 +88,7 @@ export const vietnameseProfile: LanguageProfile = {
     focus: { primary: 'tập trung', normalized: 'focus' },
     blur: { primary: 'mất tập trung', normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: 'làm-rỗng', normalized: 'empty' },
+    empty: { primary: 'làm-rỗng', alternatives: ['trống'], normalized: 'empty' },
     open: { primary: 'mở', normalized: 'open' },
     close: { primary: 'đóng', normalized: 'close' },
     select: { primary: 'đánh-dấu', normalized: 'select' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -3044,3 +3044,80 @@ describe('generated for-loop accepts identifier loop vars + the dict in-connecti
     expect([...a].sort()).toEqual(['for', 'on', 'set']);
   });
 });
+
+describe('empty-predicate adjective is a profile keyword alternative (is-empty cluster)', () => {
+  // if-empty + input-validation dropped the `empty` action in 11 languages.
+  // The `is empty` predicate is recovered through profile.keywords.empty —
+  // languages that worked (es vacío, pl pusty, de leer, pt vazio, zh 空的)
+  // list the predicate ADJECTIVE the dict emits as a keyword alternative;
+  // the failing ones listed only the command VERB (ru опустошить, it svuotare,
+  // uk спорожнити). A tokenizer entry alone is NOT sufficient — it had
+  // 'vuoto'→empty in the tokenizer and still dropped the predicate. Added the
+  // dict-emitted adjective as a keywords.empty alternative for ar فارغ,
+  // bn খালি, hi खाली, it vuoto, ms kosong, ru пустой, th ว่าง, tl walang_laman,
+  // tr boş, uk порожній, vi trống. if-empty 9/23 → 19/23 faithful,
+  // input-validation similar (avgFidelity 0.9541 → 0.9554, lossy 258 → 236,
+  // 0 regressions). Residuals tracked: he (possessive untranslated),
+  // ja/ko (SOV blur-verb hijack), qu (the dict emits no empty word at all),
+  // sw (event-head drop, separate).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped transformer output (en → lang), if-empty:
+  // `on blur if my value is empty add .error to me put "Required" into next
+  //  .error-message end`
+  const corpus: Array<[string, string]> = [
+    [
+      'ru',
+      'при размыть если мой значение есть пустой добавить .error в я затем положить "Required" в следующий .error-message конец',
+    ],
+    [
+      'it',
+      'su sfuocatura se mio valore è vuoto aggiungere .error in io allora mettere "Required" in prossimo .error-message fine',
+    ],
+    [
+      'vi',
+      'khi mất tập trung nếu của tôi giá trị là trống thêm .error vào tôi rồi đặt "Required" vào tiếp theo .error-message kết thúc',
+    ],
+    [
+      'uk',
+      'при розмиття якщо мій значення є порожній додати .error в я тоді покласти "Required" в наступний .error-message кінець',
+    ],
+  ];
+  for (const [lang, input] of corpus) {
+    it(`[${lang}] if-empty keeps the empty predicate (was dropped)`, () => {
+      const a = actions(parse(input, lang as 'ru'));
+      expect(a.has('on')).toBe(true);
+      expect(a.has('if')).toBe(true);
+      expect(a.has('empty')).toBe(true);
+      expect(a.has('add')).toBe(true);
+    });
+  }
+
+  it('[ru] the empty COMMAND verb still parses (опустошить unchanged)', () => {
+    const a = actions(parse('опустошить #list', 'ru'));
+    expect(a.has('empty')).toBe(true);
+  });
+
+  it('[en] the en reference parse is unchanged', () => {
+    const a = actions(
+      parse(
+        'on blur if my value is empty add .error to me put "Required" into next .error-message end',
+        'en'
+      )
+    );
+    expect(a.has('if')).toBe(true);
+    expect(a.has('empty')).toBe(true);
+    expect(a.has('add')).toBe(true);
+    expect(a.has('put')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-06-12T04:13:33.111Z",
-  "commit": "67e8f962",
+  "timestamp": "2026-06-12T04:25:45.202Z",
+  "commit": "a03eeddb",
   "languages": {
     "ar": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9311967924424667,
-      "avgFidelity": 0.9528322440087146,
+      "avgFidelity": 0.9554466230936819,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
@@ -18,15 +18,13 @@
         "breakpoint-command",
         "fetch-loading-state",
         "focus-trap",
-        "if-empty",
         "if-exists",
-        "input-validation",
         "keydown-key-is-syntax",
         "modal-close-button",
         "repeat-until-event",
         "window-scroll"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -650,7 +648,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8884559884559885,
-      "avgFidelity": 0.9760822510822511,
+      "avgFidelity": 0.9786796536796537,
       "degeneratePasses": [],
       "lossyPasses": [
         "announce-screen-reader",
@@ -658,15 +656,13 @@
         "fetch-do-not-throw",
         "fetch-json",
         "form-disable-on-submit",
-        "if-empty",
         "if-exists",
-        "input-validation",
         "make-element",
         "make-toast-element",
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1306,7 +1302,7 @@
         "put-before",
         "when-value-changes"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1930,7 +1926,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2558,7 +2554,7 @@
       "avgFidelity": 0.9803921568627451,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3193,7 +3189,7 @@
         "put-before",
         "when-value-changes"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3843,7 +3839,7 @@
         "trigger-event",
         "wait-then"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4467,7 +4463,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "avgFidelity": 0.9254329004329005,
+      "avgFidelity": 0.9280303030303032,
       "degeneratePasses": [
         "bind-auto-detect",
         "bind-explicit-property",
@@ -4484,13 +4480,11 @@
         "event-throttle",
         "fetch-do-not-throw",
         "fetch-json",
-        "if-empty",
-        "input-validation",
         "keydown-key-is-syntax",
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5138,7 +5132,7 @@
         "settle-animations",
         "template-literal-interpolation"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5762,16 +5756,10 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9337586886606484,
-      "avgFidelity": 0.9721132897603485,
+      "avgFidelity": 0.9747276688453158,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": [
-        "event-debounce",
-        "fetch-loading-state",
-        "if-empty",
-        "input-validation",
-        "unless-condition"
-      ],
-      "bundleSize": 407847,
+      "lossyPasses": ["event-debounce", "fetch-loading-state", "unless-condition"],
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6429,7 +6417,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7075,7 +7063,7 @@
         "unless-condition",
         "wait-for-event"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7700,7 +7688,7 @@
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.9374454032172144,
-      "avgFidelity": 0.9431767337807608,
+      "avgFidelity": 0.9458612975391499,
       "degeneratePasses": [],
       "lossyPasses": [
         "async-block",
@@ -7708,10 +7696,8 @@
         "fetch-basic",
         "fetch-loading-state",
         "get-attribute-possessive-dot",
-        "if-empty",
         "if-exists",
         "input-mirror",
-        "input-validation",
         "keydown-key-is-syntax",
         "last-in-collection",
         "make-element",
@@ -7725,7 +7711,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8354,7 +8340,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8990,7 +8976,7 @@
         "unless-condition",
         "when-value-changes"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9654,7 +9640,7 @@
         "unless-condition",
         "window-scroll"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10279,17 +10265,10 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8983302411873844,
-      "avgFidelity": 0.9820346320346319,
+      "avgFidelity": 0.9846320346320346,
       "degeneratePasses": ["install-behavior"],
-      "lossyPasses": [
-        "event-debounce",
-        "fetch-loading-state",
-        "if-empty",
-        "input-validation",
-        "trigger-event",
-        "unless-condition"
-      ],
-      "bundleSize": 407847,
+      "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event", "unless-condition"],
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10930,7 +10909,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11551,16 +11530,10 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.940960626674911,
-      "avgFidelity": 0.9917748917748919,
+      "avgFidelity": 0.9943722943722944,
       "degeneratePasses": [],
-      "lossyPasses": [
-        "event-debounce",
-        "fetch-loading-state",
-        "if-empty",
-        "input-validation",
-        "unless-condition"
-      ],
-      "bundleSize": 407847,
+      "lossyPasses": ["event-debounce", "fetch-loading-state", "unless-condition"],
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12185,15 +12158,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9122867328749679,
-      "avgFidelity": 0.9666666666666667,
+      "avgFidelity": 0.9692640692640694,
       "degeneratePasses": ["event-debounce"],
       "lossyPasses": [
         "breakpoint-command",
         "fetch-loading-state",
         "focus-trap",
-        "if-empty",
         "if-exists",
-        "input-validation",
         "modal-close-button",
         "morph-with-template",
         "render-template-with-data",
@@ -12202,7 +12173,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12827,7 +12798,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.877923021060276,
-      "avgFidelity": 0.9489106753812635,
+      "avgFidelity": 0.951525054466231,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -12840,13 +12811,11 @@
         "fetch-do-not-throw",
         "fetch-json",
         "form-disable-on-submit",
-        "if-empty",
-        "input-validation",
         "take-class-from-siblings",
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13470,17 +13439,10 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.896021438878582,
-      "avgFidelity": 0.9820346320346319,
+      "avgFidelity": 0.9846320346320346,
       "degeneratePasses": ["install-behavior"],
-      "lossyPasses": [
-        "event-debounce",
-        "fetch-loading-state",
-        "if-empty",
-        "input-validation",
-        "trigger-event",
-        "unless-condition"
-      ],
-      "bundleSize": 407847,
+      "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event", "unless-condition"],
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14105,15 +14067,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.900968872397444,
-      "avgFidelity": 0.97012987012987,
+      "avgFidelity": 0.9727272727272727,
       "degeneratePasses": [],
       "lossyPasses": [
         "event-debounce",
         "fetch-loading-state",
         "get-attribute-possessive-dot",
-        "if-empty",
         "input-mirror",
-        "input-validation",
         "keydown-key-is-syntax",
         "method-call-possessive-dot",
         "morph-with-template",
@@ -14121,7 +14081,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14759,7 +14719,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 407847,
+      "bundleSize": 407900,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15378,7 +15338,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 407847,
+      "size": 407900,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Mechanism

The `is empty` predicate is recovered through `profile.keywords.empty`. Languages that kept the `empty` action (es `vacío`, pl `pusty`, de `leer`, pt `vazio`, zh `空的`) list the predicate **adjective** the i18n dict emits as a keyword alternative; the failing 11 listed only the command **verb** (ru `опустошить`, it `svuotare`, uk `спорожнити`). A tokenizer entry alone is not sufficient — it already had `vuoto`→empty in its tokenizer and still dropped the predicate.

Added the dict-emitted adjective as a `keywords.empty` alternative for: ar `فارغ`, bn `খালি`, hi `खाली`, it `vuoto`, ms `kosong`, ru `пустой`, th `ว่าง`, tl `walang_laman`, tr `boş`, uk `порожній`, vi `trống` (the sw `tupu`/pl `pusty` class, mirrored).

## Measured A/B (same DB)

- avgFidelity **0.9541 → 0.9554**
- lossy **236** (−22)
- degenerate 67 (unchanged), 0 parse-rate drops, 0 faithful→degenerate flips
- if-empty 9/23 → 19/23 faithful; input-validation similar

Residuals tracked: he (untranslated possessive), ja/ko (SOV hijack), qu (dict emits no empty word), sw (event-head drop, separate mechanism).

Lock tests added; baseline regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)