### PR TITLE
fix(semantic): S6 hi SOV fronting — set-family + verb-medial put (25→19, hi 8→2)

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -1653,19 +1653,58 @@ tr ×3, ja ×2, bn/id/it/ko/th/uk ×1. The make-toast survivors (hi/qu/uk) are e
 a SEPARATE arc — hi SOV, qu tokenizer, uk string-truncation. See
 STRUCTURAL_ARCS_ROADMAP.md for the leverage-first continuation (S6 next).
 
+## 7y. Status update (2026-06-13, session 23 cont.): S6 hi 6/8 (25→19)
+
+**S6 (hi, the worst language) cleared 6 of its 8 cells in two zero-regression
+waves — the "per-language grind" had two clean shared sub-levers, not eight
+separate fixes.**
+
+| wave | mechanism                                                      | cleared                                            |
+| ---- | -------------------------------------------------------------- | -------------------------------------------------- |
+| 1    | set schema markerOverride.hi {destination:`को`, patient:`में`} | set-text, set-inner-html, set-style, set-attribute |
+| 2    | `put-hi-verb-medial` (`{patient} को रखें {destination} में`)   | make-element, make-toast-element                   |
+
+- **Wave 1 (set-family):** hi fronts set's TARGET to position 0
+  (`मेरा.textContent को क्लिक पर सेट "Done!" में`); the transformer marks target
+  with को and value with में — INVERTED from the hi profile defaults — but the set
+  schema had no `hi` markerOverride, so the generated hi set patterns carried the
+  swapped markers, matched no corpus, and the set-family fell to `event-hi-bare`
+  (capturing the fronted target as the EVENT). One marker pair → the existing
+  `set-event-hi-sov-2role-dest-first` pattern matches.
+- **Wave 2 (make-element/make-toast):** the transformer emits put VERB-MEDIAL in
+  fused-body then-clauses (`… बनाएं फिर यह को रखें #container में`); no hi put
+  pattern covered it, so it fell to `put-hi-bare` and grabbed the destination as
+  the patient. Added the verb-medial pattern (closes the S3 hi put role-swap share).
+- **Result:** execution **25 → 19**; meanExecutionFidelity **0.9649 → 0.9734**.
+  Both waves parse-clean (no fidelity flips); gate green; baseline regenerated; 5
+  lock tests added. Semantic 5942 green.
+- **Probed + reverted (NOT shipped) — halt-propagation:** the leaked English
+  article `the` (`the घटना`, fronted to position 0) is grabbed as the event. A
+  general leading-`the` strip fixes hi but **regresses tr/form-submit-prevent 4
+  actions → 1** — tr's leaked leading `the olay` is load-bearing for a fragile
+  halt+call+if body parse (its faithful-with-`the` parse was an action-set
+  accident — the §7j pattern). Within-tolerance, but a real per-pattern
+  regression, so reverted. Needs a hi-scoped strip or tr-body hardening.
+
+**Cluster after S6 (19 cells):** qu ×6 (qu tokenizer — largest single cluster),
+tabs-aria ×5 (bn/hi/ja/ko/tr → S1), tr ×2, id/it/ja/th/uk ×1, hi halt-propagation
+×1. hi 8→2; zh ×0; ms ×0.
+
 ## 11. Next-arc handoffs (post-#416)
 
-The cheap dict/profile-alignment wins are exhausted (R2 execution: 25 cells after
-S2, parse ship line held). The next work is decomposed into focused handoffs:
+The cheap dict/profile-alignment wins are exhausted (R2 execution: 19 cells after
+S2+S6, parse ship line held). The next work is decomposed into focused handoffs:
 
 - ✅ **Task #10 — multi-word markers + dict underscore audit:** DONE (#417).
 - ✅ **S2 — fused-event body routing / compound collapse:** DONE (session 23, §7x;
   32→25). zh + ms fully clear.
