### PR TITLE
fix(semantic): qu tokenizer arc — reference alignment + make-toast (19→13, qu 6→0)

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -1690,16 +1690,58 @@ separate fixes.**
 tabs-aria ×5 (bn/hi/ja/ko/tr → S1), tr ×2, id/it/ja/th/uk ×1, hi halt-propagation
 ×1. hi 8→2; zh ×0; ms ×0.
 
+## 7z. Status update (2026-06-13, session 23 cont.): qu tokenizer arc DONE (19→13)
+
+**The qu tokenizer arc cleared all 6 qu cells in 3 waves — and the roadmap's
+"accusative-particle over-stripping" diagnosis was wrong: it was an unknown-word
+artifact, not a particle-logic bug.**
+
+| wave | mechanism                                                          | cleared                                                                 |
+| ---- | ------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| 1    | reference alignment to dict forms (me/it/target/body)              | modal-open, modal-close-button, modal-close-backdrop, put-content-basic |
+| 2    | `cheqaq`→true in the tokenizer EXTRAS                              | set-attribute                                                           |
+| 3    | single-quote strings + fused-body at-end guard + PUT_AT_END wiring | make-toast-element                                                      |
+
+- **Wave 1 (the big lever, 4 cells):** the qu semantic profile carried formal
+  spellings — me=`ñuqa`, target=`ñawpaqman`, body=`ukhu`, it=`pay` — that appear in
+  ZERO corpus rows; the i18n dict emits noqa/punta/kurku/chay. So the put
+  destination, the matches-condition target, and the DOM body never resolved.
+  Crucially, `punta` (target) was being SPLIT into `pun`+`ta`-accusative ONLY
+  because it wasn't a known word — once it's the profile's `target` reference it
+  tokenizes whole. The §10/§7n "qu accusative over-stripping" was a phantom (no
+  particle-logic change needed) — the §7l reference-alignment idiom did it all.
+- **Wave 2:** the tokenizer mapped only arí/ari ("yes") to `true`; the dict emits
+  `cheqaq` ("correct"). `set @disabled to <undefined>` → `to true`.
+- **Wave 3 (3 sub-fixes for 1 cell):** (a) the qu string extractor rejected single
+  quotes (to dodge the glottalization apostrophe `ch'usaq`) so `'Saved!'` broke —
+  accept `'` (safe: those apostrophes are always mid-word, and the extractor only
+  runs at a token start); (b) the fused make-event body routes through
+  parseBodyWithGrammarPatterns, whose `end`-break lacked the S2 `isAtEndPositionNoun`
+  guard, so `tukuy` (end) chopped the attaching put — guard mirrored; (c)
+  `case 'qu'` didn't spread `...atEnd`, so PUT_AT_END never generated
+  `put-qu-at-end`. The `pi` event-marker/at-marker collision was a red herring once
+  the at-end pattern (priority 110) existed.
+- **Result:** execution **19 → 13**; meanExecutionFidelity up. All waves
+  semantic-only, zero regressions / fidelity flips; gate green; baseline
+  regenerated; 7 lock tests added. Semantic 5949 green. The shared
+  parseBodyWithGrammarPatterns guard is gated to a language's exact PUT_AT_END
+  at/of words, so non-qu bodies are byte-identical.
+
+**Cluster after qu (13 cells):** tabs-aria ×5 (bn/hi/ja/ko/tr → S1 en-reference-
+lossy), tr ×2 (if-matches, set-attribute), id/it/ja/th/uk ×1, hi halt-propagation
+×1. zh ×0, ms ×0, qu ×0; hi ×2. Session 23 total: **32 → 13 (19 cells, 4 arcs).**
+
 ## 11. Next-arc handoffs (post-#416)
 
-The cheap dict/profile-alignment wins are exhausted (R2 execution: 19 cells after
-S2+S6, parse ship line held). The next work is decomposed into focused handoffs:
+The cheap dict/profile-alignment wins are exhausted (R2 execution: 13 cells after
+S2+S6+qu, parse ship line held). The next work is decomposed into focused handoffs:
 
 - ✅ **Task #10 — multi-word markers + dict underscore audit:** DONE (#417).
 - ✅ **S2 — fused-event body routing / compound collapse:** DONE (session 23, §7x;
   32→25). zh + ms fully clear.
 - ◑ **S6 — hi SOV fronting:** 6/8 DONE (session 23, §7y; 25→19; hi 8→2). Remaining
   hi: halt-propagation (blocked — leaked-`the` regresses tr), tabs-aria (S1).
