### PR TITLE
fix(semantic): event-handler wrappers defer destination to the command schema

### DIFF
--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -131,6 +131,28 @@ export interface CommandSchema {
 }
 
 /**
+ * Extraction entry for the optional destination slot of event-handler
+ * wrapper patterns. Defers to the wrapped command's schema: commands whose
+ * schema has no destination role (show/hide/increment/decrement/…) get NO
+ * destination extraction, and commands that do declare one inherit the
+ * schema's own default. A hardcoded `default: me` here used to fabricate a
+ * destination role on every wrapped parse — buildAST prefers destination
+ * over patient for the args slot, so the runtime acted on `me` instead of
+ * the patient selector (invisible to recall-based R1, caught by R2).
+ */
+export function eventHandlerDestinationExtraction(
+  schema: CommandSchema
+): Record<string, { fromRole: string; default?: SemanticValue }> {
+  const destRole = schema.roles.find(r => r.role === 'destination');
+  if (!destRole) return {};
+  return {
+    destination: destRole.default
+      ? { fromRole: 'destination', default: destRole.default }
+      : { fromRole: 'destination' },
+  };
+}
+
+/**
  * Command categories for organization.
  */
 export type CommandCategory =

--- a/packages/semantic/src/generators/event-handlers-sov.ts
+++ b/packages/semantic/src/generators/event-handlers-sov.ts
@@ -10,6 +10,7 @@
 import type { LanguagePattern, PatternToken } from '../types';
 import type { LanguageProfile, KeywordTranslation, RoleMarker } from './language-profiles';
 import type { CommandSchema } from './command-schemas';
