### PR TITLE
fix(semantic): qu patient-first SOV variants for add/remove/put

### DIFF
--- a/packages/semantic/src/patterns/add.ts
+++ b/packages/semantic/src/patterns/add.ts
@@ -278,6 +278,30 @@ function getAddPatternsQu(): LanguagePattern[] {
         patient: { position: 1 },
       },
     },
+    // Patient-first with destination: .active ta #button man yapay — the i18n
+    // transformer emits PATIENT-first SOV for qu (`.modal-open ta kurku man
+    // yapay`), the dest-first pattern below never matches that order
+    // (modal-open / repeat-for-each lossy).
+    {
+      id: 'add-qu-patient-first',
+      language: 'qu',
+      command: 'add',
+      priority: 96,
+      template: {
+        format: '{patient} ta {destination} man yapay',
+        tokens: [
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: 'ta' },
+          { type: 'role', role: 'destination' },
+          { type: 'literal', value: 'man' },
+          { type: 'literal', value: 'yapay', alternatives: ['yapaykuy'] },
+        ],
+      },
+      extraction: {
+        patient: { position: 0 },
+        destination: { position: 2 },
+      },
+    },
     // With destination: #button man .active ta yapay
     {
       id: 'add-qu-with-dest',

--- a/packages/semantic/src/patterns/put.ts
+++ b/packages/semantic/src/patterns/put.ts
@@ -678,6 +678,36 @@ function getPutPatternsVi(): LanguagePattern[] {
   ];
 }
 
