### PR TITLE
fix(semantic): cross-language conditional fold — R2 wave 4

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -643,6 +643,55 @@ line: the toast appended at end of body). Zero parse-level churn (0.9742 /
 **Still deferred:** cross-language positional/conditional burn-down (SOV/VSO
 orders — now visible as the widened R2 band); behavior-\* degenerate mass.
 
+## 7j. Status update (2026-06-12, session 11): cross-language conditional fold
+
+**The conditional cluster (a) collapsed with ONE parser-routing fix.** The
+baseline's per-language `executionFailures` clustered exactly as §10 predicted:
+if-condition / if-exists / if-matches / modal-close-backdrop failed in ALL 23
+non-en languages (92 of 253 failing cells). The mechanism was NOT a per-language
+dict drift: `tryParseConditionalBlock` is already language-parameterized
+(profile-driven if/then/else/end keywords), but non-en handlers match a **fused
+grammar event pattern** that captures the body's first verb as `action` — and
+the action-captured path in `buildEventHandler` builds a flat command +
+`parseBodyWithGrammarPatterns`, which has no fold. The condition truncated to
+whatever role the pattern grabbed and the branches flattened into siblings
+(runtime: "if command requires a condition to evaluate"). Two fixes in
+`semantic-parser.ts`:
+
+1. **buildEventHandler routes fused `action='if'` through the fold** — rewind
+   to the if-keyword token, parse the remaining body via `parseBodyWithClauses`
+   (where the fold lives), and swap in ONLY when a conditional actually folded;
+   anything else falls through byte-identical. `unless` stays unfolded
+   (action-relabel desync, see the fold's own comment).
+2. **`joinTokenText` normalizes keyword tokens** in the folded condition raw —
+   the core expression evaluator reads English operator words only, so a
+   translated condition (`#modal 存在する`, `si … existe`, `jest pusty`) is
+   unevaluable as-is while its normalized join (`#modal exists`, `is empty`)
+   runs. Identifiers/selectors/literals keep their surface value; en unchanged.
+
+**Result:** if-condition 23→3, if-exists 23→1, if-matches 23→4,
+modal-close-backdrop 23→6 failing languages; meanExecutionFidelity **0.6452 →
+0.7546**, failing cells **253 → 175**. Parse-level: avgFidelity 0.9742→0.9741,
+lossy 78→80, degen 63 unchanged. The +2 lossy are ko if-empty/input-validation
+faithful→lossy flips (within tolerance) and are HONEST: the ko SOV transformer
+emits a scrambled conditional (`… 이다 추가 …` = "is add" — the copula directly
+before the then-branch verb, the empty-adjective stranded inside the add), so
+the old faithful 1.0 was an action-set accident on a broken translation. The
+fold's copula guard now swallows the add into the condition. Realigning the ko
+transformer's SOV conditional emission is a tracked dict/transformer-layer
+follow-up (NOT a parser bug). Side effect of (2): id/pl/it/vi if-empty now fold
+the `is empty` predicate INTO the condition (the en-reference shape); the two
+empty-predicate test families accept either shape (folded condition or the
+flat-compromise `empty` command for languages whose copula doesn't normalize —
+fr/pt/zh/ru/uk).
+
+**Remaining R2 clusters (next session):** make-toast-element ×23 +
+accordion-exclusive/tabs-content ×22 + modal-close-button ×21 (multi-command /
+positional bodies); halt-propagation ×18; closest-ancestor + dropdown-toggle
+×13 (positional capture, same 13 Latin-script langs — cluster (b));
+modal-open ×12 (SOV/non-Latin); conditional residue: hi/ko/qu/ru/uk/zh on
+modal-close-backdrop, id/qu/tr/zh on if-matches.
+
 ## 8. R1 / R2 — role-fidelity and execution ratchets (extend R0)
 
 Action-set fidelity (R0's signal) cannot see a parse that finds the right

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -455,6 +455,46 @@ export class SemanticParserImpl implements ISemanticParser {
     // Check if pattern captured an action (grammar-transformed patterns)
     // These patterns combine event + action in a single match
     const actionValue = match.captured.get('action');
+
+    // A fused event pattern that captured `if` as the body's first action has
+    // swallowed the conditional KEYWORD into a flat command — the condition
+    // truncates to whatever role the pattern grabbed and the branches flatten
+    // into siblings (the §2 cluster, cross-language: en folds via
+    // parseBodyWithClauses → tryParseConditionalBlock, but this action-captured
+    // path never reached the fold). Rewind to the if-keyword token and parse the
+    // remaining body through the clause path so the whole block folds. Swap in
+    // ONLY when a conditional actually folded — otherwise fall through to the
+    // existing flat path byte-identical. `unless` stays unfolded (see
+    // tryParseConditionalBlock: folding would relabel its action and desync the
+    // cross-language action-set comparison).
+    if (actionValue && actionValue.type === 'literal' && actionValue.value === 'if') {
+      const all = tokens.tokens as LanguageToken[];
+      let ifIdx = -1;
+      for (let k = tokens.position() - 1; k >= 0; k--) {
+        const kTok = all[k] as { normalized?: string; value: string };
+        const kv = (kTok.normalized ?? kTok.value).toLowerCase();
+        if (this.isIfKeyword(kv, language)) {
+          ifIdx = k;
+          break;
+        }
+      }
+      if (ifIdx >= 0) {
+        const commandPatterns = getPatternsForLanguage(language)
+          .filter(p => p.command !== 'on')
+          .sort((a, b) => b.priority - a.priority);
+        const bodyStream = new TokenStreamImpl(all.slice(ifIdx), language);
+        const folded = this.parseBodyWithClauses(bodyStream, commandPatterns, language);
+        if (folded.some(n => n.kind === 'conditional')) {
+          while (!tokens.isAtEnd()) tokens.advance(); // body fully consumed by the fold
+          return createEventHandler(resolvedEventValue, folded, eventModifiers, {
+            sourceLanguage: language,
+            patternId: match.pattern.id,
+            confidence: match.confidence,
+          });
+        }
+      }
+    }
+
     if (actionValue && actionValue.type === 'literal') {
       // Create a command node directly from captured roles
       const actionName = actionValue.value as string;
@@ -2052,10 +2092,20 @@ export class SemanticParserImpl implements ISemanticParser {
     });
   }
 
-  /** Reconstruct source-ish text from a token slice for an expression value. */
+  /**
+   * Reconstruct source-ish text from a token slice for an expression value.
+   * Keyword tokens contribute their NORMALIZED (English) form: the condition
+   * raw string is evaluated by the core expression parser, which only reads
+   * English operator words — a translated condition (`#modal 存在する`,
+   * `#modal existe`) is unevaluable as-is, while its normalized join
+   * (`#modal exists`) runs. Non-keyword tokens (identifiers, selectors,
+   * literals) keep their surface value; for en the two are identical.
+   */
   private joinTokenText(toks: readonly LanguageToken[]): string {
     return toks
-      .map(t => t.value)
+      .map(t =>
+        t.kind === 'keyword' ? ((t as { normalized?: string }).normalized ?? t.value) : t.value
+      )
       .join(' ')
       .trim();
   }

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -284,11 +284,42 @@ describe('`is empty` predicate alignment (verb vs adjective)', () => {
     return acc;
   }
 
+  /** Walk all conditional nodes and collect their condition raw strings. */
+  function conditionRaws(node: unknown, acc: string[] = []): string[] {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    const roles = rec.roles;
+    if (roles instanceof Map) {
+      const cond = roles.get('condition') as { raw?: string; value?: unknown } | undefined;
+      if (cond) acc.push(String(cond.raw ?? cond.value ?? ''));
+    }
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => conditionRaws(x, acc));
+      else if (c && typeof c === 'object') conditionRaws(c, acc);
+    }
+    return acc;
+  }
+
+  /** Predicate survives either as a folded condition word (normalized
+   * `empty`/`null` — the en-reference shape) or as the flat-compromise
+   * `empty` command action. */
+  function predicateRetained(node: unknown, a: Set<string>): boolean {
+    if (a.has('empty')) return true;
+    return conditionRaws(node).some(raw => /\b(empty|null)\b/i.test(raw));
+  }
+
   // The semantic profile's `empty` primary is the *verb* (vider/esvaziar/清空/…),
   // but the i18n transformer emits the *adjective* for the `is empty` emptiness
   // check (vide/vazio/空的/…). Without the adjective registered, the condition
-  // predicate was silently dropped. These corpus-shaped `if … is empty …` handlers
-  // must now retain the `empty` action (alongside if + body).
+  // predicate was silently dropped. The predicate must survive in one of two
+  // shapes: since the cross-language conditional fold (buildEventHandler routes
+  // a fused `if` action through tryParseConditionalBlock), languages whose
+  // copula normalizes to `is` fold the predicate INTO the condition expression
+  // (`me valore is empty` — the en-reference shape, see the [en] case in the
+  // is-empty cluster below); languages whose copula does not normalize keep the
+  // older flat compromise where the adjective parses as the `empty` COMMAND.
+  // Either way it must not silently vanish.
   const cases: Array<[string, string]> = [
     ['fr', 'sur flou si mon valeur est vide ajouter .error à moi fin'],
     ['pt', 'em desfoque se meu valor é vazio adicionar .error para eu fim'],
@@ -298,10 +329,11 @@ describe('`is empty` predicate alignment (verb vs adjective)', () => {
   ];
   for (const [lang, input] of cases) {
     it(`[${lang}] recognizes the empty predicate in a conditional`, () => {
-      const a = actions(parse(input, lang));
-      expect(a.has('empty')).toBe(true);
+      const node = parse(input, lang);
+      const a = actions(node);
       expect(a.has('if')).toBe(true);
       expect(a.has('add')).toBe(true);
+      expect(predicateRetained(node, a)).toBe(true);
     });
   }
 });
@@ -3111,13 +3143,38 @@ describe('empty-predicate adjective is a profile keyword alternative (is-empty c
       'при розмиття якщо мій значення є порожній додати .error в я тоді покласти "Required" в наступний .error-message кінець',
     ],
   ];
+  /** Walk all conditional nodes and collect their condition raw strings. */
+  function conditionRaws(node: unknown, acc: string[] = []): string[] {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    const roles = rec.roles;
+    if (roles instanceof Map) {
+      const cond = roles.get('condition') as { raw?: string; value?: unknown } | undefined;
+      if (cond) acc.push(String(cond.raw ?? cond.value ?? ''));
+    }
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => conditionRaws(x, acc));
+      else if (c && typeof c === 'object') conditionRaws(c, acc);
+    }
+    return acc;
+  }
+
   for (const [lang, input] of corpus) {
     it(`[${lang}] if-empty keeps the empty predicate (was dropped)`, () => {
-      const a = actions(parse(input, lang as 'ru'));
+      const node = parse(input, lang as 'ru');
+      const a = actions(node);
       expect(a.has('on')).toBe(true);
       expect(a.has('if')).toBe(true);
-      expect(a.has('empty')).toBe(true);
       expect(a.has('add')).toBe(true);
+      // The predicate survives either folded into the condition expression
+      // (normalized `is empty` — the en-reference shape; it/vi since the
+      // cross-language conditional fold) or as the flat-compromise `empty`
+      // command (ru/uk, whose copula doesn't normalize to `is`). Either way
+      // it must not silently vanish.
+      const retained =
+        a.has('empty') || conditionRaws(node).some(raw => /\b(empty|null)\b/i.test(raw));
+      expect(retained).toBe(true);
     });
   }
 

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T01:19:05.695Z",
-  "commit": "e53512d8",
+  "timestamp": "2026-06-13T01:49:25.704Z",
+  "commit": "54dc5ab7",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -8,23 +8,19 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8679433429145073,
       "avgFidelity": 0.9758169934640524,
