### PR TITLE
fix(semantic): clear 3 R2 execution tails (uk/it/th, 13 → 10 cells)

### DIFF
--- a/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
+++ b/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
@@ -23,6 +23,38 @@
 > wiring) (1). The "accusative over-stripping" was an unknown-word artifact, not a
 > particle bug. **Session total: 19 cells, 32 → 13.** Next: the deferred S1
 > tabs-aria family (×5) or per-language tails.
+>
+> **Progress (R2 tails batch — 13 → 10):** three independent per-language tails
+> cleared, each a localized one-mechanism fix (avgExecutionFidelity 0.9818 →
+> 0.9860), all probed-before-edit, gate-green, lock-tested:
+>
+> - **uk make-toast-element** — the Ukrainian CyrillicKeywordExtractor char class
+>   includes the apostrophe (internal letter: п'ять, об'єкт), so `canExtract`
+>   matched the OPENING quote and `'Saved!'` tokenized as `'Saved`+`!`+`'`,
+>   scrambling the fused put body. Reject a LEADING apostrophe in `canExtract`
+>   (never word-initial in Ukrainian). The predicted "string-truncation" cause was
+>   right; the mechanism was the keyword extractor, not the string extractor (the
+>   inverse of the qu fix).
+> - **it modal-close-button** — hand-crafted `remove-it-full`/`-simple` labeled the
+>   trailing `da {X}` group `destination`; the removeMapper reads `source` only, so
+>   `rimuovere .x da corpo` removed from `me`. Aligned to `source` (matches every
+>   other language; the format string already said `{target}`). zh's hand-crafted
+>   remove patterns share the `destination` label but zh's corpus matches its
+>   _generated_ `source` pattern, so zh was left untouched.
+> - **th accordion-exclusive** — hand-crafted th add patterns were redundant +
+>   harmful (no-dest `add-th-simple` at prio 100 ABOVE with-dest at 95; the
+>   with-dest used `position: 3` extraction that can't span a multi-token
+>   positional). Removed them; the generated marker-based patterns route the
+>   destination through `tryMatchPositionalExpression` (like en).
+>
+> Two surface "tokens-look-fine" cells (it/th) were actually pattern role/priority
+> bugs, not dict gaps — probe the role map, not just the tokenizer. Remaining R2
+> tails are higher-effort: **id set-style** (two-word possessive _connector_
+> `saya punya` — needs possessive-matcher or transformer work), **ja
+> put-content-basic** (S4 SOV verb-final put), **tr if-matches** (conditional
+> condition `I match .x` malformed), **tr set-attribute** (SOV `@attr` fronting),
+> **hi halt-propagation** (blocked, §7y), and **tabs-aria ×5** (S1, deliberate
+> re-baseline).
 
 > **Scope:** the **32 remaining R2 execution-failing cells** after the cheap
 > dict/profile-alignment wins were exhausted (waves 12–16 + the multi-word
@@ -223,6 +255,12 @@ on .tab set … on me` drops the `on <scope>` modifier even in English (two sets
 tr ×2 (if-matches, set-attribute), id set-style, it modal-close-button, ja
 put-content-basic, th accordion-exclusive, uk make-toast, hi halt-propagation.
 zh ×0, ms ×0, qu ×0; hi ×2.
+
+**Cluster snapshot after R2 tails batch (10 cells):** tabs-aria ×5
+(bn/hi/ja/ko/tr → S1), tr ×2 (if-matches, set-attribute), id set-style, ja
+put-content-basic, hi halt-propagation. Cleared this batch: uk make-toast, it
+modal-close-button, th accordion-exclusive. it ×0, th ×0, uk ×0; id ×1, ja ×1,
+tr ×2, hi ×2 (halt + tabs-aria), bn/ko ×1 (tabs-aria).
 
 ## Stopping rule (carried from §9)
 

--- a/packages/semantic/src/patterns/add.ts
+++ b/packages/semantic/src/patterns/add.ts
@@ -378,45 +378,18 @@ function getAddPatternsRu(): LanguagePattern[] {
 }
 
 function getAddPatternsTh(): LanguagePattern[] {
-  return [
-    // Simple pattern: เพิ่ม .active
-    {
-      id: 'add-th-simple',
-      language: 'th',
-      command: 'add',
-      priority: 100,
-      template: {
-        format: 'เพิ่ม {patient}',
-        tokens: [
-          { type: 'literal', value: 'เพิ่ม' },
-          { type: 'role', role: 'patient' },
-        ],
-      },
-      extraction: {
-        patient: { position: 1 },
-      },
-    },
-    // With destination: เพิ่ม .active ใน #button
-    {
-      id: 'add-th-with-dest',
-      language: 'th',
-      command: 'add',
-      priority: 95,
-      template: {
-        format: 'เพิ่ม {patient} ใน {destination}',
-        tokens: [
-          { type: 'literal', value: 'เพิ่ม' },
-          { type: 'role', role: 'patient' },
-          { type: 'literal', value: 'ใน' },
-          { type: 'role', role: 'destination' },
-        ],
-      },
-      extraction: {
-        patient: { position: 1 },
-        destination: { marker: 'ใน', position: 3 },
-      },
-    },
-  ];
+  // No hand-crafted Thai add patterns: the generated patterns
+  // (add-th-generated `เพิ่ม {patient} [ใน {destination}]` + add-th-generated-simple)
+  // cover both the bare and with-destination forms, exactly like English (which
+  // ships no hand-crafted add patterns). The previous hand-crafted pair was both
+  // redundant and harmful: add-th-simple (no destination) sat at priority 100 —
+  // ABOVE add-th-with-dest (95) — so it shadowed the destination clause, and
+  // add-th-with-dest used a fixed `position: 3` extraction that can only grab a
+  // single token, dropping multi-token positional destinations like
+  // `ใกล้สุด .accordion-item` (closest .accordion-item). The marker-based generated
+  // pattern routes the destination through tryMatchPositionalExpression, so the
+  // positional phrase is captured (th accordion-exclusive R2 cell).
+  return [];
 }
 
 function getAddPatternsUk(): LanguagePattern[] {

--- a/packages/semantic/src/patterns/remove.ts
+++ b/packages/semantic/src/patterns/remove.ts
@@ -140,7 +140,12 @@ function getRemovePatternsIt(): LanguagePattern[] {
       command: 'remove',
       priority: 100,
       template: {
-        format: 'rimuovere {patient} da {target}',
+        // The trailing `da X` is the element to remove FROM — role `source`,
+        // matching every other language's remove pattern and the removeMapper
+        // (which reads `source` only). It previously used `destination`, which
+        // the mapper ignores, so `rimuovere .x da corpo` silently removed from
+        // `me` instead of body (it modal-close-button R2 cell).
+        format: 'rimuovere {patient} da {source}',
         tokens: [
           {
             type: 'literal',
@@ -153,14 +158,14 @@ function getRemovePatternsIt(): LanguagePattern[] {
             optional: true,
             tokens: [
               { type: 'literal', value: 'da', alternatives: ['di'] },
-              { type: 'role', role: 'destination' },
+              { type: 'role', role: 'source' },
             ],
           },
         ],
       },
       extraction: {
         patient: { position: 1 },
-        destination: {
+        source: {
           marker: 'da',
           markerAlternatives: ['di'],
           default: { type: 'reference', value: 'me' },
@@ -185,7 +190,7 @@ function getRemovePatternsIt(): LanguagePattern[] {
       },
       extraction: {
         patient: { position: 1 },
-        destination: { default: { type: 'reference', value: 'me' } },
+        source: { default: { type: 'reference', value: 'me' } },
       },
     },
   ];

--- a/packages/semantic/src/tokenizers/extractors/cyrillic-keyword.ts
+++ b/packages/semantic/src/tokenizers/extractors/cyrillic-keyword.ts
@@ -37,7 +37,17 @@ class CyrillicKeywordExtractor implements ContextAwareExtractor {
   }
 
   canExtract(input: string, position: number): boolean {
-    return this.isLetter(input[position]);
+    const char = input[position];
+    // A leading apostrophe is a string-literal quote, not a word start. The
+    // Ukrainian char class includes the apostrophe because it is an internal
+    // letter (п'ять, об'єкт) — valid mid-word (the extract loop's
+    // isIdentifierChar keeps it) but never word-initial. Without this guard a
+    // keyword starts on the opening `'` of a literal like 'Saved!', swallowing
+    // the quote and splitting the string at the first non-letter (issue: uk
+    // make-toast-element). No-op for Russian, whose char class has no
+    // apostrophe.
+    if (char === "'") return false;
+    return this.isLetter(char);
   }
 
   extract(input: string, position: number): ExtractionResult | null {

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -6189,3 +6189,27 @@ describe('uk make-toast: apostrophe-as-letter no longer eats string quotes (R2 t
     expect(body[2]?.roles?.get('manner')).toMatchObject({ value: 'at end of' });
   });
 });
