### PR TITLE
fix(semantic): fused-event body walker recovers verb-mid SOV clauses

### DIFF
--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1028,17 +1028,38 @@ export class SemanticParserImpl implements ISemanticParser {
   ): SemanticNode[] {
     const commands: SemanticNode[] = [];
 
+    // SOV verb-anchoring recovery, per clause. The SOV grammar transforms put
+    // the verb BETWEEN roles (`#name.innerText 를 설정 그것의.name 에`), an order
+    // no command pattern covers — parseClause recovers it via
+    // parseSOVClauseByVerbAnchoring, but this body walker used to just skip the
+    // tokens, silently dropping the command (ko fetch-json/form-disable-on-submit
+    // then-tails once the fused event pattern anchors). Mirror parseClause's
+    // fallback semantics exactly: collect skipped tokens per clause and anchor
+    // them ONLY if nothing in that clause matched a pattern — additive, so a
+    // clause with any pattern match is byte-identical to the old behavior.
+    let skippedClauseTokens: LanguageToken[] = [];
+    let clauseHadMatch = false;
+    const flushClause = () => {
+      if (!clauseHadMatch && skippedClauseTokens.length > 0) {
+        commands.push(...this.parseSOVClauseByVerbAnchoring(skippedClauseTokens, language));
+      }
+      skippedClauseTokens = [];
+      clauseHadMatch = false;
+    };
+
     while (!tokens.isAtEnd()) {
       const current = tokens.peek();
 
       // Check for 'then' keyword - skip it and continue parsing
       if (current && this.isThenKeyword(current.value, language)) {
+        flushClause();
         tokens.advance();
         continue;
       }
 
       // Check for 'end' keyword - terminates block
       if (current && this.isEndKeyword(current.value, language)) {
+        flushClause();
         tokens.advance();
         break;
       }
@@ -1067,6 +1088,7 @@ export class SemanticParserImpl implements ISemanticParser {
           });
           commands.push(commandNode);
           matched = true;
+          clauseHadMatch = true;
 
           // Check if this pattern also has continuation
           const continuesValue = grammarMatch.captured.get('continues');
@@ -1087,15 +1109,18 @@ export class SemanticParserImpl implements ISemanticParser {
         if (commandMatch) {
           commands.push(this.buildCommand(commandMatch, language));
           matched = true;
+          clauseHadMatch = true;
         }
       }
 
-      // Skip unrecognized token
+      // Skip unrecognized token (collected for the per-clause SOV recovery)
       if (!matched) {
+        if (current) skippedClauseTokens.push(current);
         tokens.advance();
       }
     }
 
+    flushClause();
     return commands;
   }
 

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -3430,3 +3430,75 @@ describe('qu log emits qillqakuy (qillqay is the copy verb)', () => {
     expect(a.has('set')).toBe(true);
   });
 });
