### PR TITLE
chore(testing-framework): dist-freshness guards — CLI refusal + missing pretest hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,16 @@ Both `npm test --prefix packages/<X>` and `npm run test:check` auto-rebuild any 
 
 When you add a new internal-dep relationship between workspace packages, add the dep to the consumer's `pretest` in its `package.json` so its `dist/` stays fresh during tests.
 
+> **Neither hook fires for direct `npx vitest` / `npx tsx` invocations.** That's
+> how the qu "unreproducible baseline" incident happened (roadmap §7g): a sweep
+> executed a stale `dist/` and scored code that differed from the checkout. The
+> multilingual CLI now guards this itself — `--regression` / `--save-baseline`
+> runs REFUSE when any of intent/framework/semantic/i18n/patterns-reference/core
+> has `src/` newer than `dist/index.js` (the dist sibling of the patterns.db
+> provenance stamp). If you run vitest directly after editing an upstream
+> package, rebuild it first (`npm run check:fresh` or `npm run build --prefix
+packages/<dep>`); a green suite against a stale dist is vacuously green.
+
 ### Live Testing
 
 ```bash

--- a/packages/semantic/package.json
+++ b/packages/semantic/package.json
@@ -213,6 +213,7 @@
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
     "build:browser": "tsup src/browser.ts --format iife --global-name LokaScriptSemantic --minify",
     "dev": "tsup --watch",
+    "pretest": "../../scripts/ensure-fresh.sh ../intent ../framework",
     "test": "bash ../../scripts/vitest-run.sh",
     "test:run": "vitest run",
     "test:check": "VITEST_QUIET=1 bash ../../scripts/vitest-run.sh --reporter=dot",

--- a/packages/testing-framework/package.json
+++ b/packages/testing-framework/package.json
@@ -44,6 +44,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
+    "pretest": "../../scripts/ensure-fresh.sh ../intent ../framework ../semantic ../patterns-reference ../core",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/packages/testing-framework/src/multilingual/cli.ts
+++ b/packages/testing-framework/src/multilingual/cli.ts
@@ -5,9 +5,61 @@
  * Command-line interface for running multilingual tests.
  */
 
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { checkDbStamp, getDefaultDbPath } from '@hyperfixi/patterns-reference';
 import { TestOrchestrator } from './orchestrator';
 import type { TestConfig, LanguageCode } from './types';
+
+/**
+ * Packages whose dist/ this harness executes (directly or via imports), in
+ * topological build order. The sibling of the patterns.db provenance stamp:
+ * a sweep against a stale dist scores code that differs from the checkout.
+ */
+const DIST_GUARD_PACKAGES = [
+  'intent',
+  'framework',
+  'semantic',
+  'i18n',
+  'patterns-reference',
+  'core',
+];
+
+/** True if any .ts under dir is newer than builtAt (early-exit walk). */
+function hasNewerTs(dir: string, builtAt: number): boolean {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (hasNewerTs(p, builtAt)) return true;
+    } else if (entry.name.endsWith('.ts') && fs.statSync(p).mtimeMs > builtAt) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Names of guard packages whose src/ is newer than their built dist/ (or whose
+ * dist/ is missing entirely). Same staleness semantics as
+ * scripts/ensure-fresh.sh, but read-only — the CLI refuses instead of
+ * rebuilding, so a gate/baseline run never silently mutates build state.
+ */
+function findStaleDists(): string[] {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const packagesRoot = path.resolve(here, '../../..');
+  const stale: string[] = [];
+  for (const name of DIST_GUARD_PACKAGES) {
+    const pkg = path.join(packagesRoot, name);
+    const srcDir = path.join(pkg, 'src');
+    const marker = path.join(pkg, 'dist', 'index.js');
+    if (!fs.existsSync(srcDir)) continue;
+    if (!fs.existsSync(marker) || hasNewerTs(srcDir, fs.statSync(marker).mtimeMs)) {
+      stale.push(name);
+    }
+  }
+  return stale;
+}
 
 /**
  * Parse command-line arguments
@@ -228,6 +280,24 @@ async function main(): Promise<void> {
           '⚠ patterns.db has no provenance stamp (generated before the freshness guard); ' +
             'cannot verify it is fresh. Re-sync if results look surprising.'
         );
+      }
+
+      // Dist freshness guard (the db stamp's sibling): this CLI is normally
+      // invoked via `npx tsx`, which skips the pretest ensure-fresh hooks, and
+      // it executes the parser stack from dist/. A gate or --save-baseline run
+      // against a stale dist scores code that differs from the checkout — the
+      // "baseline saved from a transitional build" footgun (roadmap §7g/§10).
+      // Refuse rather than auto-rebuild so the run never mutates build state.
+      const staleDists = findStaleDists();
+      if (staleDists.length > 0) {
+        console.error(
+          `\n✗ Stale dist/ in: ${staleDists.join(', ')} — src/ is newer than the built output,\n` +
+            '  so this run would execute code that differs from the checkout (and a saved\n' +
+            '  baseline would not reproduce). Rebuild first:\n\n' +
+            staleDists.map(p => `    npm run build --prefix packages/${p}`).join('\n') +
+            '\n\n  (or rebuild the whole stack: npm run test:multilingual:build-deps)\n'
+        );
+        process.exit(1);
       }
     }
 


### PR DESCRIPTION
## Summary

Closes the stale-dist trap found during session 8 (roadmap §7g): the multilingual harness executes the parser stack from `dist/` but is normally invoked via `npx tsx`, which skips every pretest hook — so a gate or `--save-baseline` run can silently score code that differs from the checkout. That's how the unreproducible qu baseline happened, and the same gap makes a green vitest run vacuous when an upstream dist is stale.

## Changes

1. **CLI guard** — `--regression` / `--save-baseline` runs now refuse when any of `intent`/`framework`/`semantic`/`i18n`/`patterns-reference`/`core` has `src/` newer than `dist/index.js`. Deliberately read-only (refuse + print per-package rebuild commands, never auto-rebuild) so a gate run can't mutate build state. Sibling of the existing patterns.db provenance stamp, same placement in `main()`.
2. **Missing pretest hooks** — `semantic` and `testing-framework` get the `ensure-fresh.sh` pretest hooks the repo convention prescribes (CLAUDE.md: "add the dep to the consumer's pretest") but never had.
3. **CLAUDE.md** — documents the uncovered path and the guard.

## Verification

- Guard refuses on poked src mtimes AND caught a genuinely stale i18n dist (built from another branch's content) during testing
- Passes cleanly after rebuild; en quick gate green vs committed baseline
- `npm test --prefix packages/semantic` shows the pretest hook firing; testing-framework `typecheck` clean; validator locks 7/7

Independent of the open R2 stack (#391 → #389 → #390) — no file overlap; can merge in any order relative to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)