### PR TITLE
fix(semantic): fused {action} event patterns re-parse the body clause for roles (R2 it/th → 1.000)

### DIFF
--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -465,11 +465,64 @@ export class SemanticParserImpl implements ISemanticParser {
         }
       }
 
-      const commandNode = createCommandNode(actionName as ActionType, roles, {
+      let commandNode = createCommandNode(actionName as ActionType, roles, {
         sourceLanguage: language,
         patternId: match.pattern.id,
         confidence: match.confidence,
       });
+
+      // A handcrafted fused pattern (`su {event} {action}` / `เมื่อ {event}
+      // {action}`) captures only the body VERB — the body's arguments trail
+      // unconsumed and the command node above comes out with ZERO roles, while
+      // the en reference re-parses the same clause through the command patterns
+      // and captures everything (`set my.textContent to X` → destination +
+      // patient). When that happens, retry: re-parse [verb..clause boundary]
+      // with the command patterns and swap in the result — but only when it is
+      // a single command with the SAME action and at least one role, so a body
+      // whose standalone pattern is missing (blur/transition/breakpoint) keeps
+      // the zero-roled node instead of degenerating to nothing.
+      if (Object.keys(roles).length === 0) {
+        const all = tokens.tokens;
+        const pos = tokens.position();
+        const verbToken = pos > 0 ? all[pos - 1] : undefined;
+        const verbNormalized = verbToken
+          ? ((verbToken as { normalized?: string }).normalized ?? verbToken.value)
+          : undefined;
+        // Every action-capturing pattern puts {action} last, so the verb is the
+        // previously consumed token; require it to map to the captured action.
+        if (verbToken && verbNormalized === actionName) {
+          const clauseTokens: LanguageToken[] = [verbToken];
+          let clauseEnd = pos;
+          while (clauseEnd < all.length) {
+            const t = all[clauseEnd];
+            const isBoundary =
+              t.kind === 'conjunction' ||
+              (t.kind === 'keyword' &&
+                (this.isThenKeyword(t.value, language) || this.isEndKeyword(t.value, language)));
+            if (isBoundary) break;
+            clauseTokens.push(t);
+            clauseEnd++;
+          }
+          // Only retry when the verb has trailing arguments to reclaim.
+          if (clauseTokens.length > 1) {
+            const commandPatterns = getPatternsForLanguage(language)
+              .filter(p => p.command !== 'on')
+              .sort((a, b) => b.priority - a.priority);
+            const reparsed = this.parseClause(clauseTokens, commandPatterns, language);
+            const first = reparsed[0];
+            if (
+              reparsed.length === 1 &&
+              first &&
+              first.kind === 'command' &&
+              first.action === actionName &&
+              (first as CommandSemanticNode).roles.size > 0
+            ) {
+              commandNode = first as CommandSemanticNode;
+              while (tokens.position() < clauseEnd) tokens.advance();
+            }
+          }
+        }
+      }
 
       // Check if pattern has continuation marker (then-chains).
       const continuesValue = match.captured.get('continues');

--- a/packages/semantic/src/patterns/set.ts
+++ b/packages/semantic/src/patterns/set.ts
@@ -463,7 +463,8 @@ function getSetPatternsIt(): LanguagePattern[] {
             type: 'group',
             optional: true,
             tokens: [
-              { type: 'literal', value: 'a', alternatives: ['su', 'come'] },
+              // 'in' is what the it grammar transformer emits for en 'to'
+              { type: 'literal', value: 'a', alternatives: ['su', 'come', 'in'] },
               { type: 'role', role: 'patient' },
             ],
           },
@@ -471,7 +472,7 @@ function getSetPatternsIt(): LanguagePattern[] {
       },
       extraction: {
         destination: { position: 1 },
-        patient: { marker: 'a', markerAlternatives: ['su', 'come'] },
+        patient: { marker: 'a', markerAlternatives: ['su', 'come', 'in'] },
       },
     },
     {
@@ -701,23 +702,32 @@ function getSetPatternsSw(): LanguagePattern[] {
 
 function getSetPatternsTh(): LanguagePattern[] {
   return [
-    // Simple pattern: ตั้ง :x 5
+    // Marker pattern: ตั้ง X ใน "val" — every th corpus emission marks the
+    // value with ใน (en 'to'); positional patient mis-captured multi-token
+    // destinations (property paths) and fabricated bogus values.
     {
       id: 'set-th-simple',
       language: 'th',
       command: 'set',
       priority: 100,
       template: {
-        format: 'ตั้ง {destination} {patient}',
+        format: 'ตั้ง {destination} ใน {patient}',
         tokens: [
-          { type: 'literal', value: 'ตั้ง', alternatives: ['กำหนด'] },
+          { type: 'literal', value: 'ตั้ง', alternatives: ['กำหนด', 'ตั้งค่า'] },
           { type: 'role', role: 'destination' },
-          { type: 'role', role: 'patient' },
+          {
+            type: 'group',
+            optional: true,
+            tokens: [
+              { type: 'literal', value: 'ใน', alternatives: ['เป็น'] },
+              { type: 'role', role: 'patient' },
+            ],
+          },
         ],
       },
       extraction: {
         destination: { position: 1 },
-        patient: { position: 2 },
+        patient: { marker: 'ใน', markerAlternatives: ['เป็น'] },
       },
     },
   ];

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1498,13 +1498,31 @@ describe('socket command keyword alignment (9 native-primary languages)', () => 
   // name/url and put the verb mid-stream; the recovery is order-independent.
   const cases: Array<[string, string]> = [
     ['ar', 'مقبس ChatSocket ws://localhost:8080 ثم عند message ثم ضع هو إلى #chat end'],
-    ['bn', 'ChatSocket ws://localhost:8080 কে সকেট তারপর message এ তারপর এটি কে #chat end তে রাখুন'],
+    [
+      'bn',
+      'ChatSocket ws://localhost:8080 কে সকেট তারপর message এ তারপর এটি কে #chat end তে রাখুন',
+    ],
     ['hi', 'ChatSocket ws://localhost:8080 को सॉकेट फिर message पर फिर यह को रखें #chat end में'],
-    ['ja', 'ChatSocket ws://localhost:8080 を ソケット それから message で それから それ を #chat end に 置く'],
-    ['ko', 'ChatSocket ws://localhost:8080 를 소켓 그러면 message 그러면 그것 를 #chat end 에 넣다'],
-    ['pt', 'soquete ChatSocket ws://localhost:8080 então em message então colocar isso para #chat end'],
-    ['qu', 'ChatSocket ws://localhost:8080 ta tinkina chayqa message pi chayqa chay ta #chat end man churay'],
-    ['sw', 'soketi ChatSocket ws://localhost:8080 kisha kwenye message kisha weka hiyo kwa #chat end'],
+    [
+      'ja',
+      'ChatSocket ws://localhost:8080 を ソケット それから message で それから それ を #chat end に 置く',
+    ],
+    [
+      'ko',
+      'ChatSocket ws://localhost:8080 를 소켓 그러면 message 그러면 그것 를 #chat end 에 넣다',
+    ],
+    [
+      'pt',
+      'soquete ChatSocket ws://localhost:8080 então em message então colocar isso para #chat end',
+    ],
+    [
+      'qu',
+      'ChatSocket ws://localhost:8080 ta tinkina chayqa message pi chayqa chay ta #chat end man churay',
+    ],
+    [
+      'sw',
+      'soketi ChatSocket ws://localhost:8080 kisha kwenye message kisha weka hiyo kwa #chat end',
+    ],
     ['tr', 'ChatSocket ws://localhost:8080 i soket sonra message de sonra o i #chat end e koy'],
   ];
 
@@ -3346,10 +3364,7 @@ describe('qu patient-first SOV variants for add/remove/put (Track C core)', () =
   it('[qu] tabs-basic keeps remove + add (was {on} + spurious from)', () => {
     // Corpus-shaped transformer output (en → qu).
     const a = actions(
-      parse(
-        '.active ta .tab manta ñitiy pi qichuy chayqa .active ta noqa man yapay',
-        'qu'
-      )
+      parse('.active ta .tab manta ñitiy pi qichuy chayqa .active ta noqa man yapay', 'qu')
     );
     expect(a.has('on')).toBe(true);
     expect(a.has('remove')).toBe(true);
@@ -3461,7 +3476,10 @@ describe('fused-event body walker recovers verb-mid SOV clauses (then-tail set/p
   // Corpus-shaped transformer output (en → lang).
   it('[ja] fetch-json keeps the then-tail set (was {fetch,on})', () => {
     const a = actions(
-      parse('/api/user を クリック で フェッチ json それから #name.innerText を 設定 その.name に', 'ja')
+      parse(
+        '/api/user を クリック で フェッチ json それから #name.innerText を 設定 その.name に',
+        'ja'
+      )
     );
     expect(a.has('on')).toBe(true);
     expect(a.has('fetch')).toBe(true);
@@ -3470,7 +3488,10 @@ describe('fused-event body walker recovers verb-mid SOV clauses (then-tail set/p
 
   it('[tr] form-disable-on-submit keeps the then-tail put (was {add,on})', () => {
     const a = actions(
-      parse('@disabled i gönder de ekle <button/> in me e sonra "Submitting..." i <button/> in me e koy', 'tr')
+      parse(
+        '@disabled i gönder de ekle <button/> in me e sonra "Submitting..." i <button/> in me e koy',
+        'tr'
+      )
     );
     expect(a.has('on')).toBe(true);
     expect(a.has('add')).toBe(true);
@@ -3491,14 +3512,19 @@ describe('fused-event body walker recovers verb-mid SOV clauses (then-tail set/p
 
   it('[qu] fetch-json keeps the then-tail set (was {fetch,on})', () => {
     const a = actions(
-      parse('/api/user ta ñitiy pi apamuy json hina chayqa #name.innerText ta chaypaq.name man churanay', 'qu')
+      parse(
+        '/api/user ta ñitiy pi apamuy json hina chayqa #name.innerText ta chaypaq.name man churanay',
+        'qu'
+      )
     );
     expect(a.has('fetch')).toBe(true);
     expect(a.has('set')).toBe(true);
   });
 
   it('[en] the en reference parse is unchanged', () => {
-    const a = actions(parse('on click fetch /api/user as json then set #name.innerText to it.name', 'en'));
+    const a = actions(
+      parse('on click fetch /api/user as json then set #name.innerText to it.name', 'en')
+    );
     expect([...a].sort()).toEqual(['fetch', 'on', 'set']);
   });
 });
@@ -3564,7 +3590,10 @@ describe('ko event marker 할 때 — fused patterns anchor, custom events confi
 
   it('[ko] fetch-json keeps the then-tail set through the fused pattern + body walker', () => {
     const a = actions(
-      parse('/api/user 를 클릭 할 때 가져오기 json 로 그러면 #name.innerText 를 설정 그것의.name 에', 'ko')
+      parse(
+        '/api/user 를 클릭 할 때 가져오기 json 로 그러면 #name.innerText 를 설정 그것의.name 에',
+        'ko'
+      )
     );
     expect(a.has('on')).toBe(true);
     expect(a.has('fetch')).toBe(true);
@@ -3666,7 +3695,10 @@ describe('tl/ar VSO event recovery — mis-listed keywords + midstream-on-no-mat
 
   it('[tl] modal-close-button recovers the handler around an unmatched leading command', () => {
     const a = actions(
-      parse('itago pinakamalapit .modal kapag click pagkatapos alisin .modal-open mula sa katawan', 'tl')
+      parse(
+        'itago pinakamalapit .modal kapag click pagkatapos alisin .modal-open mula sa katawan',
+        'tl'
+      )
     );
     expect(a.has('on')).toBe(true);
     expect(a.has('remove')).toBe(true);
@@ -3691,7 +3723,10 @@ describe('tl/ar VSO event recovery — mis-listed keywords + midstream-on-no-mat
     let flattenedToHandler = false;
     try {
       const a = actions(
-        parse('behavior Removable(t)\n    من t عند نقر\n        احذف أنا\n    النهاية\nالنهاية', 'ar')
+        parse(
+          'behavior Removable(t)\n    من t عند نقر\n        احذف أنا\n    النهاية\nالنهاية',
+          'ar'
+        )
       );
       flattenedToHandler = a.has('on');
     } catch {
@@ -3840,9 +3875,18 @@ describe('marker-less fetch recovery for the fetch-loading-state/event-debounce 
   // event-debounce: `on input debounced at 300ms fetch /api/search?q=${my value}
   //  as json then put it into #results`
   const debounce: Array<[string, string]> = [
-    ['it', 'su input debounced a 300ms recuperare /api/search?q=${my value} come json allora mettere esso in #results'],
-    ['uk', 'при введення debounced в 300ms завантажити /api/search?q=${my value} як json тоді покласти це в #results'],
-    ['vi', 'khi nhập debounced tại 300ms tải /api/search?q=${my value} như json rồi đặt nó vào #results'],
+    [
+      'it',
+      'su input debounced a 300ms recuperare /api/search?q=${my value} come json allora mettere esso in #results',
+    ],
+    [
+      'uk',
+      'при введення debounced в 300ms завантажити /api/search?q=${my value} як json тоді покласти це в #results',
+    ],
+    [
+      'vi',
+      'khi nhập debounced tại 300ms tải /api/search?q=${my value} như json rồi đặt nó vào #results',
+    ],
   ];
   for (const [lang, input] of debounce) {
     it(`[${lang}] event-debounce keeps the fetch (was {on,put})`, () => {
@@ -3859,7 +3903,10 @@ describe('marker-less fetch recovery for the fetch-loading-state/event-debounce 
 
   it('[en] the en reference parse is unchanged', () => {
     const a = actions(
-      parse('on click add .loading to me fetch /api/data then remove .loading from me put it into #result', 'en')
+      parse(
+        'on click add .loading to me fetch /api/data then remove .loading from me put it into #result',
+        'en'
+      )
     );
     expect([...a].sort()).toEqual(['add', 'fetch', 'on', 'put', 'remove']);
   });
@@ -3934,7 +3981,10 @@ describe('set patterns must not claim put verbs (de setzen / fr mettre / pt colo
 
   it('[en] the en reference parse is unchanged', () => {
     const a = actions(
-      parse('on click if #modal exists show #modal else make a <div#modal/> put it into body end', 'en')
+      parse(
+        'on click if #modal exists show #modal else make a <div#modal/> put it into body end',
+        'en'
+      )
     );
     expect([...a].sort()).toEqual(['if', 'make', 'on', 'put', 'show']);
   });
@@ -4037,9 +4087,21 @@ describe('auditor realign batch 1 — trigger/take/render/settle/morph/make (17 
     ['ru', 'при загрузка запустить инициализировать', ['on', 'trigger']],
     ['tl', 'kumuha .active mula sa .tab-button kapag click pagkatapos para_sa ako', ['on', 'take']],
     ['tr', '.active i tıklama de tut .tab-button den sonra ben i için', ['on', 'take']],
-    ['id', 'pada klik olah #user-list dengan users: $data lalu taruh itu ke #container', ['on', 'render', 'put']],
-    ['qu', '.animate ta ñitiy pi yapay chayqa tiyakuy chayqa .animate ta qichuy', ['on', 'add', 'settle', 'remove']],
-    ['sw', 'kwenye bonyeza tengeneza a <div.card/> kisha weka hiyo kwa #container', ['on', 'make', 'put']],
+    [
+      'id',
+      'pada klik olah #user-list dengan users: $data lalu taruh itu ke #container',
+      ['on', 'render', 'put'],
+    ],
+    [
+      'qu',
+      '.animate ta ñitiy pi yapay chayqa tiyakuy chayqa .animate ta qichuy',
+      ['on', 'add', 'settle', 'remove'],
+    ],
+    [
+      'sw',
+      'kwenye bonyeza tengeneza a <div.card/> kisha weka hiyo kwa #container',
+      ['on', 'make', 'put'],
+    ],
   ];
   for (const [lang, input, expected] of cases) {
     it(`[${lang}] realigned emission parses {${expected.join(',')}}`, () => {
@@ -4313,7 +4375,10 @@ describe('event-wrapper trailing destination — SOV post-verb to-phrase capture
       expect(add, 'add command present').toBeTruthy();
       expect(role(add!, 'patient')).toBe('.selected');
       expect(role(add!, 'destination')).toBe('#item');
-      expect(cmds.some(c => c.action === 'into'), 'no fabricated into command').toBe(false);
+      expect(
+        cmds.some(c => c.action === 'into'),
+        'no fabricated into command'
+      ).toBe(false);
     });
   }
 
@@ -4368,5 +4433,88 @@ describe('set.ts role-convention realign — goal/target conventions → en conv
     const parsed = parse('on click set my.textContent to "Done!"', 'en');
     expect(roleType(parsed, 'destination')).toBe('property-path');
     expect(roleType(parsed, 'patient')).toBe('literal');
+  });
+});
+
+describe('Fused {action} event patterns re-parse the body clause for roles (R2 it/th)', () => {
+  // The handcrafted fused event patterns (`su {event} {action}` it,
+  // `เมื่อ {event} {action}` th, and the bn family) capture only the body
+  // VERB as a positional role — the body's arguments trail unconsumed and the
+  // handler body came out as a command with ZERO roles, while the en
+  // reference re-parses the same clause through the command patterns and
+  // captures everything. buildEventHandler now retries: when the captured
+  // action produced a role-less command, the [verb..clause-boundary] span is
+  // re-parsed with the command patterns and swapped in — but only when the
+  // re-parse yields a single command with the SAME action and ≥1 role, so a
+  // body whose standalone pattern is missing (it blur/transition, th
+  // breakpoint/put) keeps the zero-roled action instead of degenerating to
+  // nothing. Companion marker fixes: set-it-full gains the transformer's
+  // value marker `in`; set-th-simple swaps a broken positional patient for
+  // the ใน marker group every th corpus emission carries.
+  // it/th 0.824 → 1.000 (15 perfect languages), qu 0.412 → 0.765,
+  // mean 0.9130 → 0.9437.
+  function firstBody(node: unknown): Record<string, unknown> {
+    const rec = node as Record<string, unknown>;
+    const body = rec?.body as unknown;
+    return (Array.isArray(body) ? body[0] : body) as Record<string, unknown>;
+  }
+  function rolesOf(
+    cmd: Record<string, unknown> | undefined
+  ): Map<string, { type?: string; value?: unknown }> {
+    const roles = cmd?.roles as Map<string, { type?: string; value?: unknown }>;
+    return roles instanceof Map ? roles : new Map(Object.entries((roles as object) ?? {}));
+  }
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped set-text-possessive-dot (en: on click set my.textContent to "Done!").
+  const fused: Array<[string, string]> = [
+    ['it', 'su clic impostare mio.textContent in "Done!"'],
+    ['th', 'เมื่อ คลิก ตั้ง ของฉัน.textContent ใน "Done!"'],
+  ];
+  for (const [lang, input] of fused) {
+    it(`[${lang}] fused event-handler body re-parses with destination + patient (was zero roles)`, () => {
+      const roles = rolesOf(firstBody(parse(input, lang as 'it')));
+      expect(roles.get('destination')?.type).toBe('property-path');
+      expect(roles.get('patient')?.value).toBe('Done!');
+    });
+  }
+
+  // Standalone bodies (then-chain / continuation re-parse shape).
+  it('[it] standalone set with the transformer marker `in` captures the patient', () => {
+    const roles = rolesOf(parse('impostare mio.textContent in "Done!"', 'it') as never);
+    expect(roles.get('destination')?.type).toBe('property-path');
+    expect(roles.get('patient')?.value).toBe('Done!');
+  });
+  it('[th] standalone set with the ใน marker captures the patient (was bogus positional)', () => {
+    const roles = rolesOf(parse('ตั้ง ของฉัน.textContent ใน "Done!"', 'th') as never);
+    expect(roles.get('destination')?.type).toBe('property-path');
+    expect(roles.get('patient')?.value).toBe('Done!');
+  });
+
+  // Fallback guard: a body verb with no matching standalone pattern keeps its
+  // zero-roled action (the retry must never degenerate an action to nothing).
+  it('[it] blur body without a standalone pattern keeps the blur action', () => {
+    expect(actions(parse('su keydown[key=="Escape"] sfuocatura io', 'it')).has('blur')).toBe(true);
+  });
+  it('[th] breakpoint + then-chain keeps both actions', () => {
+    const a = actions(parse('เมื่อ คลิก จุดพัก แล้ว ตั้ง $x ใน 42', 'th'));
+    expect(a.has('breakpoint')).toBe(true);
+    expect(a.has('set')).toBe(true);
+  });
+
+  it('[en] the en reference parse is unchanged', () => {
+    const roles = rolesOf(firstBody(parse('on click set my.textContent to "Done!"', 'en')));
+    expect(roles.get('destination')?.type).toBe('property-path');
+    expect(roles.get('patient')?.value).toBe('Done!');
   });
 });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T16:59:46.889Z",
-  "commit": "79442169",
+  "timestamp": "2026-06-12T17:51:26.841Z",
+  "commit": "b97976ee",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -13,7 +13,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["if-exists", "repeat-until-event", "window-scroll"],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -649,7 +649,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1280,7 +1280,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1904,7 +1904,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3165,7 +3165,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3809,7 +3809,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4461,7 +4461,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5111,7 +5111,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5736,16 +5736,12 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8379396202925594,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.7135730482669262,
-      "avgExecutionFidelity": 0.8235294117647058,
-      "executionFailures": [
-        "set-inner-html-possessive-dot",
-        "set-style",
-        "set-text-possessive-dot"
-      ],
+      "avgRoleFidelity": 0.7985098801425334,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6394,7 +6390,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7041,7 +7037,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7693,7 +7689,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8319,7 +8315,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8949,7 +8945,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9574,19 +9570,13 @@
       "parseRate": 1,
       "avgConfidence": 0.6999278499278501,
       "avgFidelity": 0.9606060606060607,
-      "avgRoleFidelity": 0.6552767052767056,
-      "avgExecutionFidelity": 0.4117647058823529,
+      "avgRoleFidelity": 0.6665379665379668,
+      "avgExecutionFidelity": 0.7647058823529411,
       "executionFailures": [
-        "add-class-basic",
-        "add-class-to-other",
         "put-content-basic",
-        "remove-class-basic",
-        "remove-class-from-all",
         "set-inner-html-possessive-dot",
         "set-style",
-        "set-text-possessive-dot",
-        "toggle-class-basic",
-        "toggle-class-on-other"
+        "set-text-possessive-dot"
       ],
       "degeneratePasses": [
         "behavior-draggable",
@@ -9602,7 +9592,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10233,7 +10223,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10864,7 +10854,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "repeat-until-event", "set-color-variable"],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11486,16 +11476,12 @@
       "parseRate": 1,
       "avgConfidence": 0.8401154401154378,
       "avgFidelity": 1,
-      "avgRoleFidelity": 0.7410714285714287,
-      "avgExecutionFidelity": 0.8235294117647058,
-      "executionFailures": [
-        "set-inner-html-possessive-dot",
-        "set-style",
-        "set-text-possessive-dot"
-      ],
+      "avgRoleFidelity": 0.8062258687258687,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12126,7 +12112,7 @@
       "executionFailures": ["remove-class-from-all", "tabs-basic"],
       "degeneratePasses": [],
       "lossyPasses": ["if-exists", "window-scroll"],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12763,7 +12749,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13393,7 +13379,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14032,7 +14018,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14671,7 +14657,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 411714,
+      "bundleSize": 412260,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15293,7 +15279,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 411714,
+      "size": 412260,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Mechanism (one per PR — session 7, target 1)

The handcrafted fused event patterns (it `su {event} {action}`, th `เมื่อ {event} {action}`, and the bn family) capture only the body **verb** as a positional role — the body's arguments trail unconsumed and the handler body came out as a command with **zero roles**, while the en reference re-parses the same clause through the command patterns and captures everything. `setMapper` then had empty args and the runtime set nothing: `set-text-possessive-dot` / `set-inner-html-possessive-dot` / `set-style` failed at execution in it and th.

### Fix

`buildEventHandler` ([semantic-parser.ts](packages/semantic/src/parser/semantic-parser.ts)) now retries: when the captured action produced a role-less command, the `[verb..clause-boundary]` span is re-parsed with the command patterns and swapped in — **only** when the re-parse yields a single command with the *same* action and ≥1 role. A body whose standalone pattern is missing (it blur/transition, th breakpoint/put) keeps the zero-roled action instead of degenerating to nothing, so no R0 action-set regressions are possible by construction (verified by full it/th corpus sweep: ~40 rows gain roles, zero rows lose an action; one spurious `beep` command disappears, matching en exactly).

Companion marker fixes that make the re-parse land (same emission-defers-to-schema idiom as #376–#380):

- `set-it-full` gains the transformer's value marker `in` (pattern only knew `a`/`su`/`come`)
- `set-th-simple` swaps a broken positional patient (mis-captured multi-token property-path destinations, fabricated bogus values) for the `ใน` marker group every th corpus emission carries (+ `ตั้งค่า` verb alternative)

## Results

| Metric | Before | After |
| --- | --- | --- |
| R2 mean executionFidelity | 0.9130 | **0.9437** |
| Failing instances | 34 | **22** |
| Languages at 1.000 | 13/23 | **15/23** (+it, +th) |
| qu (bonus, same retry) | 0.412 | 0.765 |
| Parsing floor avgFidelity | 0.9717 | 0.9717 (unchanged) |

- Full 24-language gate green (`--regression`): no parse-rate / fidelity / correctness / execution regressions
- Baseline regenerated with the 24-language list; patterns.db reverted
- Lock test appended to `multilingual-roadmap-fixes.test.ts` (fused-body roles, standalone markers, fallback guards, en reference) — 415 passed
- Semantic suite: 5785 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)