### PR TITLE
Make en if/unless control-flow parse and execute (parsing-track reopen + propertyAccess runtime gap)

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -489,6 +489,48 @@ else B end` parses as flat siblings if(condition:'I') + A + B; the
   build gotcha recurred and would have silently laundered a real regression
   into the new baseline.**
 
+## 7h. Status update (2026-06-12, post-#393 — session 9): en if/unless EXECUTES
+
+**Both reopened tracks (§9 owner decision) land their first increment in one PR
+(#396). en control-flow now PARSES and EXECUTES end-to-end** — `if I match
+.active then A else B end` and `if target matches .modal-backdrop hide …`
+produce the correct DOM effects in a jsdom run. Three fixes, each independently
+gated:
+
+1. **Parsing — en if/else fold (`semantic-parser.tryParseConditionalBlock`).**
+`parseBodyWithClauses` folds an English-order `if <cond> [then] <body> [else
+<body>] [end]` into a `ConditionalSemanticNode`: full condition capture (up to
+   an explicit `then` or the first command verb, copula-guarded so `is empty`
+   stays in the condition) + recursively-parsed then/else branches. `unless` is
+   left flat on purpose — the conditional node is always action `if`, and folding
+   `unless` relabels its action and desyncs the cross-language action-set
+   comparison (caught as a 12-language faithful→lossy mid-implementation). Action
+   fidelity is recursion-aware, so nesting changes no reference action set — the
+   gate is green with **no baseline change**.
+2. **Core runtime — `propertyAccess` evaluator (§10.7 gap).** The core parser
+   emits `memberExpression`, so `evaluateAST` never handled `propertyAccess`; the
+   semantic→AST builder emits it for property paths fed straight into the runtime,
+   so valid semantic ASTs crashed `Unknown AST node type: propertyAccess` (this
+   blocked dropdown-toggle). Added an evaluator sharing `resolveNamedProperty`
+   with member access.
+3. **Expression parser — keyword comparison operators.** `is`/`matches`/
+   `contains`/`in` were matched by `checkValue()` (peek-only) but read via
+   `previous()` without advancing, so the operator was unconsumed and the operand
+   mis-attributed (`target matches .modal-backdrop` → broken `matches.modal`).
+   Now they consume properly, `match` aliases `matches`, and a selector tokenizes
+   after a comparison keyword.
+
+**Validation:** multilingual `--regression` gate green (all four ratchets, no
+baseline change); semantic 5813, expression-parser 36, core
+expressions/control-flow/parser 2580, runtime-ast-coverage 75; typechecks clean.
+
+**Next (deliberately deferred):** R2 execution-subset expansion to the
+now-executable control-flow patterns (baseline regen + subset-lock in one PR;
+the band INVERTS per §10.5). Remaining condition forms still needing
+expression-parser work: `is empty` with a possessive space-phrase subject (`my
+value is empty`) and the `exists` postfix (`#modal exists`). Other §10.7 runtime
+gaps (`@attr` family, `make` HTML-literal, `halt the event`) untouched.
+
 ## 8. R1 / R2 — role-fidelity and execution ratchets (extend R0)
 
 Action-set fidelity (R0's signal) cannot see a parse that finds the right

--- a/packages/core/src/parser/runtime-ast-coverage.test.ts
+++ b/packages/core/src/parser/runtime-ast-coverage.test.ts
@@ -7,10 +7,13 @@
  * templateLiteral, and the `does not contain` / `does not include` operator
  * cases.
  *
- * Note: `propertyAccess`, `optionalChain`, and `positionalExpression` from
- * pratt-parser fragments are NOT reached via the canonical PARSER_TABLE
- * (parser.ts uses memberExpression instead). Handlers for those types are
- * intentionally omitted; tests for them would exercise unreachable code.
+ * Note: the canonical core PARSER_TABLE never produces `propertyAccess`,
+ * `optionalChain`, or `positionalExpression` (parser.ts uses memberExpression
+ * instead). `optionalChain`/`positionalExpression` handlers remain omitted. But
+ * `propertyAccess` IS reachable cross-package: the semantic→AST builder
+ * (@lokascript/semantic) emits it for property paths fed straight into this
+ * runtime, so it now has a handler (and the coverage test below feeds the node
+ * shape directly, since the core parser won't produce it).
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -137,6 +140,42 @@ describe('AST evaluator coverage', () => {
     it('${arr.join("-")} works on locals array', async () => {
       const locals = new Map<string, unknown>([['arr', [1, 2, 3]]]);
       expect(await evalArg('return `${arr.join("-")}`', { locals })).toBe('1-2-3');
+    });
+  });
+
+  // `propertyAccess` is never produced by the core parser (it emits
+  // `memberExpression`), but the semantic→AST builder (@lokascript/semantic)
+  // emits it for property paths (`item.name`) fed straight into this runtime.
+  // Before the handler was added, evaluateAST threw `Unknown AST node type:
+  // propertyAccess`. These feed the node shape directly (the parser won't make it).
+  describe('propertyAccess (semantic→AST-builder property paths)', () => {
+    const paNode = (objectName: string, property: string) => ({
+      type: 'propertyAccess' as const,
+      object: { type: 'identifier' as const, name: objectName },
+      property,
+    });
+
+    it('resolves object.property from a local', async () => {
+      const ctx = {
+        ...createContext(),
+        registry: FULL_REGISTRY,
+      } as any;
+      ctx.locals.set('item', { name: 'alice' });
+      expect(await evaluateAST(paNode('item', 'name') as any, ctx)).toBe('alice');
+    });
+
+    it('reads a DOM element property via getElementProperty semantics', async () => {
+      const el = document.createElement('input');
+      el.value = 'typed';
+      const ctx = { ...createContext(), registry: FULL_REGISTRY } as any;
+      ctx.locals.set('field', el);
+      expect(await evaluateAST(paNode('field', 'value') as any, ctx)).toBe('typed');
+    });
+
+    it('silent null access returns undefined (does not throw)', async () => {
+      const ctx = { ...createContext(), registry: FULL_REGISTRY } as any;
+      ctx.locals.set('nada', null);
+      expect(await evaluateAST(paNode('nada', 'x') as any, ctx)).toBeUndefined();
     });
   });
 

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -88,6 +88,7 @@ type ObjectLiteralNode = ASTNode & {
   properties: Array<{ key: ASTNode & { valueType?: string }; value: ASTNode }>;
 };
 type AttributeAccessNode = ASTNode & { attributeName: string };
+type PropertyAccessNode = ASTNode & { object: ASTNode; property: string };
 type PropertyOfNode = ASTNode & { property: ASTNode; target: ASTNode };
 type TemplateLiteralNode = ASTNode & { value: string };
 type CollectionNode = ASTNode & {
@@ -182,6 +183,11 @@ export async function evaluateAST(node: ASTNode, context: ExecutionContext): Pro
 
     case 'memberExpression':
       return evaluateMemberExpression(n, context);
+
+    // Semantic→AST-builder property paths (`item.name`). The core parser uses
+    // `memberExpression`, so this only arrives from `@lokascript/semantic`.
+    case 'propertyAccess':
+      return evaluatePropertyAccess(n, context);
 
     case 'callExpression':
       return evaluateCallExpression(n, context);
@@ -1378,36 +1384,63 @@ async function evaluateMemberExpression(node: MemberNode, context: ExecutionCont
     return object?.[property];
   } else {
     // Non-computed access: object.property
-    const propertyName = node.property.name as string;
-
-    // Handle attribute access (@attr → getAttribute)
-    if (typeof propertyName === 'string' && propertyName.startsWith('@')) {
-      const attrName = propertyName.substring(1);
-      if (object && typeof object.getAttribute === 'function') {
-        return object.getAttribute(attrName);
-      }
-      return undefined;
-    }
-
-    // Element property access routes through getElementProperty so that
-    // `me.*background-color` (parsed as property "computed-background-color")
-    // and special DOM properties resolve correctly. Plain object access
-    // falls back to a direct lookup.
-    if (object instanceof Element && typeof propertyName === 'string') {
-      return getElementProperty(object, propertyName);
-    }
-
-    // A classRef/queryRef collection maps `.prop` over every member, so the dot
-    // form matches the possessive form: `.cb.checked` === `.cb's checked` →
-    // [true, false]. Same guard as the possessive evaluator (element/host
-    // collections only; skips collection-own props so `.items.length` is still
-    // the count) — delegate to it for one source of truth.
-    if (isMappableCollection(object) && !(propertyName in (object as object))) {
-      return getExpr(context, 'possessive').evaluate(context, object, propertyName);
-    }
-
-    return object?.[propertyName];
+    return resolveNamedProperty(object, node.property.name as string, context);
   }
+}
+
+/**
+ * Resolve a named (non-computed) property off an already-evaluated object,
+ * with hyperscript's DOM-aware semantics: `@attr` → getAttribute, Element
+ * properties through getElementProperty (so `me.*background-color` and special
+ * DOM props resolve), and collection mapping (`.cb.checked` → [true, false]).
+ * Shared by the `memberExpression` (parser-produced) and `propertyAccess`
+ * (semantic→AST-builder-produced) evaluators so both behave identically.
+ */
+function resolveNamedProperty(object: any, propertyName: string, context: ExecutionContext): any {
+  // Handle attribute access (@attr → getAttribute)
+  if (typeof propertyName === 'string' && propertyName.startsWith('@')) {
+    const attrName = propertyName.substring(1);
+    if (object && typeof object.getAttribute === 'function') {
+      return object.getAttribute(attrName);
+    }
+    return undefined;
+  }
+
+  // Element property access routes through getElementProperty so that
+  // `me.*background-color` (parsed as property "computed-background-color")
+  // and special DOM properties resolve correctly. Plain object access
+  // falls back to a direct lookup.
+  if (object instanceof Element && typeof propertyName === 'string') {
+    return getElementProperty(object, propertyName);
+  }
+
+  // A classRef/queryRef collection maps `.prop` over every member, so the dot
+  // form matches the possessive form: `.cb.checked` === `.cb's checked` →
+  // [true, false]. Same guard as the possessive evaluator (element/host
+  // collections only; skips collection-own props so `.items.length` is still
+  // the count) — delegate to it for one source of truth.
+  if (isMappableCollection(object) && !(propertyName in (object as object))) {
+    return getExpr(context, 'possessive').evaluate(context, object, propertyName);
+  }
+
+  return object?.[propertyName];
+}
+
+/**
+ * Evaluate a `propertyAccess` node. The canonical core parser emits
+ * `memberExpression` for dotted access, so this node type is never produced by
+ * `parse()` — but the semantic→AST builder (`@lokascript/semantic`) emits
+ * `propertyAccess` for property paths (e.g. `item.name`) it feeds straight into
+ * this runtime. Without this case the runtime threw `Unknown AST node type:
+ * propertyAccess` on otherwise-valid semantic ASTs. Resolves `object.property`
+ * with the same DOM-aware semantics as non-computed member access.
+ */
+async function evaluatePropertyAccess(
+  node: PropertyAccessNode,
+  context: ExecutionContext
+): Promise<any> {
+  const object = await evaluateAST(node.object, context);
+  return resolveNamedProperty(object, node.property, context);
 }
 
 /**

--- a/packages/semantic/src/ast-builder/expression-parser/parser.ts
+++ b/packages/semantic/src/ast-builder/expression-parser/parser.ts
@@ -129,14 +129,29 @@ export class ExpressionParser {
   private parseEquality(): ExpressionNode {
     let left = this.parseComparison();
 
-    while (
-      this.match(TokenType.COMPARISON) ||
-      this.checkValue('is') ||
-      this.checkValue('matches') ||
-      this.checkValue('contains') ||
-      this.checkValue('in')
-    ) {
-      const operator = this.previous().value;
+    while (true) {
+      let operator: string;
+      if (this.match(TokenType.COMPARISON)) {
+        // match() already consumed the symbolic comparison token.
+        operator = this.previous().value;
+      } else if (
+        this.checkValue('is') ||
+        this.checkValue('matches') ||
+        this.checkValue('match') ||
+        this.checkValue('contains') ||
+        this.checkValue('in')
+      ) {
+        // Keyword infix operators are tokenized as IDENTIFIER, so they must be
+        // CONSUMED here (checkValue only peeks — mirrors the advance() in
+        // parseAnd/parseOr). Reading previous() without advancing left the
+        // operator unconsumed and mis-attributed the operand (e.g. `target
+        // matches .x` parsed as a broken `matches.x` member access). `match` is
+        // the corpus's bare alias of `matches`.
+        const raw = this.advance().value;
+        operator = raw.toLowerCase() === 'match' ? 'matches' : raw;
+      } else {
+        break;
+      }
       const right = this.parseComparison();
       left = this.createBinaryExpression(operator, left, right);
     }

--- a/packages/semantic/src/ast-builder/expression-parser/tokenizer.ts
+++ b/packages/semantic/src/ast-builder/expression-parser/tokenizer.ts
@@ -84,6 +84,15 @@ const LOGICAL_OPERATORS = new Set(['and', 'or', 'not', 'no']);
 
 const BOOLEAN_LITERALS = new Set(['true', 'false', 'null', 'undefined']);
 
+/**
+ * Keyword infix comparison operators (tokenized as IDENTIFIER, matched by value
+ * in the parser). A selector is valid immediately after one — `target matches
+ * .modal-backdrop`, `me matches .active` — so `previousTokenAllowsSelector`
+ * treats them like the symbolic comparison operators. `match` is accepted as an
+ * alias of `matches` (the multilingual corpus uses the bare form).
+ */
+const COMPARISON_KEYWORDS = new Set(['is', 'matches', 'match', 'contains', 'in']);
+
 const TIME_UNITS = new Set([
   'ms',
   's',
@@ -112,6 +121,11 @@ export function tokenize(input: string): Token[] {
   function previousTokenAllowsSelector(): boolean {
     if (tokens.length === 0) return true;
     const prev = tokens[tokens.length - 1];
+    // A keyword comparison operator (tokenized as IDENTIFIER) is followed by a
+    // selector operand: `matches .modal-backdrop`, `is .active`.
+    if (prev.type === TokenType.IDENTIFIER && COMPARISON_KEYWORDS.has(prev.value.toLowerCase())) {
+      return true;
+    }
     // After these token types, a selector is valid
     return [
       TokenType.OPERATOR,

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -8,6 +8,7 @@
 import type {
   SemanticNode,
   CommandSemanticNode,
+  CompoundSemanticNode,
   EventHandlerSemanticNode,
   SemanticParser as ISemanticParser,
   SemanticValue,
@@ -20,6 +21,7 @@ import {
   createCommandNode,
   createEventHandler,
   createCompoundNode,
+  createConditionalNode,
   createSelector,
   createLiteral,
   createReference,
@@ -628,6 +630,23 @@ export class SemanticParserImpl implements ISemanticParser {
     while (!tokens.isAtEnd()) {
       const current = tokens.peek();
       if (!current) break;
+
+      // Fold a leading `if`/`unless` block into a ConditionalSemanticNode.
+      // At a clause boundary (no tokens accumulated for a pending command), an
+      // `if`/`unless` keyword introduces a conditional whose condition + then/else
+      // branches must nest under one node — otherwise the branches flatten into
+      // sibling commands and the condition truncates to its first token (the §2
+      // dominant cluster, observable in English itself). `tryParseConditionalBlock`
+      // consumes the whole block from the stream and returns the conditional, or
+      // null without consuming when the head isn't a usable conditional — so a
+      // non-conditional clause is byte-identical to the previous behavior.
+      if (currentClauseTokens.length === 0) {
+        const conditional = this.tryParseConditionalBlock(tokens, commandPatterns, language);
+        if (conditional) {
+          clauses.push(conditional);
+          continue;
+        }
+      }
 
       // Check if this is a conjunction token (clause boundary)
       const isConjunction =
@@ -1840,6 +1859,222 @@ export class SemanticParserImpl implements ISemanticParser {
     const curated = endKeywords[language];
     if (curated) return curated.has(v);
     return v === 'end' || this.profileKeywordMatches(language, 'end', v);
+  }
+
+  /**
+   * Check if a token value is an `if` keyword in the given language (profile
+   * primary + alternatives, with the English literal always accepted).
+   */
+  private isIfKeyword(value: string, language: string): boolean {
+    const v = value.toLowerCase();
+    if (v === 'if') return true;
+    return this.profileKeywordMatches(language, 'if', v);
+  }
+
+  /**
+   * Check if a token value is an `unless` keyword (negated conditional).
+   */
+  private isUnlessKeyword(value: string, language: string): boolean {
+    const v = value.toLowerCase();
+    if (v === 'unless') return true;
+    return this.profileKeywordMatches(language, 'unless', v);
+  }
+
+  /**
+   * Copula / negation words that, when they immediately precede a token, keep that
+   * token inside the condition even if it doubles as a command verb. `empty` is
+   * both the `empty` command and the predicate adjective in `is empty`; without
+   * this guard `if my value is empty add …` would truncate the condition at
+   * `empty` and treat it as the then-branch's first command.
+   */
+  private static readonly CONDITION_COPULAS = new Set([
+    'is',
+    'am',
+    'are',
+    'be',
+    'was',
+    'were',
+    'not',
+    'no',
+  ]);
+
+  /**
+   * Parse a leading `if`/`unless` conditional block from the stream into a
+   * ConditionalSemanticNode, consuming the whole block (condition + then/else
+   * branches, up to the matching `end` or the stream end). Returns null WITHOUT
+   * consuming when the head token is not an `if`/`unless` keyword or no condition
+   * is present, so the caller falls through unchanged.
+   *
+   * Word-order scope: this matches the English-style `if <cond> [then] <body>
+   * [else <body>] [end]` order (the §2 dominant cluster, which manifests in
+   * English itself). SOV/VSO transforms place the condition/branches differently;
+   * those clauses don't start with a bare `if`/`unless` keyword here, so they fall
+   * through to the existing per-clause path untouched.
+   */
+  private tryParseConditionalBlock(
+    tokens: ReturnType<typeof tokenizeInternal>,
+    commandPatterns: LanguagePattern[],
+    language: string
+  ): SemanticNode | null {
+    const head = tokens.peek();
+    if (!head) return null;
+    const headVal = (head.normalized ?? head.value).toLowerCase();
+    // Fold `if` only. `unless` is deliberately left on its existing flat parse:
+    // a conditional node is always action `if`, so folding `unless` would relabel
+    // its action from `unless` to `if` and desync the cross-language action-set
+    // comparison (every language that still emits `unless` would read as having
+    // dropped the conditional). Folding `if` keeps the same `if` action the flat
+    // parse already produced, so no action set changes — only the nesting and the
+    // (previously truncated) condition do.
+    if (!this.isIfKeyword(headVal, language)) return null;
+
+    const startMark = tokens.mark();
+    tokens.advance(); // consume if/unless
+
+    // Collect the whole block from the stream: every token up to the matching
+    // depth-0 `end` (or the stream end). Nested `if`/`unless` raise the depth; a
+    // nested `end` lowers it — so an inner conditional's `end` never terminates
+    // the outer block.
+    const blockTokens: LanguageToken[] = [];
+    let depth = 0;
+    while (!tokens.isAtEnd()) {
+      const t = tokens.peek();
+      if (!t) break;
+      const tv = (t.normalized ?? t.value).toLowerCase();
+      if (this.isIfKeyword(tv, language) || this.isUnlessKeyword(tv, language)) {
+        depth++;
+        blockTokens.push(t);
+        tokens.advance();
+        continue;
+      }
+      if (this.isEndKeyword(t.value, language)) {
+        if (depth === 0) {
+          tokens.advance(); // consume the terminating `end`
+          break;
+        }
+        depth--;
+        blockTokens.push(t);
+        tokens.advance();
+        continue;
+      }
+      blockTokens.push(t);
+      tokens.advance();
+    }
+
+    if (blockTokens.length === 0) {
+      tokens.reset(startMark);
+      return null;
+    }
+
+    // Split blockTokens into condition / then-branch / else-branch. The condition
+    // ends at the first depth-0 `then` keyword, or at the first depth-0 token that
+    // begins a command (copula-guarded). then/else are split at depth-0 `else`.
+    let i = 0;
+    let bodyDepth = 0;
+    const condTokens: LanguageToken[] = [];
+    let sawThen = false;
+    for (; i < blockTokens.length; i++) {
+      const t = blockTokens[i];
+      const tv = (t.normalized ?? t.value).toLowerCase();
+      if (this.isIfKeyword(tv, language) || this.isUnlessKeyword(tv, language)) bodyDepth++;
+      else if (this.isEndKeyword(t.value, language)) bodyDepth--;
+      if (bodyDepth === 0 && this.isThenKeyword(t.value, language)) {
+        sawThen = true;
+        i++; // skip the `then`
+        break;
+      }
+      if (bodyDepth === 0 && condTokens.length > 0) {
+        const prev = (blockTokens[i - 1].normalized ?? blockTokens[i - 1].value).toLowerCase();
+        if (
+          !SemanticParserImpl.CONDITION_COPULAS.has(prev) &&
+          this.tokensBeginCommand(blockTokens.slice(i), commandPatterns, language)
+        ) {
+          break; // this token starts the then-branch
+        }
+      }
+      condTokens.push(t);
+    }
+
+    if (condTokens.length === 0) {
+      tokens.reset(startMark);
+      return null;
+    }
+    void sawThen;
+
+    // Partition the remaining tokens into then- / else-branch at the depth-0 else.
+    const thenTokens: LanguageToken[] = [];
+    const elseTokens: LanguageToken[] = [];
+    let inElse = false;
+    let branchDepth = 0;
+    for (; i < blockTokens.length; i++) {
+      const t = blockTokens[i];
+      const tv = (t.normalized ?? t.value).toLowerCase();
+      if (this.isIfKeyword(tv, language) || this.isUnlessKeyword(tv, language)) branchDepth++;
+      else if (this.isEndKeyword(t.value, language)) branchDepth--;
+      if (branchDepth === 0 && !inElse && this.isElseKeyword(t.value, language)) {
+        inElse = true;
+        continue; // skip the `else`
+      }
+      (inElse ? elseTokens : thenTokens).push(t);
+    }
+
+    const conditionValue = { type: 'expression' as const, raw: this.joinTokenText(condTokens) };
+
+    const thenBranch = this.parseBranch(thenTokens, commandPatterns, language);
+    const elseBranch =
+      elseTokens.length > 0 ? this.parseBranch(elseTokens, commandPatterns, language) : undefined;
+
+    // Nothing parsed in either branch — not a usable conditional; fall through so
+    // the existing per-clause path can try (e.g. a stray `if` token).
+    if (thenBranch.length === 0 && (!elseBranch || elseBranch.length === 0)) {
+      tokens.reset(startMark);
+      return null;
+    }
+
+    return createConditionalNode(conditionValue, thenBranch, elseBranch, {
+      sourceLanguage: language,
+      patternId: `conditional-${language}-folded`,
+      confidence: 1,
+    });
+  }
+
+  /** Reconstruct source-ish text from a token slice for an expression value. */
+  private joinTokenText(toks: readonly LanguageToken[]): string {
+    return toks
+      .map(t => t.value)
+      .join(' ')
+      .trim();
+  }
+
+  /** Whether a command pattern matches at the head of the given token slice. */
+  private tokensBeginCommand(
+    toks: LanguageToken[],
+    commandPatterns: LanguagePattern[],
+    language: string
+  ): boolean {
+    if (toks.length === 0) return false;
+    const stream = new TokenStreamImpl(toks, language);
+    return patternMatcher.matchBest(stream, commandPatterns) !== null;
+  }
+
+  /**
+   * Parse a conditional branch's tokens into a flat list of statements. Reuses
+   * `parseBodyWithClauses` (so then-chains, juxtaposed commands, and nested
+   * conditionals inside the branch all work), then unwraps a single top-level
+   * compound into its statements so the branch array is flat.
+   */
+  private parseBranch(
+    toks: LanguageToken[],
+    commandPatterns: LanguagePattern[],
+    language: string
+  ): SemanticNode[] {
+    if (toks.length === 0) return [];
+    const stream = new TokenStreamImpl(toks, language);
+    const parsed = this.parseBodyWithClauses(stream, commandPatterns, language);
+    if (parsed.length === 1 && parsed[0]?.kind === 'compound') {
+      return (parsed[0] as CompoundSemanticNode).statements;
+    }
+    return parsed;
   }
 
   /**

--- a/packages/semantic/test/expression-parser.test.ts
+++ b/packages/semantic/test/expression-parser.test.ts
@@ -331,4 +331,45 @@ describe('ExpressionParser', () => {
       expect(result.success).toBe(false);
     });
   });
+
+  // Keyword infix comparison operators (is/matches/contains/in) are tokenized as
+  // IDENTIFIER and must be CONSUMED in parseEquality (checkValue only peeks).
+  // Previously they were read via previous() without advancing, so the operator
+  // was unconsumed and the operand mis-attributed — `target matches .x` came out
+  // as a broken `matches.x` member access. This locks the consume + the selector
+  // operand (a class selector tokenizes after a comparison keyword) + the `match`
+  // → `matches` corpus alias. These conditions gate en control-flow execution.
+  describe('keyword comparison operators with selector operands', () => {
+    it('parses `target matches .modal-backdrop` as a matches binary (selector intact)', () => {
+      const result = parseExpression('target matches .modal-backdrop');
+      expect(result.success).toBe(true);
+      expect(result.node).toMatchObject({
+        type: 'binaryExpression',
+        operator: 'matches',
+        left: { type: 'contextReference', name: 'target' },
+        right: { type: 'selector', value: '.modal-backdrop' },
+      });
+    });
+
+    it('accepts the bare `match` form as an alias of `matches`', () => {
+      const result = parseExpression('I match .active');
+      expect(result.success).toBe(true);
+      expect(result.node).toMatchObject({
+        type: 'binaryExpression',
+        operator: 'matches',
+        right: { type: 'selector', value: '.active' },
+      });
+    });
+
+    it('parses `result is false` as an `is` binary', () => {
+      const result = parseExpression('result is false');
+      expect(result.success).toBe(true);
+      expect(result.node).toMatchObject({
+        type: 'binaryExpression',
+        operator: 'is',
+        left: { type: 'contextReference', name: 'result' },
+        right: { type: 'literal', value: false },
+      });
+    });
+  });
 });

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -3126,17 +3126,30 @@ describe('empty-predicate adjective is a profile keyword alternative (is-empty c
     expect(a.has('empty')).toBe(true);
   });
 
-  it('[en] the en reference parse is unchanged', () => {
-    const a = actions(
-      parse(
-        'on blur if my value is empty add .error to me put "Required" into next .error-message end',
-        'en'
-      )
-    );
+  it('[en] folds the if into a conditional; `is empty` is the condition, not a spurious `empty` command', () => {
+    // The en if/unless conditional fold (semantic-parser.tryParseConditionalBlock)
+    // captures `my value is empty` as the condition EXPRESSION and nests the body
+    // under a conditional node. Previously the predicate adjective `empty` matched
+    // the `empty` COMMAND primary and surfaced as a spurious top-level action; it
+    // is now correctly part of the condition, so the reference action set is
+    // {on, if, add, put} with no bogus `empty`.
+    const node = parse(
+      'on blur if my value is empty add .error to me put "Required" into next .error-message end',
+      'en'
+    ) as Record<string, unknown>;
+    const a = actions(node);
     expect(a.has('if')).toBe(true);
-    expect(a.has('empty')).toBe(true);
     expect(a.has('add')).toBe(true);
     expect(a.has('put')).toBe(true);
+    expect(a.has('empty')).toBe(false);
+
+    // The then-branch nests under a conditional whose condition carries the predicate.
+    const handler = node as { body?: Array<Record<string, unknown>> };
+    const conditional = handler.body?.find(n => n.kind === 'conditional');
+    expect(conditional).toBeDefined();
+    const cond = (conditional!.roles as Map<string, { raw?: string }>).get('condition');
+    expect(cond?.raw).toContain('empty');
+    expect(Array.isArray(conditional!.thenBranch)).toBe(true);
   });
 });
 
@@ -4817,5 +4830,94 @@ describe('id increment dict realign — tambahkan (parses as add) → naikkan (R
   it('[id] tambahkan still parses as add (the profile alternative is untouched)', () => {
     const cmd = firstCommand(parse('tambahkan .highlight', 'id'));
     expect(cmd?.action).toBe('add');
+  });
+});
+
+describe('en if/unless conditional fold (parsing track reopen — §2 dominant cluster)', () => {
+  // The semantic parser's body assembly (parseBodyWithClauses →
+  // tryParseConditionalBlock) folds an English-order `if <cond> [then] <body>
+  // [else <body>] [end]` into a ConditionalSemanticNode: the full condition is
+  // captured (previously truncated to its first token) and the then/else branches
+  // nest (previously flattened into sibling commands). This is the §2 dominant
+  // cluster that manifests in English itself and blocked R2 control-flow
+  // expansion. `unless` is intentionally NOT folded (a conditional node is always
+  // action `if`; folding `unless` would relabel its action and desync the
+  // cross-language action-set comparison).
+  function findConditional(node: unknown): Record<string, unknown> | null {
+    if (!node || typeof node !== 'object') return null;
+    const rec = node as Record<string, unknown>;
+    if (rec.kind === 'conditional') return rec;
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      const c = rec[f];
+      if (Array.isArray(c)) {
+        for (const x of c) {
+          const found = findConditional(x);
+          if (found) return found;
+        }
+      }
+    }
+    return null;
+  }
+  const condText = (c: Record<string, unknown>): string =>
+    ((c.roles as Map<string, { raw?: string }>).get('condition')?.raw ?? '') as string;
+  const branchActions = (branch: unknown): string[] =>
+    Array.isArray(branch)
+      ? (branch as Array<Record<string, unknown>>).map(n => String(n.action))
+      : [];
+
+  it('if-condition: full condition + nested then/else branches', () => {
+    const c = findConditional(
+      parse('on click if I match .active then remove .active else add .active end', 'en')
+    );
+    expect(c).not.toBeNull();
+    expect(condText(c!)).toBe('I match .active');
+    expect(branchActions(c!.thenBranch)).toEqual(['remove']);
+    expect(branchActions(c!.elseBranch)).toEqual(['add']);
+  });
+
+  it('if-matches: no explicit `then` — condition ends at the first command verb', () => {
+    const c = findConditional(
+      parse('on click if I match .disabled halt else toggle .active end', 'en')
+    );
+    expect(condText(c!)).toBe('I match .disabled');
+    expect(branchActions(c!.thenBranch)).toEqual(['halt']);
+    expect(branchActions(c!.elseBranch)).toEqual(['toggle']);
+  });
+
+  it('if-exists: else branch keeps a juxtaposed multi-command body', () => {
+    const c = findConditional(
+      parse(
+        'on click if #modal exists show #modal else make a <div#modal/> put it into body end',
+        'en'
+      )
+    );
+    expect(condText(c!)).toBe('#modal exists');
+    expect(branchActions(c!.thenBranch)).toEqual(['show']);
+    expect(branchActions(c!.elseBranch)).toEqual(['make', 'put']);
+  });
+
+  it('is-empty copula guard: `empty` after `is` stays in the condition, not the then-branch', () => {
+    const c = findConditional(
+      parse('on blur if my value is empty add .error to me else remove .error from me end', 'en')
+    );
+    expect(condText(c!)).toBe('my value is empty');
+    expect(branchActions(c!.thenBranch)).toEqual(['add']);
+    expect(branchActions(c!.elseBranch)).toEqual(['remove']);
+  });
+
+  it('no `else`, no `end`: whole remainder is the then-branch', () => {
+    const c = findConditional(
+      parse('on click if target matches .modal-backdrop hide .modal-backdrop end', 'en')
+    );
+    expect(condText(c!)).toBe('target matches .modal-backdrop');
+    expect(branchActions(c!.thenBranch)).toEqual(['hide']);
+    expect(c!.elseBranch).toBeUndefined();
+  });
+
+  it('unless is NOT folded (keeps its flat parse / `unless` action label)', () => {
+    const c = findConditional(
+      parse('on click unless I match .disabled toggle .selected', 'en')
+    );
+    expect(c).toBeNull();
   });
 });


### PR DESCRIPTION
Acts on the two session-8 owner decisions recorded in PR #393 (CORRECTNESS_RELIABILITY_PLAN §9): the surgical parsing-track reopen (en if/unless flatten) and the approved core-runtime gaps track (§10.7). Three commits take en control-flow from "parses as flat siblings, runtime rejects the bare `if`" to **parses and executes end-to-end**.

## What was broken

The §2 dominant cluster manifests in English itself. `if I match .active then A else B end` parsed as flat sibling commands with the condition truncated to its first token (`I`); the runtime then rejected the bare `if`. Even once parsed, two runtime/expression gaps blocked execution.

## The three fixes

1. **`fix(semantic)`: fold en if/else into a conditional node.** `parseBodyWithClauses` now folds an English-order `if <cond> [then] <body> [else <body>] [end]` into a `ConditionalSemanticNode`: the full condition is captured (up to an explicit `then` or the first command verb, with a copula guard so `is empty` stays in the condition), and then/else branches nest and parse recursively. `unless` is deliberately left flat — a conditional node is always action `if`, so folding `unless` would relabel its action and desync the cross-language action-set comparison (caught as a 12-language regression mid-implementation). Action-set fidelity is recursion-aware, so nesting changes no reference action set; the multilingual gate is green with no baseline change.

2. **`fix(core)`: evaluate `propertyAccess` AST nodes in the runtime** (the named §10.7 gap). The core parser emits `memberExpression`, so `evaluateAST` never handled `propertyAccess` — but the semantic→AST builder emits it for property paths fed straight into the runtime, so valid semantic ASTs crashed with `Unknown AST node type: propertyAccess` (this blocked `dropdown-toggle`). Adds an evaluator sharing a `resolveNamedProperty` helper with member access (same `@attr`/Element/collection semantics).

3. **`fix(semantic)`: consume keyword comparison operators + selector operands.** The expression-parser's keyword infix operators (`is`/`matches`/`contains`/`in`) were matched via `checkValue()` (peek-only) but read with `previous()` without advancing, so the operator was unconsumed and the operand mis-attributed (`target matches .modal-backdrop` → broken `matches.modal` member access). Now they consume properly, `match` aliases `matches`, and a selector tokenizes after a comparison keyword.

## Result

`if I match .active then remove .active else add .active end` and `if target matches .modal-backdrop hide …` now produce the correct DOM effects in a jsdom run (verified: the else/then branches fire correctly based on the evaluated condition).

## Validation

- Multilingual `--regression` gate **green** — all four ratchets (parse-rate, fidelity, correctness, execution) hold, **no baseline change**.
- Semantic suite **5813 passed**; expression-parser **36**; core expressions/control-flow/parser **2580**; runtime-ast-coverage **75**. Typechecks clean.
- New lock tests: `multilingual-roadmap-fixes.test.ts` ("en if/unless conditional fold"), `runtime-ast-coverage.test.ts` (propertyAccess), `expression-parser.test.ts` (keyword comparison operators).

## Not in scope (clear next steps)

- **R2 execution-subset expansion** to include the now-executable control-flow patterns (needs the baseline regen + subset-lock update in one PR, per the documented rule; expect the band to "invert" per §10.5).
- **Remaining condition forms**: `is empty` with a possessive space-phrase subject (`my value is empty`) and the `exists` postfix (`#modal exists`) still need expression-parser work (possessive space-form parsing + an `exists` postfix). The `match`/`matches` + single-token-subject conditions are covered here.
- The other §10.7 runtime gaps (`@attr` selector family, `make` HTML-literal selectors, `halt the event` semantics) are untouched.

https://claude.ai/code/session_01HJVa9z2qSf6Ne3nPAbmY8W

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJVa9z2qSf6Ne3nPAbmY8W)_