+- ◑ **S6 — hi SOV fronting:** 6/8 DONE (session 23, §7y; 25→19; hi 8→2). Remaining
+  hi: halt-propagation (blocked — leaked-`the` regresses tr), tabs-aria (S1).
 - **Per-language structural arcs (the R2 tail):**
   [STRUCTURAL_ARCS_ROADMAP.md](STRUCTURAL_ARCS_ROADMAP.md). Every remaining R2 cell
   mapped to an arc, with a triage rubric (yield · leverage · confidence · risk ·
-  unblocks) and a leverage-first ranking (~~S2 fused-routing~~ > **S6 hi (next)** >
-  S3 SOV-attr > S4/tails > S1 en-lossy). Opportunistic — lower ROI than behaviors.
+  unblocks) and a leverage-first ranking (~~S2~~ > ~~S6 (6/8)~~ > **qu tokenizer
+  (×6, next)** > S3/S4/tails > S1 en-lossy). Opportunistic — lower ROI than behaviors.
 - **Track 2 — behaviors (next big track):** 49 of the 63 degenerate passes are
   `behavior-*` (draggable/resizable/sortable ×15 each + removable ×4 +
   install-behavior ×3). This is a **runtime** effort (block-structure parsing +

--- a/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
+++ b/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
@@ -9,7 +9,14 @@
 > in the clause splitter (zh make-toast), and the at-end-connective-as-possessive
 > bug (ms make-toast). avgExecutionFidelity 0.9551 → 0.9649. The make-toast
 > survivors (hi/qu/uk) belong to **other** arcs (S6 SOV, qu tokenizer, uk
-> string-truncation), not S2. Next leverage-first target: **S6 (hi)**.
+> string-truncation), not S2.
+>
+> **Progress (S6 6/8 — 25 → 19):** S6 (hi) then cleared **6 of its 8 cells** in two
+> zero-regression waves — the set-family (set-text/inner-html/style/attribute) via a
+> set markerOverride.hi alignment, and make-element/make-toast via a verb-medial hi
+> put pattern. hi 8→2; only halt-propagation (blocked — leaked-`the` strip regresses
+> tr) and tabs-aria (S1) remain. **Session total: 13 cells, 32 → 19.** Next: qu
+> tokenizer (×6) or the deferred S3/S1 families.
 
 > **Scope:** the **32 remaining R2 execution-failing cells** after the cheap
 > dict/profile-alignment wins were exhausted (waves 12–16 + the multi-word
@@ -77,9 +84,27 @@ Score each arc on five axes (H/M/L), then rank by leverage-adjusted value.
   semantic-only, parse-level byte-identical, each gate-verified + baselined +
   lock-tested. See CORRECTNESS_RELIABILITY_PLAN.md §7x.
 
-### S6 — hi worst-language SOV fronting + possessive-dot ★ highest single-lang count
+### S6 — hi worst-language SOV fronting + possessive-dot ◑ 6/8 DONE (waves 1–2)
 
-- **Cells (hi is in 8 total):** set-inner-html-possessive-dot, set-text-possessive-dot,
+- **Cleared (6):** set-text/set-inner-html/set-style/set-attribute (wave 1 — the
+  set schema gained markerOverride.hi {destination:`को`, patient:`में`}, which the
+  transformer emits inverted from the hi profile defaults; the existing
+  `set-event-hi-sov-2role-dest-first` pattern then matched). make-element +
+  make-toast (wave 2 — added `put-hi-verb-medial` `{patient} को रखें {destination}
+में`; the transformer emits put VERB-MEDIAL in fused-body then-clauses, which had
+  fallen to `put-hi-bare` and grabbed the destination as the patient). Execution
+  32→19 over the session (S2 + these); both waves zero-regression, baselined, lock-
+  tested. See §7y.
+- **Remaining (2), both DEFERRED:**
+  - **halt-propagation** — needs the leaked English article `the` (`the घटना` =
+    "the event", fronted to position 0) removed so `halt-event-hi-sov-patient-first`
+    matches. A general leading-`the` strip WORKS for hi but **regresses
+    tr/form-submit-prevent 4 actions → 1** (its leaked leading `the olay` is
+    load-bearing for a fragile halt+call+if body parse). Needs either a hi-scoped
+    strip (smell) or hardening tr's body parse first. Probed + reverted, not shipped.
+  - **tabs-aria** — S1 (en-reference-lossy `set @attr … on <scope>`); high-risk
+    band-inversion, do with a deliberate re-baseline.
+- **Original cell list (hi in 8):** set-inner-html-possessive-dot, set-text-possessive-dot,
   set-style, set-attribute, halt-propagation, make-element, make-toast, tabs-aria.
 - **Mechanism (re-probed session 23, NOT a single lever):** the hi transformer
   fronts the patient/target to position 0, BEFORE the event: `<role> को क्लिक पर
@@ -166,16 +191,19 @@ on .tab set … on me` drops the `on <scope>` modifier even in English (two sets
 1. ✅ **(Task #10)** multi-word markers + dict underscore audit — DONE (#417).
 2. ✅ **S2** fused-event body routing / compound collapse — **DONE** (5 waves,
    32→25; zh+ms fully clear; subsumes S5). See §7x.
-3. **S6** hi SOV fronting + possessive-dot — highest single-language count (hi ×8).
-   **← next.**
-4. **S3** SOV `@attr`/`set` role-scramble.
-5. **S4** SOV verb-final put + per-language tails — opportunistic.
-6. **S1** en-reference-lossy tabs-aria — last; high-risk band-inversion, do only
-   with a deliberate re-baseline.
+3. ◑ **S6** hi SOV fronting + possessive-dot — **6/8 DONE** (2 waves, 25→19; hi
+   8→2). See §7y. Remaining hi: halt (blocked), tabs-aria (S1).
+4. **S3** SOV `@attr`/`set` role-scramble — partly absorbed by S6 wave 2 (hi
+   make-element/make-toast put role-swap). Remaining: tr/qu/id set-attribute/set-style.
+5. **qu tokenizer** (×6) — now the single largest remaining language cluster.
+6. **S4** SOV verb-final put + per-language tails — opportunistic.
+7. **S1** en-reference-lossy tabs-aria (×5: bn/hi/ja/ko/tr) — last; high-risk
+   band-inversion, do only with a deliberate re-baseline.
 
-**Cluster snapshot after S2 (25 cells):** hi ×8 (S6), qu ×6 (qu tokenizer),
-tr ×3 (set-attribute, tabs-aria, if-matches), ja ×2 (put-content-basic, tabs-aria),
-bn/id/it/ko/th/uk ×1. zh ×0, ms ×0.
+**Cluster snapshot after S6 (19 cells):** qu ×6 (qu tokenizer), tabs-aria ×5
+(bn/hi/ja/ko/tr → S1), tr ×2 (if-matches, set-attribute), id set-style, it
+modal-close-button, ja put-content-basic, th accordion-exclusive, uk make-toast,
+hi halt-propagation. zh ×0, ms ×0; hi ×2 (down from 8).
 
 ## Stopping rule (carried from §9)
 

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -497,6 +497,13 @@ export const setSchema: CommandSchema = {
         tl: '', // "itakda x sa 10" - no marker before variable
         bn: 'কে', // "x কে 10 তে সেট" - patient marker on variable
         qu: 'ta', // "x ta 10 man churay" - patient marker on variable
+        // hi: the transformer marks the TARGET with को and the VALUE with में
+        // (`मेरा.textContent को … सेट "Done!" में`) — inverted from the hi profile
+        // defaults (destination=में, patient=को). Without these overrides the
+        // generated hi set patterns carried the swapped markers and matched no
+        // corpus, so the whole hi set-family (set-text/inner-html/style/attribute)
+        // fell to the bare-event fallback (S6 set-trio).
+        hi: 'को', // target (destination) gets को
       },
     },
     {
@@ -526,6 +533,7 @@ export const setSchema: CommandSchema = {
         tl: 'sa', // "itakda x sa 10" - destination prep before value
         bn: 'তে', // "x কে 10 তে সেট" - destination marker on value
         qu: 'man', // "x ta 10 man churay" - destination marker on value
+        hi: 'में', // value (patient) gets में — see the destination note above
       },
     },
   ],

--- a/packages/semantic/src/patterns/put.ts
+++ b/packages/semantic/src/patterns/put.ts
@@ -234,6 +234,36 @@ function getPutPatternsEs(): LanguagePattern[] {
 
 function getPutPatternsHi(): LanguagePattern[] {
   return [
+    // Verb-MEDIAL pattern: यह को रखें #container में (`{patient} को रखें
+    // {destination} में`). The hi transformer emits put VERB-MEDIAL in a fused
+    // event body's then-clause (`… बनाएं फिर यह को रखें #container में` —
+    // make-element / make-toast first put), with रखें BETWEEN the patient and the
+    // destination, unlike the standalone verb-FINAL `put-hi-full` below. Without
+    // this the clause fell through to `put-hi-bare` (`रखें {patient}`), which
+    // grabbed the DESTINATION (#container) as the patient and defaulted the
+    // destination to `me` — the put landed on the clicked element. Priority above
+    // put-hi-full; only matches when रखें is medial, so the verb-final form is
+    // untouched.
+    {
+      id: 'put-hi-verb-medial',
+      language: 'hi',
+      command: 'put',
+      priority: 105,
+      template: {
+        format: '{patient} को रखें {destination} में',
+        tokens: [
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: 'को' },
+          { type: 'literal', value: 'रखें', alternatives: ['रख', 'डालें', 'डाल'] },
+          { type: 'role', role: 'destination' },
+          { type: 'literal', value: 'में' },
+        ],
+      },
+      extraction: {
+        patient: { position: 0 },
+        destination: { marker: 'में', position: 3 },
+      },
+    },
     // Full pattern: "text" को #element में रखें
     {
       id: 'put-hi-full',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -6010,3 +6010,38 @@ describe('hi set-family marker alignment (S6 — fronted target before event)', 
     expect(cmd?.roles?.get('patient')?.value).toBe('true');
   });
 });
+
+describe('hi verb-medial put in fused event bodies (S6 — make-element/make-toast)', () => {
+  // The hi transformer emits put VERB-MEDIAL inside a fused event body's
+  // then-clause: `… बनाएं फिर यह को रखें #container में` — रखें sits BETWEEN the
+  // patient and the destination, unlike the standalone verb-FINAL
+  // `{patient} को {destination} में रखें`. No hi put pattern covered that order, so
+  // the clause fell to `put-hi-bare` (`रखें {patient}`), which grabbed the
+  // DESTINATION (#container) as the patient and defaulted the destination to `me`.
+  // Adding `put-hi-verb-medial` (`{patient} को रखें {destination} में`) restores
+  // the roles. Cleared hi make-element + make-toast (execution 21→19).
+  const bodyOf = (code: string) => {
+    const n = parse(code, 'hi') as {
+      body?: Array<{ action?: string; roles?: Map<string, { type?: string; value?: unknown }> }>;
+    };
+    return n.body ?? [];
+  };
+
+  it('[hi] make-element: put it→#container (was patient=#container, dest=me)', () => {
+    const body = bodyOf('a <div.card/> को क्लिक पर बनाएं फिर यह को रखें #container में');
+    expect(body.map(c => c.action)).toEqual(['make', 'put']);
+    const put = body[1];
+    expect(put?.roles?.get('patient')).toMatchObject({ type: 'reference', value: 'it' });
+    expect(put?.roles?.get('destination')).toMatchObject({ type: 'selector', value: '#container' });
+  });
+
+  it('[hi] make-toast: make + put(Saved!→it) + put(it→body, at end of)', () => {
+    const body = bodyOf(
+      "a <div.toast/> को क्लिक पर बनाएं फिर 'Saved!' को रखें यह में फिर यह पर समाप्त का बॉडी को रखें"
+    );
+    expect(body.map(c => c.action)).toEqual(['make', 'put', 'put']);
+    expect(body[1]?.roles?.get('patient')).toMatchObject({ type: 'literal', value: 'Saved!' });
+    expect(body[1]?.roles?.get('destination')).toMatchObject({ type: 'reference', value: 'it' });
+    expect(body[2]?.roles?.get('manner')).toMatchObject({ value: 'at end of' });
+  });
+});

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -5971,3 +5971,42 @@ describe('per-language `at end of` position noun (S2 — zh make-toast)', () => 
     expect(n.roles?.get('manner')).toMatchObject({ value: 'at end of' });
   });
 });
