### PR TITLE
docs(correctness): Task #10 handoff + per-language structural-arcs roadmap

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -1609,3 +1609,24 @@ Operating mode: unchanged (measure-first probe, one mechanism per PR,
 serialize on the baseline, prototype-while-CI-runs, stash with names).
 18 PRs over three overnight runs, one ratchet-blocked branch, zero broken
 mains.
+
+## 11. Next-arc handoffs (post-#416)
+
+The cheap dict/profile-alignment wins are exhausted (R2 execution: 32 cells,
+parse ship line held). The next work is decomposed into focused handoffs:
+
+- **Task #10 — multi-word markers + dict underscore audit:**
+  [TASK10_MULTIWORD_MARKER_HANDOFF.md](TASK10_MULTIWORD_MARKER_HANDOFF.md). Unblocked
+  by the #416 keystone; 3 phases (non-marker underscore audit → multi-word marker
+  support in the pattern matcher → retire the hindi/vi hardcoded lists). Highest
+  leverage; also clears the qu particle/tokenizer cells. **Do first.**
+- **Per-language structural arcs (the R2 tail):**
+  [STRUCTURAL_ARCS_ROADMAP.md](STRUCTURAL_ARCS_ROADMAP.md). Every remaining R2 cell
+  mapped to an arc, with a triage rubric (yield · leverage · confidence · risk ·
+  unblocks) and a leverage-first ranking (S2 fused-routing > S6 hi > S3 SOV-attr >
+  S4/tails > S1 en-lossy). Opportunistic — lower ROI than behaviors.
+- **Track 2 — behaviors (next big track):** 49 of the 63 degenerate passes are
+  `behavior-*` (draggable/resizable/sortable ×15 each + removable ×4 +
+  install-behavior ×3). This is a **runtime** effort (block-structure parsing +
+  behavior execution), not parsing/i18n — the biggest single mass and the
+  recommended focus after Task #10.

