### PR TITLE
fix(semantic): marker-less fetch patterns for de/ru/uk/it/vi/th/ar/tl

### DIFF
--- a/packages/semantic/src/patterns/fetch.ts
+++ b/packages/semantic/src/patterns/fetch.ts
@@ -268,6 +268,27 @@ export function getFetchPatternsForLanguage(language: string): LanguagePattern[]
       // transformer inserts the `את` accusative particle (`הבא את /url`) where the
       // generated pattern expects `מ` (from); accept either. Verb alt `טען`.
       return [markerlessFetch('fetch-he', 'he', 'הבא', 'מ', 'כ', ['טען'], ['את'])];
+    // fetch-loading-state / event-debounce cluster (9 langs): same marker-less
+    // shape — the dict verb matches the profile, but `fetch <url>` emits no
+    // source marker so the generated pattern never anchors mid then-chain.
+    case 'de':
+      return [markerlessFetch('fetch-de', 'de', 'abrufen', 'von', 'als', ['laden'])];
+    case 'ru':
+      return [markerlessFetch('fetch-ru', 'ru', 'загрузить', 'из', 'как', ['загрузи'])];
+    case 'uk':
+      return [markerlessFetch('fetch-uk', 'uk', 'завантажити', 'з', 'як', ['завантаж'])];
+    case 'it':
+      return [markerlessFetch('fetch-it', 'it', 'recuperare', 'da', 'come')];
+    case 'vi':
+      return [markerlessFetch('fetch-vi', 'vi', 'tải', 'từ', 'như')];
+    case 'th':
+      return [markerlessFetch('fetch-th', 'th', 'ดึงข้อมูล', 'จาก', 'เป็น')];
+    case 'ar':
+      return [markerlessFetch('fetch-ar', 'ar', 'احضر', 'من', 'كـ', ['جلب'])];
+    case 'tl':
+      return [
+        markerlessFetch('fetch-tl', 'tl', 'kuhanin_mula', 'mula_sa', 'bilang', ['kunin_mula']),
+      ];
     default:
       return [];
   }

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -3785,3 +3785,82 @@ describe('SOV clause-final for-loop anchors via verb-anchoring (#358 tail)', () 
     expect([...a].sort()).toEqual(['for', 'on', 'set']);
   });
 });
