### PR TITLE
fix(semantic): qu curated apostrophe rows — ñit'iy keyword + event-source wrapper steal

### DIFF
--- a/packages/semantic/src/patterns/event-handler.ts
+++ b/packages/semantic/src/patterns/event-handler.ts
@@ -1251,25 +1251,16 @@ function getEventHandlerPatternsQu(): LanguagePattern[] {
         event: { position: 1 },
       },
     },
-    {
-      id: 'event-qu-source',
-      language: 'qu',
-      command: 'on',
-      priority: 110,
-      template: {
-        format: '{event} pi {source} manta {body}',
-        tokens: [
-          { type: 'role', role: 'event' },
-          { type: 'literal', value: 'pi' },
-          { type: 'role', role: 'source' },
-          { type: 'literal', value: 'manta' },
-        ],
-      },
-      extraction: {
-        event: { position: 0 },
-        source: { marker: 'manta' },
-      },
-    },
+    // NOTE: there is deliberately no `event-qu-source` ({event} pi {source}
+    // manta {body}) wrapper. Its captured source was discarded unconditionally
+    // (the non-action buildEventHandler path drops wrapper roles other than
+    // `event`), while the shape it matched — a command's own from-phrase
+    // sitting right after the event in qu SOV order, e.g.
+    // `ñit'iy pi .items manta .active ta qichuy` — stole the manta phrase
+    // from the body command (remove lost its source and acted on `me`).
+    // The qu from-elsewhere corpus rows put the source phrase BEFORE the
+    // event phrase, so nothing legitimate matched this wrapper. With it gone,
+    // event-qu-standard matches and the body re-parse captures source+patient.
     {
       id: 'event-qu-kaqtin',
       language: 'qu',

--- a/packages/semantic/src/tokenizers/quechua.ts
+++ b/packages/semantic/src/tokenizers/quechua.ts
@@ -130,6 +130,11 @@ const QUECHUA_EXTRAS: KeywordEntry[] = [
   // Events
   { native: 'llikllay', normalized: 'click' },
   { native: 'ñitiy', normalized: 'click' },
+  // Glottalized spelling — the curated corpus rows (fix-translations.sql) and
+  // the event-handler pattern map both use ñit'iy. Without this entry the
+  // word-walk splits it at the injected English-passthrough keyword `it`
+  // (ñ + it + 'iy), wrecking every curated qu click pattern.
+  { native: "ñit'iy", normalized: 'click' },
   { native: 'click', normalized: 'click' },
   { native: 'yaykuy', normalized: 'input' },
   { native: 'llave uray', normalized: 'keydown' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -4665,3 +4665,80 @@ describe('tl source marker emission realign — grammar `mula sa` → dict/profi
     expect(role(cmds[0], 'source')).toBe('.items');
   });
 });
