### PR TITLE
fix(semantic): per-language at-end-of put patterns; R2 wave 8

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -817,6 +817,76 @@ halt-propagation ×1. Next-mechanism candidates unchanged: SOV post-verb source
 clause (parser), qu underscore-tokenizer, de `nächste`/`next` disambiguation,
 make-toast `at end of` per-language.
 
+## 7n. Status update (2026-06-13, session 15): make-toast `at end of` per-language
+
+**The biggest single R2 cluster (make-toast-element ×23) dropped to ×6 with one
+generated-pattern table.** en carries a handcrafted `put {patient} at end of
+{destination}` pattern (`put-en-at-end`); the i18n transformer translates that
+three-word position phrase verbatim into every other language, but no non-en
+language had a counterpart, so the third clause of make-toast (`put it at end of
+body`) either **dropped entirely** (SOV/VSO — the made toast is never attached →
+empty effect) or the generic into-put grabbed the `end` word as the destination.
+Fix in `packages/semantic/src/patterns/put.ts`: a `PUT_AT_END` table records the
+per-language surface words for the put verb + `at`/`end`/`of`, and
+`buildAtEndPutPatterns` reconstructs the en shape (`<verb> {patient} <at> <end>
+<of> {destination}`, SOV variant `{patient} <at> <end> <of> {destination}
+<objMarker> <verb>`) with `manner: 'at end of'` at priority 110 (above the
+generic into-put). The destination is the language's dict-canonical `body` word,
+which **already aligns** with each profile's `references.body` (the §7l
+alignment), so it resolves to the `body` contextReference with no dict change.
+
+**Result:** make-toast-element 23→6 failing (cleared **17 languages**: es, fr,
+pt, it, de, sw, id, vi, pl, ru, th, tl, ar, he, ja, ko, tr).
+meanExecutionFidelity **0.8878 → 0.9116**, failing cells **80 → 63** (−17).
+Parse-level **byte-identical** (avgFidelity 0.9743, lossy 77, degen 63 all
+unchanged): the dropped third command is a duplicate `put` action, so action-set
+fidelity was already 1.0 — exactly the lossy-but-faithful gap R2 execution
+fidelity exists to catch (same shape as the §7m halt fix). avgRoleFidelity (R1)
+ticked up slightly for the 17 (the now-parsed third put adds correct roles). Gate
+green; baseline regenerated; subset membership unchanged (make-toast was already
+in). 17 cross-language unit tests added (R2 wave 8 block). Semantic 5872 green.
+
+**Two findings worth the next session:** (1) a multi-word marker (vi `kết thúc`)
+tokenizes as ONE token whose value is the whole phrase, so the literal must carry
+the phrase verbatim — splitting on whitespace emits two literals that never
+align. (2) The single-token multi-word case is the _opposite_ of the usual
+assumption; check `tokenize(code,lang).tokens` before assuming a space splits.
+
+**make-toast survivors (6) — all SEPARATE, pre-existing mechanisms (none are
+this fix's regressions):**
+
+- **ms/tl-path**: ms drops the third clause even though every token is correct
+  and tl (identical SVO shape) works — ms's event body routes through the
+  grammar/fused path (`parseBodyWithGrammarPatterns`), not `parseBodyWithClauses`,
+  so the handcrafted at-end pattern is never consulted (the §7j routing class,
+  now manifesting on make-toast's fused make-event). tl proves the pattern is
+  correct; ms needs the body-routing fix.
+- **zh/bn compound collapse**: the whole event body parses as a single
+  `compound` (a higher-level event path), so neither the at-end nor any body
+  pattern is reached. Pre-existing.
+- **hi/uk second-put bug**: the at-end (third) put parses correctly, but the
+  SECOND clause mis-parses — hi drops `'Saved!'` (patient→it, dest→me); uk
+  truncates the string literal `'Saved!'`→`"Save"` and drops the destination
+  (`put requires content and position`). Separate string/role-capture bugs.
+- **qu**: body word mismatch (`kurku`≠profile `ukhu`) + the underscore-tokenizer
+  bug — excluded from PUT_AT_END; tracked for the qu-tokenizer arc.
+
+**Still-open R2 clusters after this (63 failing, ranked):** modal-close-button
+×10 (bn de hi it ja ko qu sw th tr — SOV post-verb source + bn/it/th
+source=undefined + de collision); accordion-exclusive ×8 (bn de hi ja ko sw th
+tr); modal-open ×7 (bn hi ja ko qu th tr); make-toast-element ×6 (bn hi ms qu uk
+zh — the survivors above); modal-close-backdrop ×6 (hi ko qu ru uk zh); tabs-aria
+×5 (bn hi ja ko tr); make-element ×3 (bn hi ms); set-attribute ×3 (hi qu tr);
+if-matches ×3 (qu tr zh); closest-ancestor ×2 (de sw); set-style ×2 (hi id);
+put-content-basic ×2 (ja qu); if-condition ×2 (qu zh); + singletons
+(halt-propagation hi, set-_-possessive-dot hi×2, if-exists zh). **Next-mechanism
+ranking:** (1) **SOV post-verb source clause** (parser, parseClause — modal-close-
+button/accordion ja/ko/tr/hi; control test in §7l proved even a selector source
+drops); (2) **qu underscore-tokenizer** (unlocks qu else/body + make-toast);
+(3) **de `nächste`/`next` disambiguation**; (4) **fused-event body routing**
+(would unlock ms/tl-class make-toast + possibly the zh/bn compound collapse — the
+§7j class generalized). Alt track: behavior-_ degenerate mass (~40 of 63 degen).
+
 ## 8. R1 / R2 — role-fidelity and execution ratchets (extend R0)
 
 Action-set fidelity (R0's signal) cannot see a parse that finds the right

--- a/packages/semantic/src/patterns/put.ts
+++ b/packages/semantic/src/patterns/put.ts
@@ -865,6 +865,164 @@ const PUT_POSITIONAL: ReadonlyArray<{
   },
 ];
 
+/**
+ * The at-end-of positional put (`put it at end of body`, make-toast-element).
+ * en carries `put-en-at-end` (a handcrafted three-literal `at end of` phrase);
+ * the i18n transformer translates that phrase word-for-word into every other
+ * language, but no non-en language had a counterpart, so the third clause of
+ * make-toast-element either dropped entirely (SOV/VSO: the made toast is never
+ * attached → empty effect) or mis-parsed (the generic into-put grabbed the
+ * `end` word as the destination). This table records the per-language surface
+ * words the transformer emits for `at`/`end`/`of` plus the put verb, so the
+ * generated pattern reconstructs the en `put {patient} <at-word> <end-word>
+ * <of-word> {destination}` shape with `manner: 'at end of'` — the exact form
+ * the core runtime's PutCommand.mapPosition accepts (beforeend).
+ *
+ * The destination is the language's `body` word (the dict-canonical form, which
+ * already aligns with each profile's `references.body` so it resolves to the
+ * `body` contextReference). qu is omitted: its dict body word (`kurku`)
+ * disagrees with the profile (`ukhu`) and its tokenizer splits `_`-joined
+ * keywords — both tracked separately. he leaves `at`/`of` untranslated, so its
+ * markers are the English literals.
+ *
+ * A multi-word marker (vi `kết thúc`) tokenizes as a SINGLE token whose value is
+ * the whole phrase, so it is carried verbatim in one literal (not split). SOV
+ * languages place the verb last (after an object marker on the body). Only
+ * `at end of` is generated — `at start of` appears in no corpus example.
+ */
+const PUT_AT_END: ReadonlyArray<{
+  lang: string;
+  verb: string;
+  verbAlts?: string[];
+  /** marker word(s) for `at` (manner phrase head). */
+  at: string;
+  /** the `end` position noun. */
+  end: string;
+  /** the `of` connective between `end` and the body destination. */
+  of: string;
+  /** verb-final word order: `{patient} at end of {destination} <objMarker> verb`. */
+  sov?: boolean;
+  /** SOV object marker between the body destination and the trailing verb. */
+  objMarker?: string;
+  /** literal inserted between verb and patient (zh 把, he את). */
+  patientPrefix?: string;
+}> = [
+  // SVO / VSO (verb-first)
+  {
+    lang: 'es',
+    verb: 'poner',
+    verbAlts: ['pon', 'colocar', 'put'],
+    at: 'en',
+    end: 'fin',
+    of: 'de',
+  },
+  { lang: 'fr', verb: 'mettre', at: 'à', end: 'fin', of: 'de' },
+  { lang: 'pt', verb: 'colocar', at: 'em', end: 'fim', of: 'de' },
+  { lang: 'it', verb: 'mettere', at: 'a', end: 'fine', of: 'di' },
+  { lang: 'de', verb: 'setzen', at: 'bei', end: 'ende', of: 'von' },
+  { lang: 'sw', verb: 'weka', at: 'katika', end: 'mwisho', of: 'ya' },
+  {
+    lang: 'id',
+    verb: 'taruh',
+    verbAlts: ['letakkan', 'masukkan', 'tempatkan'],
+    at: 'di',
+    end: 'akhir',
+    of: 'dari',
+  },
+  { lang: 'ms', verb: 'letak', at: 'di', end: 'tamat', of: 'daripada' },
+  { lang: 'vi', verb: 'đặt', at: 'tại', end: 'kết thúc', of: 'của' },
+  { lang: 'pl', verb: 'umieść', at: 'przy', end: 'koniec', of: 'z' },
+  { lang: 'ru', verb: 'положить', at: 'у', end: 'конец', of: 'из' },
+  { lang: 'uk', verb: 'покласти', at: 'в', end: 'кінець', of: 'з' },
+  { lang: 'th', verb: 'ใส่', at: 'ที่', end: 'จบ', of: 'ของ' },
+  { lang: 'tl', verb: 'ilagay', at: 'sa', end: 'wakas', of: 'ng' },
+  { lang: 'ar', verb: 'ضع', at: 'عند', end: 'النهاية', of: 'من' },
+  {
+    lang: 'zh',
+    verb: '放置',
+    verbAlts: ['放', '放入'],
+    patientPrefix: '把',
+    at: '在',
+    end: '结束',
+    of: '的',
+  },
+  { lang: 'he', verb: 'שים', patientPrefix: 'את', at: 'at', end: 'סוף', of: 'of' },
+  // SOV (verb-last, object marker before the verb)
+  { lang: 'tr', verb: 'koy', sov: true, objMarker: 'i', at: 'de', end: 'son', of: 'nin' },
+  { lang: 'ja', verb: '置く', sov: true, objMarker: 'を', at: 'で', end: '終わり', of: 'の' },
+  { lang: 'ko', verb: '넣다', sov: true, objMarker: '를', at: '에', end: '끝', of: '의' },
+  {
+    lang: 'hi',
+    verb: 'रखें',
+    verbAlts: ['रख', 'डालें', 'डाल'],
+    sov: true,
+    objMarker: 'को',
+    at: 'पर',
+    end: 'समाप्त',
+    of: 'का',
+  },
+  {
+    lang: 'bn',
+    verb: 'রাখুন',
+    verbAlts: ['রাখ'],
+    sov: true,
+    objMarker: 'কে',
+    at: 'এ',
+    end: 'শেষ',
+    of: 'র',
+  },
+];
+
+function buildAtEndPutPatterns(language: string): LanguagePattern[] {
+  const spec = PUT_AT_END.find(s => s.lang === language);
+  if (!spec) return [];
+  const tokens: LanguagePattern['template']['tokens'] = [];
+  const verbToken = spec.verbAlts
+    ? ({ type: 'literal', value: spec.verb, alternatives: spec.verbAlts } as const)
+    : ({ type: 'literal', value: spec.verb } as const);
+  // A multi-word marker (vi `kết thúc`) tokenizes as ONE token whose value is
+  // the whole phrase, so the literal must carry the phrase verbatim — splitting
+  // on whitespace would emit two literals that never align with the single
+  // token. Single-word markers are unaffected.
+  const pushWords = (phrase: string) => {
+    tokens.push({ type: 'literal', value: phrase });
+  };
+  if (!spec.sov) {
+    tokens.push(verbToken);
+    if (spec.patientPrefix) tokens.push({ type: 'literal', value: spec.patientPrefix });
+    tokens.push({ type: 'role', role: 'patient' });
+    pushWords(spec.at);
+    pushWords(spec.end);
+    pushWords(spec.of);
+    tokens.push({ type: 'role', role: 'destination' });
+  } else {
+    tokens.push({ type: 'role', role: 'patient' });
+    pushWords(spec.at);
+    pushWords(spec.end);
+    pushWords(spec.of);
+    tokens.push({ type: 'role', role: 'destination' });
+    if (spec.objMarker) tokens.push({ type: 'literal', value: spec.objMarker });
+    tokens.push(verbToken);
+  }
+  return [
+    {
+      id: `put-${spec.lang}-at-end`,
+      language: spec.lang,
+      command: 'put',
+      // Above the generic into-put (≤100) so the full `at end of` phrase wins
+      // over a put that would otherwise grab the `end` word as its destination.
+      priority: 110,
+      template: {
+        format: `put {patient} ${spec.at} ${spec.end} ${spec.of} {destination}`,
+        tokens,
+      },
+      extraction: {
+        manner: { default: { type: 'literal', value: 'at end of' } },
+      },
+    } satisfies LanguagePattern,
+  ];
+}
+
 function buildPositionalPutPatterns(language: string): LanguagePattern[] {
   const spec = PUT_POSITIONAL.find(s => s.lang === language);
   if (!spec) return [];
@@ -911,34 +1069,37 @@ function buildPositionalPutPatterns(language: string): LanguagePattern[] {
 
 export function getPutPatternsForLanguage(language: string): LanguagePattern[] {
   const positional = buildPositionalPutPatterns(language);
+  // The at-end-of positional put (make-toast-element); en carries its own
+  // handcrafted variant, every other language is generated from PUT_AT_END.
+  const atEnd = buildAtEndPutPatterns(language);
   switch (language) {
     case 'bn':
-      return getPutPatternsBn();
+      return [...getPutPatternsBn(), ...atEnd];
     case 'en':
       return getPutPatternsEn();
     case 'es':
-      return getPutPatternsEs();
+      return [...getPutPatternsEs(), ...atEnd];
     case 'hi':
-      return getPutPatternsHi();
+      return [...getPutPatternsHi(), ...atEnd];
     case 'id':
-      return [...getPutPatternsId(), ...positional];
+      return [...getPutPatternsId(), ...positional, ...atEnd];
     case 'it':
-      return getPutPatternsIt();
+      return [...getPutPatternsIt(), ...atEnd];
     case 'pl':
-      return getPutPatternsPl();
+      return [...getPutPatternsPl(), ...atEnd];
     case 'ru':
-      return getPutPatternsRu();
+      return [...getPutPatternsRu(), ...atEnd];
     case 'qu':
       return getPutPatternsQu();
     case 'th':
-      return getPutPatternsTh();
+      return [...getPutPatternsTh(), ...atEnd];
     case 'uk':
-      return getPutPatternsUk();
+      return [...getPutPatternsUk(), ...atEnd];
     case 'vi':
-      return getPutPatternsVi();
+      return [...getPutPatternsVi(), ...atEnd];
     case 'zh':
-      return [...getPutPatternsZh(), ...positional];
+      return [...getPutPatternsZh(), ...positional, ...atEnd];
     default:
-      return positional;
+      return [...positional, ...atEnd];
   }
 }

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -5195,3 +5195,54 @@ describe('en at-end-of positional put — at end of / at start of (R2 make-toast
     expect(roles(lastPut).get('manner')?.value).toBe('at end of');
   });
 });
+
+describe('cross-language at-end-of positional put (R2 wave 8 — make-toast-element)', () => {
+  // en carries a handcrafted `put {patient} at end of {destination}` pattern; the
+  // i18n transformer translates that three-word position phrase verbatim into
+  // every other language, but no non-en language had a counterpart, so the third
+  // clause of make-toast-element (`put it at end of body`) either dropped
+  // entirely (SOV/VSO — the made toast was never attached → empty effect) or the
+  // generic into-put grabbed the `end` word as the destination. PUT_AT_END
+  // (patterns/put.ts) records the per-language surface words for the verb +
+  // `at`/`end`/`of` so the generated pattern reconstructs the en shape with
+  // `manner: 'at end of'`; the destination is the language's dict-canonical body
+  // word, which already resolves to the `body` contextReference. This cleared
+  // make-toast-element in 17 languages in the execution sweep (23→6 failing).
+  // Parse-level fidelity is unchanged: the dropped third command is a duplicate
+  // `put` action, so action-set fidelity was already 1.0 — exactly the
+  // lossy-but-faithful gap R2 execution fidelity exists to catch.
+  function roles(node: unknown): Map<string, { type?: string; value?: unknown }> {
+    return (node as { roles: Map<string, { type?: string; value?: unknown }> }).roles;
+  }
+  // [lang, the corpus-shaped third clause `put 'x' <at> end <of> body`]. SOV
+  // languages (ja/ko/tr) place the verb last after an object marker; he leaves
+  // `at`/`of` untranslated; vi's `kết thúc` is a single multi-word token.
+  const atEndCases: Array<[string, string]> = [
+    ['es', "poner 'x' en fin de cuerpo"],
+    ['fr', "mettre 'x' à fin de corps"],
+    ['pt', "colocar 'x' em fim de corpo"],
+    ['it', "mettere 'x' a fine di corpo"],
+    ['de', "setzen 'x' bei ende von körper"],
+    ['sw', "weka 'x' katika mwisho ya mwili"],
+    ['id', "taruh 'x' di akhir dari badan"],
+    ['vi', "đặt 'x' tại kết thúc của body"],
+    ['pl', "umieść 'x' przy koniec z body"],
+    ['ru', "положить 'x' у конец из тело"],
+    ['th', "ใส่ 'x' ที่ จบ ของ บอดี้"],
+    ['tl', "ilagay 'x' sa wakas ng katawan"],
+    ['ar', "ضع 'x' عند النهاية من جسم"],
+    ['he', "שים את 'x' at סוף of גוף"],
+    ['ja', "'x' で 終わり の ボディ を 置く"],
+    ['ko', "'x' 에 끝 의 바디 를 넣다"],
+    ['tr', "'x' de son nin gövde i koy"],
+  ];
+  for (const [lang, input] of atEndCases) {
+    it(`[${lang}] put at end of body parses as a put with manner 'at end of' + body destination`, () => {
+      const node = parse(input, lang) as Record<string, unknown>;
+      expect(node).toBeTruthy();
+      expect(node.action).toBe('put');
+      expect(roles(node).get('manner')?.value).toBe('at end of');
+      expect(roles(node).get('destination')?.value).toBe('body');
+    });
+  }
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T04:04:28.017Z",
-  "commit": "bb25025e",
+  "timestamp": "2026-06-13T04:43:51.758Z",
+  "commit": "4ae3b107",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -8,12 +8,12 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8679433429145073,
       "avgFidelity": 0.9771241830065359,
-      "avgRoleFidelity": 0.8593780369290575,
-      "avgExecutionFidelity": 0.967741935483871,
-      "executionFailures": ["make-toast-element"],
+      "avgRoleFidelity": 0.8616456106252026,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["repeat-until-event", "window-scroll"],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -638,7 +638,7 @@
       "parseRate": 1,
       "avgConfidence": 0.8477942692228406,
       "avgFidelity": 0.9905844155844155,
-      "avgRoleFidelity": 0.7753941441441441,
+      "avgRoleFidelity": 0.7776463963963963,
       "avgExecutionFidelity": 0.8064516129032258,
       "executionFailures": [
         "accordion-exclusive",
@@ -656,7 +656,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1282,17 +1282,12 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8323373793962008,
       "avgFidelity": 0.9782135076252723,
-      "avgRoleFidelity": 0.8420877874959508,
-      "avgExecutionFidelity": 0.8709677419354839,
-      "executionFailures": [
-        "accordion-exclusive",
-        "closest-ancestor",
-        "make-toast-element",
-        "modal-close-button"
-      ],
+      "avgRoleFidelity": 0.8443553611920959,
+      "avgExecutionFidelity": 0.9032258064516129,
+      "executionFailures": ["accordion-exclusive", "closest-ancestor", "modal-close-button"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1916,7 +1911,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2542,12 +2537,12 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8352422450461645,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8277372853903467,
-      "avgExecutionFidelity": 0.967741935483871,
-      "executionFailures": ["make-toast-element"],
+      "avgRoleFidelity": 0.8288710722384194,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3172,12 +3167,12 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8261126672891358,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8294946550048593,
-      "avgExecutionFidelity": 0.967741935483871,
-      "executionFailures": ["make-toast-element"],
+      "avgRoleFidelity": 0.8317622287010044,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3802,9 +3797,9 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8263201576927067,
       "avgFidelity": 0.9589324618736381,
-      "avgRoleFidelity": 0.8729267897635247,
-      "avgExecutionFidelity": 0.967741935483871,
-      "executionFailures": ["make-toast-element"],
+      "avgRoleFidelity": 0.8751943634596696,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-resizable",
@@ -3821,7 +3816,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4446,7 +4441,7 @@
       "parseRate": 1,
       "avgConfidence": 0.9560915275200976,
       "avgFidelity": 0.928030303030303,
-      "avgRoleFidelity": 0.5914897039897042,
+      "avgRoleFidelity": 0.5926158301158303,
       "avgExecutionFidelity": 0.6129032258064516,
       "executionFailures": [
         "accordion-exclusive",
@@ -4482,7 +4477,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5108,9 +5103,9 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8404295051353855,
       "avgFidelity": 0.9640522875816994,
-      "avgRoleFidelity": 0.8213394881762228,
-      "avgExecutionFidelity": 0.9354838709677419,
-      "executionFailures": ["make-toast-element", "set-style"],
+      "avgRoleFidelity": 0.8236070618723679,
+      "avgExecutionFidelity": 0.967741935483871,
+      "executionFailures": ["set-style"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "input-mirror",
@@ -5119,7 +5114,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5744,12 +5739,12 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8379396202925594,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8137836086815678,
-      "avgExecutionFidelity": 0.9354838709677419,
-      "executionFailures": ["make-toast-element", "modal-close-button"],
+      "avgRoleFidelity": 0.8149173955296405,
+      "avgExecutionFidelity": 0.967741935483871,
+      "executionFailures": ["modal-close-button"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6374,11 +6369,10 @@
       "parseRate": 1,
       "avgConfidence": 0.8399092970521543,
       "avgFidelity": 0.941017316017316,
-      "avgRoleFidelity": 0.7536518661518664,
-      "avgExecutionFidelity": 0.8064516129032258,
+      "avgRoleFidelity": 0.7559041184041186,
+      "avgExecutionFidelity": 0.8387096774193549,
       "executionFailures": [
         "accordion-exclusive",
-        "make-toast-element",
         "modal-close-button",
         "modal-open",
         "put-content-basic",
@@ -6403,7 +6397,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7029,11 +7023,10 @@
       "parseRate": 1,
       "avgConfidence": 0.7958977530406102,
       "avgFidelity": 0.958874458874459,
-      "avgRoleFidelity": 0.7514639639639643,
-      "avgExecutionFidelity": 0.8064516129032258,
+      "avgRoleFidelity": 0.7537162162162165,
+      "avgExecutionFidelity": 0.8387096774193549,
       "executionFailures": [
         "accordion-exclusive",
-        "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
         "modal-open",
@@ -7053,7 +7046,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7694,7 +7687,7 @@
         "render-template-with-data",
         "set-color-variable"
       ],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8315,12 +8308,12 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8037866998651292,
       "avgFidelity": 0.9782135076252723,
-      "avgRoleFidelity": 0.8258098477486233,
-      "avgExecutionFidelity": 0.967741935483871,
-      "executionFailures": ["make-toast-element"],
+      "avgRoleFidelity": 0.826943634596696,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8945,12 +8938,12 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8007988380537381,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8494574020084225,
-      "avgExecutionFidelity": 0.967741935483871,
-      "executionFailures": ["make-toast-element"],
+      "avgRoleFidelity": 0.8517249757045676,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9599,7 +9592,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10225,12 +10218,12 @@
       "parseRate": 1,
       "avgConfidence": 0.8117913832199526,
       "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.8417873230373231,
-      "avgExecutionFidelity": 0.9354838709677419,
-      "executionFailures": ["make-toast-element", "modal-close-backdrop"],
+      "avgRoleFidelity": 0.8429134491634492,
+      "avgExecutionFidelity": 0.967741935483871,
+      "executionFailures": ["modal-close-backdrop"],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10856,14 +10849,9 @@
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.791841269841268,
       "avgFidelity": 0.9705555555555554,
-      "avgRoleFidelity": 0.8337053571428573,
-      "avgExecutionFidelity": 0.8709677419354839,
-      "executionFailures": [
-        "accordion-exclusive",
-        "closest-ancestor",
-        "make-toast-element",
-        "modal-close-button"
-      ],
+      "avgRoleFidelity": 0.8360201719576721,
+      "avgExecutionFidelity": 0.9032258064516129,
+      "executionFailures": ["accordion-exclusive", "closest-ancestor", "modal-close-button"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [
         "event-debounce",
@@ -10871,7 +10859,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11493,17 +11481,12 @@
       "parseRate": 1,
       "avgConfidence": 0.8401154401154378,
       "avgFidelity": 1,
-      "avgRoleFidelity": 0.8184202059202059,
-      "avgExecutionFidelity": 0.8709677419354839,
-      "executionFailures": [
-        "accordion-exclusive",
-        "make-toast-element",
-        "modal-close-button",
-        "modal-open"
-      ],
+      "avgRoleFidelity": 0.8206724581724582,
+      "avgExecutionFidelity": 0.9032258064516129,
+      "executionFailures": ["accordion-exclusive", "modal-close-button", "modal-open"],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12129,12 +12112,12 @@
       "parseRate": 1,
       "avgConfidence": 0.8494027914195967,
       "avgFidelity": 0.9983766233766234,
-      "avgRoleFidelity": 0.8861727799227802,
-      "avgExecutionFidelity": 0.967741935483871,
-      "executionFailures": ["make-toast-element"],
+      "avgRoleFidelity": 0.8884250321750323,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["window-scroll"],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12760,12 +12743,11 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8377425044091712,
       "avgFidelity": 0.9635076252723311,
-      "avgRoleFidelity": 0.7689342403628118,
-      "avgExecutionFidelity": 0.7741935483870968,
+      "avgRoleFidelity": 0.7712018140589568,
+      "avgExecutionFidelity": 0.8064516129032258,
       "executionFailures": [
         "accordion-exclusive",
         "if-matches",
-        "make-toast-element",
         "modal-close-button",
         "modal-open",
         "set-attribute",
@@ -12779,7 +12761,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13404,12 +13386,12 @@
       "parseRate": 1,
       "avgConfidence": 0.8098948670377222,
       "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.8272602960102962,
+      "avgRoleFidelity": 0.8295125482625483,
       "avgExecutionFidelity": 0.9354838709677419,
       "executionFailures": ["make-toast-element", "modal-close-backdrop"],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14035,9 +14017,9 @@
       "parseRate": 1,
       "avgConfidence": 0.8037518037518019,
       "avgFidelity": 0.985930735930736,
-      "avgRoleFidelity": 0.8643741956241957,
-      "avgExecutionFidelity": 0.967741935483871,
-      "executionFailures": ["make-toast-element"],
+      "avgRoleFidelity": 0.8666264478764479,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [
         "input-mirror",
@@ -14046,7 +14028,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14691,7 +14673,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 418583,
+      "bundleSize": 421613,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15313,7 +15295,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 418583,
+      "size": 421613,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## R2 execution-fidelity burn-down — make-toast-element (the biggest single cluster)

`make-toast-element` was the largest failing R2 execution cluster (×23 — every non-en language). Its third clause `put it at end of body` had no per-language counterpart to en's handcrafted `put-en-at-end` pattern, so the i18n-transformer's word-for-word `at end of` translation either **dropped entirely** (SOV/VSO — the made toast is never attached → empty effect) or the generic into-put grabbed the `end` word as the destination.

### Mechanism

`packages/semantic/src/patterns/put.ts`:
- A `PUT_AT_END` table records the per-language surface words for the put verb + `at`/`end`/`of` (plus `sov`/`objMarker`/`patientPrefix` flags).
- `buildAtEndPutPatterns` reconstructs the en `put {patient} <at> <end> <of> {destination}` shape (SOV variant places the verb last after an object marker) with `manner: 'at end of'` at priority 110 (above the generic into-put).
- The destination is each language's **dict-canonical body word**, which already aligns with profile `references.body` (the wave-6/§7l alignment), so it resolves to the `body` contextReference with **no dict change**.

### Result

- Clears `make-toast-element` in **17 languages** (es fr pt it de sw id vi pl ru th tl ar he ja ko tr).
- **meanExecutionFidelity 0.8878 → 0.9116**; failing execution cells **80 → 63** (−17).
- Parse-level **byte-identical** (avgFidelity 0.9743, lossy 77, degen 63 all unchanged): the dropped third command is a *duplicate* `put` action, so action-set fidelity was already 1.0 — exactly the lossy-but-faithful gap R2 execution fidelity exists to catch.
- Baseline regenerated; subset membership unchanged (make-toast was already in the subset). 17 cross-language unit tests added (R2 wave 8 block).

### Survivors (bn hi ms qu uk zh) — all separate, pre-existing mechanisms (not regressions)

- **ms/tl-path**: ms drops the third clause despite correct tokens while tl (identical SVO shape) works — ms's body routes through the grammar/fused path (`parseBodyWithGrammarPatterns`), not `parseBodyWithClauses` (the §7j routing class on make-toast's fused make-event). tl proves the pattern is correct.
- **zh/bn**: the whole event body collapses to a single `compound` (a higher-level event path).
- **hi/uk**: the at-end (third) put parses correctly, but the **second** put mis-parses (hi drops `'Saved!'`; uk truncates the string literal → `"Save"`).
- **qu**: body word mismatch (`kurku`≠profile `ukhu`) + the underscore-tokenizer bug — excluded from the table; tracked for the qu-tokenizer arc.

### Verification

- `--regression` gate green (parse-rate, fidelity, correctness, execution ratchets).
- Semantic full suite: 5872 passed / 9 skipped.
- Execution-validator subset lock test: 8 passed.
- `patterns.db` not committed (CI re-populates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)