### PR TITLE
fix(i18n,semantic): hi `मेलखाता` matches operator; R2 wave 15

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -1212,6 +1212,62 @@ set-trio + tabs-aria, ja/ko/tr tabs-aria); (3) **en-reference-lossy tabs-aria**
 - remaining qu tails. No more cheap dict-alignment wins remain in the cluster;
   the tail is genuinely the §9 "marginal session clears ~5 hard instances" regime.
 
+## 7u. Status update (2026-06-13, session 21): hi matches + session wrap (waves 12–15)
+
+**hi modal-close-backdrop cleared — the wave-12 + wave-14 mechanisms combined.**
+hi's matches both lacked a profile entry (wave-12 class) AND underscore-split
+(wave-14 class): the dict emitted `मेल_खाता`, which the hi tokenizer split into
+मेल/\_/खाता, and no hi profile entry mapped it to `matches`. Concatenate the dict
+to `मेलखाता` (no underscore) + add `मेलखाता`→matches to the hindi profile → the
+folded condition normalizes to the en-identical `target matches .modal-backdrop`.
+
+- **Result**: meanExecutionFidelity **0.9509 → 0.9523**; failing execution cells
+  **35 → 34** (−1). lossy 76, degen 63 unchanged. Gate green; baseline
+  regenerated; 1 lock test added (wave 15). Semantic 5903, i18n 846 green.
+
+### Session arc (waves 12–15): 46 → 34 failing execution cells
+
+| wave | PR     | mechanism                                             | cells |
+| ---- | ------ | ----------------------------------------------------- | ----- |
+| 12   | #411   | `matches` operator → ko/ru/uk profiles                | 46→43 |
+| 13   | #412   | de `nächstgelegene` closest vs next disambiguation    | 43→40 |
+| 14   | #413   | sw/qu `_`-joined surface words (karibuzaidi/manachus) | 40→35 |
+| 15   | (this) | hi `मेलखाता` matches (concat + profile)               | 35→34 |
+
+meanExecutionFidelity 0.9355 → 0.9523; avgFidelity / lossy 77→76 / degen 63
+essentially flat (these were execution-layer fixes — the lossy-but-faithful gap).
+All four ratchets held every wave; zero parse-level regressions; zero broken mains.
+
+### Stopping point — the cheap dict-alignment wins are EXHAUSTED
+
+The session cleared every remaining **dict/profile-alignment** mechanism (the
+"align the odd-one-out / emit a clean single-token surface form" idiom). The
+residual **34 cells are all deep structural arcs**, each its own multi-session
+effort (NOT clean single-mechanism fixes — all probed this session):
+
+1. **Fused-event body routing / compound collapse** (~12 cells: make-toast ×6,
+   make-element ×3, + zh/bn conditional residue). ms drops the trailing
+   `then put …` because `letak ia …` (put-with-`ia`) fails to parse standalone
+   (the §10 ms-put-ia bug); bn/zh collapse the whole event body to a single
+   `compound` (a higher-level event path) that bypasses the fold/grammar/at-end
+   paths. Needs semantic-parser body-routing + ms put-pattern work.
+2. **Per-language SOV scrambles** (hi set-trio + tabs-aria, ja/ko/tr tabs-aria):
+   fronted possessives captured as the event; attr/value/scope roles reorder.
+3. **en-reference-lossy tabs-aria** (×5): `set @attr … on <scope>` drops the
+   `on <scope>` modifier even in EN — a two-layer arc (fix en parse first, which
+   inverts the band).
+4. **qu particle-split** (`punta`/target → `pun`/`ta`-accusative) + dict↔profile
+   target mismatch (`punta` vs `ñawpaqman`): blocks qu modal-close-backdrop,
+   modal-open, put-content-basic. A tokenizer (particle) arc.
+5. **set-attribute / set-style / possessive-dot tails** (hi/qu/tr/id): SOV
+   fronting + possessive-phrase capture.
+
+Per §9 this is the documented stop: the marginal session now clears ~1–2 hard
+structural instances at high risk, while the same effort on Track-2 (behaviors,
+~40 of 63 degen) or R1 burn-down removes whole categories. The four ranked
+mechanisms remaining (fused-routing, SOV scrambles, en-lossy tabs-aria, qu
+particle) are each scoped above as their own arcs for a future session.
+
 ## 8. R1 / R2 — role-fidelity and execution ratchets (extend R0)
 
 Action-set fidelity (R0's signal) cannot see a parse that finds the right

--- a/packages/i18n/src/dictionaries/hi.ts
+++ b/packages/i18n/src/dictionaries/hi.ts
@@ -127,7 +127,11 @@ export const hindiDictionary: Dictionary = {
     not: 'नहीं',
     is: 'है',
     exists: 'मौजूद',
-    matches: 'मेल_खाता',
+    // Concatenated (no `_`): the hi tokenizer splits on underscore, so `मेल_खाता`
+    // tokenized as मेल/_/खाता and no `matches` operator formed (the folded
+    // conditional's raw stayed un-English and the core couldn't evaluate it).
+    // The hindi profile maps `मेलखाता`→matches (R2 wave 15).
+    matches: 'मेलखाता',
     contains: 'शामिल',
     includes: 'में_है',
     equals: 'बराबर',

--- a/packages/semantic/src/generators/profiles/hindi.ts
+++ b/packages/semantic/src/generators/profiles/hindi.ts
@@ -146,6 +146,11 @@ export const hindiProfile: LanguageProfile = {
     return: { primary: 'लौटाएं', alternatives: ['लौटा'], normalized: 'return' },
     then: { primary: 'फिर', alternatives: ['तब'], normalized: 'then' },
     and: { primary: 'और', alternatives: [], normalized: 'and' },
+    // Comparison operator — see korean.ts (R2 wave 12) for the rationale. The hi
+    // dict emits the concatenated `मेलखाता` (the old `मेल_खाता` underscore-split to
+    // मेल/_/खाता and no operator formed), which the folded conditional's raw must
+    // normalize to `matches` so the core expression parser can evaluate it.
+    matches: { primary: 'मेलखाता', normalized: 'matches' },
     end: { primary: 'समाप्त', alternatives: ['अंत'], normalized: 'end' },
     // Advanced
     js: { primary: 'जेएस', alternatives: ['js'], normalized: 'js' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -5647,3 +5647,39 @@ describe('sw/qu `_`-joined positional/conditional surface words (R2 wave 14)', (
     expect(branchActions(c!.elseBranch)).toEqual(['toggle']);
   });
 });
+
+describe('hi `मेलखाता` matches operator (R2 wave 15 — modal-close-backdrop)', () => {
+  // hi modal-close-backdrop combined the wave-12 (matches not in the profile) and
+  // wave-14 (`_`-split) failures: the hi dict emitted `मेल_खाता` for matches, which
+  // the hi tokenizer split into मेल/_/खाता, AND no hi profile entry mapped it to
+  // `matches`. So the folded condition raw came out garbled (`target मेल _` with
+  // `खाता` leaking into the hide patient) and the core couldn't evaluate it.
+  // Concatenate the dict to `मेलखाता` (no underscore) + add it to the hi profile →
+  // condition normalizes to the en-identical `target matches .modal-backdrop`.
+  function findConditional(node: unknown): Record<string, unknown> | null {
+    if (!node || typeof node !== 'object') return null;
+    const rec = node as Record<string, unknown>;
+    if (rec.kind === 'conditional') return rec;
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      const c = rec[f];
+      if (Array.isArray(c)) for (const x of c) { const r = findConditional(x); if (r) return r; }
+    }
+    return null;
+  }
+  const condText = (c: Record<string, unknown>): string =>
+    ((c.roles as Map<string, { raw?: string }>).get('condition')?.raw ?? '') as string;
+  const patientText = (c: Record<string, unknown>): unknown => {
+    const t = (c.thenBranch as Array<Record<string, unknown>>)?.[0];
+    const roles = t?.roles as Map<string, { value?: unknown; raw?: unknown }>;
+    return roles?.get('patient')?.value ?? roles?.get('patient')?.raw;
+  };
+
+  it('[hi] folds with en-identical `target matches .modal-backdrop` + clean hide patient', () => {
+    const c = findConditional(
+      parse('क्लिक पर अगर लक्ष्य मेलखाता .modal-backdrop .modal-backdrop को छिपाएं समाप्त', 'hi')
+    );
+    expect(c, 'conditional folded').not.toBeNull();
+    expect(condText(c!)).toBe('target matches .modal-backdrop');
+    expect(patientText(c!)).toBe('.modal-backdrop');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T12:32:49.128Z",
-  "commit": "c8ed5ed9",
+  "timestamp": "2026-06-13T12:47:06.449Z",
+  "commit": "cf855a37",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -4434,13 +4434,12 @@
       "parseRate": 1,
       "avgConfidence": 0.9560915275200976,
       "avgFidelity": 0.928030303030303,
-      "avgRoleFidelity": 0.5953185328185331,
-      "avgExecutionFidelity": 0.7096774193548387,
+      "avgRoleFidelity": 0.5975707850707852,
+      "avgExecutionFidelity": 0.7419354838709677,
       "executionFailures": [
         "halt-propagation",
         "make-element",
         "make-toast-element",
-        "modal-close-backdrop",
         "set-attribute",
         "set-inner-html-possessive-dot",
         "set-style",


### PR DESCRIPTION
## Mechanism

hi modal-close-backdrop combined the **wave-12** (matches missing from the profile) and **wave-14** (`_`-split) failures: the hi dict emitted `मेल_खाता` for matches, which the hi tokenizer split into मेल/_/खाता, AND no hi profile entry mapped it to `matches`. So the folded condition raw came out garbled (`target मेल _`, with `खाता` leaking into the hide patient) and the core couldn't evaluate it.

## Fix

- hi dict (`hi.ts`): `matches: 'मेल_खाता'` → `'मेलखाता'` (concatenated, no underscore)
- hindi profile (`hindi.ts`): add `matches: { primary: 'मेलखाता', normalized: 'matches' }`

→ the folded condition normalizes to the en-identical `target matches .modal-backdrop` with a clean `.modal-backdrop` hide patient.

## Result

- meanExecutionFidelity **0.9509 → 0.9523**; failing execution cells **35 → 34**
- lossy 76, degen 63 unchanged
- Gate green (all four ratchets); baseline regenerated; 1 lock test added (wave 15); semantic 5903, i18n 846 green

## Session arc (waves 12–15): 46 → 34 failing execution cells

| wave | mechanism | cells |
|---|---|---|
| 12 (#411) | `matches` operator → ko/ru/uk | 46→43 |
| 13 (#412) | de `nächstgelegene` closest vs next | 43→40 |
| 14 (#413) | sw/qu `_`-joined surface words | 40→35 |
| 15 (this) | hi `मेलखाता` matches | 35→34 |

The cheap dict-alignment wins are now exhausted; the residual 34 cells are deep structural arcs (fused-event body routing, SOV scrambles, en-lossy tabs-aria, qu particle-split) — each scoped for a future session in §7u of the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)