### PR TITLE
fix(semantic): ko set patient marker realigned to the dict emission (R2 ko → 1.000)

### DIFF
--- a/packages/hyperscript-adapter/test/preprocessor.test.ts
+++ b/packages/hyperscript-adapter/test/preprocessor.test.ts
@@ -56,7 +56,7 @@ describe('preprocessToEnglish', () => {
     it.each([
       ['es', 'establecer x a 5'],
       ['ja', 'x を 5 に 設定'],
-      ['ko', 'x 를 5 으로 설정'],
+      ['ko', 'x 를 5 에 설정'],
       ['zh', '设置 x 为 5'],
       ['fr', 'définir x à 5'],
     ])('[%s] translates set x to 5', (lang, input) => {

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -490,7 +490,7 @@ export const setSchema: CommandSchema = {
       markerOverride: {
         en: '', // No marker before destination in English: "set :x to 5"
         ja: 'を', // "x を 10 に 設定" - variable gets object marker
-        ko: '를', // "x 를 10 으로 설정" - variable gets object marker
+        ko: '를', // "x 를 10 에 설정" - variable gets object marker
         tr: 'i', // "x i 10 e ayarla" - variable gets accusative marker
         ar: '', // "عيّن x إلى 10" - no marker before variable
         sw: '', // "seti x kwenye 10" - no marker before variable

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -517,7 +517,9 @@ export const setSchema: CommandSchema = {
         de: 'auf', // "setze x auf 10"
         id: 'ke', // "atur x ke 10"
         ja: 'に', // "x を 10 に 設定" - value gets destination marker
-        ko: '으로', // "x 를 10 으로 설정" - value gets manner/instrument marker
+        // ko dict translates set's `to` as 에 (not the manner marker 으로) —
+        // every ko corpus emission is `… 설정 {value} 에`; keep aligned.
+        ko: '에', // "x 를 10 에 설정" - value gets destination marker
         tr: 'e', // "x i 10 e ayarla" - value gets dative marker
         ar: 'إلى', // "عيّن x إلى 10" - value gets preposition "to"
         sw: 'kwenye', // "seti x kwenye 10" - destination prep before value

--- a/packages/semantic/src/generators/event-handlers-sov.ts
+++ b/packages/semantic/src/generators/event-handlers-sov.ts
@@ -501,7 +501,7 @@ export function generateSOVTemporalEventHandlerPattern(
  * Patterns:
  * - Japanese put: 入力 で "test" を #output に 入れる
  *   [event] [eventMarker] [patient] [patientMarker] [destination] [destMarker] [verb]
- * - Korean set: 변경 할 때 x 를 10 으로 설정
+ * - Korean set: 변경 할 때 x 를 10 에 설정
  *   [event] [eventMarker] [role1] [role1Marker] [role2] [role2Marker] [verb]
  * - Turkish put: giriş de "test" i #output a koy
  *   [event] [eventMarker] [patient] [patientMarker] [destination] [destMarker] [verb]

--- a/packages/semantic/src/generators/pattern-generator.ts
+++ b/packages/semantic/src/generators/pattern-generator.ts
@@ -362,7 +362,7 @@ export function generateEventHandlerPatterns(
     if (hasTwoRequiredRoles) {
       // Two-role SOV pattern for put/set commands (event-first)
       // Japanese put: 入力 で "test" を #output に 入れる
-      // Korean set: 변경 할 때 x 를 10 으로 설정
+      // Korean set: 변경 할 때 x 를 10 에 설정
       patterns.push(
         generateSOVTwoRoleEventHandlerPattern(commandSchema, profile, keyword, eventMarker, config)
       );

--- a/packages/semantic/test/language-coverage/test-cases.ts
+++ b/packages/semantic/test/language-coverage/test-cases.ts
@@ -157,7 +157,7 @@ export const TEST_CASES: Record<CoreCommand, Record<SupportedLanguage, string>> 
     pl: 'ustaw x na 10',
     ja: 'x を 10 に 設定',
     zh: '设置 x 为 10',
-    ko: 'x 를 10 으로 설정',
+    ko: 'x 를 10 에 설정',
     ar: 'عيّن x إلى 10',
     tr: 'x i 10 e ayarla',  // Use primary keyword + proper markers
     id: 'atur x ke 10',
@@ -572,7 +572,7 @@ export const EVENT_HANDLER_TEST_CASES = {
 
   'set-on-change': {
     ja: '変更 で x を 10 に 設定',
-    ko: '변경 할 때 x 를 10 으로 설정',
+    ko: '변경 할 때 x 를 10 에 설정',
     tr: 'değişiklik de x i 10 e ayarla',
     ar: 'عند التغيير عيّن x إلى 10',
     hi: 'बदलाव पर x को 10 में सेट',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -4518,3 +4518,48 @@ describe('Fused {action} event patterns re-parse the body clause for roles (R2 i
     expect(roles.get('patient')?.value).toBe('Done!');
   });
 });
+
+describe('ko set patient marker realign — schema 으로 → dict 에 (R2 ko)', () => {
+  // setSchema's ko patient markerOverride said 으로 ("x 를 10 으로 설정"), but
+  // the ko dict translates set's `to` as 에 — every ko corpus emission is
+  // `{destination} 를 {event} 할 때 설정 {value} 에`. No generated set pattern
+  // could match, so the rows fell to the particle fallback, which read 를 as
+  // patient and 에 as destination — roles INVERTED vs the en reference (and
+  // the possessive destination stayed a raw literal instead of a
+  // property-path), so setMapper wrote nothing at runtime. Zero ko corpus
+  // rows use 으로; the override now matches the dict. ko 0.824 → 1.000
+  // (16 perfect languages), mean 0.9437 → 0.9514.
+  function firstBody(node: unknown): Record<string, unknown> {
+    const rec = node as Record<string, unknown>;
+    const body = rec?.body as unknown;
+    return (Array.isArray(body) ? body[0] : body) as Record<string, unknown>;
+  }
+  function rolesOf(
+    cmd: Record<string, unknown> | undefined
+  ): Map<string, { type?: string; value?: unknown }> {
+    const roles = cmd?.roles as Map<string, { type?: string; value?: unknown }>;
+    return roles instanceof Map ? roles : new Map(Object.entries((roles as object) ?? {}));
+  }
+
+  // Corpus-shaped set trio (en: on click set my.X to "...").
+  const cases: Array<[string, string]> = [
+    ['set-text', '내.textContent 를 클릭 할 때 설정 "Done!" 에'],
+    ['set-style', '내 *background 를 클릭 할 때 설정 "red" 에'],
+  ];
+  for (const [name, input] of cases) {
+    it(`[ko] ${name} matches the generated SOV wrapper with en-convention roles (was inverted fallback)`, () => {
+      const parsed = parse(input, 'ko');
+      const cmd = firstBody(parsed);
+      expect(cmd.action).toBe('set');
+      const roles = rolesOf(cmd);
+      expect(roles.get('destination')?.type).toBe('property-path');
+      expect(roles.get('patient')?.type).toBe('literal');
+    });
+  }
+
+  it('[en] the en reference parse is unchanged', () => {
+    const roles = rolesOf(firstBody(parse('on click set my.textContent to "Done!"', 'en')));
+    expect(roles.get('destination')?.type).toBe('property-path');
+    expect(roles.get('patient')?.value).toBe('Done!');
+  });
+});

--- a/packages/semantic/test/official-examples.test.ts
+++ b/packages/semantic/test/official-examples.test.ts
@@ -748,11 +748,13 @@ describe('Newly Wired Commands', () => {
       expect(node.action).toBe('set');
     });
 
-    it('Korean: :x 를 5 으로 설정', () => {
-      // Generated pattern: {destination} 를 {patient} 으로 설정
-      expect(canParse(':x 를 5 으로 설정', 'ko')).toBe(true);
+    it('Korean: :x 를 5 에 설정', () => {
+      // Generated pattern: {destination} 를 {patient} 에 설정
+      // (에 matches the ko dict's translation of set's `to`; the schema's old
+      // 으로 marker never appeared in any corpus emission)
+      expect(canParse(':x 를 5 에 설정', 'ko')).toBe(true);
 
-      const node = parse(':x 를 5 으로 설정', 'ko');
+      const node = parse(':x 를 5 에 설정', 'ko');
       expect(node.action).toBe('set');
     });
 

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T17:51:26.841Z",
-  "commit": "b97976ee",
+  "timestamp": "2026-06-12T18:05:17.347Z",
+  "commit": "4e72d38e",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -13,7 +13,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["if-exists", "repeat-until-event", "window-scroll"],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -649,7 +649,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1280,7 +1280,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1904,7 +1904,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3165,7 +3165,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3809,7 +3809,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4461,7 +4461,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5111,7 +5111,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5741,7 +5741,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6390,7 +6390,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7014,15 +7014,11 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7457122242836529,
+      "avgConfidence": 0.7911667697381983,
       "avgFidelity": 0.9595238095238094,
-      "avgRoleFidelity": 0.7045205920205924,
-      "avgExecutionFidelity": 0.8235294117647058,
-      "executionFailures": [
-        "set-inner-html-possessive-dot",
-        "set-style",
-        "set-text-possessive-dot"
-      ],
+      "avgRoleFidelity": 0.7415218790218793,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -7037,7 +7033,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7056,6 +7052,18 @@
           "confidence": 1
         },
         "remove-class-from-all": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-style": {
           "success": true,
           "confidence": 1
         },
@@ -7155,6 +7163,10 @@
           "success": true,
           "confidence": 1
         },
+        "tabs-aria": {
+          "success": true,
+          "confidence": 1
+        },
         "modal-open": {
           "success": true,
           "confidence": 1
@@ -7179,11 +7191,27 @@
           "success": true,
           "confidence": 1
         },
+        "input-char-count": {
+          "success": true,
+          "confidence": 1
+        },
         "input-validation": {
           "success": true,
           "confidence": 1
         },
+        "input-clear": {
+          "success": true,
+          "confidence": 1
+        },
         "window-scroll": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-transform": {
           "success": true,
           "confidence": 1
         },
@@ -7251,11 +7279,31 @@
           "success": true,
           "confidence": 1
         },
+        "set-text-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-inner-html-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
         "render-template-with-data": {
           "success": true,
           "confidence": 1
         },
         "make-toast-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-interpolation": {
+          "success": true,
+          "confidence": 1
+        },
+        "template-literal-list-build": {
           "success": true,
           "confidence": 1
         },
@@ -7300,6 +7348,10 @@
           "confidence": 1
         },
         "bind-non-form-display": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-write": {
           "success": true,
           "confidence": 1
         },
@@ -7395,18 +7447,6 @@
           "success": true,
           "confidence": 0.5555555555555556
         },
-        "set-text-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-attribute": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-style": {
-          "success": true,
-          "confidence": 0.5
-        },
         "put-content-basic": {
           "success": true,
           "confidence": 0.5
@@ -7459,23 +7499,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "tabs-aria": {
-          "success": true,
-          "confidence": 0.5
-        },
         "modal-close-button": {
           "success": true,
           "confidence": 0.5
         },
         "input-mirror": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "input-char-count": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "input-clear": {
           "success": true,
           "confidence": 0.5
         },
@@ -7492,14 +7520,6 @@
           "confidence": 0.5
         },
         "document-ready": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-opacity": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-transform": {
           "success": true,
           "confidence": 0.5
         },
@@ -7551,14 +7571,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "set-text-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "set-inner-html-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
         "get-value-possessive-dot": {
           "success": true,
           "confidence": 0.5
@@ -7567,23 +7579,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "chained-access-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
         "optional-chaining-possessive": {
           "success": true,
           "confidence": 0.5
         },
         "get-attribute-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "template-literal-interpolation": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "template-literal-list-build": {
           "success": true,
           "confidence": 0.5
         },
@@ -7620,10 +7620,6 @@
           "confidence": 0.5
         },
         "when-multiple-changes": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "caret-var-write": {
           "success": true,
           "confidence": 0.5
         },
@@ -7689,7 +7685,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8315,7 +8311,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8945,7 +8941,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9592,7 +9588,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10223,7 +10219,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10854,7 +10850,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "repeat-until-event", "set-color-variable"],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11481,7 +11477,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12112,7 +12108,7 @@
       "executionFailures": ["remove-class-from-all", "tabs-basic"],
       "degeneratePasses": [],
       "lossyPasses": ["if-exists", "window-scroll"],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12749,7 +12745,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13379,7 +13375,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14018,7 +14014,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14657,7 +14653,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 412260,