+- ✅ **qu tokenizer arc:** DONE (session 23, §7z; 19→13; qu 6→0).
 - **Per-language structural arcs (the R2 tail):**
   [STRUCTURAL_ARCS_ROADMAP.md](STRUCTURAL_ARCS_ROADMAP.md). Every remaining R2 cell
   mapped to an arc, with a triage rubric (yield · leverage · confidence · risk ·

--- a/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
+++ b/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
@@ -60,7 +60,11 @@ Score each arc on five axes (H/M/L), then rank by leverage-adjusted value.
    tails opportunistically when already in that language's files.
 5. Re-measure the cluster each PR (it shifts); this map is a snapshot at #416.
 
-## The arcs (ranked) — cell map at HEAD `7a0769df`
+## The arcs (ranked) — cell map progressed through session 23
+
+> Original snapshot was HEAD `7a0769df` (#416, 32 cells). Updated through the
+> S2 / S6 / qu arcs — see the per-arc status (✅/◑) and the current cluster
+> snapshot below the ranked sequence (13 cells). Re-measure before any new arc.
 
 ### S2 — fused-event body routing / compound collapse ✅ DONE (5 waves)
 
@@ -151,15 +155,17 @@ on .tab set … on me` drops the `on <scope>` modifier even in English (two sets
   reference change → baseline re-record) · Unblocks: re-qualifies the @attr family.**
 - **Verdict:** defer unless ready for a deliberate band-inversion + full re-baseline.
 
-### S3 — SOV `@attr` / `set` role-scramble
+### S3 — SOV `@attr` / `set` role-scramble ◑ mostly absorbed
 
-- **Cells (~5):** set-attribute (hi, qu, tr), set-style (hi, id).
-- **Mechanism:** SOV reorder fronts `@attr`/possessive; set's attr/value/scope
-  roles scramble. id set-style is the two-word possessive PHRASE (`saya punya
-*background`). hi/tr are SOV fronting.
+- **Remaining (2):** set-attribute (tr), set-style (id). The hi share (set-attribute,
+  set-style) was cleared by **S6 wave 1** (the set markerOverride.hi alignment) and
+  the qu share (set-attribute) by **qu wave 2** (`cheqaq`→true).
+- **Mechanism (remaining):** id set-style is the two-word possessive PHRASE
+  (`saya punya *background`); tr set-attribute is the SOV `@attr` fronting that the
+  hi marker alignment did NOT generalize (tr has its own markers).
 - **Layer:** `semantic-parser.ts` SOV + possessive-phrase matcher.
-- **Yield M (5) · Leverage M (hi/qu/tr/id) · Confidence M · Risk M · Unblocks: no.**
-- **Verdict:** medium; overlaps S6 (hi) and the qu tokenizer arc.
+- **Yield L (2) · Leverage L (id/tr, distinct) · Confidence M · Risk M · Unblocks: no.**
+- **Verdict:** mostly done via S6/qu; the id/tr residue is a 2-cell tail.
 
 ### S5 — zh compound-collapse conditionals (subsumed by S2) ✅ DONE
 
@@ -170,9 +176,11 @@ on .tab set … on me` drops the `on <scope>` modifier even in English (two sets
 
 ### S4 — SOV verb-final put
 
-- **Cells (2):** put-content-basic (ja, qu). `"Done!" を 私 に 置く クリック で` —
+- **Remaining (1):** put-content-basic (ja). `"Done!" を 私 に 置く クリック で` —
   SOV verb-final put with a trailing event phrase; no wrapper covers that order.
-- **Yield L (2) · Leverage L · Confidence M · Risk M.**
+  (The qu share was cleared by **qu wave 1** reference alignment — qu's structure
+  `{patient} ta {dest} man {event} pi {verb}` already parsed once `noqa`→me resolved.)
+- **Yield L (1) · Leverage L · Confidence M · Risk M.**
 - **Verdict:** small; do opportunistically when in the SOV event-wrapper code.
 
 ### qu particle-tokenizer ✅ DONE (3 waves — qu 6→0)

--- a/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
+++ b/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
@@ -15,8 +15,14 @@
 > zero-regression waves — the set-family (set-text/inner-html/style/attribute) via a
 > set markerOverride.hi alignment, and make-element/make-toast via a verb-medial hi
 > put pattern. hi 8→2; only halt-propagation (blocked — leaked-`the` strip regresses
-> tr) and tabs-aria (S1) remain. **Session total: 13 cells, 32 → 19.** Next: qu
-> tokenizer (×6) or the deferred S3/S1 families.
+> tr) and tabs-aria (S1) remain.
+>
+> **Progress (qu DONE — 19 → 13):** the qu tokenizer arc then cleared **all 6 qu
+> cells** in 3 waves — reference alignment to dict forms (4), `cheqaq`→true (1),
+> and make-toast (single-quote strings + fused-body at-end guard + PUT_AT_END
+> wiring) (1). The "accusative over-stripping" was an unknown-word artifact, not a
+> particle bug. **Session total: 19 cells, 32 → 13.** Next: the deferred S1
+> tabs-aria family (×5) or per-language tails.
 
 > **Scope:** the **32 remaining R2 execution-failing cells** after the cheap
 > dict/profile-alignment wins were exhausted (waves 12–16 + the multi-word
@@ -169,21 +175,26 @@ on .tab set … on me` drops the `on <scope>` modifier even in English (two sets
 - **Yield L (2) · Leverage L · Confidence M · Risk M.**
 - **Verdict:** small; do opportunistically when in the SOV event-wrapper code.
 
-### qu particle-tokenizer (overlaps Task #10)
+### qu particle-tokenizer ✅ DONE (3 waves — qu 6→0)
 
-- **Cells (qu is in 6):** modal-close-backdrop, modal-close-button, modal-open,
-  put-content-basic, set-attribute, make-toast.
-- **Mechanism:** qu accusative-particle over-stripping — `punta` (target) →
-  `pun`+`ta` (the `ta` particle); plus the body-word/`_` issues.
-- **Layer:** qu tokenizer (particle logic). **Best folded into Task #10's
-  tokenizer work** (same layer, same language).
-- **Yield M (some of qu's 6) · Leverage L (qu) · Confidence M · Risk M (qu finicky).**
-- **Verdict:** address inside Task #10.
+- **Cleared (6):** modal-open, modal-close-button, modal-close-backdrop,
+  put-content-basic (wave 1 — reference alignment to dict forms); set-attribute
+  (wave 2 — `cheqaq`→true); make-toast (wave 3 — single-quote strings +
+  fused-body at-end guard + PUT_AT_END wiring). Execution 19→13. See §7z.
+- **What it actually was (NOT particle over-stripping):** the roadmap's "accusative
+  over-stripping" (`punta`→`pun`+`ta`) was an UNKNOWN-WORD artifact — the qu profile
+  carried formal spellings (me=ñuqa, target=ñawpaqman, body=ukhu, it=pay) the dict
+  never emits (it emits noqa/punta/kurku/chay). Once `punta` is the profile's
+  `target` reference it tokenizes whole; no particle-logic change was needed. The
+  one genuine tokenizer fix was the string extractor (it rejected single quotes to
+  avoid the glottalization apostrophe, breaking `'Saved!'`).
+- **All semantic-only, zero regressions, baselined, lock-tested.**
 
 ### Per-language tails (batch opportunistically)
 
 - it modal-close-button (body captured as DESTINATION not source — role-mislabel),
-  th accordion-exclusive, qu modal-close-button. ~3 cells, 1 each.
+  th accordion-exclusive. ~2 cells, 1 each. (qu modal-close-button was cleared by
+  the qu arc.)
 - **Verdict:** not worth a dedicated arc; fix when already in that language's files.
 
 ## Ranked sequence (leverage-first)
@@ -193,17 +204,17 @@ on .tab set … on me` drops the `on <scope>` modifier even in English (two sets
    32→25; zh+ms fully clear; subsumes S5). See §7x.
 3. ◑ **S6** hi SOV fronting + possessive-dot — **6/8 DONE** (2 waves, 25→19; hi
    8→2). See §7y. Remaining hi: halt (blocked), tabs-aria (S1).
-4. **S3** SOV `@attr`/`set` role-scramble — partly absorbed by S6 wave 2 (hi
-   make-element/make-toast put role-swap). Remaining: tr/qu/id set-attribute/set-style.
-5. **qu tokenizer** (×6) — now the single largest remaining language cluster.
-6. **S4** SOV verb-final put + per-language tails — opportunistic.
+4. ✅ **qu tokenizer** — **DONE** (3 waves, 19→13; qu 6→0). See §7z.
+5. **S3** SOV `@attr`/`set` role-scramble — mostly absorbed (S6 wave 2 hi put;
+   qu wave 2 set-attribute). Remaining: tr/id set-attribute/set-style.
+6. **S4** SOV verb-final put + per-language tails (it/th) — opportunistic.
 7. **S1** en-reference-lossy tabs-aria (×5: bn/hi/ja/ko/tr) — last; high-risk
    band-inversion, do only with a deliberate re-baseline.
 
-**Cluster snapshot after S6 (19 cells):** qu ×6 (qu tokenizer), tabs-aria ×5
-(bn/hi/ja/ko/tr → S1), tr ×2 (if-matches, set-attribute), id set-style, it
-modal-close-button, ja put-content-basic, th accordion-exclusive, uk make-toast,
-hi halt-propagation. zh ×0, ms ×0; hi ×2 (down from 8).
+**Cluster snapshot after qu (13 cells):** tabs-aria ×5 (bn/hi/ja/ko/tr → S1),
+tr ×2 (if-matches, set-attribute), id set-style, it modal-close-button, ja
+put-content-basic, th accordion-exclusive, uk make-toast, hi halt-propagation.
+zh ×0, ms ×0, qu ×0; hi ×2.
 
 ## Stopping rule (carried from §9)
 

--- a/packages/semantic/src/generators/profiles/quechua.ts
+++ b/packages/semantic/src/generators/profiles/quechua.ts
@@ -21,13 +21,19 @@ export const quechuaProfile: LanguageProfile = {
     subjectDrop: true,
   },
   references: {
-    me: 'ñuqa', // "I/me"
-    it: 'pay', // "it/he/she" (same pronoun)
+    // Aligned to the i18n dict's emitted surface forms (the corpus-canonical
+    // words the parser must recognize — §7l). The dict emits noqa/punta/kurku;
+    // the old ñuqa/ñawpaqman/ukhu appear in ZERO corpus rows, so the put
+    // destination (`noqa man` → me), the matches condition target (`punta`), and
+    // the DOM body (`kurku`, for modal-open/modal-close-button/make-toast) never
+    // resolved.
+    me: 'noqa', // "I/me" (dict form; ñuqa is the formal spelling, unused in corpus)
+    it: 'chay', // dict form for `it` (pay = he/she, not the dict's choice)
     you: 'qam', // "you"
     result: 'rurasqa',
     event: 'ruwakuq',
-    target: 'ñawpaqman',
-    body: 'ukhu',
+    target: 'punta',
+    body: 'kurku',
   },
   possessive: {
     marker: '-pa', // Genitive suffix

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1410,11 +1410,25 @@ export class SemanticParserImpl implements ISemanticParser {
         continue;
       }
 
-      // Check for 'end' keyword - terminates block
+      // Check for 'end' keyword - terminates block. But an `end` keyword that is
+      // the position NOUN of an `at end of` phrase (qu `… pi tukuy pa kurku ta
+      // churay`, where `tukuy` = end) is not a block terminator — the same guard
+      // parseBodyWithClauses applies, now mirrored on this fused-body path so a
+      // make-event's trailing at-end put (make-toast) isn't chopped.
       if (current && this.isEndKeyword(current.value, language)) {
-        flushClause();
-        tokens.advance();
-        break;
+        const prevTok = tokens.peek(-1);
+        const nextTok = tokens.peek(1);
+        const isPositionalEnd = isAtEndPositionNoun(
+          language,
+          current.value,
+          prevTok?.value,
+          nextTok?.value
+        );
+        if (!isPositionalEnd) {
+          flushClause();
+          tokens.advance();
+          break;
+        }
       }
 
       let matched = false;

--- a/packages/semantic/src/patterns/put.ts
+++ b/packages/semantic/src/patterns/put.ts
@@ -1001,6 +1001,19 @@ const PUT_AT_END: ReadonlyArray<{
     end: 'শেষ',
     of: 'র',
   },
+  // qu was excluded from PUT_AT_END (§7n) while body was the unaligned `ukhu`;
+  // now that the qu profile body = `kurku` (qu arc wave 1), add the SOV at-end
+  // entry. Corpus: `chay pi tukuy pa kurku ta churay` = `{patient} pi tukuy pa
+  // {destination} ta churay` (put it at end of body — make-toast's attaching put).
+  {
+    lang: 'qu',
+    verb: 'churay',
+    sov: true,
+    objMarker: 'ta',
+    at: 'pi',
+    end: 'tukuy',
+    of: 'pa',
+  },
 ];
 
 /**
@@ -1161,7 +1174,7 @@ export function getPutPatternsForLanguage(language: string): LanguagePattern[] {
     case 'ru':
       return [...getPutPatternsRu(), ...atEnd];
     case 'qu':
-      return getPutPatternsQu();
+      return [...getPutPatternsQu(), ...atEnd];
     case 'th':
       return [...getPutPatternsTh(), ...atEnd];
     case 'uk':

--- a/packages/semantic/src/tokenizers/quechua.ts
+++ b/packages/semantic/src/tokenizers/quechua.ts
@@ -25,14 +25,20 @@ import type { ValueExtractor, ExtractionResult } from './value-extractor-types';
 
 /**
  * Custom string literal extractor for Quechua.
- * Only accepts double quotes (") to avoid conflicts with apostrophes in words
- * like "ñit'iy" (glottalized sounds).
+ *
+ * Accepts both double (") and single (') quotes. Single quotes are safe here
+ * even though Quechua glottalizes with an apostrophe (`ch'usaq`, `ñit'iy`):
+ * those apostrophes are always MID-word, and this extractor is only consulted at
+ * a token-start position (after whitespace) — no Quechua word *starts* with `'`,
+ * and the word/keyword extractor (registered after this one) consumes the whole
+ * glottalized word before its apostrophe is ever a token boundary. Without single
+ * quotes the corpus `'Saved!'` (make-toast) tokenized as `'Saved` + `!` + `'`.
  */
 class QuechuaStringLiteralExtractor implements ValueExtractor {
   readonly name = 'quechua-string-literal';
 
   canExtract(input: string, position: number): boolean {
-    return input[position] === '"';
+    return input[position] === '"' || input[position] === "'";
   }
 
   extract(input: string, position: number): ExtractionResult | null {

--- a/packages/semantic/src/tokenizers/quechua.ts
+++ b/packages/semantic/src/tokenizers/quechua.ts
@@ -99,6 +99,11 @@ const SUFFIXES = new Set([
  */
 const QUECHUA_EXTRAS: KeywordEntry[] = [
   // Values/Literals
+  // `cheqaq` ("true/correct") is the form the i18n dict emits for `true`
+  // (set-attribute `@disabled ta cheqaq man …`); without it the value tokenized
+  // as a bare identifier and `set @disabled to <undefined>` ran. arí/ari ("yes")
+  // are the colloquial alternates, kept for input tolerance.
+  { native: 'cheqaq', normalized: 'true' },
   { native: 'arí', normalized: 'true' },
   { native: 'ari', normalized: 'true' },
   { native: 'manan', normalized: 'false' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -6045,3 +6045,57 @@ describe('hi verb-medial put in fused event bodies (S6 — make-element/make-toa
     expect(body[2]?.roles?.get('manner')).toMatchObject({ value: 'at end of' });
   });
 });
+
+describe('qu reference alignment to dict surface forms (qu tokenizer arc, wave 1)', () => {
+  // The qu semantic profile carried formal/alternate spellings (me=ñuqa,
+  // target=ñawpaqman, body=ukhu, it=pay) that appear in ZERO corpus rows — the
+  // i18n dict emits noqa/punta/kurku/chay. So the put destination (`noqa man`),
+  // the matches-condition target (`punta` — which the tokenizer then SPLIT into
+  // `pun`+`ta`-accusative because it wasn't a known word), and the DOM body
+  // (`kurku`) never resolved. Aligning references to the dict forms (§7l) fixed
+  // all four — and made `punta` tokenize whole, so the "accusative over-stripping"
+  // was really an unknown-word artifact. Cleared modal-open, modal-close-button,
+  // modal-close-backdrop, put-content-basic (execution 19→15).
+  const firstBody = (code: string) => {
+    const n = parse(code, 'qu') as {
+      body?: Array<{ action?: string; roles?: Map<string, { type?: string; value?: unknown; raw?: string }> }>;
+    };
+    return n.body ?? [];
+  };
+
+  it('[qu] put-content: `noqa man` resolves the destination to me', () => {
+    const put = firstBody('"Done!" ta noqa man ñitiy pi churay').find(c => c.action === 'put');
+    expect(put?.roles?.get('destination')).toMatchObject({ value: 'me' });
+  });
+
+  it('[qu] modal-open: `kurku man` resolves the add destination to body', () => {
+    const add = firstBody('#modal ta ñitiy pi rikuchiy chayqa .modal-open ta kurku man yapay').find(
+      c => c.action === 'add'
+    );
+    expect(add?.roles?.get('destination')).toMatchObject({ value: 'body' });
+  });
+
+  it('[qu] modal-close-button: `kurku manta` resolves the remove source to body', () => {
+    const remove = firstBody(
+      'kaylla .modal ta ñitiy pi pakay chayqa .modal-open ta kurku manta qichuy'
+    ).find(c => c.action === 'remove');
+    expect(remove?.roles?.get('source')).toMatchObject({ value: 'body' });
+  });
+
+  it('[qu] modal-close-backdrop: `punta` tokenizes whole (target), not pun+ta', () => {
+    const node = parse('ñitiy pi sichus punta tupan .modal-backdrop .modal-backdrop ta pakay tukuy', 'qu');
+    const cond = (function find(n: unknown): Record<string, unknown> | null {
+      if (!n || typeof n !== 'object') return null;
+      const r = n as Record<string, unknown>;
+      if (r.kind === 'conditional') return r;
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+        const c = r[f];
+        if (Array.isArray(c)) for (const x of c) { const got = find(x); if (got) return got; }
+      }
+      return null;
+    })(node);
+    expect(cond).not.toBeNull();
+    const raw = (cond!.roles as Map<string, { raw?: string }>).get('condition')?.raw ?? '';
+    expect(raw.startsWith('target ')).toBe(true);
+  });
+});

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -6099,3 +6099,18 @@ describe('qu reference alignment to dict surface forms (qu tokenizer arc, wave 1
     expect(raw.startsWith('target ')).toBe(true);
   });
 });
+
+describe('qu `cheqaq` → true boolean literal (qu arc wave 2 — set-attribute)', () => {
+  // The qu tokenizer EXTRAS mapped only arí/ari ("yes") to `true`, but the i18n
+  // dict emits `cheqaq` ("true/correct") — set-attribute `@disabled ta cheqaq man
+  // …`. So the value tokenized as a bare identifier and `set @disabled to
+  // <undefined>` ran. Adding cheqaq→true to the tokenizer aligns it. Cleared qu
+  // set-attribute (execution 15→14).
+  it('[qu] set-attribute: cheqaq resolves to the boolean true', () => {
+    const n = parse('@disabled ta cheqaq man ñitiy pi churanay', 'qu') as {
+      body?: Array<{ action?: string; roles?: Map<string, { value?: unknown }> }>;
+    };
+    const set = (n.body ?? []).find(c => c.action === 'set');
+    expect(set?.roles?.get('patient')?.value).toBe('true');
+  });
+});

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -6114,3 +6114,39 @@ describe('qu `cheqaq` → true boolean literal (qu arc wave 2 — set-attribute)
     expect(set?.roles?.get('patient')?.value).toBe('true');
   });
 });