-      "avgRoleFidelity": 0.846339488176223,
-      "avgExecutionFidelity": 0.6774193548387096,
+      "avgRoleFidelity": 0.8571104632329124,
+      "avgExecutionFidelity": 0.8064516129032258,
       "executionFailures": [
         "accordion-exclusive",
         "halt-propagation",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-toast-element",
-        "modal-close-backdrop",
         "modal-close-button",
         "modal-open",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["if-exists", "repeat-until-event", "window-scroll"],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -649,16 +645,12 @@
       "parseRate": 1,
       "avgConfidence": 0.8477942692228406,
       "avgFidelity": 0.9905844155844155,
-      "avgRoleFidelity": 0.7624436936936935,
-      "avgExecutionFidelity": 0.6451612903225806,
+      "avgRoleFidelity": 0.7753941441441441,
+      "avgExecutionFidelity": 0.7741935483870968,
       "executionFailures": [
         "accordion-exclusive",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-element",
         "make-toast-element",
-        "modal-close-backdrop",
         "modal-close-button",
         "modal-open",
         "tabs-aria",
@@ -672,7 +664,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1298,24 +1290,20 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8323373793962008,
       "avgFidelity": 0.9782135076252723,
-      "avgRoleFidelity": 0.8256478781988986,
-      "avgExecutionFidelity": 0.6451612903225806,
+      "avgRoleFidelity": 0.8420877874959508,
+      "avgExecutionFidelity": 0.7741935483870968,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-toast-element",
-        "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1939,7 +1927,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2565,24 +2553,20 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8352422450461645,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8112973760932946,
-      "avgExecutionFidelity": 0.6451612903225806,
+      "avgRoleFidelity": 0.8277372853903467,
+      "avgExecutionFidelity": 0.7741935483870968,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-toast-element",
-        "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3207,24 +3191,20 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8261126672891358,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8130547457078071,
-      "avgExecutionFidelity": 0.6451612903225806,
+      "avgRoleFidelity": 0.8294946550048593,
+      "avgExecutionFidelity": 0.7741935483870968,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-toast-element",
-        "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3849,16 +3829,9 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8263201576927067,
       "avgFidelity": 0.9589324618736381,
-      "avgRoleFidelity": 0.8564868804664724,
-      "avgExecutionFidelity": 0.8064516129032258,
-      "executionFailures": [
-        "halt-propagation",
-        "if-condition",
-        "if-exists",
-        "if-matches",
-        "make-toast-element",
-        "modal-close-backdrop"
-      ],
+      "avgRoleFidelity": 0.8729267897635247,
+      "avgExecutionFidelity": 0.9354838709677419,
+      "executionFailures": ["halt-propagation", "make-toast-element"],
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
@@ -3875,7 +3848,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4500,14 +4473,11 @@
       "parseRate": 1,
       "avgConfidence": 0.9560915275200976,
       "avgFidelity": 0.928030303030303,
-      "avgRoleFidelity": 0.5785392535392536,
-      "avgExecutionFidelity": 0.4838709677419355,
+      "avgRoleFidelity": 0.5914897039897042,
+      "avgExecutionFidelity": 0.5806451612903226,
       "executionFailures": [
         "accordion-exclusive",
         "halt-propagation",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-element",
         "make-toast-element",
         "modal-close-backdrop",
@@ -4540,7 +4510,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5166,18 +5136,16 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8404295051353855,
       "avgFidelity": 0.9627450980392157,
-      "avgRoleFidelity": 0.8026320051830256,
-      "avgExecutionFidelity": 0.5806451612903226,
+      "avgRoleFidelity": 0.8190719144800778,
+      "avgExecutionFidelity": 0.6451612903225806,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
         "if-condition",
-        "if-exists",
         "if-matches",
         "make-toast-element",
-        "modal-close-backdrop",
         "modal-close-button",
         "modal-open",
         "set-style",
@@ -5192,7 +5160,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5817,24 +5785,20 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8379396202925594,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.797343699384516,
-      "avgExecutionFidelity": 0.6451612903225806,
+      "avgRoleFidelity": 0.8137836086815678,
+      "avgExecutionFidelity": 0.7741935483870968,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-toast-element",
-        "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6459,15 +6423,11 @@
       "parseRate": 1,
       "avgConfidence": 0.8399092970521543,
       "avgFidelity": 0.941017316017316,
-      "avgRoleFidelity": 0.7407014157014159,
-      "avgExecutionFidelity": 0.6451612903225806,
+      "avgRoleFidelity": 0.7536518661518664,
+      "avgExecutionFidelity": 0.7741935483870968,
       "executionFailures": [
         "accordion-exclusive",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-toast-element",
-        "modal-close-backdrop",
         "modal-close-button",
         "modal-open",
         "put-content-basic",
@@ -6493,7 +6453,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7118,14 +7078,11 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7958977530406102,
-      "avgFidelity": 0.9621212121212123,
-      "avgRoleFidelity": 0.7441441441441444,
-      "avgExecutionFidelity": 0.6774193548387096,
+      "avgFidelity": 0.958874458874459,
+      "avgRoleFidelity": 0.7503378378378381,
+      "avgExecutionFidelity": 0.7741935483870968,
       "executionFailures": [
         "accordion-exclusive",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
@@ -7140,8 +7097,14 @@
         "behavior-sortable",
         "window-scroll"
       ],
-      "lossyPasses": ["fetch-do-not-throw", "fetch-error-handling", "unless-condition"],
-      "bundleSize": 418022,
+      "lossyPasses": [
+        "fetch-do-not-throw",
+        "fetch-error-handling",
+        "if-empty",
+        "input-validation",
+        "unless-condition"
+      ],
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7767,19 +7730,15 @@
       "parseRate": 0.9675324675324676,
       "avgConfidence": 0.8334292106104165,
       "avgFidelity": 0.9794183445190157,
-      "avgRoleFidelity": 0.831622023809524,
-      "avgExecutionFidelity": 0.6129032258064516,
+      "avgRoleFidelity": 0.8484044312169314,
+      "avgExecutionFidelity": 0.7419354838709677,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-element",
         "make-toast-element",
-        "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
       ],
@@ -7795,7 +7754,7 @@
         "render-template-with-data",
         "set-color-variable"
       ],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8416,24 +8375,20 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8037866998651292,
       "avgFidelity": 0.9782135076252723,
-      "avgRoleFidelity": 0.8127712989957888,
-      "avgExecutionFidelity": 0.6451612903225806,
+      "avgRoleFidelity": 0.8258098477486233,
+      "avgExecutionFidelity": 0.7741935483870968,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-toast-element",
-        "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9058,24 +9013,20 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8007988380537381,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8330174927113703,
-      "avgExecutionFidelity": 0.6451612903225806,
+      "avgRoleFidelity": 0.8494574020084225,
+      "avgExecutionFidelity": 0.7741935483870968,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-toast-element",
-        "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9700,14 +9651,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7161616161616162,
       "avgFidelity": 0.9632034632034633,
-      "avgRoleFidelity": 0.7078667953667954,
-      "avgExecutionFidelity": 0.5806451612903226,
+      "avgRoleFidelity": 0.7185649935649935,
+      "avgExecutionFidelity": 0.6129032258064516,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
         "dropdown-toggle",
         "if-condition",
-        "if-exists",
         "if-matches",
         "make-toast-element",
         "modal-close-backdrop",
@@ -9729,7 +9679,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10355,14 +10305,11 @@
       "parseRate": 1,
       "avgConfidence": 0.8117913832199526,
       "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.8192648005148006,
-      "avgExecutionFidelity": 0.6774193548387096,
+      "avgRoleFidelity": 0.8355936293436294,
+      "avgExecutionFidelity": 0.7741935483870968,
       "executionFailures": [
         "accordion-exclusive",
         "halt-propagation",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
@@ -10371,7 +10318,7 @@
       ],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10997,18 +10944,14 @@
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.791841269841268,
       "avgFidelity": 0.9705555555555554,
-      "avgRoleFidelity": 0.8169229497354499,
-      "avgExecutionFidelity": 0.6451612903225806,
+      "avgRoleFidelity": 0.8337053571428573,
+      "avgExecutionFidelity": 0.7741935483870968,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-toast-element",
-        "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
       ],
@@ -11019,7 +10962,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11641,23 +11584,19 @@
       "parseRate": 1,
       "avgConfidence": 0.8401154401154378,
       "avgFidelity": 1,
-      "avgRoleFidelity": 0.8020913770913771,
-      "avgExecutionFidelity": 0.6774193548387096,
+      "avgRoleFidelity": 0.8184202059202059,
+      "avgExecutionFidelity": 0.8064516129032258,
       "executionFailures": [
         "accordion-exclusive",
         "halt-propagation",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-toast-element",
-        "modal-close-backdrop",
         "modal-close-button",
         "modal-open",
         "tabs-content"
       ],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12283,25 +12222,21 @@
       "parseRate": 1,
       "avgConfidence": 0.8494027914195967,
       "avgFidelity": 0.9970779220779221,
-      "avgRoleFidelity": 0.8732223294723296,
-      "avgExecutionFidelity": 0.6129032258064516,
+      "avgRoleFidelity": 0.8839205276705279,
+      "avgExecutionFidelity": 0.7419354838709677,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-toast-element",
-        "modal-close-backdrop",
         "modal-close-button",
         "modal-open",
         "tabs-content"
       ],
       "degeneratePasses": [],
       "lossyPasses": ["if-exists", "window-scroll"],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12927,17 +12862,14 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8377425044091712,
       "avgFidelity": 0.9635076252723311,
