### PR TITLE
fix(i18n): qu log → qillqakuy (qillqay is the copy verb) + prune stale qu set overrides

### DIFF
--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -38,7 +38,10 @@ export const qu: Dictionary = {
     call: 'qayay',
     return: 'kutimuy',
     make: 'ruray',
-    log: 'qillqay',
+    // qillqay is the semantic qu profile's `copy` primary; `log` is qillqakuy.
+    // Emitting qillqay for log made the parser read every transformed log as
+    // copy (log-value/log-element/get-value lossy) — same realign as set above.
+    log: 'qillqakuy',
     throw: 'wikchuy',
     catch: 'hapsiy',
     measure: 'tupuy',

--- a/packages/patterns-reference/scripts/fix-translations.sql
+++ b/packages/patterns-reference/scripts/fix-translations.sql
@@ -92,12 +92,4 @@ UPDATE pattern_translations
 SET hyperscript = 'ñit''iy pi .items manta .active ta qichuy', verified_parses = 0, updated_at = datetime('now')
 WHERE code_example_id = 'remove-class-from-all' AND language = 'qu';
 
--- set-text-basic: #output.innerTextta "Hello World"man ñitiypi churay -> ñit'iy pi #output.innerText ta "napaykullayki" man churay
-UPDATE pattern_translations
-SET hyperscript = 'ñit''iy pi #output.innerText ta "Hello World" man churay', verified_parses = 0, updated_at = datetime('now')
-WHERE code_example_id = 'set-text-basic' AND language = 'qu';
 
--- set-attribute: @disabledta cheqaqman ñitiypi churay -> ñit'iy pi @disabled ta cheqaq man churay
-UPDATE pattern_translations
-SET hyperscript = 'ñit''iy pi @disabled ta cheqaq man churay', verified_parses = 0, updated_at = datetime('now')
-WHERE code_example_id = 'set-attribute' AND language = 'qu';

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -3378,3 +3378,55 @@ describe('qu patient-first SOV variants for add/remove/put (Track C core)', () =
     expect([...a].sort()).toEqual(['add', 'on', 'remove']);
   });
 });
+
+describe('qu log emits qillqakuy (qillqay is the copy verb)', () => {
+  // The qu dict emitted qillqay for BOTH log and copy; the semantic qu
+  // profile reads qillqay as copy (log primary is qillqakuy), so every
+  // transformed log parsed as copy — log-value/log-element/get-value/
+  // optional-chaining-possessive/form-submit-prevent all lossy. Realigned
+  // the dict to qillqakuy (same dict↔profile class as the set/churanay
+  // realign documented in the dict). Bundled (same PR): the two stale qu
+  // set-* overrides in fix-translations.sql — written for an old spacing bug
+  // and frozen with the pre-realign churay verb — were pruned; the live
+  // transformer now emits parseable churanay forms (the overrides were
+  // re-stomping the fix on every populate). qu lossy 19 → 12
+  // (avgFidelity 0.9599 → 0.9608 global, lossy 196 → 189).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('[qu] a transformed log parses as log, not copy', () => {
+    // Corpus-shaped (en → qu): `on click log "Button clicked!"`.
+    const a = actions(parse('"Button clicked!" ta ñitiy pi qillqakuy', 'qu'));
+    expect(a.has('log')).toBe(true);
+    expect(a.has('copy')).toBe(false);
+  });
+
+  it('[qu] the root cause stays locked: qillqay reads as copy', () => {
+    // qillqay is the profile copy primary — this is WHY the dict had to move.
+    const a = actions(parse('"x" ta ñitiy pi qillqay', 'qu'));
+    expect(a.has('log')).toBe(false);
+  });
+
+  it('[qu] get-value keeps the log tail (was {copy,get,on})', () => {
+    const a = actions(parse('#input.value ta ñitiy pi taripay chayqa chay ta qillqakuy', 'qu'));
+    expect(a.has('get')).toBe(true);
+    expect(a.has('log')).toBe(true);
+  });
+
+  it('[qu] set-text-basic parses set from the live transformer emission', () => {
+    // The pruned fix-translations.sql override used to stomp this back to
+    // churay (put) on every populate.
+    const a = actions(parse('#output.innerText ta "Hello World" man ñitiy pi churanay', 'qu'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('set')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T05:14:46.962Z",
-  "commit": "c4cf8eac",
+  "timestamp": "2026-06-12T05:25:56.860Z",
+  "commit": "d75030e8",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -9572,7 +9572,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7423520923520923,
-      "avgFidelity": 0.9273809523809522,
+      "avgFidelity": 0.9470779220779221,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -9582,19 +9582,12 @@
       "lossyPasses": [
         "append-content",
         "fetch-json",
-        "form-submit-prevent",
-        "get-value",
         "if-empty",
         "input-validation",
-        "log-element",
-        "log-value",
         "modal-close-escape",
         "morph-with-template",
-        "optional-chaining-possessive",
         "render-template-with-data",
         "repeat-for-each",
-        "set-attribute",
-        "set-text-basic",
         "settle-animations",
         "take-class-from-siblings",
         "template-literal-list-build",


### PR DESCRIPTION
## Mechanism

Track C continuation, the #345/#353 dict↔profile realign class:

1. **qu dict emitted `qillqay` for BOTH `log` and `copy`.** The semantic qu profile reads qillqay as copy (log primary is `qillqakuy`), so every transformed log parsed as copy — log-value, log-element, get-value, optional-chaining-possessive, form-submit-prevent all lossy. Realigned the dict to `qillqakuy`.

2. **Pruned two stale qu overrides in `fix-translations.sql`** (set-text-basic, set-attribute). They were written for an old spacing bug and frozen with the pre-realign `churay` (put) verb — `populate` re-stomped them over the live transformer's correct `churanay` (set) emission on every run. The live emissions now parse faithfully (probe-verified before pruning; the other 6 qu overrides still beat the live output and stay).

## Measured A/B (same DB)

- avgFidelity **0.9599 → 0.9608**
- lossy **196 → 189** (−7) | degenerate 67
- qu: lossy 19 → 12, avgFidelity → 0.9471 (was 0.8923 at session start)
- 0 parse-rate drops, 0 faithful→degenerate flips, 0 warnings

Lock tests added (incl. the root-cause guard that qillqay must keep reading as copy); baseline regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)