### PR TITLE
feat(testing): R1 role-fidelity ratchet — record + ratchet avgRoleFidelity per language

### DIFF
--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T05:25:56.860Z",
-  "commit": "d75030e8",
+  "timestamp": "2026-06-12T05:39:18.434Z",
+  "commit": "a6b6a5e5",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -8,6 +8,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9311967924424667,
       "avgFidelity": 0.9554466230936819,
+      "avgRoleFidelity": 0.8255183025591192,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
@@ -649,6 +650,7 @@
       "parseRate": 1,
       "avgConfidence": 0.8884559884559885,
       "avgFidelity": 0.9786796536796537,
+      "avgRoleFidelity": 0.726488095238095,
       "degeneratePasses": [],
       "lossyPasses": [
         "announce-screen-reader",
@@ -1288,6 +1290,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9315177923021051,
       "avgFidelity": 0.9592592592592591,
+      "avgRoleFidelity": 0.7866132167152577,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "async-block",
@@ -2550,6 +2553,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9322647577549528,
       "avgFidelity": 0.9803921568627451,
+      "avgRoleFidelity": 0.800170068027211,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
       "bundleSize": 410100,
@@ -3177,6 +3181,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9292768959435616,
       "avgFidelity": 0.9681917211328975,
+      "avgRoleFidelity": 0.784353741496599,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "async-block",
@@ -3810,6 +3815,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8469447038074495,
       "avgFidelity": 0.9340958605664489,
+      "avgRoleFidelity": 0.827057013281503,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
@@ -4458,6 +4464,7 @@
       "parseRate": 1,
       "avgConfidence": 1,
       "avgFidelity": 0.9280303030303032,
+      "avgRoleFidelity": 0.5428893178893178,
       "degeneratePasses": [
         "bind-auto-detect",
         "bind-explicit-property",
@@ -5104,6 +5111,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9330117232078005,
       "avgFidelity": 0.9327886710239651,
+      "avgRoleFidelity": 0.746833495302883,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "caret-var-increment",
@@ -5749,6 +5757,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9330117232078005,
       "avgFidelity": 0.9769063180827887,
+      "avgRoleFidelity": 0.6924846128927764,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "fetch-loading-state"],
       "bundleSize": 410100,
@@ -6376,6 +6385,7 @@
       "parseRate": 1,
       "avgConfidence": 0.8787157287157287,
       "avgFidelity": 0.9340909090909091,
+      "avgRoleFidelity": 0.7027187902187902,
       "degeneratePasses": [
         "announce-screen-reader",
         "behavior-draggable",
@@ -7025,6 +7035,7 @@
       "parseRate": 1,
       "avgConfidence": 0.5553391053391054,
       "avgFidelity": 0.9307359307359307,
+      "avgRoleFidelity": 0.6881676319176323,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -7671,6 +7682,7 @@
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.9374454032172144,
       "avgFidelity": 0.9525727069351231,
+      "avgRoleFidelity": 0.7670221560846564,
       "degeneratePasses": [],
       "lossyPasses": [
         "async-block",
@@ -8312,6 +8324,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8915136424940349,
       "avgFidelity": 0.968409586056645,
+      "avgRoleFidelity": 0.7139860706187232,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["blur-element", "get-value", "keydown-key-is-syntax", "trigger-event"],
       "bundleSize": 410100,
@@ -8939,6 +8952,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8958294428882667,
       "avgFidelity": 0.9660130718954247,
+      "avgRoleFidelity": 0.804316488500162,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "async-block",
@@ -9573,6 +9587,7 @@
       "parseRate": 1,
       "avgConfidence": 0.7423520923520923,
       "avgFidelity": 0.9470779220779221,
+      "avgRoleFidelity": 0.6480694980694983,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -10219,6 +10234,7 @@
       "parseRate": 1,
       "avgConfidence": 0.8983302411873844,
       "avgFidelity": 0.9867965367965368,
+      "avgRoleFidelity": 0.7273407335907333,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event"],
       "bundleSize": 410100,
@@ -10847,6 +10863,7 @@
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.878719576719577,
       "avgFidelity": 0.9576666666666667,
+      "avgRoleFidelity": 0.7936425264550265,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "blur-element",
@@ -11482,6 +11499,7 @@
       "parseRate": 1,
       "avgConfidence": 0.9402185116470816,
       "avgFidelity": 0.9965367965367965,
+      "avgRoleFidelity": 0.7133043758043759,
       "degeneratePasses": [],
       "lossyPasses": ["event-debounce", "fetch-loading-state"],
       "bundleSize": 410100,
@@ -12110,6 +12128,7 @@
       "parseRate": 1,
       "avgConfidence": 0.9122867328749679,
       "avgFidelity": 0.9692640692640694,
+      "avgRoleFidelity": 0.8363819176319179,
       "degeneratePasses": ["event-debounce"],
       "lossyPasses": [
         "breakpoint-command",
@@ -12750,6 +12769,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.877923021060276,
       "avgFidelity": 0.951525054466231,
+      "avgRoleFidelity": 0.7177842565597665,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -13391,6 +13411,7 @@
       "parseRate": 1,
       "avgConfidence": 0.896021438878582,
       "avgFidelity": 0.9867965367965368,
+      "avgRoleFidelity": 0.7156290218790216,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event"],
       "bundleSize": 410100,
@@ -14019,6 +14040,7 @@
       "parseRate": 1,
       "avgConfidence": 0.900968872397444,
       "avgFidelity": 0.9727272727272727,
+      "avgRoleFidelity": 0.808614864864865,
       "degeneratePasses": [],
       "lossyPasses": [
         "event-debounce",
@@ -14658,6 +14680,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9882871667185392,
       "avgFidelity": 0.9632897603485838,
+      "avgRoleFidelity": 0.892095885973437,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "form-submit-prevent",

--- a/packages/testing-framework/src/multilingual/cli.ts
+++ b/packages/testing-framework/src/multilingual/cli.ts
@@ -306,6 +306,17 @@ async function main(): Promise<void> {
           r => r.avgFidelityDelta < -AVG_FIDELITY_DROP_TOLERANCE
         );
 
+        // R1 — role-fidelity ratchet (§8): same semantics as the avgFidelity
+        // ratchet, on the role-recall signal (action.role:valueType vs the en
+        // reference). Deltas are 0 unless the baseline carries avgRoleFidelity,
+        // so an un-regenerated baseline never retro-flags. Slightly looser
+        // tolerance: role signatures are bigger sets, so populate jitter moves
+        // them a bit more than action sets.
+        const AVG_ROLE_FIDELITY_DROP_TOLERANCE = 0.02;
+        const roleFidelityDrops = allResults.filter(
+          r => r.avgRoleFidelityDelta < -AVG_ROLE_FIDELITY_DROP_TOLERANCE
+        );
+
         let failed = false;
 
         if (regressed.length > 0) {
@@ -365,6 +376,20 @@ async function main(): Promise<void> {
           );
           for (const r of fidelityDrops) {
             console.error(`   ${r.language}: ΔavgFidelity ${r.avgFidelityDelta.toFixed(4)}`);
+          }
+          console.error(`   (if intentional, regenerate the baseline with --save-baseline)`);
+          failed = true;
+        }
+
+        if (roleFidelityDrops.length > 0) {
+          console.error(
+            `\n✗ avgRoleFidelity dropped > ${AVG_ROLE_FIDELITY_DROP_TOLERANCE} in ` +
+              `${roleFidelityDrops.length} language(s):`
+          );
+          for (const r of roleFidelityDrops) {
+            console.error(
+              `   ${r.language}: ΔavgRoleFidelity ${r.avgRoleFidelityDelta.toFixed(4)}`
+            );
           }
           console.error(`   (if intentional, regenerate the baseline with --save-baseline)`);
           failed = true;

--- a/packages/testing-framework/src/multilingual/fidelity.ts
+++ b/packages/testing-framework/src/multilingual/fidelity.ts
@@ -71,3 +71,54 @@ export function computeFidelity(
   }
   return hits / reference.length;
 }
+
+/**
+ * R1 — role-fidelity signature.
+ *
+ * Action-set fidelity cannot see a parse that finds the right commands with the
+ * WRONG roles: a swapped patient/destination executes wrongly while scoring 1.0.
+ * This signature captures, for every command node in the tree, which roles were
+ * filled and with what value *type* (`add.patient:selector`,
+ * `put.destination:reference`). Cross-language comparison is by role name +
+ * value type — never by value string, which is legitimately translated.
+ * The roles container is a ReadonlyMap on live nodes (serializes to {} in JSON),
+ * so the signature must be collected at validation time, not from results.json.
+ */
+export function collectRoleSignature(node: unknown): string[] {
+  const acc = new Set<string>();
+  walkRoles(node, acc, 0);
+  return [...acc].sort();
+}
+
+function walkRoles(node: unknown, acc: Set<string>, depth: number): void {
+  if (depth > 64 || node === null || typeof node !== 'object') return;
+
+  const rec = node as Record<string, unknown>;
+  const action = rec.action;
+  if (typeof action === 'string' && !STRUCTURAL_ACTIONS.has(action)) {
+    const roles = rec.roles;
+    const entries: Array<[unknown, unknown]> =
+      roles instanceof Map
+        ? [...roles.entries()]
+        : roles && typeof roles === 'object'
+          ? Object.entries(roles)
+          : [];
+    for (const [role, value] of entries) {
+      if (value === undefined || value === null) continue;
+      const kind =
+        typeof value === 'object' && typeof (value as { type?: unknown }).type === 'string'
+          ? (value as { type: string }).type
+          : typeof value;
+      acc.add(`${action}.${String(role)}:${kind}`);
+    }
+  }
+
+  for (const field of CHILD_FIELDS) {
+    const child = rec[field];
+    if (Array.isArray(child)) {
+      for (const c of child) walkRoles(c, acc, depth + 1);
+    } else if (child && typeof child === 'object') {
+      walkRoles(child, acc, depth + 1);
+    }
+  }
+}

--- a/packages/testing-framework/src/multilingual/orchestrator.ts
+++ b/packages/testing-framework/src/multilingual/orchestrator.ts
@@ -249,9 +249,14 @@ export class TestOrchestrator {
 
     // codeExampleId -> English action signature (only successful en parses).
     const reference = new Map<string, string[]>();
+    // R1: codeExampleId -> English role signature (action.role:valueType set).
+    const roleReference = new Map<string, string[]>();
     for (const r of en.parseResults) {
       if (r.success && r.actionSignature && r.actionSignature.length > 0) {
         reference.set(r.pattern.codeExampleId, r.actionSignature);
+      }
+      if (r.success && r.roleSignature && r.roleSignature.length > 0) {
+        roleReference.set(r.pattern.codeExampleId, r.roleSignature);
       }
     }
 
@@ -261,6 +266,7 @@ export class TestOrchestrator {
       const degenerate: string[] = [];
       const lossy: string[] = [];
       const scores: number[] = [];
+      const roleScores: number[] = [];
 
       for (const result of lang.parseResults) {
         if (!result.success || !result.actionSignature) continue;
@@ -274,10 +280,24 @@ export class TestOrchestrator {
         scores.push(fidelity);
         if (fidelity < FIDELITY_THRESHOLD) degenerate.push(result.pattern.codeExampleId);
         else if (fidelity < 1) lossy.push(result.pattern.codeExampleId);
+
+        // R1 — role recall vs the en role signature (role name + value type).
+        const roleRef = roleReference.get(result.pattern.codeExampleId);
+        if (roleRef && result.roleSignature) {
+          const roleFidelity = computeFidelity(roleRef, result.roleSignature);
+          if (roleFidelity !== undefined) {
+            result.roleFidelity = roleFidelity;
+            roleScores.push(roleFidelity);
+          }
+        }
       }
 
       lang.avgFidelity =
         scores.length > 0 ? scores.reduce((a, b) => a + b, 0) / scores.length : undefined;
+      lang.avgRoleFidelity =
+        roleScores.length > 0
+          ? roleScores.reduce((a, b) => a + b, 0) / roleScores.length
+          : undefined;
       lang.degeneratePasses = degenerate.sort();
       lang.lossyPasses = lossy.sort();
     }

--- a/packages/testing-framework/src/multilingual/reporters/regression-reporter.ts
+++ b/packages/testing-framework/src/multilingual/reporters/regression-reporter.ts
@@ -112,6 +112,12 @@ export class RegressionReporter implements Reporter {
       const parseRateDelta = (langResult.parseRate - baselineLang.parseRate) * 100;
       const avgConfidenceDelta = langResult.avgConfidence - baselineLang.avgConfidence;
       const avgFidelityDelta = (langResult.avgFidelity ?? 0) - (baselineLang.avgFidelity ?? 0);
+      // R1 — only meaningful when BOTH sides carry role data; an un-regenerated
+      // baseline (no avgRoleFidelity yet) must never retro-flag.
+      const avgRoleFidelityDelta =
+        langResult.avgRoleFidelity !== undefined && baselineLang.avgRoleFidelity !== undefined
+          ? langResult.avgRoleFidelity - baselineLang.avgRoleFidelity
+          : 0;
       const bundleSizeDelta = this.getBundleSizeDelta(langResult, baselineLang);
 
       // Identify new failures and successes
@@ -140,6 +146,7 @@ export class RegressionReporter implements Reporter {
         parseRateDelta,
         avgConfidenceDelta,
         avgFidelityDelta,
+        avgRoleFidelityDelta,
         bundleSizeDelta: bundleSizeDelta !== undefined ? bundleSizeDelta : undefined,
         newFailures,
         newSuccesses,
@@ -317,6 +324,9 @@ export class RegressionReporter implements Reporter {
         // Structural fidelity vs the English reference parse — tracks degenerate
         // (non-null but shallow) passes that the parse rate alone can't surface.
         avgFidelity: langResult.avgFidelity ?? undefined,
+        // R1 — role fidelity (role name + value type vs the en reference).
+        // Recorded + ratcheted; burn-down is NOT part of the parsing-track goal.
+        avgRoleFidelity: langResult.avgRoleFidelity ?? undefined,
         degeneratePasses: langResult.degeneratePasses ?? undefined,
         lossyPasses: langResult.lossyPasses ?? undefined,
         bundleSize: langResult.bundleSize ?? undefined,

--- a/packages/testing-framework/src/multilingual/types.ts
+++ b/packages/testing-framework/src/multilingual/types.ts
@@ -124,6 +124,14 @@ export interface ParseResult {
   actionSignature?: string[];
 
   /**
+   * R1 — role-level signature: `action.role:valueType` for every command node
+   * in the tree (`add.patient:selector`, `put.destination:reference`).
+   * Cross-language comparison is by role name + value TYPE, never the value
+   * string (which is legitimately translated). Set by the validator.
+   */
+  roleSignature?: string[];
+
+  /**
    * Structural fidelity vs the English reference parse, in [0, 1]: the fraction
    * of the English parse's distinct actions also present in this language's
    * parse (recall). `1` = same command structure; low values flag a *degenerate*
@@ -132,6 +140,14 @@ export interface ParseResult {
    * usable English reference or this parse failed.
    */
   fidelity?: number;
+
+  /**
+   * R1 — role fidelity vs the English reference, in [0, 1]: the fraction of the
+   * English parse's role-signature entries also present here. Catches a parse
+   * that finds the right commands with the WRONG roles (swapped
+   * patient/destination executes wrongly while action-fidelity scores 1.0).
+   */
+  roleFidelity?: number;
 }
 
 /**
@@ -165,6 +181,13 @@ export interface LanguageResults {
    * reference (see ParseResult.fidelity). `undefined` for English itself.
    */
   avgFidelity?: number | undefined;
+
+  /**
+   * R1 — mean `roleFidelity` over successful parses with an English reference.
+   * Recorded + ratcheted in the baseline; the burn-down is deliberately NOT part
+   * of the parsing-track goal (see CORRECTNESS_RELIABILITY_PLAN.md §8).
+   */
+  avgRoleFidelity?: number | undefined;
 
   /**
    * Pattern IDs that pass (non-null) but parse *degenerately* — fidelity below
@@ -235,6 +258,8 @@ export interface Baseline {
         avgConfidence: number;
         /** Mean structural fidelity vs the English reference parse (see ParseResult.fidelity). */
         avgFidelity?: number | undefined;
+        /** R1 — mean role fidelity vs the English reference (see ParseResult.roleFidelity). */
+        avgRoleFidelity?: number | undefined;
         /** Pattern IDs that pass but parse degenerately (fidelity below threshold). */
         degeneratePasses?: string[] | undefined;
         /** Pattern IDs that pass *lossily* (fidelity in [0.5, 1.0) — drop ≥1 command). */
@@ -264,6 +289,8 @@ export interface RegressionResult {
   avgConfidenceDelta: number; // absolute change
   /** Absolute change in avgFidelity (current − baseline). Negative = correctness drop. */
   avgFidelityDelta: number;
+  /** R1 — absolute change in avgRoleFidelity (current − baseline). 0 when either side lacks data. */
+  avgRoleFidelityDelta: number;
   bundleSizeDelta: number | undefined; // % change
   newFailures: string[]; // pattern IDs
   newSuccesses: string[]; // pattern IDs

--- a/packages/testing-framework/src/multilingual/validators/parse-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/parse-validator.ts
@@ -5,7 +5,7 @@
 import { MultilingualHyperscript } from '@hyperfixi/core/multilingual';
 import type { SemanticNode } from '@lokascript/semantic';
 import type { PatternTranslation, ParseResult, Validator } from '../types';
-import { collectActions } from '../fidelity';
+import { collectActions, collectRoleSignature } from '../fidelity';
 
 /**
  * Parse Validator
@@ -87,6 +87,9 @@ export class ParseValidator implements Validator<ParseResult[]> {
         parser: 'semantic',
         // Structural signature for cross-language fidelity scoring (see fidelity.ts).
         actionSignature: collectActions(semanticNode),
+        // R1 role signature (role name + value type per command) — collected here
+        // because live nodes carry roles as a ReadonlyMap that serializes to {}.
+        roleSignature: collectRoleSignature(semanticNode),
         duration: performance.now() - startTime,
       };
     } catch (error) {


### PR DESCRIPTION
## §8 R1 — role-fidelity ratchet (static stage)

Action-set fidelity (R0) cannot see a parse that finds the right commands with the **wrong roles** — a swapped patient/destination executes wrongly while scoring 1.0.

- `collectRoleSignature(node)` walks the parse tree and emits `action.role:valueType` for every command node (`add.patient:selector`, `put.destination:reference`). Comparison is by role name + value **type**, never the value string (legitimately translated). Collected at validation time — live nodes carry roles as a `ReadonlyMap` that serializes to `{}` in results.json.
- Per-parse `roleFidelity` = recall vs the en reference signature; per-language `avgRoleFidelity` recorded in the baseline.
- Ratchet mirrors the avgFidelity ratchet (tolerance 0.02); deltas are 0 unless the baseline carries the field, so an un-regenerated baseline never retro-flags.

## First measurement (recorded only — §8: do NOT burn down in the parsing track)

Cross-language mean **0.7505**. Worst: hi 0.543, qu 0.648, ko 0.688, it 0.693, ja 0.703, th 0.713. As §8 predicted, a new failure band ~3× the size of the action-fidelity band — now visible and non-regressable.

Action metrics unchanged (avgFidelity 0.9608, lossy 189); testing-framework only, no parser/dict files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)