+
+describe('it remove `da X` is the source, not destination (R2 tails batch)', () => {
+  // The hand-crafted remove-it-full/simple patterns labeled the trailing
+  // `da {X}` group as `destination`. The removeMapper reads `source` ONLY, so
+  // `rimuovere .modal-open da corpo` silently removed from `me` (#btn) instead
+  // of body — the body effect vanished (it modal-close-button R2 cell). Every
+  // other language's remove pattern uses `source`; aligned it to match.
+  it('[it] `rimuovere .modal-open da corpo` resolves source=body', () => {
+    const n = parse('rimuovere .modal-open da corpo', 'it') as {
+      action?: string;
+      roles?: Map<string, { value?: unknown }>;
+    };
+    expect(n.action).toBe('remove');
+    expect(n.roles?.get('source')).toMatchObject({ value: 'body' });
+    expect(n.roles?.get('destination')).toBeUndefined();
+  });
+
+  it('[it] bare `rimuovere .x` defaults source=me (not destination)', () => {
+    const n = parse('rimuovere .highlight', 'it') as {
+      roles?: Map<string, { value?: unknown }>;
+    };
+    expect(n.roles?.get('source')).toMatchObject({ value: 'me' });
+  });
+});

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -6150,3 +6150,42 @@ describe('qu make-toast: single-quote strings + fused-body at-end (qu arc wave 3
     expect(body[2]?.roles?.get('manner')).toMatchObject({ value: 'at end of' });
   });
 });