+
+describe('hi set-family marker alignment (S6 — fronted target before event)', () => {
+  // hi fronts set's TARGET before the event: `मेरा.textContent को क्लिक पर सेट
+  // "Done!" में`. The transformer marks the target with को and the value with में
+  // — INVERTED from the hi profile defaults (destination=में, patient=को) — but the
+  // set schema had no `hi` markerOverride, so the generated hi set patterns carried
+  // the swapped markers, matched no corpus, and the whole set-family fell to the
+  // `event-hi-bare` fallback (which captured the fronted target as the EVENT).
+  // Adding markerOverride.hi = {destination:'को', patient:'में'} lets the existing
+  // `set-event-hi-sov-2role-dest-first` pattern match. Cleared hi set-text,
+  // set-inner-html, set-style, set-attribute (execution 25→21).
+  const setBody = (code: string) => {
+    const n = parse(code, 'hi') as { body?: Array<{ action?: string; roles?: Map<string, { type?: string; value?: unknown; object?: unknown; property?: unknown }> }> };
+    return (n.body ?? [])[0];
+  };
+
+  it('[hi] set-text: destination=me.textContent property-path, patient="Done!"', () => {
+    const cmd = setBody('मेरा.textContent को क्लिक पर सेट "Done!" में');
+    expect(cmd?.action).toBe('set');
+    expect(cmd?.roles?.get('destination')).toMatchObject({ type: 'property-path', property: 'textContent' });
+    expect(cmd?.roles?.get('patient')).toMatchObject({ type: 'literal', value: 'Done!' });
+  });
+
+  it('[hi] set-style: destination=me.*background property-path, patient="red"', () => {
+    const cmd = setBody('मेरा *background को क्लिक पर सेट "red" में');
+    expect(cmd?.action).toBe('set');
+    expect(cmd?.roles?.get('destination')).toMatchObject({ type: 'property-path' });
+    expect(cmd?.roles?.get('patient')).toMatchObject({ type: 'literal', value: 'red' });
+  });
+
+  it('[hi] set-attribute: destination=@disabled, patient=true', () => {
+    const cmd = setBody('@disabled को क्लिक पर सेट सच में') as
+      | { action?: string; roles?: Map<string, { raw?: string; value?: unknown }> }
+      | undefined;
+    expect(cmd?.action).toBe('set');
+    expect(cmd?.roles?.get('destination')?.raw).toBe('@disabled');
+    expect(cmd?.roles?.get('patient')?.value).toBe('true');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T21:12:51.714Z",
-  "commit": "cb9b96cd",
+  "timestamp": "2026-06-13T21:36:25.830Z",
+  "commit": "7257b2fd",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -13,7 +13,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["repeat-until-event", "window-scroll"],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -643,7 +643,7 @@
       "executionFailures": ["tabs-aria"],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1274,7 +1274,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1898,7 +1898,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2529,7 +2529,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3159,7 +3159,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3803,7 +3803,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4428,18 +4428,9 @@
       "parseRate": 1,
       "avgConfidence": 0.9560915275200976,
       "avgFidelity": 0.928030303030303,
-      "avgRoleFidelity": 0.5975707850707852,
-      "avgExecutionFidelity": 0.7419354838709677,
-      "executionFailures": [
-        "halt-propagation",
-        "make-element",
-        "make-toast-element",
-        "set-attribute",
-        "set-inner-html-possessive-dot",
-        "set-style",
-        "set-text-possessive-dot",
-        "tabs-aria"
-      ],
+      "avgRoleFidelity": 0.6570945945945947,
+      "avgExecutionFidelity": 0.8709677419354839,
+      "executionFailures": ["halt-propagation", "make-element", "make-toast-element", "tabs-aria"],
       "degeneratePasses": [
         "bind-auto-detect",
         "bind-explicit-property",
@@ -4460,7 +4451,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5097,7 +5088,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5727,7 +5718,7 @@
       "executionFailures": ["modal-close-button"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6374,7 +6365,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7017,7 +7008,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7648,7 +7639,7 @@
       "executionFailures": [],
       "degeneratePasses": ["socket-basic"],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8275,7 +8266,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8905,7 +8896,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9552,7 +9543,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10183,7 +10174,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10814,7 +10805,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "repeat-until-event", "set-color-variable"],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11441,7 +11432,7 @@
       "executionFailures": ["accordion-exclusive"],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12072,7 +12063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["window-scroll"],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12709,7 +12700,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13339,7 +13330,7 @@
       "executionFailures": ["make-toast-element"],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13976,7 +13967,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14615,7 +14606,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 424972,
+      "bundleSize": 425014,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15237,7 +15228,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 424972,
+      "size": 425014,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T21:36:25.830Z",
-  "commit": "7257b2fd",
+  "timestamp": "2026-06-13T21:51:47.049Z",
+  "commit": "ded81618",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -13,7 +13,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["repeat-until-event", "window-scroll"],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -643,7 +643,7 @@
       "executionFailures": ["tabs-aria"],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1274,7 +1274,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1898,7 +1898,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2529,7 +2529,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3159,7 +3159,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3803,7 +3803,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4428,9 +4428,9 @@
       "parseRate": 1,
       "avgConfidence": 0.9560915275200976,
       "avgFidelity": 0.928030303030303,
-      "avgRoleFidelity": 0.6570945945945947,
-      "avgExecutionFidelity": 0.8709677419354839,
-      "executionFailures": ["halt-propagation", "make-element", "make-toast-element", "tabs-aria"],
+      "avgRoleFidelity": 0.6876126126126128,
+      "avgExecutionFidelity": 0.9354838709677419,
+      "executionFailures": ["halt-propagation", "tabs-aria"],
       "degeneratePasses": [
         "bind-auto-detect",
         "bind-explicit-property",
@@ -4451,7 +4451,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5088,7 +5088,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5718,7 +5718,7 @@
       "executionFailures": ["modal-close-button"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6365,7 +6365,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7008,7 +7008,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7639,7 +7639,7 @@
       "executionFailures": [],
       "degeneratePasses": ["socket-basic"],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8266,7 +8266,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8896,7 +8896,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9543,7 +9543,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10174,7 +10174,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10805,7 +10805,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "repeat-until-event", "set-color-variable"],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11432,7 +11432,7 @@
       "executionFailures": ["accordion-exclusive"],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12063,7 +12063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["window-scroll"],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12700,7 +12700,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13330,7 +13330,7 @@
       "executionFailures": ["make-toast-element"],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13967,7 +13967,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14606,7 +14606,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 425014,
+      "bundleSize": 425556,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15228,7 +15228,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 425014,
+      "size": 425556,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## S6 arc — hi worst-language SOV fronting (6 of 8 cells)

Continues `docs-internal/STRUCTURAL_ARCS_ROADMAP.md` into **S6 (hi)**, the worst language. The roadmap flagged S6 as a "per-language grind," but measure-first found **two clean shared sub-levers** that clear **6 of hi's 8 cells** with zero regressions — dropping the cluster **25 → 19** (`avgExecutionFidelity` 0.9649 → 0.9734) and taking hi from **8 failing cells to 2**.

| Wave | Mechanism | Cleared |
|---|---|---|
| 1 | set schema `markerOverride.hi` = {destination:`को`, patient:`में`} | set-text, set-inner-html, set-style, set-attribute |
| 2 | `put-hi-verb-medial` pattern (`{patient} को रखें {destination} में`) | make-element, make-toast-element |

### Wave 1 — set-family marker alignment
hi fronts set's **target** to position 0 (`मेरा.textContent को क्लिक पर सेट "Done!" में`). The transformer marks the target with `को` and the value with `में` — **inverted** from the hi profile defaults (destination=`में`, patient=`को`) — but the set schema had no `hi` markerOverride, so the generated hi set patterns carried swapped markers, matched no corpus, and the whole set-family fell to the `event-hi-bare` fallback (which captured the fronted target as the **event**). One marker pair lets the existing `set-event-hi-sov-2role-dest-first` pattern match, with the fronted possessive-dot / `*style` / `@attr` target captured as the destination.

### Wave 2 — verb-medial put
The transformer emits put **verb-medial** in fused-event-body then-clauses (`… बनाएं फिर यह को रखें #container में` — रखें between patient and destination). No hi put pattern covered it, so the clause fell to `put-hi-bare` and grabbed the **destination** (`#container`) as the patient. The new pattern restores the roles; make-toast's verb-final SOV at-end put was already handled by `PUT_AT_END`. (Also closes the S3 hi put role-swap share.)

### Correctness / safety
- Both waves **parse-clean** (no fidelity flips); all four gate ratchets held; baseline regenerated per wave.
- **5 lock tests** added; semantic suite green (5942).
- No hi set/put parsed correctly before, so these can only help.

### Deferred (documented in §7y, not in this PR)
- **halt-propagation** — needs the leaked English article `the` (`the घटना`, fronted to position 0) removed, but a general leading-`the` strip **regresses tr/form-submit-prevent 4 actions → 1** (tr's leaked `the olay` is load-bearing for a fragile halt+call+if parse). Probed and **reverted** rather than shipped; needs a hi-scoped strip or tr-body hardening.
- **tabs-aria** — S1 (en-reference-lossy); high-risk band-inversion.

### Notes
- **Base:** stacked on `feat/s2-fused-event-body-routing` (#418); merge that first.
- `patterns.db` intentionally not committed (CI re-populates it).
- Cluster after S6 (19): qu ×6 (qu tokenizer — now the largest), tabs-aria ×5 (S1), tr ×2, id/it/ja/th/uk ×1, hi halt-propagation ×1. zh ×0, ms ×0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)