### PR TITLE
fix(framework): boundary-aware keyword breaks for space-delimited word-walks

### DIFF
--- a/packages/framework/src/core/tokenization/base-tokenizer.ts
+++ b/packages/framework/src/core/tokenization/base-tokenizer.ts
@@ -494,6 +494,37 @@ export abstract class BaseTokenizer implements LanguageTokenizer {
   }
 
   /**
+   * Check if a known keyword starts at the given position AND ends at a word
+   * boundary (end of input or a non-word character).
+   *
+   * Space-delimited languages must use this (not `isKeywordStart`) for
+   * word-walk break checks: the keyword table includes English canonical
+   * fallbacks (me, it, you, …), so a raw `startsWith` check splits any native
+   * word with an embedded fallback mid-word (e.g. Quechua ñit'iy contains
+   * "it"). CJK/no-space tokenizers rely on mid-text keyword starts and must
+   * keep using `isKeywordStart`.
+   *
+   * @param input - Input string
+   * @param pos - Current position
+   * @param isWordChar - Language-specific word-character predicate; pass the
+   *   tokenizer's letter classifier so e.g. the Quechua glottal apostrophe
+   *   counts as part of a word. Defaults to Unicode letters/digits/underscore.
+   * @returns true if a keyword starts here and is not followed by a word char
+   */
+  protected isKeywordStartAtBoundary(
+    input: string,
+    pos: number,
+    isWordChar: (char: string) => boolean = ch => /[\p{L}\p{N}_]/u.test(ch)
+  ): boolean {
+    const remaining = input.slice(pos);
+    return this.profileKeywords.some(entry => {
+      if (!remaining.startsWith(entry.native)) return false;
+      const after = input[pos + entry.native.length];
+      return after === undefined || !isWordChar(after);
+    });
+  }
+
+  /**
    * Look up a keyword by native word (case-insensitive).
    * O(1) lookup using the keyword map.
    *

--- a/packages/framework/src/core/tokenization/keyword-boundary.test.ts
+++ b/packages/framework/src/core/tokenization/keyword-boundary.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Contract tests for BaseTokenizer.isKeywordStartAtBoundary().
+ *
+ * The keyword table injects English canonical reference words (me, it, you, …)
+ * for every language. Space-delimited tokenizers that break their word-walk on
+ * a raw isKeywordStart() therefore split native words around embedded English
+ * fallbacks (e.g. Quechua ñit'iy contains "it"). The boundary-aware variant
+ * only fires when the keyword match ends at a word boundary.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BaseTokenizer } from './base-tokenizer';
+import type { TokenKind } from '../types';
+
+class ProbeTokenizer extends BaseTokenizer {
+  readonly language = 'xx';
+  readonly direction = 'ltr' as const;
+
+  constructor() {
+    super();
+    this.initializeKeywordsFromProfile({
+      keywords: { toggle: { primary: 'tikray' } },
+      // references inject the English canonical fallbacks "it" and "me" too
+      references: { it: 'pay', me: 'nuqa' },
+    });
+  }
+
+  classifyToken(): TokenKind {
+    return 'identifier';
+  }
+
+  probeRaw(input: string, pos: number): boolean {
+    return this.isKeywordStart(input, pos);
+  }
+
+  probeBoundary(input: string, pos: number, isWordChar?: (ch: string) => boolean): boolean {
+    return this.isKeywordStartAtBoundary(input, pos, isWordChar);
+  }
+}
+
+describe('isKeywordStartAtBoundary', () => {
+  const t = new ProbeTokenizer();
+
+  it('does not fire on an English fallback embedded mid-word', () => {
+    // "it" inside "umitaq" — raw check fires, boundary check must not
+    expect(t.probeRaw('umitaq', 2)).toBe(true);
+    expect(t.probeBoundary('umitaq', 2)).toBe(false);
+    // "me" inside "umema"
+    expect(t.probeRaw('umema', 1)).toBe(true);
+    expect(t.probeBoundary('umema', 1)).toBe(false);
+  });
+
+  it('fires when the keyword match ends at end of input', () => {
+    expect(t.probeBoundary('umit', 2)).toBe(true);
+  });
+
+  it('fires when the keyword match is followed by a non-word char', () => {
+    expect(t.probeBoundary('um it goes', 3)).toBe(true);
+    expect(t.probeBoundary('xit.', 1)).toBe(true);
+  });
+
+  it('respects a language-specific word-char predicate', () => {
+    // Default predicate: apostrophe is not a word char → boundary fires
+    expect(t.probeBoundary("xit'y", 1)).toBe(true);
+    // Quechua-style predicate counting the glottal apostrophe → no boundary
+    const quechuaLike = (ch: string) => /[a-zñ'’]/i.test(ch);
+    expect(t.probeBoundary("xit'y", 1, quechuaLike)).toBe(false);
+  });
+
+  it('returns false when no keyword starts at the position at all', () => {
+    expect(t.probeBoundary('umitaq', 0)).toBe(false);
+  });
+});

--- a/packages/framework/src/interfaces/value-extractor.ts
+++ b/packages/framework/src/interfaces/value-extractor.ts
@@ -407,6 +407,21 @@ export interface TokenizerContext {
   isKeywordStart(input: string, position: number): boolean;
 
   /**
+   * Like `isKeywordStart`, but only true when the keyword match ends at a
+   * word boundary (end of input or a char rejected by `isWordChar`).
+   * Space-delimited languages must use this for word-walk break checks —
+   * the keyword table includes English canonical fallbacks (me, it, you, …),
+   * so the raw check splits native words mid-word (e.g. Quechua ñit'iy
+   * contains "it"). Optional for backward compatibility with hand-rolled
+   * contexts; callers should treat absence as "no boundary keyword here".
+   */
+  isKeywordStartAtBoundary?(
+    input: string,
+    position: number,
+    isWordChar?: (char: string) => boolean
+  ): boolean;
+
+  /**
    * Optional morphological normalizer for this language.
    */
   readonly normalizer?: MorphologicalNormalizer;