+
+describe('uk make-toast: apostrophe-as-letter no longer eats string quotes (R2 tails batch)', () => {
+  // The Ukrainian CyrillicKeywordExtractor's char class includes the apostrophe
+  // because it is an internal Ukrainian letter (п'ять, об'єкт). canExtract
+  // therefore matched the OPENING quote of a string literal, so `'Saved!'`
+  // tokenized as `'Saved` + `!` + `'`. That scrambled the make-toast fused body
+  // (make + put + put): the trailing `put it at end of body` lost its position
+  // role and threw `put requires content and position` at runtime. The fix
+  // rejects a LEADING apostrophe in canExtract (an apostrophe is never
+  // word-initial in Ukrainian); internal apostrophes still tokenize via the
+  // extract loop's isIdentifierChar. Cleared uk make-toast (execution −1).
+  it('[uk] single-quoted string `\x27Saved!\x27` tokenizes as one string literal', () => {
+    const toks = getTokenizer('uk')!.tokenize("покласти 'Saved!' в це").tokens;
+    const lit = toks.find(t => t.value.startsWith("'"));
+    expect(lit?.value).toBe("'Saved!'");
+  });
+
+  it('[uk] internal apostrophe (п\x27ять, об\x27єкт) still tokenizes whole (no regression)', () => {
+    const toks = getTokenizer('uk')!.tokenize("п'ять об'єкт").tokens;
+    expect(toks.map(t => t.value)).toEqual(["п'ять", "об'єкт"]);
+  });
+
+  it('[uk] make-toast parses make + put(Saved!→it) + put(it→body, at end of)', () => {
+    const n = parse(
+      "при клік створити a <div.toast/> тоді покласти 'Saved!' в це тоді покласти це в кінець з тіло",
+      'uk'
+    ) as {
+      body?: Array<{ action?: string; roles?: Map<string, { value?: unknown; raw?: string }> }>;
+    };
+    const body = n.body ?? [];
+    expect(body.map(c => c.action)).toEqual(['make', 'put', 'put']);
+    const p1 = body[1]?.roles?.get('patient');
+    expect(String(p1?.raw ?? p1?.value)).toContain('Saved!');
+    expect(body[1]?.roles?.get('destination')).toMatchObject({ value: 'it' });
+    expect(body[2]?.roles?.get('patient')).toMatchObject({ value: 'it' });
+    expect(body[2]?.roles?.get('destination')).toMatchObject({ value: 'body' });
+    expect(body[2]?.roles?.get('manner')).toMatchObject({ value: 'at end of' });
+  });
+});

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -6213,3 +6213,34 @@ describe('it remove `da X` is the source, not destination (R2 tails batch)', () 
     expect(n.roles?.get('source')).toMatchObject({ value: 'me' });
   });
 });