+      "bundleSize": 412254,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15279,7 +15275,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 412260,
+      "size": 412254,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Mechanism (one per PR — session 7, target 2)

`setSchema`'s ko patient `markerOverride` said `으로` ("x 를 10 으로 설정"), but the ko dict translates set's `to` as `에` — every ko corpus emission is `{destination} 를 {event} 할 때 설정 {value} 에`. No generated set pattern could match that shape, so the set rows fell to the particle-based SOV fallback, which read `를` as patient and `에` as destination: roles **inverted** vs the en reference, the possessive destination stayed a raw literal instead of a property-path, and `setMapper` wrote nothing at runtime — `set-text-possessive-dot` / `set-inner-html-possessive-dot` / `set-style` failed at execution in ko.

### Fix

One line in [command-schemas.ts](packages/semantic/src/generators/command-schemas.ts): the ko patient override now matches the dict (`에`). The rows match `set-event-ko-sov-2role-dest-first` with en-identical roles (`destination=property-path(me.X)`, `patient=value`). Zero ko corpus rows use `으로` (verified by corpus query); the two test fixtures that hardcoded the drifted `으로` form are updated to the dict-canonical `에` form.

Blast radius checked with a full 164-row ko corpus sweep: 13 rows flip from the particle fallback to the proper wrapper, action sets identical everywhere, no row loses anything.

## Results

| Metric | Before | After |
| --- | --- | --- |
| R2 mean executionFidelity | 0.9437 | **0.9514** |
| Failing instances | 22 | **19** |
| ko executionFidelity | 0.824 | **1.000** (16/23 perfect) |
| Parsing floor avgFidelity | 0.9717 | 0.9717 (unchanged) |

- Full 24-language gate green (`--regression`); baseline regenerated with the 24-language list; patterns.db reverted
- Lock test appended to `multilingual-roadmap-fixes.test.ts`; semantic suite 5788 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)