### PR TITLE
fix(semantic): reclaim trailing positional destination; R2 wave 11

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -945,6 +945,66 @@ sw); set-style ×2 (hi id); put-content-basic ×2 (ja qu); if-condition ×2 (qu 
   event body routing** (ms/tl make-toast + zh/bn compound collapse). Alt track:
   behavior-\* degenerate mass (~40 of 63 degen).
 
+## 7q. Status update (2026-06-13, session 18): trailing positional destination
+
+**accordion-exclusive 8→3 by extending the trailing-role reclaim to positional
+phrases.** accordion's body is `remove .open from .accordion-item then add .open
+to closest .accordion-item`; the add's to-phrase trails the verb as a POSITIONAL
+phrase — SOV `… 最も近い .accordion-item に` (closest + selector + to-marker) —
+which the wave-10 single-token reclaim couldn't capture (the leading token is the
+`closest` keyword, not a selector/reference), so the destination defaulted to
+`me`. Added a positional branch to `tryAttachTrailingRole`: when the strict
+(destination) role's trailing tokens are `<positional-keyword> <selector>
+<marker>`, it builds the same `{ type: 'expression', raw: 'closest
+.accordion-item' }` the English reference produces (normalized positional keyword
+
+- selector surface), so the core's positional evaluator resolves it identically.
+
+**Result:** accordion-exclusive 8→3 failing (cleared bn, hi, ja, ko, tr), plus a
+ride-along (toggle-aria-expanded's `next .panel` destination, also positional).
+meanExecutionFidelity **0.9285 → 0.9355**; failing execution cells **51 → 46**
+(−5). Parse-level byte-identical (avgFidelity 0.9743, lossy 77, degen 63); the
+clean same-`patterns.db` diff showed only the two correct positional captures
+(`closest .accordion-item`, `next .panel`) across the five languages — no
+cascading. Gate green; baseline regenerated; subset membership unchanged. 5 unit
+tests added (R2 wave 11; tr omitted — see below).
+
+**tr — populate-jitter on the execution boundary (important reliability note).**
+tr's `closest` keyword is two words (`en yakın`); the i18n transformer joins it
+non-deterministically across populates — `en yakın` (space) and `enyakın`
+(joined) both tokenize to `closest` (tr PASSES), but `en_yakın` (underscore)
+splits to `en`/`_`/`yakın` (tr FAILS). Before this PR, tr accordion failed
+**regardless** of the join (no reclaim → destination always `me`), so it was
+stably failing. This PR puts tr on the jitter boundary. Six consecutive fresh
+`npm run populate` runs all produced a passing form (`enyakın`); the failing
+`en_yakın` was only in the stale committed `patterns.db`, which **CI overwrites
+with a fresh populate** before the gate — so CI sees the passing form and the
+baseline (tr passing) is consistent. tr is therefore counted as a win, but it is
+**omitted from the wave-11 parse-lock** to keep the unit test decoupled from the
+jittery corpus surface form. The proper fix is the underscore-tokenizer arc
+(below) — once tr/sw `closest` tokenizes deterministically, this boundary
+disappears. The four locked languages (ja/ko/hi/bn) use single-token `closest`
+words that never jitter.
+
+**Still-open R2 clusters after this (46 failing, ranked):** make-toast-element ×6
+(bn hi ms qu uk zh); modal-close-backdrop ×6 (hi ko qu ru uk zh); tabs-aria ×5
+(bn hi ja ko tr); modal-close-button ×4 (de it qu sw); make-element ×3 (bn hi
+ms); accordion-exclusive ×3 (de sw th — de nächste, sw/th underscore/other);
+set-attribute ×3 (hi qu tr); if-matches ×3 (qu tr zh); closest-ancestor ×2 (de
+sw); set-style ×2 (hi id); put-content-basic ×2 (ja qu); if-condition ×2 (qu zh);
+
+- singletons. **Next-mechanism ranking:** (1) **underscore-tokenizer** (qu
+  `mana_chayqa`, tr `en_yakın`, sw `karibu_zaidi`, de? — the `_`-joined multi-word
+  keyword split; qu in 8 cells, also unlocks tr/sw `closest` in accordion, and the
+  qu else/body alignments reverted in #405); (2) **modal-close-backdrop condition
+  keyword normalization** — `if target matches .X`'s `matches` keyword (일치/
+  соответствует/відповідає) is not normalized to English so the core can't evaluate
+  the condition, AND the then-branch (`hide`) is dropped (conditional residue, the
+  §7j/#403 class); (3) **tabs-aria `set @attr to X on scope`** — the `on <scope>`
+  target and the attr/value roles scramble under SOV reordering; (4) **de
+  `nächste`/`next` disambiguation**; (5) **fused-event body routing** (ms/tl
+  make-toast + zh/bn compound collapse). Alt track: behavior-\* degenerate mass.
+
 ## 7p. Status update (2026-06-13, session 17): trailing post-verb destination
 
 **modal-open 7→1 by generalizing the wave-9 source reclaim to destinations.**

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -67,6 +67,21 @@ const NON_VALUE_KEYWORDS = new Set([
   'and',
 ]);
 
+/**
+ * Positional keywords that lead a positional-phrase role value (`closest .card`,
+ * `next .panel`). tryAttachTrailingRole uses these to reclaim a trailing
+ * `<positional> <selector> <marker>` destination as the `{ type: 'expression' }`
+ * shape the core runtime evaluates — matching the English reference parse.
+ */
+const POSITIONAL_VALUE_KEYWORDS = new Set([
+  'first',
+  'last',
+  'next',
+  'previous',
+  'random',
+  'closest',
+]);
+
 // =============================================================================
 // Parse Error with Diagnostics (Phase 3.4)
 // =============================================================================
@@ -973,6 +988,25 @@ export class SemanticParserImpl implements ISemanticParser {
       const tok0 = stream.peek();
       const tok1 = stream.peek(1);
       if (!tok0 || !tok1) return;
+
+      // Positional-phrase value: `<closest|next|…> <selector> <marker>`
+      // (accordion `add .open to closest .accordion-item` → SOV `… 最も近い
+      // .accordion-item に`). Only meaningful for the strict (destination) role and
+      // only postpositional — the only corpus shape. Built as the same
+      // `{ type: 'expression', raw: 'closest .accordion-item' }` the English
+      // reference produces (normalized positional keyword + selector surface), so
+      // the core's positional evaluator resolves it identically.
+      if (strict && marker.position === 'after') {
+        const tok2 = stream.peek(2);
+        const pos = (tok0.normalized ?? tok0.value).toLowerCase();
+        if (POSITIONAL_VALUE_KEYWORDS.has(pos) && tok1.kind === 'selector' && isMarker(tok2)) {
+          roles.set(role, { type: 'expression', raw: `${pos} ${tok1.value}` } as SemanticValue);
+          stream.advance();
+          stream.advance();
+          stream.advance();
+          return;
+        }
+      }
 
       if (marker.position === 'after') {
         // Postpositional `<value> <marker>` (SOV: ja から/に, ko 에서/에, …).

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -5396,3 +5396,66 @@ describe('trailing post-verb destination clause in fused-event bodies (R2 wave 1
     expect(role(add!, 'destination')).toBe('body');
   });
 });
+
+describe('trailing post-verb POSITIONAL destination (R2 wave 11 — accordion-exclusive)', () => {
+  // accordion-exclusive's body is `remove .open from .accordion-item then add
+  // .open to closest .accordion-item`. The to-phrase trails the add verb as a
+  // POSITIONAL phrase — SOV `… 最も近い .accordion-item に` (closest + selector +
+  // to-marker) — which neither the per-command add pattern nor wave 10's single-
+  // token reclaim claimed, so the destination defaulted to `me` (the class landed
+  // on the clicked button instead of the closest .accordion-item). tryAttachTrailingRole
+  // now also reclaims a `<positional-keyword> <selector> <marker>` destination,
+  // building the same `{ type: 'expression', raw: 'closest .accordion-item' }` the
+  // English reference produces (normalized positional keyword + selector surface)
+  // so the core's positional evaluator resolves it identically. Cleared
+  // accordion-exclusive in 5 languages (8→3) plus toggle-aria-expanded's
+  // `next .panel` destination as a ride-along.
+  function commands(node: unknown): Array<Record<string, unknown>> {
+    const out: Array<Record<string, unknown>> = [];
+    const walk = (c: unknown) => {
+      if (!c || typeof c !== 'object') return;
+      const rec = c as Record<string, unknown>;
+      if (typeof rec.action === 'string' && !['on', 'compound'].includes(rec.action as string))
+        out.push(rec);
+      for (const f of ['body', 'statements']) {
+        const ch = rec[f];
+        if (Array.isArray(ch)) ch.forEach(walk);
+        else if (ch) walk(ch);
+      }
+    };
+    walk(node);
+    return out;
+  }
+  function destRaw(cmd: Record<string, unknown>): unknown {
+    const roles = cmd.roles as Map<string, { raw?: unknown; value?: unknown }>;
+    const m = roles instanceof Map ? roles : new Map(Object.entries((roles as object) ?? {}));
+    const d = m.get('destination') as { raw?: unknown; value?: unknown } | undefined;
+    return d?.raw ?? d?.value;
+  }
+
+  // tr is a real execution win too, but its corpus `closest` surface form jitters
+  // across populates (`en yakın` / `enyakın` / `en_yakın`), so it is left out of
+  // this parse-level lock to keep the test decoupled from corpus jitter. The four
+  // cases below use single-token `closest` words that never jitter.
+  const cases: Array<[string, string]> = [
+    ['ja', '.open を クリック で 削除 .accordion-item から それから .open を 追加 最も近い .accordion-item に'],
+    ['ko', '.open 를 클릭 제거 .accordion-item 에서 그러면 .open 를 추가 가장가까운 .accordion-item 에'],
+    ['hi', '.open को क्लिक पर हटाएं .accordion-item से फिर .open को जोड़ें निकटतम .accordion-item में'],
+    ['bn', '.open কে ক্লিক এ সরান .accordion-item থেকে তারপর .open কে যোগ নিকটতম .accordion-item তে'],
+  ];
+  for (const [lang, input] of cases) {
+    it(`[${lang}] the trailing positional destination resolves to closest .accordion-item`, () => {
+      const add = commands(parse(input, lang as 'ja')).find(c => c.action === 'add');
+      expect(add, 'add command present').toBeTruthy();
+      expect(destRaw(add!)).toBe('closest .accordion-item');
+    });
+  }
+
+  it('[en] the en reference parse is unchanged', () => {
+    const add = commands(
+      parse('on click remove .open from .accordion-item add .open to closest .accordion-item', 'en')
+    ).find(c => c.action === 'add');
+    expect(add).toBeTruthy();
+    expect(destRaw(add!)).toBe('closest .accordion-item');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T05:51:41.867Z",
-  "commit": "2d0e4cf9",
+  "timestamp": "2026-06-13T06:22:20.309Z",
+  "commit": "dbe7cf8b",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -13,7 +13,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["repeat-until-event", "window-scroll"],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -638,14 +638,9 @@
       "parseRate": 1,
       "avgConfidence": 0.8477942692228406,
       "avgFidelity": 0.9905844155844155,
-      "avgRoleFidelity": 0.7832770270270271,
-      "avgExecutionFidelity": 0.8709677419354839,
-      "executionFailures": [
-        "accordion-exclusive",
-        "make-element",
-        "make-toast-element",
-        "tabs-aria"
-      ],
+      "avgRoleFidelity": 0.7859797297297297,
+      "avgExecutionFidelity": 0.9032258064516129,
+      "executionFailures": ["make-element", "make-toast-element", "tabs-aria"],
       "degeneratePasses": [],
       "lossyPasses": [
         "fetch-do-not-throw",
@@ -654,7 +649,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1285,7 +1280,7 @@
       "executionFailures": ["accordion-exclusive", "closest-ancestor", "modal-close-button"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1909,7 +1904,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2540,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3170,7 +3165,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3814,7 +3809,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4439,10 +4434,9 @@
       "parseRate": 1,
       "avgConfidence": 0.9560915275200976,
       "avgFidelity": 0.928030303030303,
-      "avgRoleFidelity": 0.5926158301158303,
-      "avgExecutionFidelity": 0.6774193548387096,
+      "avgRoleFidelity": 0.5953185328185331,
+      "avgExecutionFidelity": 0.7096774193548387,
       "executionFailures": [
-        "accordion-exclusive",
         "halt-propagation",
         "make-element",
         "make-toast-element",
@@ -4473,7 +4467,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5110,7 +5104,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5740,7 +5734,7 @@
       "executionFailures": ["modal-close-button"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6365,9 +6359,9 @@
       "parseRate": 1,
       "avgConfidence": 0.8399092970521543,
       "avgFidelity": 0.941017316017316,
-      "avgRoleFidelity": 0.7559041184041186,
-      "avgExecutionFidelity": 0.9032258064516129,
-      "executionFailures": ["accordion-exclusive", "put-content-basic", "tabs-aria"],
+      "avgRoleFidelity": 0.7586068211068213,
+      "avgExecutionFidelity": 0.9354838709677419,
+      "executionFailures": ["put-content-basic", "tabs-aria"],
       "degeneratePasses": [
         "announce-screen-reader",
         "behavior-draggable",
@@ -6387,7 +6381,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7013,9 +7007,9 @@
       "parseRate": 1,
       "avgConfidence": 0.7958977530406102,
       "avgFidelity": 0.958874458874459,
-      "avgRoleFidelity": 0.7514639639639643,
-      "avgExecutionFidelity": 0.9032258064516129,
-      "executionFailures": ["accordion-exclusive", "modal-close-backdrop", "tabs-aria"],
+      "avgRoleFidelity": 0.754166666666667,
+      "avgExecutionFidelity": 0.9354838709677419,
+      "executionFailures": ["modal-close-backdrop", "tabs-aria"],
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -7030,7 +7024,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7671,7 +7665,7 @@
         "render-template-with-data",
         "set-color-variable"
       ],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8297,7 +8291,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8927,7 +8921,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9576,7 +9570,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10207,7 +10201,7 @@
       "executionFailures": ["modal-close-backdrop"],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10843,7 +10837,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11470,7 +11464,7 @@
       "executionFailures": ["accordion-exclusive"],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12101,7 +12095,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["window-scroll"],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12727,9 +12721,9 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8377425044091712,
       "avgFidelity": 0.9635076252723311,
-      "avgRoleFidelity": 0.7712018140589568,
-      "avgExecutionFidelity": 0.8709677419354839,
-      "executionFailures": ["accordion-exclusive", "if-matches", "set-attribute", "tabs-aria"],
+      "avgRoleFidelity": 0.773922902494331,
+      "avgExecutionFidelity": 0.9032258064516129,
+      "executionFailures": ["if-matches", "set-attribute", "tabs-aria"],
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -12738,7 +12732,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13368,7 +13362,7 @@
       "executionFailures": ["make-toast-element", "modal-close-backdrop"],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14005,7 +13999,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14650,7 +14644,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 422859,
+      "bundleSize": 423145,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15272,7 +15266,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 422859,
+      "size": 423145,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## R2 execution-fidelity burn-down — accordion-exclusive (positional destination)

The positional extension of [#408](https://github.com/codetalcott/hyperfixi/pull/408)/[#409](https://github.com/codetalcott/hyperfixi/pull/409). accordion-exclusive's body is `remove .open from .accordion-item then add .open to closest .accordion-item`. The add's `to` phrase trails the verb as a **positional phrase** — SOV `… 最も近い .accordion-item に` (closest + selector + to-marker) — which wave 10's single-token reclaim couldn't capture (the leading token is the `closest` keyword, not a selector/reference), so the destination defaulted to `me` (the class landed on the clicked button instead of the closest `.accordion-item`).

### Mechanism

A positional branch in `tryAttachTrailingRole`: when the strict (destination) role's trailing tokens are `<positional-keyword> <selector> <marker>`, it builds the same `{ type: 'expression', raw: 'closest .accordion-item' }` the English reference produces (normalized positional keyword + selector surface), so the core's positional evaluator resolves it identically. `POSITIONAL_VALUE_KEYWORDS = first/last/next/previous/random/closest`.

### Result

- Clears accordion-exclusive in **5 languages** (bn, hi, ja, ko, tr), plus a ride-along (toggle-aria-expanded's `next .panel` destination, also positional and matching en).
- **meanExecutionFidelity 0.9285 → 0.9355**; failing execution cells **51 → 46** (−5); accordion-exclusive **8 → 3**.
- Parse-level **byte-identical** (avgFidelity 0.9743, lossy 77, degen 63). The clean same-`patterns.db` diff showed only the two correct positional captures — no cascading.

### tr / populate-jitter note

tr's `closest` is two words (`en yakın`); the transformer joins it non-deterministically (`enyakın`/`en yakın` → closest, tr passes; `en_yakın` → splits, tr fails). Six consecutive fresh populates all produced a passing form; the failing `en_yakın` was only in the stale committed `patterns.db`, which **CI overwrites with a fresh populate** before the gate — so the baseline (tr passing) is consistent. tr is counted as a win but **omitted from the wave-11 parse-lock** to keep the test decoupled from the jittery corpus surface form. The four locked test languages (ja/ko/hi/bn) use single-token `closest` words. The root fix is the underscore-tokenizer arc (tr/sw/qu).

### Verification

- `--regression` gate green; semantic suite green; 5 cross-language unit tests added (R2 wave 11).
- Baseline regenerated; subset membership unchanged. `patterns.db` not committed (CI re-populates).
- Survivors (de sw th) are separate (nächste collision, underscore tokenizer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)