### PR TITLE
feat(i18n,semantic): ko event marker 할 때 end-to-end

### DIFF
--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -1767,3 +1767,38 @@ describe('destination `on` is not confused with the event head `on`', () => {
     }
   });
 });
+
+describe('ko event marker 할 때 + selector-event marker suppression', () => {
+  // koreanProfile gained the event-role marker 할 때 — the semantic
+  // *-event-ko-sov-* patterns anchor on it; before, every ko handler emitted a
+  // bare event name no fused pattern could match. The companion guard lives in
+  // insertMarkers: a SELECTOR-shaped "event" (the dangling target of a locative
+  // `on` — `set @role to "alert" on #sr-announce` — split off as a headless
+  // pseudo-handler because set/put are deliberately NOT in ON_TARGET_COMMANDS)
+  // must NOT receive the marker, or the emission grows a spurious mid-stream
+  // event anchor (`#sr-announce 할 때` / ja `#sr-announce で`).
+  it('[ko] a real event gets the marker', () => {
+    const t = new GrammarTransformer('en', 'ko');
+    expect(t.transform('on click increment #counter')).toBe('#counter 를 클릭 할 때 증가');
+  });
+
+  it('[ko] a dangling selector pseudo-event does NOT get the marker', () => {
+    const t = new GrammarTransformer('en', 'ko');
+    const out = t.transform(
+      'on success put event.detail.message into #sr-announce set @role to "alert" on #sr-announce'
+    );
+    // The real event keeps its marker…
+    expect(out).toContain('success 할 때');
+    // …the selector tail does not.
+    expect(out.endsWith('#sr-announce')).toBe(true);
+    expect(out.match(/할 때/g)?.length).toBe(1);
+  });
+
+  it('[ja] the same suppression strips the spurious で', () => {
+    const t = new GrammarTransformer('en', 'ja');
+    const out = t.transform(
+      'on success put event.detail.message into #sr-announce set @role to "alert" on #sr-announce'
+    );
+    expect(out.endsWith('#sr-announce')).toBe(true);
+  });
+});

