### PR TITLE
fix(semantic): tl/ar VSO event recovery — mis-listed keywords + midstream-on-no-match

### DIFF
--- a/packages/semantic/src/generators/profiles/arabic.ts
+++ b/packages/semantic/src/generators/profiles/arabic.ts
@@ -125,7 +125,12 @@ export const arabicProfile: LanguageProfile = {
     return: { primary: 'ارجع', alternatives: ['عُد'], normalized: 'return' },
     then: { primary: 'ثم', alternatives: ['بعدها', 'ثمّ'], normalized: 'then' },
     and: { primary: 'وأيضاً', alternatives: ['أيضاً'], normalized: 'and' },
-    end: { primary: 'نهاية', alternatives: ['انتهى', 'آخر'], normalized: 'end' },
+    // آخر is deliberately ABSENT: it is the positional `last` keyword
+    // (آخر <button/> في .modal — see pattern-matcher's positional handling).
+    // Listing it as an end-alternative made parseBodyWithClauses chop every
+    // clause containing a positional `last` at that token (ar focus-trap lost
+    // its if-branch body). النهاية is what the i18n dict actually emits.
+    end: { primary: 'نهاية', alternatives: ['انتهى', 'النهاية'], normalized: 'end' },
     // Advanced
     js: { primary: 'جافاسكربت', alternatives: ['js'], normalized: 'js' },
     async: { primary: 'متزامن', normalized: 'async' },

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -288,6 +288,35 @@ export class SemanticParserImpl implements ISemanticParser {
       )
     );
 
