### PR TITLE
fix(semantic): recognize emitted possessive-dot heads in id/ms/vi/qu profiles (R2 → 0.9770)

### DIFF
--- a/packages/semantic/src/generators/profiles/indonesian.ts
+++ b/packages/semantic/src/generators/profiles/indonesian.ts
@@ -44,6 +44,11 @@ export const indonesianProfile: LanguageProfile = {
       saya: 'me', // formal
       aku: 'me', // informal
       ku: 'me', // clitic
+      // The id dict's `my` is the two-word 'saya punya', which the dot-notation
+      // transformer can't prefix onto `my.X` — those corpus heads stay literal
+      // English `my.textContent`. Recognize the passthrough so the possessive
+      // matcher can assemble the property-path (set-text/set-style rows).
+      my: 'me', // untranslated dot-notation passthrough
       // "your" - formal and informal
       anda: 'you', // formal
       kamu: 'you', // informal

--- a/packages/semantic/src/generators/profiles/ms.ts
+++ b/packages/semantic/src/generators/profiles/ms.ts
@@ -35,6 +35,11 @@ export const malayProfile: LanguageProfile = {
     keywords: {
       // Full pronoun forms (also serve as possessives)
       saya: 'me', // my (formal)
+      // The ms dict translates possessive-dot `my.X` as saya_punya.X (the
+      // underscore keeps it one token for the dot-notation transformer) —
+      // recognize that emitted form so the possessive matcher can assemble
+      // the property-path (set-text/set-style corpus rows).
+      saya_punya: 'me', // my (dict dot-notation emission)
       aku: 'me', // my (informal)
       awak: 'you', // your (informal, Malaysian)
       kamu: 'you', // your (informal)

--- a/packages/semantic/src/generators/profiles/quechua.ts
+++ b/packages/semantic/src/generators/profiles/quechua.ts
@@ -38,6 +38,10 @@ export const quechuaProfile: LanguageProfile = {
       // "my" - ñuqapa, ñuqaypa
       ñuqapa: 'me',
       ñuqaypa: 'me',
+      // The qu dict's `my` is the romanization noqaq — what the dot-notation
+      // transformer emits into possessive-dot heads (noqaq.textContent).
+      // Recognize it so the possessive matcher can assemble the property-path.
+      noqaq: 'me',
       // "your" - qampa
       qampa: 'you',
       // "its/his/her" - paypa

--- a/packages/semantic/src/generators/profiles/vietnamese.ts
+++ b/packages/semantic/src/generators/profiles/vietnamese.ts
@@ -44,6 +44,11 @@ export const vietnameseProfile: LanguageProfile = {
       // Multi-word possessive phrases
       // Note: These may require tokenizer support for multi-word recognition
       'của tôi': 'me', // my
+      // The vi dict's `my` is the two-word 'của tôi', which the dot-notation
+      // transformer can't prefix onto `my.X` — those corpus heads stay literal
+      // English `my.textContent`. Recognize the passthrough so the possessive
+      // matcher can assemble the property-path (set-text/set-inner-html rows).
+      my: 'me', // untranslated dot-notation passthrough
       'của bạn': 'you', // your (informal)
       'của anh': 'you', // your (male speaker, formal)
       'của chị': 'you', // your (female speaker, formal)

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -4563,3 +4563,54 @@ describe('ko set patient marker realign — schema 으로 → dict 에 (R2 ko)',
     expect(roles.get('patient')?.value).toBe('Done!');
   });
 });
+
+describe('Possessive-dot passthrough heads assemble property-paths (R2 id/ms/vi)', () => {
+  // The dot-notation transformer can't prefix a multi-word possessive onto
+  // `my.X` heads, so the id dict ('saya punya') and vi dict ('của tôi') leave
+  // the corpus heads as literal English `my.textContent`; the ms dict emits
+  // the single-token saya_punya.X, which the ms profile never listed. In all
+  // three, the possessive matcher found no keyword, the head parsed as a raw
+  // expression instead of property-path(me.X), and the runtime set nothing
+  // (set-text/set-inner-html/set-style failed at execution). The profiles now
+  // recognize the emitted forms (id/vi: `my` passthrough, ms: saya_punya), so
+  // the matcher assembles the en-identical property-path.
+  function firstBody(node: unknown): Record<string, unknown> {
+    const rec = node as Record<string, unknown>;
+    const body = rec?.body as unknown;
+    return (Array.isArray(body) ? body[0] : body) as Record<string, unknown>;
+  }
+  function rolesOf(
+    cmd: Record<string, unknown> | undefined
+  ): Map<string, { type?: string; value?: unknown }> {
+    const roles = cmd?.roles as Map<string, { type?: string; value?: unknown }>;
+    return roles instanceof Map ? roles : new Map(Object.entries((roles as object) ?? {}));
+  }
+
+  // Corpus-shaped set-text-possessive-dot (en: on click set my.textContent to "Done!").
+  const cases: Array<[string, string]> = [
+    ['id', 'pada klik atur my.textContent ke "Done!"'],
+    ['ms', 'apabila click tetapkan saya_punya.textContent ke "Done!"'],
+    ['vi', 'khi nhấp gán my.textContent vào "Done!"'],
+  ];
+  for (const [lang, input] of cases) {
+    it(`[${lang}] possessive-dot head parses as property-path(me.textContent) (was raw expression)`, () => {
+      const cmd = firstBody(parse(input, lang as 'id'));
+      expect(cmd.action).toBe('set');
+      const roles = rolesOf(cmd);
+      const dest = roles.get('destination') as
+        | { type?: string; object?: { value?: string }; property?: string }
+        | undefined;
+      expect(dest?.type).toBe('property-path');
+      expect(dest?.object?.value).toBe('me');
+      expect(dest?.property).toBe('textContent');
+      expect(roles.get('patient')?.value).toBe('Done!');
+    });
+  }
+
+  it('[en] the en reference parse is unchanged', () => {
+    const cmd = firstBody(parse('on click set my.textContent to "Done!"', 'en'));
+    const roles = rolesOf(cmd);
+    expect((roles.get('destination') as { type?: string } | undefined)?.type).toBe('property-path');
+    expect(roles.get('patient')?.value).toBe('Done!');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T18:05:17.347Z",
-  "commit": "4e72d38e",
+  "timestamp": "2026-06-12T18:26:54.259Z",
+  "commit": "4119da0b",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -13,7 +13,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["if-exists", "repeat-until-event", "window-scroll"],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -649,7 +649,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1280,7 +1280,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1904,7 +1904,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3165,7 +3165,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3809,7 +3809,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4461,7 +4461,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5086,24 +5086,17 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8437908496732007,
-      "avgFidelity": 0.9431372549019609,
-      "avgRoleFidelity": 0.7724570780693231,
-      "avgExecutionFidelity": 0.7647058823529411,
-      "executionFailures": [
-        "increment-counter",
-        "set-inner-html-possessive-dot",
-        "set-style",
-        "set-text-possessive-dot"
-      ],
+      "avgFidelity": 0.9496732026143792,
+      "avgRoleFidelity": 0.7939990281827016,
+      "avgExecutionFidelity": 0.8823529411764706,
+      "executionFailures": ["increment-counter", "set-style"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "caret-var-increment",
-        "get-attribute-possessive-dot",
         "if-exists",
         "increment-by-amount",
         "increment-counter",
         "input-mirror",
-        "method-call-possessive-dot",
         "repeat-until-event",
         "repeat-while",
         "set-opacity",
@@ -5111,7 +5104,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5741,7 +5734,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6390,7 +6383,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7033,7 +7026,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7658,34 +7651,23 @@
       "parseFailure": 5,
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.8334292106104165,
-      "avgFidelity": 0.9559284116331096,
-      "avgRoleFidelity": 0.7883184523809527,
-      "avgExecutionFidelity": 0.8235294117647058,
-      "executionFailures": [
-        "set-inner-html-possessive-dot",
-        "set-style",
-        "set-text-possessive-dot"
-      ],
+      "avgFidelity": 0.9794183445190157,
+      "avgRoleFidelity": 0.8357721560846563,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [
         "async-block",
         "event-debounce",
         "fetch-basic",
         "fetch-loading-state",
-        "get-attribute-possessive-dot",
         "if-exists",
-        "input-mirror",
         "last-in-collection",
         "make-element",
-        "method-call-possessive-dot",
         "render-template-with-data",
-        "set-color-variable",
-        "set-opacity",
-        "set-style",
-        "set-transform",
-        "template-literal-interpolation"
+        "set-color-variable"
       ],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8311,7 +8293,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8941,7 +8923,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9566,14 +9548,9 @@
       "parseRate": 1,
       "avgConfidence": 0.6999278499278501,
       "avgFidelity": 0.9606060606060607,
-      "avgRoleFidelity": 0.6665379665379668,
-      "avgExecutionFidelity": 0.7647058823529411,
-      "executionFailures": [
-        "put-content-basic",
-        "set-inner-html-possessive-dot",
-        "set-style",
-        "set-text-possessive-dot"
-      ],
+      "avgRoleFidelity": 0.6935649935649936,
+      "avgExecutionFidelity": 0.9411764705882353,
+      "executionFailures": ["put-content-basic"],
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -9588,7 +9565,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10219,7 +10196,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10850,7 +10827,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "repeat-until-event", "set-color-variable"],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11477,7 +11454,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12108,7 +12085,7 @@
       "executionFailures": ["remove-class-from-all", "tabs-basic"],
       "degeneratePasses": [],
       "lossyPasses": ["if-exists", "window-scroll"],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12745,7 +12722,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13375,7 +13352,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13999,22 +13976,20 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8014430014429995,
-      "avgFidelity": 0.9794372294372293,
-      "avgRoleFidelity": 0.8293355855855857,
-      "avgExecutionFidelity": 0.8823529411764706,
-      "executionFailures": ["set-inner-html-possessive-dot", "set-text-possessive-dot"],
+      "avgConfidence": 0.8037518037518019,
+      "avgFidelity": 0.985930735930736,
+      "avgRoleFidelity": 0.8507319819819822,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [
-        "get-attribute-possessive-dot",
         "input-mirror",
-        "method-call-possessive-dot",
         "morph-with-template",
         "render-template-with-data",
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14101,6 +14076,14 @@
           "confidence": 1
         },
         "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 1
         },
@@ -14292,15 +14275,7 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "chained-access-possessive-dot": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -14653,7 +14628,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 412254,
+      "bundleSize": 412262,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15275,7 +15250,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 412254,
+      "size": 412262,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Mechanism (one per PR — session 7, target 3)

The dot-notation transformer (`translatePossessiveDotNotation`, packages/i18n) **skips multi-word translations** — it can't prefix them onto `my.X` heads. So:

- **id** dict (`my: 'saya punya'`) and **vi** dict (`my: 'của tôi'`) leave the corpus heads as literal English `my.textContent`
- **ms** dict emits the single-token `saya_punya.X` — a form the ms profile never listed
- **qu** dict emits the romanization `noqaq.X` — the qu profile only knows `ñuqapa`/`ñuqaypa`

In all four, `tryMatchPossessiveExpression` found no possessive keyword, the head parsed as a raw `expression` instead of `property-path(me.X)`, and `setMapper` wrote nothing at runtime — `set-text-possessive-dot` / `set-inner-html-possessive-dot` / `set-style` failed at execution.

### Fix

Add the **emitted forms** to the four semantic profiles' `possessive.keywords` (id/vi: `my` passthrough, ms: `saya_punya`, qu: `noqaq`). Parse-side only — zero corpus text changes, so no baseline churn outside the target rows. Blast radius verified with full id/ms/vi corpus sweeps: 4 rows gain previously-dropped `put` commands, set rows flip destination type expression → property-path, nothing loses an action.

## Results

| Metric | Before | After |
| --- | --- | --- |
| R2 mean executionFidelity | 0.9514 | **0.9770** |
| Failing instances | 19 | **9** |
| ms / vi | 0.824 | **1.000** (18/23 perfect) |
| qu | 0.765 | 0.941 |
| id | 0.765 | 0.882 |
| Parsing floor avgFidelity | 0.9717 | 0.9717 (unchanged) |

Deliberately excluded (different mechanisms, documented in the commit): id `set-style` uses the two-word phrase `saya punya *background` (the matcher reads `punya` as the property); hi is blocked by `event-hi-bare` swallowing the fronted possessive as the event.

- Full 24-language gate green (`--regression`); baseline regenerated (24-language list); patterns.db reverted
- Lock test appended to `multilingual-roadmap-fixes.test.ts`; semantic 5792 / i18n 846 / testing-framework 174 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)