### PR TITLE
fix(i18n,semantic): sw/qu `_`-joined positional/conditional surface words; R2 wave 14

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -1163,6 +1163,55 @@ tabs-aria (`on <scope>` dropped even in en — a two-layer arc). Probed this ses
 make-element/set-attribute/tabs-aria are each scattered per-language structural
 bugs, NOT clean single mechanisms.
 
+## 7t. Status update (2026-06-13, session 20): sw/qu `_`-joined surface words
+
+**The underscore-tokenizer "arc" turned out to be a small dict-alignment win,
+not the multi-PR effort the §7q framing implied — measure-first corrected three
+stale assumptions.** Re-probing against the current dist showed: (1) **ms is NOT
+underscore** — `ke_dalam` tokenizes cleanly (`_` is a malay word-char); ms's
+make-element/make-toast drop is the fused-body-routing class (§7n). (2) **tr is
+already fixed** — the tr dict emits the concatenated `enyakın`, not `en_yakın`
+(the §7q jitter note is stale); and tr's failing cells don't use closest anyway.
+(3) The genuine `_`-split cases are **sw** and **qu**, each a one-line dict
+realign to a clean single-token form (the established `enyakın` pattern).
+
+- **sw closest**: dict `karibu_zaidi` → `karibuzaidi` (+ a swahili tokenizer
+  EXTRAS entry `karibuzaidi`→closest). The `_ zaidi` had stranded and broken the
+  positional `closest <selector>` capture (destination defaulted to `me`).
+  Cleared sw **accordion-exclusive, closest-ancestor, AND modal-close-button**
+  (the last via `hide closest .modal` — the §7o "sw hide drops" diagnosis was
+  actually this closest break). 3 cells; also a parse-level bonus
+  (modal-close-button lossy→faithful, sw avgFidelity 0.9706→0.9728, lossy 77→76).
+- **qu else**: dict `mana_chayqa` → `manachus` (the qu profile's existing else
+  word — a dict↔profile alignment, no tokenizer change). The old form tokenized
+  as `mana`(false)/`_`/`chayqa`(then), so no else keyword formed and qu
+  conditionals never split their else branch. Cleared qu **if-matches,
+  if-condition**. 2 cells.
+
+- **Result**: meanExecutionFidelity **0.9439 → 0.9509**; failing execution cells
+  **40 → 35** (−5). lossy 77→76, degen 63 unchanged. Gate green (all four
+  ratchets); baseline regenerated; 2 lock tests added (wave 14). Semantic 5902,
+  i18n 846 green.
+- **Remaining underscore residue is NOT a clean win**: qu `punta` (target) is a
+  _particle_ split (`pun`/`ta`-accusative), not underscore — blocks qu
+  modal-close-backdrop separately; qu `closest` is `kaylla` (no underscore).
+
+**Still-open R2 clusters after this (35 failing, ranked):** make-toast-element ×6
+(bn hi ms qu uk zh); tabs-aria ×5 (bn hi ja ko tr); make-element ×3 (bn hi ms);
+modal-close-backdrop ×3 (hi qu zh); set-attribute ×3 (hi qu tr); set-style ×2 (hi
+id); modal-close-button ×2 (it qu); put-content-basic ×2 (ja qu); if-matches ×2
+(tr zh); + singletons (halt-propagation hi, set-{inner-html,text}-possessive-dot
+hi, modal-open qu, accordion-exclusive th, if-condition zh, if-exists zh). **The
+residual is now dominated by structural blockers, each its own hard arc**:
+(1) **fused-event body routing / zh-bn-ms compound collapse** — the largest
+remaining lever (ms make-element/make-toast, bn make-element/make-toast/tabs-aria,
+zh make-toast + conditional residue); (2) **per-language SOV scrambles** (hi
+set-trio + tabs-aria, ja/ko/tr tabs-aria); (3) **en-reference-lossy tabs-aria**
+(`on <scope>` dropped even in en — two-layer arc); (4) qu particle-split (`punta`)
+
+- remaining qu tails. No more cheap dict-alignment wins remain in the cluster;
+  the tail is genuinely the §9 "marginal session clears ~5 hard instances" regime.
+
 ## 8. R1 / R2 — role-fidelity and execution ratchets (extend R0)
 
 Action-set fidelity (R0's signal) cannot see a parse that finds the right

--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -137,7 +137,11 @@ export const qu: Dictionary = {
     has: 'kachkan',
     have: 'kachkani',
     then: 'chayqa',
-    else: 'mana_chayqa',
+    // Align to the semantic profile's else word `manachus`. The old `mana_chayqa`
+    // tokenized as `mana`(false) + `_` + `chayqa`(then) — no else keyword formed,
+    // so qu conditionals never split their else branch. `manachus` is a single
+    // token the profile-derived keyword map reads as `else` (dict↔profile align).
+    else: 'manachus',
     otherwise: 'huk_kaqpi',
     end: 'tukuy',
     live: 'kawsay',

--- a/packages/i18n/src/dictionaries/sw.ts
+++ b/packages/i18n/src/dictionaries/sw.ts
@@ -206,7 +206,12 @@ export const sw: Dictionary = {
     prev: 'awali',
     at: 'katika',
     random: 'nasibu',
-    closest: 'karibu_zaidi',
+    // Concatenated (no `_`): the swahili tokenizer splits on underscore, so the
+    // old `karibu_zaidi` tokenized as `karibu`(closest) + `_` + `zaidi`, and the
+    // stray `_ zaidi` broke the positional `closest <selector>` capture (the
+    // destination defaulted to `me`). The fused `karibuzaidi` is a single token
+    // the tokenizer maps →closest (the established `enyakın` pattern).
+    closest: 'karibuzaidi',
     parent: 'mzazi',
     children: 'watoto',
     within: 'ndani_ya',

--- a/packages/semantic/src/tokenizers/swahili.ts
+++ b/packages/semantic/src/tokenizers/swahili.ts
@@ -87,6 +87,10 @@ const SWAHILI_EXTRAS: KeywordEntry[] = [
   { native: 'iliyotangulia', normalized: 'previous' },
   { native: 'iliyopita', normalized: 'previous' }, // i18n dict emission
   { native: 'karibu', normalized: 'closest' },
+  // Fused superlative the i18n dict now emits for closest ("nearer/nearest").
+  // The dict used to emit `karibu_zaidi`, but the tokenizer splits on `_`, so the
+  // `_ zaidi` stranded and broke positional `closest <selector>` capture.
+  { native: 'karibuzaidi', normalized: 'closest' },
   { native: 'mzazi', normalized: 'parent' },
 
   // Events

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -5581,3 +5581,69 @@ describe('de `nächstgelegene` → closest disambiguation (R2 wave 13)', () => {
     expect(String(roleRaw(put!, 'destination'))).toContain('next');
   });
 });
+
+describe('sw/qu `_`-joined positional/conditional surface words (R2 wave 14)', () => {
+  // The sw and qu tokenizers split on `_`, so a dict word joined with an
+  // underscore tokenizes as `word`/`_`/`word` and never matches its keyword.
+  // Two instances cleared by emitting a clean single-token surface form (the
+  // established `enyakın` pattern), aligning dict → tokenizer/profile:
+  //  - sw closest: `karibu_zaidi` → `karibuzaidi` (+ tokenizer EXTRAS entry).
+  //    The stray `_ zaidi` had broken positional `closest <sel>` capture, so the
+  //    destination defaulted to `me`. Cleared sw accordion-exclusive,
+  //    closest-ancestor, AND modal-close-button (`hide closest .modal`).
+  //  - qu else: `mana_chayqa` → `manachus` (the profile's existing else word).
+  //    The old form tokenized as `mana`(false)/`_`/`chayqa`(then), so no else
+  //    keyword formed and qu conditionals never split their else branch. Cleared
+  //    qu if-matches, if-condition.
+  function commands(node: unknown): Array<Record<string, unknown>> {
+    const out: Array<Record<string, unknown>> = [];
+    const walk = (c: unknown) => {
+      if (!c || typeof c !== 'object') return;
+      const rec = c as Record<string, unknown>;
+      if (typeof rec.action === 'string' && !['on', 'compound'].includes(rec.action as string))
+        out.push(rec);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+        const ch = rec[f];
+        if (Array.isArray(ch)) ch.forEach(walk);
+        else if (ch) walk(ch);
+      }
+    };
+    walk(node);
+    return out;
+  }
+  const roleRaw = (cmd: Record<string, unknown>, role: string): unknown => {
+    const roles = cmd.roles as Map<string, { raw?: unknown; value?: unknown }>;
+    const m = roles instanceof Map ? roles : new Map(Object.entries((roles as object) ?? {}));
+    const d = m.get(role) as { raw?: unknown; value?: unknown } | undefined;
+    return d?.raw ?? d?.value;
+  };
+  function findConditional(node: unknown): Record<string, unknown> | null {
+    if (!node || typeof node !== 'object') return null;
+    const rec = node as Record<string, unknown>;
+    if (rec.kind === 'conditional') return rec;
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      const c = rec[f];
+      if (Array.isArray(c)) for (const x of c) { const f2 = findConditional(x); if (f2) return f2; }
+    }
+    return null;
+  }
+  const branchActions = (branch: unknown): string[] =>
+    Array.isArray(branch) ? (branch as Array<Record<string, unknown>>).map(n => String(n.action)) : [];
+
+  it('[sw] toggle destination captures `closest .card` (karibuzaidi)', () => {
+    const toggle = commands(parse('kwenye bonyeza badilisha .expanded kwa karibuzaidi .card', 'sw')).find(
+      c => c.action === 'toggle'
+    );
+    expect(toggle, 'toggle present').toBeTruthy();
+    expect(roleRaw(toggle!, 'destination')).toBe('closest .card');
+  });
+
+  it('[qu] if-matches folds with the else branch (manachus)', () => {
+    const c = findConditional(
+      parse('ñitiy pi sichus I match .disabled sayay manachus .active ta tikray tukuy', 'qu')
+    );
+    expect(c, 'conditional folded').not.toBeNull();
+    expect(branchActions(c!.thenBranch)).toEqual(['halt']);
+    expect(branchActions(c!.elseBranch)).toEqual(['toggle']);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T12:18:56.369Z",
-  "commit": "6b7a21bf",
+  "timestamp": "2026-06-13T12:32:49.128Z",
+  "commit": "c8ed5ed9",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -9547,10 +9547,8 @@
       "avgConfidence": 0.7161616161616162,
       "avgFidelity": 0.9632034632034633,
       "avgRoleFidelity": 0.7185649935649935,
-      "avgExecutionFidelity": 0.7419354838709677,
+      "avgExecutionFidelity": 0.8064516129032258,
       "executionFailures": [
-        "if-condition",
-        "if-matches",
         "make-toast-element",
         "modal-close-backdrop",
         "modal-close-button",
@@ -10825,18 +10823,13 @@
       "parseSuccess": 150,
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
-      "avgConfidence": 0.791841269841268,
-      "avgFidelity": 0.9705555555555554,
-      "avgRoleFidelity": 0.8360201719576721,
-      "avgExecutionFidelity": 0.9032258064516129,
-      "executionFailures": ["accordion-exclusive", "closest-ancestor", "modal-close-button"],
+      "avgConfidence": 0.7926455026455007,
+      "avgFidelity": 0.9727777777777777,
+      "avgRoleFidelity": 0.8428488756613759,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": [
-        "event-debounce",
-        "modal-close-button",
-        "repeat-until-event",
-        "set-color-variable"
-      ],
+      "lossyPasses": ["event-debounce", "repeat-until-event", "set-color-variable"],
       "bundleSize": 423296,
       "patterns": {
         "toggle-class-on-other": {
@@ -10871,6 +10864,10 @@
           "success": true,
           "confidence": 1
         },
+        "accordion-toggle": {
+          "success": true,
+          "confidence": 1
+        },
         "dropdown-toggle": {
           "success": true,
           "confidence": 1
@@ -10884,6 +10881,10 @@
           "confidence": 1
         },
         "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "closest-ancestor": {
           "success": true,
           "confidence": 1
         },
@@ -10995,14 +10996,6 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
-        "accordion-toggle": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
-        "closest-ancestor": {
-          "success": true,
-          "confidence": 0.8857142857142858
-        },
         "set-text-basic": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -11052,10 +11045,6 @@
           "confidence": 0.8222222222222222
         },
         "tabs-aria": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "modal-close-button": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -11256,6 +11245,10 @@
           "confidence": 0.7142857142857143
         },
         "modal-open": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "modal-close-button": {
           "success": true,
           "confidence": 0.7142857142857143
         },


### PR DESCRIPTION
## Mechanism

The sw and qu tokenizers split on `_`, so a dict word joined with an underscore tokenizes as `word`/`_`/`word` and never matches its keyword. Two instances, each a one-line dict realign to a clean single-token form (the established `enyakın` pattern):

- **sw closest**: dict `karibu_zaidi` → `karibuzaidi` (+ a swahili tokenizer EXTRAS entry `karibuzaidi`→closest). The stray `_ zaidi` broke positional `closest <selector>` capture → destination defaulted to `me`. Cleared sw **accordion-exclusive, closest-ancestor, AND modal-close-button** (`hide closest .modal` — the §7o "sw hide drops" diagnosis was actually this closest break). Parse-level bonus: modal-close-button lossy→faithful.
- **qu else**: dict `mana_chayqa` → `manachus` (the qu profile's existing else word — dict↔profile alignment, no tokenizer change). The old form tokenized as `mana`(false)/`_`/`chayqa`(then) → no else keyword formed → qu conditionals never split their else branch. Cleared qu **if-matches, if-condition**.

## Measure-first corrected three stale §7q assumptions

- **ms is NOT underscore** — `ke_dalam` tokenizes cleanly (`_` is a malay word-char); ms's drop is fused-body-routing.
- **tr already emits** concatenated `enyakın` (the §7q jitter note is stale); tr's failing cells don't use closest.
- **qu `punta`** (target) is a *particle* split (`pun`/`ta`-accusative), not underscore — left for a separate arc.

## Result

- meanExecutionFidelity **0.9439 → 0.9509**; failing execution cells **40 → 35** (−5)
- lossy 77→76 (sw parse bonus), degen 63 unchanged
- Gate green (all four ratchets); baseline regenerated; 2 lock tests added (wave 14); semantic 5902, i18n 846 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)