### PR TITLE
fix: at-end-of positional put executes end-to-end; R2 wave 3b

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -610,9 +610,38 @@ behavior the translations don't yet produce — mean executionFidelity 0.7706 �
 unchanged (0.9742; one within-tolerance sw flip). Baseline regenerated; gate
 green against it.
 
-**Still deferred:** the at-end-of positional put (`put it at end of body`,
-make-toast-element); cross-language positional/conditional burn-down (SOV/VSO
-orders — now visible as the widened R2 band).
+**Wave 3b (same session, post-#401): the at-end-of positional put SHIPPED.**
+`put it at end of body` (make-toast-element) needed five small fixes across
+the stack, found by walking the failure end-to-end:
+
+1. **en put patterns** for `at end of` / `at start of` (patterns/put.ts) —
+   the three-word position phrase matched as consecutive literal tokens,
+   recorded whole in `manner`.
+2. **The end-noun guard** (parseBodyWithClauses) — the `end` in `at end of`
+   hit the block-terminator break and the body clause parsed EMPTY; the guard
+   is sandwich-gated (previous token `at`, next token `of`), so real
+   block-`end`s still terminate.
+3. **putMapper reads `manner`** (was `method`, which no producer sets) — this
+   also fixed a LATENT bug: `put X before Y` silently built a put-INTO AST.
+4. **Core PutCommand accepts the multi-word modifier keys** (`at end of` /
+   `at start of`) on the semantic-modifiers path.
+5. **contextReference `body`/`document`/`window` resolve** in the core
+   runtime (the builder emits these surface forms; `body` fell through to
+   undefined and the put landed on `me`). The identifier path deliberately
+   does NOT pre-empt `body` (would shadow user locals).
+
+Harness: the effect snapshot now serializes **body under its own key** —
+before, a body write was invisible (and the old modal-open en reference was
+only scoreable because its `add .modal-open to body` WRONGLY fell back to
+`me`); modal-close-button's PATTERN_SETUP also pre-adds `.modal-open` so the
+body remove is scoreable. Subset 30 → **31** (make-toast-element — the last
+R2 candidate excluded for an unusable en reference; en signature is one clean
+line: the toast appended at end of body). Zero parse-level churn (0.9742 /
+78 lossy / 63 degen identical); meanExecutionFidelity 0.6957 → 0.6452
+(recorded band: the new pattern + re-scored body signatures).
+
+**Still deferred:** cross-language positional/conditional burn-down (SOV/VSO
+orders — now visible as the widened R2 band); behavior-\* degenerate mass.
 
 ## 8. R1 / R2 — role-fidelity and execution ratchets (extend R0)
 

--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -572,11 +572,47 @@ expressions/control-flow/parser 2580, runtime-ast-coverage 75; typechecks clean.
   28 → 29 (dropdown-toggle; `.dropdown-menu` fixture element). Zero
   parse-level fidelity churn from the fold (gate green, no avgFidelity moves).
 
-**Still deferred (the deep en body-parse arc):** `hide closest .modal`
-(modal-close-button) and `show the next <div.tab-panel/>` (tabs-content §10.5)
-still DROP at the semantic parse — body segmentation, not expression work; the
-at-end-of positional put (`put it at end of body`, make-toast-element);
-cross-language conditional folding (SOV/VSO orders).
+## 7i. Status update (2026-06-12, session 10): positional-phrase patients (wave 3)
+
+**The "deep en body-parse arc" turned out to be three small pattern-matcher
+gaps, not body segmentation.** `hide closest .modal` and `show the next
+<div.tab-panel/>` dropped because the role matcher never RECOGNIZED the
+phrase — once the role captures it as one expression, the existing clause
+segmentation, the #400 expression-parser positional fold, and the core
+runtime all already work. Three fixes in `pattern-matcher.ts`:
+
+1. **`closest` joins POSITIONAL_KEYWORDS** — `tryMatchPositionalExpression`
+   only fired for first/last/next/previous/random, so a `closest <sel>`
+   patient/destination rejected the keyword and the whole command dropped from
+   the event body. Bonus surface: destinations — `toggle .x on closest .card`
+   previously captured destination literal `"closest"` (selector stranded) and
+   `add .x to closest .card` silently defaulted to `me`; both now capture the
+   full positional expression (closest-ancestor / accordion-exclusive
+   references improved).
+2. **`skipNoiseWords` skips articles before positional keywords** — `the
+next <div.tab-panel/>` never reached the positional matcher because the
+   article was only skipped before selectors/identifiers (tabs-content §10.5).
+3. **Source-clause command-verb guard** — the positional matcher's optional
+   `<marker> <selector>` source clause accepted ANY keyword as the marker, so
+   in the juxtaposed modal-close-button body (`hide closest .modal remove
+.modal-open from body`) it swallowed `remove` as a locative marker and the
+   following command was lost. Markers whose normalized form is a schema
+   action (`commandSchemas` keys — language-independent) are now refused.
+
+**Validation:** semantic 5835 green; en references for tabs-content (all FOUR
+commands, §10.5 resolved), modal-close-button, closest-ancestor now parse and
+EXECUTE end-to-end in jsdom. Subset 29 → 30 (modal-close-button +
+PATTERN_SETUP giving #btn a `.modal` ancestor); membership lock updated in the
+same PR. **The §10.5 band inversion happened as predicted**: 58 execution rows
+re-recorded (the four improved en signatures now demand correct positional
+behavior the translations don't yet produce — mean executionFidelity 0.7706 →
+0.6957, the recorded-band outcome, NOT a regression). Parse-level fidelity
+unchanged (0.9742; one within-tolerance sw flip). Baseline regenerated; gate
+green against it.
+
+**Still deferred:** the at-end-of positional put (`put it at end of body`,
+make-toast-element); cross-language positional/conditional burn-down (SOV/VSO
+orders — now visible as the widened R2 band).
 
 ## 8. R1 / R2 — role-fidelity and execution ratchets (extend R0)
 

--- a/packages/core/src/commands/dom/put.ts
+++ b/packages/core/src/commands/dom/put.ts
@@ -91,8 +91,10 @@ export class PutCommand implements DecoratedCommand {
       targetArg: ASTNode | null = null;
     if (prepIdx === -1) {
       // Check modifiers for semantic parsing format (e.g., { args: [content], modifiers: { into: target } })
-      if (raw.modifiers.into || raw.modifiers.before || raw.modifiers.after) {
-        const prepKey = raw.modifiers.into ? 'into' : raw.modifiers.before ? 'before' : 'after';
+      // Any valid preposition can arrive as a modifier key, including the
+      // multi-word positional forms ('at start of' / 'at end of').
+      const prepKey = validPreps.find(p => raw.modifiers[p]);
+      if (prepKey) {
         contentArg = raw.args[0];
         prepKw = prepKey;
         targetArg = raw.modifiers[prepKey] as ASTNode;

--- a/packages/core/src/parser/runtime-ast-coverage.test.ts
+++ b/packages/core/src/parser/runtime-ast-coverage.test.ts
@@ -203,6 +203,25 @@ describe('AST evaluator coverage', () => {
       const ctx = { ...createContext(), registry: FULL_REGISTRY, you: el } as any;
       expect(await evaluateAST(ref('your') as any, ctx)).toBe(el);
     });
+
+    // Document references: the semantic→AST builder emits `body` / `document`
+    // / `window` as contextReference (`put it at end of body` → reference
+    // 'body'); without these cases they fell through to undefined and the put
+    // landed on `me` instead of body.
+    it("'body' resolves to document.body", async () => {
+      const ctx = { ...createContext(), registry: FULL_REGISTRY } as any;
+      expect(await evaluateAST(ref('body') as any, ctx)).toBe(document.body);
+    });
+
+    it("'document' resolves to the document", async () => {
+      const ctx = { ...createContext(), registry: FULL_REGISTRY } as any;
+      expect(await evaluateAST(ref('document') as any, ctx)).toBe(document);
+    });
+
+    it("'window' resolves to the window", async () => {
+      const ctx = { ...createContext(), registry: FULL_REGISTRY } as any;
+      expect(await evaluateAST(ref('window') as any, ctx)).toBe(window);
+    });
   });
 
   describe('optional chaining (?.)', () => {

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -121,7 +121,10 @@ type ContextRefNode = ASTNode & {
     | 'it'
     | 'its'
     | 'target'
-    | 'event';
+    | 'event'
+    | 'body'
+    | 'document'
+    | 'window';
 };
 type PossessiveNode = ASTNode & { object: ASTNode; property: { name: string } };
 type EventHandlerNode = ASTNode & { event?: unknown; selector?: unknown; commands: ASTNode[] };
@@ -1671,6 +1674,17 @@ async function evaluateContextReference(
         (context as any).event?.target ??
         getExpr(context, 'me').evaluate(context)
       );
+    // Document references: the semantic→AST builder emits these surface forms
+    // as contextReference (`put it at end of body` → reference 'body'). The
+    // identifier path deliberately does NOT pre-empt `body` (a user local named
+    // `body` would be shadowed); the contextReference node only ever comes
+    // from the builder, so resolving it here is unambiguous.
+    case 'body':
+      return typeof document !== 'undefined' ? document.body : undefined;
+    case 'document':
+      return getExpr(context, 'document').evaluate(context);
+    case 'window':
+      return getExpr(context, 'window').evaluate(context);
     default:
       return undefined;
   }

--- a/packages/semantic/src/ast-builder/command-mappers.ts
+++ b/packages/semantic/src/ast-builder/command-mappers.ts
@@ -333,7 +333,7 @@ const logMapper: CommandMapper = {
 /**
  * Put command mapper.
  *
- * Semantic: put patient:"hello" destination:#output method:into
+ * Semantic: put patient:"hello" destination:#output manner:into
  * AST: { name: 'put', args: ["hello"], modifiers: { into: #output } }
  */
 const putMapper: CommandMapper = {
@@ -341,14 +341,17 @@ const putMapper: CommandMapper = {
   toAST(node, _builder) {
     const patient = convertRoleValue(node, 'patient');
     const destination = convertRoleValue(node, 'destination');
-    const method = getRole(node, 'method'); // before, after, into, etc.
+    // The handcrafted put patterns record the position phrase in `manner`
+    // (before / after / at end of / at start of). `method` is kept as a
+    // fallback for any older producer. Reading only `method` was a latent
+    // bug: `put X before Y` silently built a put-INTO AST.
+    const position = getRole(node, 'manner') ?? getRole(node, 'method');
 
     const args: ExpressionNode[] = patient ? [patient] : [];
     const modifiers: Record<string, ExpressionNode> = {};
 
     if (destination) {
-      // Determine the preposition based on method or default to 'into'
-      const prep = method?.type === 'literal' ? String(method.value) : 'into';
+      const prep = position?.type === 'literal' ? String(position.value) : 'into';
       modifiers[prep] = destination;
     }
 

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -23,6 +23,7 @@ import {
   isValidReference,
 } from '../types';
 import { isTypeCompatible } from './utils/type-validation';
+import { commandSchemas } from '../generators/command-schemas';
 import { getPossessiveReference } from './utils/possessive-keywords';
 import type { LanguageProfile } from '../generators/profiles/types';
 import { tryGetProfile } from '../registry';
@@ -562,6 +563,11 @@ export class PatternMatcher {
   /**
    * Positional query keywords (English + normalized forms produced by the
    * tokenizers for every language, e.g. AR آخر→last, TL huli→last).
+   * `closest` is included: `closest <sel>` is the ancestor-scope query form
+   * (`hide closest .modal`, `toggle .x on closest .card`) and folds to the
+   * same call-expression shape the runtime's positional expressions evaluate
+   * (the expression-parser positional fold). Without it the patient/destination
+   * role rejected the keyword and the whole command dropped from event bodies.
    */
   private static readonly POSITIONAL_KEYWORDS = new Set([
     'first',
@@ -569,6 +575,7 @@ export class PatternMatcher {
     'next',
     'previous',
     'random',
+    'closest',
   ]);
 
   /**
@@ -610,6 +617,16 @@ export class PatternMatcher {
     'self',
     'this',
   ]);
+
+  /**
+   * Normalized command-action keywords (the schema registry's action names).
+   * Tokenizers normalize every language's command verbs to these forms, so the
+   * set is language-independent. Used to keep the positional source clause
+   * from consuming a following command's verb as a locative marker.
+   */
+  private static readonly COMMAND_ACTION_KEYWORDS = new Set(
+    Object.keys(commandSchemas).map(a => a.toLowerCase())
+  );
 
   /**
    * Try to match a positional query expression:
@@ -674,7 +691,12 @@ export class PatternMatcher {
       source &&
       source.kind === 'selector' &&
       (marker.kind === 'keyword' || marker.kind === 'particle' || marker.kind === 'identifier') &&
-      !PatternMatcher.POSITIONAL_KEYWORDS.has((marker.normalized ?? marker.value).toLowerCase())
+      !PatternMatcher.POSITIONAL_KEYWORDS.has((marker.normalized ?? marker.value).toLowerCase()) &&
+      // A command verb is never a locative marker: in a juxtaposed body
+      // (`hide closest .modal remove .modal-open from body`) the next clause's
+      // verb (`remove`) would otherwise be swallowed as the source marker and
+      // the following command lost.
+      !PatternMatcher.COMMAND_ACTION_KEYWORDS.has((marker.normalized ?? marker.value).toLowerCase())
     ) {
       parts.push(marker.value, source.value);
       tokens.advance();
@@ -1458,7 +1480,15 @@ export class PatternMatcher {
         return;
       }
 
-      // Not followed by a selector or identifier, revert
+      // "the next <sel>" / "the closest .modal": the article also precedes
+      // positional-phrase heads, which tokenize as keywords/literals — skip it
+      // so tryMatchPositionalExpression sees the positional keyword first.
+      const nextNorm = nextToken ? (nextToken.normalized ?? nextToken.value).toLowerCase() : '';
+      if (nextToken && PatternMatcher.POSITIONAL_OR_SCOPE_KEYWORDS.has(nextNorm)) {
+        return;
+      }
+
+      // Not followed by a selector, identifier, or positional keyword — revert
       tokens.reset(mark);
     }
 

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -653,8 +653,22 @@ export class SemanticParserImpl implements ISemanticParser {
         current.kind === 'conjunction' ||
         (current.kind === 'keyword' && this.isThenKeyword(current.value, language));
 
-      // Check if this is an 'end' keyword (terminates block)
-      const isEnd = current.kind === 'keyword' && this.isEndKeyword(current.value, language);
+      // Check if this is an 'end' keyword (terminates block). The English
+      // positional-put phrase `at end of <target>` contains the literal word
+      // `end` — when the pending clause ends with `at` and the next token is
+      // `of`, this `end` is the position noun, not a block terminator
+      // (`put it at end of body`, make-toast-element). The sandwich check is
+      // value-based and language-safe: no other language's end keyword sits
+      // between literal `at`/`of` tokens.
+      const prevClauseToken = currentClauseTokens[currentClauseTokens.length - 1];
+      const followingToken = tokens.peek(1);
+      const isPositionalEndNoun =
+        prevClauseToken?.value.toLowerCase() === 'at' &&
+        followingToken?.value.toLowerCase() === 'of';
+      const isEnd =
+        current.kind === 'keyword' &&
+        this.isEndKeyword(current.value, language) &&
+        !isPositionalEndNoun;
 
       if (isConjunction) {
         // We've reached a clause boundary - parse accumulated tokens

--- a/packages/semantic/src/patterns/put.ts
+++ b/packages/semantic/src/patterns/put.ts
@@ -116,6 +116,55 @@ function getPutPatternsEn(): LanguagePattern[] {
         manner: { default: { type: 'literal', value: 'after' } },
       },
     },
+    // The at-end-of / at-start-of positional puts (`put it at end of body`,
+    // make-toast-element). The three-word position phrase is matched as
+    // consecutive literal tokens and recorded whole in `manner` — the exact
+    // form the core runtime's PutCommand.mapPosition accepts (beforeend /
+    // afterbegin).
+    {
+      id: 'put-en-at-end',
+      language: 'en',
+      command: 'put',
+      priority: 96,
+      template: {
+        format: 'put {patient} at end of {destination}',
+        tokens: [
+          { type: 'literal', value: 'put' },
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: 'at' },
+          { type: 'literal', value: 'end' },
+          { type: 'literal', value: 'of' },
+          { type: 'role', role: 'destination' },
+        ],
+      },
+      extraction: {
+        patient: { position: 1 },
+        destination: { position: 5 },
+        manner: { default: { type: 'literal', value: 'at end of' } },
+      },
+    },
+    {
+      id: 'put-en-at-start',
+      language: 'en',
+      command: 'put',
+      priority: 96,
+      template: {
+        format: 'put {patient} at start of {destination}',
+        tokens: [
+          { type: 'literal', value: 'put' },
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: 'at' },
+          { type: 'literal', value: 'start' },
+          { type: 'literal', value: 'of' },
+          { type: 'role', role: 'destination' },
+        ],
+      },
+      extraction: {
+        patient: { position: 1 },
+        destination: { position: 5 },
+        manner: { default: { type: 'literal', value: 'at start of' } },
+      },
+    },
   ];
 }
 

--- a/packages/semantic/test/command-mappers.test.ts
+++ b/packages/semantic/test/command-mappers.test.ts
@@ -331,6 +331,36 @@ describe('Put Command Mapper', () => {
     expect(result.args[0]).toMatchObject({ type: 'literal', value: 'Hello World' });
     expect(result.modifiers!['into']).toMatchObject({ type: 'contextReference', contextType: 'me' });
   });
+
+  it('maps the manner role to the position modifier (before/after)', () => {
+    // The handcrafted put patterns record the position phrase in `manner`.
+    // Reading only `method` was a latent bug: `put X before Y` silently built
+    // a put-INTO AST (wrong insertion position at runtime).
+    const node = createCommandNode('put', {
+      patient: literal('x', 'string'),
+      destination: reference('me'),
+      manner: literal('before', 'string'),
+    });
+    const result = getCommandMapper('put')!.toAST(node, new ASTBuilder());
+    expect(result.modifiers!['before']).toBeDefined();
+    expect(result.modifiers!['into']).toBeUndefined();
+  });
+
+  it('maps the at-end-of positional put to the multi-word modifier key', () => {
+    // `put it at end of body` (make-toast-element): the position phrase is the
+    // exact key the core PutCommand accepts ('at end of' → beforeend).
+    const node = createCommandNode('put', {
+      patient: reference('it'),
+      destination: reference('body'),
+      manner: literal('at end of', 'string'),
+    });
+    const result = getCommandMapper('put')!.toAST(node, new ASTBuilder());
+    expect(result.modifiers!['at end of']).toMatchObject({
+      type: 'contextReference',
+      contextType: 'body',
+    });
+    expect(result.modifiers!['into']).toBeUndefined();
+  });
 });
 
 // =============================================================================

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -4921,3 +4921,86 @@ describe('en if/unless conditional fold (parsing track reopen — §2 dominant c
     expect(c).toBeNull();
   });
 });
+
+describe('en positional-phrase patients — closest <sel> and the-led positionals (R2 wave 3)', () => {
+  // `hide closest .modal` / `show the next <div.tab-panel/>` previously
+  // DROPPED at the semantic parse: `closest` was not a positional-expression
+  // lead keyword (only first/last/next/previous/random), and skipNoiseWords
+  // only skipped `the` before selectors/identifiers — never before a
+  // positional keyword. Both forms now capture the whole phrase as a single
+  // expression value, which the expression parser folds to the positional
+  // call shape the core runtime evaluates (see the #400 fold).
+  function roles(node: unknown): Map<string, { type?: string; raw?: string; value?: string }> {
+    return (node as { roles: Map<string, { type?: string; raw?: string; value?: string }> })
+      .roles;
+  }
+
+  it('hide closest .modal captures the patient as a positional expression', () => {
+    const node = parse('hide closest .modal', 'en') as Record<string, unknown>;
+    expect(node).toBeTruthy();
+    expect(node.action).toBe('hide');
+    const patient = roles(node).get('patient');
+    expect(patient?.type).toBe('expression');
+    expect(patient?.raw).toBe('closest .modal');
+  });
+
+  it('show the next <div.tab-panel/> skips the article and captures the positional', () => {
+    const node = parse('show the next <div.tab-panel/>', 'en') as Record<string, unknown>;
+    expect(node).toBeTruthy();
+    expect(node.action).toBe('show');
+    const patient = roles(node).get('patient');
+    expect(patient?.type).toBe('expression');
+    expect(patient?.raw).toBe('next <div.tab-panel/>');
+  });
+
+  it('toggle … on closest .card captures the destination as a positional expression', () => {
+    // Previously the destination captured the bare literal `closest` and the
+    // selector stranded (closest-ancestor / accordion-toggle corpus rows).
+    const node = parse('on click toggle .expanded on closest .card', 'en') as {
+      body?: Array<Record<string, unknown>>;
+    };
+    const toggle = node.body?.find(n => n.action === 'toggle');
+    expect(toggle).toBeDefined();
+    const dest = roles(toggle).get('destination');
+    expect(dest?.type).toBe('expression');
+    expect(dest?.raw).toBe('closest .card');
+  });
+
+  it('a juxtaposed following command is not swallowed as the positional source clause', () => {
+    // modal-close-button: `hide closest .modal remove .modal-open from body` —
+    // the optional `<marker> <selector>` source clause must not consume the
+    // next clause's verb (`remove`) as a locative marker. Guarded by the
+    // schema-action keyword set (language-independent: tokenizers normalize
+    // every language's verbs to these forms).
+    const node = parse('on click hide closest .modal remove .modal-open from body', 'en') as {
+      body?: Array<Record<string, unknown>>;
+    };
+    const stmts =
+      node.body?.flatMap(n =>
+        n.kind === 'compound' ? (n.statements as Array<Record<string, unknown>>) : [n]
+      ) ?? [];
+    const actions = stmts.map(s => s.action);
+    expect(actions).toContain('hide');
+    expect(actions).toContain('remove');
+    const hide = stmts.find(s => s.action === 'hide')!;
+    expect(roles(hide).get('patient')?.raw).toBe('closest .modal');
+    const remove = stmts.find(s => s.action === 'remove')!;
+    expect(roles(remove).get('patient')?.value).toBe('.modal-open');
+  });
+
+  it('tabs-content parses all four commands including the article-led show', () => {
+    // §10.5: the en reference was lossy (show dropped), which made 13
+    // faithful languages read as failers. All four commands now survive.
+    const node = parse(
+      'on click remove .active from .tab add .active to me hide .tab-panel show the next <div.tab-panel/>',
+      'en'
+    ) as { body?: Array<Record<string, unknown>> };
+    const stmts =
+      node.body?.flatMap(n =>
+        n.kind === 'compound' ? (n.statements as Array<Record<string, unknown>>) : [n]
+      ) ?? [];
+    expect(stmts.map(s => s.action)).toEqual(['remove', 'add', 'hide', 'show']);
+    const show = stmts.find(s => s.action === 'show')!;
+    expect(roles(show).get('patient')?.raw).toBe('next <div.tab-panel/>');
+  });
+});

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -5004,3 +5004,61 @@ describe('en positional-phrase patients — closest <sel> and the-led positional
     expect(roles(show).get('patient')?.raw).toBe('next <div.tab-panel/>');
   });
 });
+
+describe('en at-end-of positional put — at end of / at start of (R2 make-toast-element)', () => {
+  function roles(node: unknown): Map<string, { type?: string; raw?: string; value?: unknown }> {
+    return (node as { roles: Map<string, { type?: string; raw?: string; value?: unknown }> })
+      .roles;
+  }
+
+  it("put 'x' at end of #out captures destination + the whole position phrase", () => {
+    const node = parse("put 'x' at end of #out", 'en') as Record<string, unknown>;
+    expect(node).toBeTruthy();
+    expect(node.action).toBe('put');
+    expect(roles(node).get('destination')?.value).toBe('#out');
+    expect(roles(node).get('manner')?.value).toBe('at end of');
+  });
+
+  it("put 'x' at start of #out captures the at-start-of form", () => {
+    const node = parse("put 'x' at start of #out", 'en') as Record<string, unknown>;
+    expect(node).toBeTruthy();
+    expect(roles(node).get('manner')?.value).toBe('at start of');
+  });
+
+  it('the position noun `end` does not terminate an event body clause', () => {
+    // parseBodyWithClauses treats `end` as the block terminator; in
+    // `put it at end of body` it is the position noun. The sandwich guard
+    // (previous clause token `at`, following token `of`) keeps the clause
+    // intact — previously the body parsed EMPTY.
+    const node = parse("on click put 'a' at end of #x", 'en') as {
+      body?: Array<Record<string, unknown>>;
+    };
+    expect(node.body?.length).toBe(1);
+    expect(node.body?.[0].action).toBe('put');
+    expect(roles(node.body![0]).get('manner')?.value).toBe('at end of');
+  });
+
+  it('a real block-terminating end still terminates (guard is sandwich-gated)', () => {
+    const node = parse(
+      'on click if I match .active then add .x to me end',
+      'en'
+    ) as { body?: Array<Record<string, unknown>> };
+    const conditional = node.body?.find(n => n.kind === 'conditional');
+    expect(conditional).toBeDefined();
+  });
+
+  it('make-toast-element parses all three commands including the at-end-of put', () => {
+    const node = parse(
+      "on click make a <div.toast/> then put 'Saved!' into it then put it at end of body",
+      'en'
+    ) as { body?: Array<Record<string, unknown>> };
+    const stmts =
+      node.body?.flatMap(n =>
+        n.kind === 'compound' ? (n.statements as Array<Record<string, unknown>>) : [n]
+      ) ?? [];
+    expect(stmts.map(s => s.action)).toEqual(['make', 'put', 'put']);
+    const lastPut = stmts[2];
+    expect(roles(lastPut).get('destination')?.value).toBe('body');
+    expect(roles(lastPut).get('manner')?.value).toBe('at end of');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,25 +1,27 @@
 {
-  "timestamp": "2026-06-13T00:22:49.663Z",
-  "commit": "df71fd6",
+  "timestamp": "2026-06-13T00:58:00.188Z",
+  "commit": "98225f69",
   "languages": {
     "ar": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8651992823273096,
+      "avgConfidence": 0.8679433429145073,
       "avgFidelity": 0.9758169934640524,
-      "avgRoleFidelity": 0.8449789439585359,
-      "avgExecutionFidelity": 0.8275862068965517,
+      "avgRoleFidelity": 0.8486070618723681,
+      "avgExecutionFidelity": 0.7666666666666667,
       "executionFailures": [
+        "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["if-exists", "repeat-until-event", "window-scroll"],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -121,6 +123,10 @@
           "success": true,
           "confidence": 1
         },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
         "dropdown-toggle": {
           "success": true,
           "confidence": 1
@@ -174,6 +180,10 @@
           "confidence": 1
         },
         "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -341,14 +351,6 @@
           "success": true,
           "confidence": 0.9722222222222222
         },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.9722222222222222
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 0.9722222222222222
-        },
         "remove-class-basic": {
           "success": true,
           "confidence": 0.9277777777777777
@@ -438,6 +440,10 @@
           "confidence": 0.8642857142857143
         },
         "modal-open": {
+          "success": true,
+          "confidence": 0.8642857142857143
+        },
+        "modal-close-button": {
           "success": true,
           "confidence": 0.8642857142857143
         },
@@ -593,10 +599,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.5
-        },
         "window-scroll": {
           "success": true,
           "confidence": 0.5
@@ -642,11 +644,12 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8430632859204288,
+      "avgConfidence": 0.8477942692228406,
       "avgFidelity": 0.9905844155844155,
-      "avgRoleFidelity": 0.7613175675675675,
-      "avgExecutionFidelity": 0.7586206896551724,
+      "avgRoleFidelity": 0.7641328828828827,
+      "avgExecutionFidelity": 0.7333333333333333,
       "executionFailures": [
+        "accordion-exclusive",
         "if-condition",
         "if-exists",
         "if-matches",
@@ -663,7 +666,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -809,11 +812,19 @@
           "success": true,
           "confidence": 1
         },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 1
+        },
         "modal-close-escape": {
           "success": true,
           "confidence": 1
         },
         "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
           "success": true,
           "confidence": 1
         },
@@ -870,6 +881,10 @@
           "confidence": 1
         },
         "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -1069,15 +1084,7 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "form-disable-on-submit": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "closest-ancestor": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -1185,10 +1192,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.5
-        },
         "form-submit-prevent": {
           "success": true,
           "confidence": 0.5
@@ -1289,19 +1292,23 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8323373793962008,
       "avgFidelity": 0.9782135076252723,
-      "avgRoleFidelity": 0.8229267897635244,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgRoleFidelity": 0.8279154518950437,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "modal-close-button",
+        "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1925,7 +1932,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2549,21 +2556,25 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8371096586782839,
+      "avgConfidence": 0.8352422450461645,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8158325234855849,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgRoleFidelity": 0.8124311629413672,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "modal-close-button",
+        "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -2690,10 +2701,6 @@
           "confidence": 1
         },
         "first-in-parent": {
-          "success": true,
-          "confidence": 1
-        },
-        "last-in-collection": {
           "success": true,
           "confidence": 1
         },
@@ -3037,6 +3044,10 @@
           "success": true,
           "confidence": 0.7142857142857143
         },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "event-key-combo": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -3189,18 +3200,22 @@
       "avgConfidence": 0.8261126672891358,
       "avgFidelity": 0.9803921568627451,
       "avgRoleFidelity": 0.8153223194039522,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "modal-close-button",
+        "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3825,15 +3840,14 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8263201576927067,
       "avgFidelity": 0.9589324618736381,
-      "avgRoleFidelity": 0.8551263362487853,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgRoleFidelity": 0.8587544541626174,
+      "avgExecutionFidelity": 0.8333333333333334,
       "executionFailures": [
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop",
-        "tabs-content"
+        "modal-close-backdrop"
       ],
       "degeneratePasses": [
         "behavior-draggable",
@@ -3851,7 +3865,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4474,11 +4488,12 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.9546072974644388,
+      "avgConfidence": 0.9560915275200976,
       "avgFidelity": 0.928030303030303,
-      "avgRoleFidelity": 0.5768500643500645,
-      "avgExecutionFidelity": 0.5862068965517241,
+      "avgRoleFidelity": 0.5791023166023168,
+      "avgExecutionFidelity": 0.5666666666666667,
       "executionFailures": [
+        "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
@@ -4512,7 +4527,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -4714,6 +4729,10 @@
           "success": true,
           "confidence": 1
         },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
         "accordion-exclusive": {
           "success": true,
           "confidence": 1
@@ -4783,6 +4802,10 @@
           "confidence": 1
         },
         "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -5058,15 +5081,7 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "form-disable-on-submit": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "closest-ancestor": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -5139,15 +5154,19 @@
       "avgConfidence": 0.8404295051353855,
       "avgFidelity": 0.9627450980392157,
       "avgRoleFidelity": 0.8048995788791706,
-      "avgExecutionFidelity": 0.7586206896551724,
+      "avgExecutionFidelity": 0.6333333333333333,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
         "modal-close-backdrop",
-        "set-style"
+        "modal-close-button",
+        "set-style",
+        "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
@@ -5158,7 +5177,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5783,20 +5802,23 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8379396202925594,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.7965500485908652,
-      "avgExecutionFidelity": 0.7586206896551724,
+      "avgRoleFidelity": 0.7984774862325885,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
         "modal-close-backdrop",
+        "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6419,11 +6441,12 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8351783137497423,
+      "avgConfidence": 0.8399092970521543,
       "avgFidelity": 0.941017316017316,
-      "avgRoleFidelity": 0.7373230373230375,
-      "avgExecutionFidelity": 0.7586206896551724,
+      "avgRoleFidelity": 0.7429536679536681,
+      "avgExecutionFidelity": 0.7333333333333333,
       "executionFailures": [
+        "accordion-exclusive",
         "if-condition",
         "if-exists",
         "if-matches",
@@ -6451,7 +6474,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6601,11 +6624,19 @@
           "success": true,
           "confidence": 1
         },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 1
+        },
         "modal-close-escape": {
           "success": true,
           "confidence": 1
         },
         "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
           "success": true,
           "confidence": 1
         },
@@ -6654,6 +6685,10 @@
           "confidence": 1
         },
         "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -6849,15 +6884,7 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "form-disable-on-submit": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "closest-ancestor": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -6958,10 +6985,6 @@
           "confidence": 0.5
         },
         "async-block": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-close-button": {
           "success": true,
           "confidence": 0.5
         },
@@ -7075,11 +7098,12 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7911667697381983,
+      "avgConfidence": 0.7958977530406102,
       "avgFidelity": 0.9621212121212123,
-      "avgRoleFidelity": 0.7407657657657661,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgRoleFidelity": 0.7463963963963967,
+      "avgExecutionFidelity": 0.7666666666666667,
       "executionFailures": [
+        "accordion-exclusive",
         "if-condition",
         "if-exists",
         "if-matches",
@@ -7095,7 +7119,7 @@
         "window-scroll"
       ],
       "lossyPasses": ["fetch-do-not-throw", "fetch-error-handling", "unless-condition"],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7233,11 +7257,19 @@
           "success": true,
           "confidence": 1
         },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 1
+        },
         "modal-close-escape": {
           "success": true,
           "confidence": 1
         },
         "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
           "success": true,
           "confidence": 1
         },
@@ -7282,6 +7314,10 @@
           "confidence": 1
         },
         "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -7437,15 +7473,7 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "form-disable-on-submit": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "closest-ancestor": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -7558,10 +7586,6 @@
           "confidence": 0.5
         },
         "async-block": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-close-button": {
           "success": true,
           "confidence": 0.5
         },
@@ -7722,15 +7746,19 @@
       "avgConfidence": 0.8334292106104165,
       "avgFidelity": 0.9794183445190157,
       "avgRoleFidelity": 0.8339368386243388,
-      "avgExecutionFidelity": 0.7586206896551724,
+      "avgExecutionFidelity": 0.6333333333333333,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
         "make-element",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "modal-close-button",
+        "tabs-content"
       ],
       "degeneratePasses": [],
       "lossyPasses": [
@@ -7744,7 +7772,7 @@
         "render-template-with-data",
         "set-color-variable"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8365,20 +8393,23 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8037866998651292,
       "avgFidelity": 0.9782135076252723,
-      "avgRoleFidelity": 0.8125445416261743,
-      "avgExecutionFidelity": 0.7586206896551724,
+      "avgRoleFidelity": 0.8139050858438615,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
         "modal-close-backdrop",
+        "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9004,18 +9035,22 @@
       "avgConfidence": 0.8007988380537381,
       "avgFidelity": 0.9803921568627451,
       "avgRoleFidelity": 0.8352850664075154,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "modal-close-button",
+        "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9638,16 +9673,19 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7064213564213565,
+      "avgConfidence": 0.7161616161616162,
       "avgFidelity": 0.9632034632034633,
-      "avgRoleFidelity": 0.7041023166023167,
-      "avgExecutionFidelity": 0.7241379310344828,
+      "avgRoleFidelity": 0.7095559845559846,
+      "avgExecutionFidelity": 0.6333333333333333,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "if-condition",
         "if-exists",
         "if-matches",
         "modal-close-backdrop",
+        "modal-close-button",
         "put-content-basic",
         "set-attribute",
         "tabs-content"
@@ -9664,7 +9702,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9770,7 +9808,15 @@
           "success": true,
           "confidence": 1
         },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 1
+        },
         "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
           "success": true,
           "confidence": 1
         },
@@ -9787,6 +9833,10 @@
           "confidence": 1
         },
         "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -10058,15 +10108,7 @@
           "success": true,
           "confidence": 0.5
         },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.5
-        },
         "modal-close-escape": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "accordion-toggle": {
           "success": true,
           "confidence": 0.5
         },
@@ -10127,10 +10169,6 @@
           "confidence": 0.5
         },
         "previous-element": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "closest-ancestor": {
           "success": true,
           "confidence": 0.5
         },
@@ -10290,9 +10328,10 @@
       "parseRate": 1,
       "avgConfidence": 0.8117913832199526,
       "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.8184765122265123,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgRoleFidelity": 0.8203909266409267,
+      "avgExecutionFidelity": 0.7666666666666667,
       "executionFailures": [
+        "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
@@ -10302,7 +10341,7 @@
       ],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10927,20 +10966,29 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.791841269841268,
-      "avgFidelity": 0.9727777777777777,
-      "avgRoleFidelity": 0.8223627645502647,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgFidelity": 0.9705555555555554,
+      "avgRoleFidelity": 0.8192377645502646,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "modal-close-button",
+        "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": ["event-debounce", "repeat-until-event", "set-color-variable"],
-      "bundleSize": 416817,
+      "lossyPasses": [
+        "event-debounce",
+        "modal-close-button",
+        "repeat-until-event",
+        "set-color-variable"
+      ],
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11562,9 +11610,10 @@
       "parseRate": 1,
       "avgConfidence": 0.8401154401154378,
       "avgFidelity": 1,
-      "avgRoleFidelity": 0.8036196911196911,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgRoleFidelity": 0.8043436293436294,
+      "avgExecutionFidelity": 0.7666666666666667,
       "executionFailures": [
+        "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
@@ -11574,7 +11623,7 @@
       ],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12198,21 +12247,25 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8457025234336144,
+      "avgConfidence": 0.8494027914195967,
       "avgFidelity": 0.9970779220779221,
-      "avgRoleFidelity": 0.8718709781209784,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgRoleFidelity": 0.8754745817245817,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "modal-close-button",
+        "tabs-content"
       ],
       "degeneratePasses": [],
       "lossyPasses": ["if-exists", "window-scroll"],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12302,6 +12355,10 @@
           "success": true,
           "confidence": 1
         },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
         "dropdown-toggle": {
           "success": true,
           "confidence": 1
@@ -12355,6 +12412,10 @@
           "confidence": 1
         },
         "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -12558,14 +12619,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "remove-class-basic": {
           "success": true,
           "confidence": 0.7777777777777777
@@ -12675,6 +12728,10 @@
           "confidence": 0.7142857142857143
         },
         "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-button": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -12806,10 +12863,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "modal-close-button": {
-          "success": true,
-          "confidence": 0.5
-        },
         "window-scroll": {
           "success": true,
           "confidence": 0.5
@@ -12836,16 +12889,19 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8329805996472663,
+      "avgConfidence": 0.8377425044091712,
       "avgFidelity": 0.9635076252723311,
-      "avgRoleFidelity": 0.7524943310657596,
-      "avgExecutionFidelity": 0.7241379310344828,
+      "avgRoleFidelity": 0.7581632653061223,
+      "avgExecutionFidelity": 0.6333333333333333,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "if-condition",
         "if-exists",
         "if-matches",
         "modal-close-backdrop",
+        "modal-close-button",
         "set-attribute",
         "tabs-aria",
         "tabs-content"
@@ -12858,7 +12914,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13004,11 +13060,19 @@
           "success": true,
           "confidence": 1
         },
+        "modal-close-button": {
+          "success": true,
+          "confidence": 1
+        },
         "modal-close-escape": {
           "success": true,
           "confidence": 1
         },
         "modal-close-backdrop": {
+          "success": true,
+          "confidence": 1
+        },
+        "accordion-toggle": {
           "success": true,
           "confidence": 1
         },
@@ -13061,6 +13125,10 @@
           "confidence": 1
         },
         "previous-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -13252,14 +13320,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -13361,10 +13421,6 @@
           "confidence": 0.5
         },
         "async-block": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "modal-close-button": {
           "success": true,
           "confidence": 0.5
         },
@@ -13483,9 +13539,10 @@
       "parseRate": 1,
       "avgConfidence": 0.8098948670377222,
       "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.8067648005148006,
-      "avgExecutionFidelity": 0.7931034482758621,
+      "avgRoleFidelity": 0.808679214929215,
+      "avgExecutionFidelity": 0.7666666666666667,
       "executionFailures": [
+        "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
@@ -13495,7 +13552,7 @@
       ],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14121,15 +14178,18 @@
       "parseRate": 1,
       "avgConfidence": 0.8037518037518019,
       "avgFidelity": 0.985930735930736,
-      "avgRoleFidelity": 0.8489462676962678,
-      "avgExecutionFidelity": 0.7586206896551724,
+      "avgRoleFidelity": 0.8502976190476191,
+      "avgExecutionFidelity": 0.6666666666666666,
       "executionFailures": [
+        "accordion-exclusive",
+        "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
         "modal-close-backdrop",
+        "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": [],
@@ -14140,7 +14200,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14766,14 +14826,16 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9871667185392676,
       "avgFidelity": 0.9632897603485838,
-      "avgRoleFidelity": 0.8889212827988336,
-      "avgExecutionFidelity": 0.8275862068965517,
+      "avgRoleFidelity": 0.8925494007126659,
+      "avgExecutionFidelity": 0.7666666666666667,
       "executionFailures": [
+        "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
-        "modal-close-backdrop"
+        "modal-close-backdrop",
+        "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
@@ -14785,7 +14847,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 416817,
+      "bundleSize": 417073,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15407,7 +15469,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 416817,
+      "size": 417073,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T00:58:00.188Z",
-  "commit": "98225f69",
+  "timestamp": "2026-06-13T01:19:05.695Z",
+  "commit": "e53512d8",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -8,20 +8,23 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8679433429145073,
       "avgFidelity": 0.9758169934640524,
-      "avgRoleFidelity": 0.8486070618723681,
-      "avgExecutionFidelity": 0.7666666666666667,
+      "avgRoleFidelity": 0.846339488176223,
+      "avgExecutionFidelity": 0.6774193548387096,
       "executionFailures": [
         "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
+        "modal-close-button",
+        "modal-open",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["if-exists", "repeat-until-event", "window-scroll"],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,15 +649,18 @@
       "parseRate": 1,
       "avgConfidence": 0.8477942692228406,
       "avgFidelity": 0.9905844155844155,
-      "avgRoleFidelity": 0.7641328828828827,
-      "avgExecutionFidelity": 0.7333333333333333,
+      "avgRoleFidelity": 0.7624436936936935,
+      "avgExecutionFidelity": 0.6451612903225806,
       "executionFailures": [
         "accordion-exclusive",
         "if-condition",
         "if-exists",
         "if-matches",
         "make-element",
+        "make-toast-element",
         "modal-close-backdrop",
+        "modal-close-button",
+        "modal-open",
         "tabs-aria",
         "tabs-content"
       ],
@@ -666,7 +672,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1292,8 +1298,8 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8323373793962008,
       "avgFidelity": 0.9782135076252723,
-      "avgRoleFidelity": 0.8279154518950437,
-      "avgExecutionFidelity": 0.6666666666666666,
+      "avgRoleFidelity": 0.8256478781988986,
+      "avgExecutionFidelity": 0.6451612903225806,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
@@ -1302,13 +1308,14 @@
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1932,7 +1939,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2558,8 +2565,8 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8352422450461645,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8124311629413672,
-      "avgExecutionFidelity": 0.6666666666666666,
+      "avgRoleFidelity": 0.8112973760932946,
+      "avgExecutionFidelity": 0.6451612903225806,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
@@ -2568,13 +2575,14 @@
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3199,8 +3207,8 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8261126672891358,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8153223194039522,
-      "avgExecutionFidelity": 0.6666666666666666,
+      "avgRoleFidelity": 0.8130547457078071,
+      "avgExecutionFidelity": 0.6451612903225806,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
@@ -3209,13 +3217,14 @@
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3840,13 +3849,14 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8263201576927067,
       "avgFidelity": 0.9589324618736381,
-      "avgRoleFidelity": 0.8587544541626174,
-      "avgExecutionFidelity": 0.8333333333333334,
+      "avgRoleFidelity": 0.8564868804664724,
+      "avgExecutionFidelity": 0.8064516129032258,
       "executionFailures": [
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop"
       ],
       "degeneratePasses": [
@@ -3865,7 +3875,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4490,8 +4500,8 @@
       "parseRate": 1,
       "avgConfidence": 0.9560915275200976,
       "avgFidelity": 0.928030303030303,
-      "avgRoleFidelity": 0.5791023166023168,
-      "avgExecutionFidelity": 0.5666666666666667,
+      "avgRoleFidelity": 0.5785392535392536,
+      "avgExecutionFidelity": 0.4838709677419355,
       "executionFailures": [
         "accordion-exclusive",
         "halt-propagation",
@@ -4499,7 +4509,10 @@
         "if-exists",
         "if-matches",
         "make-element",
+        "make-toast-element",
         "modal-close-backdrop",
+        "modal-close-button",
+        "modal-open",
         "set-attribute",
         "set-inner-html-possessive-dot",
         "set-style",
@@ -4527,7 +4540,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5153,8 +5166,8 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8404295051353855,
       "avgFidelity": 0.9627450980392157,
-      "avgRoleFidelity": 0.8048995788791706,
-      "avgExecutionFidelity": 0.6333333333333333,
+      "avgRoleFidelity": 0.8026320051830256,
+      "avgExecutionFidelity": 0.5806451612903226,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
@@ -5163,8 +5176,10 @@
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
+        "modal-open",
         "set-style",
         "tabs-content"
       ],
@@ -5177,7 +5192,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5802,8 +5817,8 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8379396202925594,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.7984774862325885,
-      "avgExecutionFidelity": 0.6666666666666666,
+      "avgRoleFidelity": 0.797343699384516,
+      "avgExecutionFidelity": 0.6451612903225806,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
@@ -5812,13 +5827,14 @@
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6443,14 +6459,17 @@
       "parseRate": 1,
       "avgConfidence": 0.8399092970521543,
       "avgFidelity": 0.941017316017316,
-      "avgRoleFidelity": 0.7429536679536681,
-      "avgExecutionFidelity": 0.7333333333333333,
+      "avgRoleFidelity": 0.7407014157014159,
+      "avgExecutionFidelity": 0.6451612903225806,
       "executionFailures": [
         "accordion-exclusive",
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
+        "modal-close-button",
+        "modal-open",
         "put-content-basic",
         "tabs-aria",
         "tabs-content"
@@ -6474,7 +6493,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7100,14 +7119,17 @@
       "parseRate": 1,
       "avgConfidence": 0.7958977530406102,
       "avgFidelity": 0.9621212121212123,
-      "avgRoleFidelity": 0.7463963963963967,
-      "avgExecutionFidelity": 0.7666666666666667,
+      "avgRoleFidelity": 0.7441441441441444,
+      "avgExecutionFidelity": 0.6774193548387096,
       "executionFailures": [
         "accordion-exclusive",
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
+        "modal-close-button",
+        "modal-open",
         "tabs-aria",
         "tabs-content"
       ],
@@ -7119,7 +7141,7 @@
         "window-scroll"
       ],
       "lossyPasses": ["fetch-do-not-throw", "fetch-error-handling", "unless-condition"],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7745,8 +7767,8 @@
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.8334292106104165,
       "avgFidelity": 0.9794183445190157,
-      "avgRoleFidelity": 0.8339368386243388,
-      "avgExecutionFidelity": 0.6333333333333333,
+      "avgRoleFidelity": 0.831622023809524,
+      "avgExecutionFidelity": 0.6129032258064516,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
@@ -7756,6 +7778,7 @@
         "if-exists",
         "if-matches",
         "make-element",
+        "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
@@ -7772,7 +7795,7 @@
         "render-template-with-data",
         "set-color-variable"
       ],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8393,8 +8416,8 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8037866998651292,
       "avgFidelity": 0.9782135076252723,
-      "avgRoleFidelity": 0.8139050858438615,
-      "avgExecutionFidelity": 0.6666666666666666,
+      "avgRoleFidelity": 0.8127712989957888,
+      "avgExecutionFidelity": 0.6451612903225806,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
@@ -8403,13 +8426,14 @@
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9034,8 +9058,8 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8007988380537381,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8352850664075154,
-      "avgExecutionFidelity": 0.6666666666666666,
+      "avgRoleFidelity": 0.8330174927113703,
+      "avgExecutionFidelity": 0.6451612903225806,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
@@ -9044,13 +9068,14 @@
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9675,8 +9700,8 @@
       "parseRate": 1,
       "avgConfidence": 0.7161616161616162,
       "avgFidelity": 0.9632034632034633,
-      "avgRoleFidelity": 0.7095559845559846,
-      "avgExecutionFidelity": 0.6333333333333333,
+      "avgRoleFidelity": 0.7078667953667954,
+      "avgExecutionFidelity": 0.5806451612903226,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
@@ -9684,8 +9709,10 @@
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
+        "modal-open",
         "put-content-basic",
         "set-attribute",
         "tabs-content"
@@ -9702,7 +9729,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10328,20 +10355,23 @@
       "parseRate": 1,
       "avgConfidence": 0.8117913832199526,
       "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.8203909266409267,
-      "avgExecutionFidelity": 0.7666666666666667,
+      "avgRoleFidelity": 0.8192648005148006,
+      "avgExecutionFidelity": 0.6774193548387096,
       "executionFailures": [
         "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
+        "modal-close-button",
+        "modal-open",
         "tabs-content"
       ],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10967,8 +10997,8 @@
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.791841269841268,
       "avgFidelity": 0.9705555555555554,
-      "avgRoleFidelity": 0.8192377645502646,
-      "avgExecutionFidelity": 0.6666666666666666,
+      "avgRoleFidelity": 0.8169229497354499,
+      "avgExecutionFidelity": 0.6451612903225806,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
@@ -10977,6 +11007,7 @@
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
@@ -10988,7 +11019,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11610,20 +11641,23 @@
       "parseRate": 1,
       "avgConfidence": 0.8401154401154378,
       "avgFidelity": 1,
-      "avgRoleFidelity": 0.8043436293436294,
-      "avgExecutionFidelity": 0.7666666666666667,
+      "avgRoleFidelity": 0.8020913770913771,
+      "avgExecutionFidelity": 0.6774193548387096,
       "executionFailures": [
         "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
+        "modal-close-button",
+        "modal-open",
         "tabs-content"
       ],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12249,8 +12283,8 @@
       "parseRate": 1,
       "avgConfidence": 0.8494027914195967,
       "avgFidelity": 0.9970779220779221,
-      "avgRoleFidelity": 0.8754745817245817,
-      "avgExecutionFidelity": 0.6666666666666666,
+      "avgRoleFidelity": 0.8732223294723296,
+      "avgExecutionFidelity": 0.6129032258064516,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
@@ -12259,13 +12293,15 @@
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
+        "modal-open",
         "tabs-content"
       ],
       "degeneratePasses": [],
       "lossyPasses": ["if-exists", "window-scroll"],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12891,8 +12927,8 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8377425044091712,
       "avgFidelity": 0.9635076252723311,
-      "avgRoleFidelity": 0.7581632653061223,
-      "avgExecutionFidelity": 0.6333333333333333,
+      "avgRoleFidelity": 0.7558956916099772,
+      "avgExecutionFidelity": 0.5806451612903226,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
@@ -12900,8 +12936,10 @@
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
+        "modal-open",
         "set-attribute",
         "tabs-aria",
         "tabs-content"
@@ -12914,7 +12952,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13539,20 +13577,23 @@
       "parseRate": 1,
       "avgConfidence": 0.8098948670377222,
       "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.808679214929215,
-      "avgExecutionFidelity": 0.7666666666666667,
+      "avgRoleFidelity": 0.808116151866152,
+      "avgExecutionFidelity": 0.6774193548387096,
       "executionFailures": [
         "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
+        "modal-close-button",
+        "modal-open",
         "tabs-content"
       ],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14178,8 +14219,8 @@
       "parseRate": 1,
       "avgConfidence": 0.8037518037518019,
       "avgFidelity": 0.985930735930736,
-      "avgRoleFidelity": 0.8502976190476191,
-      "avgExecutionFidelity": 0.6666666666666666,
+      "avgRoleFidelity": 0.8480453667953669,
+      "avgExecutionFidelity": 0.6451612903225806,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
@@ -14188,6 +14229,7 @@
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
@@ -14200,7 +14242,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14826,14 +14868,15 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9871667185392676,
       "avgFidelity": 0.9632897603485838,
-      "avgRoleFidelity": 0.8925494007126659,
-      "avgExecutionFidelity": 0.7666666666666667,
+      "avgRoleFidelity": 0.8902818270165207,
+      "avgExecutionFidelity": 0.7419354838709677,
       "executionFailures": [
         "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
+        "make-toast-element",
         "modal-close-backdrop",
         "tabs-content"
       ],
@@ -14847,7 +14890,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 417073,
+      "bundleSize": 418022,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15469,7 +15512,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 417073,
+      "size": 418022,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
@@ -19,7 +19,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { ExecutionValidator, EXECUTION_SUBSET, loadExecutionSubset } from './execution-validator';
 
 describe('R2 execution subset (lock)', () => {
-  it('contains exactly the 30 curated patterns', () => {
+  it('contains exactly the 31 curated patterns', () => {
     // Changing this list recalibrates avgExecutionFidelity for every language.
     // If you expand the subset, regenerate the baseline (--save-baseline) in
     // the SAME PR and update this lock.
@@ -74,8 +74,14 @@ describe('R2 execution subset (lock)', () => {
         // Session-10 expansion wave 3: positional-phrase patients — the
         // pattern matcher captures `closest <sel>` / `the next <sel>`, so
         // `hide closest .modal` parses and executes (PATTERN_SETUP gives #btn
-        // a .modal ancestor). make-toast-element still out (at-end-of put).
+        // a .modal ancestor).
         'modal-close-button',
+        // Session-10 expansion wave 3b: the at-end-of positional put — en
+        // `at end of`/`at start of` patterns + the parseBodyWithClauses
+        // end-noun guard + putMapper manner + core multi-word modifier keys
+        // + contextReference body. The last R2 candidate excluded for an
+        // unusable en reference is now in.
+        'make-toast-element',
       ].sort()
     );
   });

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
@@ -19,7 +19,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { ExecutionValidator, EXECUTION_SUBSET, loadExecutionSubset } from './execution-validator';
 
 describe('R2 execution subset (lock)', () => {
-  it('contains exactly the 29 curated patterns', () => {
+  it('contains exactly the 30 curated patterns', () => {
     // Changing this list recalibrates avgExecutionFidelity for every language.
     // If you expand the subset, regenerate the baseline (--save-baseline) in
     // the SAME PR and update this lock.
@@ -71,6 +71,11 @@ describe('R2 execution subset (lock)', () => {
         // Session-9 expansion wave 2d: `next .sel` folds to a positional call
         // expression. make-toast-element still out (at-end-of positional put).
         'dropdown-toggle',
+        // Session-10 expansion wave 3: positional-phrase patients — the
+        // pattern matcher captures `closest <sel>` / `the next <sel>`, so
+        // `hide closest .modal` parses and executes (PATTERN_SETUP gives #btn
+        // a .modal ancestor). make-toast-element still out (at-end-of put).
+        'modal-close-button',
       ].sort()
     );
   });

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.ts
@@ -62,16 +62,9 @@ export const EXECUTION_SUBSET: readonly string[] = [
   // Expansion wave 1 (session 8): multi-command click patterns — sync,
   // network/timer-free sequences of 2–4 commands. Same eligibility bar as the
   // original subset: the en reference must execute with a non-empty effect
-  // signature in the current runtime. Eleven candidates were probed; two are
-  // still deliberately absent because their EN reference is unusable:
-  //   modal-close-button    — en parse DROPS `hide closest .modal`; the
-  //                           surviving body-class change is invisible to the
-  //                           snapshot (body isn't serialized)
-  //   make-toast-element    — the make + into-it puts now work, but the final
-  //                           `put it at end of body` is the at-end-of
-  //                           positional-put form (distinct from the now-fixed
-  //                           `next .sel` fold), so the detached toast never
-  //                           enters the DOM
+  // signature in the current runtime. Eleven candidates were probed; the two
+  // then-excluded for unusable EN references (modal-close-button,
+  // make-toast-element) joined in waves 3/3b once their en parses were fixed.
   'tabs-content',
   'accordion-exclusive',
   // Expansion wave 2 (session 9, post en-conditional work): control-flow click
@@ -114,8 +107,15 @@ export const EXECUTION_SUBSET: readonly string[] = [
   // command dropped from the body entirely). The en reference for
   // modal-close-button now hides the enclosing .modal (PATTERN_SETUP gives
   // #btn a .modal ancestor, mirroring the real-page structure).
-  // make-toast-element stays out (at-end-of positional put, distinct form).
   'modal-close-button',
+  // Expansion wave 3b (session 10): the at-end-of positional put — en put
+  // patterns for `at end of` / `at start of`, the parseBodyWithClauses
+  // end-noun guard (the `end` in `at end of` is a position noun, not the
+  // block terminator), putMapper reads `manner` (also fixing the latent
+  // before/after→into bug), core PutCommand accepts the multi-word modifier
+  // keys, and contextReference body/document/window resolve. The en
+  // reference appends the toast at end of body: one clean effect line.
+  'make-toast-element',
 ];
 
 /**
@@ -157,8 +157,12 @@ const PATTERN_SETUP: Record<string, (doc: Document) => void> = {
   // backdrop (the real-page case is a click landing on the backdrop itself).
   'modal-close-backdrop': doc => doc.getElementById('btn')!.classList.add('modal-backdrop'),
   // `hide closest .modal` needs #btn inside a .modal (the real-page case is a
-  // close button inside the modal it closes).
-  'modal-close-button': doc => doc.querySelector('.card')!.classList.add('modal'),
+  // close button inside the modal it closes), and `remove .modal-open from
+  // body` needs the class present so the body write is scoreable.
+  'modal-close-button': doc => {
+    doc.querySelector('.card')!.classList.add('modal');
+    doc.body.classList.add('modal-open');
+  },
 };
 
 /** Result of executing one pattern translation. */
@@ -178,23 +182,33 @@ export interface ExecutionResult {
  * Keyed by #id when present, else tag[document-order-index]; the fixture is
  * identical across languages, so keys are comparable.
  */
+function serializeElement(el: Element): string {
+  const attrs = Array.from(el.attributes)
+    .filter(a => a.name !== 'class' && a.name !== 'style')
+    .map(a => `${a.name}=${a.value}`)
+    .sort()
+    .join(',');
+  const classes = Array.from(el.classList).sort().join(' ');
+  const style = (el as HTMLElement).getAttribute('style') ?? '';
+  // Leaf text only — container text would duplicate every child mutation.
+  const text =
+    el.childNodes.length === 0 || (el.childNodes.length === 1 && el.firstChild?.nodeType === 3)
+      ? (el.textContent ?? '')
+      : '';
+  return `cls[${classes}] attr[${attrs}] style[${style}] text[${text}]`;
+}
+
 function snapshot(document: Document): Map<string, string> {
   const out = new Map<string, string>();
+  // body participates under its own stable key: body-targeted effects
+  // (`add .modal-open to body`, modal-open/modal-close-button) must be
+  // visible in the signature now that the runtime resolves `body`. Before
+  // wave 3b these writes fell back to `me` (visible by accident); a correct
+  // body write was invisible and a dropped one unscoreable.
+  out.set('body', serializeElement(document.body));
   document.body.querySelectorAll('*').forEach((el, i) => {
     const key = el.id ? `#${el.id}` : `${el.tagName.toLowerCase()}[${i}]`;
-    const attrs = Array.from(el.attributes)
-      .filter(a => a.name !== 'class' && a.name !== 'style')
-      .map(a => `${a.name}=${a.value}`)
-      .sort()
-      .join(',');
-    const classes = Array.from(el.classList).sort().join(' ');
-    const style = (el as HTMLElement).getAttribute('style') ?? '';
-    // Leaf text only — container text would duplicate every child mutation.
-    const text =
-      el.childNodes.length === 0 || (el.childNodes.length === 1 && el.firstChild?.nodeType === 3)
-        ? (el.textContent ?? '')
-        : '';
-    out.set(key, `cls[${classes}] attr[${attrs}] style[${style}] text[${text}]`);
+    out.set(key, serializeElement(el));
   });
   return out;
 }

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.ts
@@ -108,6 +108,14 @@ export const EXECUTION_SUBSET: readonly string[] = [
   // and the toggle target evaluated to NaN. `.dropdown-menu` added to the
   // fixture (appended last; existing snapshot indexes unchanged).
   'dropdown-toggle',
+  // Expansion wave 3 (session 10): positional-phrase patients/destinations —
+  // the pattern matcher now captures `closest <sel>` and article-led
+  // `the next <sel>` as positional expressions (previously the hide/show
+  // command dropped from the body entirely). The en reference for
+  // modal-close-button now hides the enclosing .modal (PATTERN_SETUP gives
+  // #btn a .modal ancestor, mirroring the real-page structure).
+  // make-toast-element stays out (at-end-of positional put, distinct form).
+  'modal-close-button',
 ];
 
 /**
@@ -148,6 +156,9 @@ const PATTERN_SETUP: Record<string, (doc: Document) => void> = {
   // click's target is #btn, so the condition only fires when #btn IS the
   // backdrop (the real-page case is a click landing on the backdrop itself).
   'modal-close-backdrop': doc => doc.getElementById('btn')!.classList.add('modal-backdrop'),
+  // `hide closest .modal` needs #btn inside a .modal (the real-page case is a
+  // close button inside the modal it closes).
+  'modal-close-button': doc => doc.querySelector('.card')!.classList.add('modal'),
 };
 
 /** Result of executing one pattern translation. */


### PR DESCRIPTION
## Summary

Continues the correctness arc directly after [#401](https://github.com/codetalcott/hyperfixi/pull/401) (positional-phrase patients). The at-end-of positional put — `put it at end of body`, the make-toast-element pattern and the **last R2 candidate excluded for an unusable en reference** — now parses and executes end-to-end. Five small fixes, found by walking the failure through the stack:

1. **en put patterns for `at end of` / `at start of`** ([put.ts](packages/semantic/src/patterns/put.ts)) — the three-word position phrase matches as consecutive literal tokens, recorded whole in `manner`.
2. **`parseBodyWithClauses` end-noun guard** ([semantic-parser.ts](packages/semantic/src/parser/semantic-parser.ts)) — the `end` in `at end of` hit the block-terminator break, so inside an event body the clause parsed **EMPTY**. The guard is sandwich-gated (previous token `at`, next token `of`) — real block-`end`s still terminate, in every language.
3. **`putMapper` reads `manner`** (was `method`, which no producer sets) — this also fixes a **latent bug**: `put X before Y` silently built a put-INTO AST (wrong insertion position at runtime).
4. **Core `PutCommand` accepts the multi-word modifier keys** (`at end of` / `at start of`) on the semantic-modifiers path; `mapPosition` already supported them.
5. **contextReference `body`/`document`/`window` resolve** in the core runtime — the semantic builder emits these surface forms; `body` fell through to undefined and the put landed on `me`. The identifier path deliberately does NOT pre-empt `body` (a user local named `body` would be shadowed); the contextReference node only comes from the builder, so resolving it there is unambiguous.

### Harness

The effect snapshot now serializes **body under its own key**. Before, a body write was invisible — the old modal-open en reference was only scoreable because its `add .modal-open to body` *wrongly* fell back to `me`. With `body` resolving correctly, the write would have vanished from the signature entirely. modal-close-button's PATTERN_SETUP also pre-adds `.modal-open` so the body remove is scoreable.

### R2 / baseline

- Subset **30 → 31** (make-toast-element; en signature is one clean line — the toast appended at end of body). Membership lock updated in the same PR per the locked rule.
- **Zero parse-level churn**: avgFidelity 0.9742, 78 lossy, 63 degenerate — byte-identical to the #401 baseline.
- meanExecutionFidelity 0.6957 → 0.6452 — the recorded-band outcome (new pattern failing in most of the 23 non-en languages + the re-scored body signatures); the cross-language burn-down remains its own track.
- Baseline regenerated against a freshly populated patterns.db; `--regression` gate green against it; patterns.db reverted before commit.

## Validation

- semantic: 5842 passed (incl. 5 new parse locks + 2 new putMapper locks)
- core: 6985 passed (incl. 3 new contextReference locks in runtime-ast-coverage)
- testing-framework: 175 passed (31-pattern membership lock)
- typecheck clean (semantic + core + testing-framework)

## Still deferred

- cross-language positional/conditional burn-down (SOV/VSO orders — the widened R2 band)
- behavior-* degenerate mass (block-structure parsing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)