### PR TITLE
fix(semantic): cross-language positional keyword normalization — R2 wave 5

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -692,6 +692,51 @@ positional bodies); halt-propagation ×18; closest-ancestor + dropdown-toggle
 modal-open ×12 (SOV/non-Latin); conditional residue: hi/ko/qu/ru/uk/zh on
 modal-close-backdrop, id/qu/tr/zh on if-matches.
 
+## 7k. Status update (2026-06-13, session 12): cross-language positional normalize
+
+**The positional cluster (b) + most of the multi-command positional bodies
+collapsed with ONE parser fix — the positional analog of §7j's joinTokenText.**
+`tryMatchPositionalExpression` (pattern-matcher.ts) built the captured `raw`
+from each token's SURFACE value, so a source-language positional keyword
+(`cercano`, `nächste`, `次`, `다음`, `التالي`, `الأقرب`) survived into the role
+value. The core's positional expression parser is English-only (`next(...)`,
+`closest(...)`), so the runtime either errored ("got number"), dropped to `me`,
+or — with the keyword silently ignored — matched EVERY element (e.g.
+`show <div.tab-panel/>` revealing all panels instead of the next one). Fix: the
+leading positional keyword and the optional locative source marker (`in`/`from`)
+now contribute their NORMALIZED English form to `raw`; selectors/identifiers are
+code and keep their surface value (en byte-identical).
+
+**Result:** meanExecutionFidelity **0.7546 → 0.8471**, failing cells **175 →
+109** (−66). tabs-content 22→0, dropdown-toggle 13→0, closest-ancestor 13→2,
+accordion-exclusive 22→8, modal-close-button 21→15. Parse-level byte-identical
+(avgFidelity 0.9741, 80 lossy, 63 degen — only the execution layer moved, since
+the change touches only the captured expression's raw text the runtime reads,
+not the action set or role shapes). Gate green; baseline regenerated. 7
+cross-language unit tests added (R2 wave 5 block).
+
+**Residuals on the targeted patterns are now DISTINCT, separate-layer issues
+(not parser bugs this fix introduced):**
+
+- **de `nächste`→`next` collision** (accordion/modal-close-button de): German
+  `nächste` means both "next" and "nearest"; the tokenizer normalizes it to
+  `next`, so a de "closest" surfaces as `next` and the wrong element is hit.
+  Needs a de dict/normalizer disambiguation (closest = `nächstgelegene`?) —
+  dict-layer.
+- **`body`/`körper`/`جسم`/SOV body source not recognized** (modal-close-button
+  ja/ko/ar/de): `remove .modal-open from body` captures source `body` in en/es
+  (cuerpo→body) but ja/ko/ar/de leave it untranslated, falling back to `me`.
+  Needs the per-language `body` contextReference word in the dict — dict-layer.
+- **ja/ko SOV destination-position positional drop** (accordion ja/ko):
+  `最も近い .accordion-item に` (closest in DESTINATION role) drops to `me`,
+  while the SAME `最も近い` in PATIENT position (modal-close-button) now
+  captures correctly. The SOV destination path doesn't reach
+  tryMatchPositionalExpression. Parser follow-up, narrower scope.
+- **make-toast-element ×23 untouched** — its `put it at end of body` needs the
+  `at end of` manner phrase + the third clause, which non-en translations drop
+  entirely (the handcrafted en put patterns for `at end of` have no per-language
+  counterpart). Separate, harder mechanism — its own track.
+
 ## 8. R1 / R2 — role-fidelity and execution ratchets (extend R0)
 
 Action-set fidelity (R0's signal) cannot see a parse that finds the right

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -653,7 +653,15 @@ export class PatternMatcher {
     }
 
     const mark = tokens.mark();
-    const parts: string[] = [token.value];
+    // The captured `raw` is evaluated by the core's English positional
+    // expression parser (`next(...)`, `closest(...)`), so the positional KEYWORD
+    // must be its normalized English form — a source-language keyword
+    // (`cercano`, `次`, `التالي`) is unevaluable as-is and the runtime either
+    // errors, drops to `me`, or matches every element. Same idiom as the
+    // conditional fold's joinTokenText (semantic-parser): keyword/marker tokens
+    // contribute their normalized form; selectors/identifiers are code and keep
+    // their surface value (for en the two are identical).
+    const parts: string[] = [token.normalized ?? token.value];
     tokens.advance();
 
     // Required: the queried selector (e.g. <.message/>, .message, <button/>).
@@ -698,7 +706,9 @@ export class PatternMatcher {
       // the following command lost.
       !PatternMatcher.COMMAND_ACTION_KEYWORDS.has((marker.normalized ?? marker.value).toLowerCase())
     ) {
-      parts.push(marker.value, source.value);
+      // Marker is a locative keyword/particle (`in`/`from`/في/から) the English
+      // runtime reads — normalize it; the source selector is code.
+      parts.push(marker.normalized ?? marker.value, source.value);
       tokens.advance();
       tokens.advance();
     }

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -5060,6 +5060,33 @@ describe('en positional-phrase patients — closest <sel> and the-led positional
     const show = stmts.find(s => s.action === 'show')!;
     expect(roles(show).get('patient')?.raw).toBe('next <div.tab-panel/>');
   });