+import { eventHandlerDestinationExtraction } from './command-schemas';
 import type { GeneratorConfig } from './pattern-generator';
 
 /**
@@ -91,7 +92,7 @@ export function generateSOVEventHandlerPattern(
       action: { value: commandSchema.action }, // Extract the wrapped command
       event: { fromRole: 'event' },
       patient: { fromRole: 'patient' },
-      destination: { fromRole: 'destination', default: { type: 'reference', value: 'me' } },
+      ...eventHandlerDestinationExtraction(commandSchema),
     },
   };
 }
@@ -164,7 +165,7 @@ export function generateSOVPatientFirstEventHandlerPattern(
       action: { value: commandSchema.action },
       event: { fromRole: 'event' },
       patient: { fromRole: 'patient' },
-      destination: { fromRole: 'destination', default: { type: 'reference', value: 'me' } },
+      ...eventHandlerDestinationExtraction(commandSchema),
     },
   };
 }
@@ -332,7 +333,7 @@ export function generateSOVCompactEventHandlerPattern(
       action: { value: commandSchema.action }, // Extract the wrapped command
       event: { fromRole: 'event' },
       patient: { fromRole: 'patient' },
-      destination: { fromRole: 'destination', default: { type: 'reference', value: 'me' } },
+      ...eventHandlerDestinationExtraction(commandSchema),
     },
   };
 }

--- a/packages/semantic/src/generators/event-handlers-vso.ts
+++ b/packages/semantic/src/generators/event-handlers-vso.ts
@@ -10,6 +10,7 @@
 import type { LanguagePattern, PatternToken } from '../types';
 import type { LanguageProfile, KeywordTranslation, RoleMarker } from './language-profiles';
 import type { CommandSchema } from './command-schemas';
+import { eventHandlerDestinationExtraction } from './command-schemas';
 import type { GeneratorConfig } from './pattern-generator';
 
 /**
@@ -72,7 +73,7 @@ export function generateVSOEventHandlerPattern(
       action: { value: commandSchema.action }, // Extract the wrapped command
       event: { fromRole: 'event' },
       patient: { fromRole: 'patient' },
-      destination: { fromRole: 'destination', default: { type: 'reference', value: 'me' } },
+      ...eventHandlerDestinationExtraction(commandSchema),
     },
   };
 }
@@ -143,7 +144,7 @@ export function generateVSOVerbFirstEventHandlerPattern(
       action: { value: commandSchema.action },
       event: { fromRole: 'event' },
       patient: { fromRole: 'patient' },
-      destination: { fromRole: 'destination', default: { type: 'reference', value: 'me' } },
+      ...eventHandlerDestinationExtraction(commandSchema),
     },
   };
 }
@@ -409,7 +410,7 @@ export function generateVSONegatedEventHandlerPattern(
       action: { value: commandSchema.action }, // Extract the wrapped command
       event: { fromRole: 'event' },
       patient: { fromRole: 'patient' },
-      destination: { fromRole: 'destination', default: { type: 'reference', value: 'me' } },
+      ...eventHandlerDestinationExtraction(commandSchema),
     },
   };
 }
@@ -483,7 +484,7 @@ export function generateVSOProcliticEventHandlerPattern(
       action: { value: commandSchema.action }, // Extract the wrapped command
       event: { fromRole: 'event' },
       patient: { fromRole: 'patient' },
-      destination: { fromRole: 'destination', default: { type: 'reference', value: 'me' } },
+      ...eventHandlerDestinationExtraction(commandSchema),
     },
   };
 }

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -4108,3 +4108,55 @@ describe('he accusative את — send/trigger/wait tolerate the marked object', 
     expect([...a].sort()).toEqual(['on', 'send']);
   });
 });
+
+describe('event-wrapper destination injection — wrappers defer to the command schema (R2 #376)', () => {
+  // The SOV/VSO event-handler wrapper generators (also reused by SVO) hardcoded
+  // `destination: { fromRole: 'destination', default: me }` into EVERY wrapped
+  // command's extraction — including show/hide/increment/decrement, whose
+  // schemas have no destination role at all. buildAST's show/hide/increment
+  // mappers fill the args slot with `destination ?? patient`, so the fabricated
+  // `destination:me` beat the real patient and the runtime acted on the clicked
+  // element instead of the named selector in ~18 languages (R2's 0.412 shelf).
+  // Recall-based R1 scores extra roles 1.0, which is how this survived five
+  // sessions invisible. Wrappers now defer to the wrapped schema via
+  // eventHandlerDestinationExtraction(): no destination role → no extraction;
+  // a declared destination role keeps the schema's own default (toggle/add/
+  // remove keep default me — benign, those mappers route it to modifiers).
+  // R2 0.5141 → 0.7801, failing instances 190 → 86, ar joins he/zh at 1.000.
+  function bodyRoles(node: unknown): Map<string, unknown> {
+    const rec = node as Record<string, unknown> | null;
+    const body = rec?.body as unknown;
+    const first = Array.isArray(body) ? body[0] : body;
+    const roles = (first as Record<string, unknown> | undefined)?.roles;
+    return roles instanceof Map ? roles : new Map(Object.entries((roles as object) ?? {}));
+  }
+
+  // Corpus-shaped wrapped commands whose schema has NO destination role:
+  // the parse must carry the patient and must NOT fabricate destination:me.
+  const noDestCases: Array<[string, string, string]> = [
+    ['es', 'en clic mostrar #modal', '#modal'],
+    ['de', 'bei klick zeigen #modal', '#modal'],
+    ['ru', 'при клик увеличить #counter', '#counter'],
+    ['it', 'su clic nascondere #modal', '#modal'],
+  ];
+  for (const [lang, input, patient] of noDestCases) {
+    it(`[${lang}] "${input}" keeps patient ${patient} and gains no destination`, () => {
+      const roles = bodyRoles(parse(input, lang as 'es'));
+      expect((roles.get('patient') as { value?: unknown })?.value).toBe(patient);
+      expect(roles.has('destination')).toBe(false);
+    });
+  }
+
+  it('[es] a schema WITH a destination role still captures a surface destination', () => {
+    // toggle declares destination (default me); the captured #menu must win.
+    const roles = bodyRoles(parse('en clic alternar .open a #menu', 'es'));
+    expect((roles.get('patient') as { value?: unknown })?.value).toBe('.open');
+    expect((roles.get('destination') as { value?: unknown })?.value).toBe('#menu');
+  });
+
+  it('[en] the en reference parse is unchanged', () => {
+    const roles = bodyRoles(parse('on click show #modal', 'en'));
+    expect((roles.get('patient') as { value?: unknown })?.value).toBe('#modal');
+    expect(roles.has('destination')).toBe(false);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,25 +1,19 @@
 {
-  "timestamp": "2026-06-12T15:41:29.702Z",
-  "commit": "f8ec7251",
+  "timestamp": "2026-06-12T16:14:23.016Z",
+  "commit": "8b752f9c",
   "languages": {
     "ar": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.9304498269896188,
+      "avgConfidence": 0.8851183610699171,
       "avgFidelity": 0.9758169934640524,
       "avgRoleFidelity": 0.8445092322643346,
-      "avgExecutionFidelity": 0.7058823529411765,
-      "executionFailures": [
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
-        "show-element"
-      ],
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["if-exists", "repeat-until-event", "window-scroll"],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -73,35 +67,7 @@
           "success": true,
           "confidence": 1
         },
-        "remove-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 1
-        },
         "toggle-visibility": {
-          "success": true,
-          "confidence": 1
-        },
-        "wait-then": {
           "success": true,
           "confidence": 1
         },
@@ -129,39 +95,11 @@
           "success": true,
           "confidence": 1
         },
-        "increment-counter": {
-          "success": true,
-          "confidence": 1
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 1
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 1
-        },
         "halt-propagation": {
           "success": true,
           "confidence": 1
         },
         "go-url": {
-          "success": true,
-          "confidence": 1
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "log-element": {
           "success": true,
           "confidence": 1
         },
@@ -190,10 +128,6 @@
           "confidence": 1
         },
         "tabs-aria": {
-          "success": true,
-          "confidence": 1
-        },
-        "modal-open": {
           "success": true,
           "confidence": 1
         },
@@ -345,10 +279,6 @@
           "success": true,
           "confidence": 1
         },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 1
-        },
         "template-literal-interpolation": {
           "success": true,
           "confidence": 1
@@ -425,10 +355,6 @@
           "success": true,
           "confidence": 1
         },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 1
-        },
         "caret-var-on-target": {
           "success": true,
           "confidence": 1
@@ -453,117 +379,77 @@
           "success": true,
           "confidence": 0.9722222222222222
         },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "trigger-event": {
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "fetch-basic": {
+        "remove-element": {
           "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
-        "fetch-json": {
+        "make-element": {
           "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
-        "fetch-with-method": {
+        "show-element": {
           "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
-        "if-condition": {
+        "show-with-transition": {
           "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
-        "go-back": {
+        "hide-element": {
           "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
-        "get-value": {
+        "hide-with-transition": {
           "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
-        "modal-close-backdrop": {
+        "wait-then": {
           "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
-        "input-validation": {
+        "increment-counter": {
           "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
-        "repeat-forever": {
+        "increment-by-amount": {
           "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
-        "event-key-combo": {
+        "decrement-counter": {
           "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
-        "fetch-error-handling": {
+        "focus-element": {
           "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
-        "if-matches": {
+        "blur-element": {
           "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
-        "if-exists": {
+        "log-value": {
           "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
-        "if-empty": {
+        "log-element": {
           "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
-        "stagger-animation": {
+        "modal-open": {
           "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
-        "its-value-possessive-dot": {
+        "make-toast-element": {
           "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
-        "render-template-with-data": {
+        "caret-var-increment": {
           "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8857142857142858
+          "confidence": 0.8642857142857143
         },
         "install-behavior": {
           "success": true,
@@ -576,6 +462,114 @@
         "repeat-for-each": {
           "success": true,
           "confidence": 0.7647058823529411
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.7142857142857143
         },
         "modal-close-escape": {
           "success": true,
@@ -645,15 +639,10 @@
       "avgConfidence": 0.8884559884559885,
       "avgFidelity": 0.9905844155844155,
       "avgRoleFidelity": 0.7300916988416986,
-      "avgExecutionFidelity": 0.47058823529411764,
+      "avgExecutionFidelity": 0.7647058823529411,
       "executionFailures": [
         "add-class-to-other",
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
         "remove-class-from-all",
-        "show-element",
         "tabs-basic",
         "toggle-class-on-other"
       ],
@@ -665,7 +654,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1289,22 +1278,14 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.9307708268492572,
+      "avgConfidence": 0.8478576615831489,
       "avgFidelity": 0.9782135076252725,
       "avgRoleFidelity": 0.8072643343051509,
-      "avgExecutionFidelity": 0.5882352941176471,
-      "executionFailures": [
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
-        "remove-class-from-all",
-        "show-element",
-        "tabs-basic"
-      ],
+      "avgExecutionFidelity": 0.8823529411764706,
+      "executionFailures": ["remove-class-from-all", "tabs-basic"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1594,50 +1575,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "settle-animations": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -1650,261 +1587,305 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-url": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "last-in-collection": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.7142857142857143
         },
         "behavior-removable": {
           "success": false
@@ -1928,7 +1909,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2552,22 +2533,14 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.9322647577549528,
+      "avgConfidence": 0.8515924888473881,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.800170068027211,
-      "avgExecutionFidelity": 0.5882352941176471,
-      "executionFailures": [
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
-        "remove-class-from-all",
-        "show-element",
-        "tabs-basic"
-      ],
+      "avgRoleFidelity": 0.8001700680272111,
+      "avgExecutionFidelity": 0.8823529411764706,
+      "executionFailures": ["remove-class-from-all", "tabs-basic"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -2865,50 +2838,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "settle-animations": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -2921,253 +2850,297 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-url": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.7142857142857143
         },
         "behavior-removable": {
           "success": false
@@ -3190,22 +3163,14 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.9285299304907139,
+      "avgConfidence": 0.84225542068679,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.7996598639455785,
-      "avgExecutionFidelity": 0.5882352941176471,
-      "executionFailures": [
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
-        "remove-class-from-all",
-        "show-element",
-        "tabs-basic"
-      ],
+      "avgRoleFidelity": 0.7996598639455784,
+      "avgExecutionFidelity": 0.8823529411764706,
+      "executionFailures": ["remove-class-from-all", "tabs-basic"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3483,50 +3448,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "settle-animations": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -3539,273 +3460,317 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-url": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "last-in-collection": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.7142857142857143
         },
         "behavior-removable": {
           "success": false
@@ -3828,8 +3793,8 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8469447038074495,
-      "avgFidelity": 0.956971677559913,
+      "avgConfidence": 0.8290175329391014,
+      "avgFidelity": 0.9569716775599126,
       "avgRoleFidelity": 0.8520003239390994,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -3849,7 +3814,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -3934,70 +3899,6 @@
         "intercept-cache-strategies": {
           "success": true,
           "confidence": 1
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "default-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8857142857142858
         },
         "toggle-class-basic": {
           "success": true,
@@ -4450,6 +4351,70 @@
         "reactive-array-push": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "default-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.7142857142857143
         },
         "behavior-removable": {
           "success": false
@@ -4475,18 +4440,13 @@
       "avgConfidence": 1,
       "avgFidelity": 0.9280303030303032,
       "avgRoleFidelity": 0.5428893178893178,
-      "avgExecutionFidelity": 0.29411764705882354,
+      "avgExecutionFidelity": 0.5882352941176471,
       "executionFailures": [
         "add-class-to-other",
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
         "remove-class-from-all",
         "set-inner-html-possessive-dot",
         "set-style",
         "set-text-possessive-dot",
-        "show-element",
         "tabs-basic",
         "toggle-class-on-other"
       ],
@@ -4510,7 +4470,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5134,20 +5094,16 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.9330117232078005,
+      "avgConfidence": 0.8568212470173231,
       "avgFidelity": 0.9431372549019609,
-      "avgRoleFidelity": 0.7549967606090054,
-      "avgExecutionFidelity": 0.4117647058823529,
+      "avgRoleFidelity": 0.7549967606090056,
+      "avgExecutionFidelity": 0.6470588235294118,
       "executionFailures": [
-        "decrement-counter",
-        "hide-element",
         "increment-counter",
-        "modal-open",
         "remove-class-from-all",
         "set-inner-html-possessive-dot",
         "set-style",
         "set-text-possessive-dot",
-        "show-element",
         "tabs-basic"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
@@ -5166,7 +5122,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5468,50 +5424,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "settle-animations": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -5524,18 +5436,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "increment-counter": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -5544,229 +5444,285 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "reactive-array-push": {
           "success": true,
           "confidence": 0.8857142857142858
         },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.7142857142857143
         },
         "behavior-removable": {
           "success": false
@@ -5789,25 +5745,20 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.9330117232078005,
+      "avgConfidence": 0.8534599024795076,
       "avgFidelity": 0.9803921568627451,
       "avgRoleFidelity": 0.6924846128927764,
-      "avgExecutionFidelity": 0.4117647058823529,
+      "avgExecutionFidelity": 0.7058823529411765,
       "executionFailures": [
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
         "remove-class-from-all",
         "set-inner-html-possessive-dot",
         "set-style",
         "set-text-possessive-dot",
-        "show-element",
         "tabs-basic"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6109,50 +6060,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "settle-animations": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -6165,249 +6072,293 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.7142857142857143
         },
         "behavior-removable": {
           "success": false
@@ -6433,16 +6384,11 @@
       "avgConfidence": 0.8787157287157287,
       "avgFidelity": 0.9384199134199134,
       "avgRoleFidelity": 0.7027187902187902,
-      "avgExecutionFidelity": 0.4117647058823529,
+      "avgExecutionFidelity": 0.7058823529411765,
       "executionFailures": [
         "add-class-to-other",
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
         "put-content-basic",
         "remove-class-from-all",
-        "show-element",
         "tabs-basic",
         "toggle-class-on-other"
       ],
@@ -6467,7 +6413,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7094,19 +7040,14 @@
       "avgConfidence": 0.7878066378066378,
       "avgFidelity": 0.9595238095238094,
       "avgRoleFidelity": 0.6736647361647365,
-      "avgExecutionFidelity": 0.29411764705882354,
+      "avgExecutionFidelity": 0.5882352941176471,
       "executionFailures": [
         "add-class-to-other",
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
         "put-content-basic",
         "remove-class-from-all",
         "set-inner-html-possessive-dot",
         "set-style",
         "set-text-possessive-dot",
-        "show-element",
         "tabs-basic"
       ],
       "degeneratePasses": [
@@ -7123,7 +7064,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7747,20 +7688,15 @@
       "parseSuccess": 149,
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
-      "avgConfidence": 0.9374454032172144,
+      "avgConfidence": 0.8500053265153905,
       "avgFidelity": 0.9559284116331096,
       "avgRoleFidelity": 0.7704943783068786,
-      "avgExecutionFidelity": 0.4117647058823529,
+      "avgExecutionFidelity": 0.7058823529411765,
       "executionFailures": [
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
         "remove-class-from-all",
         "set-inner-html-possessive-dot",
         "set-style",
         "set-text-possessive-dot",
-        "show-element",
         "tabs-basic"
       ],
       "degeneratePasses": [],
@@ -7782,7 +7718,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8060,50 +7996,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "settle-animations": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -8116,269 +8008,313 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-url": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.7142857142857143
         },
         "socket-basic": {
           "success": false
@@ -8401,25 +8337,20 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8919286233011726,
+      "avgConfidence": 0.8134972507521501,
       "avgFidelity": 0.9782135076252725,
-      "avgRoleFidelity": 0.7230563654033038,
-      "avgExecutionFidelity": 0.4117647058823529,
+      "avgRoleFidelity": 0.7230563654033048,
+      "avgExecutionFidelity": 0.7058823529411765,
       "executionFailures": [
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
         "remove-class-from-all",
         "set-inner-html-possessive-dot",
         "set-style",
         "set-text-possessive-dot",
-        "show-element",
         "tabs-basic"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8581,50 +8512,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "settle-animations": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -8634,242 +8521,6 @@
           "confidence": 0.8857142857142858
         },
         "trigger-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "reactive-array-push": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -9020,6 +8671,286 @@
         "caret-var-write": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.7142857142857143
         },
         "behavior-removable": {
           "success": false
@@ -9042,22 +8973,14 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.896659404502542,
+      "avgConfidence": 0.8148666874157042,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8196226109491417,
-      "avgExecutionFidelity": 0.5882352941176471,
-      "executionFailures": [
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
-        "remove-class-from-all",
-        "show-element",
-        "tabs-basic"
-      ],
+      "avgRoleFidelity": 0.8196226109491418,
+      "avgExecutionFidelity": 0.8823529411764706,
+      "executionFailures": ["remove-class-from-all", "tabs-basic"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9231,50 +9154,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "settle-animations": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -9284,254 +9163,6 @@
           "confidence": 0.8857142857142858
         },
         "trigger-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "reactive-array-push": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -9658,6 +9289,298 @@
         "caret-var-write": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.7142857142857143
         },
         "behavior-removable": {
           "success": false
@@ -9683,21 +9606,16 @@
       "avgConfidence": 0.7423520923520923,
       "avgFidelity": 0.9606060606060607,
       "avgRoleFidelity": 0.6552767052767055,
-      "avgExecutionFidelity": 0.11764705882352941,
+      "avgExecutionFidelity": 0.4117647058823529,
       "executionFailures": [
         "add-class-basic",
         "add-class-to-other",
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
         "put-content-basic",
         "remove-class-basic",
         "remove-class-from-all",
         "set-inner-html-possessive-dot",
         "set-style",
         "set-text-possessive-dot",
-        "show-element",
         "toggle-class-basic",
         "toggle-class-on-other"
       ],
@@ -9715,7 +9633,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10339,25 +10257,20 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8983302411873844,
+      "avgConfidence": 0.8204081632653035,
       "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.7295929858429855,
-      "avgExecutionFidelity": 0.4117647058823529,
+      "avgRoleFidelity": 0.7295929858429864,
+      "avgExecutionFidelity": 0.7058823529411765,
       "executionFailures": [
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
         "remove-class-from-all",
         "set-inner-html-possessive-dot",
         "set-style",
         "set-text-possessive-dot",
-        "show-element",
         "tabs-basic"
       ],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10527,50 +10440,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "settle-animations": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -10580,242 +10449,6 @@
           "confidence": 0.8857142857142858
         },
         "trigger-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "reactive-array-push": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -10971,6 +10604,286 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "install-behavior": {
           "success": true,
           "confidence": 0.5555555555555556
@@ -10981,22 +10894,14 @@
       "parseSuccess": 150,
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
-      "avgConfidence": 0.8851322751322754,
+      "avgConfidence": 0.8051322751322725,
       "avgFidelity": 0.9727777777777777,
-      "avgRoleFidelity": 0.8052166005291005,
-      "avgExecutionFidelity": 0.5882352941176471,
-      "executionFailures": [
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
-        "remove-class-from-all",
-        "show-element",
-        "tabs-basic"
-      ],
+      "avgRoleFidelity": 0.8052166005291008,
+      "avgExecutionFidelity": 0.8823529411764706,
+      "executionFailures": ["remove-class-from-all", "tabs-basic"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "repeat-until-event", "set-color-variable"],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11142,50 +11047,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "settle-animations": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -11198,247 +11059,11 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "accordion-toggle": {
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "closest-ancestor": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "reactive-array-push": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -11577,6 +11202,286 @@
         "caret-var-write": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.7142857142857143
         },
         "input-char-count": {
           "success": false
@@ -11616,25 +11521,20 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.9402185116470816,
+      "avgConfidence": 0.8567305710162828,
       "avgFidelity": 1,
-      "avgRoleFidelity": 0.7133043758043759,
-      "avgExecutionFidelity": 0.4117647058823529,
+      "avgRoleFidelity": 0.713304375804376,
+      "avgExecutionFidelity": 0.7058823529411765,
       "executionFailures": [
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
         "remove-class-from-all",
         "set-inner-html-possessive-dot",
         "set-style",
         "set-text-possessive-dot",
-        "show-element",
         "tabs-basic"
       ],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11936,50 +11836,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "settle-animations": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -11992,265 +11848,309 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-url": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-resize": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "last-in-collection": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-resize": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.7142857142857143
         }
       }
     },
@@ -12258,22 +12158,14 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.9140183346065697,
+      "avgConfidence": 0.8639255702280895,
       "avgFidelity": 0.9970779220779221,
       "avgRoleFidelity": 0.8596927284427288,
-      "avgExecutionFidelity": 0.5882352941176471,
-      "executionFailures": [
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
-        "remove-class-from-all",
-        "show-element",
-        "tabs-basic"
-      ],
+      "avgExecutionFidelity": 0.8823529411764706,
+      "executionFailures": ["remove-class-from-all", "tabs-basic"],
       "degeneratePasses": [],
       "lossyPasses": ["if-exists", "window-scroll"],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12599,38 +12491,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "settle-animations": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -12640,154 +12500,6 @@
           "confidence": 0.8857142857142858
         },
         "multiple-events": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "caret-var-increment": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -12850,6 +12562,186 @@
         "repeat-for-each": {
           "success": true,
           "confidence": 0.7647058823529411
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.7142857142857143
         },
         "modal-close-escape": {
           "success": true,
@@ -12900,15 +12792,8 @@
       "avgConfidence": 0.877923021060276,
       "avgFidelity": 0.9635076252723311,
       "avgRoleFidelity": 0.7227729186912859,
-      "avgExecutionFidelity": 0.6470588235294118,
-      "executionFailures": [
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
-        "show-element",
-        "tabs-basic"
-      ],
+      "avgExecutionFidelity": 0.9411764705882353,
+      "executionFailures": ["tabs-basic"],
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -12917,7 +12802,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13540,25 +13425,20 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.896021438878582,
+      "avgConfidence": 0.8180993609565013,
       "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.7178812741312739,
-      "avgExecutionFidelity": 0.4117647058823529,
+      "avgRoleFidelity": 0.7178812741312746,
+      "avgExecutionFidelity": 0.7058823529411765,
       "executionFailures": [
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
         "remove-class-from-all",
         "set-inner-html-possessive-dot",
         "set-style",
         "set-text-possessive-dot",
-        "show-element",
         "tabs-basic"
       ],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13720,50 +13600,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "settle-animations": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -13773,242 +13609,6 @@
           "confidence": 0.8857142857142858
         },
         "trigger-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "reactive-array-push": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -14172,6 +13772,286 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "install-behavior": {
           "success": true,
           "confidence": 0.5555555555555556
@@ -14182,19 +14062,14 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.900968872397444,
-      "avgFidelity": 0.9794372294372296,
-      "avgRoleFidelity": 0.8119932432432434,
-      "avgExecutionFidelity": 0.47058823529411764,
+      "avgConfidence": 0.8174809317666433,
+      "avgFidelity": 0.9794372294372293,
+      "avgRoleFidelity": 0.8119932432432435,
+      "avgExecutionFidelity": 0.7647058823529411,
       "executionFailures": [
-        "decrement-counter",
-        "hide-element",
-        "increment-counter",
-        "modal-open",
         "remove-class-from-all",
         "set-inner-html-possessive-dot",
         "set-text-possessive-dot",
-        "show-element",
         "tabs-basic"
       ],
       "degeneratePasses": [],
@@ -14207,7 +14082,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14373,50 +14248,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "remove-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "swap-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "show-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "hide-with-transition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-then": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "wait-for-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "settle-animations": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -14426,262 +14257,6 @@
           "confidence": 0.8857142857142858
         },
         "trigger-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-json": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "decrement-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-condition": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-for-each": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-url": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "go-back": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "blur-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "log-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "get-value": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "call-function": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "js-inline": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-open": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-escape": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "modal-close-backdrop": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "input-validation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-keydown": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "window-scroll": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "document-ready": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "last-in-collection": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-forever": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-from-elsewhere": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "event-key-combo": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-error-handling": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-matches": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-exists": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "if-empty": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "stagger-animation": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "its-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "render-template-with-data": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-fetch-result": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-with-template": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "morph-form-update": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-headers": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-with-method-body": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-formdata": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "fetch-do-not-throw": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "tell-other-element": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "pick-text-range": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "reactive-array-push": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -14824,6 +14399,306 @@
         "caret-var-write": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "remove-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "swap-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "show-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "hide-with-transition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-then": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "wait-for-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-json": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-by-amount": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "decrement-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-times": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-for-each": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-url": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "blur-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "get-value": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "call-function": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "js-inline": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-escape": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-backdrop": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "input-validation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-keydown": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-scroll": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "document-ready": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-forever": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "repeat-while": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-from-elsewhere": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "event-key-combo": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-error-handling": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-matches": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-exists": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "stagger-animation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "its-value-possessive-dot": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "render-template-with-data": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-fetch-result": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-with-template": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "morph-form-update": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-headers": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-with-method-body": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-formdata": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "fetch-do-not-throw": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-other-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "pick-text-range": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "take-class-from-siblings": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "caret-var-increment": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "reactive-array-push": {
+          "success": true,
+          "confidence": 0.7142857142857143
         }
       }
     },
@@ -14831,7 +14706,7 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.9882871667185392,
+      "avgConfidence": 0.9871667185392676,
       "avgFidelity": 0.9632897603485838,
       "avgRoleFidelity": 0.892095885973437,
       "avgExecutionFidelity": 1,
@@ -14846,7 +14721,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 410892,
+      "bundleSize": 410595,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15440,13 +15315,13 @@
           "success": true,
           "confidence": 1
         },
-        "focus-trap": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "focus-trap": {
+          "success": true,
+          "confidence": 0.7142857142857143
         },
         "behavior-removable": {
           "success": false
@@ -15468,7 +15343,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 410892,
+      "size": 410595,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Mechanism (R2 burn-down #1 — the role-injection class, §10 item 1)

The SOV/VSO event-handler wrapper generators (also reused by SVO languages) hardcoded `destination: { fromRole: 'destination', default: me }` into **every** wrapped command's extraction — including `show`/`hide`/`increment`/`decrement`, whose schemas declare **no destination role at all**. `buildAST`'s show/hide/increment/decrement mappers fill the args slot with `destination ?? patient`, so the fabricated `destination:me` beat the real patient and the runtime acted on the clicked element instead of the named selector (`show #modal` showed the button) across ~18 languages — R2's 0.412 shelf.

Recall-based R1 scores extra roles 1.0, which is how this survived five sessions invisible; R2 caught it in its first sweep (#375).

## Fix (emission side, schema-aware)

New helper `eventHandlerDestinationExtraction(schema)` in `command-schemas.ts`, applied at all 7 hardcoded sites (4 VSO + 3 SOV):
- schema has no destination role → **no destination extraction** (mirrors the en parse shape)
- schema declares one → inherit the **schema's own default** (toggle/add/remove keep `default: me` — benign: their mappers route destination to `modifiers`, matching runtime defaults; verified `toggle .open a #menu` still captures the surface destination `#menu`)

## Results (full 24-language sweep, fresh populate)

- R2 executionFidelity mean **0.5141 → 0.7801**, failing instances **190 → 86** (104 cleared, beating the predicted ~90)
- Every language moved; **ar joins he/zh at 1.000**; worst movers: qu 0.118→0.412, hi/ko 0.294→0.588, the ten-language 0.412 shelf → 0.647–0.706
- Parsing floor unchanged: avgFidelity 0.9717, lossy 99, degenerate 63; R1 byte-stable (recall-based, as expected)
- Gate green (parse-rate, fidelity, correctness, execution ratchets); all 5755 semantic tests pass
- Locked by the #376 describe-block in `multilingual-roadmap-fixes.test.ts` (4 no-destination cases + destination-capture guard + en reference guard)

Baseline regenerated with the 24-language list; patterns.db untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)