-      "avgRoleFidelity": 0.7558956916099772,
-      "avgExecutionFidelity": 0.5806451612903226,
+      "avgRoleFidelity": 0.7689342403628118,
+      "avgExecutionFidelity": 0.6774193548387096,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
         "dropdown-toggle",
-        "if-condition",
-        "if-exists",
         "if-matches",
         "make-toast-element",
-        "modal-close-backdrop",
         "modal-close-button",
         "modal-open",
         "set-attribute",
@@ -12952,7 +12884,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13577,14 +13509,11 @@
       "parseRate": 1,
       "avgConfidence": 0.8098948670377222,
       "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.808116151866152,
-      "avgExecutionFidelity": 0.6774193548387096,
+      "avgRoleFidelity": 0.8210666023166023,
+      "avgExecutionFidelity": 0.7741935483870968,
       "executionFailures": [
         "accordion-exclusive",
         "halt-propagation",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
@@ -13593,7 +13522,7 @@
       ],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14219,18 +14148,14 @@
       "parseRate": 1,
       "avgConfidence": 0.8037518037518019,
       "avgFidelity": 0.985930735930736,
-      "avgRoleFidelity": 0.8480453667953669,
-      "avgExecutionFidelity": 0.6451612903225806,
+      "avgRoleFidelity": 0.8643741956241957,
+      "avgExecutionFidelity": 0.7741935483870968,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
         "dropdown-toggle",
         "halt-propagation",