+
+  // Cross-language positional NORMALIZATION (R2 wave 5). The captured `raw` is
+  // evaluated by the core's English positional expression parser, so a
+  // source-language positional keyword (`cercano`/`次`/`التالي`) must surface in
+  // the raw as its normalized English form — otherwise the runtime errors,
+  // drops to `me`, or matches every element (same idiom as the conditional
+  // fold's joinTokenText). Selectors are code and keep their surface value.
+  // This is what cleared tabs-content (22→0), dropdown-toggle (13→0), and most
+  // of accordion/modal-close-button/closest-ancestor in the execution sweep.
+  const positionalCases: Array<[string, string, string]> = [
+    ['es', 'mostrar siguiente <div.tab-panel/>', 'next <div.tab-panel/>'],
+    ['de', 'zeigen the nächste <div.tab-panel/>', 'next <div.tab-panel/>'],
+    ['ja', '次 <div.tab-panel/> を 表示', 'next <div.tab-panel/>'],
+    ['ko', '다음 <div.tab-panel/> 를 보이다', 'next <div.tab-panel/>'],
+    ['ar', 'اظهر التالي <div.tab-panel/>', 'next <div.tab-panel/>'],
+    ['es', 'ocultar cercano .modal', 'closest .modal'],
+    ['ar', 'اخف الأقرب .modal', 'closest .modal'],
+  ];
+  for (const [lang, input, expectedRaw] of positionalCases) {
+    it(`[${lang}] positional keyword normalizes to English in the captured raw`, () => {
+      const node = parse(input, lang) as Record<string, unknown>;
+      expect(node).toBeTruthy();
+      const patient = roles(node).get('patient');
+      expect(patient?.type).toBe('expression');
+      expect(patient?.raw).toBe(expectedRaw);
+    });
+  }
 });
 
 describe('en at-end-of positional put — at end of / at start of (R2 make-toast-element)', () => {

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T01:49:25.704Z",
-  "commit": "54dc5ab7",
+  "timestamp": "2026-06-13T03:10:35.511Z",
+  "commit": "bad3c12a",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -9,18 +9,16 @@
       "avgConfidence": 0.8679433429145073,
       "avgFidelity": 0.9758169934640524,
       "avgRoleFidelity": 0.8571104632329124,
-      "avgExecutionFidelity": 0.8064516129032258,
+      "avgExecutionFidelity": 0.8709677419354839,
       "executionFailures": [
-        "accordion-exclusive",
         "halt-propagation",
         "make-toast-element",
         "modal-close-button",
-        "modal-open",
-        "tabs-content"
+        "modal-open"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["if-exists", "repeat-until-event", "window-scroll"],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,15 +644,14 @@
       "avgConfidence": 0.8477942692228406,
       "avgFidelity": 0.9905844155844155,
       "avgRoleFidelity": 0.7753941441441441,
-      "avgExecutionFidelity": 0.7741935483870968,
+      "avgExecutionFidelity": 0.8064516129032258,
       "executionFailures": [
         "accordion-exclusive",
         "make-element",
         "make-toast-element",
         "modal-close-button",
         "modal-open",
-        "tabs-aria",
-        "tabs-content"
+        "tabs-aria"
       ],
       "degeneratePasses": [],
       "lossyPasses": [
@@ -664,7 +661,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1291,19 +1288,17 @@
       "avgConfidence": 0.8323373793962008,
       "avgFidelity": 0.9782135076252723,
       "avgRoleFidelity": 0.8420877874959508,
-      "avgExecutionFidelity": 0.7741935483870968,
+      "avgExecutionFidelity": 0.8387096774193549,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
-        "dropdown-toggle",
         "halt-propagation",
         "make-toast-element",
-        "modal-close-button",
-        "tabs-content"
+        "modal-close-button"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1927,7 +1922,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2554,19 +2549,11 @@
       "avgConfidence": 0.8352422450461645,
       "avgFidelity": 0.9803921568627451,
       "avgRoleFidelity": 0.8277372853903467,
-      "avgExecutionFidelity": 0.7741935483870968,
-      "executionFailures": [
-        "accordion-exclusive",
-        "closest-ancestor",
-        "dropdown-toggle",
-        "halt-propagation",
-        "make-toast-element",
-        "modal-close-button",
-        "tabs-content"
-      ],
+      "avgExecutionFidelity": 0.9354838709677419,
+      "executionFailures": ["halt-propagation", "make-toast-element"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3192,19 +3179,11 @@
       "avgConfidence": 0.8261126672891358,
       "avgFidelity": 0.9803921568627451,
       "avgRoleFidelity": 0.8294946550048593,
-      "avgExecutionFidelity": 0.7741935483870968,
-      "executionFailures": [
-        "accordion-exclusive",
-        "closest-ancestor",
-        "dropdown-toggle",
-        "halt-propagation",
-        "make-toast-element",
-        "modal-close-button",
-        "tabs-content"
-      ],
+      "avgExecutionFidelity": 0.9354838709677419,
+      "executionFailures": ["halt-propagation", "make-toast-element"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3848,7 +3827,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4474,7 +4453,7 @@
       "avgConfidence": 0.9560915275200976,
       "avgFidelity": 0.928030303030303,
       "avgRoleFidelity": 0.5914897039897042,
-      "avgExecutionFidelity": 0.5806451612903226,
+      "avgExecutionFidelity": 0.6129032258064516,
       "executionFailures": [
         "accordion-exclusive",
         "halt-propagation",
@@ -4487,8 +4466,7 @@
         "set-inner-html-possessive-dot",
         "set-style",
         "set-text-possessive-dot",
-        "tabs-aria",
-        "tabs-content"
+        "tabs-aria"
       ],
       "degeneratePasses": [
         "bind-auto-detect",
@@ -4510,7 +4488,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5137,19 +5115,15 @@
       "avgConfidence": 0.8404295051353855,
       "avgFidelity": 0.9627450980392157,
       "avgRoleFidelity": 0.8190719144800778,
-      "avgExecutionFidelity": 0.6451612903225806,
+      "avgExecutionFidelity": 0.7741935483870968,
       "executionFailures": [
-        "accordion-exclusive",
-        "closest-ancestor",
-        "dropdown-toggle",
         "halt-propagation",
         "if-condition",
         "if-matches",
         "make-toast-element",
         "modal-close-button",
         "modal-open",
-        "set-style",
-        "tabs-content"
+        "set-style"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
@@ -5160,7 +5134,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5786,19 +5760,11 @@
       "avgConfidence": 0.8379396202925594,
       "avgFidelity": 0.9803921568627451,
       "avgRoleFidelity": 0.8137836086815678,
-      "avgExecutionFidelity": 0.7741935483870968,
-      "executionFailures": [
-        "accordion-exclusive",
-        "closest-ancestor",
-        "dropdown-toggle",
-        "halt-propagation",
-        "make-toast-element",
-        "modal-close-button",
-        "tabs-content"
-      ],
+      "avgExecutionFidelity": 0.9032258064516129,
+      "executionFailures": ["halt-propagation", "make-toast-element", "modal-close-button"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6424,15 +6390,14 @@
       "avgConfidence": 0.8399092970521543,
       "avgFidelity": 0.941017316017316,
       "avgRoleFidelity": 0.7536518661518664,
-      "avgExecutionFidelity": 0.7741935483870968,
+      "avgExecutionFidelity": 0.8064516129032258,
       "executionFailures": [
         "accordion-exclusive",
         "make-toast-element",
         "modal-close-button",
         "modal-open",
         "put-content-basic",
-        "tabs-aria",
-        "tabs-content"
+        "tabs-aria"
       ],
       "degeneratePasses": [
         "announce-screen-reader",
@@ -6453,7 +6418,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7080,15 +7045,14 @@
       "avgConfidence": 0.7958977530406102,
       "avgFidelity": 0.958874458874459,
       "avgRoleFidelity": 0.7503378378378381,
-      "avgExecutionFidelity": 0.7741935483870968,
+      "avgExecutionFidelity": 0.8064516129032258,
       "executionFailures": [
         "accordion-exclusive",
         "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
         "modal-open",
-        "tabs-aria",
-        "tabs-content"
+        "tabs-aria"
       ],
       "degeneratePasses": [
         "behavior-draggable",
@@ -7104,7 +7068,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7731,17 +7695,8 @@
       "avgConfidence": 0.8334292106104165,
       "avgFidelity": 0.9794183445190157,
       "avgRoleFidelity": 0.8484044312169314,
-      "avgExecutionFidelity": 0.7419354838709677,
-      "executionFailures": [
-        "accordion-exclusive",
-        "closest-ancestor",
-        "dropdown-toggle",
-        "halt-propagation",
-        "make-element",
-        "make-toast-element",
-        "modal-close-button",
-        "tabs-content"
-      ],
+      "avgExecutionFidelity": 0.9032258064516129,
+      "executionFailures": ["halt-propagation", "make-element", "make-toast-element"],
       "degeneratePasses": [],
       "lossyPasses": [
         "async-block",
@@ -7754,7 +7709,7 @@
         "render-template-with-data",
         "set-color-variable"
       ],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8376,19 +8331,11 @@
       "avgConfidence": 0.8037866998651292,
       "avgFidelity": 0.9782135076252723,
       "avgRoleFidelity": 0.8258098477486233,
-      "avgExecutionFidelity": 0.7741935483870968,
-      "executionFailures": [
-        "accordion-exclusive",
-        "closest-ancestor",
-        "dropdown-toggle",
-        "halt-propagation",
-        "make-toast-element",
-        "modal-close-button",
-        "tabs-content"
-      ],
+      "avgExecutionFidelity": 0.9354838709677419,
+      "executionFailures": ["halt-propagation", "make-toast-element"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9014,19 +8961,11 @@
       "avgConfidence": 0.8007988380537381,
       "avgFidelity": 0.9803921568627451,
       "avgRoleFidelity": 0.8494574020084225,
-      "avgExecutionFidelity": 0.7741935483870968,
-      "executionFailures": [
-        "accordion-exclusive",
-        "closest-ancestor",
-        "dropdown-toggle",
-        "halt-propagation",
-        "make-toast-element",
-        "modal-close-button",
-        "tabs-content"
-      ],
+      "avgExecutionFidelity": 0.9354838709677419,
+      "executionFailures": ["halt-propagation", "make-toast-element"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9652,11 +9591,8 @@
       "avgConfidence": 0.7161616161616162,
       "avgFidelity": 0.9632034632034633,
       "avgRoleFidelity": 0.7185649935649935,
-      "avgExecutionFidelity": 0.6129032258064516,
+      "avgExecutionFidelity": 0.7419354838709677,
       "executionFailures": [
-        "accordion-exclusive",
-        "closest-ancestor",
-        "dropdown-toggle",
         "if-condition",
         "if-matches",
         "make-toast-element",
@@ -9664,8 +9600,7 @@
         "modal-close-button",
         "modal-open",
         "put-content-basic",
-        "set-attribute",
-        "tabs-content"
+        "set-attribute"
       ],
       "degeneratePasses": [
         "behavior-draggable",
@@ -9679,7 +9614,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10306,19 +10241,17 @@
       "avgConfidence": 0.8117913832199526,
       "avgFidelity": 0.9935064935064936,
       "avgRoleFidelity": 0.8355936293436294,
-      "avgExecutionFidelity": 0.7741935483870968,
+      "avgExecutionFidelity": 0.8387096774193549,
       "executionFailures": [
-        "accordion-exclusive",
         "halt-propagation",
         "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
-        "modal-open",
-        "tabs-content"
+        "modal-open"
       ],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10945,15 +10878,13 @@
       "avgConfidence": 0.791841269841268,
       "avgFidelity": 0.9705555555555554,
       "avgRoleFidelity": 0.8337053571428573,
-      "avgExecutionFidelity": 0.7741935483870968,
+      "avgExecutionFidelity": 0.8387096774193549,
       "executionFailures": [
         "accordion-exclusive",
         "closest-ancestor",
-        "dropdown-toggle",
         "halt-propagation",
         "make-toast-element",
-        "modal-close-button",
-        "tabs-content"
+        "modal-close-button"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
@@ -10962,7 +10893,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11585,18 +11516,17 @@
       "avgConfidence": 0.8401154401154378,
       "avgFidelity": 1,
       "avgRoleFidelity": 0.8184202059202059,
-      "avgExecutionFidelity": 0.8064516129032258,
+      "avgExecutionFidelity": 0.8387096774193549,
       "executionFailures": [
         "accordion-exclusive",
         "halt-propagation",
         "make-toast-element",
         "modal-close-button",
-        "modal-open",
-        "tabs-content"
+        "modal-open"
       ],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12223,20 +12153,16 @@
       "avgConfidence": 0.8494027914195967,
       "avgFidelity": 0.9970779220779221,
       "avgRoleFidelity": 0.8839205276705279,
-      "avgExecutionFidelity": 0.7419354838709677,
+      "avgExecutionFidelity": 0.8709677419354839,
       "executionFailures": [
-        "accordion-exclusive",
-        "closest-ancestor",
-        "dropdown-toggle",
         "halt-propagation",
         "make-toast-element",
         "modal-close-button",
-        "modal-open",
-        "tabs-content"
+        "modal-open"
       ],
       "degeneratePasses": [],
       "lossyPasses": ["if-exists", "window-scroll"],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12863,18 +12789,15 @@
       "avgConfidence": 0.8377425044091712,
       "avgFidelity": 0.9635076252723311,
       "avgRoleFidelity": 0.7689342403628118,
-      "avgExecutionFidelity": 0.6774193548387096,
+      "avgExecutionFidelity": 0.7741935483870968,
       "executionFailures": [
         "accordion-exclusive",
-        "closest-ancestor",
-        "dropdown-toggle",
         "if-matches",
         "make-toast-element",
         "modal-close-button",
         "modal-open",
         "set-attribute",
-        "tabs-aria",
-        "tabs-content"
+        "tabs-aria"
       ],
       "degeneratePasses": [
         "behavior-draggable",
@@ -12884,7 +12807,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13510,19 +13433,17 @@
       "avgConfidence": 0.8098948670377222,
       "avgFidelity": 0.9935064935064936,
       "avgRoleFidelity": 0.8210666023166023,
-      "avgExecutionFidelity": 0.7741935483870968,
+      "avgExecutionFidelity": 0.8387096774193549,
       "executionFailures": [
-        "accordion-exclusive",
         "halt-propagation",
         "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
-        "modal-open",
-        "tabs-content"
+        "modal-open"
       ],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14149,16 +14070,8 @@
       "avgConfidence": 0.8037518037518019,
       "avgFidelity": 0.985930735930736,
       "avgRoleFidelity": 0.8643741956241957,
-      "avgExecutionFidelity": 0.7741935483870968,
-      "executionFailures": [
-        "accordion-exclusive",
-        "closest-ancestor",
-        "dropdown-toggle",
-        "halt-propagation",
-        "make-toast-element",
-        "modal-close-button",
-        "tabs-content"
-      ],
+      "avgExecutionFidelity": 0.9354838709677419,
+      "executionFailures": ["halt-propagation", "make-toast-element"],
       "degeneratePasses": [],
       "lossyPasses": [
         "input-mirror",
@@ -14167,7 +14080,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14794,16 +14707,14 @@
       "avgConfidence": 0.9871667185392676,
       "avgFidelity": 0.9632897603485838,
       "avgRoleFidelity": 0.8925494007126659,
-      "avgExecutionFidelity": 0.7419354838709677,
+      "avgExecutionFidelity": 0.8064516129032258,
       "executionFailures": [
-        "accordion-exclusive",
         "halt-propagation",
         "if-condition",
         "if-exists",
         "if-matches",
         "make-toast-element",
-        "modal-close-backdrop",
-        "tabs-content"
+        "modal-close-backdrop"
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
@@ -14815,7 +14726,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 418542,
+      "bundleSize": 418570,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15437,7 +15348,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 418542,
+      "size": 418570,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Targeted the multi-command / positional-body R2 cluster (make-toast-element ×23, accordion-exclusive ×22, tabs-content ×22, modal-close-button ×21). Found **one shared mechanism** behind three of the four — the positional analog of [#403](https://github.com/codetalcott/hyperfixi/pull/403)'s condition normalization.

### Mechanism

`tryMatchPositionalExpression` (pattern-matcher.ts) built the captured `raw` from each token's **surface** value, so a source-language positional keyword (`cercano`, `nächste`, `次`, `다음`, `التالي`, `الأقرب`) survived into the role value. The core's positional expression parser is **English-only** (`next(...)`, `closest(...)`), so the runtime either errored ("got number"), dropped to `me`, or — with the keyword silently ignored — matched **every** element (e.g. `show <div.tab-panel/>` revealing all panels instead of the next).

**Fix:** the leading positional keyword and the optional locative source marker (`in`/`from`) now contribute their **normalized English** form to `raw`; selectors/identifiers are code and keep their surface value (en byte-identical). Same idiom as the conditional fold's `joinTokenText`.

### Results

| metric | before | after |
| --- | --- | --- |
| meanExecutionFidelity | 0.7546 | **0.8471** |
| failing execution cells | 175 | **109** (−66) |
| tabs-content | 22 langs | **0** |
| dropdown-toggle | 13 langs | **0** |
| closest-ancestor | 13 langs | **2** |
| accordion-exclusive | 22 langs | 8 |
| modal-close-button | 21 langs | 15 |

Parse-level **byte-identical** (avgFidelity 0.9741, 80 lossy, 63 degenerate) — only the execution layer moved, since the change touches just the captured expression's raw text the runtime reads, not the action set or role shapes.

### Residuals are distinct, separate-layer issues (not parser bugs this fix introduced)

- **de `nächste`→`next` collision** — German `nächste` means both "next" and "nearest"; tokenizer normalizes to `next`, so a de "closest" surfaces as `next`. Dict-layer.
- **`body`/`körper`/`جسم` source not recognized** (modal-close-button ja/ko/ar/de) — `from body` captures source `body` in en/es but other langs leave it untranslated → `me`. Dict-layer.
- **ja/ko SOV destination-position positional drop** (accordion) — `最も近い` in DESTINATION drops to `me` while the same word in PATIENT captures fine. Narrower parser follow-up.
- **make-toast-element ×23 untouched** — `put it at end of body` needs the `at end of` manner phrase + third clause that non-en translations drop entirely. Separate, harder track.

### Validation

- semantic: 5842 + 7 new cross-language positional tests, all green
- testing-framework: 175 passed
- full multilingual `--regression` sweep: green; baseline regenerated in same PR; patterns.db not committed
- subset membership unchanged (no lock edit needed)

Plan doc updated with §7k (session 12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)