### PR TITLE
fix(semantic): SOV fallback path strips quote chars from string literals

### DIFF
--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -86,6 +86,20 @@ function withDiagnostics<T extends SemanticNode>(node: T, diagnostics: Diagnosti
   return { ...node, diagnostics } as T;
 }
 
+/**
+ * Strip a symmetric pair of surrounding quote characters from a string
+ * literal token's raw value. Unbalanced values are returned unchanged.
+ */
+function stripQuotes(val: string): string {
+  if (val.length >= 2) {
+    const first = val[0];
+    if ((first === '"' || first === "'") && val.endsWith(first)) {
+      return val.slice(1, -1);
+    }
+  }
+  return val;
+}
+
 // =============================================================================
 // Semantic Parser Implementation
 // =============================================================================
@@ -992,7 +1006,7 @@ export class SemanticParserImpl implements ISemanticParser {
       return createSelector(combined);
     }
     if (first.kind === 'literal' || first.value.startsWith('"') || first.value.startsWith("'")) {
-      return createLiteral(combined);
+      return createLiteral(stripQuotes(combined), 'string');
     }
     if ((first.kind as string) === 'reference') {
       return createReference(combined as 'me' | 'it' | 'you' | 'result');
@@ -1018,9 +1032,12 @@ export class SemanticParserImpl implements ISemanticParser {
       return createSelector(val);
     }
 
-    // String literals
+    // String literals — strip the quote characters like the pattern-matcher
+    // path does (parseLiteralValue); keeping them put literal `"Done!"`
+    // (quotes and all) into the DOM at runtime in the particle-based parse
+    // path while en wrote `Done!`.
     if (val.startsWith('"') || val.startsWith("'")) {
-      return createLiteral(val);
+      return createLiteral(stripQuotes(val), 'string');
     }
 
     // Numbers

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -4160,3 +4160,43 @@ describe('event-wrapper destination injection — wrappers defer to the command 
     expect(roles.has('destination')).toBe(false);
   });
 });
+
+describe('ko literal quoting — the SOV fallback path strips quote chars (R2 #377)', () => {
+  // `"Done!" 를 클릭 넣다 나 에` parsed with patient literal `"Done!"` — quote
+  // characters INCLUDED — so the runtime wrote `"Done!"` into the DOM where
+  // en wrote `Done!`. The ko tokenizer correctly emits the token as
+  // kind=literal; the bug was in semantic-parser's own tokenToSemanticValue /
+  // tokensToSemanticValue (the particle-based SOV fallback path), which
+  // wrapped the RAW value in createLiteral without stripping quotes — unlike
+  // pattern-matcher's parseLiteralValue, which every other language's parse
+  // path goes through. Both sites now strip symmetric quotes and tag
+  // dataType string. ko execution 0.588 → 0.647.
+  function firstBody(node: unknown): Record<string, unknown> {
+    const rec = node as Record<string, unknown>;
+    const body = rec?.body as unknown;
+    return (Array.isArray(body) ? body[0] : body) as Record<string, unknown>;
+  }
+  function role(node: unknown, name: string): { value?: unknown; dataType?: string } {
+    const cmd = firstBody(node);
+    const roles = cmd?.roles as Map<string, unknown>;
+    const m = roles instanceof Map ? roles : new Map(Object.entries((roles as object) ?? {}));
+    return (m.get(name) ?? {}) as { value?: unknown; dataType?: string };
+  }
+
+  it('[ko] put-content-basic patient literal has no quote chars (was "\\"Done!\\"")', () => {
+    const p = role(parse('"Done!" 를 클릭 넣다 나 에', 'ko'), 'patient');
+    expect(p.value).toBe('Done!');
+    expect(p.dataType).toBe('string');
+  });
+
+  it('[ko] single-quoted literal strips too', () => {
+    const p = role(parse("'OK' 를 클릭 넣다 나 에", 'ko'), 'patient');
+    expect(p.value).toBe('OK');
+  });
+
+  it('[en] the en reference parse is unchanged', () => {
+    const p = role(parse('on click put "Done!" into me', 'en'), 'patient');
+    expect(p.value).toBe('Done!');
+    expect(p.dataType).toBe('string');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T16:14:23.016Z",
-  "commit": "8b752f9c",
+  "timestamp": "2026-06-12T16:26:36.579Z",
+  "commit": "31eb8cc1",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -13,7 +13,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["if-exists", "repeat-until-event", "window-scroll"],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -654,7 +654,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -1285,7 +1285,7 @@
       "executionFailures": ["remove-class-from-all", "tabs-basic"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1909,7 +1909,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2540,7 +2540,7 @@
       "executionFailures": ["remove-class-from-all", "tabs-basic"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3170,7 +3170,7 @@
       "executionFailures": ["remove-class-from-all", "tabs-basic"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3814,7 +3814,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4470,7 +4470,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -5122,7 +5122,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5758,7 +5758,7 @@
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6413,7 +6413,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7040,10 +7040,9 @@
       "avgConfidence": 0.7878066378066378,
       "avgFidelity": 0.9595238095238094,
       "avgRoleFidelity": 0.6736647361647365,
-      "avgExecutionFidelity": 0.5882352941176471,
+      "avgExecutionFidelity": 0.6470588235294118,
       "executionFailures": [
         "add-class-to-other",
-        "put-content-basic",
         "remove-class-from-all",
         "set-inner-html-possessive-dot",
         "set-style",
@@ -7064,7 +7063,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -7718,7 +7717,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8350,7 +8349,7 @@
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8980,7 +8979,7 @@
       "executionFailures": ["remove-class-from-all", "tabs-basic"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9633,7 +9632,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -10270,7 +10269,7 @@
       ],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10901,7 +10900,7 @@
       "executionFailures": ["remove-class-from-all", "tabs-basic"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "repeat-until-event", "set-color-variable"],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11534,7 +11533,7 @@
       ],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12165,7 +12164,7 @@
       "executionFailures": ["remove-class-from-all", "tabs-basic"],
       "degeneratePasses": [],
       "lossyPasses": ["if-exists", "window-scroll"],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12802,7 +12801,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -13438,7 +13437,7 @@
       ],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14082,7 +14081,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14721,7 +14720,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 410595,
+      "bundleSize": 410730,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15343,7 +15342,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 410595,
+      "size": 410730,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Mechanism (R2 burn-down #2 — ko literal quoting, §10 item 2)

`"Done!" 를 클릭 넣다 나 에` parsed with patient literal `"Done!"` — quote characters included — so the runtime wrote `"Done!"` into the DOM where en wrote `Done!`.

The ko tokenizer is innocent (it emits the token as `kind=literal` correctly). The bug was in the particle-based SOV fallback path: `semantic-parser.ts`'s own `tokenToSemanticValue` / `tokensToSemanticValue` wrapped the **raw** token value in `createLiteral` without stripping quotes or tagging `dataType` — unlike `pattern-matcher.ts`'s `parseLiteralValue`, which every other parse path goes through. Both sites now strip symmetric quote pairs (unbalanced values pass through unchanged) and tag `dataType: 'string'`.

## Results (full 24-language sweep)

- ko executionFidelity **0.588 → 0.647** (put-content-basic now byte-matches en's effect signature)
- R2 mean **0.7801 → 0.7826**, failing instances **86 → 85**
- Gate green; parsing floor and all other languages byte-stable
- Locked by the #377 describe-block in `multilingual-roadmap-fixes.test.ts`

Note: ko `set-style` remains failing on a separate mechanism (patient/destination role swap on the ko set pattern) — documented for the next session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)