+    // Stage 2.5 (VSO): mid-stream event with an UNMATCHED leading command.
+    // The stage-midstream-cmd path above only runs when Stage 2 matched a
+    // command — but the leading clause is often unmatchable (`itago
+    // pinakamalapit .modal kapag click ثم …`: hide-closest has no tl pattern;
+    // `breakpoint kapag click …`: breakpoint isn't a command keyword), so the
+    // event + then-chain fell through to compound parsing and the handler was
+    // lost (tl/ar modal-close-button, tl breakpoint-command). Same extractor,
+    // same guard: fires only on a real on-marked event whose body parses, so
+    // it can only add parses. Restricted to VSO like stage-midstream-cmd, and
+    // to SINGLE-LINE input: a multi-line block (`behavior … init … on click …`)
+    // legitimately contains an on-marked event in its body, and extracting it
+    // would flatten the whole block into one handler (ar behavior-removable).
+    if (!parseInput.includes('\n') && tryGetProfile(language)?.wordOrder === 'VSO') {
+      const midNoCmd = this.tryMidStreamEventExtraction(parseInput, language, sortedPatterns);
+      if (midNoCmd) {
+        diagnostics.push(
+          parseDiagnostic(
+            'mid-stream event extraction succeeded with no leading command match',
+            'info',
+            'stage-midstream-nocmd'
+          )
+        );
+        const result = modifiers
+          ? this.applyModifiers(midNoCmd as EventHandlerSemanticNode, modifiers)
+          : midNoCmd;
+        return withDiagnostics(result, diagnostics);
+      }
+    }
+
     // Stage 3: Try SOV event trigger extraction
     const sovResult = this.trySOVEventExtraction(parseInput, language, sortedPatterns);
     if (sovResult) {
@@ -1715,7 +1744,10 @@ export class SemanticParserImpl implements ISemanticParser {
     const endKeywords: Record<string, Set<string>> = {
       en: new Set(['end']),
       ja: new Set(['終わり', '終了', 'おわり']),
-      ar: new Set(['نهاية', 'انتهى', 'آخر']),
+      // ar آخر is deliberately ABSENT: it is the positional `last` keyword;
+      // listing it here chopped clauses at every positional last (ar focus-trap
+      // lost its if-branch body). النهاية is what the i18n dict emits for end.
+      ar: new Set(['نهاية', 'انتهى', 'النهاية']),
       es: new Set(['fin', 'final', 'terminar']),
       ko: new Set(['끝', '종료', '마침']),
       zh: new Set(['结束', '终止', '完']),

--- a/packages/semantic/src/patterns/event-handler.ts
+++ b/packages/semantic/src/patterns/event-handler.ts
@@ -1520,7 +1520,11 @@ function getEventHandlerPatternsTl(): LanguagePattern[] {
       template: {
         format: 'kapag {event} mula_sa {source} {body}',
         tokens: [
-          { type: 'literal', value: 'kapag', alternatives: ['kung', 'sa'] },
+          // 'kung' is deliberately ABSENT: it is tl's IF keyword. Listing it as
+          // a kapag-alternative made if-first emissions (`kung <cond> kapag
+          // <event> …`, focus-trap) match THIS pattern with event=<cond's first
+          // token>, eating the if-clause. 'sa' stays (a genuine on-variant).
+          { type: 'literal', value: 'kapag', alternatives: ['sa'] },
           { type: 'role', role: 'event' },
           { type: 'literal', value: 'mula_sa', alternatives: ['galing_sa'] },
           { type: 'role', role: 'source' },
@@ -1540,7 +1544,8 @@ function getEventHandlerPatternsTl(): LanguagePattern[] {
       template: {
         format: 'kapag {event} {body}',
         tokens: [
-          { type: 'literal', value: 'kapag', alternatives: ['kung', 'sa'] },
+          // 'kung' deliberately absent — see event-tl-kapag-source above.
+          { type: 'literal', value: 'kapag', alternatives: ['sa'] },
           { type: 'role', role: 'event' },
         ],
       },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -3602,3 +3602,107 @@ describe('ko event marker 할 때 — fused patterns anchor, custom events confi
     expect([...a].sort()).toEqual(['on', 'put', 'set']);
   });
 });
+
+describe('tl/ar VSO event recovery — mis-listed keywords + midstream-on-no-match (Track B)', () => {
+  // Three small pieces clearing the tl/ar focus-trap/modal-close/breakpoint
+  // cluster (7 instances, 0 regressions; avgFidelity 0.9629 → 0.9641):
+  //
+  // 1. ar آخر removed from the end-keyword set (curated parser set + profile
+  //    alternatives). آخر is ar's positional `last`; listing it as `end` made
+  //    parseBodyWithClauses chop every clause at a positional last, so the
+  //    ar focus-trap if-branch body (focus/halt) vanished. النهاية — the form
+  //    the i18n dict actually emits for end — replaces it. Same collision
+  //    class as tr son/sonuncu (locked earlier).
+  // 2. tl 'kung' (= IF) removed from the kapag-alternatives of the
+  //    event-tl-kapag patterns. if-first emissions (`kung <cond> kapag <event>
+  //    …`) matched the EVENT pattern with event=<cond fragment>, eating the
+  //    if-clause. With kung gone, Stage 2 matches `if` (a block action) and
+  //    the existing midstream-loop extraction builds handler+if correctly —
+  //    the §10-planned Stage-1.5 reorder turned out unnecessary.
+  // 3. Stage 2.5: tryMidStreamEventExtraction now also runs for VSO when
+  //    Stage 2 found NO command (`itago pinakamalapit .modal kapag click …` —
+  //    hide-closest has no tl pattern; `breakpoint kapag click …` — not a
+  //    command keyword). Gated to single-line input: a multi-line behavior
+  //    block legitimately contains on-marked events in its body and must not
+  //    be flattened into one handler (ar behavior-removable caught this).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped transformer output (en → lang).
+  it('[ar] focus-trap keeps the if-branch body (آخر no longer chops the clause)', () => {
+    const a = actions(
+      parse(
+        'إذا هدف يطابق آخر <button/> في .modal من .modal عند keydown[key=="Tab"] ثم تركيز أول <button/> في .modal ثم أوقف النهاية',
+        'ar'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('if')).toBe(true);
+    expect(a.has('focus')).toBe(true);
+    expect(a.has('halt')).toBe(true);
+  });
+
+  it('[tl] focus-trap: kung anchors if, kapag anchors the event (was event=cond fragment)', () => {
+    const a = actions(
+      parse(
+        'kung target tumutugma huli <button/> sa_loob .modal mula sa .modal kapag keydown[key=="Tab"] pagkatapos ituon una <button/> sa_loob .modal pagkatapos huminto wakas',
+        'tl'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('if')).toBe(true);
+    expect(a.has('focus')).toBe(true);
+    expect(a.has('halt')).toBe(true);
+  });
+
+  it('[tl] modal-close-button recovers the handler around an unmatched leading command', () => {
+    const a = actions(
+      parse('itago pinakamalapit .modal kapag click pagkatapos alisin .modal-open mula sa katawan', 'tl')
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('remove')).toBe(true);
+  });
+
+  it('[ar] modal-close-button recovers the handler likewise', () => {
+    const a = actions(parse('اخف الأقرب .modal عند نقر ثم احذف .modal-open من جسم', 'ar'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('remove')).toBe(true);
+  });
+
+  it('[tl] breakpoint-command keeps the handler (breakpoint is not a command keyword)', () => {
+    const a = actions(parse('breakpoint kapag click pagkatapos itakda $x sa 42', 'tl'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('set')).toBe(true);
+  });
+
+  it('[ar] a multi-line behavior block is NOT flattened by the new stage (single-line guard)', () => {
+    // Reduced behavior-removable shape. The guard's contract: the multi-line
+    // block must never be swallowed into a single on-handler (a parse failure
+    // here is acceptable — the full corpus block parses via the behavior path).
+    let flattenedToHandler = false;
+    try {
+      const a = actions(
+        parse('behavior Removable(t)\n    من t عند نقر\n        احذف أنا\n    النهاية\nالنهاية', 'ar')
+      );
+      flattenedToHandler = a.has('on');
+    } catch {
+      // not parseable as a single statement — fine, the behavior path owns it
+    }
+    expect(flattenedToHandler).toBe(false);
+  });
+
+  it('[en] the en reference parses are unchanged', () => {
+    const a = actions(parse('on click hide closest .modal remove .modal-open from body', 'en'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('remove')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,31 +1,24 @@
 {
-  "timestamp": "2026-06-12T12:39:08.977Z",
-  "commit": "1507578c",
+  "timestamp": "2026-06-12T12:50:55.167Z",
+  "commit": "d9866454",
   "languages": {
     "ar": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9311967924424667,
-      "avgFidelity": 0.9554466230936819,
-      "avgRoleFidelity": 0.8255183025591192,
-      "degeneratePasses": [
-        "behavior-draggable",
-        "behavior-resizable",
-        "behavior-sortable",
-        "event-debounce"
-      ],
+      "avgFidelity": 0.9690631808278866,
+      "avgRoleFidelity": 0.8385568513119536,
+      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
-        "breakpoint-command",
+        "event-debounce",
         "fetch-loading-state",
-        "focus-trap",
         "if-exists",
         "keydown-key-is-syntax",
-        "modal-close-button",
         "repeat-until-event",
         "window-scroll"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -660,7 +653,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1299,7 +1292,7 @@
         "keydown-key-is-syntax",
         "when-value-changes"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1923,7 +1916,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2552,7 +2545,7 @@
       "avgRoleFidelity": 0.800170068027211,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3186,7 +3179,7 @@
         "if-exists",
         "when-value-changes"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3835,7 +3828,7 @@
         "trigger-event",
         "wait-then"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4481,7 +4474,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5128,7 +5121,7 @@
         "settle-animations",
         "template-literal-interpolation"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5756,7 +5749,7 @@
       "avgRoleFidelity": 0.6924846128927764,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "fetch-loading-state"],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6404,7 +6397,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7046,7 +7039,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7693,7 +7686,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8317,7 +8310,7 @@
       "avgRoleFidelity": 0.7139860706187232,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["blur-element", "get-value", "keydown-key-is-syntax", "trigger-event"],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8952,7 +8945,7 @@
         "unless-condition",
         "when-value-changes"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9596,7 +9589,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10225,7 +10218,7 @@
       "avgRoleFidelity": 0.7273407335907333,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event"],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10865,7 +10858,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11490,7 +11483,7 @@
       "avgRoleFidelity": 0.7133043758043759,
       "degeneratePasses": [],
       "lossyPasses": ["event-debounce", "fetch-loading-state"],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12115,23 +12108,20 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9122867328749679,
-      "avgFidelity": 0.9692640692640694,
-      "avgRoleFidelity": 0.8363819176319179,
-      "degeneratePasses": ["event-debounce"],
+      "avgFidelity": 0.9833333333333332,
+      "avgRoleFidelity": 0.8527107464607466,
+      "degeneratePasses": [],
       "lossyPasses": [
-        "breakpoint-command",
+        "event-debounce",
         "fetch-loading-state",
-        "focus-trap",
         "if-exists",
-        "modal-close-button",
         "morph-with-template",
         "render-template-with-data",
         "settle-animations",
         "take-class-from-siblings",
-        "window-keydown",
         "window-scroll"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12771,7 +12761,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13399,7 +13389,7 @@
       "avgRoleFidelity": 0.7156290218790216,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event"],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14039,7 +14029,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14676,7 +14666,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 410580,
+      "bundleSize": 410875,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15298,7 +15288,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 410580,
+      "size": 410875,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary
Track B from the §10 handoff — landed cheaper than planned (no Stage-1.5 reorder needed):

1. **ar آخر-as-end collision**: آخر is the positional `last`; listing it in the end-keyword set chopped every clause at a positional last (ar focus-trap lost its if-branch body — found via per-token tracing of `parseBodyWithClauses`). Replaced with النهاية, the form the i18n dict actually emits. Same collision class as tr son/sonuncu.
2. **tl kung-as-kapag**: 'kung' (= if) was a kapag-alternative in `event-tl-kapag`, so if-first emissions matched the event pattern with event=cond-fragment. With it removed, the existing midstream-loop extraction handles `kung <cond> kapag <event> …` correctly.
3. **Stage 2.5 midstream-on-no-match (VSO)**: the existing extractor only ran when Stage 2 matched a leading command; unmatchable leading clauses (`itago pinakamalapit`, `breakpoint`) lost the handler. Single-line guard keeps multi-line behavior blocks out (ar behavior-removable regression caught and locked).

## Measured
- avgFidelity 0.9629 → 0.9641 | lossy 176 → 171 | degenerate 65 → 63 | 0 regressions
- Cleared: focus-trap (ar/tl), modal-close-button (ar/tl), breakpoint-command (ar/tl), tl window-keydown

## Testing
- New lock describe-block (7 cases incl. the multi-line behavior guard + en reference).
- semantic suite 5684 passed; full regression gate green; baseline regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)