### PR TITLE
fix(semantic,i18n): SOV clause-final for-loop anchors via verb-anchoring

### DIFF
--- a/packages/i18n/src/dictionaries/hi.ts
+++ b/packages/i18n/src/dictionaries/hi.ts
@@ -21,7 +21,7 @@ export const hindiDictionary: Dictionary = {
     if: 'अगर',
     unless: 'जब_तक_नहीं',
     repeat: 'दोहराएं',
-    for: 'के_लिए',
+    for: 'हेतु', // single token — के_लिए splits at _ in the hi extractor
     while: 'जब_तक',
     until: 'तक',
     continue: 'जारी',

--- a/packages/i18n/src/dictionaries/ko.ts
+++ b/packages/i18n/src/dictionaries/ko.ts
@@ -21,7 +21,7 @@ export const ko: Dictionary = {
     if: '만약',
     unless: '아니면',
     repeat: '반복',
-    for: '동안',
+    for: '각각', // profile's for word — 동안 is while (collision)
     while: '동안',
     until: '까지',
     continue: '계속',

--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -27,7 +27,7 @@ export const qu: Dictionary = {
     if: 'sichus',
     unless: 'mana_sichus',
     repeat: 'kutipay',
-    for: 'rayku',
+    for: 'sapankaq', // profile's for word — rayku doubles as `by`
     while: 'kay_kaq',
     until: 'hayk_akama',
     continue: 'purichiy',

--- a/packages/semantic/src/generators/profiles/hindi.ts
+++ b/packages/semantic/src/generators/profiles/hindi.ts
@@ -134,7 +134,10 @@ export const hindiProfile: LanguageProfile = {
     where: { primary: 'कहाँ', normalized: 'where' },
     else: { primary: 'वरना', alternatives: ['नहीं तो'], normalized: 'else' },
     repeat: { primary: 'दोहराएं', alternatives: ['दोहरा'], normalized: 'repeat' },
-    for: { primary: 'के लिए', alternatives: [], normalized: 'for' },
+    // हेतु is what the i18n dict emits (के_लिए split at `_` in the word
+    // extractor; के लिए is two tokens — neither could anchor the clause-final
+    // SOV for-loop).
+    for: { primary: 'के लिए', alternatives: ['हेतु'], normalized: 'for' },
     while: { primary: 'जब तक', alternatives: [], normalized: 'while' },
     continue: { primary: 'जारी', alternatives: [], normalized: 'continue' },
     halt: { primary: 'रोकें', alternatives: ['रोक'], normalized: 'halt' },

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -729,10 +729,14 @@ export class SemanticParserImpl implements ISemanticParser {
   }): Map<string, string> {
     const lookup = new Map<string, string>();
     for (const [action, kw] of Object.entries(profile.keywords)) {
-      // Skip non-command keywords (on, if, else, etc.)
-      if (
-        ['on', 'if', 'else', 'when', 'where', 'while', 'for', 'end', 'then', 'and'].includes(action)
-      ) {
+      // Skip non-command keywords (on, if, else, etc.). `for` is deliberately
+      // NOT skipped: the SOV grammar transforms put the for-loop keyword
+      // clause-FINAL (`item の中 $items を ために` / `item içinde $items i için`)
+      // — an order no generated pattern covers — so the verb-anchoring fallback
+      // is exactly where it must anchor. This path only runs when nothing else
+      // in the clause matched, so a `for` in an otherwise-parseable clause is
+      // untouched.
+      if (['on', 'if', 'else', 'when', 'where', 'while', 'end', 'then', 'and'].includes(action)) {
         continue;
       }
       lookup.set(kw.primary.toLowerCase(), action);

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -3706,3 +3706,82 @@ describe('tl/ar VSO event recovery — mis-listed keywords + midstream-on-no-mat
     expect(a.has('remove')).toBe(true);
   });
 });
+
+describe('SOV clause-final for-loop anchors via verb-anchoring (#358 tail)', () => {
+  // #358's markerOverride table fixed the SVO for-loops; the six SOV languages
+  // emit the for-keyword clause-FINAL (`item の中 $items を ために`) — an order
+  // no generated pattern covers, so parseClause dropped the whole loop clause.
+  // `for` is no longer skipped in buildVerbLookup: the verb-anchoring fallback
+  // (which only fires when nothing else in the clause matched) anchors on the
+  // trailing for-word. Plus dict↔profile realigns where the dict emitted a
+  // word the profile reads as something else (the #361/#364 class):
+  //   ko 동안 → 각각  (동안 is WHILE — the profile comment already warned)
+  //   qu rayku → sapankaq  (rayku doubles as `by`)
+  //   hi के_लिए → हेतु  (splits at `_` in the word extractor; new profile alt)
+  // bn জন্য and tr için needed no realign — verb-anchoring matches by token
+  // VALUE, so their particle-kind for-words anchor as-is.
+  // Fixed template-literal-list-build in bn/ja/ko/qu/tr (avgFidelity
+  // 0.9641 → 0.9646, lossy 171 → 166, 0 regressions). hi remains: a generated
+  // into-pattern matches `में …` first, so the clause never reaches the
+  // fallback (separate mechanism, tracked in the handoff).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped transformer output (en → lang), template-literal-list-build.
+  const corpus: Array<[string, string]> = [
+    [
+      'ja',
+      '$html を クリック で 設定 "" に それから item の中 $items を ために それから $html を 設定 $html + `<li>${item.name}</li>` 終わり に それから #list.innerHTML を 設定 $html に',
+    ],
+    [
+      'tr',
+      '$html i tıklama de ayarla "" e sonra item içinde $items i için sonra $html i ayarla $html + `<li>${item.name}</li>` son e sonra #list.innerHTML i ayarla $html e',
+    ],
+    [
+      'ko',
+      '$html 를 클릭 할 때 설정 "" 에 그러면 item 안에 $items 를 각각 그러면 $html 를 설정 $html + `<li>${item.name}</li>` 끝 에 그러면 #list.innerHTML 를 설정 $html 에',
+    ],
+    [
+      'bn',
+      '$html কে ক্লিক এ সেট "" তে তারপর item এ $items কে জন্য তারপর $html কে সেট $html + `<li>${item.name}</li>` শেষ তে তারপর #list.innerHTML কে সেট $html তে',
+    ],
+    [
+      'qu',
+      '$html ta "" man ñitiy pi churanay chayqa item ukupi $items ta sapankaq chayqa $html ta $html + `<li>${item.name}</li>` tukuy man churanay chayqa #list.innerHTML ta $html man churanay',
+    ],
+  ];
+  for (const [lang, input] of corpus) {
+    it(`[${lang}] template-literal-list-build keeps the for loop (was {on,set})`, () => {
+      const a = actions(parse(input, lang as 'ja'));
+      expect(a.has('on')).toBe(true);
+      expect(a.has('for')).toBe(true);
+      expect(a.has('set')).toBe(true);
+    });
+  }
+
+  it('[ko] 동안 still reads as while, not for (the realign reason stays locked)', () => {
+    // The ko profile reads 동안 as WHILE; the dict realign (동안 → 각각) exists
+    // because emitting 동안 for `for` could never anchor a for-loop.
+    const a = actions(parse('item 안에 $items 를 동안 그러면 $html 를 설정 $html 에', 'ko'));
+    expect(a.has('for')).toBe(false);
+  });
+
+  it('[en] the en reference parse is unchanged', () => {
+    const a = actions(
+      parse(
+        'on click set $html to "" then for item in $items set $html to $html + `<li>${item.name}</li>` end then set #list.innerHTML to $html',
+        'en'
+      )
+    );
+    expect([...a].sort()).toEqual(['for', 'on', 'set']);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T12:50:55.167Z",
-  "commit": "d9866454",
+  "timestamp": "2026-06-12T13:04:18.133Z",
+  "commit": "3b2c1ceb",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -18,7 +18,7 @@
         "repeat-until-event",
         "window-scroll"
       ],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -642,7 +642,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8884559884559885,
-      "avgFidelity": 0.9884199134199132,
+      "avgFidelity": 0.9905844155844155,
       "avgRoleFidelity": 0.7300916988416986,
       "degeneratePasses": [],
       "lossyPasses": [
@@ -650,10 +650,9 @@
         "if-exists",
         "make-element",
         "make-toast-element",
-        "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1292,7 +1291,7 @@
         "keydown-key-is-syntax",
         "when-value-changes"
       ],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1916,7 +1915,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2545,7 +2544,7 @@
       "avgRoleFidelity": 0.800170068027211,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3179,7 +3178,7 @@
         "if-exists",
         "when-value-changes"
       ],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3828,7 +3827,7 @@
         "trigger-event",
         "wait-then"
       ],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4474,7 +4473,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5121,7 +5120,7 @@
         "settle-animations",
         "template-literal-interpolation"
       ],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5749,7 +5748,7 @@
       "avgRoleFidelity": 0.6924846128927764,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "fetch-loading-state"],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6373,7 +6372,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8787157287157287,
-      "avgFidelity": 0.9362554112554111,
+      "avgFidelity": 0.9384199134199134,
       "avgRoleFidelity": 0.7027187902187902,
       "degeneratePasses": [
         "announce-screen-reader",
@@ -6394,10 +6393,9 @@
         "method-call-possessive-dot",
         "on-custom-event-receive",
         "put-content-basic",
-        "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7022,7 +7020,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7878066378066378,
-      "avgFidelity": 0.9573593073593072,
+      "avgFidelity": 0.9595238095238094,
       "avgRoleFidelity": 0.6736647361647365,
       "degeneratePasses": [
         "behavior-draggable",
@@ -7036,10 +7034,9 @@
         "fetch-error-handling",
         "if-empty",
         "input-validation",
-        "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7686,7 +7683,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8310,7 +8307,7 @@
       "avgRoleFidelity": 0.7139860706187232,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["blur-element", "get-value", "keydown-key-is-syntax", "trigger-event"],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8945,7 +8942,7 @@
         "unless-condition",
         "when-value-changes"
       ],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9569,7 +9566,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7423520923520923,
-      "avgFidelity": 0.9514069264069263,
+      "avgFidelity": 0.9535714285714285,
       "avgRoleFidelity": 0.6505469755469757,
       "degeneratePasses": [
         "behavior-draggable",
@@ -9586,10 +9583,9 @@
         "render-template-with-data",
         "settle-animations",
         "take-class-from-siblings",
-        "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10218,7 +10214,7 @@
       "avgRoleFidelity": 0.7273407335907333,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event"],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10858,7 +10854,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11483,7 +11479,7 @@
       "avgRoleFidelity": 0.7133043758043759,
       "degeneratePasses": [],
       "lossyPasses": ["event-debounce", "fetch-loading-state"],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12121,7 +12117,7 @@
         "take-class-from-siblings",
         "window-scroll"
       ],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12746,7 +12742,7 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.877923021060276,
-      "avgFidelity": 0.9580610021786493,
+      "avgFidelity": 0.960239651416122,
       "avgRoleFidelity": 0.7205053449951407,
       "degeneratePasses": [
         "behavior-draggable",
@@ -12755,13 +12751,8 @@
         "behavior-sortable",
         "default-value"
       ],
-      "lossyPasses": [
-        "fetch-do-not-throw",
-        "take-class-from-siblings",
-        "template-literal-list-build",
-        "unless-condition"
-      ],
-      "bundleSize": 410875,
+      "lossyPasses": ["fetch-do-not-throw", "take-class-from-siblings", "unless-condition"],
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13389,7 +13380,7 @@
       "avgRoleFidelity": 0.7156290218790216,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event"],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14029,7 +14020,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14666,7 +14657,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 410875,
+      "bundleSize": 410869,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15288,7 +15279,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 410875,
+      "size": 410869,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary
Track S part 1 (#358's SOV residue). The six SOV languages emit the for-keyword clause-FINAL (`item の中 $items を ために`) — no generated pattern covers that order, so `parseClause` dropped the loop clause entirely.

- `for` is no longer skipped in `buildVerbLookup`: the verb-anchoring fallback (fires only when nothing else in the clause matched) anchors on the trailing for-word.
- Dict→profile realigns (the #361/#364 class): ko 동안→각각 (동안 is *while* — the profile comment already warned), qu rayku→sapankaq (rayku doubles as `by`), hi के_लिए→हेतु (underscore compounds split in the hi extractor; हेतु added as profile alternative).
- bn জন্য / tr için needed no realign — verb-anchoring matches by token value, so particle-kind for-words anchor as-is.

## Measured
- avgFidelity 0.9641 → 0.9646 | lossy 171 → 166 | 0 regressions
- Fixed: template-literal-list-build in bn/ja/ko/qu/tr. hi remains (a generated into-pattern matches `में …` first so the clause never reaches the fallback — tracked in the handoff).

## Testing
- Lock describe-block: 5 corpus-shaped cases + ko 동안-stays-while negative guard + en reference.
- semantic 5691 passed, i18n 840 passed, gate green, baseline regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)