### PR TITLE
fix(i18n,semantic): sw closest → natural `karibu`; underscore design note; R2 wave 16

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -1268,6 +1268,52 @@ structural instances at high risk, while the same effort on Track-2 (behaviors,
 mechanisms remaining (fused-routing, SOV scrambles, en-lossy tabs-aria, qu
 particle) are each scoped above as their own arcs for a future session.
 
+## 7v. Design note (2026-06-13, session 22): the underscore convention is wrong — prefer native-natural surface forms
+
+**Owner question, answered: is the `_`-joined multi-word keyword surface form
+(`karibu_zaidi`, `मेल_खाता`, `mana_chayqa`, `के_साथ`) correct, or just
+confusing? Verdict: WRONG on both axes — unnatural AND usually unparseable.**
+
+1. **Unnatural.** No native author writes snake_case in their own language; it's
+   a C-identifier convention leaking into text that is supposed to BE the
+   language. It defeats the "write code in your language" premise.
+2. **Mis-tokenizes.** Most tokenizers treat `_` as a non-word char, so
+   `मेल_खाता` → `मेल`/`_`/`खाता` (a stray `_` token) and the keyword never forms —
+   the exact bug class waves 14/15 fixed. Smoking gun: the hi dict emits
+   `के_साथ` (with) which tokenizes BROKEN, while the natural `के साथ` tokenizes as
+   one token. It only "works" in Malay, by accident (malay's letter-class
+   includes `_`).
+
+**Preference hierarchy for multi-word/compound keywords (apply going forward):**
+
+1. **Real single word** if one exists — de `nächstgelegene` (closest), qu
+   `manachus` (else), sw `karibu` (closest). Natural and parseable.
+2. **Natural spaced phrase** with longest-match multi-word tokenization — the hi
+   tokenizer ALREADY does this for `के लिए`/`जब तक` (the `for`/`while` keywords).
+3. **Concatenation** (`enyakın`, `karibuzaidi`, `मेलखाता`) ONLY as a last resort,
+   documented as a parse-driven compromise. Better than `_` (parses), but still
+   not how the language is written.
+4. **Never `_`.**
+
+**State of the migration (already in progress, unfinished):** the semantic
+profiles increasingly use natural spaced forms (hi `के लिए`/`जब तक`) while the
+i18n dicts still emit underscores (`के_साथ`, `से_पहले`, `के_बीच`, `mana_sichus`,
+`kay_kaq`, … — dozens across ~20 langs). Many are latent `के_साथ`-class parse
+bugs waiting for a pattern to use them. **session-22 correction (this PR):** sw
+`karibuzaidi` → `karibu` (the wave-14 fused form replaced with the real word;
+zero metric change, pure naturalness). hi stays on `मेलखाता` because the natural
+`मेल खाता` does NOT tokenize — the hi extractor's multi-word support is a
+**hardcoded postpositional-compound allowlist** (`hindi-keyword.ts`: `के लिए`,
+`के साथ`, …) that doesn't cover a two-word verb phrase.
+
+**The proper fix (recommended arc, not yet done):** (a) generalize multi-word
+keyword tokenization — replace the per-language hardcoded compound allowlists
+with real longest-phrase matching against the profile keyword set (the framework
+`tryProfileKeyword` already does `startsWith` across spaces; the extractor-based
+tokenizers need to consult it for multi-token keywords); then (b) audit every
+`_` in the dicts and replace with the natural single/spaced form. (a) unblocks
+(b) for every language at once and lets the `_` convention be deleted wholesale.
+
 ## 8. R1 / R2 — role-fidelity and execution ratchets (extend R0)
 
 Action-set fidelity (R0's signal) cannot see a parse that finds the right

--- a/packages/i18n/src/dictionaries/sw.ts
+++ b/packages/i18n/src/dictionaries/sw.ts
@@ -206,12 +206,13 @@ export const sw: Dictionary = {
     prev: 'awali',
     at: 'katika',
     random: 'nasibu',
-    // Concatenated (no `_`): the swahili tokenizer splits on underscore, so the
-    // old `karibu_zaidi` tokenized as `karibu`(closest) + `_` + `zaidi`, and the
-    // stray `_ zaidi` broke the positional `closest <selector>` capture (the
-    // destination defaulted to `me`). The fused `karibuzaidi` is a single token
-    // the tokenizer maps →closest (the established `enyakın` pattern).
-    closest: 'karibuzaidi',
+    // Natural Swahili: `karibu` ("near/close") is the ordinary word and already
+    // maps to closest. The earlier `karibu_zaidi` ("nearer") underscore-split to
+    // karibu/_/zaidi (the stray `_ zaidi` broke positional capture); the fused
+    // `karibuzaidi` parsed but isn't real Swahili. `karibu` alone is both natural
+    // and correct (the sw tokenizer is single-word-only, so a spaced `karibu
+    // zaidi` would strand `zaidi` regardless).
+    closest: 'karibu',
     parent: 'mzazi',
     children: 'watoto',
     within: 'ndani_ya',

--- a/packages/semantic/src/tokenizers/swahili.ts
+++ b/packages/semantic/src/tokenizers/swahili.ts
@@ -86,11 +86,7 @@ const SWAHILI_EXTRAS: KeywordEntry[] = [
   { native: 'ijayo', normalized: 'next' }, // i18n dict emits 'ijayo' for next
   { native: 'iliyotangulia', normalized: 'previous' },
   { native: 'iliyopita', normalized: 'previous' }, // i18n dict emission
-  { native: 'karibu', normalized: 'closest' },
-  // Fused superlative the i18n dict now emits for closest ("nearer/nearest").
-  // The dict used to emit `karibu_zaidi`, but the tokenizer splits on `_`, so the
-  // `_ zaidi` stranded and broke positional `closest <selector>` capture.
-  { native: 'karibuzaidi', normalized: 'closest' },
+  { native: 'karibu', normalized: 'closest' }, // natural Swahili "near/close"; the dict emits this for closest
   { native: 'mzazi', normalized: 'parent' },
 
   // Events

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -5587,10 +5587,12 @@ describe('sw/qu `_`-joined positional/conditional surface words (R2 wave 14)', (
   // underscore tokenizes as `word`/`_`/`word` and never matches its keyword.
   // Two instances cleared by emitting a clean single-token surface form (the
   // established `enyakın` pattern), aligning dict → tokenizer/profile:
-  //  - sw closest: `karibu_zaidi` → `karibuzaidi` (+ tokenizer EXTRAS entry).
-  //    The stray `_ zaidi` had broken positional `closest <sel>` capture, so the
-  //    destination defaulted to `me`. Cleared sw accordion-exclusive,
-  //    closest-ancestor, AND modal-close-button (`hide closest .modal`).
+  //  - sw closest: `karibu_zaidi` → `karibu` (natural Swahili "near/close", which
+  //    the tokenizer already maps to closest; R2 wave 16 — wave 14 first used the
+  //    fused `karibuzaidi`, since corrected to the natural single word). The stray
+  //    `_ zaidi` had broken positional `closest <sel>` capture, so the destination
+  //    defaulted to `me`. Cleared sw accordion-exclusive, closest-ancestor, AND
+  //    modal-close-button (`hide closest .modal`).
   //  - qu else: `mana_chayqa` → `manachus` (the profile's existing else word).
   //    The old form tokenized as `mana`(false)/`_`/`chayqa`(then), so no else
   //    keyword formed and qu conditionals never split their else branch. Cleared
@@ -5630,8 +5632,8 @@ describe('sw/qu `_`-joined positional/conditional surface words (R2 wave 14)', (
   const branchActions = (branch: unknown): string[] =>
     Array.isArray(branch) ? (branch as Array<Record<string, unknown>>).map(n => String(n.action)) : [];
 
-  it('[sw] toggle destination captures `closest .card` (karibuzaidi)', () => {
-    const toggle = commands(parse('kwenye bonyeza badilisha .expanded kwa karibuzaidi .card', 'sw')).find(
+  it('[sw] toggle destination captures `closest .card` (natural `karibu`)', () => {
+    const toggle = commands(parse('kwenye bonyeza badilisha .expanded kwa karibu .card', 'sw')).find(
       c => c.action === 'toggle'
     );
     expect(toggle, 'toggle present').toBeTruthy();

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T12:47:06.449Z",
-  "commit": "cf855a37",
+  "timestamp": "2026-06-13T13:10:20.300Z",
+  "commit": "a9d52b16",
   "languages": {
     "ar": {
       "parseSuccess": 153,


### PR DESCRIPTION
## Why

Owner review asked whether the `_`-joined multi-word keyword surface forms (`karibu_zaidi`, `मेल_खाता`, `mana_chayqa`, `के_साथ`) are correct or just confusing — **from the perspective of someone writing code in their native language.**

Verdict: **wrong on both axes** — unnatural to native authors AND usually unparseable (most tokenizers split on `_`; only Malay tolerates it, by accident; the hi dict's `के_साथ` tokenizes *broken* while natural `के साथ` works as one token).

## Change

A native-naturalness correction to something I shipped earlier this session:

- **sw closest**: `karibuzaidi` (wave 14 — parses, but not real Swahili) → **`karibu`** ("near/close", the ordinary word, already mapped to closest in the tokenizer). Verified `karibu .card` → `closest .card`. Removed the now-dead `karibuzaidi` tokenizer entry; updated the wave-14 lock test.

**Pure naturalness change — zero metric impact:** meanExecutionFidelity 0.9523, failing cells 34, lossy 76, degen 63 all unchanged. Gate green; baseline regenerated (only metadata/bundle-size moved). Semantic 5903, i18n 846 green.

## Design note (§7v in the plan doc)

Documents the verdict and a **preference hierarchy** for multi-word/compound keywords going forward:

1. **Real single word** (de `nächstgelegene`, qu `manachus`, sw `karibu`)
2. **Natural spaced phrase** with longest-match tokenization (hi already does this for `के लिए`/`जब तक`)
3. **Concatenation** only as a last-resort, documented compromise
4. **Never `_`**

Plus: the migration is already in progress but unfinished (profiles use natural spaced forms; dicts still emit underscores — dozens of latent `के_साथ`-class parse bugs), why hi `मेल खाता` can't go natural yet (the hi extractor's multi-word support is a hardcoded postpositional allowlist), and the recommended arc — **generalize multi-word keyword tokenization, then audit out every dict `_`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)