+
+describe('marker-less fetch recovery for the fetch-loading-state/event-debounce cluster', () => {
+  // The dict fetch verbs already matched their profiles (de abrufen, th
+  // ดึงข้อมูล, it recuperare …) — the §10 "fetch drops mid then-chain"
+  // diagnosis pointed at the chain, but the probe showed the BARE clause
+  // (`abrufen /api/data`) failing standalone: for `fetch <url>` (no `from`)
+  // the transformer emits NO source marker, while the generated
+  // fetch-<lang>-generated pattern requires one. The fetch-fr/fetch-pt
+  // markerlessFetch shape already existed for exactly this; extended the
+  // table to de/ru/uk/it/vi/th/ar/tl. Fixed event-debounce AND
+  // fetch-loading-state in all 8 (16 instances — ar/tl despite their
+  // jumbled debounce-fronted emissions): avgFidelity 0.9646 → 0.9658,
+  // lossy 166 → 150, 0 regressions.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped transformer output (en → lang), fetch-loading-state:
+  // `on click add .loading to me fetch /api/data then remove .loading from me
+  //  put it into #result`
+  const loadingState: Array<[string, string]> = [
+    [
+      'de',
+      'bei klick hinzufügen .loading zu ich dann abrufen /api/data dann entfernen .loading von ich dann setzen es zu #result',
+    ],
+    [
+      'ru',
+      'при клик добавить .loading в я затем загрузить /api/data затем удалить .loading из я затем положить это в #result',
+    ],
+    [
+      'th',
+      'เมื่อ คลิก เพิ่ม .loading ใน ฉัน แล้ว ดึงข้อมูล /api/data แล้ว ลบ .loading จาก ฉัน แล้ว ใส่ มัน ใน #result',
+    ],
+  ];
+  for (const [lang, input] of loadingState) {
+    it(`[${lang}] fetch-loading-state keeps the mid-chain fetch (was {add,on,put,remove})`, () => {
+      const a = actions(parse(input, lang as 'de'));
+      expect(a.has('fetch')).toBe(true);
+      expect(a.has('add')).toBe(true);
+      expect(a.has('remove')).toBe(true);
+      expect(a.has('put')).toBe(true);
+    });
+  }
+
+  // event-debounce: `on input debounced at 300ms fetch /api/search?q=${my value}
+  //  as json then put it into #results`
+  const debounce: Array<[string, string]> = [
+    ['it', 'su input debounced a 300ms recuperare /api/search?q=${my value} come json allora mettere esso in #results'],
+    ['uk', 'при введення debounced в 300ms завантажити /api/search?q=${my value} як json тоді покласти це в #results'],
+    ['vi', 'khi nhập debounced tại 300ms tải /api/search?q=${my value} như json rồi đặt nó vào #results'],
+  ];
+  for (const [lang, input] of debounce) {
+    it(`[${lang}] event-debounce keeps the fetch (was {on,put})`, () => {
+      const a = actions(parse(input, lang as 'it'));
+      expect(a.has('on')).toBe(true);
+      expect(a.has('fetch')).toBe(true);
+      expect(a.has('put')).toBe(true);
+    });
+  }
+
+  it('[de] the bare marker-less clause parses standalone (the probe shape)', () => {
+    expect(actions(parse('abrufen /api/data', 'de')).has('fetch')).toBe(true);
+  });
+
+  it('[en] the en reference parse is unchanged', () => {
+    const a = actions(
+      parse('on click add .loading to me fetch /api/data then remove .loading from me put it into #result', 'en')
+    );
+    expect([...a].sort()).toEqual(['add', 'fetch', 'on', 'put', 'remove']);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,23 +1,16 @@
 {
-  "timestamp": "2026-06-12T13:04:18.133Z",
-  "commit": "3b2c1ceb",
+  "timestamp": "2026-06-12T13:19:12.544Z",
+  "commit": "4b04c1c3",
   "languages": {
     "ar": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9311967924424667,
-      "avgFidelity": 0.9690631808278866,
-      "avgRoleFidelity": 0.8385568513119536,
+      "avgFidelity": 0.9725490196078432,
+      "avgRoleFidelity": 0.8411078717201169,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": [
-        "event-debounce",
-        "fetch-loading-state",
-        "if-exists",
-        "keydown-key-is-syntax",
-        "repeat-until-event",
-        "window-scroll"
-      ],
+      "lossyPasses": ["if-exists", "keydown-key-is-syntax", "repeat-until-event", "window-scroll"],
       "bundleSize": 410869,
       "patterns": {
         "toggle-class-basic": {
@@ -1277,14 +1270,12 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9315177923021051,
-      "avgFidelity": 0.9592592592592591,
+      "avgFidelity": 0.9627450980392156,
       "avgRoleFidelity": 0.7866132167152577,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "async-block",
         "blur-element",
-        "event-debounce",
-        "fetch-loading-state",
         "fetch-with-headers",
         "get-value",
         "if-exists",
@@ -5744,10 +5735,10 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9330117232078005,
-      "avgFidelity": 0.9769063180827887,
+      "avgFidelity": 0.9803921568627451,
       "avgRoleFidelity": 0.6924846128927764,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": ["event-debounce", "fetch-loading-state"],
+      "lossyPasses": [],
       "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
@@ -10210,10 +10201,10 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8983302411873844,
-      "avgFidelity": 0.9867965367965368,
+      "avgFidelity": 0.9902597402597403,
       "avgRoleFidelity": 0.7273407335907333,
       "degeneratePasses": ["install-behavior"],
-      "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event"],
+      "lossyPasses": ["trigger-event"],
       "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
@@ -11475,10 +11466,10 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9402185116470816,
-      "avgFidelity": 0.9965367965367965,
+      "avgFidelity": 1,
       "avgRoleFidelity": 0.7133043758043759,
       "degeneratePasses": [],
-      "lossyPasses": ["event-debounce", "fetch-loading-state"],
+      "lossyPasses": [],
       "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
@@ -12104,12 +12095,10 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9122867328749679,
-      "avgFidelity": 0.9833333333333332,
+      "avgFidelity": 0.9867965367965368,
       "avgRoleFidelity": 0.8527107464607466,
       "degeneratePasses": [],
       "lossyPasses": [
-        "event-debounce",
-        "fetch-loading-state",
         "if-exists",
         "morph-with-template",
         "render-template-with-data",
@@ -13376,10 +13365,10 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.896021438878582,
-      "avgFidelity": 0.9867965367965368,
+      "avgFidelity": 0.9902597402597403,
       "avgRoleFidelity": 0.7156290218790216,
       "degeneratePasses": ["install-behavior"],
-      "lossyPasses": ["event-debounce", "fetch-loading-state", "trigger-event"],
+      "lossyPasses": ["trigger-event"],
       "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
@@ -14005,12 +13994,10 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.900968872397444,
-      "avgFidelity": 0.9727272727272727,
+      "avgFidelity": 0.9761904761904763,
       "avgRoleFidelity": 0.808614864864865,
       "degeneratePasses": [],
       "lossyPasses": [
-        "event-debounce",
-        "fetch-loading-state",
         "get-attribute-possessive-dot",
         "input-mirror",
         "keydown-key-is-syntax",


### PR DESCRIPTION
## Summary
Track P, fetch clusters (§10: fetch-loading-state ×9, event-debounce ×8). The probe falsified the 'drops mid then-chain' framing — the BARE clause `abrufen /api/data` fails standalone: for `fetch <url>` (no `from`) the transformer emits no source marker, while the generated pattern requires one. The `markerlessFetch` builder (fetch-fr/fetch-pt precedent) already existed; this extends the table to de/ru/uk/it/vi/th/ar/tl with each language's verb + from/as markers.

## Measured
- avgFidelity 0.9646 → 0.9658 | lossy 166 → 150 | 0 regressions
- Fixed both clusters in all 8 languages (16 instances), including ar/tl despite their debounce-fronted emissions.

## Testing
- Lock describe-block: 3 fetch-loading-state + 3 event-debounce corpus cases, the bare-clause probe shape, en reference.
- semantic 5699 passed; gate green; baseline regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)