+function getPutPatternsQu(): LanguagePattern[] {
+  return [
+    // Patient-first SOV with destination: chay ta kurku man churay — the i18n
+    // transformer emits PATIENT-first for qu (`chay ta noqa man churay`,
+    // async-block / fetch-with-headers / if-exists then-tails); there were no
+    // handcrafted qu put patterns at all and the generated SOV order is
+    // dest-first, so every marked-destination put dropped.
+    {
+      id: 'put-qu-patient-first',
+      language: 'qu',
+      command: 'put',
+      priority: 96,
+      template: {
+        format: '{patient} ta {destination} man churay',
+        tokens: [
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: 'ta' },
+          { type: 'role', role: 'destination' },
+          { type: 'literal', value: 'man' },
+          { type: 'literal', value: 'churay', alternatives: ['tiyachiy'] },
+        ],
+      },
+      extraction: {
+        patient: { position: 0 },
+        destination: { position: 2 },
+      },
+    },
+  ];
+}
+
 function getPutPatternsZh(): LanguagePattern[] {
   return [
     {
@@ -849,6 +879,8 @@ export function getPutPatternsForLanguage(language: string): LanguagePattern[] {
       return getPutPatternsPl();
     case 'ru':
       return getPutPatternsRu();
+    case 'qu':
+      return getPutPatternsQu();
     case 'th':
       return getPutPatternsTh();
     case 'uk':

--- a/packages/semantic/src/patterns/remove.ts
+++ b/packages/semantic/src/patterns/remove.ts
@@ -279,6 +279,31 @@ function getRemovePatternsQu(): LanguagePattern[] {
         patient: { position: 1 },
       },
     },
+    // Patient-first with source: .active ta #button manta qichuy — the i18n
+    // transformer emits PATIENT-first SOV for qu (`.highlight ta noqa manta
+    // qichuy`), but the source-first pattern below never matches that order,
+    // so every remove-with-source dropped (9 lossy patterns: tabs-basic,
+    // modal-close-button, dropdown-close-outside, window-scroll, …).
+    {
+      id: 'remove-qu-patient-first',
+      language: 'qu',
+      command: 'remove',
+      priority: 96,
+      template: {
+        format: '{patient} ta {source} manta qichuy',
+        tokens: [
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: 'ta' },
+          { type: 'role', role: 'source' },
+          { type: 'literal', value: 'manta' },
+          { type: 'literal', value: 'qichuy', alternatives: ['hurquy', 'anchuchiy'] },
+        ],
+      },
+      extraction: {
+        patient: { position: 0 },
+        source: { position: 2 },
+      },
+    },
     // With source: #button manta .active ta qichuy
     {
       id: 'remove-qu-with-source',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -3318,3 +3318,63 @@ describe('positional put (before/after) for the 8 languages without variants', (
     expect([...a].sort()).toEqual(['on', 'put']);
   });
 });
+
+describe('qu patient-first SOV variants for add/remove/put (Track C core)', () => {
+  // The qu transformer emits PATIENT-first SOV for marked two-role commands
+  // (`.highlight ta noqa manta qichuy`, `.modal-open ta kurku man yapay`,
+  // `chay ta noqa man churay`) but the handcrafted qu patterns were
+  // source/dest-FIRST only ({source} manta {patient} ta qichuy) and put had
+  // no qu patterns at all — so every marked remove (9 patterns: tabs-*,
+  // modal-close-button, dropdown-close-outside, …), add (modal-open,
+  // repeat-for-each) and then-tail put (if-exists, fetch-with-headers)
+  // dropped its command. Added patient-first variants at priority 96
+  // (above the source-first 95 forms, below the simple 100 forms).
+  // qu lossy 30 → 19 across the session (avgFidelity 0.9586 → 0.9599 global,
+  // lossy 207 → 196, degen 68 → 67, 0 regressions).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('[qu] tabs-basic keeps remove + add (was {on} + spurious from)', () => {
+    // Corpus-shaped transformer output (en → qu).
+    const a = actions(
+      parse(
+        '.active ta .tab manta ñitiy pi qichuy chayqa .active ta noqa man yapay',
+        'qu'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('remove')).toBe(true);
+    expect(a.has('add')).toBe(true);
+  });
+
+  it('[qu] modal-close-button keeps the remove tail', () => {
+    const a = actions(
+      parse('kaylla .modal ta ñitiy pi pakay chayqa .modal-open ta kurku manta qichuy', 'qu')
+    );
+    expect(a.has('hide')).toBe(true);
+    expect(a.has('remove')).toBe(true);
+  });
+
+  it('[qu] a then-tail put with marked destination parses', () => {
+    expect(actions(parse('chay ta noqa man churay', 'qu')).has('put')).toBe(true);
+  });
+
+  it('[qu] the source-first order still parses (both orders valid SOV)', () => {
+    const a = actions(parse('noqa manta .highlight ta qichuy', 'qu'));
+    expect(a.has('remove')).toBe(true);
+  });
+
+  it('[en] the en reference parse is unchanged', () => {
+    const a = actions(parse('on click remove .active from .tab add .active to me', 'en'));
+    expect([...a].sort()).toEqual(['add', 'on', 'remove']);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T05:02:38.973Z",
-  "commit": "11e468da",
+  "timestamp": "2026-06-12T05:14:46.962Z",
+  "commit": "c4cf8eac",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -24,7 +24,7 @@
         "repeat-until-event",
         "window-scroll"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -662,7 +662,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1300,7 +1300,7 @@
         "keydown-key-is-syntax",
         "when-value-changes"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1924,7 +1924,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2552,7 +2552,7 @@
       "avgFidelity": 0.9803921568627451,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3185,7 +3185,7 @@
         "if-exists",
         "when-value-changes"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3833,7 +3833,7 @@
         "trigger-event",
         "wait-then"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4478,7 +4478,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5124,7 +5124,7 @@
         "settle-animations",
         "template-literal-interpolation"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5751,7 +5751,7 @@
       "avgFidelity": 0.9769063180827887,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "fetch-loading-state"],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6399,7 +6399,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7045,7 +7045,7 @@
         "unless-condition",
         "wait-for-event"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7691,7 +7691,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8314,7 +8314,7 @@
       "avgFidelity": 0.968409586056645,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["blur-element", "get-value", "keydown-key-is-syntax", "trigger-event"],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8948,7 +8948,7 @@
         "unless-condition",
         "when-value-changes"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9572,47 +9572,35 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7423520923520923,
-      "avgFidelity": 0.8968614718614719,
+      "avgFidelity": 0.9273809523809522,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
         "behavior-resizable",
-        "behavior-sortable",
-        "modal-close-escape"
+        "behavior-sortable"
       ],
       "lossyPasses": [
-        "accordion-exclusive",
         "append-content",
-        "async-block",
-        "dropdown-close-outside",
-        "event-from-elsewhere",
         "fetch-json",
-        "fetch-with-headers",
         "form-submit-prevent",
         "get-value",
         "if-empty",
-        "if-exists",
         "input-validation",
         "log-element",
         "log-value",
-        "modal-close-button",
-        "modal-open",
+        "modal-close-escape",
         "morph-with-template",
         "optional-chaining-possessive",
-        "previous-element",
         "render-template-with-data",
         "repeat-for-each",
         "set-attribute",
         "set-text-basic",
         "settle-animations",
-        "tabs-basic",
-        "tabs-content",
         "take-class-from-siblings",
         "template-literal-list-build",
-        "unless-condition",
-        "window-scroll"
+        "unless-condition"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10240,7 +10228,7 @@
       "avgFidelity": 0.9867965367965368,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event"],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10879,7 +10867,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11503,7 +11491,7 @@
       "avgFidelity": 0.9965367965367965,
       "degeneratePasses": [],
       "lossyPasses": ["event-debounce", "fetch-loading-state"],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12143,7 +12131,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12785,7 +12773,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13412,7 +13400,7 @@
       "avgFidelity": 0.9867965367965368,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event"],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14051,7 +14039,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14687,7 +14675,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 409686,
+      "bundleSize": 410100,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15309,7 +15297,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 409686,
+      "size": 410100,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Mechanism

Track C core. The qu transformer emits **patient-first** SOV for marked two-role commands (`.highlight ta noqa manta qichuy`, `.modal-open ta kurku man yapay`, `chay ta noqa man churay`), but the handcrafted qu patterns were source/dest-**first** only (`{source} manta {patient} ta qichuy`), and `put` had no qu patterns at all. Every marked remove (9 lossy patterns: tabs-\*, modal-close-button, dropdown-close-outside, …), add (modal-open, repeat-for-each), and then-tail put (if-exists, fetch-with-headers) dropped its command — the body re-parse skipped to the verb and emitted a spurious `from` node.

Added patient-first variants at priority 96 (above source-first 95, below simple 100). Both orders are valid SOV; the source-first forms keep working (locked).

## Measured A/B (same DB)

- avgFidelity **0.9586 → 0.9599**
- lossy **207 → 196** (−11) | degenerate 68 → 67
- qu: lossy 30 → 19, avgFidelity → 0.9274
- 0 parse-rate drops, 0 faithful→degenerate flips, 0 warnings

Lock tests added; baseline regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)