### PR TITLE
fix(semantic): body reference dict↔profile alignment — R2 wave 6

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -737,6 +737,50 @@ cross-language unit tests added (R2 wave 5 block).
   entirely (the handcrafted en put patterns for `at end of` have no per-language
   counterpart). Separate, harder mechanism — its own track.
 
+## 7l. Status update (2026-06-13, session 13): body reference dict↔profile align
+
+**Half of §7k's "body source not recognized" residual was a dict↔profile word
+drift, fixed by aligning the semantic profile's `references.body` to the i18n
+dict's emitted word** (the corpus-canonical surface form the parser must
+recognize). Three profiles carried the literal English placeholder `'body'`
+(ru/tl/uk) instead of the language's word (`тело`/`katawan`/`тіло`); three more
+disagreed on a real word (ar `الجسم`≠dict `جسم`; ko `본문`="main text", wrong for
+the DOM body, ≠dict `바디`; id `tubuh`≠dict `badan`). Aligned profile→dict
+(lowest blast radius — changes only parser recognition, not the committed
+corpus). Cleared ar/id/ru/tl on **modal-close-button** (15→10 failing) and
+**modal-open** (12→7).
+
+**A measurement-exposed latent bug rode along (and got fixed):** id `if-exists`
+was faithful-by-accident — its else word `lainnya` wasn't a profile else
+alternative (profile only had `selainnya`), so the else-branch (`make`+`put into
+body`) flattened into the _then_-branch; with the condition true and `body`
+unrecognized, the stray `put` was an inert no-op that happened to match en. Once
+`body` resolved, that put produced a spurious effect (an honest faithful→failing
+exposure, exactly the §7j ko pattern). Fixed at the root by adding `lainnya` as
+a profile else alternative → the else-branch nests, doesn't execute, if-exists
+is _truly_ faithful. (`mana_chayqa` for qu is the same drift but blocked by a
+separate **tokenizer underscore-split** bug — `mana_chayqa` tokenizes as
+`mana`/`_`/`chayqa` = false/\_/then — so qu's body+else changes were REVERTED to
+keep qu at baseline until the tokenizer is fixed; tracked below.)
+
+**Result:** meanExecutionFidelity **0.8471 → 0.8640**, failing cells **109 →
+97** (−12). Parse-level essentially flat (avgFidelity 0.9741→0.9743, lossy 80→77
+from the id if-exists nesting, degen 63 unchanged). Gate green; baseline
+regenerated; 6 unit tests added (R2 wave 6 block). Semantic 5855 green.
+
+**Remaining body-source residual (still separate-layer):**
+
+- **SOV/marker-after post-verb source clause** (ja/ko/tr/hi modal-close-button):
+  a control test (`.modal-open を 削除 .container から`) proved even a SELECTOR
+  source drops to `me` in the SOV post-verb position — the trailing source
+  clause after the verb isn't parsed. Structural parser follow-up.
+- **`source=undefined`** (bn/it/th modal-close-button): the source role isn't
+  captured at all (dict word matches the profile, so not a word issue) — a
+  different role-capture path.
+- **qu underscore-tokenization**: the qu tokenizer splits dict words joined with
+  `_` (`mana_chayqa`, and any other multi-word qu dict emission). Until fixed,
+  qu else/body dict alignments can't land. Tokenizer-layer.
+
 ## 8. R1 / R2 — role-fidelity and execution ratchets (extend R0)
 
 Action-set fidelity (R0's signal) cannot see a parse that finds the right

--- a/packages/semantic/src/generators/profiles/arabic.ts
+++ b/packages/semantic/src/generators/profiles/arabic.ts
@@ -28,7 +28,7 @@ export const arabicProfile: LanguageProfile = {
     result: 'النتيجة',
     event: 'الحدث',
     target: 'الهدف',
-    body: 'الجسم',
+    body: 'جسم', // matches the i18n dict's emitted body word (corpus-canonical, parser must recognize it)
   },
   possessive: {
     marker: '', // No explicit marker - uses possessive pronouns

--- a/packages/semantic/src/generators/profiles/indonesian.ts
+++ b/packages/semantic/src/generators/profiles/indonesian.ts
@@ -28,7 +28,7 @@ export const indonesianProfile: LanguageProfile = {
     result: 'hasil',
     event: 'peristiwa',
     target: 'target',
-    body: 'tubuh',
+    body: 'badan', // matches the i18n dict's emitted body word (corpus-canonical; tubuh = anatomical body)
   },
   possessive: {
     marker: '', // Indonesian: "X saya" (X of mine), possessor follows noun
@@ -109,7 +109,7 @@ export const indonesianProfile: LanguageProfile = {
     unless: { primary: 'kecuali', normalized: 'unless' },
     when: { primary: 'ketika', normalized: 'when' },
     where: { primary: 'di_mana', normalized: 'where' },
-    else: { primary: 'selainnya', normalized: 'else' },
+    else: { primary: 'selainnya', alternatives: ['lainnya'], normalized: 'else' }, // lainnya = the i18n dict's emitted else word (corpus-canonical)
     repeat: { primary: 'ulangi', normalized: 'repeat' },
     for: { primary: 'untuk', normalized: 'for' },
     while: { primary: 'selama', normalized: 'while' },

--- a/packages/semantic/src/generators/profiles/korean.ts
+++ b/packages/semantic/src/generators/profiles/korean.ts
@@ -29,7 +29,7 @@ export const koreanProfile: LanguageProfile = {
     result: '결과',
     event: '이벤트',
     target: '대상',
-    body: '본문',
+    body: '바디', // matches the i18n dict's emitted body word (본문 = "main text", wrong for the DOM body element)
   },
   possessive: {
     marker: '의', // Possessive particle

--- a/packages/semantic/src/generators/profiles/russian.ts
+++ b/packages/semantic/src/generators/profiles/russian.ts
@@ -30,7 +30,7 @@ export const russianProfile: LanguageProfile = {
     result: 'результат',
     event: 'событие',
     target: 'цель',
-    body: 'body',
+    body: 'тело', // was an English placeholder; the i18n dict emits the Russian word
   },
   possessive: {
     marker: '',

--- a/packages/semantic/src/generators/profiles/tl.ts
+++ b/packages/semantic/src/generators/profiles/tl.ts
@@ -27,7 +27,7 @@ export const tagalogProfile: LanguageProfile = {
     result: 'resulta', // "result"
     event: 'pangyayari', // "event"
     target: 'target', // "target"
-    body: 'body',
+    body: 'katawan', // was an English placeholder; the i18n dict emits the Tagalog word
   },
   possessive: {
     marker: 'ng', // Linker used in possessive constructions

--- a/packages/semantic/src/generators/profiles/ukrainian.ts
+++ b/packages/semantic/src/generators/profiles/ukrainian.ts
@@ -30,7 +30,7 @@ export const ukrainianProfile: LanguageProfile = {
     result: 'результат',
     event: 'подія',
     target: 'ціль',
-    body: 'body',
+    body: 'тіло', // was an English placeholder; the i18n dict emits the Ukrainian word
   },
   possessive: {
     marker: '',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -5089,6 +5089,55 @@ describe('en positional-phrase patients — closest <sel> and the-led positional
   }
 });
 
+describe('body reference dict↔profile alignment (R2 wave 6)', () => {
+  // The semantic profile's `references.body` word MUST equal the word the i18n
+  // dict emits (the corpus-canonical surface form), or the parser never maps the
+  // translated body word to the `body` contextReference and the source/
+  // destination role falls back to `me`. Three profiles carried the literal
+  // English placeholder `'body'` (ru/tl/uk) and three more disagreed with the
+  // dict on a real word (ar الجسم≠جسم, ko 본문≠바디 — 본문 means "main text",
+  // wrong for the DOM body; id tubuh≠badan). Aligned profile→dict; this cleared
+  // ar/id/ru/tl on modal-close-button + modal-open in the execution sweep.
+  // (qu kurku/ukhu is a separate underscore-tokenization issue — the dict emits
+  //  mana_chayqa/kurku which the qu tokenizer splits; tracked, not fixed here.)
+  function roles(node: unknown): Map<string, { type?: string; value?: unknown; raw?: unknown }> {
+    return (node as { roles: Map<string, { type?: string; value?: unknown; raw?: unknown }> }).roles;
+  }
+  // [lang, corpus-shaped `remove .x from <body-word>`, expected source value]
+  const bodyCases: Array<[string, string]> = [
+    ['ar', 'احذف .modal-open من جسم'],
+    ['id', 'hapus .modal-open dari badan'],
+    ['ru', 'удалить .modal-open из тело'],
+    ['tl', 'alisin .modal-open mula_sa katawan'],
+    ['uk', 'видалити .modal-open з тіло'],
+  ];
+  for (const [lang, input] of bodyCases) {
+    it(`[${lang}] the dict's body word resolves to the body reference (not me)`, () => {
+      const node = parse(input, lang) as Record<string, unknown>;
+      expect(node).toBeTruthy();
+      const source = roles(node).get('source');
+      expect(source?.value).toBe('body');
+    });
+  }
+
+  it('[id] lainnya is recognized as else so if-exists nests (else-branch does not flatten into then)', () => {
+    // The id dict emits `lainnya` for else but the profile only had `selainnya`,
+    // so the else-branch flattened into then. With the condition true (the modal
+    // exists), the flattened make+put-into-body then executed and produced a
+    // spurious effect. `lainnya` is now a profile else alternative.
+    const node = parse(
+      'pada klik jika #modal ada tampilkan #modal lainnya buat a <div#modal/> lalu taruh itu ke badan akhir',
+      'id'
+    ) as { body?: Array<Record<string, unknown>> };
+    const conditional = node.body?.find(n => n.kind === 'conditional') as
+      | { thenBranch?: unknown[]; elseBranch?: unknown[] }
+      | undefined;
+    expect(conditional).toBeDefined();
+    expect(conditional!.thenBranch?.length).toBe(1); // show #modal only
+    expect(conditional!.elseBranch?.length).toBe(2); // make + put, NOT flattened into then
+  });
+});
+
 describe('en at-end-of positional put — at end of / at start of (R2 make-toast-element)', () => {
   function roles(node: unknown): Map<string, { type?: string; raw?: string; value?: unknown }> {
     return (node as { roles: Map<string, { type?: string; raw?: string; value?: unknown }> })

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,24 +1,19 @@
 {
-  "timestamp": "2026-06-13T03:10:35.511Z",
-  "commit": "bad3c12a",
+  "timestamp": "2026-06-13T03:40:12.694Z",
+  "commit": "b1dd0774",
   "languages": {
     "ar": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8679433429145073,
-      "avgFidelity": 0.9758169934640524,
-      "avgRoleFidelity": 0.8571104632329124,
-      "avgExecutionFidelity": 0.8709677419354839,
-      "executionFailures": [
-        "halt-propagation",
-        "make-toast-element",
-        "modal-close-button",
-        "modal-open"
-      ],
+      "avgFidelity": 0.9771241830065359,
+      "avgRoleFidelity": 0.8593780369290575,
+      "avgExecutionFidelity": 0.9354838709677419,
+      "executionFailures": ["halt-propagation", "make-toast-element"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": ["if-exists", "repeat-until-event", "window-scroll"],
-      "bundleSize": 418570,
+      "lossyPasses": ["repeat-until-event", "window-scroll"],
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -661,7 +656,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1298,7 +1293,7 @@
       ],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1922,7 +1917,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2553,7 +2548,7 @@
       "executionFailures": ["halt-propagation", "make-toast-element"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3183,7 +3178,7 @@
       "executionFailures": ["halt-propagation", "make-toast-element"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3827,7 +3822,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4488,7 +4483,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5113,28 +5108,19 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8404295051353855,
-      "avgFidelity": 0.9627450980392157,
-      "avgRoleFidelity": 0.8190719144800778,
-      "avgExecutionFidelity": 0.7741935483870968,
-      "executionFailures": [
-        "halt-propagation",
-        "if-condition",
-        "if-matches",
-        "make-toast-element",
-        "modal-close-button",
-        "modal-open",
-        "set-style"
-      ],
+      "avgFidelity": 0.9640522875816994,
+      "avgRoleFidelity": 0.8213394881762228,
+      "avgExecutionFidelity": 0.9032258064516129,
+      "executionFailures": ["halt-propagation", "make-toast-element", "set-style"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
-        "if-exists",
         "input-mirror",
         "set-opacity",
         "set-style",
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5764,7 +5750,7 @@
       "executionFailures": ["halt-propagation", "make-toast-element", "modal-close-button"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6418,7 +6404,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7044,7 +7030,7 @@
       "parseRate": 1,
       "avgConfidence": 0.7958977530406102,
       "avgFidelity": 0.958874458874459,
-      "avgRoleFidelity": 0.7503378378378381,
+      "avgRoleFidelity": 0.7514639639639643,
       "avgExecutionFidelity": 0.8064516129032258,
       "executionFailures": [
         "accordion-exclusive",
@@ -7068,7 +7054,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7709,7 +7695,7 @@
         "render-template-with-data",
         "set-color-variable"
       ],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8335,7 +8321,7 @@
       "executionFailures": ["halt-propagation", "make-toast-element"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8965,7 +8951,7 @@
       "executionFailures": ["halt-propagation", "make-toast-element"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9614,7 +9600,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10240,18 +10226,12 @@
       "parseRate": 1,
       "avgConfidence": 0.8117913832199526,
       "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.8355936293436294,
-      "avgExecutionFidelity": 0.8387096774193549,
-      "executionFailures": [
-        "halt-propagation",
-        "make-toast-element",
-        "modal-close-backdrop",
-        "modal-close-button",
-        "modal-open"
-      ],
+      "avgRoleFidelity": 0.8417873230373231,
+      "avgExecutionFidelity": 0.9032258064516129,
+      "executionFailures": ["halt-propagation", "make-toast-element", "modal-close-backdrop"],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10893,7 +10873,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11526,7 +11506,7 @@
       ],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12151,18 +12131,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8494027914195967,
-      "avgFidelity": 0.9970779220779221,
-      "avgRoleFidelity": 0.8839205276705279,
-      "avgExecutionFidelity": 0.8709677419354839,
-      "executionFailures": [
-        "halt-propagation",
-        "make-toast-element",
-        "modal-close-button",
-        "modal-open"
-      ],
+      "avgFidelity": 0.9983766233766234,
+      "avgRoleFidelity": 0.8861727799227802,
+      "avgExecutionFidelity": 0.9354838709677419,
+      "executionFailures": ["halt-propagation", "make-toast-element"],
       "degeneratePasses": [],
-      "lossyPasses": ["if-exists", "window-scroll"],
-      "bundleSize": 418570,
+      "lossyPasses": ["window-scroll"],
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12807,7 +12782,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13432,18 +13407,12 @@
       "parseRate": 1,
       "avgConfidence": 0.8098948670377222,
       "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.8210666023166023,
-      "avgExecutionFidelity": 0.8387096774193549,
-      "executionFailures": [
-        "halt-propagation",
-        "make-toast-element",
-        "modal-close-backdrop",
-        "modal-close-button",
-        "modal-open"
-      ],
+      "avgRoleFidelity": 0.8272602960102962,
+      "avgExecutionFidelity": 0.9032258064516129,
+      "executionFailures": ["halt-propagation", "make-toast-element", "modal-close-backdrop"],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14080,7 +14049,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14726,7 +14695,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 418570,
+      "bundleSize": 418583,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15348,7 +15317,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 418570,
+      "size": 418583,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Continuing the R2 execution burn-down. The §7k residual "body source not recognized" split into a clean dict-layer half and a structural half — this PR fixes the dict-layer half.

### Mechanism

The semantic profile's `references.body` word must equal the word the i18n dict emits (the corpus-canonical surface form the parser sees), or the parser never maps the translated body word to the `body` contextReference and the source/destination role falls back to `me`.

Audit found **7 dict↔profile mismatches**; 6 are pure word drift (qu deferred — see below):
- **English placeholders** in the profile: ru (`'body'`→`тело`), tl (`'body'`→`katawan`), uk (`'body'`→`тіло`)
- **Real-word disagreements**: ar (`الجسم`→`جسم`), ko (`본문`→`바디`; 본문 means "main text", wrong for the DOM body), id (`tubuh`→`badan`)

Aligned profile→dict (lowest blast radius — changes only parser recognition, not the committed corpus).

### Rode-along latent bug (fixed at root)

id `if-exists` was **faithful-by-accident**: its else word `lainnya` wasn't a profile else alternative (profile only had `selainnya`), so the else-branch (`make`+`put into body`) flattened into the *then*-branch. With the condition true and `body` unrecognized, the stray `put` was an inert no-op that happened to match en. Once `body` resolved, the put produced a spurious effect — an honest faithful→failing exposure. Fixed by adding `lainnya` as a profile else alternative so the branch nests correctly (if-exists now *truly* faithful, not accidentally).

### Results

| metric | before | after |
| --- | --- | --- |
| meanExecutionFidelity | 0.8471 | **0.8640** |
| failing execution cells | 109 | **97** (−12) |
| modal-close-button | 15 langs | 10 |
| modal-open | 12 langs | 7 |

Parse-level essentially flat (avgFidelity 0.9741→0.9743, lossy 80→77 from the id nesting, degen 63 unchanged).

### Deferred (tracked in §7l)

- **qu** has the same body+else drift (`kurku`, `mana_chayqa`) but is blocked by a separate **tokenizer underscore-split** bug (`mana_chayqa` → `mana`/`_`/`chayqa` = false/_/then). qu changes **reverted** to keep qu at baseline until the tokenizer is fixed.
- **SOV/marker-after post-verb source clause** (ja/ko/tr/hi): a control test proved even a *selector* source drops to `me` there — structural, not a word issue.
- **`source=undefined`** (bn/it/th): a different role-capture path.

### Validation

- semantic: 5855 (incl. 6 new R2-wave-6 tests), green
- testing-framework: 175 green
- full multilingual `--regression` sweep: green; baseline regenerated in same PR; patterns.db not committed
- subset membership unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)