-        "if-condition",
-        "if-exists",
-        "if-matches",
         "make-toast-element",
-        "modal-close-backdrop",
         "modal-close-button",
         "tabs-content"
       ],
@@ -14242,7 +14167,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14868,7 +14793,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9871667185392676,
       "avgFidelity": 0.9632897603485838,
-      "avgRoleFidelity": 0.8902818270165207,
+      "avgRoleFidelity": 0.8925494007126659,
       "avgExecutionFidelity": 0.7419354838709677,
       "executionFailures": [
         "accordion-exclusive",
@@ -14890,7 +14815,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 418022,
+      "bundleSize": 418542,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15512,7 +15437,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 418022,
+      "size": 418542,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

The dominant cross-language R2 cluster — **if-condition / if-exists / if-matches / modal-close-backdrop failing in all 23 non-en languages** (92 of 253 failing cells) — collapses with one parser-routing fix plus a condition-normalization fix.

### Mechanism

`tryParseConditionalBlock` was already language-parameterized (profile-driven if/then/else/end keywords), but non-en handlers match a **fused grammar event pattern** that captures the body's first verb as `action` — and that action-captured path in `buildEventHandler` built a flat command + `parseBodyWithGrammarPatterns`, which has no fold. The condition truncated to whatever role the pattern grabbed and the branches flattened into siblings (runtime: "if command requires a condition to evaluate").

1. **`buildEventHandler` routes fused `action='if'` through the fold** — rewind to the if-keyword token, parse the remaining body via `parseBodyWithClauses` (where the fold lives), swap in only when a conditional actually folded; anything else falls through byte-identical. `unless` stays unfolded (deliberate, see fold comment).
2. **`joinTokenText` normalizes keyword tokens** in the folded condition raw — the core (English) expression evaluator can now read translated conditions (`#modal 存在する` → `#modal exists`, `jest pusty` → `is empty`). Identifiers/selectors/literals keep their surface value; en unchanged.

### Results

| metric | before | after |
| --- | --- | --- |
| meanExecutionFidelity | 0.6452 | **0.7546** |
| failing execution cells | 253 | **175** |
| if-condition | 23 langs | 3 (id,qu,zh) |
| if-exists | 23 langs | 1 (zh) |
| if-matches | 23 langs | 4 (id,qu,tr,zh) |
| modal-close-backdrop | 23 langs | 6 (hi,ko,qu,ru,uk,zh) |

Parse-level: avgFidelity 0.9742 → 0.9741, lossy 78 → 80, degenerate 63 unchanged. The +2 lossy are **honest ko flips** (if-empty / input-validation): the ko SOV transformer emits a scrambled conditional (`… 이다 추가 …` = "is add") and the old faithful 1.0 was an action-set accident on a broken translation. Realigning the ko transformer emission is a tracked dict-layer follow-up.

Side effect of (2): id/pl/it/vi if-empty now fold the `is empty` predicate into the condition (the en-reference shape); the two empty-predicate test families accept either shape.

### Validation

- semantic: 5842 passed (76 files)
- testing-framework: 175 passed
- full multilingual sweep `--regression`: green (2 within-tolerance ko warnings, explained above)
- baseline regenerated in same PR per protocol; patterns.db not committed

Plan doc updated with §7j (session 11). Remaining R2 clusters listed there for next session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)