--- a/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
+++ b/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
@@ -1,0 +1,142 @@
+# Per-language structural arcs roadmap (R2 execution tail)
+
+> **Scope:** the **32 remaining R2 execution-failing cells** after the cheap
+> dict/profile-alignment wins were exhausted (waves 12–16 + the multi-word
+> keyword generalization, #411–#416). These are deep, structural, often
+> per-language bugs — each its own mini-arc. This doc enumerates them, maps every
+> failing cell to an arc, and gives a **triage rubric** so they can be picked off
+> by leverage rather than ad hoc.
+>
+> **Context for sequencing:** per CORRECTNESS_RELIABILITY_PLAN.md §9, the R2
+> structural tail is **lower ROI** than Track 2 (behaviors — 49 of 63 degenerate
+> passes). Recommended order overall: **Task #10** (multi-word markers + dict
+> underscore audit — unblocked, high-leverage) → **behaviors** (biggest single
+> mass) → these structural arcs **opportunistically**, best-leverage first.
+
+## Triage rubric
+
+Score each arc on five axes (H/M/L), then rank by leverage-adjusted value.
+`PRIORITY ≈ Yield + Leverage + Confidence + Unblocks − Risk`.
+
+| Axis           | Meaning                                                                                                                  | High =           |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| **Yield**      | R2 cells the arc can clear                                                                                               | more cells       |
+| **Leverage**   | one fix → many languages (shared mechanism) vs one-lang tail                                                             | shared mechanism |
+| **Confidence** | mechanism probed & understood vs speculative                                                                             | probed           |
+| **Risk**       | blast radius: localized parser tweak (low) vs core-parser / **en-reference** change with baseline churn/inversion (high) | localized        |
+| **Unblocks**   | enables other arcs / removes a category                                                                                  | yes              |
+
+**Heuristics that fall out of the rubric:**
+
+1. Prefer **shared-mechanism** arcs (clear N languages at once) over per-language tails.
+2. Prefer **probed** mechanisms over speculative — measure-first before committing an arc.
+3. **Defer en-reference-changing arcs** (they invert the gate band and churn the
+   baseline) unless you're ready for a full re-record.
+4. A 1-cell single-language tail is almost never worth a dedicated arc — batch
+   tails opportunistically when already in that language's files.
+5. Re-measure the cluster each PR (it shifts); this map is a snapshot at #416.
+
+## The arcs (ranked) — cell map at HEAD `7a0769df`
+
+### S2 — fused-event body routing / compound collapse ★ best shared lever
+
+- **Cells (~7):** make-toast-element (ms, zh, uk), make-element (ms), modal-close-backdrop (zh), if-condition/if-exists/if-matches (zh) — the zh share overlaps S5.
+- **Languages:** ms, zh, bn (latent).
+- **Mechanism:** (a) ms drops the trailing `then …` clause because the standalone
+  command fails to parse — the §10 **ms put-with-`ia`** bug (`letak ia ke …`).
+  (b) zh/bn collapse the **whole event body into a single `compound`** (a
+  higher-level event path) that bypasses the fold / grammar / at-end paths (§7n).
+- **Layer:** `semantic-parser.ts` body routing + the ms put pattern.
+- **Yield H · Leverage H (ms+zh+bn) · Confidence M (probed §7n/§7o) · Risk M-H
+  (parser body routing) · Unblocks: collapses most of zh too.**
+- **Verdict:** the single biggest structural lever. Tackle first among S-arcs.
+
+### S6 — hi worst-language SOV fronting + possessive-dot ★ highest single-lang count
+
+- **Cells (hi is in 8 total):** set-inner-html-possessive-dot, set-text-possessive-dot,
+  set-style, set-attribute, halt-propagation, make-element, make-toast, tabs-aria.
+- **Mechanism:** hi `into`-pattern (`में …`) matches before fallbacks; **fronted
+  possessive captured as the event** (`मेरा.textContent … सेट …` → possessive
+  becomes the event, body collapses); possessive-dot head assembly (§10 hi set-trio).
+- **Layer:** `semantic-parser.ts` (hi event-pattern ordering) + possessive matcher.
+- **Yield H (8) · Leverage L (one language) · Confidence M (probed §10) · Risk M ·
+  Unblocks: no.**
+- **Verdict:** big count but a per-language grind; several of its cells also belong
+  to S1/S3, so partial credit comes from those. Do after S2.
+
+### S1 — en-reference-lossy patterns (`set @attr … on <scope>`) ⚠ high-risk
+
+- **Cells (~5):** tabs-aria (bn, hi, ja, ko, tr). Also gates the excluded
+  set-attribute@scope family.
+- **Mechanism:** the **en reference itself is lossy** — `set @aria-selected to "x"
+on .tab set … on me` drops the `on <scope>` modifier even in English (two sets,
+  no scope). Translations diverge by capturing the 2nd set's roles differently.
+- **Layer:** TWO layers — fix the **en parse** (`on <scope>` capture) first, which
+  **inverts the gate band** (today's passers become failers), then per-language.
+- **Yield M (5) · Leverage M · Confidence H (probed §7g/§10.5) · Risk **H** (en
+  reference change → baseline re-record) · Unblocks: re-qualifies the @attr family.**
+- **Verdict:** defer unless ready for a deliberate band-inversion + full re-baseline.
+
+### S3 — SOV `@attr` / `set` role-scramble
+
+- **Cells (~5):** set-attribute (hi, qu, tr), set-style (hi, id).
+- **Mechanism:** SOV reorder fronts `@attr`/possessive; set's attr/value/scope
+  roles scramble. id set-style is the two-word possessive PHRASE (`saya punya
+*background`). hi/tr are SOV fronting.
+- **Layer:** `semantic-parser.ts` SOV + possessive-phrase matcher.
+- **Yield M (5) · Leverage M (hi/qu/tr/id) · Confidence M · Risk M · Unblocks: no.**
+- **Verdict:** medium; overlaps S6 (hi) and the qu tokenizer arc.
+
+### S5 — zh compound-collapse conditionals (overlaps S2 root)
+
+- **Cells (~4):** if-condition (zh), if-exists (zh), if-matches (zh, tr).
+- **Mechanism:** zh whole event body → single `compound`, bypassing the
+  conditional fold (the same root as S2's zh share). tr if-matches is a separate
+  then-branch issue.
+- **Verdict:** **fold into S2** — fixing the zh compound-collapse clears these too.
+  Not a separate arc; listed so the cells are accounted for.
+
+### S4 — SOV verb-final put
+
+- **Cells (2):** put-content-basic (ja, qu). `"Done!" を 私 に 置く クリック で` —
+  SOV verb-final put with a trailing event phrase; no wrapper covers that order.
+- **Yield L (2) · Leverage L · Confidence M · Risk M.**
+- **Verdict:** small; do opportunistically when in the SOV event-wrapper code.
+
+### qu particle-tokenizer (overlaps Task #10)
+
+- **Cells (qu is in 6):** modal-close-backdrop, modal-close-button, modal-open,
+  put-content-basic, set-attribute, make-toast.
+- **Mechanism:** qu accusative-particle over-stripping — `punta` (target) →
+  `pun`+`ta` (the `ta` particle); plus the body-word/`_` issues.
+- **Layer:** qu tokenizer (particle logic). **Best folded into Task #10's
+  tokenizer work** (same layer, same language).
+- **Yield M (some of qu's 6) · Leverage L (qu) · Confidence M · Risk M (qu finicky).**
+- **Verdict:** address inside Task #10.
+
+### Per-language tails (batch opportunistically)
+
+- it modal-close-button (body captured as DESTINATION not source — role-mislabel),
+  th accordion-exclusive, qu modal-close-button. ~3 cells, 1 each.
+- **Verdict:** not worth a dedicated arc; fix when already in that language's files.
+
+## Ranked sequence (leverage-first)
+
+1. **(Task #10)** multi-word markers + dict underscore audit — also clears qu
+   tokenizer cells. _Unblocked now; see TASK10_MULTIWORD_MARKER_HANDOFF.md._
+2. **S2** fused-event body routing / compound collapse — biggest shared lever
+   (ms + zh + bn; subsumes S5).
+3. **S6** hi SOV fronting + possessive-dot — highest single-language count.
+4. **S3** SOV `@attr`/`set` role-scramble.
+5. **S4** SOV verb-final put + per-language tails — opportunistic.
+6. **S1** en-reference-lossy tabs-aria — last; high-risk band-inversion, do only
+   with a deliberate re-baseline.
+
+## Stopping rule (carried from §9)
+
+The R2 tail has diminishing returns: a session now clears ~1–2 hard cells at real
+risk, while the same effort on **behaviors** (Track 2) removes a whole category
+(49 degenerate passes). Treat S-arcs as opportunistic between the higher-leverage
+tracks. Re-measure the cluster from the committed baseline before starting any arc
+(`node -e` over `packages/testing-framework/baselines/multilingual-priority.json`
+→ `executionFailures` per language) — it shifts every PR.

--- a/docs-internal/TASK10_MULTIWORD_MARKER_HANDOFF.md
+++ b/docs-internal/TASK10_MULTIWORD_MARKER_HANDOFF.md
@@ -1,0 +1,160 @@
+# Task #10 handoff — multi-word marker keywords → retire compound lists → dict underscore audit
+
+> **Status:** ready to start. Unblocked by #416 (the multi-word keyword
+> tokenization keystone). One coherent arc, 3 phases, each gate-verified and
+> shippable on its own. Start with Phase A (lowest risk, already unblocked).
+
+## Objective
+
+Finish the §7v/§7w "retire the underscore convention" work: make every language
+write its multi-word keywords the **natural** way (real single word, or natural
+spaced phrase), and delete the per-language hardcoded compound lists. This removes
+both an authoring smell (`snake_case` in natural-language code) and a class of
+latent parse bugs (most tokenizers split on the underscore character).
+
+## What #416 already did (your foundation)
+
+The framework base tokenizer now does **profile-driven longest-phrase multi-word
+keyword matching** (`packages/framework/src/core/tokenization/base-tokenizer.ts`):
+
+- `initializeKeywordsFromProfile` builds `multiWordKeywords` = the space-containing
+  `profileKeywords`, **minus** anything whose normalized is in
+  `MARKER_CONCEPT_NORMALIZEDS`.
+- `tokenizeWithExtractors` calls `tryMultiWordKeyword` (after whitespace-skip,
+  before the per-language extractors) — matches the longest multi-word profile
+  keyword at a word boundary, emits ONE keyword token.
+
+So **non-marker** multi-word keywords (verbs, control-flow, event names) already
+tokenize naturally across all languages. The remaining work is the **marker**
+concepts that were deliberately excluded, plus the dict cleanup.
+
+## The blocker (why markers were excluded)
+
+`MARKER_CONCEPT_NORMALIZEDS` excludes into/from/to/with/before/after/over/…
+
+- role names (patient/destination/source/event/eventMarker/…). Reason: the
+  **pattern matcher consumes markers as single tokens** (peek/advance one token,
+  checked by `kind ∈ {particle, keyword, identifier}` and `.value`/`.normalized`
+  — see `packages/semantic/src/parser/pattern-matcher.ts`, e.g. the source-clause
+  matcher ~L228–247 and the generic marker matcher ~L692–707). When the first cut
+  let markers into multi-word matching, two real regressions appeared:
+
+* **id `ke dalam` (into)** — `ke dalam` matched as one `into` keyword token, which
+  **shadowed the single-word `ke` destination marker** the generated put pattern
+  expects (`put {patient} <ke> {dest}`). Put stopped parsing.
+* **ko `할 때` (eventMarker)** — pre-empted the SOV event extraction
+  (`trySOVEventExtraction`), breaking modal-close-backdrop + the #367 work.
+
+**Key distinction to internalize:** there are TWO kinds of marker phrase.
+
+1. **Overlap-conflict** (id `ke dalam`): a single-word marker (`ke`) already
+   exists and the patterns use it; the multi-word _keyword_ form (`ke dalam`=into)
+   is redundant and must NOT shadow it. → keep it out of multi-word matching.
+2. **Genuinely multi-word marker** (hi `से पहले`=before, vi `vào trong`=into):
+   there is NO single-word form; the marker IS the phrase. The pattern matcher
+   must accept the multi-word token here. → needs the Phase-B fix.
+
+Longest-first matching already disambiguates the two readings at the _token_
+level (`से पहले`→before only when ` पहले` follows; else `से`→from). The gap is
+purely on the _pattern-matcher_ side accepting a multi-word marker token.
+
+## Phases
+
+### Phase A — non-marker underscore audit (UNBLOCKED NOW, lowest risk)
+
+Many dict `_` forms are NOT markers (events, verbs, compounds) and #416 already
+makes their natural spaced forms tokenize. Migrate them now:
+
+1. Enumerate every `_`-joined value in `packages/i18n/src/dictionaries/*.ts`
+   whose normalized concept is **not** in `MARKER_CONCEPT_NORMALIZEDS`
+   (e.g. hi events `डबल_क्लिक`, `माउस_नीचे`; any `X_Y` verb/event/compound).
+2. For each, confirm the natural spaced form tokenizes to the right keyword
+   (probe: `getTokenizer(lang).tokenize('X Y').tokens`), then change `X_Y`→`X Y`
+   in the dict.
+3. Per-language, gate-verify (no regression) and migrate in small batches.
+   These are pure naturalness fixes (should be ~zero metric change), but some may
+   be **latent bugs** (a `_` form that never tokenized → the corpus silently used
+   a fallback); those will show as fidelity _improvements_.
+
+> Triage within Phase A: prioritize forms that appear in the **gate corpus**
+> (they affect real parses) over decorative ones. Use the lexicon-emit-mismatch
+> auditor (`packages/semantic/test/lexicon-emit-mismatch.test.ts`) and a corpus
+> grep over `patterns.db` (`SELECT language, hyperscript FROM pattern_translations
+WHERE INSTR(hyperscript, char(95)) > 0` — `char(95)` is the underscore) to find
+> the live ones.
+
+### Phase B — multi-word marker support in the pattern matcher (the keystone)
+
+Make the marker-matching paths accept a multi-word marker **token** (the base
+tokenizer already emits one if the marker is in `multiWordKeywords`). Two sub-steps:
+
+1. **Decide the inclusion rule.** Remove from `MARKER_CONCEPT_NORMALIZEDS` only
+   the concepts that are **genuinely multi-word with no single-word conflict** in
+   the languages that need them (start with `before`/`after`/`until`, which are
+   put-position modifiers, not destination markers). KEEP `into`/`from`/`to`/
+   `destination`/`eventMarker` excluded for now (the id/ko overlap class) — or fix
+   those via the marker matcher (below) before removing them.
+2. **Teach the pattern matcher to accept the multi-word marker token.** The marker
+   matchers compare `marker.normalized ?? marker.value` against the profile's
+   roleMarker `primary`/`alternatives`. If the base tokenizer emits `से पहले` as
+   one `before`-normalized keyword token, the matcher must recognize it where it
+   expects the `before`/position marker. Verify the roleMarker→pattern wiring (the
+   generated patterns in `packages/semantic/src/generators/`) treats the
+   multi-word marker token the same as a single-word one.
+
+> Measure-first: pick ONE genuinely-multi-word marker (hi `से पहले`=before) and
+> drive it end-to-end (tokenize → pattern match → AST) before generalizing. The
+> id `ke dalam` overlap is the hard case — leave `into` excluded unless you
+> explicitly make the put pattern prefer the multi-word marker when present.
+
+### Phase C — retire the hardcoded compound lists
+
+Once A+B cover the phrases, delete:
+
+- the hindi extractor's compound allowlist
+  (`packages/semantic/src/tokenizers/extractors/hindi-keyword.ts`, the
+  `[' के लिए', ' के साथ', …]` array + its space-walking branch);
+- the vietnamese extractor's `multiWordPhrases` (~80 entries)
+  (`packages/semantic/src/tokenizers/extractors/vietnamese-keyword.ts`).
+
+Before deleting each entry, confirm the base mechanism covers it (it must be a
+profile keyword, and either non-marker or handled by Phase B). Gate-verify after
+each list. Watch for entries that are in the hardcoded list but NOT in the profile
+(those would break — add them to the profile first).
+
+## Method (unchanged repo discipline)
+
+- **One mechanism per PR**, measure-first probe before editing, clean A/B on the
+  same DB, lock test + regenerate baseline (`--save-baseline`), `patterns.db`
+  never committed, prettier the baseline.
+- **Gate:** from a cold/changed tree —
+  ```
+  npm run test:multilingual:build-deps
+  npm run populate --prefix packages/patterns-reference
+  cd packages/testing-framework && npx tsx src/multilingual/cli.ts --full --bundle browser-priority --regression
+  ```
+  Then `--save-baseline` (24-language list) after an intentional change; revert
+  `patterns.db`; `npx prettier --write` the baseline before commit.
+- **Also run** framework + semantic + i18n + all 8 domain suites (the base
+  tokenizer is shared — `npm run test:check --prefix packages/<pkg>`).
+
+## Gotchas
+
+- `multiWordKeywords` is **case-sensitive** against the stored native form
+  (mirrors `tryProfileKeyword`); the i18n dicts emit a fixed surface case.
+- Lengths use UTF-16 code units consistently (don't `toLowerCase()` before
+  slicing — German `ß` etc. change length).
+- The base multi-word match runs BEFORE the per-language extractors, so the
+  hardcoded lists are already mostly-dead for non-marker phrases; deleting them is
+  safe only after confirming base coverage.
+- Domains share the framework base tokenizer — they're unaffected today (no
+  marker-eligible multi-word keywords), but re-run their suites after Phase B.
+
+## Definition of done
+
+- The hindi + vietnamese hardcoded compound lists are deleted.
+- No `_`-joined keyword surface form remains in the dicts where a natural form
+  parses (or the residue is documented as genuinely needing `_`).
+- `MARKER_CONCEPT_NORMALIZEDS` is reduced to only the concepts that truly cannot
+  be multi-word-matched (documented why).
+- Gate green; all package suites green; lock tests added.


### PR DESCRIPTION
Two durable handoffs for the post-#416 work (docs only, no code change):

- **`TASK10_MULTIWORD_MARKER_HANDOFF.md`** — self-contained, actionable prompt for the multi-word marker arc (unblocked by the #416 keystone). 3 phases: (A) non-marker underscore audit [unblocked now], (B) multi-word marker support in the pattern matcher [the blocker — markers are consumed as single tokens; the `id ke dalam` / `ko 할 때` overlap class explained], (C) retire the hindi/vi hardcoded compound lists. Includes gate/build commands, file paths, method, and gotchas.

- **`STRUCTURAL_ARCS_ROADMAP.md`** — maps every remaining R2 execution cell (32 at HEAD) to a structural arc, with a triage rubric (yield · leverage · confidence · risk · unblocks) and a leverage-first ranking: **S2 fused-routing > S6 hi > S3 SOV-attr > S4/tails > S1 en-lossy** (deferred, high-risk band-inversion). qu particle-tokenizer folds into Task #10.

- **§11** in `CORRECTNESS_RELIABILITY_PLAN.md` points to both + frames behaviors (Track 2, 49 of 63 degenerate passes) as the next big track after Task #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)