### PR TITLE
fix(semantic): positional put (before/after) for the 8 languages without variants

### DIFF
--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1606,7 +1606,10 @@ export class SemanticParserImpl implements ISemanticParser {
       ar: new Set(['ثم', 'بعدها', 'ثمّ']),
       es: new Set(['entonces', 'luego', 'después']),
       ko: new Set(['그다음', '그리고', '그런후', '그러면']),
-      zh: new Set(['然后', '接着', '之后']),
+      // 之后 is deliberately ABSENT: the zh transformer emits it as positional
+      // `after` (`放置 把 X 之后 Y`, put-after) and emits 那么 for then — keeping
+      // it here split the put clause at 之后 and dropped the put.
+      zh: new Set(['然后', '接着', '那么']),
       tr: new Set(['sonra', 'ardından', 'daha sonra']),
       pt: new Set(['então', 'depois', 'logo']),
       fr: new Set(['puis', 'ensuite', 'alors']),

--- a/packages/semantic/src/patterns/put.ts
+++ b/packages/semantic/src/patterns/put.ts
@@ -742,7 +742,96 @@ function getPutPatternsZh(): LanguagePattern[] {
 /**
  * Get put patterns for a specific language.
  */
+/**
+ * Positional put (before/after) for languages whose handcrafted/generated put
+ * patterns cover only the into-destination form. The i18n transformer emits
+ * `<verb> {patient} <before|after-word> {destination}` (he inserts the את
+ * patient marker after the verb; zh fronts 把 between verb and patient).
+ * Without these, `put X after/before Y` keeps the event but drops the put
+ * (put-after/put-before lossy in exactly these 8 languages). en/es/pl/ru/uk/vi
+ * carry their own handcrafted before/after variants — this table is only for
+ * the languages that had none.
+ */
+const PUT_POSITIONAL: ReadonlyArray<{
+  lang: string;
+  verb: string;
+  verbAlts?: string[];
+  before: string;
+  after: string;
+  /** literal inserted between verb and patient (he את, zh 把-optional) */
+  patientPrefix?: string;
+  patientPrefixOptional?: boolean;
+}> = [
+  { lang: 'de', verb: 'setzen', before: 'vor', after: 'nach' },
+  { lang: 'fr', verb: 'mettre', before: 'avant', after: 'après' },
+  { lang: 'he', verb: 'שים', patientPrefix: 'את', before: 'לפני', after: 'אחרי' },
+  {
+    lang: 'id',
+    verb: 'taruh',
+    verbAlts: ['letakkan', 'masukkan', 'tempatkan'],
+    before: 'sebelum',
+    after: 'setelah',
+  },
+  { lang: 'ms', verb: 'letak', before: 'sebelum', after: 'selepas' },
+  { lang: 'pt', verb: 'colocar', before: 'antes', after: 'depois' },
+  { lang: 'sw', verb: 'weka', before: 'kabla', after: 'baada' },
+  {
+    lang: 'zh',
+    verb: '放置',
+    verbAlts: ['放', '放入'],
+    patientPrefix: '把',
+    patientPrefixOptional: true,
+    before: '之前',
+    after: '之后',
+  },
+];
+
+function buildPositionalPutPatterns(language: string): LanguagePattern[] {
+  const spec = PUT_POSITIONAL.find(s => s.lang === language);
+  if (!spec) return [];
+  return (['before', 'after'] as const).map(manner => {
+    const posWord = spec[manner];
+    const tokens: LanguagePattern['template']['tokens'] = [
+      spec.verbAlts
+        ? { type: 'literal', value: spec.verb, alternatives: spec.verbAlts }
+        : { type: 'literal', value: spec.verb },
+    ];
+    if (spec.patientPrefix) {
+      tokens.push(
+        spec.patientPrefixOptional
+          ? {
+              type: 'group',
+              optional: true,
+              tokens: [{ type: 'literal', value: spec.patientPrefix }],
+            }
+          : { type: 'literal', value: spec.patientPrefix }
+      );
+    }
+    tokens.push(
+      { type: 'role', role: 'patient' },
+      { type: 'literal', value: posWord },
+      { type: 'role', role: 'destination' }
+    );
+    return {
+      id: `put-${spec.lang}-${manner}`,
+      language: spec.lang,
+      command: 'put',
+      priority: 95,
+      template: {
+        format: `${spec.verb} {patient} ${posWord} {destination}`,
+        tokens,
+      },
+      extraction: {
+        patient: { position: spec.patientPrefix && !spec.patientPrefixOptional ? 2 : 1 },
+        destination: { marker: posWord },
+        manner: { default: { type: 'literal', value: manner } },
+      },
+    } satisfies LanguagePattern;
+  });
+}
+
 export function getPutPatternsForLanguage(language: string): LanguagePattern[] {
+  const positional = buildPositionalPutPatterns(language);
   switch (language) {
     case 'bn':
       return getPutPatternsBn();
@@ -753,7 +842,7 @@ export function getPutPatternsForLanguage(language: string): LanguagePattern[] {
     case 'hi':
       return getPutPatternsHi();
     case 'id':
-      return getPutPatternsId();
+      return [...getPutPatternsId(), ...positional];
     case 'it':
       return getPutPatternsIt();
     case 'pl':
@@ -767,8 +856,8 @@ export function getPutPatternsForLanguage(language: string): LanguagePattern[] {
     case 'vi':
       return getPutPatternsVi();
     case 'zh':
-      return getPutPatternsZh();
+      return [...getPutPatternsZh(), ...positional];
     default:
-      return [];
+      return positional;
   }
 }

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -3249,3 +3249,72 @@ describe('unless keyword exists in profiles the dicts emit for (pl/it/ru/uk/th)'
     expect([...a].sort()).toEqual(['on', 'toggle', 'unless']);
   });
 });
+
+describe('positional put (before/after) for the 8 languages without variants', () => {
+  // put-after/put-before were lossy in exactly de/fr/he/id/ms/pt/sw/zh — the
+  // languages whose handcrafted/generated put patterns cover only the
+  // into-destination form (en/es/pl/ru/uk/vi carry their own before/after
+  // variants). The transformer emits `<verb> {patient} <pos-word> {dest}`
+  // (he inserts the את patient marker; zh fronts 把). Added a table-driven
+  // builder mirroring the put-es-after shape for the 8.
+  //
+  // zh needed one more mechanism: 之后 was in the parser's curated zh
+  // then-keyword set, so `放置 把 X 之后 Y` split at 之后 and the put dropped
+  // even with the pattern present. The zh transformer emits 那么 for then
+  // (now in the set) and 之后 only as positional after — removed from the set.
+  // Side effect: zh behavior-* go null-parse → degenerate (bodies now split
+  // at 那么), a strict improvement. lossy 223 → 207, avgFidelity
+  // 0.9571 → 0.9586, 0 regressions.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped transformer output (en → lang), put-after:
+  // `on click put "<p>New</p>" after me`
+  const corpus: Array<[string, string]> = [
+    ['de', 'bei klick setzen "<p>New</p>" nach ich'],
+    ['fr', 'sur clic mettre "<p>New</p>" après moi'],
+    ['he', 'ב לחיצה שים את "<p>New</p>" אחרי אני'],
+    ['id', 'pada klik taruh "<p>New</p>" setelah saya'],
+    ['ms', 'apabila click letak "<p>New</p>" selepas saya'],
+    ['pt', 'em clique colocar "<p>New</p>" depois eu'],
+    ['sw', 'kwenye bonyeza weka "<p>New</p>" baada mimi'],
+    ['zh', '当 点击 时 放置 把 "<p>New</p>" 之后 我'],
+  ];
+  for (const [lang, input] of corpus) {
+    it(`[${lang}] put-after keeps the put (was {on})`, () => {
+      const a = actions(parse(input, lang as 'de'));
+      expect(a.has('on')).toBe(true);
+      expect(a.has('put')).toBe(true);
+    });
+  }
+
+  it('[zh] put-before works symmetrically', () => {
+    const a = actions(parse('当 点击 时 放置 把 "<p>New</p>" 之前 我', 'zh'));
+    expect(a.has('put')).toBe(true);
+  });
+
+  it('[zh] 那么 then-chains still split (replacement for the removed 之后)', () => {
+    const a = actions(parse('当 点击 时 设置 把 $x 到 "1" 那么 切换 .active', 'zh'));
+    expect(a.has('set')).toBe(true);
+    expect(a.has('toggle')).toBe(true);
+  });
+
+  it('[de] the into-destination put is unchanged', () => {
+    const a = actions(parse('bei klick setzen "x" zu #out', 'de'));
+    expect(a.has('on')).toBe(true);
+  });
+
+  it('[en] the en reference parse is unchanged', () => {
+    const a = actions(parse('on click put "<p>New</p>" after me', 'en'));
+    expect([...a].sort()).toEqual(['on', 'put']);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T04:51:24.618Z",
-  "commit": "e603e963",
+  "timestamp": "2026-06-12T05:02:38.973Z",
+  "commit": "11e468da",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -24,7 +24,7 @@
         "repeat-until-event",
         "window-scroll"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -662,7 +662,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1287,7 +1287,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9315177923021051,
-      "avgFidelity": 0.9527233115468409,
+      "avgFidelity": 0.9592592592592591,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "async-block",
@@ -1298,11 +1298,9 @@
         "get-value",
         "if-exists",
         "keydown-key-is-syntax",
-        "put-after",
-        "put-before",
         "when-value-changes"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1926,7 +1924,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2554,7 +2552,7 @@
       "avgFidelity": 0.9803921568627451,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3178,18 +3176,16 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9292768959435616,
-      "avgFidelity": 0.9616557734204793,
+      "avgFidelity": 0.9681917211328975,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "async-block",
         "blur-element",
         "fetch-with-headers",
         "if-exists",
-        "put-after",
-        "put-before",
         "when-value-changes"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3813,7 +3809,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8469447038074495,
-      "avgFidelity": 0.9275599128540306,
+      "avgFidelity": 0.9340958605664489,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
@@ -3828,8 +3824,6 @@
         "input-validation",
         "keydown-key-is-syntax",
         "last-in-collection",
-        "put-after",
-        "put-before",
         "send-event",
         "send-event-to-form",
         "send-with-detail",
@@ -3839,7 +3833,7 @@
         "trigger-event",
         "wait-then"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4484,7 +4478,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5109,7 +5103,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9330117232078005,
-      "avgFidelity": 0.9262527233115468,
+      "avgFidelity": 0.9327886710239651,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "caret-var-increment",
@@ -5121,8 +5115,6 @@
         "keydown-key-is-syntax",
         "method-call-possessive-dot",
         "morph-with-template",
-        "put-after",
-        "put-before",
         "render-template-with-data",
         "repeat-until-event",
         "repeat-while",
@@ -5132,7 +5124,7 @@
         "settle-animations",
         "template-literal-interpolation"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5759,7 +5751,7 @@
       "avgFidelity": 0.9769063180827887,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "fetch-loading-state"],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6407,7 +6399,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7053,7 +7045,7 @@
         "unless-condition",
         "wait-for-event"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7678,7 +7670,7 @@
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.9374454032172144,
-      "avgFidelity": 0.9458612975391499,
+      "avgFidelity": 0.9525727069351231,
       "degeneratePasses": [],
       "lossyPasses": [
         "async-block",
@@ -7692,8 +7684,6 @@
         "last-in-collection",
         "make-element",
         "method-call-possessive-dot",
-        "put-after",
-        "put-before",
         "render-template-with-data",
         "set-color-variable",
         "set-opacity",
@@ -7701,7 +7691,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8324,7 +8314,7 @@
       "avgFidelity": 0.968409586056645,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["blur-element", "get-value", "keydown-key-is-syntax", "trigger-event"],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8948,19 +8938,17 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8958294428882667,
-      "avgFidelity": 0.9594771241830065,
+      "avgFidelity": 0.9660130718954247,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "async-block",
         "blur-element",
         "fetch-with-headers",
         "if-exists",
-        "put-after",
-        "put-before",
         "unless-condition",
         "when-value-changes"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9624,7 +9612,7 @@
         "unless-condition",
         "window-scroll"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10252,7 +10240,7 @@
       "avgFidelity": 0.9867965367965368,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event"],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10877,7 +10865,7 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.878719576719577,
-      "avgFidelity": 0.9510000000000001,
+      "avgFidelity": 0.9576666666666667,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "blur-element",
@@ -10888,12 +10876,10 @@
         "keydown-key-is-syntax",
         "make-element",
         "make-toast-element",
-        "put-after",
-        "put-before",
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11517,7 +11503,7 @@
       "avgFidelity": 0.9965367965367965,
       "degeneratePasses": [],
       "lossyPasses": ["event-debounce", "fetch-loading-state"],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12157,7 +12143,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12799,7 +12785,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13426,7 +13412,7 @@
       "avgFidelity": 0.9867965367965368,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event"],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14065,7 +14051,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14686,24 +14672,22 @@
       }
     },
     "zh": {
-      "parseSuccess": 150,
-      "parseFailure": 4,
-      "parseRate": 0.974025974025974,
-      "avgConfidence": 0.99805291005291,
-      "avgFidelity": 0.9758888888888888,
-      "degeneratePasses": [],
+      "parseSuccess": 153,
+      "parseFailure": 1,
+      "parseRate": 0.9935064935064936,
+      "avgConfidence": 0.9882871667185392,
+      "avgFidelity": 0.9632897603485838,
+      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "form-submit-prevent",
         "get-value",
-        "put-after",
-        "put-before",
         "set-color-variable",
         "take-class-from-siblings",
         "tell-command",
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 408235,
+      "bundleSize": 409686,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15309,20 +15293,23 @@
           "success": false
         },
         "behavior-draggable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-sortable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-resizable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         }
       }
     }
   },
   "bundles": {
     "browser-priority": {
-      "size": 408235,
+      "size": 409686,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Mechanism

`put-after`/`put-before` were lossy in exactly **de/fr/he/id/ms/pt/sw/zh** — the languages whose handcrafted/generated put patterns cover only the into-destination form (en/es/pl/ru/uk/vi carry their own before/after variants). The transformer emits `<verb> {patient} <pos-word> {destination}` (he inserts the את patient marker; zh fronts 把). Added a table-driven builder mirroring the existing `put-es-after` shape.

zh needed a second mechanism: **之后 was in the parser's curated zh then-keyword set**, so `放置 把 X 之后 Y` split at 之后 and the put dropped even with the pattern present. The zh transformer emits 那么 for then (added to the set) and 之后 only as positional after (removed from it).

## Measured A/B (same DB)

- avgFidelity **0.9571 → 0.9586**
- lossy **223 → 207** (−16: put-after + put-before × 8 languages)
- degenerate 65 → 68 — the +3 are zh `behavior-*` flipping **null-parse → degenerate** (bodies now split at 那么): parse-rate up, strictly better, behavior family is deferred Track 2
- 0 parse-rate drops, 0 faithful→degenerate flips, 0 warnings

Lock tests added; baseline regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)