### PR TITLE
fix(semantic): ja particle reading must not split a longer keyword (もし → も+し)

### DIFF
--- a/packages/semantic/src/tokenizers/extractors/japanese-particle.ts
+++ b/packages/semantic/src/tokenizers/extractors/japanese-particle.ts
@@ -60,14 +60,30 @@ export class JapaneseParticleExtractor implements ContextAwareExtractor {
 
   setContext(context: TokenizerContext): void {
     this._context = context;
-    void this._context; // Satisfy noUnusedLocals
+  }
+
+  /**
+   * A single-character particle reading must NOT split a longer keyword that
+   * starts at the same position: もし (if) would otherwise tokenize as
+   * も[particle] + し[identifier] and the conditional could never anchor.
+   * Checks exact 2..4-char slices against the keyword map (longest first).
+   */
+  private longerKeywordStartsHere(input: string, position: number): boolean {
+    if (!this._context) return false;
+    for (let len = 4; len >= 2; len--) {
+      const slice = input.slice(position, position + len);
+      if (slice.length === len && this._context.isKeyword(slice)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   canExtract(input: string, position: number): boolean {
     const char = input[position];
 
-    // Check single-character particles
-    if (SINGLE_CHAR_PARTICLES.has(char)) {
+    // Check single-character particles (unless a longer keyword starts here)
+    if (SINGLE_CHAR_PARTICLES.has(char) && !this.longerKeywordStartsHere(input, position)) {
       return true;
     }
 
@@ -97,8 +113,10 @@ export class JapaneseParticleExtractor implements ContextAwareExtractor {
       }
     }
 
-    // Try single-character particles
+    // Try single-character particles (the canExtract keyword gate re-applies
+    // because extract() can be reached through a different dispatch path)
     const char = input[position];
+    if (this.longerKeywordStartsHere(input, position)) return null;
     const metadata = SINGLE_CHAR_PARTICLES.get(char);
     if (metadata) {
       return {

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { parse, canParse } from '../src';
+import { parse, canParse, getTokenizer } from '../src';
 
 describe('Korean fetch keyword alignment (가져오기)', () => {
   // Corpus-shaped event handlers from the multilingual baseline.
@@ -3119,5 +3119,69 @@ describe('empty-predicate adjective is a profile keyword alternative (is-empty c
     expect(a.has('empty')).toBe(true);
     expect(a.has('add')).toBe(true);
     expect(a.has('put')).toBe(true);
+  });
+});
+
+describe('ja particle reading must not split a longer keyword (もし → も+し)', () => {
+  // The documented Track-A diagnosis ("the SOV generators never emit an
+  // if-event variant for ja") was wrong: if-event-ja-sov(-simple/-temporal…)
+  // are all generated. They could never anchor because the ja TOKENIZER never
+  // produced an if token — JapaneseParticleExtractor runs before the keyword
+  // extractor and read the も of もし as the standalone "also" particle,
+  // splitting the conditional into も[particle] + し[identifier]. The particle
+  // extractor now defers when an exact 2..4-char profile keyword starts at the
+  // same position (checked via TokenizerContext.isKeyword — the hook reserved
+  // for exactly this). One fix, two ja failure modes: もし anchors the fused
+  // if-event patterns, AND the ぼかし(blur-event)-as-verb hijack disappears
+  // because the higher-priority event pattern can now outrank the bare verb
+  // match. ja if-condition/if-matches/if-exists flip faithful (avgFidelity
+  // 0.9554 → 0.9566, lossy 236 → 228, degenerate 67 → 65, 0 regressions).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('[ja] もし tokenizes as the if keyword, not も+し', () => {
+    const t = getTokenizer('ja');
+    const tok = t.tokenize('もし $x').peek() as { value: string; normalized?: string };
+    expect(tok.value).toBe('もし');
+    expect(tok.normalized).toBe('if');
+  });
+
+  it('[ja] the fused if-event head anchors (was: no pattern at all)', () => {
+    const a = actions(
+      parse(
+        'クリック で もし 私の 値 である 追加 .error を 空 私 に それから "Required" を 次 .error-message に 置く 終わり',
+        'ja'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('if')).toBe(true);
+    expect(a.has('add')).toBe(true);
+  });
+
+  it('[ja] the blur-event head no longer hijacks the handler into a bare blur verb', () => {
+    // if-empty corpus shape — used to parse as {blur} via blur-ja-generated.
+    const a = actions(
+      parse(
+        'ぼかし で もし 私の 値 である 追加 .error を 空 私 に それから "Required" を 次 .error-message に 置く 終わり',
+        'ja'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('if')).toBe(true);
+    expect(a.has('blur')).toBe(false);
+  });
+
+  it('[ja] genuine particles still tokenize (を/に roles unchanged)', () => {
+    const a = actions(parse('.active を 切り替え', 'ja'));
+    expect(a.has('toggle')).toBe(true);
   });
 });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T04:25:45.202Z",
-  "commit": "a03eeddb",
+  "timestamp": "2026-06-12T04:38:03.311Z",
+  "commit": "1cfdd303",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -24,7 +24,7 @@
         "repeat-until-event",
         "window-scroll"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -662,7 +662,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1302,7 +1302,7 @@
         "put-before",
         "when-value-changes"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1926,7 +1926,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2554,7 +2554,7 @@
       "avgFidelity": 0.9803921568627451,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3189,7 +3189,7 @@
         "put-before",
         "when-value-changes"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3839,7 +3839,7 @@
         "trigger-event",
         "wait-then"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4484,7 +4484,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5132,7 +5132,7 @@
         "settle-animations",
         "template-literal-interpolation"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5759,7 +5759,7 @@
       "avgFidelity": 0.9747276688453158,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "unless-condition"],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6382,42 +6382,32 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8507936507936508,
-      "avgFidelity": 0.90487012987013,
+      "avgConfidence": 0.8787157287157287,
+      "avgFidelity": 0.9340909090909091,
       "degeneratePasses": [
         "announce-screen-reader",
         "behavior-draggable",
         "behavior-removable",
         "behavior-resizable",
-        "behavior-sortable",
-        "if-empty",
-        "input-validation"
+        "behavior-sortable"
       ],
       "lossyPasses": [
         "caret-var-on-target",
-        "event-key-combo",
         "fetch-do-not-throw",
-        "fetch-error-handling",
         "fetch-json",
-        "focus-trap",
         "form-disable-on-submit",
-        "form-submit-prevent",
         "get-attribute-possessive-dot",
         "get-value-possessive-dot",
-        "if-condition",
-        "if-exists",
-        "if-matches",
+        "if-empty",
         "input-mirror",
+        "input-validation",
         "method-call-possessive-dot",
-        "modal-close-backdrop",
         "on-custom-event-receive",
         "put-content-basic",
         "template-literal-list-build",
-        "unless-condition",
-        "window-keydown",
-        "window-scroll"
+        "unless-condition"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -6543,6 +6533,10 @@
           "success": true,
           "confidence": 1
         },
+        "if-condition": {
+          "success": true,
+          "confidence": 1
+        },
         "repeat-for-each": {
           "success": true,
           "confidence": 1
@@ -6603,6 +6597,10 @@
           "success": true,
           "confidence": 1
         },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
         "accordion-toggle": {
           "success": true,
           "confidence": 1
@@ -6624,6 +6622,10 @@
           "confidence": 1
         },
         "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-validation": {
           "success": true,
           "confidence": 1
         },
@@ -6671,6 +6673,10 @@
           "success": true,
           "confidence": 1
         },
+        "repeat-while": {
+          "success": true,
+          "confidence": 1
+        },
         "event-once": {
           "success": true,
           "confidence": 1
@@ -6679,11 +6685,27 @@
           "success": true,
           "confidence": 1
         },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 1
+        },
         "fetch-loading-state": {
           "success": true,
           "confidence": 1
         },
         "fetch-error-handling": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-empty": {
           "success": true,
           "confidence": 1
         },
@@ -6704,6 +6726,10 @@
           "confidence": 1
         },
         "announce-screen-reader": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-trap": {
           "success": true,
           "confidence": 1
         },
