### PR TITLE
fix(i18n,semantic): de `nächstgelegene` disambiguates closest from next; R2 wave 13

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -1122,6 +1122,47 @@ modal-close-backdrop, sw closest, + the qu else/body alignments reverted in
 cluster at ×5); (3) **de `nächste`/`next` disambiguation**; (4) **fused-event
 body routing / zh-bn compound collapse**. Alt track: behavior-\* degenerate mass.
 
+## 7s. Status update (2026-06-13, session 19 cont.): de nächste/closest disambiguation
+
+**de cleared entirely (3 cells) — the §7k/§7q de `nächste`/`next` collision.**
+German `nächste` is genuinely ambiguous (next/nearest); the de i18n dict emitted
+it for BOTH `next` and `closest`, and the german tokenizer deliberately
+normalizes `nächste`→next (last-wins — a second `closest` entry would shadow the
+positional-capable `next`, documented in german.ts). So a translated `closest .X`
+surfaced as `next .X` and the wrong element was hit at runtime (accordion-exclusive,
+closest-ancestor, modal-close-button).
+
+- **Fix** (align-the-odd-one-out idiom, two layers): de dict emits the
+  unambiguous `nächstgelegene` ("nearest-located") for `closest`; the german
+  tokenizer maps `nächstgelegene`→closest. Distinct word → no shadowing of
+  `next`; closest round-trips. Pruned the now-fixed `de:closest` from the
+  `positional-keyword-drift` burn-down allowlist (the list only shrinks). A probe
+  confirmed all three de cells capture en-identical roles (`closest .accordion-item`,
+  `closest .card`, `hide closest .modal`; modal-close-button's `körper`→body
+  source already resolved, so de modal-close-button is fully clean).
+- **Result**: de now has **0** execution failures (was 3). meanExecutionFidelity
+  **0.9397 → 0.9439**; failing execution cells **43 → 40** (−3). Parse-level
+  byte-identical (avgFidelity / lossy 77 / degen 63 unchanged — only the captured
+  positional `raw` the runtime reads moved from next/me to `closest .X`). Gate
+  green; baseline regenerated; 3 lock tests added (wave 13). Semantic 5900, i18n
+  846 green.
+
+**Still-open R2 clusters after this (40 failing, ranked):** make-toast-element ×6
+(bn hi ms qu uk zh); tabs-aria ×5 (bn hi ja ko tr); make-element ×3 (bn hi ms);
+modal-close-backdrop ×3 (hi qu zh); set-attribute ×3 (hi qu tr); modal-close-button
+×3 (it qu sw); if-matches ×3 (qu tr zh); set-style ×2 (hi id); put-content-basic ×2
+(ja qu); if-condition ×2 (qu zh); accordion-exclusive ×2 (sw th); + singletons
+(halt-propagation hi, set-{inner-html,text}-possessive-dot hi, modal-open qu,
+closest-ancestor sw, if-exists zh). **The residual is now dominated by two
+cross-cutting blockers**: (1) **underscore/particle tokenizer** — qu (8 cells via
+`mana_chayqa`/`punta`), sw (`karibu_zaidi` → accordion/closest-ancestor), ms
+(`ke_dalam` → make-element/make-toast); (2) **zh/bn fused-event compound collapse**
+(zh all conditionals + make-toast; bn make-element/make-toast/tabs-aria). Plus
+per-language SOV scrambles (hi set-trio, tabs-aria SOV) and the en-reference-lossy
+tabs-aria (`on <scope>` dropped even in en — a two-layer arc). Probed this session:
+make-element/set-attribute/tabs-aria are each scattered per-language structural
+bugs, NOT clean single mechanisms.
+
 ## 8. R1 / R2 — role-fidelity and execution ratchets (extend R0)
 
 Action-set fidelity (R0's signal) cannot see a parse that finds the right

--- a/packages/i18n/src/dictionaries/de.ts
+++ b/packages/i18n/src/dictionaries/de.ts
@@ -201,7 +201,13 @@ export const de: Dictionary = {
     prev: 'vorh',
     at: 'bei',
     random: 'zufällig',
-    closest: 'nächste',
+    // `nächste` already serves `next` (line above). German `nächste` is
+    // genuinely ambiguous (next/nearest), so emitting it for `closest` too
+    // collided: the semantic tokenizer normalizes `nächste`→next (a deliberate
+    // last-wins choice — see german.ts), and a closest reading is impossible to
+    // recover. Use the unambiguous `nächstgelegene` ("nearest-located") for
+    // closest so the two readings stay distinct end-to-end.
+    closest: 'nächstgelegene',
     parent: 'elternteil',
     children: 'kinder',
     within: 'innerhalb',

--- a/packages/i18n/src/positional-keyword-drift.test.ts
+++ b/packages/i18n/src/positional-keyword-drift.test.ts
@@ -50,8 +50,11 @@ const POSITIONAL_CONCEPTS = [
  *   masculine nominative forms the dict emits were never listed; fixed.
  * - qu next/previous were CROSS-MAPPED (qhipantin→last, ñawpaqnin→first —
  *   morphology bound the prefixes); fixed with exact tokenizer entries.
- * - de closest→nächste normalizes to `next` by design (one word covers both
- *   readings; POSITIONAL_OR_SCOPE_KEYWORDS accepts either) — expected to stay.
+ * - de closest: FIXED (R2 wave 13). The dict used to emit `nächste` for both
+ *   next and closest, and the tokenizer normalizes `nächste`→next by design, so
+ *   closest was unrecoverable. The dict now emits the unambiguous
+ *   `nächstgelegene` for closest, which the tokenizer maps →closest (distinct
+ *   word, no shadowing of next).
  * - bn last (শেষ) normalizes to `end` (the block terminator) — a polysemous
  *   word claimed by the structural keyword. (sw had the same collision via
  *   mwisho; fixed by emitting the distinct concatenated adjective `wamwisho`,
@@ -62,7 +65,6 @@ const KNOWN_DRIFT = new Set<string>([
   'ar:random',
   'bn:last',
   'bn:random',
-  'de:closest',
   'de:parent',
   'de:random',
   'es:random',

--- a/packages/semantic/src/tokenizers/german.ts
+++ b/packages/semantic/src/tokenizers/german.ts
@@ -57,6 +57,12 @@ const GERMAN_EXTRAS: KeywordEntry[] = [
   // (POSITIONAL_OR_SCOPE_KEYWORDS), so normalizing to 'next' serves both readings.
   { native: 'nächste', normalized: 'next' },
   { native: 'nachste', normalized: 'next' },
+  // The de dict emits the unambiguous `nächstgelegene` ("nearest-located") for
+  // `closest` (it used to also emit `nächste`, which the line above swallows as
+  // `next` — closest was unrecoverable, so closest .X resolved to the wrong
+  // element). Distinct word → no shadowing of `next`; closest now round-trips.
+  { native: 'nächstgelegene', normalized: 'closest' },
+  { native: 'nachstgelegene', normalized: 'closest' },
   { native: 'vorherige', normalized: 'previous' },
   { native: 'eltern', normalized: 'parent' },
 

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -5518,3 +5518,66 @@ describe('`matches` comparison-operator normalization (R2 wave 12 — modal-clos
     expect(condText(c!)).toBe('target matches .modal-backdrop');
   });
 });
+
+describe('de `nächstgelegene` → closest disambiguation (R2 wave 13)', () => {
+  // German `nächste` is genuinely ambiguous (next/nearest). The de i18n dict
+  // emitted it for BOTH `next` and `closest`, and the german tokenizer
+  // deliberately normalizes `nächste`→next (last-wins; a second closest entry
+  // would shadow the positional-capable `next`). So a translated `closest .X`
+  // surfaced as `next .X` (or, where next isn't positional in that slot, dropped
+  // to `me`) and the wrong element was targeted at runtime. The dict now emits
+  // the unambiguous `nächstgelegene` ("nearest-located") for closest, and the
+  // tokenizer maps it →closest — distinct word, no shadowing of next. Cleared de
+  // on accordion-exclusive, closest-ancestor, modal-close-button (de now 0
+  // execution failures). Parse-level unchanged (the captured positional `raw`
+  // text the runtime reads moved from `next`/`me` to `closest .X`, not the
+  // action set). Hand-built minimal de inputs (decoupled from corpus jitter).
+  function commands(node: unknown): Array<Record<string, unknown>> {
+    const out: Array<Record<string, unknown>> = [];
+    const walk = (c: unknown) => {
+      if (!c || typeof c !== 'object') return;
+      const rec = c as Record<string, unknown>;
+      if (typeof rec.action === 'string' && !['on', 'compound'].includes(rec.action as string))
+        out.push(rec);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+        const ch = rec[f];
+        if (Array.isArray(ch)) ch.forEach(walk);
+        else if (ch) walk(ch);
+      }
+    };
+    walk(node);
+    return out;
+  }
+  const roleRaw = (cmd: Record<string, unknown>, role: string): unknown => {
+    const roles = cmd.roles as Map<string, { raw?: unknown; value?: unknown }>;
+    const m = roles instanceof Map ? roles : new Map(Object.entries((roles as object) ?? {}));
+    const d = m.get(role) as { raw?: unknown; value?: unknown } | undefined;
+    return d?.raw ?? d?.value;
+  };
+
+  it('toggle destination captures `closest .card` (closest-ancestor shape)', () => {
+    const toggle = commands(parse('bei klick umschalten .expanded zu nächstgelegene .card', 'de')).find(
+      c => c.action === 'toggle'
+    );
+    expect(toggle, 'toggle present').toBeTruthy();
+    expect(roleRaw(toggle!, 'destination')).toBe('closest .card');
+  });
+
+  it('hide patient captures `closest .modal` (modal-close-button shape)', () => {
+    const hide = commands(parse('bei klick verstecken nächstgelegene .modal', 'de')).find(
+      c => c.action === 'hide'
+    );
+    expect(hide, 'hide present').toBeTruthy();
+    expect(roleRaw(hide!, 'patient')).toBe('closest .modal');
+  });
+
+  it('`nächste` still normalizes to next (no shadowing regression)', () => {
+    // The positional-capable `next` reading must survive: a distinct closest word
+    // means `nächste` is untouched. `put X into next .y` keeps next.
+    const put = commands(parse('bei klick setzen "x" in nächste .panel', 'de')).find(
+      c => c.action === 'put'
+    );
+    expect(put, 'put present').toBeTruthy();
+    expect(String(roleRaw(put!, 'destination'))).toContain('next');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T11:57:22.552Z",
-  "commit": "ca4f247c",
+  "timestamp": "2026-06-13T12:18:56.369Z",
+  "commit": "6b7a21bf",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -13,7 +13,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["repeat-until-event", "window-scroll"],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -649,7 +649,7 @@
         "make-toast-element",
         "unless-condition"
       ],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1276,11 +1276,11 @@
       "avgConfidence": 0.8323373793962008,
       "avgFidelity": 0.9782135076252723,
       "avgRoleFidelity": 0.8443553611920959,
-      "avgExecutionFidelity": 0.9032258064516129,
-      "executionFailures": ["accordion-exclusive", "closest-ancestor", "modal-close-button"],
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1904,7 +1904,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3165,7 +3165,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3809,7 +3809,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4467,7 +4467,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5104,7 +5104,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5734,7 +5734,7 @@
       "executionFailures": ["modal-close-button"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6381,7 +6381,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7024,7 +7024,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7665,7 +7665,7 @@
         "render-template-with-data",
         "set-color-variable"
       ],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8291,7 +8291,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8921,7 +8921,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9570,7 +9570,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10201,7 +10201,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10837,7 +10837,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11464,7 +11464,7 @@
       "executionFailures": ["accordion-exclusive"],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12095,7 +12095,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["window-scroll"],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12732,7 +12732,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13362,7 +13362,7 @@
       "executionFailures": ["make-toast-element"],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13999,7 +13999,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14644,7 +14644,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 423199,
+      "bundleSize": 423296,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15266,7 +15266,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 423199,
+      "size": 423296,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Mechanism

German `nächste` is genuinely ambiguous (next/nearest). The de i18n dict emitted it for **both** `next` and `closest`, and the german tokenizer deliberately normalizes `nächste`→next (last-wins — a second `closest` entry would shadow the positional-capable `next`, documented in `german.ts`). So a translated `closest .X` surfaced as `next .X` (or dropped to `me`) and the **wrong element was targeted** at runtime: `accordion-exclusive`, `closest-ancestor`, `modal-close-button`.

## Fix (align-the-odd-one-out, two layers)

- de dict (`de.ts`) emits the unambiguous `nächstgelegene` ("nearest-located") for `closest`.
- german tokenizer (`german.ts`) maps `nächstgelegene` → `closest`.

Distinct word → no shadowing of `next`; closest round-trips end-to-end. Pruned the now-fixed `de:closest` entry from the `positional-keyword-drift` burn-down list (the list only shrinks).

## Result

- **de now has 0 execution failures** (was 3)
- meanExecutionFidelity **0.9397 → 0.9439**; failing execution cells **43 → 40**
- Parse-level **byte-identical** (avgFidelity / lossy 77 / degen 63 unchanged — only the captured positional `raw` the runtime reads moved from next/me to `closest .X`)
- Gate green (all four ratchets); baseline regenerated; 3 lock tests added (wave 13); semantic 5900, i18n 846 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)