### PR TITLE
feat(testing-framework): R2 subset expansion wave 1 — 17 → 19 patterns + recalibrated baseline

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -440,6 +440,55 @@ reads punya as the property; new mechanism found this session), id
 increment-counter (1 — dict emits tambahkan which parses as add; keyword-
 collision family).
 
+## 7g. Status update (2026-06-12, post-#387/#388 — session 8): R2 SUBSET EXPANSION WAVE 1
+
+**Subset 17 → 19 patterns (tabs-content + accordion-exclusive) | recalibrated
+mean executionFidelity 0.9542 | 9/23 perfect | failing instances 20 = the 7
+carried tails + a NEW 13-language tabs-content band | parsing floor
+unchanged.** Two PRs: #387 (qu restore, see below) then #388 (expansion +
+baseline). accordion-exclusive passes 24/24 on arrival.
+
+- **Eligibility probe (13 candidates, 11 excluded).** Probed 8 multi-command
+  - 5 control-flow click patterns through the validator in en FIRST
+    (lesson 15). Only tabs-content and accordion-exclusive have a usable en
+    reference. The nine exclusions are en-side gaps, documented in the subset
+    comment (execution-validator.ts) and itemized in §10.6:
+  * `halt the event then toggle …` — runtime halt exits the WHOLE handler
+    (patient parses as bare 'the'); the second command never runs.
+  * `set @attr … on <sel>` — "Invalid selector @aria-selected" (joins the
+    set-attribute/toggle-visibility family).
+  * `hide closest .modal …` — the en SEMANTIC PARSE drops the hide command
+    entirely; only the following remove survives.
+  * `toggle .open on next .dropdown-menu halt` — buildAST emits a
+    propertyAccess node the runtime rejects.
+  * `make a <div.card/>` — runtime "Invalid selector <div.card/>" (make with
+    HTML-literal selector), 2 patterns.
+  * **if/unless flatten IN ENGLISH** (5 patterns): `if I match .active then A
+else B end` parses as flat siblings if(condition:'I') + A + B; the
+    runtime rejects the bare if. The §2 dominant cluster is not a
+    translation problem — control-flow R2 expansion is BLOCKED on it.
+- **The tabs-content band (13 langs: bn he hi it ja ko pl qu ru th tr uk
+  vi).** A 4-command juxtaposed chain (remove/add/hide/show) — en itself
+  drops cmd 4 (`show the next <div.tab-panel/>`), and 13 translations drop
+  more. This is the multi-command-drop surface the expansion exists to
+  expose; it is RECORDED in the baseline, not folded into the old tail.
+- **qu incident + #387.** The session opened with the committed baseline
+  unreproducible: 6 curated qu rows (fix-translations.sql glottalized
+  spellings) failed execution on a clean ordered rebuild of HEAD, though the
+  baseline said they passed. Root causes (both fixed in #387, no baseline
+  change needed): (1) tokenizer keyword table lacked `ñit'iy`, so the
+  word-walk split it at the framework-injected English passthrough `it`
+  (ñ + it + 'iy — event parsed as literal "'iy"); (2) the hand-crafted
+  `event-qu-source` wrapper stole a body command's own `manta` from-phrase
+  (qu SOV puts it right after the event) and the non-action
+  buildEventHandler path discards wrapper roles other than `event`, so any
+  match lost the phrase — removed, nothing legitimate matched its shape.
+  **Process lesson (extends the stale-handoff rule): before regenerating a
+  baseline, first verify the COMMITTED one reproduces — a clean rebuild +
+  `--regression` run is the cheap check. The §10 save-from-transitional-
+  build gotcha recurred and would have silently laundered a real regression
+  into the new baseline.**
+
 ## 8. R1 / R2 — role-fidelity and execution ratchets (extend R0)
 
 Action-set fidelity (R0's signal) cannot see a parse that finds the right
@@ -502,14 +551,18 @@ landed.
 **Out of scope for the ship line:** Track 2 behaviors, R2 execution, the
 `component-*` HTML templates, and R1's burn-down (baseline only).
 
-## 10. Handoff — next session (written 2026-06-12, post-#385, session 7)
+## 10. Handoff — next session (written 2026-06-12, post-#388, session 8)
 
-**R2 burn-down is in the tail: 0.9821, 7 failing instances, 19/23
-languages perfect (§7f).** All four ratchets hold; the parsing track remains
-STOPPED (§9). HARD-LEARNED THIS SESSION: handoff instance-lists go stale —
-two of session 6's four ranked targets had already cleared by the time they
-were probed. ALWAYS re-read `executionFailures` from the current baseline
-before picking a target. The remaining 7, re-probed this session:
+**R2 now runs the 19-pattern subset: mean 0.9542 (recalibrated), 9/23
+perfect, 20 failing instances = 7 carried tails + the 13-language
+tabs-content band (§7g).** All four ratchets hold; the parsing track remains
+STOPPED (§9). Two session-8 process rules, both hard-learned: (1) handoff
+instance-lists go stale — ALWAYS re-read `executionFailures` from the
+current baseline before picking a target; (2) before regenerating a
+baseline, VERIFY THE COMMITTED ONE REPRODUCES on a clean ordered rebuild
+(`--regression`, zero hits expected) — session 8 caught a silently
+unreproducible baseline (qu, fixed in #387) that a blind regen would have
+laundered into the new floor. The remaining instances:
 
 1. **hi set trio (3: set-text/set-inner-html possessive-dot + set-style).**
    `मेरा.textContent को क्लिक पर सेट "Done!" में` — `event-hi-bare` matches
@@ -533,16 +586,30 @@ saya punya *background ke "red"` (space form — NOT the dot-head the
    as ADD (keyword collision family; the #373 allowlist lists it). Fix the
    dict word (id increment → e.g. naikkan) AND prune the allowlist row in
    the same PR.
-5. **R2 subset expansion** — with the burn-down at 7, expansion is now the
-   higher-leverage move: multi-command patterns, then control-flow
-   (`if-matches`, `unless-condition`), then behavior-\*. RULE (locked by
-   test): any subset change regenerates the baseline AND updates the
-   membership lock in the SAME PR. Expect a new failure band on first
-   expansion — record + ratchet, don't fold into this tail.
-6. **Runtime gaps visible in en** (from the subset exclusions):
-   `toggle @hidden`, `set #output.innerText to X`, `set @disabled to true`
-   fail in ENGLISH in the current runtime. Core-runtime track, independent
-   of translation.
+5. **The tabs-content band (13 langs — the new R2 work surface).** A
+   4-command juxtaposed chain; per-language drops of commands 2–4. Expect
+   clusters, not 13 mechanisms: probe which command each language loses
+   first (the §7e/§7f mechanism idiom applies — find the drifted layer per
+   cluster). NOTE: the en reference itself drops cmd 4 (`show the next
+<div.tab-panel/>`) — translations are scored against en's 3-command
+   effects, so a translation keeping all 4 would DIVERGE; don't "fix" a
+   language past the reference.
+6. **Expansion waves remaining:** control-flow (`if-matches`,
+   `unless-condition`, …) is BLOCKED on the en if/unless flatten (§7g —
+   the §2 dominant cluster, parsing track); behavior-\* still out. Wave 2
+   becomes possible only after en control-flow parses execute. RULE
+   (locked by test) unchanged: any subset change regenerates the baseline
+   AND updates the membership lock in the SAME PR.
+7. **Runtime/parse gaps visible in en** (from the subset exclusions; the
+   session-8 probe added five): `toggle @hidden`, `set #output.innerText
+to X`, `set @disabled to true`, `set @attr … on <sel>` (tabs-aria);
+   runtime `halt` exits the whole handler even as `halt the event`
+   (halt-propagation); en parse drops `hide closest .modal`
+   (modal-close-button); buildAST emits propertyAccess for `next .X` that
+   the runtime rejects (dropdown-toggle); `make a <div.card/>` invalid
+   selector (make-element, make-toast-element); en if/unless branch
+   flatten (5 control-flow patterns). Core-runtime/parsing tracks,
+   independent of translation.
 
 Mechanism idiom, now 9-for-9 across two sessions (§7e/§7f): find which of
 the three layers drifted — dict emission, grammar-profile emission, or

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T18:39:06.288Z",
-  "commit": "61c334ff",
+  "timestamp": "2026-06-12T19:54:16.472Z",
+  "commit": "942907ae",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -13,7 +13,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["if-exists", "repeat-until-event", "window-scroll"],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -639,8 +639,8 @@
       "avgConfidence": 0.8430632859204288,
       "avgFidelity": 0.9905844155844155,
       "avgRoleFidelity": 0.7622345559845559,
-      "avgExecutionFidelity": 1,
-      "executionFailures": [],
+      "avgExecutionFidelity": 0.9473684210526315,
+      "executionFailures": ["tabs-content"],
       "degeneratePasses": [],
       "lossyPasses": [
         "fetch-do-not-throw",
@@ -649,7 +649,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1280,7 +1280,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1904,7 +1904,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3165,7 +3165,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3791,8 +3791,8 @@
       "avgConfidence": 0.8263201576927067,
       "avgFidelity": 0.9569716775599126,
       "avgRoleFidelity": 0.8520003239390994,
-      "avgExecutionFidelity": 1,
-      "executionFailures": [],
+      "avgExecutionFidelity": 0.9473684210526315,
+      "executionFailures": ["tabs-content"],
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
@@ -3809,7 +3809,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4435,11 +4435,12 @@
       "avgConfidence": 0.9546072974644388,
       "avgFidelity": 0.928030303030303,
       "avgRoleFidelity": 0.5759974259974261,
-      "avgExecutionFidelity": 0.8235294117647058,
+      "avgExecutionFidelity": 0.7894736842105263,
       "executionFailures": [
         "set-inner-html-possessive-dot",
         "set-style",
-        "set-text-possessive-dot"
+        "set-text-possessive-dot",
+        "tabs-content"
       ],
       "degeneratePasses": [
         "bind-auto-detect",
@@ -4461,7 +4462,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5088,7 +5089,7 @@
       "avgConfidence": 0.8437908496732007,
       "avgFidelity": 0.9496732026143792,
       "avgRoleFidelity": 0.7939990281827016,
-      "avgExecutionFidelity": 0.8823529411764706,
+      "avgExecutionFidelity": 0.8947368421052632,
       "executionFailures": ["increment-counter", "set-style"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
@@ -5104,7 +5105,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5730,11 +5731,11 @@
       "avgConfidence": 0.8379396202925594,
       "avgFidelity": 0.9803921568627451,
       "avgRoleFidelity": 0.7985098801425334,
-      "avgExecutionFidelity": 1,
-      "executionFailures": [],
+      "avgExecutionFidelity": 0.9473684210526315,
+      "executionFailures": ["tabs-content"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6360,8 +6361,8 @@
       "avgConfidence": 0.8351783137497423,
       "avgFidelity": 0.9384199134199134,
       "avgRoleFidelity": 0.7358268983268984,
-      "avgExecutionFidelity": 0.9411764705882353,
-      "executionFailures": ["put-content-basic"],
+      "avgExecutionFidelity": 0.8947368421052632,
+      "executionFailures": ["put-content-basic", "tabs-content"],
       "degeneratePasses": [
         "announce-screen-reader",
         "behavior-draggable",
@@ -6383,7 +6384,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7010,8 +7011,8 @@
       "avgConfidence": 0.7911667697381983,
       "avgFidelity": 0.9595238095238094,
       "avgRoleFidelity": 0.7415218790218793,
-      "avgExecutionFidelity": 1,
-      "executionFailures": [],
+      "avgExecutionFidelity": 0.9473684210526315,
+      "executionFailures": ["tabs-content"],
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -7026,7 +7027,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7667,7 +7668,7 @@
         "render-template-with-data",
         "set-color-variable"
       ],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8289,11 +8290,11 @@
       "avgConfidence": 0.8037866998651292,
       "avgFidelity": 0.9782135076252723,
       "avgRoleFidelity": 0.814342403628118,
-      "avgExecutionFidelity": 1,
-      "executionFailures": [],
+      "avgExecutionFidelity": 0.9473684210526315,
+      "executionFailures": ["tabs-content"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8923,7 +8924,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9548,9 +9549,9 @@
       "parseRate": 1,
       "avgConfidence": 0.6999278499278501,
       "avgFidelity": 0.9606060606060607,
-      "avgRoleFidelity": 0.6935649935649936,
-      "avgExecutionFidelity": 0.9411764705882353,
-      "executionFailures": ["put-content-basic"],
+      "avgRoleFidelity": 0.6980694980694981,
+      "avgExecutionFidelity": 0.8947368421052632,
+      "executionFailures": ["put-content-basic", "tabs-content"],
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -9565,7 +9566,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10192,11 +10193,11 @@
       "avgConfidence": 0.8117913832199526,
       "avgFidelity": 0.9935064935064936,
       "avgRoleFidelity": 0.8202622265122268,
-      "avgExecutionFidelity": 1,
-      "executionFailures": [],
+      "avgExecutionFidelity": 0.9473684210526315,
+      "executionFailures": ["tabs-content"],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10827,7 +10828,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "repeat-until-event", "set-color-variable"],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11450,11 +11451,11 @@
       "avgConfidence": 0.8401154401154378,
       "avgFidelity": 1,
       "avgRoleFidelity": 0.8062258687258687,
-      "avgExecutionFidelity": 1,
-      "executionFailures": [],
+      "avgExecutionFidelity": 0.9473684210526315,
+      "executionFailures": ["tabs-content"],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12085,7 +12086,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["if-exists", "window-scroll"],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12712,8 +12713,8 @@
       "avgConfidence": 0.8329805996472663,
       "avgFidelity": 0.9635076252723311,
       "avgRoleFidelity": 0.750664075153871,
-      "avgExecutionFidelity": 1,
-      "executionFailures": [],
+      "avgExecutionFidelity": 0.9473684210526315,
+      "executionFailures": ["tabs-content"],
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -12722,7 +12723,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13348,11 +13349,11 @@
       "avgConfidence": 0.8098948670377222,
       "avgFidelity": 0.9935064935064936,
       "avgRoleFidelity": 0.8085505148005151,
-      "avgExecutionFidelity": 1,
-      "executionFailures": [],
+      "avgExecutionFidelity": 0.9473684210526315,
+      "executionFailures": ["tabs-content"],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13979,8 +13980,8 @@
       "avgConfidence": 0.8037518037518019,
       "avgFidelity": 0.985930735930736,
       "avgRoleFidelity": 0.8507319819819822,
-      "avgExecutionFidelity": 1,
-      "executionFailures": [],
+      "avgExecutionFidelity": 0.9473684210526315,
+      "executionFailures": ["tabs-content"],
       "degeneratePasses": [],
       "lossyPasses": [
         "input-mirror",
@@ -13989,7 +13990,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14628,7 +14629,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 412262,
+      "bundleSize": 411967,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15250,7 +15251,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 412262,
+      "size": 411967,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/scripts/probe-r2-en.ts
+++ b/packages/testing-framework/scripts/probe-r2-en.ts
@@ -1,0 +1,56 @@
+/**
+ * Session-8 probe: validate the en reference of every EXECUTION_SUBSET pattern
+ * (lesson 15 — exclude broken references before scoring languages against them).
+ * Usage: npx tsx scripts/probe-r2-en.ts [lang ...]
+ */
+import {
+  ExecutionValidator,
+  EXECUTION_SUBSET,
+  loadExecutionSubset,
+} from '../src/multilingual/validators/execution-validator';
+import type { LanguageCode } from '../src/multilingual/types';
+
+async function main() {
+  const langs = (process.argv.slice(2).length ? process.argv.slice(2) : ['en']) as LanguageCode[];
+  const validator = new ExecutionValidator();
+  await validator.initialize();
+  const sources = await loadExecutionSubset(['en', ...langs.filter(l => l !== 'en')]);
+
+  const enRef = new Map<string, string[]>();
+  for (const lang of langs) {
+    console.log(`\n=== ${lang} ===`);
+    const byId = sources.get(lang)!;
+    for (const id of EXECUTION_SUBSET) {
+      const code = byId.get(id);
+      if (!code) {
+        console.log(`${id}: NO SOURCE`);
+        continue;
+      }
+      const res = await validator.execute(id, code, lang);
+      if (lang === 'en') enRef.set(id, res.effects);
+      const status = res.error
+        ? `ERROR: ${res.error}`
+        : res.effects.length === 0
+          ? 'NO EFFECTS'
+          : lang === 'en'
+            ? 'OK'
+            : JSON.stringify(res.effects) === JSON.stringify(enRef.get(id))
+              ? 'MATCH'
+              : 'DIVERGE';
+      console.log(`${id}: ${status}`);
+      if (lang === 'en' && !res.error && res.effects.length) {
+        for (const e of res.effects) console.log(`    ${e}`);
+      }
+      if (status === 'DIVERGE') {
+        console.log(`    en: ${JSON.stringify(enRef.get(id))}`);
+        console.log(`    ${lang}: ${JSON.stringify(res.effects)}  code: ${code}`);
+      }
+    }
+  }
+  process.exit(0);
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
@@ -19,7 +19,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { ExecutionValidator, EXECUTION_SUBSET, loadExecutionSubset } from './execution-validator';
 
 describe('R2 execution subset (lock)', () => {
-  it('contains exactly the 17 curated patterns', () => {
+  it('contains exactly the 19 curated patterns', () => {
     // Changing this list recalibrates avgExecutionFidelity for every language.
     // If you expand the subset, regenerate the baseline (--save-baseline) in
     // the SAME PR and update this lock.
@@ -42,6 +42,11 @@ describe('R2 execution subset (lock)', () => {
         'set-inner-html-possessive-dot',
         'set-style',
         'closest-ancestor',
+        // Session-8 expansion wave 1 (multi-command): see the eligibility
+        // probe notes in execution-validator.ts for the nine candidates
+        // excluded because their en reference doesn't execute.
+        'tabs-content',
+        'accordion-exclusive',
       ].sort()
     );
   });

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.ts
@@ -59,6 +59,31 @@ export const EXECUTION_SUBSET: readonly string[] = [
   'set-inner-html-possessive-dot',
   'set-style',
   'closest-ancestor',
+  // Expansion wave 1 (session 8): multi-command click patterns — sync,
+  // network/timer-free sequences of 2–4 commands. Same eligibility bar as the
+  // original subset: the en reference must execute with a non-empty effect
+  // signature in the current runtime. Eleven candidates were probed; nine are
+  // deliberately absent because their EN reference is unusable:
+  //   halt-propagation      — runtime `halt` exits the whole handler (patient
+  //                           parses as bare 'the'), second command never runs
+  //   tabs-aria             — `set @attr … on <sel>`: "Invalid selector
+  //                           @aria-selected" (the set-attribute family gap)
+  //   modal-close-button    — en parse DROPS `hide closest .modal`; the
+  //                           surviving body-class change is invisible to the
+  //                           snapshot (body isn't serialized)
+  //   dropdown-toggle       — AST emits a propertyAccess node the runtime
+  //                           can't execute
+  //   make-element,
+  //   make-toast-element    — runtime "Invalid selector <div.card/>" (make
+  //                           with an HTML-literal selector)
+  //   if-condition, if-matches, if-exists, unless-condition,
+  //   modal-close-backdrop  — the en SEMANTIC PARSE flattens if/unless
+  //                           branches into sibling commands (condition
+  //                           truncated to 'I'); the runtime then rejects the
+  //                           bare `if`. Control-flow expansion is blocked on
+  //                           the parsing track's dominant cluster — in en too.
+  'tabs-content',
+  'accordion-exclusive',
 ];
 
 /**
@@ -77,6 +102,9 @@ const FIXTURE_HTML = `<!DOCTYPE html><html><body>
   <ul><li class="items active"></li><li class="items active"></li></ul>
   <div class="tab active"></div>
   <div class="tab"></div>
+  <div class="tab-panel"></div>
+  <div class="tab-panel"></div>
+  <div class="accordion-item open"></div>
 </body></html>`;
 
 /** Per-pattern fixture preconditions (applied identically for every language). */
@@ -87,6 +115,9 @@ const PATTERN_SETUP: Record<string, (doc: Document) => void> = {
   'show-element': doc => {
     (doc.getElementById('modal') as HTMLElement).style.display = 'none';
   },
+  // `add .open to closest .accordion-item` needs #btn inside one; the
+  // fixture's standalone `.accordion-item.open` is the exclusivity victim.
+  'accordion-exclusive': doc => doc.querySelector('.card')!.classList.add('accordion-item'),
 };
 
 /** Result of executing one pattern translation. */


### PR DESCRIPTION
## Summary

First R2 subset expansion (§10.5 of the roadmap): probed 13 multi-command/control-flow candidates, added the 2 with usable en references, regenerated the baseline, and recorded the new failure band.

**Stacked on #387** (the qu apostrophe restore) — merge that first; this PR's own files don't overlap, so it retargets to main cleanly.

## Subset change (membership lock updated in the same PR, per the locked rule)

- **Added:** `tabs-content` (4-command juxtaposed chain), `accordion-exclusive` (2-command + closest destination). Fixture gains `.tab-panel` ×2 and `.accordion-item.open`; `accordion-exclusive` gets a per-pattern setup.
- **11 candidates excluded** — their en reference doesn't execute. Documented in the subset comment and roadmap §7g/§10.7: the `halt`-exits-handler gap, the `@attr` selector family, en parse dropping `hide closest .modal`, a `propertyAccess` AST node the runtime rejects, `make` with HTML-literal selectors, and — blocking all of expansion wave 2 — **the en if/unless branch flatten** (the §2 dominant cluster manifests in English).

## New baseline (24 languages, fresh populate, db reverted)

- Mean executionFidelity **0.9542** (recalibrated for 19 patterns; was 0.9821/17)
- **accordion-exclusive: 24/24 languages pass on arrival**
- New band: **tabs-content fails in 13 languages** (bn he hi it ja ko pl qu ru th tr uk vi) — the multi-command drop surface this expansion exists to expose; recorded + ratcheted, not folded into the 7-instance tail
- The 7 carried tails are unchanged (hi ×3, id ×2, ja/qu put-content-basic)

## Verification

- 19-pattern membership lock + en-reference locks: 7/7 passed
- All 19 en references execute with non-empty deterministic signatures (`scripts/probe-r2-en.ts`, committed as the mechanized eligibility probe)
- 21-language `--regression` gate green before the baseline regen (zero ratchet hits on top of #387)

🤖 Generated with [Claude Code](https://claude.com/claude-code)