### PR TITLE
feat(framework): generalize multi-word keyword tokenization (profile-driven)

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -1314,6 +1314,53 @@ tokenizers need to consult it for multi-token keywords); then (b) audit every
 `_` in the dicts and replace with the natural single/spaced form. (a) unblocks
 (b) for every language at once and lets the `_` convention be deleted wholesale.
 
+## 7w. Status update (2026-06-13, session 22): multi-word keyword tokenization GENERALIZED (the §7v keystone)
+
+**Shipped the keystone from §7v(a): profile-driven longest-phrase multi-word
+keyword matching in the framework base tokenizer.** Measure-first found that
+multi-word profile keywords were DEAD in ~8 languages (id `ke dalam`, qu
+`mana waqtalla`, he `כל עוד`, bn `তৈরি করুন`, tr `üzerine gelme`, es `tecla
+abajo`, sw `isiyo sawia` all split) — only vi and hi worked, each via its OWN
+**hardcoded compound list** (the vietnamese extractor's 80-entry
+`multiWordPhrases`, the hindi extractor's allowlist). The generalization makes it
+one mechanism, profile-driven.
+
+- **Mechanism** (`packages/framework/src/core/tokenization/base-tokenizer.ts`):
+  `initializeKeywordsFromProfile` now also builds `multiWordKeywords` (the
+  space-containing `profileKeywords`, longest-first). `tokenizeWithExtractors`
+  calls `tryMultiWordKeyword` after whitespace-skip, BEFORE the per-language
+  extractors: it matches the longest multi-word profile keyword at a word
+  boundary and emits one keyword token. No-op for single-word and no-space (CJK)
+  languages (`multiWordKeywords` empty).
+- **Marker/modifier concepts are EXCLUDED** (`MARKER_CONCEPT_NORMALIZEDS`):
+  into/from/to/with/before/after/… + role names (patient/destination/source/
+  event/eventMarker/…). Those are matched POSITIONALLY by the pattern matcher;
+  greedily pre-matching a multi-word marker phrase shadows the single-word marker
+  patterns depend on. Found via two real regressions the first cut produced: id
+  `ke dalam` (into) swallowed the `ke` destination marker (broke the put pattern),
+  and ko `할 때` (eventMarker) pre-empted the SOV event extraction (broke
+  modal-close-backdrop + the §7-#367 event-marker handling). Command verbs /
+  control-flow / event names are KEPT (vi `với mỗi`=for, es `tecla abajo`=keydown,
+  bn `তৈরি করুন`=make) — those are keyword literals, so one-token matching helps.
+- **Result**: failing execution cells **34 → 32** (bn make-element +
+  make-toast-element cleared — `তৈরি করুন`=make now parses whole);
+  meanExecutionFidelity 0.9523 → 0.9551; **lossy 76 → 73** (the bn pair went
+  lossy→faithful — a parse-level improvement too); degen 63 unchanged. Gate green
+  (all four ratchets); no language regressed. Framework 764, semantic 5916, i18n
+  846, all 8 domain suites green; typechecks clean.
+- **hi natural-form migration (§7v(b), partial)**: hi `matches` `मेलखाता` (wave-15
+  concatenation) → natural spaced **`मेल खाता`**, now that the base matches it.
+  The wave-15 lock test updated to the natural form.
+
+**Deferred (tracked):** fully retiring the hindi/vi hardcoded lists + the
+dict-wide `_` audit (§7v(b) remainder). Blocker: those lists also hold
+MARKER-phrases (`से पहले`/before, `vào trong`/into, `के साथ`/with) that the base
+matcher excludes — fully retiring needs the PATTERN MATCHER to accept multi-word
+marker keywords (so into/before/after can leave `MARKER_CONCEPT_NORMALIZEDS`).
+The lists are now redundant for non-marker keywords (the base runs first) and
+coexist harmlessly. That pattern-matcher work + the underscore audit is the next
+arc.
+
 ## 8. R1 / R2 — role-fidelity and execution ratchets (extend R0)
 
 Action-set fidelity (R0's signal) cannot see a parse that finds the right

--- a/packages/framework/src/core/tokenization/base-tokenizer.ts
+++ b/packages/framework/src/core/tokenization/base-tokenizer.ts
@@ -32,6 +32,48 @@ import { getDefaultExtractors } from './default-extractors';
 // Uses the canonical list from OperatorExtractor to avoid duplication.
 const SIMPLE_TOKENIZER_OPERATOR_SET = new Set(DEFAULT_OPERATORS);
 
+/**
+ * Normalized concepts that are handled POSITIONALLY by the pattern matcher
+ * (role markers + prepositional modifiers), so a multi-word phrase carrying one
+ * of them must NOT be pre-matched as a single keyword token — doing so shadows
+ * the single-word marker the patterns expect (e.g. id `ke dalam`=into hides the
+ * `ke` destination marker; ko `할 때`=eventMarker pre-empts SOV event extraction).
+ * Command verbs / control-flow / event names are intentionally absent — those
+ * are keyword literals the matcher reads whole, so multi-word matching helps.
+ * See `multiWordKeywords` / `tryMultiWordKeyword`.
+ */
+const MARKER_CONCEPT_NORMALIZEDS: ReadonlySet<string> = new Set([
+  // Role-marker role names (profile.roleMarkers normalizeds)
+  'patient',
+  'destination',
+  'source',
+  'style',
+  'event',
+  'eventMarker',
+  'agent',
+  'goal',
+  'manner',
+  // Prepositional / positional modifier concepts (profile.keywords "Modifiers")
+  'into',
+  'from',
+  'to',
+  'with',
+  'at',
+  'of',
+  'as',
+  'by',
+  'in',
+  'on',
+  'before',
+  'after',
+  'over',
+  'under',
+  'between',
+  'through',
+  'without',
+  'until',
+]);
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -113,6 +155,15 @@ export abstract class BaseTokenizer implements LanguageTokenizer {
 
   /** Keywords derived from profile, sorted longest-first for greedy matching */
   protected profileKeywords: KeywordEntry[] = [];
+
+  /**
+   * Space-containing profile keywords (multi-word phrases), longest-first.
+   * Used by `tryMultiWordKeyword` so natural spaced forms (hi `मेल खाता`,
+   * vi `chuyển đổi`, es `tecla abajo`, …) tokenize as ONE keyword — the
+   * profile-driven replacement for the per-language hardcoded compound lists.
+   * Empty for no-space (CJK) languages, so they are unaffected.
+   */
+  protected multiWordKeywords: KeywordEntry[] = [];
 
   /** Map for O(1) keyword lookups by lowercase native word */
   protected profileKeywordMap: Map<string, KeywordEntry> = new Map();
@@ -218,6 +269,19 @@ export abstract class BaseTokenizer implements LanguageTokenizer {
         pos++;
       }
       if (pos >= input.length) break;
+
+      // Multi-word keyword pre-match: a profile keyword containing a space
+      // (e.g. hi `मेल खाता`, vi `chuyển đổi`, es `tecla abajo`) is matched as ONE
+      // keyword token at a word boundary, longest-first. Runs before the
+      // per-language extractors so natural spaced multi-word keywords tokenize
+      // without each tokenizer hardcoding a compound list. No-op for single-word
+      // and no-space (CJK) languages (multiWordKeywords is empty).
+      const multiWord = this.tryMultiWordKeyword(input, pos);
+      if (multiWord) {
+        tokens.push(multiWord);
+        pos = multiWord.position.end;
+        continue;
+      }
 
       // Try registered extractors in order
       let extracted = false;
@@ -429,6 +493,20 @@ export abstract class BaseTokenizer implements LanguageTokenizer {
       (a, b) => b.native.length - a.native.length
     );
 
+    // Multi-word (space-containing) keywords, for longest-phrase matching at a
+    // token boundary. Already longest-first (profileKeywords is sorted above).
+    // Marker/modifier concepts are EXCLUDED: those are matched positionally by
+    // the pattern matcher (role markers), and greedily consuming a multi-word
+    // marker phrase shadows the single-word marker patterns rely on — e.g. id
+    // `ke dalam` (into) would swallow the `ke` destination marker, and ko `할 때`
+    // (eventMarker) would pre-empt the SOV event extraction. Command verbs,
+    // control-flow, and event-name keywords (vi `với mỗi`=for, es `tecla abajo`=
+    // keydown, bn `তৈরি করুন`=make) are kept — the pattern matcher treats those
+    // as keyword literals, so one-token matching is strictly better.
+    this.multiWordKeywords = this.profileKeywords.filter(
+      k => k.native.includes(' ') && !MARKER_CONCEPT_NORMALIZEDS.has(k.normalized)
+    );
+
     // Build Map for O(1) lookups (case-insensitive + diacritic-insensitive)
     // This allows matching both 'بدّل' (with shadda) and 'بدل' (without) to the same entry
     this.profileKeywordMap = new Map();
@@ -476,6 +554,40 @@ export abstract class BaseTokenizer implements LanguageTokenizer {
           entry.normalized
         );
       }
+    }
+    return null;
+  }
+
+  /**
+   * Match the longest multi-word (space-containing) profile keyword at `pos`,
+   * requiring the match to end at a word boundary. The profile-driven
+   * counterpart of the per-language hardcoded compound lists (the hindi and
+   * vietnamese keyword extractors). Returns a keyword token (with the normalized
+   * form) or null. Case-sensitive against the stored native form, mirroring
+   * `tryProfileKeyword`/`isKeywordStart` (the i18n dicts emit a fixed surface
+   * case). No-op when `multiWordKeywords` is empty (no-space/CJK languages).
+   *
+   * @param input - Input string
+   * @param pos - Current position (must be a token-start boundary)
+   * @param isWordChar - End-boundary predicate (defaults to Unicode letter/digit/_)
+   */
+  protected tryMultiWordKeyword(
+    input: string,
+    pos: number,
+    isWordChar: (char: string) => boolean = ch => /[\p{L}\p{N}_]/u.test(ch)
+  ): LanguageToken | null {
+    if (this.multiWordKeywords.length === 0) return null;
+    const rest = input.slice(pos);
+    for (const entry of this.multiWordKeywords) {
+      if (!rest.startsWith(entry.native)) continue;
+      const after = input[pos + entry.native.length];
+      if (after !== undefined && isWordChar(after)) continue; // not a word boundary
+      return createToken(
+        entry.native,
+        'keyword',
+        createPosition(pos, pos + entry.native.length),
+        entry.normalized
+      );
     }
     return null;
   }

--- a/packages/i18n/src/dictionaries/hi.ts
+++ b/packages/i18n/src/dictionaries/hi.ts
@@ -127,11 +127,11 @@ export const hindiDictionary: Dictionary = {
     not: 'नहीं',
     is: 'है',
     exists: 'मौजूद',
-    // Concatenated (no `_`): the hi tokenizer splits on underscore, so `मेल_खाता`
-    // tokenized as मेल/_/खाता and no `matches` operator formed (the folded
-    // conditional's raw stayed un-English and the core couldn't evaluate it).
-    // The hindi profile maps `मेलखाता`→matches (R2 wave 15).
-    matches: 'मेलखाता',
+    // Natural spaced phrase `मेल खाता` ("matches") — how Hindi writes it. The base
+    // tokenizer now matches multi-word profile keywords, so the hindi profile maps
+    // `मेल खाता`→matches without the underscore (`मेल_खाता` split) or the
+    // concatenated `मेलखाता` (parsed, but unnatural) workarounds.
+    matches: 'मेल खाता',
     contains: 'शामिल',
     includes: 'में_है',
     equals: 'बराबर',

--- a/packages/semantic/src/generators/profiles/hindi.ts
+++ b/packages/semantic/src/generators/profiles/hindi.ts
@@ -146,11 +146,13 @@ export const hindiProfile: LanguageProfile = {
     return: { primary: 'लौटाएं', alternatives: ['लौटा'], normalized: 'return' },
     then: { primary: 'फिर', alternatives: ['तब'], normalized: 'then' },
     and: { primary: 'और', alternatives: [], normalized: 'and' },
-    // Comparison operator — see korean.ts (R2 wave 12) for the rationale. The hi
-    // dict emits the concatenated `मेलखाता` (the old `मेल_खाता` underscore-split to
-    // मेल/_/खाता and no operator formed), which the folded conditional's raw must
-    // normalize to `matches` so the core expression parser can evaluate it.
-    matches: { primary: 'मेलखाता', normalized: 'matches' },
+    // Comparison operator — see korean.ts (R2 wave 12) for the rationale. Uses the
+    // NATURAL spaced phrase `मेल खाता` ("matches"), now that the base tokenizer
+    // matches multi-word profile keywords (longest-phrase at a word boundary). The
+    // folded conditional's raw normalizes it to `matches` for the core expression
+    // parser. (History: `मेल_खाता` underscore-split to मेल/_/खाता; the concatenated
+    // `मेलखाता` parsed but isn't how Hindi is written.)
+    matches: { primary: 'मेल खाता', normalized: 'matches' },
     end: { primary: 'समाप्त', alternatives: ['अंत'], normalized: 'end' },
     // Advanced
     js: { primary: 'जेएस', alternatives: ['js'], normalized: 'js' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -5650,14 +5650,14 @@ describe('sw/qu `_`-joined positional/conditional surface words (R2 wave 14)', (
   });
 });
 
-describe('hi `मेलखाता` matches operator (R2 wave 15 — modal-close-backdrop)', () => {
+describe('hi `मेल खाता` matches operator (R2 wave 15 → natural-form migration)', () => {
   // hi modal-close-backdrop combined the wave-12 (matches not in the profile) and
   // wave-14 (`_`-split) failures: the hi dict emitted `मेल_खाता` for matches, which
   // the hi tokenizer split into मेल/_/खाता, AND no hi profile entry mapped it to
-  // `matches`. So the folded condition raw came out garbled (`target मेल _` with
-  // `खाता` leaking into the hide patient) and the core couldn't evaluate it.
-  // Concatenate the dict to `मेलखाता` (no underscore) + add it to the hi profile →
-  // condition normalizes to the en-identical `target matches .modal-backdrop`.
+  // `matches`. wave-15 used a concatenated `मेलखाता` (parsed, but unnatural). Now
+  // that the base tokenizer matches multi-word profile keywords, this uses the
+  // NATURAL spaced `मेल खाता` — condition normalizes to en-identical
+  // `target matches .modal-backdrop`.
   function findConditional(node: unknown): Record<string, unknown> | null {
     if (!node || typeof node !== 'object') return null;
     const rec = node as Record<string, unknown>;
@@ -5678,10 +5678,71 @@ describe('hi `मेलखाता` matches operator (R2 wave 15 — modal-clos
 
   it('[hi] folds with en-identical `target matches .modal-backdrop` + clean hide patient', () => {
     const c = findConditional(
-      parse('क्लिक पर अगर लक्ष्य मेलखाता .modal-backdrop .modal-backdrop को छिपाएं समाप्त', 'hi')
+      parse('क्लिक पर अगर लक्ष्य मेल खाता .modal-backdrop .modal-backdrop को छिपाएं समाप्त', 'hi')
     );
     expect(c, 'conditional folded').not.toBeNull();
     expect(condText(c!)).toBe('target matches .modal-backdrop');
     expect(patientText(c!)).toBe('.modal-backdrop');
+  });
+});
+
+describe('generalized multi-word keyword tokenization (base-tokenizer)', () => {
+  // The base tokenizer now matches the longest space-containing profile keyword
+  // at a word boundary BEFORE the per-language extractors (profile-driven, not a
+  // per-language hardcoded list). Natural spaced multi-word keywords tokenize as
+  // ONE keyword across all languages — replacing the underscore/concatenation
+  // workarounds. Marker/modifier concepts are excluded (handled positionally),
+  // so e.g. id `ke dalam` (into) stays split and the destination marker `ke`
+  // survives for the put pattern.
+  const norm = (lang: string, text: string): string[] => {
+    const toks = getTokenizer(lang as 'en').tokenize(text).tokens as Array<{
+      value: string;
+      normalized?: string;
+    }>;
+    return toks.map(t => t.normalized ?? t.value);
+  };
+
+  // Command verbs / control-flow / event names: one keyword, correct normalized.
+  const oneKeyword: Array<[string, string, string]> = [
+    ['es', 'tecla abajo', 'keydown'],
+    ['he', 'כל עוד', 'while'],
+    ['he', 'ברירת מחדל', 'default'],
+    ['bn', 'তৈরি করুন', 'make'],
+    ['bn', 'চালিয়ে যান', 'continue'],
+    ['tr', 'üzerine gelme', 'hover'],
+    ['qu', 'mana waqtalla', 'async'],
+    ['vi', 'chuyển đổi', 'toggle'],
+    ['vi', 'với mỗi', 'for'],
+    ['hi', 'के लिए', 'for'],
+    ['hi', 'मेल खाता', 'matches'], // natural spaced matches (no more मेलखाता concat)
+  ];
+  for (const [lang, phrase, want] of oneKeyword) {
+    it(`[${lang}] "${phrase}" → single keyword \`${want}\``, () => {
+      expect(norm(lang, phrase)).toEqual([want]);
+    });
+  }
+
+  it('[id] marker concept `ke dalam` (into) stays split so the `ke` destination marker survives', () => {
+    // `into` is a positional marker concept — excluded from multi-word matching.
+    // The destination roleMarker `ke` must remain a separate token for the put pattern.
+    const toks = norm('id', 'ke dalam');
+    expect(toks[0]).toBe('destination'); // `ke` → destination marker
+    expect(toks).not.toEqual(['into']);
+  });
+
+  it('[hi] modal-close-backdrop folds with natural `मेल खाता` matches', () => {
+    const c = (function find(n: unknown): Record<string, unknown> | null {
+      if (!n || typeof n !== 'object') return null;
+      const r = n as Record<string, unknown>;
+      if (r.kind === 'conditional') return r;
+      for (const f of ['body', 'thenBranch', 'elseBranch']) {
+        const ch = r[f];
+        if (Array.isArray(ch)) for (const x of ch) { const got = find(x); if (got) return got; }
+      }
+      return null;
+    })(parse('क्लिक पर अगर लक्ष्य मेल खाता .modal-backdrop .modal-backdrop को छिपाएं समाप्त', 'hi'));
+    expect(c).not.toBeNull();
+    const cond = (c!.roles as Map<string, { raw?: string }>).get('condition')?.raw;
+    expect(cond).toBe('target matches .modal-backdrop');
   });
 });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T13:10:20.300Z",
-  "commit": "a9d52b16",
+  "timestamp": "2026-06-13T15:17:37.527Z",
+  "commit": "4590f643",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -13,7 +13,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["repeat-until-event", "window-scroll"],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -636,20 +636,14 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8477942692228406,
-      "avgFidelity": 0.9905844155844155,
-      "avgRoleFidelity": 0.7859797297297297,
-      "avgExecutionFidelity": 0.9032258064516129,
-      "executionFailures": ["make-element", "make-toast-element", "tabs-aria"],
+      "avgConfidence": 0.8542877757163472,
+      "avgFidelity": 0.9962121212121211,
+      "avgRoleFidelity": 0.7899211711711711,
+      "avgExecutionFidelity": 0.967741935483871,
+      "executionFailures": ["tabs-aria"],
       "degeneratePasses": [],
-      "lossyPasses": [
-        "fetch-do-not-throw",
-        "if-exists",
-        "make-element",
-        "make-toast-element",
-        "unless-condition"
-      ],
-      "bundleSize": 423296,
+      "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -684,6 +678,10 @@
           "confidence": 1
         },
         "put-content-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "make-element": {
           "success": true,
           "confidence": 1
         },
@@ -971,6 +969,10 @@
           "success": true,
           "confidence": 1
         },
+        "make-toast-element": {
+          "success": true,
+          "confidence": 1
+        },
         "template-literal-interpolation": {
           "success": true,
           "confidence": 1
@@ -1147,10 +1149,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "make-element": {
-          "success": true,
-          "confidence": 0.5
-        },
         "send-with-detail": {
           "success": true,
           "confidence": 0.5
@@ -1219,10 +1217,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "make-toast-element": {
-          "success": true,
-          "confidence": 0.5
-        },
         "eventsource-basic": {
           "success": true,
           "confidence": 0.5
@@ -1280,7 +1274,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1904,7 +1898,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2529,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3165,7 +3159,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3788,7 +3782,7 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8263201576927067,
+      "avgConfidence": 0.8266106442577031,
       "avgFidelity": 0.9589324618736381,
       "avgRoleFidelity": 0.8751943634596696,
       "avgExecutionFidelity": 1,
@@ -3809,7 +3803,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4060,6 +4054,10 @@
           "confidence": 0.8222222222222222
         },
         "get-value": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "default-value": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -4347,10 +4345,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "default-value": {
-          "success": true,
-          "confidence": 0.7777777777777778
-        },
         "wait-for-event": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -4466,7 +4460,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5103,7 +5097,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5733,7 +5727,7 @@
       "executionFailures": ["modal-close-button"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6380,7 +6374,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7023,7 +7017,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7664,7 +7658,7 @@
         "render-template-with-data",
         "set-color-variable"
       ],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8290,7 +8284,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8920,7 +8914,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9567,7 +9561,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10198,7 +10192,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10829,7 +10823,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "repeat-until-event", "set-color-variable"],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11456,7 +11450,7 @@
       "executionFailures": ["accordion-exclusive"],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12087,7 +12081,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["window-scroll"],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12724,7 +12718,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13354,7 +13348,7 @@
       "executionFailures": ["make-toast-element"],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13991,7 +13985,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14636,7 +14630,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 423296,
+      "bundleSize": 424049,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15258,7 +15252,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 423296,
+      "size": 424049,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Keystone fix from the §7v underscore design note

Multi-word (spaced) profile keywords were **dead in ~8 languages** — `id ke dalam`, `qu mana waqtalla`, `he כל עוד`, `bn তৈরি করুন`, `tr üzerine gelme`, `es tecla abajo`, `sw isiyo sawia` all split into separate tokens. Only **vi** and **hi** worked, each via its own **hardcoded compound list** (the vietnamese extractor's ~80-entry `multiWordPhrases`; the hindi extractor's allowlist). This replaces those with one profile-driven mechanism.

## Mechanism (`base-tokenizer.ts`)

- `initializeKeywordsFromProfile` builds `multiWordKeywords` (space-containing `profileKeywords`, longest-first).
- `tokenizeWithExtractors` calls `tryMultiWordKeyword` after whitespace-skip, **before** the per-language extractors — matches the longest multi-word profile keyword at a word boundary, emits one keyword token.
- No-op for single-word and no-space (CJK) languages.

## Marker concepts excluded (`MARKER_CONCEPT_NORMALIZEDS`)

into/from/to/with/before/after/… + role names (patient/destination/source/event/eventMarker/…) are **excluded** — those are matched positionally by the pattern matcher, and pre-matching a multi-word marker phrase shadows the single-word marker patterns rely on. Found via two real regressions the first cut produced: `id ke dalam` (into) swallowed the `ke` destination marker; `ko 할 때` (eventMarker) pre-empted SOV event extraction. Command verbs / control-flow / event names are kept.

Also migrates `hi matches` from the wave-15 concatenation `मेलखाता` → natural spaced **`मेल खाता`**, now that the base matches it.

## Result

- failing execution cells **34 → 32** (bn make-element + make-toast-element cleared — `তৈরি করুন`=make now parses whole)
- meanExecutionFidelity **0.9523 → 0.9551**; **lossy 76 → 73** (bn pair lossy→faithful); degen 63 unchanged
- Gate green (all four ratchets); **no language regressed**
- framework 764, semantic 5916, i18n 846, all 8 domain suites green; typechecks clean; 13 lock tests added

## Deferred (§7w, tracked)

Fully retiring the hindi/vi hardcoded lists + the dict-wide `_` audit — blocked on the pattern matcher accepting multi-word **marker** keywords (so into/before/after can leave the exclusion set). The lists are now redundant for non-marker keywords and coexist harmlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)