+
+describe('th add destination: positional phrase captured (R2 tails batch)', () => {
+  // The hand-crafted th add patterns were redundant and harmful: add-th-simple
+  // (no destination) was priority 100, ABOVE add-th-with-dest (95), so it
+  // shadowed the destination clause; and add-th-with-dest used a fixed
+  // `position: 3` extraction that grabs a single token, dropping multi-token
+  // positional destinations like `ใกล้สุด .accordion-item` (closest
+  // .accordion-item). Removing them lets the generated marker-based pattern
+  // route the destination through tryMatchPositionalExpression — exactly like
+  // English. Clears th accordion-exclusive.
+  it('[th] add `ใน ใกล้สุด .accordion-item` → destination closest expression', () => {
+    const n = parse(
+      'เมื่อ คลิก เพิ่ม .open ใน ใกล้สุด .accordion-item',
+      'th'
+    ) as { body?: Array<{ action?: string; roles?: Map<string, { type?: string; raw?: string }> }> };
+    const add = (n.body ?? []).find(c => c.action === 'add');
+    expect(add?.roles?.get('destination')).toMatchObject({
+      type: 'expression',
+      raw: 'closest .accordion-item',
+    });
+  });
+
+  it('[th] plain-selector and bare add destinations still resolve', () => {
+    const withDest = parse('เพิ่ม .selected ใน #item', 'th') as {
+      roles?: Map<string, { value?: unknown }>;
+    };
+    expect(withDest.roles?.get('destination')).toMatchObject({ value: '#item' });
+    const bare = parse('เพิ่ม .highlight', 'th') as { roles?: Map<string, { value?: unknown }> };
+    expect(bare.roles?.get('destination')).toMatchObject({ value: 'me' });
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-13T22:17:37.247Z",
-  "commit": "fdd01ec4",
+  "timestamp": "2026-06-14T00:12:12.246Z",
+  "commit": "61ef63f8",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -5713,9 +5713,9 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8379396202925594,
       "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8149173955296405,
-      "avgExecutionFidelity": 0.967741935483871,
-      "executionFailures": ["modal-close-button"],
+      "avgRoleFidelity": 0.8237042436022028,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
       "bundleSize": 425708,
@@ -11420,9 +11420,9 @@
       "parseRate": 1,
       "avgConfidence": 0.8401154401154378,
       "avgFidelity": 1,
-      "avgRoleFidelity": 0.8279922779922779,
-      "avgExecutionFidelity": 0.967741935483871,
-      "executionFailures": ["accordion-exclusive"],
+      "avgRoleFidelity": 0.8401705276705276,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
       "bundleSize": 425708,
@@ -13316,11 +13316,11 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8098948670377222,
+      "avgConfidence": 0.8110492681921234,
       "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.8295125482625483,
-      "avgExecutionFidelity": 0.967741935483871,
-      "executionFailures": ["make-toast-element"],
+      "avgRoleFidelity": 0.8317648005148005,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
       "bundleSize": 425708,
@@ -13430,6 +13430,10 @@
           "confidence": 1
         },
         "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "on-custom-event-receive": {
           "success": true,
           "confidence": 1
         },
@@ -13630,10 +13634,6 @@
           "confidence": 0.8222222222222222
         },
         "template-literal-list-build": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "on-custom-event-receive": {
           "success": true,
           "confidence": 0.8222222222222222
         },


### PR DESCRIPTION
## Summary

Three independent per-language R2 execution-tail fixes, each a localized
one-mechanism change. **Execution divergence 13 → 10** cells;
avgExecutionFidelity 0.9818 → 0.9860. All probed-before-edit, gate-green,
lock-tested. `it`, `th`, `uk` now have **zero** execution-failing cells.

| cell | lang | root cause | fix |
| --- | --- | --- | --- |
| `make-toast-element` | uk | CyrillicKeywordExtractor char class includes the apostrophe (internal Ukrainian letter `п'ять`/`об'єкт`), so `canExtract` matched the OPENING `'` of `'Saved!'` → tokenized `'Saved`+`!`+`'`, scrambling the fused put body | reject a **leading** apostrophe in `canExtract` (never word-initial in Ukrainian); internal apostrophes still tokenize via the extract loop |
| `modal-close-button` | it | hand-crafted `remove-it-full`/`-simple` labeled the trailing `da {X}` group `destination`; the removeMapper reads `source` only, so `rimuovere .x da corpo` removed from `me` | align it remove patterns to `source` (matches every other language; the format string already said `{target}`) |
| `accordion-exclusive` | th | redundant hand-crafted th add patterns: no-dest `add-th-simple` at prio 100 **above** with-dest (95), and `position: 3` extraction can't span a multi-token positional destination (`ใกล้สุด .accordion-item`) | remove them; generated marker-based patterns route the destination through `tryMatchPositionalExpression` (like en) |

Two of these ("tokens look fine") were pattern role/priority bugs, not dict
gaps — confirmed by probing the parsed role map, not just the tokenizer.

## Verification

- `npm run test:check --prefix packages/semantic` → **5958 passed**, incl. new lock tests in `multilingual-roadmap-fixes.test.ts`.
- Multilingual `--regression` gate **green** on all four ratchets (parse-rate / fidelity / correctness / execution).
- Baseline regenerated against a freshly populated `patterns.db` (not committed; CI repopulates). Diff is entirely improvements — three cells' execFidelity 0.968 → 1.0, plus a bonus uk `on-custom-event-receive` confidence 0.82 → 1.0.

## Not in scope

Remaining R2 tails are higher-effort and deferred (see roadmap): `id` set-style (two-word possessive *connector* `saya punya`), `ja` put-content-basic (S4 SOV verb-final put), `tr` if-matches + set-attribute (SOV), `hi` halt-propagation (blocked), and `tabs-aria ×5` (S1, deliberate re-baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)