### PR TITLE
fix(semantic): reclaim trailing post-verb source clause; R2 wave 9

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -887,6 +887,64 @@ drops); (2) **qu underscore-tokenizer** (unlocks qu else/body + make-toast);
 (would unlock ms/tl-class make-toast + possibly the zh/bn compound collapse — the
 §7j class generalized). Alt track: behavior-_ degenerate mass (~40 of 63 degen).
 
+## 7o. Status update (2026-06-13, session 16): trailing post-verb source clause
+
+**modal-close-button 10→4 by reclaiming the trailing post-verb source.** Its
+body is `hide closest .modal then remove .modal-open from body`; the grammar
+transformer emits the from-phrase AFTER the verb — SOV `.modal-open を 削除 ボディ
+から` (bn/hi/ja/ko/tr), SVO th `ลบ .modal-open จาก บอดี้` — and the per-command
+remove pattern (which ends at the verb) never claims it, so the class was removed
+from the clicked button (the schema's `me` default) instead of the document body
+(no effect).
+
+**Key discovery (the handoff's parseClause hypothesis was half-right):** the
+remove clause does NOT go through `parseClause`. modal-close-button's fused event
+pattern captures the first command (`hide`) as the action, so the trailing
+`remove …` clause is parsed by **`parseBodyWithGrammarPatterns`** (the §7j fused-
+body path), not `parseBodyWithClauses → parseClause`. A `parseClause`-only fix
+therefore never fired (confirmed by an instrumented probe). The fix adds a shared
+`tryAttachTrailingSource` helper called at BOTH the `parseClause` and the
+`parseBodyWithGrammarPatterns` `matchBest` call sites: after a command matches, if
+its schema declares a `source` role that is currently absent or the defaulted
+`me`, and the next tokens form a clean marker+value pair in the profile's
+source-marker order (postpositional `<value> <from>` for SOV; prepositional
+`<from> <value>` for SVO), it reclaims the trailing source. The body-clause twin
+of #379's event-wrapper trailing source group.
+
+**Result:** modal-close-button 10→4 failing (cleared **6 languages**: bn, hi, ja,
+ko, th, tr). meanExecutionFidelity **0.9116 → 0.9201**; failing execution cells
+**63 → 57** (−6). Parse-level byte-identical (avgFidelity 0.9743, lossy 77, degen
+63 — the remove command was already present, only its source role was wrong);
+avgRoleFidelity (R1) ticked up for the 6. Conservative guard verified: accordion-
+exclusive / remove-class-from-all / take-class-from-siblings keep their genuinely
+captured sources (`.accordion-item` / `.items` / `.tab-button`) — the reclaim
+returns early on a non-`me` existing source. Gate green; baseline regenerated;
+subset membership unchanged. 9 cross-language unit tests added (R2 wave 9 block).
+Semantic 5881 green.
+
+**modal-close-button survivors (4) — separate mechanisms:** de (`nächste`→next
+collision, hide targets the wrong element); it (captures body as DESTINATION not
+source — a role-mislabel in the it path); sw (the `hide` command drops entirely);
+qu (body word `kurku`≠profile + underscore tokenizer).
+
+**Still-open R2 clusters after this (57 failing, ranked):** accordion-exclusive
+×8 (bn de hi ja ko sw th tr — the SOV **destination**-positional drop: `add .open
+to closest .accordion-item` → destination `me`, a DIFFERENT mechanism from the
+source clause); modal-open ×7 (bn hi ja ko qu th tr); make-toast-element ×6 (bn hi
+ms qu uk zh); modal-close-backdrop ×6 (hi ko qu ru uk zh); tabs-aria ×5 (bn hi ja
+ko tr); modal-close-button ×4 (de it qu sw); make-element ×3 (bn hi ms);
+set-attribute ×3 (hi qu tr); if-matches ×3 (qu tr zh); closest-ancestor ×2 (de
+sw); set-style ×2 (hi id); put-content-basic ×2 (ja qu); if-condition ×2 (qu zh);
+
+- singletons. **Next-mechanism ranking:** (1) **SOV destination-positional drop**
+  (accordion-exclusive `add` destination `closest .accordion-item`→`me` in
+  bn/hi/ja/ko/sw/tr — the destination twin of this PR's source reclaim, but in the
+  positional-phrase path; ~6 cells, the largest cluster); (2) **qu underscore-
+  tokenizer** (qu appears in 8 cells); (3) **de `nächste`/`next` disambiguation**
+  (de in 3 cells: modal-close-button, accordion, closest-ancestor); (4) **fused-
+  event body routing** (ms/tl make-toast + zh/bn compound collapse). Alt track:
+  behavior-\* degenerate mass (~40 of 63 degen).
+
 ## 8. R1 / R2 — role-fidelity and execution ratchets (extend R0)
 
 Action-set fidelity (R0's signal) cannot see a parse that finds the right

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -12,9 +12,11 @@ import type {
   EventHandlerSemanticNode,
   SemanticParser as ISemanticParser,
   SemanticValue,
+  SemanticRole,
   ActionType,
   LanguagePattern,
   LanguageToken,
+  TokenStream,
   Diagnostic,
 } from '../types';
 import {
@@ -33,6 +35,7 @@ import {
 } from '../tokenizers';
 // Import from registry for tree-shaking (registry uses directly-registered patterns first)
 import { getPatternsForLanguage, tryGetProfile } from '../registry';
+import { getSchema } from '../generators/command-schemas';
 import { patternMatcher } from './pattern-matcher';
 import { eventNameTranslations } from '../patterns/event-handler';
 import { render as renderExplicitFn } from '../explicit/renderer';
@@ -818,7 +821,9 @@ export class SemanticParserImpl implements ISemanticParser {
       // Try to match as a command
       const commandMatch = patternMatcher.matchBest(clauseStream, commandPatterns);
       if (commandMatch) {
-        commands.push(this.buildCommand(commandMatch, language));
+        const cmd = this.buildCommand(commandMatch, language);
+        commands.push(cmd);
+        this.tryAttachTrailingSource(clauseStream, cmd, language);
       } else {
         // A `for`-binding loop (`repeat for <var> in <coll>`) loses its `for`
         // binder keyword in transit (the i18n transformer emits `repeat <var> in
@@ -855,6 +860,80 @@ export class SemanticParserImpl implements ISemanticParser {
     }
 
     return commands;
+  }
+
+  /**
+   * Attach a trailing post-verb source phrase that the per-command pattern left
+   * unconsumed. The SOV grammar transformer emits `remove .x from body` as
+   * `.x を 削除 ボディ から` (modal-close-button) — patient + verb, then a
+   * postpositional `<body-word> <from-marker>` the SOV remove pattern (which
+   * ends at the verb) never claims; parseClause's loop would otherwise skip it
+   * and source defaults to `me` (the class is removed from the clicked button,
+   * not the document body). SVO languages (th) trail a prepositional
+   * `<from-marker> <body-word>` after `verb patient`. This is the body-clause
+   * twin of the #379 event-wrapper trailing source group.
+   *
+   * Conservative by construction: fires only when (1) the command's schema
+   * declares a `source` role, (2) that role is currently absent or the defaulted
+   * `me`, and (3) the very next tokens form a clean marker+value pair in the
+   * profile's source-marker order — so it can neither overwrite a real source
+   * (accordion's `remove .open from .accordion-item` keeps its captured source)
+   * nor steal a following command's tokens (a trailing `then add …` has no
+   * source marker adjacent to the verb).
+   */
+  private tryAttachTrailingSource(
+    stream: TokenStream,
+    command: CommandSemanticNode,
+    language: string
+  ): void {
+    const schema = getSchema(command.action as ActionType);
+    if (!schema?.roles.some(r => r.role === 'source')) return;
+
+    const roles = command.roles as Map<SemanticRole, SemanticValue>;
+    const existing = roles.get('source');
+    // Only fill a missing source or override the schema's `me` default — never a
+    // genuinely captured one.
+    if (existing && !(existing.type === 'reference' && existing.value === 'me')) return;
+
+    const src = tryGetProfile(language)?.roleMarkers?.source;
+    if (!src) return;
+    const isMarker = (t: LanguageToken | null): boolean => {
+      if (!t || (t.kind !== 'particle' && t.kind !== 'keyword')) return false;
+      if ((t.normalized ?? '').toLowerCase() === 'source') return true;
+      const v = t.value.toLowerCase();
+      return (
+        src.primary?.toLowerCase() === v || !!src.alternatives?.some(a => a.toLowerCase() === v)
+      );
+    };
+    const isValue = (t: LanguageToken | null): boolean =>
+      !!t &&
+      (t.kind === 'selector' ||
+        (t.normalized ?? '').toLowerCase() === 'body' ||
+        t.kind === 'identifier' ||
+        (t.kind as string) === 'reference');
+
+    const tok0 = stream.peek();
+    const tok1 = stream.peek(1);
+    if (!tok0 || !tok1) return;
+
+    if (src.position === 'after') {
+      // Postpositional `<value> <from-marker>` (ja から, ko 에서, bn থেকে,
+      // hi से, tr den).
+      if (isValue(tok0) && isMarker(tok1)) {
+        const v = this.tokenToSemanticValue(tok0);
+        stream.advance();
+        stream.advance();
+        if (v) roles.set('source', v);
+      }
+    } else {
+      // Prepositional `<from-marker> <value>` (th จาก and other SVO langs whose
+      // transformer trails the from-phrase after `verb patient`).
+      if (isMarker(tok0) && isValue(tok1)) {
+        stream.advance();
+        const v = this.tokenToSemanticValue(stream.advance());
+        if (v) roles.set('source', v);
+      }
+    }
   }
 
   // ==========================================================================
@@ -1283,7 +1362,13 @@ export class SemanticParserImpl implements ISemanticParser {
       if (!matched) {
         const commandMatch = patternMatcher.matchBest(tokens, commandPatterns);
         if (commandMatch) {
-          commands.push(this.buildCommand(commandMatch, language));
+          const cmd = this.buildCommand(commandMatch, language);
+          commands.push(cmd);
+          // Reclaim a trailing post-verb source phrase the matched pattern left
+          // unconsumed (`remove .x from body` → `.x を 削除 ボディ から`); without
+          // this the SOV grammar body walker skips `ボディ から` and source stays
+          // the `me` default. Same guard as the parseClause call site.
+          this.tryAttachTrailingSource(tokens, cmd, language);
           matched = true;
           clauseHadMatch = true;
         }

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -5246,3 +5246,79 @@ describe('cross-language at-end-of positional put (R2 wave 8 — make-toast-elem
     });
   }
 });
+
+describe('trailing post-verb source clause in fused-event bodies (R2 wave 9 — modal-close-button)', () => {
+  // modal-close-button's body is `hide closest .modal then remove .modal-open
+  // from body`. The grammar transformer emits the from-phrase AFTER the verb —
+  // SOV `... .modal-open を 削除 ボディ から`, SVO th `... ลบ .modal-open จาก
+  // บอดี้` — and the per-command remove pattern (which ends at the verb) never
+  // claims it. Because the fused event pattern captures the first command (hide)
+  // as the action, the trailing `remove …` clause is parsed by
+  // parseBodyWithGrammarPatterns, which used to skip `<body-word> <from-marker>`
+  // and leave the schema's `me` default, so `.modal-open` was removed from the
+  // clicked button instead of the document body (no effect). tryAttachTrailingSource
+  // now reclaims the trailing source (postpositional or prepositional, per the
+  // profile's source-marker position) — the body-clause twin of the #379
+  // event-wrapper trailing source group. Cleared 6 languages in the execution
+  // sweep (modal-close-button 10→4). Fires only when the matched command's schema
+  // declares a source role that is currently absent or the defaulted `me`.
+  function commands(node: unknown): Array<Record<string, unknown>> {
+    const out: Array<Record<string, unknown>> = [];
+    const walk = (c: unknown) => {
+      if (!c || typeof c !== 'object') return;
+      const rec = c as Record<string, unknown>;
+      if (typeof rec.action === 'string' && !['on', 'compound'].includes(rec.action as string))
+        out.push(rec);
+      for (const f of ['body', 'statements']) {
+        const ch = rec[f];
+        if (Array.isArray(ch)) ch.forEach(walk);
+        else if (ch) walk(ch);
+      }
+    };
+    walk(node);
+    return out;
+  }
+  function role(cmd: Record<string, unknown>, name: string): unknown {
+    const roles = cmd.roles as Map<string, { value?: unknown }>;
+    const m = roles instanceof Map ? roles : new Map(Object.entries((roles as object) ?? {}));
+    return (m.get(name) as { value?: unknown } | undefined)?.value;
+  }
+
+  // Corpus modal-close-button translations: `hide closest .modal then remove
+  // .modal-open from body`. bn/hi/ja/ko/tr trail a postpositional `<body>
+  // <from-marker>`; th a prepositional `<from-marker> <body>` after the verb.
+  const cases: Array<[string, string]> = [
+    ['ja', '最も近い .modal を クリック で 隠す それから .modal-open を 削除 ボディ から'],
+    ['ko', '가장가까운 .modal 를 클릭 할 때 숨기다 그러면 .modal-open 를 제거 바디 에서'],
+    ['bn', 'নিকটতম .modal কে ক্লিক এ লুকান তারপর .modal-open কে সরান বডি থেকে'],
+    ['hi', 'निकटतम .modal को क्लिक पर छिपाएं फिर .modal-open को हटाएं बॉडी से'],
+    ['tr', 'enyakın .modal i tıklama de gizle sonra .modal-open i kaldır gövde den'],
+    ['th', 'เมื่อ คลิก ซ่อน ใกล้สุด .modal แล้ว ลบ .modal-open จาก บอดี้'],
+  ];
+  for (const [lang, input] of cases) {
+    it(`[${lang}] the trailing post-verb remove captures source = body (was the me default)`, () => {
+      const remove = commands(parse(input, lang as 'ja')).find(c => c.action === 'remove');
+      expect(remove, 'remove command present').toBeTruthy();
+      expect(role(remove!, 'patient')).toBe('.modal-open');
+      expect(role(remove!, 'source')).toBe('body');
+    });
+  }
+
+  it('[ja] a genuinely captured source is not overwritten (accordion remove keeps .accordion-item)', () => {
+    // accordion-exclusive's `remove .open from .accordion-item` captures its
+    // source through the existing path; the trailing-source reclaim must not
+    // touch it (the guard returns early on a non-`me` existing source).
+    const input =
+      '.open を クリック で 削除 .accordion-item から それから .open を 追加 最も近い .accordion-item に';
+    const remove = commands(parse(input, 'ja')).find(c => c.action === 'remove');
+    expect(remove).toBeTruthy();
+    expect(role(remove!, 'source')).toBe('.accordion-item');
+  });
+
+  it('[en] the en reference parse is unchanged (no trailing source phrase to reclaim)', () => {
+    const cmds = commands(parse('on click hide closest .modal remove .modal-open from body', 'en'));
+    const remove = cmds.find(c => c.action === 'remove');
+    expect(remove).toBeTruthy();
+    expect(role(remove!, 'source')).toBe('body');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T04:43:51.758Z",
-  "commit": "4ae3b107",
+  "timestamp": "2026-06-13T05:16:14.056Z",
+  "commit": "84c5aea2",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -13,7 +13,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["repeat-until-event", "window-scroll"],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -638,13 +638,12 @@
       "parseRate": 1,
       "avgConfidence": 0.8477942692228406,
       "avgFidelity": 0.9905844155844155,
-      "avgRoleFidelity": 0.7776463963963963,
-      "avgExecutionFidelity": 0.8064516129032258,
+      "avgRoleFidelity": 0.7821509009009009,
+      "avgExecutionFidelity": 0.8387096774193549,
       "executionFailures": [
         "accordion-exclusive",
         "make-element",
         "make-toast-element",
-        "modal-close-button",
         "modal-open",
         "tabs-aria"
       ],
@@ -656,7 +655,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1287,7 +1286,7 @@
       "executionFailures": ["accordion-exclusive", "closest-ancestor", "modal-close-button"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1911,7 +1910,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2542,7 +2541,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3172,7 +3171,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3816,7 +3815,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4441,15 +4440,14 @@
       "parseRate": 1,
       "avgConfidence": 0.9560915275200976,
       "avgFidelity": 0.928030303030303,
-      "avgRoleFidelity": 0.5926158301158303,
-      "avgExecutionFidelity": 0.6129032258064516,
+      "avgRoleFidelity": 0.5937419562419565,
+      "avgExecutionFidelity": 0.6451612903225806,
       "executionFailures": [
         "accordion-exclusive",
         "halt-propagation",
         "make-element",
         "make-toast-element",
         "modal-close-backdrop",
-        "modal-close-button",
         "modal-open",
         "set-attribute",
         "set-inner-html-possessive-dot",
@@ -4477,7 +4475,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5114,7 +5112,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5744,7 +5742,7 @@
       "executionFailures": ["modal-close-button"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6369,15 +6367,9 @@
       "parseRate": 1,
       "avgConfidence": 0.8399092970521543,
       "avgFidelity": 0.941017316017316,
-      "avgRoleFidelity": 0.7559041184041186,
-      "avgExecutionFidelity": 0.8387096774193549,
-      "executionFailures": [
-        "accordion-exclusive",
-        "modal-close-button",
-        "modal-open",
-        "put-content-basic",
-        "tabs-aria"
-      ],
+      "avgRoleFidelity": 0.7570302445302447,
+      "avgExecutionFidelity": 0.8709677419354839,
+      "executionFailures": ["accordion-exclusive", "modal-open", "put-content-basic", "tabs-aria"],
       "degeneratePasses": [
         "announce-screen-reader",
         "behavior-draggable",
@@ -6397,7 +6389,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7024,11 +7016,10 @@
       "avgConfidence": 0.7958977530406102,
       "avgFidelity": 0.958874458874459,
       "avgRoleFidelity": 0.7537162162162165,
-      "avgExecutionFidelity": 0.8387096774193549,
+      "avgExecutionFidelity": 0.8709677419354839,
       "executionFailures": [
         "accordion-exclusive",
         "modal-close-backdrop",
-        "modal-close-button",
         "modal-open",
         "tabs-aria"
       ],
@@ -7046,7 +7037,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7687,7 +7678,7 @@
         "render-template-with-data",
         "set-color-variable"
       ],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8313,7 +8304,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8943,7 +8934,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9592,7 +9583,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10223,7 +10214,7 @@
       "executionFailures": ["modal-close-backdrop"],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10859,7 +10850,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11481,12 +11472,12 @@
       "parseRate": 1,
       "avgConfidence": 0.8401154401154378,
       "avgFidelity": 1,
-      "avgRoleFidelity": 0.8206724581724582,
-      "avgExecutionFidelity": 0.9032258064516129,
-      "executionFailures": ["accordion-exclusive", "modal-close-button", "modal-open"],
+      "avgRoleFidelity": 0.8251769626769626,
+      "avgExecutionFidelity": 0.9354838709677419,
+      "executionFailures": ["accordion-exclusive", "modal-open"],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12117,7 +12108,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["window-scroll"],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12743,12 +12734,11 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8377425044091712,
       "avgFidelity": 0.9635076252723311,
-      "avgRoleFidelity": 0.7712018140589568,
-      "avgExecutionFidelity": 0.8064516129032258,
+      "avgRoleFidelity": 0.7723356009070294,
+      "avgExecutionFidelity": 0.8387096774193549,
       "executionFailures": [
         "accordion-exclusive",
         "if-matches",
-        "modal-close-button",
         "modal-open",
         "set-attribute",
         "tabs-aria"
@@ -12761,7 +12751,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13391,7 +13381,7 @@
       "executionFailures": ["make-toast-element", "modal-close-backdrop"],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14028,7 +14018,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14673,7 +14663,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 421613,
+      "bundleSize": 422536,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15295,7 +15285,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 421613,
+      "size": 422536,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## R2 execution-fidelity burn-down — modal-close-button (trailing post-verb source)

modal-close-button's body is `hide closest .modal then remove .modal-open from body`. The grammar transformer emits the `from` phrase **after the verb** — SOV `.modal-open を 削除 ボディ から` (bn/hi/ja/ko/tr), SVO th `ลบ .modal-open จาก บอดี้` — and the per-command `remove` pattern (which ends at the verb) never claims it. So `.modal-open` was removed from the clicked button (the schema's `me` default) instead of the document body, producing **no effect**.

### Key discovery

The handoff's hypothesis (fix in `parseClause`) was half-right. The remove clause does **not** go through `parseClause`: modal-close-button's fused event pattern captures the first command (`hide`) as the action, so the trailing `remove …` clause is parsed by **`parseBodyWithGrammarPatterns`** (the §7j fused-body path). A `parseClause`-only fix never fired (confirmed by an instrumented probe).

### Mechanism

A shared `tryAttachTrailingSource(stream, command, language)` helper, called at **both** the `parseClause` and the `parseBodyWithGrammarPatterns` `matchBest` call sites. After a command matches, if its schema declares a `source` role that is currently absent or the defaulted `me`, and the next tokens form a clean marker+value pair in the profile's source-marker order (postpositional `<value> <from>` for SOV; prepositional `<from> <value>` for SVO), it reclaims the trailing source. The body-clause twin of #379's event-wrapper trailing source group.

### Result

- Clears modal-close-button in **6 languages** (bn, hi, ja, ko, th, tr).
- **meanExecutionFidelity 0.9116 → 0.9201**; failing execution cells **63 → 57** (−6).
- modal-close-button **10 → 4** failing.
- Parse-level **byte-identical** (avgFidelity 0.9743, lossy 77, degen 63): the `remove` command was already present, only its `source` role was wrong; avgRoleFidelity (R1) ticked up for the 6.

### No regressions (conservative guard)

The reclaim returns early on a non-`me` existing source, so genuinely captured sources are untouched — verified that accordion-exclusive (`.accordion-item`), remove-class-from-all (`.items`), and take-class-from-siblings (`.tab-button`) keep their sources. A dedicated no-overwrite unit test locks this.

### Survivors (de it qu sw) — separate mechanisms

de (`nächste`→next collision), it (captures body as *destination* not source), sw (the `hide` command drops entirely), qu (body word mismatch + underscore tokenizer).

### Verification

- `--regression` gate green; semantic suite 5881 passed; 9 cross-language unit tests added (R2 wave 9).
- Baseline regenerated; subset membership unchanged. `patterns.db` not committed (CI re-populates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)