### PR TITLE
fix(i18n): id increment dict realign — tambahkan (parses as add) → naikkan

### DIFF
--- a/packages/i18n/src/dictionaries/id.ts
+++ b/packages/i18n/src/dictionaries/id.ts
@@ -40,7 +40,11 @@ export const id: Dictionary = {
     catch: 'tangkap',
     measure: 'ukur',
     transition: 'transisi',
-    increment: 'tambahkan',
+    // naikkan (raise), not tambahkan — tambahkan is the semantic profile's
+    // `add` alternative, so emitting it made increment-counter parse as ADD
+    // (the #373 collision family). naikkan is the profile's increment
+    // alternative, pairing naturally with the decrement side.
+    increment: 'naikkan',
     decrement: 'kurangi',
     default: 'bawaan',
     go: 'pergi',

--- a/packages/semantic/test/lexicon-emit-mismatch.test.ts
+++ b/packages/semantic/test/lexicon-emit-mismatch.test.ts
@@ -54,7 +54,6 @@ const KNOWN_MISMATCHES = new Set([
   'id:break:hentikan',
   'id:catch:tangkap',
   'id:close:tutup',
-  'id:increment:tambahkan',
   'id:pushUrl:tambahUrl',
   'id:replaceUrl:gantiUrl',
   'id:select:pilih',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -4742,3 +4742,36 @@ describe("qu curated apostrophe rows — ñit'iy keyword + event-source wrapper 
     expect(role(remove!, 'source')).toBe('.items');
   });
 });
+
+describe('id increment dict realign — tambahkan (parses as add) → naikkan (R2 id)', () => {
+  // The id dict emitted tambahkan for increment, but tambahkan is the id
+  // semantic profile's `add` ALTERNATIVE — increment-counter parsed as
+  // add(#counter) and execution diverged (the #373 keyword-collision family;
+  // its allowlist row is pruned in the same PR). The dict now emits naikkan,
+  // the profile's increment alternative.
+  function firstCommand(node: unknown): Record<string, unknown> | undefined {
+    if (!node || typeof node !== 'object') return undefined;
+    const rec = node as Record<string, unknown>;
+    if (rec.kind === 'command') return rec;
+    for (const f of ['body', 'statements', 'commands']) {
+      const c = rec[f];
+      if (Array.isArray(c)) {
+        for (const x of c) {
+          const r = firstCommand(x);
+          if (r) return r;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  it('[id] increment-counter emission parses as increment, not add', () => {
+    const cmd = firstCommand(parse('pada klik naikkan #counter', 'id'));
+    expect(cmd?.action).toBe('increment');
+  });
+
+  it('[id] tambahkan still parses as add (the profile alternative is untouched)', () => {
+    const cmd = firstCommand(parse('tambahkan .highlight', 'id'));
+    expect(cmd?.action).toBe('add');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-12T19:54:16.472Z",
-  "commit": "942907ae",
+  "timestamp": "2026-06-12T20:00:11.439Z",
+  "commit": "326197ce",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -5086,20 +5086,15 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8437908496732007,
-      "avgFidelity": 0.9496732026143792,
-      "avgRoleFidelity": 0.7939990281827016,
-      "avgExecutionFidelity": 0.8947368421052632,
-      "executionFailures": ["increment-counter", "set-style"],
+      "avgConfidence": 0.8404295051353855,
+      "avgFidelity": 0.9627450980392157,
+      "avgRoleFidelity": 0.8053368966634273,
+      "avgExecutionFidelity": 0.9473684210526315,
+      "executionFailures": ["set-style"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
-        "caret-var-increment",
         "if-exists",
-        "increment-by-amount",
-        "increment-counter",
         "input-mirror",
-        "repeat-until-event",
-        "repeat-while",
         "set-opacity",
         "set-style",
         "set-transform",
@@ -5419,18 +5414,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "increment-counter": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "increment-by-amount": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "caret-var-increment": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -5500,6 +5483,14 @@
           "confidence": 0.7142857142857143
         },
         "wait-for-event": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-counter": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "increment-by-amount": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -5632,6 +5623,10 @@
           "confidence": 0.7142857142857143
         },
         "keydown-key-is-syntax": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "caret-var-increment": {
           "success": true,
           "confidence": 0.7142857142857143
         },


### PR DESCRIPTION
## Summary

Clears the `id/increment-counter` R2 tail instance (§10.4 of the roadmap): the id dict emitted `tambahkan` for *increment*, but `tambahkan` is the id semantic profile's **add** alternative — so `pada klik tambahkan #counter` parsed as `add(#counter)` and execution diverged (the #373 keyword-collision family).

**Stacked on #388** (third in the serialized chain: #387 → #388 → this) — it regenerates the baseline, so it must land after #388's recalibration.

## Changes

- id dict: `increment: 'naikkan'` (the profile's increment alternative; pairs with `kurangi` on the decrement side, which is likewise a profile alternative)
- Allowlist row `id:increment:tambahkan` pruned from `lexicon-emit-mismatch.test.ts` in the same PR — the prune-down test enforces the deletion
- 2 new locks in `multilingual-roadmap-fixes.test.ts` (`naikkan` → increment; `tambahkan` still → add)
- Baseline regenerated (24 languages, fresh populate, db reverted): **failing instances 20 → 19**, id now carries only `set-style`

## Verification

- i18n: 846 passed | lexicon prune-down: 23 passed | roadmap locks: 432 passed
- 21-language `--regression` gate green before the regen
- Execution probe: `pada klik naikkan #counter` produces the en-identical effect signature (`#counter` text 0 → 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)