### PR TITLE
fix(semantic): positional-phrase patients — closest/article-led positionals; R2 wave 3

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -572,11 +572,47 @@ expressions/control-flow/parser 2580, runtime-ast-coverage 75; typechecks clean.
   28 → 29 (dropdown-toggle; `.dropdown-menu` fixture element). Zero
   parse-level fidelity churn from the fold (gate green, no avgFidelity moves).
 
-**Still deferred (the deep en body-parse arc):** `hide closest .modal`
-(modal-close-button) and `show the next <div.tab-panel/>` (tabs-content §10.5)
-still DROP at the semantic parse — body segmentation, not expression work; the
-at-end-of positional put (`put it at end of body`, make-toast-element);
-cross-language conditional folding (SOV/VSO orders).
+## 7i. Status update (2026-06-12, session 10): positional-phrase patients (wave 3)
+
+**The "deep en body-parse arc" turned out to be three small pattern-matcher
+gaps, not body segmentation.** `hide closest .modal` and `show the next
+<div.tab-panel/>` dropped because the role matcher never RECOGNIZED the
+phrase — once the role captures it as one expression, the existing clause
+segmentation, the #400 expression-parser positional fold, and the core
+runtime all already work. Three fixes in `pattern-matcher.ts`:
+
+1. **`closest` joins POSITIONAL_KEYWORDS** — `tryMatchPositionalExpression`
+   only fired for first/last/next/previous/random, so a `closest <sel>`
+   patient/destination rejected the keyword and the whole command dropped from
+   the event body. Bonus surface: destinations — `toggle .x on closest .card`
+   previously captured destination literal `"closest"` (selector stranded) and
+   `add .x to closest .card` silently defaulted to `me`; both now capture the
+   full positional expression (closest-ancestor / accordion-exclusive
+   references improved).
+2. **`skipNoiseWords` skips articles before positional keywords** — `the
+next <div.tab-panel/>` never reached the positional matcher because the
+   article was only skipped before selectors/identifiers (tabs-content §10.5).
+3. **Source-clause command-verb guard** — the positional matcher's optional
+   `<marker> <selector>` source clause accepted ANY keyword as the marker, so
+   in the juxtaposed modal-close-button body (`hide closest .modal remove
+.modal-open from body`) it swallowed `remove` as a locative marker and the
+   following command was lost. Markers whose normalized form is a schema
+   action (`commandSchemas` keys — language-independent) are now refused.
+
+**Validation:** semantic 5835 green; en references for tabs-content (all FOUR
+commands, §10.5 resolved), modal-close-button, closest-ancestor now parse and
+EXECUTE end-to-end in jsdom. Subset 29 → 30 (modal-close-button +
+PATTERN_SETUP giving #btn a `.modal` ancestor); membership lock updated in the
+same PR. **The §10.5 band inversion happened as predicted**: 58 execution rows
+re-recorded (the four improved en signatures now demand correct positional
+behavior the translations don't yet produce — mean executionFidelity 0.7706 →
+0.6957, the recorded-band outcome, NOT a regression). Parse-level fidelity
+unchanged (0.9742; one within-tolerance sw flip). Baseline regenerated; gate
+green against it.
+
+**Still deferred:** the at-end-of positional put (`put it at end of body`,
+make-toast-element); cross-language positional/conditional burn-down (SOV/VSO
+orders — now visible as the widened R2 band).
 
 ## 8. R1 / R2 — role-fidelity and execution ratchets (extend R0)
 

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -23,6 +23,7 @@ import {
   isValidReference,
 } from '../types';
 import { isTypeCompatible } from './utils/type-validation';
+import { commandSchemas } from '../generators/command-schemas';
 import { getPossessiveReference } from './utils/possessive-keywords';
 import type { LanguageProfile } from '../generators/profiles/types';
 import { tryGetProfile } from '../registry';
@@ -562,6 +563,11 @@ export class PatternMatcher {
   /**
    * Positional query keywords (English + normalized forms produced by the
    * tokenizers for every language, e.g. AR آخر→last, TL huli→last).
+   * `closest` is included: `closest <sel>` is the ancestor-scope query form
+   * (`hide closest .modal`, `toggle .x on closest .card`) and folds to the
+   * same call-expression shape the runtime's positional expressions evaluate
+   * (the expression-parser positional fold). Without it the patient/destination
+   * role rejected the keyword and the whole command dropped from event bodies.
    */
   private static readonly POSITIONAL_KEYWORDS = new Set([
     'first',
@@ -569,6 +575,7 @@ export class PatternMatcher {
     'next',
     'previous',
     'random',
+    'closest',
   ]);
 
   /**
@@ -610,6 +617,16 @@ export class PatternMatcher {
     'self',
     'this',
   ]);
+
+  /**
+   * Normalized command-action keywords (the schema registry's action names).
+   * Tokenizers normalize every language's command verbs to these forms, so the
+   * set is language-independent. Used to keep the positional source clause
+   * from consuming a following command's verb as a locative marker.
+   */
+  private static readonly COMMAND_ACTION_KEYWORDS = new Set(
+    Object.keys(commandSchemas).map(a => a.toLowerCase())
+  );
 
   /**
    * Try to match a positional query expression:
@@ -674,7 +691,12 @@ export class PatternMatcher {
       source &&
       source.kind === 'selector' &&
       (marker.kind === 'keyword' || marker.kind === 'particle' || marker.kind === 'identifier') &&
-      !PatternMatcher.POSITIONAL_KEYWORDS.has((marker.normalized ?? marker.value).toLowerCase())
+      !PatternMatcher.POSITIONAL_KEYWORDS.has((marker.normalized ?? marker.value).toLowerCase()) &&
+      // A command verb is never a locative marker: in a juxtaposed body
+      // (`hide closest .modal remove .modal-open from body`) the next clause's
+      // verb (`remove`) would otherwise be swallowed as the source marker and
+      // the following command lost.
+      !PatternMatcher.COMMAND_ACTION_KEYWORDS.has((marker.normalized ?? marker.value).toLowerCase())
     ) {
       parts.push(marker.value, source.value);
       tokens.advance();
@@ -1458,7 +1480,15 @@ export class PatternMatcher {
         return;
       }
 
-      // Not followed by a selector or identifier, revert
+      // "the next <sel>" / "the closest .modal": the article also precedes
+      // positional-phrase heads, which tokenize as keywords/literals — skip it
+      // so tryMatchPositionalExpression sees the positional keyword first.
+      const nextNorm = nextToken ? (nextToken.normalized ?? nextToken.value).toLowerCase() : '';
+      if (nextToken && PatternMatcher.POSITIONAL_OR_SCOPE_KEYWORDS.has(nextNorm)) {
+        return;
+      }
+
+      // Not followed by a selector, identifier, or positional keyword — revert
       tokens.reset(mark);
     }
 

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -4921,3 +4921,86 @@ describe('en if/unless conditional fold (parsing track reopen — §2 dominant c
     expect(c).toBeNull();
   });
 });
+
+describe('en positional-phrase patients — closest <sel> and the-led positionals (R2 wave 3)', () => {
+  // `hide closest .modal` / `show the next <div.tab-panel/>` previously
+  // DROPPED at the semantic parse: `closest` was not a positional-expression
+  // lead keyword (only first/last/next/previous/random), and skipNoiseWords
+  // only skipped `the` before selectors/identifiers — never before a
+  // positional keyword. Both forms now capture the whole phrase as a single
+  // expression value, which the expression parser folds to the positional
+  // call shape the core runtime evaluates (see the #400 fold).
+  function roles(node: unknown): Map<string, { type?: string; raw?: string; value?: string }> {
+    return (node as { roles: Map<string, { type?: string; raw?: string; value?: string }> })
+      .roles;
+  }
+
+  it('hide closest .modal captures the patient as a positional expression', () => {
+    const node = parse('hide closest .modal', 'en') as Record<string, unknown>;
+    expect(node).toBeTruthy();
+    expect(node.action).toBe('hide');
+    const patient = roles(node).get('patient');
+    expect(patient?.type).toBe('expression');
+    expect(patient?.raw).toBe('closest .modal');
+  });
+
+  it('show the next <div.tab-panel/> skips the article and captures the positional', () => {
+    const node = parse('show the next <div.tab-panel/>', 'en') as Record<string, unknown>;
+    expect(node).toBeTruthy();
+    expect(node.action).toBe('show');
+    const patient = roles(node).get('patient');
+    expect(patient?.type).toBe('expression');
+    expect(patient?.raw).toBe('next <div.tab-panel/>');
+  });
+
+  it('toggle … on closest .card captures the destination as a positional expression', () => {
+    // Previously the destination captured the bare literal `closest` and the
+    // selector stranded (closest-ancestor / accordion-toggle corpus rows).
+    const node = parse('on click toggle .expanded on closest .card', 'en') as {
+      body?: Array<Record<string, unknown>>;
+    };
+    const toggle = node.body?.find(n => n.action === 'toggle');
+    expect(toggle).toBeDefined();
+    const dest = roles(toggle).get('destination');
+    expect(dest?.type).toBe('expression');
+    expect(dest?.raw).toBe('closest .card');
+  });
+
+  it('a juxtaposed following command is not swallowed as the positional source clause', () => {
+    // modal-close-button: `hide closest .modal remove .modal-open from body` —
+    // the optional `<marker> <selector>` source clause must not consume the
+    // next clause's verb (`remove`) as a locative marker. Guarded by the
+    // schema-action keyword set (language-independent: tokenizers normalize
+    // every language's verbs to these forms).
+    const node = parse('on click hide closest .modal remove .modal-open from body', 'en') as {
+      body?: Array<Record<string, unknown>>;
+    };
+    const stmts =
+      node.body?.flatMap(n =>
+        n.kind === 'compound' ? (n.statements as Array<Record<string, unknown>>) : [n]
+      ) ?? [];
+    const actions = stmts.map(s => s.action);
+    expect(actions).toContain('hide');
+    expect(actions).toContain('remove');
+    const hide = stmts.find(s => s.action === 'hide')!;
+    expect(roles(hide).get('patient')?.raw).toBe('closest .modal');
+    const remove = stmts.find(s => s.action === 'remove')!;
+    expect(roles(remove).get('patient')?.value).toBe('.modal-open');
+  });
+
+  it('tabs-content parses all four commands including the article-led show', () => {
+    // §10.5: the en reference was lossy (show dropped), which made 13
+    // faithful languages read as failers. All four commands now survive.
+    const node = parse(
+      'on click remove .active from .tab add .active to me hide .tab-panel show the next <div.tab-panel/>',
+      'en'
+    ) as { body?: Array<Record<string, unknown>> };
+    const stmts =
+      node.body?.flatMap(n =>
+        n.kind === 'compound' ? (n.statements as Array<Record<string, unknown>>) : [n]
+      ) ?? [];
+    expect(stmts.map(s => s.action)).toEqual(['remove', 'add', 'hide', 'show']);
+    const show = stmts.find(s => s.action === 'show')!;
+    expect(roles(show).get('patient')?.raw).toBe('next <div.tab-panel/>');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,25 +1,27 @@
 {
-  "timestamp": "2026-06-13T00:22:49.663Z",
-  "commit": "df71fd6",
+  "timestamp": "2026-06-13T00:58:00.188Z",
+  "commit": "98225f69",
   "languages": {
     "ar": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8651992823273096,
+      "avgConfidence": 0.8679433429145073,
       "avgFidelity": 0.9758169934640524,
-      "avgRoleFidelity": 0.8449789439585359,
-      "avgExecutionFidelity": 0.8275862068965517,
+      "avgRoleFidelity": 0.8486070618723681,
+      "avgExecutionFidelity": 0.7666666666666667,
       "executionFailures": [
+        "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["if-exists", "repeat-until-event", "window-scroll"],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -121,6 +123,10 @@
           "success": true,
           "confidence": 1
         },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
         "dropdown-toggle": {
           "success": true,
           "confidence": 1
@@ -174,6 +180,10 @@
           "confidence": 1
         },
         "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -341,14 +351,6 @@
           "success": true,
           "confidence": 0.9722222222222222
         },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.9722222222222222
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 0.9722222222222222
-        },
         "remove-class-basic": {
           "success": true,
           "confidence": 0.9277777777777777
@@ -438,6 +440,10 @@
           "confidence": 0.8642857142857143
         },
         "modal-open": {
+          "success": true,
+          "confidence": 0.8642857142857143
+        },
+        "modal-close-button": {
           "success": true,
           "confidence": 0.8642857142857143
         },
@@ -593,10 +599,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.5
-        },
         "window-scroll": {
           "success": true,
           "confidence": 0.5
@@ -642,11 +644,12 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8430632859204288,
+      "avgConfidence": 0.8477942692228406,
       "avgFidelity": 0.9905844155844155,
-      "avgRoleFidelity": 0.7613175675675675,
-      "avgExecutionFidelity": 0.7586206896551724,
+      "avgRoleFidelity": 0.7641328828828827,
+      "avgExecutionFidelity": 0.7333333333333333,
       "executionFailures": [
+        "accordion-exclusive",
         "if-condition",
         "if-exists",
         "if-matches",
@@ -663,7 +666,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -809,11 +812,19 @@
           "success": true,
           "confidence": 1
         },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 1
+        },
         "modal-close-escape": {
           "success": true,
           "confidence": 1
         },
         "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
           "success": true,
           "confidence": 1
         },
@@ -870,6 +881,10 @@
           "confidence": 1
         },
         "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -1069,15 +1084,7 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "form-disable-on-submit": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "closest-ancestor": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -1185,10 +1192,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.5
-        },
         "form-submit-prevent": {
           "success": true,
           "confidence": 0.5
@@ -1289,19 +1292,23 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8323373793962008,
       "avgFidelity": 0.9782135076252723,
-      "avgRoleFidelity": 0.8229267897635244,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgRoleFidelity": 0.8279154518950437,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "modal-close-button",
+        "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1925,7 +1932,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2549,21 +2556,25 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8371096586782839,
+      "avgConfidence": 0.8352422450461645,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8158325234855849,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgRoleFidelity": 0.8124311629413672,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "modal-close-button",
+        "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -2690,10 +2701,6 @@
           "confidence": 1
         },
         "first-in-parent": {
-          "success": true,
-          "confidence": 1
-        },
-        "last-in-collection": {
           "success": true,
           "confidence": 1
         },
@@ -3037,6 +3044,10 @@
           "success": true,
           "confidence": 0.7142857142857143
         },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "event-key-combo": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -3189,18 +3200,22 @@
       "avgConfidence": 0.8261126672891358,
       "avgFidelity": 0.9803921568627451,
       "avgRoleFidelity": 0.8153223194039522,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "modal-close-button",
+        "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3825,15 +3840,14 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8263201576927067,
       "avgFidelity": 0.9589324618736381,
-      "avgRoleFidelity": 0.8551263362487853,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgRoleFidelity": 0.8587544541626174,
+      "avgExecutionFidelity": 0.8333333333333334,
       "executionFailures": [
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop",
-        "tabs-content"
+        "modal-close-backdrop"
       ],
       "degeneratePasses": [
         "behavior-draggable",
@@ -3851,7 +3865,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4474,11 +4488,12 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.9546072974644388,
+      "avgConfidence": 0.9560915275200976,
       "avgFidelity": 0.928030303030303,
-      "avgRoleFidelity": 0.5768500643500645,
-      "avgExecutionFidelity": 0.5862068965517241,
+      "avgRoleFidelity": 0.5791023166023168,
+      "avgExecutionFidelity": 0.5666666666666667,
       "executionFailures": [
+        "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
@@ -4512,7 +4527,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -4714,6 +4729,10 @@
           "success": true,
           "confidence": 1
         },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
         "accordion-exclusive": {
           "success": true,
           "confidence": 1
@@ -4783,6 +4802,10 @@
           "confidence": 1
         },
         "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -5058,15 +5081,7 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "form-disable-on-submit": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "closest-ancestor": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -5139,15 +5154,19 @@
       "avgConfidence": 0.8404295051353855,
       "avgFidelity": 0.9627450980392157,
       "avgRoleFidelity": 0.8048995788791706,
-      "avgExecutionFidelity": 0.7586206896551724,
+      "avgExecutionFidelity": 0.6333333333333333,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
         "modal-close-backdrop",
-        "set-style"
+        "modal-close-button",
+        "set-style",
+        "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
@@ -5158,7 +5177,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5783,20 +5802,23 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8379396202925594,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.7965500485908652,
-      "avgExecutionFidelity": 0.7586206896551724,
+      "avgRoleFidelity": 0.7984774862325885,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
         "modal-close-backdrop",
+        "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6419,11 +6441,12 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8351783137497423,
+      "avgConfidence": 0.8399092970521543,
       "avgFidelity": 0.941017316017316,
-      "avgRoleFidelity": 0.7373230373230375,
-      "avgExecutionFidelity": 0.7586206896551724,
+      "avgRoleFidelity": 0.7429536679536681,
+      "avgExecutionFidelity": 0.7333333333333333,
       "executionFailures": [
+        "accordion-exclusive",
         "if-condition",
         "if-exists",
         "if-matches",
@@ -6451,7 +6474,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6601,11 +6624,19 @@
           "success": true,
           "confidence": 1
         },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 1
+        },
         "modal-close-escape": {
           "success": true,
           "confidence": 1
         },
         "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
           "success": true,
           "confidence": 1
         },
@@ -6654,6 +6685,10 @@
           "confidence": 1
         },
         "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -6849,15 +6884,7 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "form-disable-on-submit": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "closest-ancestor": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -6958,10 +6985,6 @@
           "confidence": 0.5
         },
         "async-block": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-close-button": {
           "success": true,
           "confidence": 0.5
         },
@@ -7075,11 +7098,12 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7911667697381983,
+      "avgConfidence": 0.7958977530406102,
       "avgFidelity": 0.9621212121212123,
-      "avgRoleFidelity": 0.7407657657657661,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgRoleFidelity": 0.7463963963963967,
+      "avgExecutionFidelity": 0.7666666666666667,
       "executionFailures": [
+        "accordion-exclusive",
         "if-condition",
         "if-exists",
         "if-matches",
@@ -7095,7 +7119,7 @@
         "window-scroll"
       ],
       "lossyPasses": ["fetch-do-not-throw", "fetch-error-handling", "unless-condition"],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7233,11 +7257,19 @@
           "success": true,
           "confidence": 1
         },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 1
+        },
         "modal-close-escape": {
           "success": true,
           "confidence": 1
         },
         "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
           "success": true,
           "confidence": 1
         },
@@ -7282,6 +7314,10 @@
           "confidence": 1
         },
         "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -7437,15 +7473,7 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "form-disable-on-submit": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "closest-ancestor": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -7558,10 +7586,6 @@
           "confidence": 0.5
         },
         "async-block": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-close-button": {
           "success": true,
           "confidence": 0.5
         },
@@ -7722,15 +7746,19 @@
       "avgConfidence": 0.8334292106104165,
       "avgFidelity": 0.9794183445190157,
       "avgRoleFidelity": 0.8339368386243388,
-      "avgExecutionFidelity": 0.7586206896551724,
+      "avgExecutionFidelity": 0.6333333333333333,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
         "make-element",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "modal-close-button",
+        "tabs-content"
       ],
       "degeneratePasses": [],
       "lossyPasses": [
@@ -7744,7 +7772,7 @@
         "render-template-with-data",
         "set-color-variable"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8365,20 +8393,23 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8037866998651292,
       "avgFidelity": 0.9782135076252723,
-      "avgRoleFidelity": 0.8125445416261743,
-      "avgExecutionFidelity": 0.7586206896551724,
+      "avgRoleFidelity": 0.8139050858438615,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
         "modal-close-backdrop",
+        "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9004,18 +9035,22 @@
       "avgConfidence": 0.8007988380537381,
       "avgFidelity": 0.9803921568627451,
       "avgRoleFidelity": 0.8352850664075154,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "modal-close-button",
+        "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9638,16 +9673,19 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7064213564213565,
+      "avgConfidence": 0.7161616161616162,
       "avgFidelity": 0.9632034632034633,
-      "avgRoleFidelity": 0.7041023166023167,
-      "avgExecutionFidelity": 0.7241379310344828,
+      "avgRoleFidelity": 0.7095559845559846,
+      "avgExecutionFidelity": 0.6333333333333333,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "if-condition",
         "if-exists",
         "if-matches",
         "modal-close-backdrop",
+        "modal-close-button",
         "put-content-basic",
         "set-attribute",
         "tabs-content"
@@ -9664,7 +9702,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9770,7 +9808,15 @@
           "success": true,
           "confidence": 1
         },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 1
+        },
         "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
           "success": true,
           "confidence": 1
         },
@@ -9787,6 +9833,10 @@
           "confidence": 1
         },
         "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -10058,15 +10108,7 @@
           "success": true,
           "confidence": 0.5
         },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.5
-        },
         "modal-close-escape": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "accordion-toggle": {
           "success": true,
           "confidence": 0.5
         },
@@ -10127,10 +10169,6 @@
           "confidence": 0.5
         },
         "previous-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "closest-ancestor": {
           "success": true,
           "confidence": 0.5
         },
@@ -10290,9 +10328,10 @@
       "parseRate": 1,
       "avgConfidence": 0.8117913832199526,
       "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.8184765122265123,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgRoleFidelity": 0.8203909266409267,
+      "avgExecutionFidelity": 0.7666666666666667,
       "executionFailures": [
+        "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
@@ -10302,7 +10341,7 @@
       ],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10927,20 +10966,29 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.791841269841268,
-      "avgFidelity": 0.9727777777777777,
-      "avgRoleFidelity": 0.8223627645502647,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgFidelity": 0.9705555555555554,
+      "avgRoleFidelity": 0.8192377645502646,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "modal-close-button",
+        "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": ["event-debounce", "repeat-until-event", "set-color-variable"],
-      "bundleSize": 416817,
+      "lossyPasses": [
+        "event-debounce",
+        "modal-close-button",
+        "repeat-until-event",
+        "set-color-variable"
+      ],
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11562,9 +11610,10 @@
       "parseRate": 1,
       "avgConfidence": 0.8401154401154378,
       "avgFidelity": 1,
-      "avgRoleFidelity": 0.8036196911196911,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgRoleFidelity": 0.8043436293436294,
+      "avgExecutionFidelity": 0.7666666666666667,
       "executionFailures": [
+        "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
@@ -11574,7 +11623,7 @@
       ],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12198,21 +12247,25 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8457025234336144,
+      "avgConfidence": 0.8494027914195967,
       "avgFidelity": 0.9970779220779221,
-      "avgRoleFidelity": 0.8718709781209784,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgRoleFidelity": 0.8754745817245817,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "modal-close-button",
+        "tabs-content"
       ],
       "degeneratePasses": [],
       "lossyPasses": ["if-exists", "window-scroll"],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12302,6 +12355,10 @@
           "success": true,
           "confidence": 1
         },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
         "dropdown-toggle": {
           "success": true,
           "confidence": 1
@@ -12355,6 +12412,10 @@
           "confidence": 1
         },
         "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -12558,14 +12619,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "remove-class-basic": {
           "success": true,
           "confidence": 0.7777777777777777
@@ -12675,6 +12728,10 @@
           "confidence": 0.7142857142857143
         },
         "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-button": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -12806,10 +12863,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.5
-        },
         "window-scroll": {
           "success": true,
           "confidence": 0.5
@@ -12836,16 +12889,19 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8329805996472663,
+      "avgConfidence": 0.8377425044091712,
       "avgFidelity": 0.9635076252723311,
-      "avgRoleFidelity": 0.7524943310657596,
-      "avgExecutionFidelity": 0.7241379310344828,
+      "avgRoleFidelity": 0.7581632653061223,
+      "avgExecutionFidelity": 0.6333333333333333,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "if-condition",
         "if-exists",
         "if-matches",
         "modal-close-backdrop",
+        "modal-close-button",
         "set-attribute",
         "tabs-aria",
         "tabs-content"
@@ -12858,7 +12914,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13004,11 +13060,19 @@
           "success": true,
           "confidence": 1
         },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 1
+        },
         "modal-close-escape": {
           "success": true,
           "confidence": 1
         },
         "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
           "success": true,
           "confidence": 1
         },
@@ -13061,6 +13125,10 @@
           "confidence": 1
         },
         "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -13252,14 +13320,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -13361,10 +13421,6 @@
           "confidence": 0.5
         },
         "async-block": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-close-button": {
           "success": true,
           "confidence": 0.5
         },
@@ -13483,9 +13539,10 @@
       "parseRate": 1,
       "avgConfidence": 0.8098948670377222,
       "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.8067648005148006,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgRoleFidelity": 0.808679214929215,
+      "avgExecutionFidelity": 0.7666666666666667,
       "executionFailures": [
+        "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
@@ -13495,7 +13552,7 @@
       ],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14121,15 +14178,18 @@
       "parseRate": 1,
       "avgConfidence": 0.8037518037518019,
       "avgFidelity": 0.985930735930736,
-      "avgRoleFidelity": 0.8489462676962678,
-      "avgExecutionFidelity": 0.7586206896551724,
+      "avgRoleFidelity": 0.8502976190476191,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
         "modal-close-backdrop",
+        "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": [],
@@ -14140,7 +14200,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14766,14 +14826,16 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9871667185392676,
       "avgFidelity": 0.9632897603485838,
-      "avgRoleFidelity": 0.8889212827988336,
-      "avgExecutionFidelity": 0.8275862068965517,
+      "avgRoleFidelity": 0.8925494007126659,
+      "avgExecutionFidelity": 0.7666666666666667,
       "executionFailures": [
+        "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
@@ -14785,7 +14847,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15407,7 +15469,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 416817,
+      "size": 417073,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
@@ -19,7 +19,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { ExecutionValidator, EXECUTION_SUBSET, loadExecutionSubset } from './execution-validator';
 
 describe('R2 execution subset (lock)', () => {
-  it('contains exactly the 29 curated patterns', () => {
+  it('contains exactly the 30 curated patterns', () => {
     // Changing this list recalibrates avgExecutionFidelity for every language.
     // If you expand the subset, regenerate the baseline (--save-baseline) in
     // the SAME PR and update this lock.
@@ -71,6 +71,11 @@ describe('R2 execution subset (lock)', () => {
         // Session-9 expansion wave 2d: `next .sel` folds to a positional call
         // expression. make-toast-element still out (at-end-of positional put).
         'dropdown-toggle',
+        // Session-10 expansion wave 3: positional-phrase patients — the
+        // pattern matcher captures `closest <sel>` / `the next <sel>`, so
+        // `hide closest .modal` parses and executes (PATTERN_SETUP gives #btn
+        // a .modal ancestor). make-toast-element still out (at-end-of put).
+        'modal-close-button',
       ].sort()
     );
   });

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.ts
@@ -108,6 +108,14 @@ export const EXECUTION_SUBSET: readonly string[] = [
   // and the toggle target evaluated to NaN. `.dropdown-menu` added to the
   // fixture (appended last; existing snapshot indexes unchanged).
   'dropdown-toggle',
+  // Expansion wave 3 (session 10): positional-phrase patients/destinations —
+  // the pattern matcher now captures `closest <sel>` and article-led
+  // `the next <sel>` as positional expressions (previously the hide/show
+  // command dropped from the body entirely). The en reference for
+  // modal-close-button now hides the enclosing .modal (PATTERN_SETUP gives
+  // #btn a .modal ancestor, mirroring the real-page structure).
+  // make-toast-element stays out (at-end-of positional put, distinct form).
+  'modal-close-button',
 ];
 
 /**
@@ -148,6 +156,9 @@ const PATTERN_SETUP: Record<string, (doc: Document) => void> = {
   // click's target is #btn, so the condition only fires when #btn IS the
   // backdrop (the real-page case is a click landing on the backdrop itself).
   'modal-close-backdrop': doc => doc.getElementById('btn')!.classList.add('modal-backdrop'),
+  // `hide closest .modal` needs #btn inside a .modal (the real-page case is a
+  // close button inside the modal it closes).
+  'modal-close-button': doc => doc.querySelector('.card')!.classList.add('modal'),
 };
 
 /** Result of executing one pattern translation. */


### PR DESCRIPTION
## Summary

Continues the correctness/reliability arc (sessions 8–9, #396–#400). The deferred "deep en body-parse arc" (`hide closest .modal`, `show the next <div.tab-panel/>`) turned out to be **three pattern-matcher gaps, not body segmentation** — once the role matcher captures the positional phrase as one expression value, the existing clause segmentation, the #400 expression-parser positional fold, and the core runtime already evaluate it end-to-end.

### Fixes (all in `packages/semantic/src/parser/pattern-matcher.ts`)

1. **`closest` joins POSITIONAL_KEYWORDS** — `tryMatchPositionalExpression` only fired for first/last/next/previous/random, so a `closest <sel>` patient rejected the keyword and the whole command **dropped from the event body** (modal-close-button). Bonus surface — destinations: `toggle .x on closest .card` previously captured destination literal `"closest"` (selector stranded), and `add .x to closest .card` silently defaulted to `me`; both now capture the full positional expression (closest-ancestor / accordion-exclusive en references improved).
2. **`skipNoiseWords` skips articles before positional keywords** — `the next <div.tab-panel/>` never reached the positional matcher (tabs-content, plan §10.5 — the en reference was lossy, making 13 faithful languages read as failers). All four tabs-content commands now parse and execute.
3. **Source-clause command-verb guard** — the positional matcher's optional `<marker> <selector>` source clause accepted *any* keyword as the marker, so the juxtaposed modal-close-button body swallowed `remove` as a locative marker and lost `remove .modal-open from body`. Markers whose normalized form is a schema action (`commandSchemas` keys — language-independent) are now refused.

### R2 / baseline

- Subset **29 → 30** (`modal-close-button`, with a PATTERN_SETUP giving `#btn` a `.modal` ancestor, mirroring the real-page structure); membership lock updated in the same PR per the locked rule.
- **The §10.5 band inversion happened exactly as predicted**: 58 execution rows re-recorded against the four improved en signatures (mean executionFidelity 0.7706 → 0.6957 — the recorded-band outcome documented in plan §8, **not** a regression; the cross-language positional burn-down is its own track).
- Parse-level fidelity unchanged (0.9742; one within-tolerance sw flip). Baseline regenerated against a freshly populated patterns.db; `--regression` gate green against it; patterns.db reverted before commit per repo convention.

## Validation

- semantic: 5835 passed (incl. 5 new locks in `multilingual-roadmap-fixes.test.ts`)
- testing-framework: 175 passed (incl. updated 30-pattern membership lock)
- core: 6982 passed
- typecheck clean (semantic + testing-framework)
- multilingual `--regression` gate: green against the regenerated baseline; committed-baseline reproduction verified before any work

## Still deferred

- at-end-of positional put (`put it at end of body`, make-toast-element)
- cross-language positional/conditional burn-down (SOV/VSO orders — now visible as the widened R2 band)

🤖 Generated with [Claude Code](https://claude.com/claude-code)