+
+describe('qu make-toast: single-quote strings + fused-body at-end (qu arc wave 3)', () => {
+  // make-toast qu (`… 'Saved!' ta chay man churay … chay pi tukuy pa kurku ta
+  // churay`) needed three fixes: (1) the qu string extractor only accepted `"`,
+  // so the single-quoted `'Saved!'` tokenized as `'Saved`+`!`+`'` — now `'` is
+  // accepted (safe: Quechua apostrophes are mid-word, never at a token start);
+  // (2) the fused make-event body routes through parseBodyWithGrammarPatterns,
+  // whose `end`-keyword break lacked the isAtEndPositionNoun guard, so `tukuy`
+  // (end) chopped the attaching at-end put — guard mirrored from
+  // parseBodyWithClauses; (3) `case 'qu'` in getPutPatternsForLanguage didn't
+  // spread `...atEnd`, so PUT_AT_END never generated `put-qu-at-end`. Cleared qu
+  // make-toast (execution 14→13) — qu fully clear.
+  it('[qu] single-quoted string `\x27Saved!\x27` tokenizes as one string literal', () => {
+    const toks = getTokenizer('qu').tokenize("'Saved!' ta").tokens;
+    expect(toks[0]?.value).toBe("'Saved!'");
+  });
+
+  it('[qu] make-toast parses make + put(Saved!→it) + put(it→body, at end of)', () => {
+    const n = parse(
+      "a <div.toast/> ta ñitiy pi ruray chayqa 'Saved!' ta chay man churay chayqa chay pi tukuy pa kurku ta churay",
+      'qu'
+    ) as {
+      body?: Array<{ action?: string; roles?: Map<string, { value?: unknown; raw?: string }> }>;
+    };
+    const body = n.body ?? [];
+    expect(body.map(c => c.action)).toEqual(['make', 'put', 'put']);
+    // The single-quoted literal now tokenizes whole (was `'Saved`+`!`+`'`); the
+    // put captures it as an expression whose raw carries the Saved! text.
+    const p1 = body[1]?.roles?.get('patient');
+    expect(String(p1?.raw ?? p1?.value)).toContain('Saved!');
+    expect(body[1]?.roles?.get('destination')).toMatchObject({ value: 'it' });
+    expect(body[2]?.roles?.get('patient')).toMatchObject({ value: 'it' });
+    expect(body[2]?.roles?.get('destination')).toMatchObject({ value: 'body' });
+    expect(body[2]?.roles?.get('manner')).toMatchObject({ value: 'at end of' });
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T21:51:47.049Z",
-  "commit": "ded81618",
+  "timestamp": "2026-06-13T22:02:07.954Z",
+  "commit": "6bcfaefd",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -9521,16 +9521,9 @@
       "parseRate": 1,
       "avgConfidence": 0.7161616161616162,
       "avgFidelity": 0.9632034632034633,
-      "avgRoleFidelity": 0.7185649935649935,
-      "avgExecutionFidelity": 0.8064516129032258,
-      "executionFailures": [
-        "make-toast-element",
-        "modal-close-backdrop",
-        "modal-close-button",
-        "modal-open",
-        "put-content-basic",
-        "set-attribute"
-      ],
+      "avgRoleFidelity": 0.757142857142857,
+      "avgExecutionFidelity": 0.9354838709677419,
+      "executionFailures": ["make-toast-element", "set-attribute"],
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T22:02:07.954Z",
-  "commit": "6bcfaefd",
+  "timestamp": "2026-06-13T22:04:54.721Z",
+  "commit": "25df9e38",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -9521,9 +9521,9 @@
       "parseRate": 1,
       "avgConfidence": 0.7161616161616162,
       "avgFidelity": 0.9632034632034633,
-      "avgRoleFidelity": 0.757142857142857,
-      "avgExecutionFidelity": 0.9354838709677419,
-      "executionFailures": ["make-toast-element", "set-attribute"],
+      "avgRoleFidelity": 0.7593951093951092,
+      "avgExecutionFidelity": 0.967741935483871,
+      "executionFailures": ["make-toast-element"],
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T22:04:54.721Z",
-  "commit": "25df9e38",
+  "timestamp": "2026-06-13T22:17:37.247Z",
+  "commit": "fdd01ec4",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -13,7 +13,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["repeat-until-event", "window-scroll"],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -643,7 +643,7 @@
       "executionFailures": ["tabs-aria"],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1274,7 +1274,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1898,7 +1898,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2529,7 +2529,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3159,7 +3159,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3803,7 +3803,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4451,7 +4451,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5088,7 +5088,7 @@
         "set-transform",
         "template-literal-interpolation"
       ],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5718,7 +5718,7 @@
       "executionFailures": ["modal-close-button"],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6365,7 +6365,7 @@
         "put-content-basic",
         "unless-condition"
       ],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7008,7 +7008,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7639,7 +7639,7 @@
       "executionFailures": [],
       "degeneratePasses": ["socket-basic"],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8266,7 +8266,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8896,7 +8896,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9521,9 +9521,9 @@
       "parseRate": 1,
       "avgConfidence": 0.7161616161616162,
       "avgFidelity": 0.9632034632034633,
-      "avgRoleFidelity": 0.7593951093951092,
-      "avgExecutionFidelity": 0.967741935483871,
-      "executionFailures": ["make-toast-element"],
+      "avgRoleFidelity": 0.7616473616473615,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -9536,7 +9536,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10167,7 +10167,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10798,7 +10798,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "repeat-until-event", "set-color-variable"],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11425,7 +11425,7 @@
       "executionFailures": ["accordion-exclusive"],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12056,7 +12056,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["window-scroll"],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12693,7 +12693,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13323,7 +13323,7 @@
       "executionFailures": ["make-toast-element"],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13960,7 +13960,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14599,7 +14599,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 425556,
+      "bundleSize": 425708,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15221,7 +15221,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 425556,
+      "size": 425708,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## qu tokenizer arc — fully clears Quechua (6 of 6 cells)

Continues the roadmap into the **qu tokenizer arc**, clearing **all 6 qu execution cells** in 3 waves (cluster **19 → 13**). The roadmap's "accusative-particle over-stripping" diagnosis turned out to be wrong — it was an **unknown-word artifact**, not a particle-logic bug.

| Wave | Mechanism | Cleared |
|---|---|---|
| 1 | reference alignment to dict forms (me/it/target/body) | modal-open, modal-close-button, modal-close-backdrop, put-content-basic |
| 2 | `cheqaq`→true in tokenizer EXTRAS | set-attribute |
| 3 | single-quote strings + fused-body at-end guard + PUT_AT_END wiring | make-toast-element |

### Wave 1 — reference alignment (the big lever, 4 cells)
The qu semantic profile carried formal spellings — me=`ñuqa`, target=`ñawpaqman`, body=`ukhu`, it=`pay` — that appear in **zero** corpus rows; the i18n dict emits noqa/punta/kurku/chay. So the put destination, the matches-condition target, and the DOM body never resolved. Notably, `punta` (target) was being split into `pun`+`ta`-accusative **only because it wasn't a known word** — once it's the profile's `target` reference it tokenizes whole. No particle-logic change was needed (the §7l reference-alignment idiom did it all).

### Wave 2 — `cheqaq` → true
The tokenizer mapped only arí/ari ("yes") to `true`; the dict emits `cheqaq` ("correct"). `set @disabled to <undefined>` → `to true`.

### Wave 3 — make-toast (3 sub-fixes, none cluster-visible alone)
1. The qu string extractor rejected single quotes (to dodge the glottalization apostrophe `ch'usaq`), so `'Saved!'` tokenized broken. Accept `'` — safe because those apostrophes are always mid-word and the extractor only runs at a token start.
2. The fused make-event body routes through `parseBodyWithGrammarPatterns`, whose `end`-break lacked the `isAtEndPositionNoun` guard that `parseBodyWithClauses` got in S2 — so `tukuy` (end) chopped the attaching put. Guard mirrored.
3. `case 'qu'` in `getPutPatternsForLanguage` didn't spread `...atEnd`, so PUT_AT_END never generated `put-qu-at-end`. Wired in. (The `pi` event/at-marker collision was a red herring once the at-end pattern existed.)

### Correctness / safety
- All waves **semantic-only**, **zero regressions / fidelity flips**; gate green; baseline regenerated per wave.
- The shared `parseBodyWithGrammarPatterns` guard is gated to a language's exact PUT_AT_END at/of words, so non-qu bodies are byte-identical.
- **7 lock tests** added; semantic suite green (5949).

### Notes
- **Base:** stacked on `feat/s6-hi-sov-fronting` (#419); merge that first.
- `patterns.db` intentionally not committed (CI re-populates it).
- Cluster after qu (13): tabs-aria ×5 (S1), tr ×2, id/it/ja/th/uk ×1, hi halt-propagation ×1. zh ×0, ms ×0, qu ×0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)