### PR TITLE
fix(i18n): tl source marker emission realigned to mula_sa (R2 tl → 1.000)

### DIFF
--- a/packages/i18n/src/grammar/profiles/index.ts
+++ b/packages/i18n/src/grammar/profiles/index.ts
@@ -926,7 +926,11 @@ export const tagalogProfile: LanguageProfile = {
   markers: [
     { form: 'kapag', role: 'event', position: 'preposition', required: true },
     { form: 'sa', role: 'destination', position: 'preposition', required: false },
-    { form: 'mula sa', role: 'source', position: 'preposition', required: false },
+    // mula_sa (underscore) matches the tl dict and the semantic profile's
+    // source marker — the spaced form emitted two tokens the generated
+    // patterns' single mula_sa literal could never match, so `remove X
+    // mula sa Y` lost its source and the schema default fabricated me.
+    { form: 'mula_sa', role: 'source', position: 'preposition', required: false },
     { form: 'nang', role: 'style', position: 'preposition', required: false },
     { form: 'bilang', role: 'method', position: 'preposition', required: false },
   ],

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -4614,3 +4614,54 @@ describe('Possessive-dot passthrough heads assemble property-paths (R2 id/ms/vi)
     expect(roles.get('patient')?.value).toBe('Done!');
   });
 });
+
+describe('tl source marker emission realign — grammar `mula sa` → dict/profile mula_sa (R2 tl)', () => {
+  // Three-way drift, with the i18n grammar profile as the odd one out: its
+  // source marker was the spaced 'mula sa' while both the tl dict and the
+  // semantic profile use the underscore convention mula_sa (like every other
+  // multi-word tl form: kuhanin_mula, idagdag_sa_simula, galing_sa). The
+  // spaced emission produced two tokens the generated patterns' single
+  // mula_sa literal could never match, so `alisin X mula sa Y` lost its
+  // source phrase and the remove schema's default fabricated source=me —
+  // remove-class-from-all and tabs-basic removed .active from the handler
+  // element instead of the real targets. The grammar profile now emits
+  // mula_sa. tl 0.882 → 1.000 (19/23 perfect), mean 0.9770 → 0.9821.
+  function commands(node: unknown, acc: Array<Record<string, unknown>> = []) {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (rec.kind === 'command') acc.push(rec);
+    for (const f of ['body', 'statements', 'commands']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => commands(x, acc));
+    }
+    return acc;
+  }
+  function role(cmd: Record<string, unknown>, name: string): unknown {
+    const roles = cmd.roles as Map<string, { value?: unknown }>;
+    const m = roles instanceof Map ? roles : new Map(Object.entries((roles as object) ?? {}));
+    return (m.get(name) as { value?: unknown } | undefined)?.value;
+  }
+
+  it('[tl] remove-class-from-all captures the real source (was default me)', () => {
+    const cmds = commands(parse('alisin .active mula_sa .items kapag click', 'tl'));
+    const remove = cmds.find(c => c.action === 'remove');
+    expect(remove, 'remove command present').toBeTruthy();
+    expect(role(remove!, 'patient')).toBe('.active');
+    expect(role(remove!, 'source')).toBe('.items');
+  });
+
+  it('[tl] tabs-basic keeps remove source + add destination', () => {
+    const cmds = commands(
+      parse('alisin .active mula_sa .tab kapag click pagkatapos idagdag .active sa ako', 'tl')
+    );
+    const remove = cmds.find(c => c.action === 'remove');
+    const add = cmds.find(c => c.action === 'add');
+    expect(role(remove!, 'source')).toBe('.tab');
+    expect(role(add!, 'destination')).toBe('me');
+  });
+
+  it('[en] the en reference parse is unchanged', () => {
+    const cmds = commands(parse('on click remove .active from .items', 'en'));
+    expect(role(cmds[0], 'source')).toBe('.items');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T18:26:54.259Z",
-  "commit": "4119da0b",
+  "timestamp": "2026-06-12T18:39:06.288Z",
+  "commit": "61c334ff",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -12078,11 +12078,11 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8482999260310177,
+      "avgConfidence": 0.8457025234336144,
       "avgFidelity": 0.9970779220779221,
-      "avgRoleFidelity": 0.8596927284427288,
-      "avgExecutionFidelity": 0.8823529411764706,
-      "executionFailures": ["remove-class-from-all", "tabs-basic"],
+      "avgRoleFidelity": 0.8736566924066927,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["if-exists", "window-scroll"],
       "bundleSize": 412262,
@@ -12423,14 +12423,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "send-with-detail": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -12439,27 +12431,7 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "dropdown-close-outside": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "previous-element": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -12467,13 +12439,41 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 0.7777777777777777
+        },
+        "remove-class-from-all": {
+          "success": true,
+          "confidence": 0.7777777777777777
+        },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 0.7777777777777777
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 0.7777777777777777
+        },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 0.7777777777777777
+        },
+        "dropdown-close-outside": {
+          "success": true,
+          "confidence": 0.7777777777777777
+        },
+        "previous-element": {
+          "success": true,
+          "confidence": 0.7777777777777777
+        },
         "event-from-elsewhere": {
           "success": true,
-          "confidence": 0.8222222222222222
+          "confidence": 0.7777777777777777
         },
         "take-class-from-siblings": {
           "success": true,
-          "confidence": 0.8222222222222222
+          "confidence": 0.7777777777777777
         },
         "repeat-times": {
           "success": true,


### PR DESCRIPTION
## Mechanism (one per PR — session 7, target 4)

Three-way drift with the i18n grammar profile as the odd one out: its tl source marker was the spaced `mula sa` while both the tl **dict** (`from: 'mula_sa'`) and the **semantic profile** (`source: { primary: 'mula_sa' }`) use the underscore convention — like every other multi-word tl form (`kuhanin_mula`, `idagdag_sa_simula`, `galing_sa`). The spaced emission produced two tokens that the generated patterns' single `mula_sa` literal could never match, so `alisin X mula sa Y` lost its source phrase and the remove schema's default fabricated `source=me` — `remove-class-from-all` and `tabs-basic` removed `.active` from the handler element instead of the real targets at execution.

### Fix

One line in the i18n grammar profile ([profiles/index.ts](packages/i18n/src/grammar/profiles/index.ts)): the marker form is now `mula_sa`. Emission-side only — the corpus regenerates to the parseable shape; no parser or pattern changes. Probe-verified: both rows now capture the real source (`.items` / `.tab`) with en-identical roles.

## Results

| Metric | Before | After |
| --- | --- | --- |
| R2 mean executionFidelity | 0.9770 | **0.9821** |
| Failing instances | 9 | **7** |
| tl | 0.882 | **1.000** (19/23 perfect) |
| Parsing floor avgFidelity | 0.9717 | 0.9717 (unchanged) |

- Full 24-language gate green (`--regression`); baseline regenerated (24-language list); patterns.db reverted
- Lock test appended to `multilingual-roadmap-fixes.test.ts`; semantic 5795 / i18n 846 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)