### PR TITLE
fix(semantic): set patterns must not claim put verbs (de/fr/pt)

### DIFF
--- a/packages/semantic/src/patterns/set.ts
+++ b/packages/semantic/src/patterns/set.ts
@@ -65,7 +65,10 @@ function getSetPatternsDe(): LanguagePattern[] {
       template: {
         format: 'setze {destination} auf {patient}',
         tokens: [
-          { type: 'literal', value: 'setze', alternatives: ['setzen', 'stelle', 'stellen', 'set'] },
+          // setzen/stellen are deliberately ABSENT: they are de's PUT verbs (dict
+          // put: setzen; profile put: setzen/stellen) — listing them here made
+          // every transformed put (`setzen es zu körper`) parse as set.
+          { type: 'literal', value: 'setze', alternatives: ['set'] },
           {
             type: 'role',
             role: 'destination',
@@ -88,7 +91,8 @@ function getSetPatternsDe(): LanguagePattern[] {
       template: {
         format: 'festlegen auf {destination} {patient}',
         tokens: [
-          { type: 'literal', value: 'festlegen', alternatives: ['einstellen', 'setzen'] },
+          // setzen deliberately absent — see set-de-full above.
+          { type: 'literal', value: 'festlegen', alternatives: ['einstellen'] },
           { type: 'literal', value: 'auf', alternatives: ['an'] },
           {
             type: 'role',
@@ -222,7 +226,9 @@ function getSetPatternsFr(): LanguagePattern[] {
           {
             type: 'literal',
             value: 'définir',
-            alternatives: ['definir', 'mettre', 'fixer', 'set'],
+            // mettre is deliberately ABSENT: it is fr's PUT verb — listing it here
+            // made every transformed put (`mettre ça à corps`) parse as set.
+            alternatives: ['definir', 'fixer', 'set'],
           },
           {
             type: 'role',
@@ -543,7 +549,9 @@ function getSetPatternsPt(): LanguagePattern[] {
       template: {
         format: 'definir {destination} para {patient}',
         tokens: [
-          { type: 'literal', value: 'definir', alternatives: ['estabelecer', 'colocar', 'set'] },
+          // colocar is deliberately ABSENT: it is pt's PUT verb — listing it here
+          // made every transformed put (`colocar isso para corpo`) parse as set.
+          { type: 'literal', value: 'definir', alternatives: ['estabelecer', 'set'] },
           {
             type: 'role',
             role: 'destination',
@@ -566,7 +574,8 @@ function getSetPatternsPt(): LanguagePattern[] {
       template: {
         format: 'definir em {destination} {patient}',
         tokens: [
-          { type: 'literal', value: 'definir', alternatives: ['estabelecer', 'colocar'] },
+          // colocar deliberately absent — see above.
+          { type: 'literal', value: 'definir', alternatives: ['estabelecer'] },
           { type: 'literal', value: 'em', alternatives: ['para', 'a'] },
           {
             type: 'role',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -3864,3 +3864,78 @@ describe('marker-less fetch recovery for the fetch-loading-state/event-debounce 
     expect([...a].sort()).toEqual(['add', 'fetch', 'on', 'put', 'remove']);
   });
 });
+
+describe('set patterns must not claim put verbs (de setzen / fr mettre / pt colocar)', () => {
+  // The handcrafted set-de/fr/pt patterns listed the language's PUT verb as a
+  // set-verb alternative (de setze + ['setzen','stellen'], fr définir +
+  // ['mettre'], pt definir + ['colocar']). The dicts emit DISTINCT verbs
+  // (set: festlegen/définir/definir; put: setzen/mettre/colocar), so every
+  // transformed put parsed as set — with roles swapped — across four whole
+  // clusters: if-exists, async-block, fetch-with-headers, when-value-changes
+  // (12 instances, all three languages each). Removing the put verbs from the
+  // set alternatives restores the split; genuine set forms (setze/définir/
+  // definir heads) are untouched. Same mis-listed-keyword class as tl kung
+  // (#368) and ko 아니면 (#361). avgFidelity → +12 instances, 0 regressions.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped then-tail clauses (en `put it into body`).
+  it('[de] setzen parses as put, not set', () => {
+    const a = actions(parse('setzen es zu körper', 'de'));
+    expect(a.has('put')).toBe(true);
+    expect(a.has('set')).toBe(false);
+  });
+
+  it('[fr] mettre parses as put, not set', () => {
+    const a = actions(parse('mettre ça à corps', 'fr'));
+    expect(a.has('put')).toBe(true);
+    expect(a.has('set')).toBe(false);
+  });
+
+  it('[pt] colocar parses as put, not set', () => {
+    const a = actions(parse('colocar isso para corpo', 'pt'));
+    expect(a.has('put')).toBe(true);
+    expect(a.has('set')).toBe(false);
+  });
+
+  // Genuine set forms keep parsing as set.
+  const setForms: Array<[string, string]> = [
+    ['de', 'setze $x auf 5'],
+    ['fr', 'définir $x à 5'],
+    ['pt', 'definir $x para 5'],
+  ];
+  for (const [lang, input] of setForms) {
+    it(`[${lang}] the genuine set head still parses as set`, () => {
+      const a = actions(parse(input, lang as 'de'));
+      expect(a.has('set')).toBe(true);
+    });
+  }
+
+  it('[de] if-exists keeps the else-branch put (was {if,make,on,set,show})', () => {
+    const a = actions(
+      parse(
+        'bei klick falls #modal existiert zeigen #modal sonst erstellen a <div#modal/> dann setzen es zu körper ende',
+        'de'
+      )
+    );
+    expect(a.has('if')).toBe(true);
+    expect(a.has('make')).toBe(true);
+    expect(a.has('put')).toBe(true);
+  });
+
+  it('[en] the en reference parse is unchanged', () => {
+    const a = actions(
+      parse('on click if #modal exists show #modal else make a <div#modal/> put it into body end', 'en')
+    );
+    expect([...a].sort()).toEqual(['if', 'make', 'on', 'put', 'show']);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T13:19:12.544Z",
-  "commit": "4b04c1c3",
+  "timestamp": "2026-06-12T13:30:09.411Z",
+  "commit": "fe597217",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -1270,18 +1270,10 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9315177923021051,
-      "avgFidelity": 0.9627450980392156,
-      "avgRoleFidelity": 0.7866132167152577,
+      "avgFidelity": 0.9716775599128542,
+      "avgRoleFidelity": 0.7985179786200195,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": [
-        "async-block",
-        "blur-element",
-        "fetch-with-headers",
-        "get-value",
-        "if-exists",
-        "keydown-key-is-syntax",
-        "when-value-changes"
-      ],
+      "lossyPasses": ["blur-element", "get-value", "keydown-key-is-syntax"],
       "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
@@ -3159,16 +3151,10 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9292768959435616,
-      "avgFidelity": 0.9681917211328975,
-      "avgRoleFidelity": 0.784353741496599,
+      "avgFidelity": 0.9771241830065359,
+      "avgRoleFidelity": 0.7962585034013608,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": [
-        "async-block",
-        "blur-element",
-        "fetch-with-headers",
-        "if-exists",
-        "when-value-changes"
-      ],
+      "lossyPasses": ["blur-element"],
       "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {
@@ -8922,17 +8908,10 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8958294428882667,
-      "avgFidelity": 0.9660130718954247,
-      "avgRoleFidelity": 0.804316488500162,
+      "avgFidelity": 0.9749455337690631,
+      "avgRoleFidelity": 0.816221250404924,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": [
-        "async-block",
-        "blur-element",
-        "fetch-with-headers",
-        "if-exists",
-        "unless-condition",
-        "when-value-changes"
-      ],
+      "lossyPasses": ["blur-element", "unless-condition"],
       "bundleSize": 410869,
       "patterns": {
         "toggle-class-on-other": {


### PR DESCRIPTION
## Summary
Track P. `set-de-full`/`set-fr-full`/`set-pt-*` listed the language's PUT verb (setzen/stellen, mettre, colocar) as a set-verb alternative. The dicts emit distinct verbs for set vs put, so every transformed put parsed as set (roles swapped). One collision, four clusters: if-exists, async-block, fetch-with-headers, when-value-changes — 12 instances across de/fr/pt.

Same mis-listed-keyword class as tl kung ([#368](https://github.com/codetalcott/hyperfixi/pull/368)) and ko 아니면 (#361).

## Measured
- avgFidelity 0.9658 → 0.9669 | lossy 150 → 138 | 0 regressions

## Testing
- Lock describe-block: put-not-set for all three + genuine set heads still set + de if-exists corpus case + en reference.
- semantic 5707 passed; gate green; baseline regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)