+
+describe('fused-event body walker recovers verb-mid SOV clauses (then-tail set/put drops)', () => {
+  // When a fused `*-event-<lang>-sov-*` pattern anchors the handler, the
+  // trailing then-chain is parsed by parseBodyWithGrammarPatterns — which only
+  // tried pattern matches and SKIPPED everything else. The SOV grammar
+  // transformer puts the verb BETWEEN roles for two-role then-tail clauses
+  // (`#name.innerText を 設定 その.name に` — patient, VERB, value) — an order no
+  // command pattern covers. parseClause (the stage-3 SOV-extraction body path)
+  // already recovers these via parseSOVClauseByVerbAnchoring; the fused-pattern
+  // body walker now mirrors that fallback per clause, firing ONLY when nothing
+  // in the clause matched a pattern (additive — a clause with any pattern match
+  // is unchanged). Cleared 10 instances across bn/ja/qu/tr (fetch-json ×4,
+  // announce-screen-reader ×2, form-disable-on-submit ×2, bn breakpoint-command,
+  // qu repeat-for-each): avgFidelity 0.9608 → 0.9617, lossy 189 → 179,
+  // 0 regressions. Also the precondition for the ko event-marker track: with
+  // 할 때 emitted, ko then-tails route through this same walker.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped transformer output (en → lang).
+  it('[ja] fetch-json keeps the then-tail set (was {fetch,on})', () => {
+    const a = actions(
+      parse('/api/user を クリック で フェッチ json それから #name.innerText を 設定 その.name に', 'ja')
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('fetch')).toBe(true);
+    expect(a.has('set')).toBe(true);
+  });
+
+  it('[tr] form-disable-on-submit keeps the then-tail put (was {add,on})', () => {
+    const a = actions(
+      parse('@disabled i gönder de ekle <button/> in me e sonra "Submitting..." i <button/> in me e koy', 'tr')
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('add')).toBe(true);
+    expect(a.has('put')).toBe(true);
+  });
+
+  it('[bn] announce-screen-reader keeps put + set (was {on,put})', () => {
+    const a = actions(
+      parse(
+        'event.detail.message কে success এ রাখুন #sr-announce তে তারপর @role কে সেট "alert" তে তারপর #sr-announce এ',
+        'bn'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('put')).toBe(true);
+    expect(a.has('set')).toBe(true);
+  });
+
+  it('[qu] fetch-json keeps the then-tail set (was {fetch,on})', () => {
+    const a = actions(
+      parse('/api/user ta ñitiy pi apamuy json hina chayqa #name.innerText ta chaypaq.name man churanay', 'qu')
+    );
+    expect(a.has('fetch')).toBe(true);
+    expect(a.has('set')).toBe(true);
+  });
+
+  it('[en] the en reference parse is unchanged', () => {
+    const a = actions(parse('on click fetch /api/user as json then set #name.innerText to it.name', 'en'));
+    expect([...a].sort()).toEqual(['fetch', 'on', 'set']);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T05:39:18.434Z",
-  "commit": "a6b6a5e5",
+  "timestamp": "2026-06-12T12:20:07.279Z",
+  "commit": "3bfa7f1e",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -25,7 +25,7 @@
         "repeat-until-event",
         "window-scroll"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -649,22 +649,18 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8884559884559885,
-      "avgFidelity": 0.9786796536796537,
-      "avgRoleFidelity": 0.726488095238095,
+      "avgFidelity": 0.9884199134199132,
+      "avgRoleFidelity": 0.7300916988416986,
       "degeneratePasses": [],
       "lossyPasses": [
-        "announce-screen-reader",
-        "breakpoint-command",
         "fetch-do-not-throw",
-        "fetch-json",
-        "form-disable-on-submit",
         "if-exists",
         "make-element",
         "make-toast-element",
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1303,7 +1299,7 @@
         "keydown-key-is-syntax",
         "when-value-changes"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1927,7 +1923,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2556,7 +2552,7 @@
       "avgRoleFidelity": 0.800170068027211,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3190,7 +3186,7 @@
         "if-exists",
         "when-value-changes"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3839,7 +3835,7 @@
         "trigger-event",
         "wait-then"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4485,7 +4481,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5132,7 +5128,7 @@
         "settle-animations",
         "template-literal-interpolation"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5760,7 +5756,7 @@
       "avgRoleFidelity": 0.6924846128927764,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "fetch-loading-state"],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6384,7 +6380,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8787157287157287,
-      "avgFidelity": 0.9340909090909091,
+      "avgFidelity": 0.9362554112554111,
       "avgRoleFidelity": 0.7027187902187902,
       "degeneratePasses": [
         "announce-screen-reader",
@@ -6396,7 +6392,6 @@
       "lossyPasses": [
         "caret-var-on-target",
         "fetch-do-not-throw",
-        "fetch-json",
         "form-disable-on-submit",
         "get-attribute-possessive-dot",
         "get-value-possessive-dot",
@@ -6409,7 +6404,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7056,7 +7051,7 @@
         "unless-condition",
         "wait-for-event"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "wait-for-event": {
           "success": true,
@@ -7703,7 +7698,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8327,7 +8322,7 @@
       "avgRoleFidelity": 0.7139860706187232,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["blur-element", "get-value", "keydown-key-is-syntax", "trigger-event"],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8962,7 +8957,7 @@
         "unless-condition",
         "when-value-changes"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9586,8 +9581,8 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7423520923520923,
-      "avgFidelity": 0.9470779220779221,
-      "avgRoleFidelity": 0.6480694980694983,
+      "avgFidelity": 0.9514069264069263,
+      "avgRoleFidelity": 0.6505469755469757,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -9596,19 +9591,17 @@
       ],
       "lossyPasses": [
         "append-content",
-        "fetch-json",
         "if-empty",
         "input-validation",
         "modal-close-escape",
         "morph-with-template",
         "render-template-with-data",
-        "repeat-for-each",
         "settle-animations",
         "take-class-from-siblings",
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10237,7 +10230,7 @@
       "avgRoleFidelity": 0.7273407335907333,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event"],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10877,7 +10870,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11502,7 +11495,7 @@
       "avgRoleFidelity": 0.7133043758043759,
       "degeneratePasses": [],
       "lossyPasses": ["event-debounce", "fetch-loading-state"],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12143,7 +12136,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12768,8 +12761,8 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.877923021060276,
-      "avgFidelity": 0.951525054466231,
-      "avgRoleFidelity": 0.7177842565597665,
+      "avgFidelity": 0.9580610021786493,
+      "avgRoleFidelity": 0.7205053449951407,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -12778,15 +12771,12 @@
         "default-value"
       ],
       "lossyPasses": [
-        "announce-screen-reader",
         "fetch-do-not-throw",
-        "fetch-json",
-        "form-disable-on-submit",
         "take-class-from-siblings",
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13414,7 +13404,7 @@
       "avgRoleFidelity": 0.7156290218790216,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event"],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14054,7 +14044,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14691,7 +14681,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 410100,
+      "bundleSize": 410232,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15313,7 +15303,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 410100,
+      "size": 410232,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary
- `parseBodyWithGrammarPatterns` (then-tail parser for fused `*-event-<lang>-sov-*` handler matches) only tried pattern matches and skipped unmatched tokens, silently dropping verb-mid SOV clauses (`#name.innerText を 設定 その.name に`).
- `parseClause` already recovers these via `parseSOVClauseByVerbAnchoring`; this mirrors that fallback per clause, gated to clauses where nothing matched a pattern — additive, a clause with any pattern match is byte-identical.

## Measured
- avgFidelity 0.9608 → 0.9617, lossy 189 → 179, degenerate 67 (unchanged), 0 regressions.
- Cleared: fetch-json (bn/ja/qu/tr), announce-screen-reader (bn/tr), form-disable-on-submit (bn/tr), bn breakpoint-command, qu repeat-for-each.
- Precondition for the ko event-marker track (Track K): with 할 때 emitted, ko then-tails route through this walker.

## Testing
- New lock describe-block with corpus-shaped ja/tr/bn/qu inputs + en reference guard.
- Full semantic suite: 5670 passed. Full multilingual regression gate: green. Baseline regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)