### PR TITLE
fix(semantic): normalize `matches` operator in folded conditions; R2 wave 12

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -1069,6 +1069,59 @@ tokenizer** (the `_`-joined multi-word keyword split — qu in 8 cells, also unl
 tr/sw `closest`). (3) **de `nächste`/`next` disambiguation**. (4) **fused-event
 body routing**. Alt track: behavior-\* degenerate mass.
 
+## 7r. Status update (2026-06-13, session 19): `matches` operator normalization
+
+**modal-close-backdrop 6→3 with a three-line profile addition — the §7q/#2
+condition-keyword-normalization mechanism, confirmed by measure-first.** The
+fresh wave-11 baseline cluster (46 failing cells) was dominated by the
+conditional family (modal-close-backdrop ×6, if-matches ×3, if-condition ×2,
+if-exists ×1). A parse-probe of every modal-close-backdrop translation
+(`if target matches .modal-backdrop hide … end`) showed the fold is already
+STRUCTURALLY CORRECT in every language (condition + then-`hide`) — the only
+divergence is the `matches` operator word left untranslated in the condition
+raw: ko `target 일치 .modal-backdrop`, ru `target соответствует …`, uk `target
+відповідає …`. `joinTokenText` only normalizes `kind === 'keyword'` tokens, and
+**no profile defined `matches`** (it's a comparison operator — core territory —
+so it had always tokenized as an identifier), so the raw stayed un-English and
+the core expression parser (English operators only) couldn't evaluate it; the
+condition failed and the then-branch dropped at runtime.
+
+- **Fix**: add `matches: { primary: '<word>', normalized: 'matches' }` to the
+  ko/ru/uk profiles (the exact corpus surface words `일치`/`соответствует`/
+  `відповідає`). Now `matches` tokenizes as a keyword and the condition
+  normalizes to the en-identical `target matches .modal-backdrop`. Parser-side
+  only (the i18n dict already emits these words); lowest blast radius. The three
+  words occur in exactly two corpus patterns (modal-close-backdrop, focus-trap),
+  both as the comparison operator — no non-operator collision.
+- **Result**: modal-close-backdrop 6→3 failing (cleared ko, ru, uk).
+  meanExecutionFidelity **0.9355 → 0.9397**; failing execution cells **46 → 43**
+  (−3). Parse-level **byte-identical** (avgFidelity unchanged, lossy 77, degen
+  63 — the action set was always {if, hide}; only the un-normalized condition
+  raw moved, the lossy-but-faithful gap R2 exists to catch). Gate green (all four
+  ratchets); baseline regenerated; 4 lock tests added (wave 12). Semantic 5893.
+- **The remaining 3 are each a SEPARATE, pre-existing bug** (adding `matches`
+  doesn't help them): **hi** `मेल_खाता` (matches) underscore-splits to
+  `मेल`/`_`/`खाता`; **qu** `punta` (target) splits to `pun`/`ta`-particle (and
+  `tupan`/matches also unnormalized); **zh** the whole event body collapses to a
+  `compound` (the §7n zh/bn compound-collapse path) so the fold never runs at
+  all. hi/qu are blocked by the underscore/particle tokenizer; zh by body
+  routing.
+
+**Still-open R2 clusters after this (43 failing, ranked):** make-toast-element
+×6 (bn hi ms qu uk zh); modal-close-backdrop ×3 (hi qu zh — the survivors
+above); tabs-aria ×5 (bn hi ja ko tr); modal-close-button ×4 (de it qu sw);
+make-element ×3 (bn hi ms); accordion-exclusive ×3 (de sw th); set-attribute ×3
+(hi qu tr); if-matches ×3 (qu tr zh); closest-ancestor ×2 (de sw); set-style ×2
+(hi id); put-content-basic ×2 (ja qu); if-condition ×2 (qu zh); + singletons
+(halt-propagation hi, set-{inner-html,text}-possessive-dot hi, modal-open qu,
+if-exists zh). **Next-mechanism ranking unchanged from §7q:** (1) **underscore-
+tokenizer** (qu `mana_chayqa`/`punta`-ish, tr `en_yakın`, sw `karibu_zaidi` — a
+`_`-joined or particle-suffix multi-word keyword split; would unblock hi/qu
+modal-close-backdrop, sw closest, + the qu else/body alignments reverted in
+#405); (2) **tabs-aria `set @attr to X on scope`** (now the largest single
+cluster at ×5); (3) **de `nächste`/`next` disambiguation**; (4) **fused-event
+body routing / zh-bn compound collapse**. Alt track: behavior-\* degenerate mass.
+
 ## 8. R1 / R2 — role-fidelity and execution ratchets (extend R0)
 
 Action-set fidelity (R0's signal) cannot see a parse that finds the right

--- a/packages/semantic/src/generators/profiles/korean.ts
+++ b/packages/semantic/src/generators/profiles/korean.ts
@@ -128,6 +128,13 @@ export const koreanProfile: LanguageProfile = {
     return: { primary: '반환', normalized: 'return' },
     then: { primary: '그다음', alternatives: ['그런후'], normalized: 'then' },
     and: { primary: '그리고', alternatives: ['또한', '및'], normalized: 'and' },
+    // Comparison operator. The semantic package doesn't evaluate operators (core
+    // does), but a folded conditional's raw condition is reconstructed from the
+    // token stream and read by the core expression parser, which only understands
+    // English operator words — so `target 일치 .x` must normalize to `target
+    // matches .x`. Without this keyword `일치` stays an identifier and the
+    // condition is unevaluable (modal-close-backdrop drops its then-branch).
+    matches: { primary: '일치', normalized: 'matches' },
     end: { primary: '끝', alternatives: ['마침'], normalized: 'end' },
     // Advanced
     js: { primary: 'JS실행', alternatives: ['js'], normalized: 'js' },

--- a/packages/semantic/src/generators/profiles/russian.ts
+++ b/packages/semantic/src/generators/profiles/russian.ts
@@ -264,6 +264,11 @@ export const russianProfile: LanguageProfile = {
     },
     then: { primary: 'затем', alternatives: ['потом', 'тогда'], normalized: 'then' },
     and: { primary: 'и', normalized: 'and' },
+    // Comparison operator — see korean.ts for the rationale. A folded conditional's
+    // raw condition is read by the core expression parser (English operators only),
+    // so `target соответствует .x` must normalize to `target matches .x`; otherwise
+    // `соответствует` stays an identifier and modal-close-backdrop drops its then-branch.
+    matches: { primary: 'соответствует', normalized: 'matches' },
     end: { primary: 'конец', normalized: 'end' },
     // Advanced
     js: { primary: 'js', normalized: 'js' },

--- a/packages/semantic/src/generators/profiles/ukrainian.ts
+++ b/packages/semantic/src/generators/profiles/ukrainian.ts
@@ -274,6 +274,11 @@ export const ukrainianProfile: LanguageProfile = {
     },
     then: { primary: 'потім', alternatives: ['далі', 'тоді'], normalized: 'then' },
     and: { primary: 'і', alternatives: ['та'], normalized: 'and' },
+    // Comparison operator — see korean.ts for the rationale. A folded conditional's
+    // raw condition is read by the core expression parser (English operators only),
+    // so `target відповідає .x` must normalize to `target matches .x`; otherwise
+    // `відповідає` stays an identifier and modal-close-backdrop drops its then-branch.
+    matches: { primary: 'відповідає', normalized: 'matches' },
     end: { primary: 'кінець', normalized: 'end' },
     // Advanced
     js: { primary: 'js', normalized: 'js' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -5459,3 +5459,62 @@ describe('trailing post-verb POSITIONAL destination (R2 wave 11 — accordion-ex
     expect(destRaw(add!)).toBe('closest .accordion-item');
   });
 });
+
+describe('`matches` comparison-operator normalization (R2 wave 12 — modal-close-backdrop)', () => {
+  // modal-close-backdrop's body is `if target matches .modal-backdrop hide
+  // .modal-backdrop end`. The fold (tryParseConditionalBlock) already produced the
+  // right structure (condition + then-`hide`) in every language, but the condition
+  // raw is reconstructed from the token stream via joinTokenText, which only
+  // normalizes `kind === 'keyword'` tokens. The translated `matches` operator
+  // (`일치` / `соответствует` / `відповідає`) was an IDENTIFIER — no profile defined
+  // `matches` — so the raw stayed `target 일치 .modal-backdrop`, which the core
+  // expression parser (English operators only) can't evaluate; the condition was
+  // unevaluable and modal-close-backdrop dropped its then-branch at runtime.
+  // Adding `matches` to the ko/ru/uk profiles makes it tokenize as a keyword so the
+  // raw normalizes to the en-identical `target matches .modal-backdrop`. Parse-level
+  // action set is unchanged (still if + hide); only execution fidelity moved (the
+  // lossy-but-faithful gap R2 exists to catch). Cleared modal-close-backdrop in ko,
+  // ru, uk (6→3 failing; only hi/qu/zh remain, each blocked by a separate bug —
+  // hi `मेल_खाता` underscore-split, qu `punta`→`pun`/`ta` split, zh compound-collapse).
+  function findConditional(node: unknown): Record<string, unknown> | null {
+    if (!node || typeof node !== 'object') return null;
+    const rec = node as Record<string, unknown>;
+    if (rec.kind === 'conditional') return rec;
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      const c = rec[f];
+      if (Array.isArray(c)) {
+        for (const x of c) {
+          const found = findConditional(x);
+          if (found) return found;
+        }
+      }
+    }
+    return null;
+  }
+  const condText = (c: Record<string, unknown>): string =>
+    ((c.roles as Map<string, { raw?: string }>).get('condition')?.raw ?? '') as string;
+
+  // The corpus surface form per language (freshly populated). `matches` is the only
+  // word being keyword-ified here; it appears in exactly two patterns
+  // (modal-close-backdrop, focus-trap), both as the comparison operator.
+  const cases: Array<[string, string]> = [
+    ['ko', '클릭 할 때 만약 대상 일치 .modal-backdrop .modal-backdrop 를 숨기다 끝'],
+    ['ru', 'при клик если цель соответствует .modal-backdrop скрыть .modal-backdrop конец'],
+    ['uk', 'при клік якщо ціль відповідає .modal-backdrop сховати .modal-backdrop кінець'],
+  ];
+  for (const [lang, input] of cases) {
+    it(`[${lang}] the folded condition normalizes to en-identical \`target matches .modal-backdrop\``, () => {
+      const c = findConditional(parse(input, lang as 'ko'));
+      expect(c, 'conditional folded').not.toBeNull();
+      expect(condText(c!)).toBe('target matches .modal-backdrop');
+    });
+  }
+
+  it('[en] the en reference condition is unchanged', () => {
+    const c = findConditional(
+      parse('on click if target matches .modal-backdrop hide .modal-backdrop end', 'en')
+    );
+    expect(c).not.toBeNull();
+    expect(condText(c!)).toBe('target matches .modal-backdrop');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T06:22:20.309Z",
-  "commit": "dbe7cf8b",
+  "timestamp": "2026-06-13T11:57:22.552Z",
+  "commit": "ca4f247c",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -13,7 +13,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["repeat-until-event", "window-scroll"],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -649,7 +649,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1280,7 +1280,7 @@
       "executionFailures": ["accordion-exclusive", "closest-ancestor", "modal-close-button"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1904,7 +1904,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3165,7 +3165,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3809,7 +3809,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4467,7 +4467,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5104,7 +5104,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5734,7 +5734,7 @@
       "executionFailures": ["modal-close-button"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6381,7 +6381,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7008,8 +7008,8 @@
       "avgConfidence": 0.7958977530406102,
       "avgFidelity": 0.958874458874459,
       "avgRoleFidelity": 0.754166666666667,
-      "avgExecutionFidelity": 0.9354838709677419,
-      "executionFailures": ["modal-close-backdrop", "tabs-aria"],
+      "avgExecutionFidelity": 0.967741935483871,
+      "executionFailures": ["tabs-aria"],
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -7024,7 +7024,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7665,7 +7665,7 @@
         "render-template-with-data",
         "set-color-variable"
       ],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8291,7 +8291,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8921,7 +8921,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9570,7 +9570,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10197,11 +10197,11 @@
       "avgConfidence": 0.8117913832199526,
       "avgFidelity": 0.9935064935064936,
       "avgRoleFidelity": 0.8429134491634492,
-      "avgExecutionFidelity": 0.967741935483871,
-      "executionFailures": ["modal-close-backdrop"],
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10837,7 +10837,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11464,7 +11464,7 @@
       "executionFailures": ["accordion-exclusive"],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12095,7 +12095,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["window-scroll"],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12732,7 +12732,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13358,11 +13358,11 @@
       "avgConfidence": 0.8098948670377222,
       "avgFidelity": 0.9935064935064936,
       "avgRoleFidelity": 0.8295125482625483,
-      "avgExecutionFidelity": 0.9354838709677419,
-      "executionFailures": ["make-toast-element", "modal-close-backdrop"],
+      "avgExecutionFidelity": 0.967741935483871,
+      "executionFailures": ["make-toast-element"],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13999,7 +13999,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14644,7 +14644,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 423145,
+      "bundleSize": 423199,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15266,7 +15266,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 423145,
+      "size": 423199,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Mechanism

`modal-close-backdrop` (`on click if target matches .modal-backdrop hide .modal-backdrop end`) folds correctly in every language, but the condition raw is rebuilt from the token stream via `joinTokenText`, which only normalizes `kind === 'keyword'` tokens. **No profile defined the `matches` comparison operator** (it's core-expression-parser territory), so the translated word (`일치` / `соответствует` / `відповідає`) stayed an identifier and the raw came out as `target 일치 .modal-backdrop` — unevaluable by the core expression parser (English operators only). The condition failed and the then-branch (`hide`) dropped at runtime.

## Fix

Add `matches: { primary: '<word>', normalized: 'matches' }` to the **ko / ru / uk** profiles (the exact corpus surface words). Now `matches` tokenizes as a keyword and the condition normalizes to the en-identical `target matches .modal-backdrop`. Parser-side only — the i18n dict already emits these words; lowest blast radius. The three words occur in exactly two corpus patterns (`modal-close-backdrop`, `focus-trap`), both as the comparison operator — no non-operator collision.

## Result

- `modal-close-backdrop` **6→3** failing (cleared ko, ru, uk)
- meanExecutionFidelity **0.9355 → 0.9397**; failing execution cells **46 → 43**
- Parse-level **byte-identical** (avgFidelity unchanged, lossy 77, degen 63) — the lossy-but-faithful gap R2 exists to catch
- Gate green (all four ratchets); baseline regenerated; 4 lock tests added (wave 12); semantic 5893 green

The remaining 3 (hi/qu/zh) are each blocked by a **separate** bug: hi `मेल_खाता` underscore-split, qu `punta`→`pun`/`ta` split, zh compound-collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)