--- a/packages/i18n/src/grammar/profiles/index.ts
+++ b/packages/i18n/src/grammar/profiles/index.ts
@@ -142,6 +142,10 @@ export const koreanProfile: LanguageProfile = {
     { form: '를', role: 'patient', position: 'postposition', required: true, alternatives: ['을'] },
     { form: '에', role: 'destination', position: 'postposition', required: true },
     { form: '에서', role: 'source', position: 'postposition', required: true },
+    // Event marker — the semantic *-event-ko-sov-* patterns anchor on 할 때
+    // (the generator profile's eventMarker); without it every ko handler
+    // emitted a bare event name no fused pattern could anchor.
+    { form: '할 때', role: 'event', position: 'postposition', required: true },
     {
       form: '로',
       role: 'style',

--- a/packages/i18n/src/grammar/types.ts
+++ b/packages/i18n/src/grammar/types.ts
@@ -538,7 +538,18 @@ export function insertMarkers(
   const result: string[] = [];
 
   for (const element of elements) {
-    const marker = markers.find(m => m.role === element.role);
+    let marker = markers.find(m => m.role === element.role);
+
+    // A selector-shaped "event" is never a trigger. It's the dangling target of
+    // a locative `on` (`set @role to "alert" on #sr-announce`) that
+    // splitOnCommandBoundaries splits off as a headless pseudo-handler (set/put
+    // are deliberately NOT in ON_TARGET_COMMANDS — dual-destination collision).
+    // Emitting the event marker after it (ko 할 때, ja で, bn এ, tr de) plants a
+    // spurious mid-stream event anchor in the emission; suppress the marker and
+    // emit the bare selector, which body parsers skip harmlessly.
+    if (marker?.role === 'event' && /^[#.<@[]/.test(element.translated || element.value)) {
+      marker = undefined;
+    }
 
     if (marker) {
       if (adpositionType === 'preposition') {

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1202,11 +1202,38 @@ export class SemanticParserImpl implements ISemanticParser {
    */
   private static readonly SOV_EVENT_MARKERS: Record<string, Set<string>> = {
     ja: new Set(['で']),
-    ko: new Set(), // Korean doesn't use event marker particles
+    ko: new Set(), // ko's marker is the two-token 할 때 phrase — see SOV_EVENT_MARKER_PHRASES
     tr: new Set(['de', 'da', 'te', 'ta']),
     bn: new Set(['এ']),
     qu: new Set(['pi']),
   };
+
+  /**
+   * OPTIONAL multi-token event-marker phrases consumed after the event token.
+   * The ko i18n profile emits 할 때 after the event role; it tokenizes as TWO
+   * tokens (할 identifier + 때 keyword), invisible to the single-token marker
+   * check above. Unlike SOV_EVENT_MARKERS these never gate event detection —
+   * ko events still anchor bare (pre-marker emissions, hand-written input) —
+   * the phrase is just consumed when present so it doesn't leak into the body,
+   * and it CONFIRMS a custom (identifier) event the way ja's で does.
+   */
+  private static readonly SOV_EVENT_MARKER_PHRASES: Record<string, string[][]> = {
+    ko: [['할', '때'], ['할때']],
+  };
+
+  /** Length (in tokens) of an event-marker phrase starting at startIdx, or 0. */
+  private matchEventMarkerPhrase(
+    allTokens: readonly LanguageToken[],
+    startIdx: number,
+    language: string
+  ): number {
+    const phrases = SemanticParserImpl.SOV_EVENT_MARKER_PHRASES[language];
+    if (!phrases) return 0;
+    for (const phrase of phrases) {
+      if (phrase.every((w, j) => allTokens[startIdx + j]?.value === w)) return phrase.length;
+    }
+    return 0;
+  }
 
   /**
    * SOV source markers ("from" equivalents) and window tokens per language.
@@ -1468,11 +1495,13 @@ export class SemanticParserImpl implements ISemanticParser {
             break;
           }
         } else {
-          // Languages without event markers (KO): event keyword stands alone
+          // Languages without single-token event markers (KO): event keyword
+          // stands alone, or is followed by an optional marker phrase (할 때),
+          // consumed so it doesn't leak into the body parse.
           eventIndex = i;
           eventName = resolvedName;
           keyFilter = tokenKeyFilter;
-          tokensToRemove = 1; // Remove event keyword only
+          tokensToRemove = 1 + this.matchEventMarkerPhrase(allTokens, i + 1, language);
           break;
         }
       }
@@ -1516,8 +1545,19 @@ export class SemanticParserImpl implements ISemanticParser {
             break;
           }
         } else {
-          // Marker-less Korean: the event identifier sits immediately before the
-          // body's command verb (e.g. `… hello 넣다 …`).
+          // Korean: the 할 때 marker phrase confirms a custom event the way
+          // ja's で does (`… success 할 때 넣다 …`)…
+          const phraseLen = this.matchEventMarkerPhrase(allTokens, i + 1, language);
+          if (phraseLen > 0) {
+            eventIndex = i;
+            eventName = token.value;
+            keyFilter = '';
+            tokensToRemove = 1 + phraseLen;
+            break;
+          }
+          // …or, marker-less (pre-marker emissions, hand-written input), the
+          // event identifier sits immediately before the body's command verb
+          // (e.g. `… hello 넣다 …`).
           const nextToken = allTokens[i + 1];
           if (
             nextToken &&

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -3502,3 +3502,103 @@ describe('fused-event body walker recovers verb-mid SOV clauses (then-tail set/p
     expect([...a].sort()).toEqual(['fetch', 'on', 'set']);
   });
 });
+
+describe('ko event marker 할 때 — fused patterns anchor, custom events confirmed', () => {
+  // The i18n koreanProfile was the only SOV profile with NO event-role marker
+  // (ja emits で, tr de/da), so every ko handler emitted a bare event name the
+  // fused *-event-ko-sov-* patterns (which expect 할 때) could never anchor.
+  // Three pieces, one mechanism (the marker end-to-end):
+  //  1. i18n profile marker { form: '할 때', role: 'event' } — handlers now emit
+  //     `클릭 할 때`, and the fused patterns + the #366 body walker carry the
+  //     then-tails.
+  //  2. i18n insertMarkers suppresses the event marker for SELECTOR-shaped
+  //     "events": `set @role to "alert" on #sr-announce` splits at the locative
+  //     `on` (set/put are deliberately NOT in ON_TARGET_COMMANDS) and the
+  //     dangling `on #sr-announce` parses as a headless pseudo-handler — the
+  //     marker turned that into a spurious mid-stream `#sr-announce 할 때`
+  //     anchor (this also stripped ja's `#sr-announce で`).
+  //  3. semantic trySOVEventExtraction consumes the OPTIONAL two-token 할 때
+  //     phrase (할 identifier + 때 keyword — invisible to the single-token
+  //     marker check) and lets it confirm a custom identifier event the way
+  //     ja's で does. Never required: bare-event ko keeps parsing.
+  // ko 0.9307 → 0.9574, lossy 9 → 6, degen 7 → 5 (caret-var-increment,
+  // increment-by-amount, increment-counter, decrement-counter, wait-for-event
+  // fixed; if-empty/input-validation degenerate → lossy). Global avgFidelity
+  // 0.9617 → 0.9629, lossy 179 → 176, degenerate 67 → 65, 0 regressions.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped transformer output (en → ko).
+  it('[ko] increment-counter anchors the handler on 클릭 할 때 (was {increment})', () => {
+    const a = actions(parse('#counter 를 클릭 할 때 증가', 'ko'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('increment')).toBe(true);
+  });
+
+  it('[ko] wait-for-event keeps the handler (was {wait})', () => {
+    const a = actions(parse('클릭 할 때 대기 transitionend', 'ko'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('wait')).toBe(true);
+  });
+
+  it('[ko] a custom identifier event is confirmed by the marker phrase (announce-screen-reader)', () => {
+    const a = actions(
+      parse(
+        'event.detail.message 를 success 할 때 넣다 #sr-announce 에 그러면 @role 를 설정 "alert" 에 그러면 #sr-announce',
+        'ko'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('put')).toBe(true);
+    expect(a.has('set')).toBe(true);
+  });
+
+  it('[ko] fetch-json keeps the then-tail set through the fused pattern + body walker', () => {
+    const a = actions(
+      parse('/api/user 를 클릭 할 때 가져오기 json 로 그러면 #name.innerText 를 설정 그것의.name 에', 'ko')
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('fetch')).toBe(true);
+    expect(a.has('set')).toBe(true);
+  });
+
+  it('[ko] if-exists keeps the else-branch put (the 4th probe flip, now locked)', () => {
+    const a = actions(
+      parse(
+        '클릭 할 때 만약 #modal 존재 #modal 를 보이다 아니면 a <div#modal/> 를 만들다 그러면 그것 를 바디 에 넣다 끝',
+        'ko'
+      )
+    );
+    expect(a.has('if')).toBe(true);
+    expect(a.has('show')).toBe(true);
+    expect(a.has('make')).toBe(true);
+    expect(a.has('put')).toBe(true);
+    // The locked #361 guard still holds: 아니면 is else, never unless.
+    expect(a.has('unless')).toBe(false);
+  });
+
+  it('[ko] marker-less events still parse (pre-marker emissions, hand-written input)', () => {
+    // The phrase is OPTIONAL: the fetch keyword-alignment corpus shape (no 할 때).
+    const a = actions(parse('/api/form 를 제출 가져오기 method:"POST" body:form 로', 'ko'));
+    expect(a.has('on')).toBe(true);
+  });
+
+  it('[en] the en reference parse is unchanged', () => {
+    const a = actions(
+      parse(
+        'on success put event.detail.message into #sr-announce set @role to "alert" on #sr-announce',
+        'en'
+      )
+    );
+    expect([...a].sort()).toEqual(['on', 'put', 'set']);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T12:20:07.279Z",
-  "commit": "3bfa7f1e",
+  "timestamp": "2026-06-12T12:39:08.977Z",
+  "commit": "1507578c",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -25,7 +25,7 @@
         "repeat-until-event",
         "window-scroll"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -660,7 +660,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1299,7 +1299,7 @@
         "keydown-key-is-syntax",
         "when-value-changes"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1923,7 +1923,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2552,7 +2552,7 @@
       "avgRoleFidelity": 0.800170068027211,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3186,7 +3186,7 @@
         "if-exists",
         "when-value-changes"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3835,7 +3835,7 @@
         "trigger-event",
         "wait-then"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4481,7 +4481,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5128,7 +5128,7 @@
         "settle-animations",
         "template-literal-interpolation"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5756,7 +5756,7 @@
       "avgRoleFidelity": 0.6924846128927764,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "fetch-loading-state"],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6404,7 +6404,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7028,32 +7028,111 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.5553391053391054,
-      "avgFidelity": 0.9307359307359307,
-      "avgRoleFidelity": 0.6881676319176323,
+      "avgConfidence": 0.7878066378066378,
+      "avgFidelity": 0.9573593073593072,
+      "avgRoleFidelity": 0.6736647361647365,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
         "behavior-resizable",
         "behavior-sortable",
-        "if-empty",
-        "input-validation",
         "window-scroll"
       ],
       "lossyPasses": [
-        "caret-var-increment",
-        "decrement-counter",
         "fetch-do-not-throw",
         "fetch-error-handling",
-        "increment-by-amount",
-        "increment-counter",
+        "if-empty",
+        "input-validation",
         "template-literal-list-build",
-        "unless-condition",
-        "wait-for-event"
+        "unless-condition"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
+        "toggle-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-class-on-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "add-class-to-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-visibility": {
+          "success": true,
+          "confidence": 1
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 1
+        },
         "wait-for-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "settle-animations": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "trigger-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method": {
           "success": true,
           "confidence": 1
         },
@@ -7069,11 +7148,115 @@
           "success": true,
           "confidence": 1
         },
+        "if-condition": {
+          "success": true,
+          "confidence": 1
+        },
         "repeat-for-each": {
           "success": true,
           "confidence": 1
         },
+        "go-url": {
+          "success": true,
+          "confidence": 1
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 1
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 1
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-disable-on-submit": {
+          "success": true,
+          "confidence": 1
+        },
         "window-scroll": {
+          "success": true,
+          "confidence": 1
+        },
+        "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
+          "success": true,
+          "confidence": 1
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-until-event": {
           "success": true,
           "confidence": 1
         },
@@ -7085,7 +7268,107 @@
           "success": true,
           "confidence": 1
         },
+        "event-once": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 1
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 1
+        },
+        "slide-toggle": {
+          "success": true,
+          "confidence": 1
+        },
         "stagger-animation": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 1
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 1
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-send": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 1
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 1
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 1
+        },
+        "take-class-from-siblings": {
           "success": true,
           "confidence": 1
         },
@@ -7121,38 +7404,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.6
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.6
-        },
-        "toggle-class-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "toggle-class-on-other": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "add-class-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "add-class-to-other": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.5
-        },
         "set-text-basic": {
           "success": true,
           "confidence": 0.5
@@ -7181,42 +7432,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "toggle-visibility": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.5
-        },
         "transition-opacity": {
           "success": true,
           "confidence": 0.5
@@ -7225,39 +7440,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "settle-animations": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "send-event": {
-          "success": true,
-          "confidence": 0.5
-        },
         "send-with-detail": {
           "success": true,
           "confidence": 0.5
         },
-        "trigger-event": {
-          "success": true,
-          "confidence": 0.5
-        },
         "multiple-events": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-condition": {
           "success": true,
           "confidence": 0.5
         },
@@ -7269,39 +7456,7 @@
           "success": true,
           "confidence": 0.5
         },
-        "go-url": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 0.5
-        },
         "default-value": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "tell-command": {
           "success": true,
           "confidence": 0.5
         },
@@ -7313,51 +7468,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.5
-        },
         "tabs-aria": {
           "success": true,
           "confidence": 0.5
         },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.5
-        },
         "modal-close-button": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "dropdown-toggle": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "dropdown-close-outside": {
           "success": true,
           "confidence": 0.5
         },
@@ -7374,10 +7489,6 @@
           "confidence": 0.5
         },
         "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "form-disable-on-submit": {
           "success": true,
           "confidence": 0.5
         },
@@ -7409,31 +7520,7 @@
           "success": true,
           "confidence": 0.5
         },
-        "next-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 0.5
-        },
         "first-in-parent": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "last-in-collection": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "event-once": {
           "success": true,
           "confidence": 0.5
         },
@@ -7442,30 +7529,6 @@
           "confidence": 0.5
         },
         "event-throttle": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-loading-state": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-exists": {
           "success": true,
           "confidence": 0.5
         },
@@ -7481,19 +7544,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "slide-toggle": {
-          "success": true,
-          "confidence": 0.5
-        },
         "two-way-binding": {
           "success": true,
           "confidence": 0.5
         },
         "computed-value": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "toggle-aria-expanded": {
           "success": true,
           "confidence": 0.5
         },
@@ -7533,35 +7588,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.5
-        },
         "template-literal-interpolation": {
           "success": true,
           "confidence": 0.5
         },
         "template-literal-list-build": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "morph-form-update": {
           "success": true,
           "confidence": 0.5
         },
@@ -7573,43 +7604,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "socket-send": {
-          "success": true,
-          "confidence": 0.5
-        },
         "worker-basic": {
           "success": true,
           "confidence": 0.5
         },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "send-event-to-form": {
-          "success": true,
-          "confidence": 0.5
-        },
         "on-custom-event-receive": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "keydown-key-is-syntax": {
           "success": true,
           "confidence": 0.5
         },
@@ -7622,10 +7621,6 @@
           "confidence": 0.5
         },
         "pick-text-range": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "take-class-from-siblings": {
           "success": true,
           "confidence": 0.5
         },
@@ -7698,7 +7693,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8322,7 +8317,7 @@
       "avgRoleFidelity": 0.7139860706187232,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["blur-element", "get-value", "keydown-key-is-syntax", "trigger-event"],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8957,7 +8952,7 @@
         "unless-condition",
         "when-value-changes"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9601,7 +9596,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10230,7 +10225,7 @@
       "avgRoleFidelity": 0.7273407335907333,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event"],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10870,7 +10865,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11495,7 +11490,7 @@
       "avgRoleFidelity": 0.7133043758043759,
       "degeneratePasses": [],
       "lossyPasses": ["event-debounce", "fetch-loading-state"],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12136,7 +12131,7 @@
         "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12776,7 +12771,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13404,7 +13399,7 @@
       "avgRoleFidelity": 0.7156290218790216,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event"],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14044,7 +14039,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14681,7 +14676,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 410232,
+      "bundleSize": 410580,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15303,7 +15298,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 410232,
+      "size": 410580,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary
Track K from the §10 handoff. The i18n `koreanProfile` was the only SOV profile with no event-role marker, so ko handlers emitted bare event names the fused `*-event-ko-sov-*` patterns could never anchor. Three pieces, one mechanism:

1. **i18n profile marker** `{ form: '할 때', role: 'event', position: 'postposition' }`.
2. **insertMarkers selector-event suppression** — `set @role to "alert" on #sr-announce` splits at the locative `on` (set/put deliberately not in `ON_TARGET_COMMANDS`); the dangling `on #sr-announce` is a headless pseudo-handler whose selector "event" must not get the marker (also strips ja's spurious `#sr-announce で`).
3. **semantic `trySOVEventExtraction`** consumes the optional two-token 할 때 phrase (할 identifier + 때 keyword) and lets it confirm custom identifier events the way ja's で does. Marker never required — bare-event ko keeps parsing.

## Measured
- ko 0.9307 → 0.9574 | lossy 9 → 6 | degen 7 → 5
- Global avgFidelity 0.9617 → 0.9629 | lossy 179 → 176 | degenerate 67 → 65 | 0 regressions
- The 4 probe flips that blocked this branch last session (announce-screen-reader, fetch-json, form-disable-on-submit, if-exists — see §10) are all locked faithful. The #366 body walker was the missing precondition.

## Testing
- Lock describe-blocks in both `multilingual-roadmap-fixes.test.ts` (7 cases incl. marker-less compat + the 아니면-never-unless guard) and `grammar.test.ts` (marker emission + suppression, ko + ja).
- semantic 5677 passed, i18n 840 passed, full regression gate green, baseline regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)