### PR TITLE
fix(i18n,semantic): dict↔profile realigns — clear ×8, command blur ×5, pt unless

### DIFF
--- a/packages/i18n/src/dictionaries/ar.ts
+++ b/packages/i18n/src/dictionaries/ar.ts
@@ -59,7 +59,7 @@ export const ar: Dictionary = {
     exit: 'اخرج',
     install: 'ثبّت',
     breakpoint: 'نقطة-توقف',
-    clear: 'امسح',
+    clear: 'نظّف', // امسح is a remove alternative in the profile
     close: 'أغلق',
     open: 'افتح',
     select: 'اختر',

--- a/packages/i18n/src/dictionaries/de.ts
+++ b/packages/i18n/src/dictionaries/de.ts
@@ -16,6 +16,9 @@ export const de: Dictionary = {
     add: 'hinzufügen',
     remove: 'entfernen',
     toggle: 'umschalten',
+    // command blur (the events section has the blur EVENT word; without this
+    // entry the transformer fell back to it and no profile read it as the verb)
+    blur: 'defokussieren',
     hide: 'verstecken',
     show: 'zeigen',
     // Align with the semantic German profile's `if` primary (`falls`). The previous
@@ -61,7 +64,7 @@ export const de: Dictionary = {
     exit: 'beenden',
     install: 'installieren',
     breakpoint: 'haltepunkt',
-    clear: 'löschen',
+    clear: 'bereinigen', // löschen is a remove alternative in the profile
     close: 'schließen',
     open: 'öffnen',
     select: 'auswählen',

--- a/packages/i18n/src/dictionaries/fr.ts
+++ b/packages/i18n/src/dictionaries/fr.ts
@@ -16,6 +16,9 @@ export const fr: Dictionary = {
     add: 'ajouter',
     remove: 'supprimer',
     toggle: 'basculer',
+    // command blur (the events section has the blur EVENT word; without this
+    // entry the transformer fell back to it and no profile read it as the verb)
+    blur: 'défocaliser',
     hide: 'cacher',
     show: 'montrer',
     if: 'si',

--- a/packages/i18n/src/dictionaries/he.ts
+++ b/packages/i18n/src/dictionaries/he.ts
@@ -11,6 +11,7 @@ export const he: Dictionary = {
     beep: 'ביפ',
     break: 'שבור',
     call: 'קרא',
+    clear: 'נקה', // profile's clear word — was untranslated (parsed as nothing)
     continue: 'המשך',
     copy: 'העתק',
     decrement: 'הקטן',

--- a/packages/i18n/src/dictionaries/id.ts
+++ b/packages/i18n/src/dictionaries/id.ts
@@ -59,7 +59,7 @@ export const id: Dictionary = {
     exit: 'keluar',
     install: 'pasang',
     breakpoint: 'titik-henti',
-    clear: 'hapus',
+    clear: 'bersihkan', // hapus is the remove PRIMARY in the profile
     close: 'tutup',
     open: 'buka',
     select: 'pilih',

--- a/packages/i18n/src/dictionaries/ms.ts
+++ b/packages/i18n/src/dictionaries/ms.ts
@@ -63,7 +63,7 @@ export const malayDictionary: Dictionary = {
     init: 'mula',
     clone: 'klon',
     breakpoint: 'titik-henti',
-    clear: 'padam',
+    clear: 'bersihkan', // padam is a remove alternative in the profile
     close: 'tutup',
     open: 'buka',
     select: 'pilih',

--- a/packages/i18n/src/dictionaries/pl.ts
+++ b/packages/i18n/src/dictionaries/pl.ts
@@ -16,6 +16,9 @@ export const pl: Dictionary = {
     add: 'dodaj',
     remove: 'usuń',
     toggle: 'przełącz',
+    // command blur (the events section has the blur EVENT word; without this
+    // entry the transformer fell back to it and no profile read it as the verb)
+    blur: 'rozmyj',
     hide: 'ukryj',
     show: 'pokaż',
     if: 'jeśli',
@@ -56,7 +59,7 @@ export const pl: Dictionary = {
     exit: 'wyjdź',
     install: 'zainstaluj',
     breakpoint: 'punkt-przerwania',
-    clear: 'wyczyść',
+    clear: 'zeruj', // wyczyść is a remove alternative in the profile
     close: 'zamknij',
     open: 'otwórz',
     select: 'wybierz',

--- a/packages/i18n/src/dictionaries/pt.ts
+++ b/packages/i18n/src/dictionaries/pt.ts
@@ -16,10 +16,13 @@ export const pt: Dictionary = {
     add: 'adicionar',
     remove: 'remover',
     toggle: 'alternar',
+    // command blur (the events section has the blur EVENT word; without this
+    // entry the transformer fell back to it and no profile read it as the verb)
+    blur: 'desfocar',
     hide: 'esconder',
     show: 'mostrar',
     if: 'se',
-    unless: 'a_menos',
+    unless: 'salvo', // a_menos splits at _ in the pt extractor (see profile)
     repeat: 'repetir',
     for: 'para',
     while: 'enquanto',

--- a/packages/i18n/src/dictionaries/sw.ts
+++ b/packages/i18n/src/dictionaries/sw.ts
@@ -19,6 +19,9 @@ export const sw: Dictionary = {
     add: 'ongeza',
     remove: 'ondoa',
     toggle: 'badilisha',
+    // command blur (the events section has the blur EVENT word; without this
+    // entry the transformer fell back to it and no profile read it as the verb)
+    blur: 'blur',
     hide: 'ficha',
     show: 'onyesha',
     if: 'kama',
@@ -59,7 +62,7 @@ export const sw: Dictionary = {
     exit: 'toka',
     install: 'sakinisha',
     breakpoint: 'nukta-simama',
-    clear: 'futa',
+    clear: 'safisha', // futa is a remove alternative in the profile
     close: 'funga',
     open: 'fungua',
     select: 'chagua',

--- a/packages/i18n/src/dictionaries/vi.ts
+++ b/packages/i18n/src/dictionaries/vi.ts
@@ -63,7 +63,7 @@ export const vi: Dictionary = {
     prepend: 'thêm đầu',
     else: 'không thì',
     breakpoint: 'điểm-dừng',
-    clear: 'xóa',
+    clear: 'tẩy', // xóa is the remove PRIMARY in the profile
     close: 'đóng',
     open: 'mở',
     select: 'chọn',

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -1802,3 +1802,34 @@ describe('ko event marker 할 때 + selector-event marker suppression', () => {
     expect(out.endsWith('#sr-announce')).toBe(true);
   });
 });
+
+describe('command blur translates via commands.blur, not the blur EVENT word', () => {
+  // de/fr/pt/pl/sw dicts had blur only in the EVENTS section (unscharf/flou/
+  // desfoque/rozmycie/poteza_macho); the COMMAND `blur me` fell back to that
+  // event word, which no semantic profile reads as the blur verb — blur-element
+  // was lossy in all five. commands.blur now emits the profile's verb.
+  const cases: Array<[string, string]> = [
+    ['de', 'defokussieren'],
+    ['fr', 'défocaliser'],
+    ['pt', 'desfocar'],
+    ['pl', 'rozmyj'],
+    ['sw', 'blur'],
+  ];
+  for (const [lang, verb] of cases) {
+    it(`[${lang}] blur me emits ${verb}`, () => {
+      const t = new GrammarTransformer('en', lang);
+      const out = t.transform('on keydown[key=="Escape"] blur me');
+      expect(out).toContain(verb);
+    });
+  }
+
+  it('[de] the blur EVENT now also emits the command word (shadowing, parse-safe)', () => {
+    // commands.blur shadows events.blur in event-name translation too. That is
+    // accepted: defokussieren is in the semantic eventNameTranslations for de,
+    // so `bei defokussieren …` still anchors the handler (gate green), and the
+    // command/event senses can never diverge again.
+    const t = new GrammarTransformer('en', 'de');
+    const out = t.transform('on blur add .error to me');
+    expect(out).toContain('defokussieren');
+  });
+});

--- a/packages/semantic/src/generators/profiles/portuguese.ts
+++ b/packages/semantic/src/generators/profiles/portuguese.ts
@@ -100,7 +100,10 @@ export const portugueseProfile: LanguageProfile = {
     fetch: { primary: 'buscar', normalized: 'fetch' },
     settle: { primary: 'estabilizar', normalized: 'settle' },
     if: { primary: 'se', normalized: 'if' },
-    unless: { primary: 'a_menos', normalized: 'unless' },
+    // salvo — single token ('salvo se' = unless). a_menos kept as an
+    // alternative documenting intent: the pt word extractor splits at `_`
+    // (a + _ + menos), so the compound could never tokenize as one keyword.
+    unless: { primary: 'salvo', alternatives: ['a_menos'], normalized: 'unless' },
     when: { primary: 'quando', normalized: 'when' },
     where: { primary: 'onde', normalized: 'where' },
     else: { primary: 'senão', normalized: 'else' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -3939,3 +3939,70 @@ describe('set patterns must not claim put verbs (de setzen / fr mettre / pt colo
     expect([...a].sort()).toEqual(['if', 'make', 'on', 'put', 'show']);
   });
 });
+
+describe('dict↔profile realigns: clear (8 langs), command blur (5), pt unless salvo', () => {
+  // Three sweeps of the same class — the dict emitted a word the semantic
+  // profile reads as a DIFFERENT action (or could not read at all):
+  //  1. clear: de löschen / pl wyczyść / vi xóa / id hapus / ms padam /
+  //     sw futa / ar امسح are all REMOVE words in their profiles, so
+  //     keydown-key-is-syntax (`on keyup[key=='Escape'] clear me`) parsed
+  //     clear-as-remove in 8 languages; he had no clear entry at all
+  //     (untranslated). Dicts realigned to the profile clear verbs
+  //     (bereinigen/zeruj/tẩy/bersihkan/bersihkan/safisha/نظّف/נקה).
+  //  2. blur: de/fr/pt/pl/sw dicts had blur only in the EVENTS section, so
+  //     the COMMAND `blur me` fell back to the event word, which no profile
+  //     reads as the verb (blur-element ×5; sw's event word also blocked
+  //     if-empty/input-validation). commands.blur added (see grammar.test.ts).
+  //  3. pt unless: dict+profile agreed on a_menos, but the pt word extractor
+  //     splits at `_` (a + _ + menos — the #361 underscore class), so the
+  //     keyword never tokenized. Realigned to salvo (the it precedent).
+  // Combined: avgFidelity 0.9669 → ~0.9685, −16 instances, 0 regressions.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped post-realign emissions (en → lang), keydown-key-is-syntax.
+  const clearCases: Array<[string, string]> = [
+    ['de', 'bei keyup[key=="Escape"] bereinigen ich'],
+    ['pl', 'gdy keyup[key=="Escape"] zeruj ja'],
+    ['vi', 'khi keyup[key=="Escape"] tẩy tôi'],
+    ['id', 'pada keyup[key=="Escape"] bersihkan saya'],
+    ['ms', 'apabila keyup[key=="Escape"] bersihkan saya'],
+    ['sw', 'kwenye keyup[key=="Escape"] safisha mimi'],
+    ['ar', 'عند keyup[key=="Escape"] نظّف أنا'],
+    ['he', 'ב keyup[key=="Escape"] נקה את אני'],
+  ];
+  for (const [lang, input] of clearCases) {
+    it(`[${lang}] keydown-key-is-syntax parses clear, not remove`, () => {
+      const a = actions(parse(input, lang as 'de'));
+      expect(a.has('on')).toBe(true);
+      expect(a.has('clear')).toBe(true);
+      expect(a.has('remove')).toBe(false);
+    });
+  }
+
+  it('[de] löschen still parses as remove (the realign reason stays locked)', () => {
+    const a = actions(parse('bei klick löschen .active von ich', 'de'));
+    expect(a.has('remove')).toBe(true);
+  });
+
+  it('[pt] unless-condition parses the unless wrapper via salvo (was {on,toggle})', () => {
+    const a = actions(parse('em clique salvo I match .disabled alternar .selected', 'pt'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('unless')).toBe(true);
+    expect(a.has('toggle')).toBe(true);
+  });
+
+  it('[en] the en reference parse is unchanged', () => {
+    const a = actions(parse("on keyup[key=='Escape'] clear me", 'en'));
+    expect([...a].sort()).toEqual(['clear', 'on']);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,17 +1,17 @@
 {
-  "timestamp": "2026-06-12T13:30:09.411Z",
-  "commit": "fe597217",
+  "timestamp": "2026-06-12T13:42:03.852Z",
+  "commit": "9ee7cd87",
   "languages": {
     "ar": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.9311967924424667,
-      "avgFidelity": 0.9725490196078432,
-      "avgRoleFidelity": 0.8411078717201169,
+      "avgConfidence": 0.9304498269896188,
+      "avgFidelity": 0.9758169934640524,
+      "avgRoleFidelity": 0.8445092322643346,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": ["if-exists", "keydown-key-is-syntax", "repeat-until-event", "window-scroll"],
-      "bundleSize": 410869,
+      "lossyPasses": ["if-exists", "repeat-until-event", "window-scroll"],
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -373,10 +373,6 @@
           "success": true,
           "confidence": 1
         },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 1
-        },
         "beep-debug-expression": {
           "success": true,
           "confidence": 1
@@ -557,6 +553,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -645,7 +645,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1269,12 +1269,12 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.9315177923021051,
-      "avgFidelity": 0.9716775599128542,
-      "avgRoleFidelity": 0.7985179786200195,
+      "avgConfidence": 0.9307708268492572,
+      "avgFidelity": 0.9782135076252725,
+      "avgRoleFidelity": 0.8072643343051509,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": ["blur-element", "get-value", "keydown-key-is-syntax"],
-      "bundleSize": 410869,
+      "lossyPasses": ["get-value"],
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1337,10 +1337,6 @@
           "confidence": 1
         },
         "repeat-for-each": {
-          "success": true,
-          "confidence": 1
-        },
-        "blur-element": {
           "success": true,
           "confidence": 1
         },
@@ -1672,6 +1668,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "log-value": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -1898,7 +1898,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2527,7 +2527,7 @@
       "avgRoleFidelity": 0.800170068027211,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3150,12 +3150,12 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.9292768959435616,
-      "avgFidelity": 0.9771241830065359,
-      "avgRoleFidelity": 0.7962585034013608,
+      "avgConfidence": 0.9285299304907139,
+      "avgFidelity": 0.9803921568627451,
+      "avgRoleFidelity": 0.7996598639455785,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": ["blur-element"],
-      "bundleSize": 410869,
+      "lossyPasses": [],
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3214,10 +3214,6 @@
           "confidence": 1
         },
         "multiple-events": {
-          "success": true,
-          "confidence": 1
-        },
-        "blur-element": {
           "success": true,
           "confidence": 1
         },
@@ -3545,6 +3541,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "log-value": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -3779,8 +3779,8 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8469447038074495,
-      "avgFidelity": 0.9340958605664489,
-      "avgRoleFidelity": 0.827057013281503,
+      "avgFidelity": 0.937363834422658,
+      "avgRoleFidelity": 0.8304583738257207,
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
@@ -3793,7 +3793,6 @@
         "get-value",
         "if-empty",
         "input-validation",
-        "keydown-key-is-syntax",
         "last-in-collection",
         "send-event",
         "send-event-to-form",
@@ -3804,7 +3803,7 @@
         "trigger-event",
         "wait-then"
       ],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4450,7 +4449,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5075,8 +5074,8 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9330117232078005,
-      "avgFidelity": 0.9327886710239651,
-      "avgRoleFidelity": 0.746833495302883,
+      "avgFidelity": 0.9360566448801743,
+      "avgRoleFidelity": 0.7502348558471007,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "caret-var-increment",
@@ -5085,7 +5084,6 @@
         "increment-by-amount",
         "increment-counter",
         "input-mirror",
-        "keydown-key-is-syntax",
         "method-call-possessive-dot",
         "morph-with-template",
         "render-template-with-data",
@@ -5097,7 +5095,7 @@
         "settle-animations",
         "template-literal-interpolation"
       ],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5725,7 +5723,7 @@
       "avgRoleFidelity": 0.6924846128927764,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6372,7 +6370,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7013,7 +7011,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7638,8 +7636,8 @@
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.9374454032172144,
-      "avgFidelity": 0.9525727069351231,
-      "avgRoleFidelity": 0.7670221560846564,
+      "avgFidelity": 0.9559284116331096,
+      "avgRoleFidelity": 0.7704943783068786,
       "degeneratePasses": [],
       "lossyPasses": [
         "async-block",
@@ -7649,7 +7647,6 @@
         "get-attribute-possessive-dot",
         "if-exists",
         "input-mirror",
-        "keydown-key-is-syntax",
         "last-in-collection",
         "make-element",
         "method-call-possessive-dot",
@@ -7660,7 +7657,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8279,12 +8276,12 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8915136424940349,
-      "avgFidelity": 0.968409586056645,
-      "avgRoleFidelity": 0.7139860706187232,
+      "avgConfidence": 0.8919286233011726,
+      "avgFidelity": 0.9749455337690633,
+      "avgRoleFidelity": 0.7207887917071586,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": ["blur-element", "get-value", "keydown-key-is-syntax", "trigger-event"],
-      "bundleSize": 410869,
+      "lossyPasses": ["get-value", "trigger-event"],
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8546,6 +8543,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "log-value": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -8767,10 +8768,6 @@
           "confidence": 0.8222222222222222
         },
         "go-url": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "blur-element": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -8907,12 +8904,12 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8958294428882667,
-      "avgFidelity": 0.9749455337690631,
-      "avgRoleFidelity": 0.816221250404924,
+      "avgConfidence": 0.896659404502542,
+      "avgFidelity": 0.9803921568627451,
+      "avgRoleFidelity": 0.8196226109491417,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": ["blur-element", "unless-condition"],
-      "bundleSize": 410869,
+      "lossyPasses": [],
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9190,6 +9187,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "log-value": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -9306,6 +9307,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "copy-to-clipboard": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -9410,10 +9415,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "default-value": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -9463,10 +9464,6 @@
           "confidence": 0.8222222222222222
         },
         "event-throttle": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "unless-condition": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -9555,7 +9552,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10184,7 +10181,7 @@
       "avgRoleFidelity": 0.7273407335907333,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["trigger-event"],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10808,23 +10805,19 @@
       "parseSuccess": 150,
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
-      "avgConfidence": 0.878719576719577,
-      "avgFidelity": 0.9576666666666667,
-      "avgRoleFidelity": 0.7936425264550265,
+      "avgConfidence": 0.8842857142857147,
+      "avgFidelity": 0.9669999999999999,
+      "avgRoleFidelity": 0.800586970899471,
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
-        "blur-element",
         "event-debounce",
-        "if-empty",
         "if-exists",
-        "input-validation",
-        "keydown-key-is-syntax",
         "make-element",
         "make-toast-element",
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11070,6 +11063,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "log-value": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -11122,6 +11119,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "form-submit-prevent": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -11171,6 +11172,10 @@
           "confidence": 0.8857142857142858
         },
         "if-exists": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "if-empty": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -11290,10 +11295,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "default-value": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -11401,19 +11402,11 @@
         "input-char-count": {
           "success": false
         },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.5
-        },
         "repeat-until-event": {
           "success": true,
           "confidence": 0.5
         },
         "event-debounce": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "if-empty": {
           "success": true,
           "confidence": 0.5
         },
@@ -11449,7 +11442,7 @@
       "avgRoleFidelity": 0.7133043758043759,
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12085,7 +12078,7 @@
         "take-class-from-siblings",
         "window-scroll"
       ],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12720,7 +12713,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "take-class-from-siblings", "unless-condition"],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13348,7 +13341,7 @@
       "avgRoleFidelity": 0.7156290218790216,
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["trigger-event"],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13973,20 +13966,19 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.900968872397444,
-      "avgFidelity": 0.9761904761904763,
-      "avgRoleFidelity": 0.808614864864865,
+      "avgFidelity": 0.9794372294372296,
+      "avgRoleFidelity": 0.8119932432432434,
       "degeneratePasses": [],
       "lossyPasses": [
         "get-attribute-possessive-dot",
         "input-mirror",
-        "keydown-key-is-syntax",
         "method-call-possessive-dot",
         "morph-with-template",
         "render-template-with-data",
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14623,7 +14615,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 410869,
+      "bundleSize": 410892,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15245,7 +15237,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 410869,
+      "size": 410892,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary
Track P realign sweep — three batches of the same dict↔profile class:

1. **clear** (8 langs): the dict clear words are all REMOVE words in their profiles (de löschen, pl wyczyść, vi xóa, id hapus, ms padam, sw futa, ar امسح); he had no clear entry at all. `on keyup[key=='Escape'] clear me` parsed clear-as-remove. Realigned to the profile clear verbs.
2. **command blur** (5 langs): dicts carried blur only in the *events* section, so the blur COMMAND fell back to the event word no profile reads as a verb. `commands.blur` added (de defokussieren, fr défocaliser, pt desfocar, pl rozmyj, sw blur). sw's event word was also blocking if-empty/input-validation.
3. **pt unless**: a_menos splits at `_` in the pt extractor (the #361 underscore class); realigned to salvo (the it precedent).

## Measured
- avgFidelity 0.9669 → 0.9690 | lossy 138 → 122 | R1 0.7525 → 0.7552 | 0 regressions
- Fixed: keydown-key-is-syntax ×8, blur-element ×5, sw if-empty + input-validation, pt unless-condition

## Testing
- Lock describe-blocks in both packages (clear-not-remove ×8 + löschen-stays-remove guard + pt salvo; blur emissions ×5 + event-shadowing note).
- semantic 5718, i18n 846 passed; gate green; baseline regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)