@@ -6851,14 +6877,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.6
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.6
-        },
         "put-before": {
           "success": true,
           "confidence": 0.5
@@ -6876,10 +6894,6 @@
           "confidence": 0.5
         },
         "multiple-events": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-condition": {
           "success": true,
           "confidence": 0.5
         },
@@ -6904,10 +6918,6 @@
           "confidence": 0.5
         },
         "modal-close-button": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-close-backdrop": {
           "success": true,
           "confidence": 0.5
         },
@@ -6939,27 +6949,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.5
-        },
         "event-debounce": {
           "success": true,
           "confidence": 0.5
         },
         "event-throttle": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-exists": {
           "success": true,
           "confidence": 0.5
         },
@@ -6976,10 +6970,6 @@
           "confidence": 0.5
         },
         "computed-value": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "focus-trap": {
           "success": true,
           "confidence": 0.5
         },
@@ -7063,7 +7053,7 @@
         "unless-condition",
         "wait-for-event"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7711,7 +7701,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8340,7 +8330,7 @@
         "trigger-event",
         "unless-condition"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8976,7 +8966,7 @@
         "unless-condition",
         "when-value-changes"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9640,7 +9630,7 @@
         "unless-condition",
         "window-scroll"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10268,7 +10258,7 @@
       "avgFidelity": 0.9846320346320346,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event", "unless-condition"],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10909,7 +10899,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11533,7 +11523,7 @@
       "avgFidelity": 0.9943722943722944,
       "degeneratePasses": [],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "unless-condition"],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12173,7 +12163,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12815,7 +12805,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13442,7 +13432,7 @@
       "avgFidelity": 0.9846320346320346,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event", "unless-condition"],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14081,7 +14071,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14719,7 +14709,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 407900,
+      "bundleSize": 408136,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15338,7 +15328,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 407900,
+      "size": 408136,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Mechanism

Track A probe result — the documented diagnosis ("the SOV generators never emit an if-event variant for ja") was **wrong**: `if-event-ja-sov`, `-sov-simple`, `-sov-temporal` etc. are all generated. They could never anchor because the ja **tokenizer** never produced an `if` token: `JapaneseParticleExtractor` runs before the keyword extractor and read the も of もし as the standalone "also" particle, splitting the conditional into も[particle] + し[identifier].

The particle extractor now defers when an exact 2..4-char profile keyword starts at the same position, via `TokenizerContext.isKeyword` — the context hook reserved for exactly this ("particle boundary detection").

One fix, two ja failure modes:
1. もし anchors the fused if-event patterns (`クリック で もし …` → `if-event-ja-sov-simple`)
2. the ぼかし(blur-event)-as-verb hijack disappears — the higher-priority event pattern now outranks the bare `blur` verb match that used to swallow whole handlers into `{blur}`

## Measured A/B (same DB)

- avgFidelity **0.9554 → 0.9566**
- lossy **236 → 228** (−8) | degenerate **67 → 65** (−2)
- 0 parse-rate drops, 0 faithful→degenerate flips
- ja: if-condition, if-matches, if-exists, if-empty(partial) flip

Lock tests added; baseline regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)