@@ -449,6 +464,11 @@ export function createTokenizerContext(tokenizer: {
   lookupKeyword(native: string): KeywordEntry | undefined;
   isKeyword(native: string): boolean;
   isKeywordStart(input: string, position: number): boolean;
+  isKeywordStartAtBoundary?(
+    input: string,
+    position: number,
+    isWordChar?: (char: string) => boolean
+  ): boolean;
   normalizer?: MorphologicalNormalizer;
 }): TokenizerContext {
   const ctx: TokenizerContext = {
@@ -457,6 +477,9 @@ export function createTokenizerContext(tokenizer: {
     lookupKeyword: tokenizer.lookupKeyword.bind(tokenizer),
     isKeyword: tokenizer.isKeyword.bind(tokenizer),
     isKeywordStart: tokenizer.isKeywordStart.bind(tokenizer),
+    ...(tokenizer.isKeywordStartAtBoundary
+      ? { isKeywordStartAtBoundary: tokenizer.isKeywordStartAtBoundary.bind(tokenizer) }
+      : {}),
   };
 
   if (tokenizer.normalizer) {

--- a/packages/semantic/src/tokenizers/extractors/quechua-keyword.ts
+++ b/packages/semantic/src/tokenizers/extractors/quechua-keyword.ts
@@ -123,6 +123,13 @@ export class QuechuaKeywordExtractor implements ContextAwareExtractor {
     for (let len = Math.min(maxKeywordLen, input.length - startPos); len >= 2; len--) {
       const candidate = input.slice(startPos, startPos + len);
 
+      // Only accept a match that ends at a word boundary. Without this, a
+      // keyword prefix steals the front of a longer native word (ñit'iy
+      // matching inside ñit'iyq leaves a stray `q` token). Boundary-broken
+      // suffix splits (wasita → wasi + ta) still happen in the word-walk below.
+      const after = input[startPos + len];
+      if (after !== undefined && isQuechuaLetter(after)) continue;
+
       // Check all chars are Quechua
       let allQuechua = true;
       for (let i = 0; i < candidate.length; i++) {
@@ -169,8 +176,12 @@ export class QuechuaKeywordExtractor implements ContextAwareExtractor {
     let pos = position;
 
     while (pos < input.length && isQuechuaLetter(input[pos])) {
-      // Check if we're at the start of a known keyword (for word boundary detection)
-      if (word.length > 0 && this.context.isKeywordStart(input, pos)) {
+      // Break for an attached keyword (agglutinative suffix like `-ta`, `-man`)
+      // only when the match ends at a word boundary. A raw isKeywordStart check
+      // splits native words around embedded English-fallback keywords (me, it,
+      // you, … are injected for every language): ñit'iy → ñ + it + 'iy.
+      // isQuechuaLetter keeps the glottal apostrophe inside the word.
+      if (word.length > 0 && this.context.isKeywordStartAtBoundary?.(input, pos, isQuechuaLetter)) {
         break;
       }
       word += input[pos];

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -4743,6 +4743,50 @@ describe("qu curated apostrophe rows — ñit'iy keyword + event-source wrapper 
   });
 });
 
+describe('qu word-walk keyword breaks require a word boundary (systemic #387 follow-up)', () => {
+  // #387 fixed one live instance (ñit'iy) by adding it as a keyword, but the
+  // hazard was systemic: the keyword table injects English canonical reference
+  // words (me, it, you, …) for EVERY language, and the qu word-walk broke at
+  // any position where a known keyword merely starts (raw startsWith). Any
+  // unknown space-delimited word with an embedded fallback split mid-word.
+  // The walk now uses isKeywordStartAtBoundary (framework base-tokenizer) with
+  // isQuechuaLetter, so a break needs the match to end at a word boundary —
+  // and the longest-keyword scan at word start applies the same guard, so a
+  // keyword prefix no longer steals the front of a longer word (ñit'iyq).
+  function values(input: string): string[] {
+    return getTokenizer('qu')
+      .tokenize(input)
+      .tokens.map((t: { value: string }) => t.value);
+  }
+
+  it('[qu] unknown word with embedded English fallback "it" stays whole', () => {
+    expect(values('umitaq')).toEqual(['umitaq']);
+  });
+
+  it('[qu] unknown word with embedded English fallback "me" stays whole', () => {
+    expect(values('umema')).toEqual(['umema']);
+  });
+
+  it("[qu] keyword-prefix word ñit'iyq stays whole (no click + stray q)", () => {
+    expect(values("ñit'iyq")).toEqual(["ñit'iyq"]);
+  });
+
+  it('[qu] mid-sentence: embedded-fallback word is one token, clause still parses', () => {
+    expect(values('.active ta umitaq man yapay')).toEqual([
+      '.active',
+      'ta',
+      'umitaq',
+      'man',
+      'yapay',
+    ]);
+  });
+
+  it('[qu] agglutinated case suffix still splits at the word boundary', () => {
+    // Boundary-ending keyword breaks are load-bearing: wasita → wasi + ta
+    expect(values('wasita')).toEqual(['wasi', 'ta']);
+  });
+});
+
 describe('id increment dict realign — tambahkan (parses as add) → naikkan (R2 id)', () => {
   // The id dict emitted tambahkan for increment, but tambahkan is the id
   // semantic profile's `add` ALTERNATIVE — increment-counter parsed as


### PR DESCRIPTION
## Summary

Closes the systemic hazard behind #387. The framework keyword table injects English canonical reference words (`me`, `it`, `you`, …) as fallbacks for **every** language, and `isKeywordStart` is a raw `startsWith` over all keywords — so in space-delimited scripts, any native word containing an embedded fallback split mid-word (qu `umitaq` → `um` + `it`…). #387 fixed the one live instance by adding `ñit'iy` as a keyword; this PR fixes the class.

> Stacked on #389 ← #388 ← #387 (depends on #387's `ñit'iy` keyword row — the new `ñit'iyq` regression test and test-file anchor both require it). Retarget to the parent's base as the stack merges down.

## Changes

- **framework**: new `BaseTokenizer.isKeywordStartAtBoundary(input, pos, isWordChar?)` — only fires when the keyword match ends at end-of-input or a non-word char, with a language-specific letter predicate (default: Unicode letters/digits/underscore). Exposed as an **optional** `TokenizerContext` method (hand-rolled contexts unaffected) and bound in `createTokenizerContext`.
- **semantic/qu**: both keyword paths in `quechua-keyword.ts` now use the boundary check with `isQuechuaLetter` (glottal apostrophe counts as a letter):
  1. the word-walk break — `umitaq`/`umema` stay whole;
  2. the start-anchored longest-keyword scan — a keyword prefix no longer steals the front of a longer word (`ñit'iyq` no longer yields `ñit'iy[click]` + stray `q`).

  Boundary-ending agglutinative suffix splits are preserved (`wasita` → `wasi` + `ta`).

## Audit of other extractors

qu was the **only** space-delimited extractor with the mid-word break. Korean/Thai/Chinese rely on mid-text keyword starts and keep raw `isKeywordStart` (CJK/no-space behavior unchanged); the Hebrew/Arabic/Japanese `isKeywordStart` calls are no-ops (empty if-bodies that already decline to break mid-word).

## Tests

- `packages/framework/src/core/tokenization/keyword-boundary.test.ts` — 5 contract tests (embedded fallbacks, end-of-input/non-word boundaries, custom word-char predicate).
- New qu describe block in `packages/semantic/test/multilingual-roadmap-fixes.test.ts` — 5 regression tests (`umitaq`, `umema`, `ñit'iyq`, mid-sentence case, `wasita` suffix-split guard).

## Verification

- framework: 764/764, typecheck clean
- semantic: 5807 passed / 9 skipped, typecheck clean; #387 lock tests unchanged
- multilingual gate (`--full --bundle browser-priority --regression`): ✓ no regression (parse-rate, fidelity, correctness, execution ratchets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)