+
+describe("qu curated apostrophe rows — ñit'iy keyword + event-source wrapper steal (R2 qu)", () => {
+  // Two qu execution killers, both hit the six curated fix-translations.sql
+  // rows (the linguistically-correct glottalized forms):
+  //
+  // 1. The tokenizer keyword table only listed the dict's ñitiy, so the
+  //    curated ñit'iy fell to the regular word-walk, which breaks at any
+  //    position where a known keyword starts — including the injected
+  //    English-passthrough `it` INSIDE ñit'iy (ñ + it + 'iy). The event came
+  //    out as literal "'iy" and the whole clause collapsed. ñit'iy is now a
+  //    keyword (patterns/event-handler.ts already mapped it to click).
+  //
+  // 2. The hand-crafted event-qu-source wrapper ({event} pi {source} manta
+  //    {body}) misclaimed a body command's own from-phrase sitting after the
+  //    event in qu SOV order, and the non-action buildEventHandler path
+  //    discards wrapper roles other than `event` — so the manta phrase was
+  //    lost either way and remove acted on `me`. The wrapper is removed; the
+  //    qu from-elsewhere rows put the source phrase before the event, so
+  //    nothing legitimate matched it.
+  function commands(node: unknown, acc: Array<Record<string, unknown>> = []) {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (rec.kind === 'command') acc.push(rec);
+    for (const f of ['body', 'statements', 'commands']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => commands(x, acc));
+    }
+    return acc;
+  }
+  function role(cmd: Record<string, unknown>, name: string): unknown {
+    const roles = cmd.roles as Map<string, { value?: unknown }>;
+    const m = roles instanceof Map ? roles : new Map(Object.entries((roles as object) ?? {}));
+    return (m.get(name) as { value?: unknown } | undefined)?.value;
+  }
+  function eventOf(node: unknown): unknown {
+    const rec = node as Record<string, unknown>;
+    const roles = rec?.roles as Map<string, { value?: unknown }>;
+    const m = roles instanceof Map ? roles : new Map(Object.entries((roles as object) ?? {}));
+    return (m.get('event') as { value?: unknown } | undefined)?.value;
+  }
+
+  it("[qu] ñit'iy tokenizes as one click keyword (no ñ + it + 'iy split)", () => {
+    const tokens = getTokenizer('qu').tokenize("ñit'iy pi .highlight ta yapay").tokens;
+    const first = tokens[0] as { value: string; normalized?: string };
+    expect(first.value).toBe("ñit'iy");
+    expect(first.normalized).toBe('click');
+  });
+
+  it("[qu] add-class-basic curated row: event click + add patient (was event \"'iy\")", () => {
+    const node = parse("ñit'iy pi .highlight ta yapay", 'qu');
+    expect(eventOf(node)).toBe('click');
+    const add = commands(node).find(c => c.action === 'add');
+    expect(role(add!, 'patient')).toBe('.highlight');
+  });
+
+  it("[qu] toggle-class-on-other curated row keeps destination (t'ikray verb)", () => {
+    const node = parse("ñit'iy pi #menu pa .open ta t'ikray", 'qu');
+    expect(eventOf(node)).toBe('click');
+    const toggle = commands(node).find(c => c.action === 'toggle');
+    expect(role(toggle!, 'patient')).toBe('.open');
+  });
+
+  it('[qu] remove-class-from-all keeps the manta source (was stolen by event-qu-source)', () => {
+    const node = parse("ñit'iy pi .items manta .active ta qichuy", 'qu');
+    expect(eventOf(node)).toBe('click');
+    const remove = commands(node).find(c => c.action === 'remove');
+    expect(role(remove!, 'patient')).toBe('.active');
+    expect(role(remove!, 'source')).toBe('.items');
+  });
+
+  it('[qu] the dict ñitiy form still parses identically', () => {
+    const node = parse('ñitiy pi .items manta .active ta qichuy', 'qu');
+    expect(eventOf(node)).toBe('click');
+    const remove = commands(node).find(c => c.action === 'remove');
+    expect(role(remove!, 'source')).toBe('.items');
+  });
+});


### PR DESCRIPTION
## Summary

Restores the six curated qu (Quechua) corpus rows (`fix-translations.sql` glottalized spellings) that fail R2 execution on a clean HEAD build, despite the committed baseline recording them as passing.

**Root causes (both fixed):**

1. **Tokenizer keyword gap** — the keyword table listed only the dict's `ñitiy`; the curated `ñit'iy` fell to the regular word-walk, which breaks wherever a known keyword starts — including the framework-injected English passthrough `it` *inside* `ñit'iy` (`ñ` + `it` + `'iy`). The event parsed as literal `'iy` and every curated qu click row collapsed. `ñit'iy → click` is now a tokenizer keyword (the event-handler pattern map has carried that form since February).

2. **`event-qu-source` wrapper steal** — the hand-crafted `{event} pi {source} manta {body}` wrapper misclaimed a body command's own from-phrase (qu SOV puts it right after the event), and the non-action `buildEventHandler` path discards wrapper roles other than `event` — so the `manta` phrase was lost on every match and `remove` acted on `me`. Removed: the qu from-elsewhere rows put the source phrase *before* the event, so nothing legitimate ever matched it.

**No baseline regeneration** — the committed baseline already records these rows as passing; this PR restores reality to match it.

## Verification

- semantic: 5800 passed (5 new locks in the qu describe-block of `multilingual-roadmap-fixes.test.ts`)
- 21-language `--regression` gate: green, zero ratchet hits
- en+qu `--regression` gate: green — qu `executionFailures` back to `[put-content-basic]` only
- Parsing floor unchanged

## Note for reviewers

The morning baseline (saved 14:39, stamped 61c334ff) records these six rows as passing, but a clean ordered rebuild of HEAD cannot reproduce that — evidence the save ran against a transitional build (§10's documented `--save-baseline` workflow gotcha). Serialize: merge this before the R2 subset-expansion PR that follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)