### PR TITLE
fix(semantic): R2 structural tails batch 2 — 10 → 5 execution cells

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -1731,6 +1731,41 @@ artifact, not a particle-logic bug.**
 lossy), tr ×2 (if-matches, set-attribute), id/it/ja/th/uk ×1, hi halt-propagation
 ×1. zh ×0, ms ×0, qu ×0; hi ×2. Session 23 total: **32 → 13 (19 cells, 4 arcs).**
 
+## 7aa. Status update (R2 structural tails — batch 2: 10 → 5)
+
+**The five remaining non-S1 R2 execution cells are cleared — each a distinct,
+localized, probed-before-edit, gate-green, zero-fidelity-regression fix.** The
+only remaining execution cluster is **S1 tabs-aria ×5** (the deferred
+en-reference band-inversion). avgExecutionFidelity **0.9860 → 0.9930**.
+
+| cell                 | mechanism                                                                                                                                                                                                                                                                                                                                                                                                          |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| tr set-attribute     | `doğru` ("true") was in POSTPOSITIONS ("towards"), classified before isKeyword → `kind='particle'` (no `tokenToSemanticValue` case) → patient rejected. Plus the dative allomorph `ya` (vowel harmony) wasn't a marker alt. Removed `doğru` from POSTPOSITIONS; wired schema `markerVariants` into the SOV two-role generators (new `resolveRoleMarker`); added tr dative allomorphs (e/a/ye/ya) to set's patient. |
+| ja put-content-basic | event phrase trails the verb (`"Done!" を 私 に 置く クリック で`); no event-LAST SOV variant, so it fell to the bare command (runs pre-click → invisible). Added `generateSOVTwoRoleEventLastEventHandlerPattern`.                                                                                                                                                                                                |
+| id set-style         | dict renders "my" as two-word `saya punya`; the connector `punya` broke the possessive matcher. Added `PossessiveConfig.connectors` (id: `punya`), skipped after the possessor keyword.                                                                                                                                                                                                                            |
+| tr if-matches        | folded-`if` condition truncated at the first command-beginning token; in SOV the then-verb is clause-final, so `match .disabled durdur` spuriously matched a verb-last halt pattern, cutting the condition to `I`. Added `CONDITION_OPERATORS` guard (an operator never begins a command).                                                                                                                         |
+| hi halt-propagation  | the §7y-blocked one. hi fronts the halt patient with a leaked English article (`the घटना को क्लिक पर रोकें …`); the patient role grabbed only `the`, the marker `को` failed, halt fell to a BARE halt (stops handler). `skipNoiseWords` now skips a leaked `the` before `the <ref-noun> <marker>` only.                                                                                                            |
+
+- **The §7y blocker (leaked-`the` strip regresses tr/form-submit-prevent) is
+  SOLVED, not avoided.** The fix is gated three ways — non-English only (en `the`
+  is authored), reference-noun keyword only (event/body/target/…, via
+  `isValidReference`), AND a following particle marker. The last gate is the key:
+  hi `the घटना को` has a MARKER after the ref noun (a fronted patient → skip), but
+  tr `the olay çağır …` has a VERB (`call`) after it (→ leave `the` intact). tr
+  form-submit-prevent keeps its 4 actions (halt,call,if,log) — verified by lock
+  test and the full gate (zero fidelity regressions, vs the 1 within-tolerance
+  flip the naive non-en-only gate produced).
+- **All semantic-only; en reference byte-identical** (the leaked-`the` skip is
+  excluded for en). Full `--regression` gate green (parse-rate, fidelity,
+  correctness, execution ratchets); baseline regenerated against a freshly
+  populated patterns.db; 11 lock tests added (`multilingual-roadmap-fixes.test.ts`
+  → 580 in file). Semantic 5958 green.
+
+**Cluster after batch 2 (5 cells):** tabs-aria ×5 (bn/hi/ja/ko/tr → S1) — all that
+remains. The next R2 move is S1 (a deliberate en-reference band-inversion + full
+re-record) or, per the stopping rule, switch to behaviors (Track 2). See
+STRUCTURAL_ARCS_ROADMAP.md.
+
 ## 11. Next-arc handoffs (post-#416)
 
 The cheap dict/profile-alignment wins are exhausted (R2 execution: 13 cells after
@@ -1739,14 +1774,18 @@ S2+S6+qu, parse ship line held). The next work is decomposed into focused handof
 - ✅ **Task #10 — multi-word markers + dict underscore audit:** DONE (#417).
 - ✅ **S2 — fused-event body routing / compound collapse:** DONE (session 23, §7x;
   32→25). zh + ms fully clear.
-- ◑ **S6 — hi SOV fronting:** 6/8 DONE (session 23, §7y; 25→19; hi 8→2). Remaining
-  hi: halt-propagation (blocked — leaked-`the` regresses tr), tabs-aria (S1).
+- ✅ **S6 — hi SOV fronting:** 7/8 DONE (§7y + §7aa). hi halt-propagation cleared in
+  batch 2 (the leaked-`the` blocker solved with a marker-gated skip). Only hi
+  tabs-aria (S1) remains.
 - ✅ **qu tokenizer arc:** DONE (session 23, §7z; 19→13; qu 6→0).
+- ✅ **R2 structural tails — S3/S4/tails:** DONE (§7aa; 10→5). tr set-attribute, ja
+  put-content-basic, id set-style, tr if-matches, hi halt-propagation. Only S1
+  tabs-aria ×5 remains.
 - **Per-language structural arcs (the R2 tail):**
   [STRUCTURAL_ARCS_ROADMAP.md](STRUCTURAL_ARCS_ROADMAP.md). Every remaining R2 cell
   mapped to an arc, with a triage rubric (yield · leverage · confidence · risk ·
-  unblocks) and a leverage-first ranking (~~S2~~ > ~~S6 (6/8)~~ > **qu tokenizer
-  (×6, next)** > S3/S4/tails > S1 en-lossy). Opportunistic — lower ROI than behaviors.
+  unblocks) and a leverage-first ranking (~~S2~~ > ~~S6~~ > ~~qu~~ > ~~S3/S4/tails~~
+  > **S1 en-lossy (only remaining, deferred)**). Opportunistic — lower ROI than behaviors.
 - **Track 2 — behaviors (next big track):** 49 of the 63 degenerate passes are
   `behavior-*` (draggable/resizable/sortable ×15 each + removable ×4 +
   install-behavior ×3). This is a **runtime** effort (block-structure parsing +

--- a/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
+++ b/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
@@ -40,9 +40,10 @@
 >   entirely (authored `the`, not a leak) — en reference byte-identical.
 >
 > **Cluster after batch 2 (5 cells):** tabs-aria ×5 (bn/hi/ja/ko/tr → S1). All
-> other languages clear. S1 is the en-reference-lossy arc (`set @attr … on
-<scope>` drops the scope even in English) — defer to a dedicated band-inversion
-> with a full re-record. See CORRECTNESS_RELIABILITY_PLAN.md §7aa.
+> other languages clear. S1 is the en-reference-lossy arc — the en `set`
+> reference drops its trailing `on`-scope modifier even in English. Defer to a
+> dedicated band-inversion with a full re-record. See
+> CORRECTNESS_RELIABILITY_PLAN.md §7aa.
 
 > **Progress (S2 DONE — 32 → 25 execution cells):** the **S2 fused-event
 > body-routing / compound-collapse arc is complete** (5 waves, semantic-only).

--- a/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
+++ b/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
@@ -1,5 +1,50 @@
 # Per-language structural arcs roadmap (R2 execution tail)
 
+> **Progress (R2 structural tails batch 2 — 10 → 5):** the five remaining
+> non-S1 cells were each cleared as a localized, probed-before-edit,
+> gate-green, zero-regression fix (avgExecutionFidelity 0.9860 → **0.9930**).
+> **Only the S1 tabs-aria ×5 cluster remains** (the deferred en-reference
+> band-inversion). The five:
+>
+> - **tr set-attribute** — TWO compounding bugs. (1) `doğru` ("true") was in the
+>   tokenizer's POSTPOSITIONS set ("towards") and classifyToken checks
+>   POSTPOSITIONS before isKeyword, so the boolean tokenized as `kind='particle'`
+>   — which `tokenToSemanticValue` has no case for, so the set patient rejected
+>   it. (2) The i18n transformer emits the dative under vowel harmony (`e` for
+>   quoted strings, `-ya` for `doğru`); markerOverride is a single string so the
+>   tr set patterns carried only `e`. Removed `doğru` from POSTPOSITIONS + wired
+>   the schema's `markerVariants` into the SOV two-role generators (new
+>   `resolveRoleMarker` helper) + added tr dative allomorphs to set's patient.
+> - **ja put-content-basic** (S4) — the event phrase trails the verb (`"Done!" を
+私 に 置く クリック で`); no SOV two-role variant covered event-LAST order, so
+>   it fell to the bare command pattern (runs at execute() time, before the click
+>   → invisible). Added `generateSOVTwoRoleEventLastEventHandlerPattern`.
+> - **id set-style** (S3) — the dict renders "my" as the two-word `saya punya`
+>   ("I have"); the connector `punya` between the possessor (saya→me) and the
+>   property broke the possessive matcher. Added a `connectors` field to
+>   `PossessiveConfig` (id: `punya`) skipped after the possessor keyword.
+> - **tr if-matches** — the folded-`if` condition extraction truncated at the
+>   first token that begins a command; in SOV the then-verb is clause-final, so
+>   `match .disabled durdur` spuriously matched a verb-last halt pattern and cut
+>   the condition `I match .disabled` down to `I`. (ja/ko/hi escaped only because
+>   their halt pattern happened not to match the span — the same English `I match`
+>   leaks into every language.) Added a `CONDITION_OPERATORS` guard: an operator
+>   is never a command head, so don't truncate at one.
+> - **hi halt-propagation** (the §7y-blocked one) — hi fronts the halt patient to
+>   position 0 with a leaked English article (`the घटना को क्लिक पर रोकें …`); the
+>   patient role grabbed only `the`, the marker `को` failed, and the halt fell to
+>   a BARE halt (stops the handler). `skipNoiseWords` now skips a leaked `the`
+>   before `the <ref-noun> <marker>`. The §7y tr/form-submit-prevent regression
+>   is **avoided** by the 2-token gate: `the olay çağır …` has the ref noun
+>   followed by a VERB (not a marker), so `the` is left intact. en excluded
+>   entirely (authored `the`, not a leak) — en reference byte-identical.
+>
+> **Cluster after batch 2 (5 cells):** tabs-aria ×5 (bn/hi/ja/ko/tr → S1). All
+> other languages clear. S1 is the en-reference-lossy arc (`set @attr … on
+<scope>` drops the scope even in English) — defer to a dedicated band-inversion
+>
+> - full re-record. See CORRECTNESS_RELIABILITY_PLAN.md §7aa.
+
 > **Progress (S2 DONE — 32 → 25 execution cells):** the **S2 fused-event
 > body-routing / compound-collapse arc is complete** (5 waves, semantic-only).
 > It cleared **7 cells — zh ×5 and ms ×2, both languages now fully clear**:
@@ -137,8 +182,14 @@ Score each arc on five axes (H/M/L), then rank by leverage-adjusted value.
   fallen to `put-hi-bare` and grabbed the destination as the patient). Execution
   32→19 over the session (S2 + these); both waves zero-regression, baselined, lock-
   tested. See §7y.
-- **Remaining (2), both DEFERRED:**
-  - **halt-propagation** — needs the leaked English article `the` (`the घटना` =
+- **Remaining (2):**
+  - **halt-propagation** — ✅ **CLEARED (batch 2, §7aa).** The §7y "leaked-`the`
+    strip regresses tr" blocker was solved with a 2-token gate: skip the leaked
+    `the` only before `the <ref-noun> <marker>` (a fronted patient). tr
+    form-submit-prevent's `the olay çağır …` has a VERB after the ref noun, so
+    `the` is left intact — no regression. The note below is the original framing.
+  - **tabs-aria** — still S1 (the only remaining hi cell).
+  - **(historical)** halt-propagation — needs the leaked English article `the` (`the घटना` =
     "the event", fronted to position 0) removed so `halt-event-hi-sov-patient-first`
     matches. A general leading-`the` strip WORKS for hi but **regresses
     tr/form-submit-prevent 4 actions → 1** (its leaked leading `the olay` is
@@ -187,9 +238,13 @@ on .tab set … on me` drops the `on <scope>` modifier even in English (two sets
   reference change → baseline re-record) · Unblocks: re-qualifies the @attr family.**
 - **Verdict:** defer unless ready for a deliberate band-inversion + full re-baseline.
 
-### S3 — SOV `@attr` / `set` role-scramble ◑ mostly absorbed
+### S3 — SOV `@attr` / `set` role-scramble ✅ DONE
 
-- **Remaining (2):** set-attribute (tr), set-style (id). The hi share (set-attribute,
+- **Closed (batch 2):** tr set-attribute (`doğru`-as-particle in POSTPOSITIONS +
+  dative allomorph via `markerVariants` wired into the SOV two-role generators);
+  id set-style (two-word possessive connector `punya` via `PossessiveConfig.connectors`).
+  The hi + qu shares were already cleared (S6 wave 1 / qu wave 2). See §7aa.
+- **(historical)** Remaining (2): set-attribute (tr), set-style (id). The hi share (set-attribute,
   set-style) was cleared by **S6 wave 1** (the set markerOverride.hi alignment) and
   the qu share (set-attribute) by **qu wave 2** (`cheqaq`→true).
 - **Mechanism (remaining):** id set-style is the two-word possessive PHRASE
@@ -206,9 +261,13 @@ on .tab set … on me` drops the `on <scope>` modifier even in English (two sets
   compound-collapse — see the per-language tails).
 - **Verdict:** folded into S2 as predicted; the zh share is cleared.
 
-### S4 — SOV verb-final put
+### S4 — SOV verb-final put ✅ DONE
 
-- **Remaining (1):** put-content-basic (ja). `"Done!" を 私 に 置く クリック で` —
+- **Closed (batch 2):** ja put-content-basic via
+  `generateSOVTwoRoleEventLastEventHandlerPattern` (`{roles} {verb} {event}
+{eventMarker}`) — the event phrase trails the verb. The qu share was cleared by
+  qu wave 1. See §7aa.
+- **(historical)** Remaining (1): put-content-basic (ja). `"Done!" を 私 に 置く クリック で` —
   SOV verb-final put with a trailing event phrase; no wrapper covers that order.
   (The qu share was cleared by **qu wave 1** reference alignment — qu's structure
   `{patient} ta {dest} man {event} pi {verb}` already parsed once `noqa`→me resolved.)
@@ -230,12 +289,14 @@ on .tab set … on me` drops the `on <scope>` modifier even in English (two sets
   avoid the glottalization apostrophe, breaking `'Saved!'`).
 - **All semantic-only, zero regressions, baselined, lock-tested.**
 
-### Per-language tails (batch opportunistically)
+### Per-language tails (batch opportunistically) ✅ DONE
 
-- it modal-close-button (body captured as DESTINATION not source — role-mislabel),
-  th accordion-exclusive. ~2 cells, 1 each. (qu modal-close-button was cleared by
-  the qu arc.)
-- **Verdict:** not worth a dedicated arc; fix when already in that language's files.
+- **R2 tails batch:** it modal-close-button, th accordion-exclusive, uk make-toast.
+- **R2 batch 2:** tr if-matches (CONDITION_OPERATORS — don't truncate the folded-if
+  condition at an operator; SOV verb-last halt patterns spuriously matched the
+  `match .disabled <verb>` span). See §7aa.
+- **Verdict:** all cleared opportunistically while in each language's files, exactly
+  per the rubric heuristic #4.
 
 ## Ranked sequence (leverage-first)
 
@@ -245,11 +306,13 @@ on .tab set … on me` drops the `on <scope>` modifier even in English (two sets
 3. ◑ **S6** hi SOV fronting + possessive-dot — **6/8 DONE** (2 waves, 25→19; hi
    8→2). See §7y. Remaining hi: halt (blocked), tabs-aria (S1).
 4. ✅ **qu tokenizer** — **DONE** (3 waves, 19→13; qu 6→0). See §7z.
-5. **S3** SOV `@attr`/`set` role-scramble — mostly absorbed (S6 wave 2 hi put;
-   qu wave 2 set-attribute). Remaining: tr/id set-attribute/set-style.
-6. **S4** SOV verb-final put + per-language tails (it/th) — opportunistic.
-7. **S1** en-reference-lossy tabs-aria (×5: bn/hi/ja/ko/tr) — last; high-risk
-   band-inversion, do only with a deliberate re-baseline.
+5. ✅ **S3** SOV `@attr`/`set` role-scramble — **DONE** (hi via S6 wave 2 + qu wave
+   2; tr set-attribute + id set-style via batch 2). See §7aa.
+6. ✅ **S4** SOV verb-final put — **DONE** (qu via wave 1; ja put-content-basic via
+   batch 2's event-last wrapper). Per-language tails (it/th) cleared in R2 tails
+   batch; tr if-matches + hi halt-propagation cleared in batch 2.
+7. **S1** en-reference-lossy tabs-aria (×5: bn/hi/ja/ko/tr) — **the only remaining
+   cluster**; high-risk band-inversion, do only with a deliberate re-baseline.
 
 **Cluster snapshot after qu (13 cells):** tabs-aria ×5 (bn/hi/ja/ko/tr → S1),
 tr ×2 (if-matches, set-attribute), id set-style, it modal-close-button, ja
@@ -261,6 +324,32 @@ zh ×0, ms ×0, qu ×0; hi ×2.
 put-content-basic, hi halt-propagation. Cleared this batch: uk make-toast, it
 modal-close-button, th accordion-exclusive. it ×0, th ×0, uk ×0; id ×1, ja ×1,
 tr ×2, hi ×2 (halt + tabs-aria), bn/ko ×1 (tabs-aria).
+
+**Cluster snapshot after R2 structural tails batch 2 (5 cells):** tabs-aria ×5
+(bn/hi/ja/ko/tr → S1) — **all that remains**. Cleared this batch: tr
+set-attribute, ja put-content-basic, id set-style, tr if-matches, hi
+halt-propagation. id ×0, ja ×0, tr ×0 except tabs-aria; hi ×1 (tabs-aria only).
+avgExecutionFidelity 0.9860 → 0.9930. The next R2 move is S1 (deliberate
+band-inversion) — or, per the stopping rule, switch to behaviors (Track 2).
+
+## S1 — tabs-aria ×5: the only remaining cluster (deferred, deliberate)
+
+The en reference is itself lossy: `on click set @aria-selected to "false" on .tab
+set @aria-selected to "true" on me` parses to two `set` commands that BOTH drop
+their `on <scope>` modifier (verified: en AST has destination=@aria-selected,
+patient=false/true, no scope), so both write `#btn` and the net visible effect is
+`aria-selected=true` on `#btn`. The five translations only reach the first set
+(`aria-selected=false`) and then error/drop the second, so they don't even match
+the lossy en effect.
+
+A real fix is two-layer: (1) teach the core/semantic `set` to capture `… on
+<scope>` (a scope modifier or third role) so the en reference becomes
+`aria-selected=false on .tab` + `aria-selected=true on me` — **this inverts the
+gate band** (today's en effect signature changes, and every language re-compares
+against the new reference); then (2) per-language scope capture. Because step 1
+churns the en reference and the whole execution baseline, this must be a dedicated
+arc done with `--save-baseline` immediately after, not bundled with zero-regression
+tail work. Until then it stays the documented R2 floor.
 
 ## Stopping rule (carried from §9)
 

--- a/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
+++ b/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
@@ -42,8 +42,7 @@
 > **Cluster after batch 2 (5 cells):** tabs-aria ×5 (bn/hi/ja/ko/tr → S1). All
 > other languages clear. S1 is the en-reference-lossy arc (`set @attr … on
 <scope>` drops the scope even in English) — defer to a dedicated band-inversion
->
-> - full re-record. See CORRECTNESS_RELIABILITY_PLAN.md §7aa.
+> with a full re-record. See CORRECTNESS_RELIABILITY_PLAN.md §7aa.
 
 > **Progress (S2 DONE — 32 → 25 execution cells):** the **S2 fused-event
 > body-routing / compound-collapse arc is complete** (5 waves, semantic-only).

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -535,6 +535,16 @@ export const setSchema: CommandSchema = {
         qu: 'man', // "x ta 10 man churay" - destination marker on value
         hi: 'में', // value (patient) gets में — see the destination note above
       },
+      // Turkish dative is allomorphic under vowel harmony: the i18n transformer
+      // emits `e` for quoted-string values (`"red" e`) but `-ya` for a value
+      // ending in a vowel (`doğru ya` = "true" in set-attribute). markerOverride
+      // is a single string, so the generated tr set patterns carried only `e`
+      // and set-attribute fell to the role-scrambling generic SOV extraction.
+      // markerVariants supplies the allomorphs the SOV two-role generators merge
+      // in as marker alternatives. See STRUCTURAL_ARCS_ROADMAP.md (tr set-attribute).
+      markerVariants: {
+        tr: ['e', 'a', 'ye', 'ya'],
+      },
     },
   ],
   // Runtime error documentation

--- a/packages/semantic/src/generators/event-handlers-sov.ts
+++ b/packages/semantic/src/generators/event-handlers-sov.ts
@@ -9,7 +9,7 @@
 
 import type { LanguagePattern, PatternToken } from '../types';
 import type { LanguageProfile, KeywordTranslation, RoleMarker } from './language-profiles';
-import type { CommandSchema } from './command-schemas';
+import type { CommandSchema, RoleSpec } from './command-schemas';
 import {
   eventHandlerDestinationExtraction,
   eventHandlerDestinationGroup,
@@ -17,6 +17,49 @@ import {
   eventHandlerSourceGroup,
 } from './command-schemas';
 import type { GeneratorConfig } from './pattern-generator';
+
+/**
+ * Resolve the surface marker (and any allomorph alternatives) for a role in a
+ * given language. Prefers the schema's per-command `markerOverride`, else the
+ * profile's default roleMarker. In BOTH cases, `markerVariants[code]` is merged
+ * in as alternatives so the generated pattern matches every surface form the
+ * i18n transformer can produce.
+ *
+ * Why: `markerOverride` is a single string, so it silently dropped the allomorph
+ * alternatives the profile roleMarker would otherwise have supplied. The Turkish
+ * dative the transformer emits under vowel harmony (e/a/ye/ya) is the canonical
+ * case: tr set-attribute's `… doğru ya ayarla` (value=true marked with the -ya
+ * dative) failed to match the `e`-only patient marker, so the whole set fell to
+ * the role-scrambling generic SOV extraction. See STRUCTURAL_ARCS_ROADMAP.md.
+ */
+function resolveRoleMarker(
+  roleSpec: RoleSpec,
+  profile: LanguageProfile
+): { marker: string | undefined; alternatives: string[] | undefined } {
+  let marker: string | undefined;
+  let alternatives: string[] | undefined;
+
+  if (roleSpec.markerOverride && roleSpec.markerOverride[profile.code] !== undefined) {
+    marker = roleSpec.markerOverride[profile.code];
+  } else {
+    const roleMarker = profile.roleMarkers[roleSpec.role];
+    if (roleMarker) {
+      marker = roleMarker.primary;
+      alternatives = roleMarker.alternatives ? [...roleMarker.alternatives] : undefined;
+    }
+  }
+
+  const variants = roleSpec.markerVariants?.[profile.code];
+  if (variants && variants.length > 0) {
+    const merged = alternatives ? [...alternatives] : [];
+    for (const v of variants) {
+      if (v !== marker && !merged.includes(v)) merged.push(v);
+    }
+    alternatives = merged;
+  }
+
+  return { marker, alternatives };
+}
 
 /**
  * Generate SOV event handler pattern (Japanese, Korean, Turkish).
@@ -551,21 +594,8 @@ export function generateSOVTwoRoleEventHandlerPattern(
     // Add the role
     tokens.push({ type: 'role', role: roleSpec.role, optional: false });
 
-    // Get marker for this role - check for override first
-    let marker: string | undefined;
-    let markerAlternatives: string[] | undefined;
-
-    if (roleSpec.markerOverride && roleSpec.markerOverride[profile.code] !== undefined) {
-      // Use the override marker
-      marker = roleSpec.markerOverride[profile.code];
-    } else {
-      // Use default role marker from profile
-      const roleMarker = profile.roleMarkers[roleSpec.role];
-      if (roleMarker) {
-        marker = roleMarker.primary;
-        markerAlternatives = roleMarker.alternatives;
-      }
-    }
+    // Get marker for this role - markerOverride/profile default + markerVariants.
+    const { marker, alternatives: markerAlternatives } = resolveRoleMarker(roleSpec, profile);
 
     // Add the marker token
     if (marker) {
@@ -632,16 +662,16 @@ export function generateSOVTwoRoleDestFirstEventHandlerPattern(
   const firstRole = sortedRoles[0];
   tokens.push({ type: 'role', role: firstRole.role, optional: false });
 
-  // First role marker
-  let firstMarker: string | undefined;
-  if (firstRole.markerOverride && firstRole.markerOverride[profile.code] !== undefined) {
-    firstMarker = firstRole.markerOverride[profile.code];
-  } else {
-    const roleMarker = profile.roleMarkers[firstRole.role];
-    if (roleMarker) firstMarker = roleMarker.primary;
-  }
+  // First role marker (markerOverride/profile default + markerVariants allomorphs)
+  const { marker: firstMarker, alternatives: firstMarkerAlts } = resolveRoleMarker(
+    firstRole,
+    profile
+  );
   if (firstMarker) {
-    tokens.push({ type: 'literal', value: firstMarker });
+    const firstMarkerToken: PatternToken = firstMarkerAlts
+      ? { type: 'literal', value: firstMarker, alternatives: firstMarkerAlts }
+      : { type: 'literal', value: firstMarker };
+    tokens.push(firstMarkerToken);
   }
 
   // Event role
@@ -672,18 +702,11 @@ export function generateSOVTwoRoleDestFirstEventHandlerPattern(
   const secondRole = sortedRoles[1];
   tokens.push({ type: 'role', role: secondRole.role, optional: false });
 
-  // Second role marker
-  let secondMarker: string | undefined;
-  let secondMarkerAlts: string[] | undefined;
-  if (secondRole.markerOverride && secondRole.markerOverride[profile.code] !== undefined) {
-    secondMarker = secondRole.markerOverride[profile.code];
-  } else {
-    const roleMarker = profile.roleMarkers[secondRole.role];
-    if (roleMarker) {
-      secondMarker = roleMarker.primary;
-      secondMarkerAlts = roleMarker.alternatives;
-    }
-  }
+  // Second role marker (markerOverride/profile default + markerVariants allomorphs)
+  const { marker: secondMarker, alternatives: secondMarkerAlts } = resolveRoleMarker(
+    secondRole,
+    profile
+  );
   if (secondMarker) {
     const markerToken: PatternToken = secondMarkerAlts
       ? { type: 'literal', value: secondMarker, alternatives: secondMarkerAlts }

--- a/packages/semantic/src/generators/event-handlers-sov.ts
+++ b/packages/semantic/src/generators/event-handlers-sov.ts
@@ -633,6 +633,91 @@ export function generateSOVTwoRoleEventHandlerPattern(
 }
 
 /**
+ * Generate event-LAST SOV two-role event handler pattern.
+ *
+ * Some SOV emissions place the whole event phrase AFTER the command verb, as a
+ * trailing afterthought:
+ * - Japanese put: "Done!" を 私 に 置く クリック で
+ *   [patient] [pMarker] [destination] [dMarker] [verb] [event] [eventMarker]
+ *
+ * The event-first (`{event} で {p} {d} 置く`) and dest-first
+ * (`{p} {event} で 置く {d}`) variants both expect the event before the verb, so
+ * this order fell to the bare command pattern (`put-ja-generated`) — which runs
+ * immediately at execute() time, before the click is dispatched, so the effect
+ * is invisible to the R2 execution snapshot (S4, ja put-content-basic).
+ */
+export function generateSOVTwoRoleEventLastEventHandlerPattern(
+  commandSchema: CommandSchema,
+  profile: LanguageProfile,
+  keyword: KeywordTranslation,
+  eventMarker: RoleMarker,
+  config: GeneratorConfig
+): LanguagePattern {
+  const tokens: PatternToken[] = [];
+
+  const requiredRoles = commandSchema.roles.filter(r => r.required);
+  const sortedRoles = [...requiredRoles].sort((a, b) => {
+    const aPos = a.sovPosition ?? 999;
+    const bPos = b.sovPosition ?? 999;
+    return aPos - bPos;
+  });
+
+  // Roles + their markers first (SOV position order)
+  for (const roleSpec of sortedRoles) {
+    tokens.push({ type: 'role', role: roleSpec.role, optional: false });
+    const { marker, alternatives: markerAlternatives } = resolveRoleMarker(roleSpec, profile);
+    if (marker) {
+      tokens.push(
+        markerAlternatives
+          ? { type: 'literal', value: marker, alternatives: markerAlternatives }
+          : { type: 'literal', value: marker }
+      );
+    }
+  }
+
+  // Command verb (SOV: after the roles)
+  tokens.push(
+    keyword.alternatives
+      ? { type: 'literal', value: keyword.primary, alternatives: keyword.alternatives }
+      : { type: 'literal', value: keyword.primary }
+  );
+
+  // Trailing event phrase: {event} {eventMarker}
+  tokens.push({ type: 'role', role: 'event', optional: false });
+  if (eventMarker.position === 'after') {
+    const markerWords = eventMarker.primary.split(/\s+/);
+    if (markerWords.length > 1) {
+      for (const word of markerWords) tokens.push({ type: 'literal', value: word });
+    } else {
+      tokens.push(
+        eventMarker.alternatives
+          ? { type: 'literal', value: eventMarker.primary, alternatives: eventMarker.alternatives }
+          : { type: 'literal', value: eventMarker.primary }
+      );
+    }
+  }
+
+  const roleNames = sortedRoles.map(r => `{${r.role}}`).join(' ');
+
+  return {
+    id: `${commandSchema.action}-event-${profile.code}-sov-2role-event-last`,
+    language: profile.code,
+    command: 'on',
+    // Below the event-first / dest-first variants — this is the fallback order.
+    priority: (config.basePriority ?? 100) + 40,
+    template: {
+      format: `${roleNames} ${keyword.primary} {event} ${eventMarker.primary}`,
+      tokens,
+    },
+    extraction: {
+      action: { value: commandSchema.action },
+      event: { fromRole: 'event' },
+      ...Object.fromEntries(sortedRoles.map(r => [r.role, { fromRole: r.role }])),
+    },
+  };
+}
+
+/**
  * Generate destination-first SOV two-role event handler pattern.
  *
  * For languages where the roles precede the event in SOV order:

--- a/packages/semantic/src/generators/pattern-generator.ts
+++ b/packages/semantic/src/generators/pattern-generator.ts
@@ -25,6 +25,7 @@ import {
   generateSOVTemporalEventHandlerPattern,
   generateSOVTwoRoleEventHandlerPattern,
   generateSOVTwoRoleDestFirstEventHandlerPattern,
+  generateSOVTwoRoleEventLastEventHandlerPattern,
 } from './event-handlers-sov';
 import {
   generateVSOEventHandlerPattern,
@@ -372,6 +373,18 @@ export function generateEventHandlerPatterns(
       // Quechua set: x ta ñitiy pi 10 man churay
       patterns.push(
         generateSOVTwoRoleDestFirstEventHandlerPattern(
+          commandSchema,
+          profile,
+          keyword,
+          eventMarker,
+          config
+        )
+      );
+
+      // Two-role SOV pattern (event-last variant) — the event phrase trails the
+      // verb: Japanese put `"Done!" を 私 に 置く クリック で` (S4 put-content-basic).
+      patterns.push(
+        generateSOVTwoRoleEventLastEventHandlerPattern(
           commandSchema,
           profile,
           keyword,

--- a/packages/semantic/src/generators/profiles/indonesian.ts
+++ b/packages/semantic/src/generators/profiles/indonesian.ts
@@ -57,6 +57,11 @@ export const indonesianProfile: LanguageProfile = {
       nya: 'it', // third person clitic (suffix form: -nya)
       dia: 'it', // third person pronoun
     },
+    // `saya punya *background` = "I have *background" = "my *background". The
+    // i18n dict's `my` is the two-word `saya punya`; `punya` ("have/own") is a
+    // connector between the possessor (saya→me) and the property. Skipped by the
+    // possessive matcher so the property is reached (set-style set-text rows).
+    connectors: ['punya'],
   },
   roleMarkers: {
     destination: { primary: 'pada', alternatives: ['ke', 'di'], position: 'before' },

--- a/packages/semantic/src/generators/profiles/types.ts
+++ b/packages/semantic/src/generators/profiles/types.ts
@@ -75,6 +75,14 @@ export interface PossessiveConfig {
    * Example: { my: 'me', your: 'you', its: 'it' }
    */
   readonly keywords?: Record<string, string>;
+  /**
+   * Connector words that sit BETWEEN a possessor keyword and the property in a
+   * possessor-first construction, e.g. Indonesian `saya punya *background`
+   * ("I have *background" = "my *background"). The pattern matcher skips a
+   * connector after the possessor keyword so the property is reached.
+   * English ("my value") needs none; this is only for multi-word possessives.
+   */
+  readonly connectors?: readonly string[];
 }
 
 /**

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -835,6 +835,23 @@ export class PatternMatcher {
     const mark = tokens.mark();
     tokens.advance();
 
+    // Skip a possessive CONNECTOR for multi-word possessor-first constructions
+    // (Indonesian `saya punya *background` = "I have *background" = "my
+    // *background"). The connector sits between the possessor keyword and the
+    // property; without skipping it, `punya` is read as the property and the
+    // whole set body fails to parse (id set-style/set-text).
+    const connectors = this.currentProfile.possessive?.connectors;
+    if (connectors && connectors.length > 0) {
+      const next = tokens.peek();
+      if (next) {
+        const nv = next.value.toLowerCase();
+        const nn = (next.normalized ?? '').toLowerCase();
+        if (connectors.some(c => c.toLowerCase() === nv || c.toLowerCase() === nn)) {
+          tokens.advance();
+        }
+      }
+    }
+
     const propertyToken = tokens.peek();
     if (!propertyToken) {
       // Just the possessive keyword, no property - revert

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -1563,6 +1563,32 @@ export class PatternMatcher {
         return;
       }
 
+      // Leaked English article before a FRONTED reference-noun patient: in a
+      // non-English parse `the` is never authored — it's a dict/transformer leak
+      // (hi `the घटना को …` = "the event", the fronted halt patient). Without
+      // skipping it the patient role grabs only `the` and the following marker
+      // fails, so `halt-event-hi-sov-patient-first` (`{patient} को {event} पर
+      // रोकें`) never matches and the halt loses its patient (a bare halt stops
+      // the handler). The reference noun (घटना→event) then fills the patient, so
+      // `halt the event` continues.
+      //
+      // Gated to `the <ref-noun> <particle-marker>` — a fronted patient phrase.
+      // This deliberately does NOT fire for `the <ref-noun> <verb>` (tr
+      // form-submit-prevent's `the olay çağır …` = "the event call …", where the
+      // ref noun is followed by the `call` verb, not a marker): skipping `the`
+      // there breaks tr's fragile body parse (the §7y regression). English keeps
+      // `the` (authored, not a leak) — byte identical, so the en reference parse
+      // is untouched. See STRUCTURAL_ARCS_ROADMAP.md (hi halt-propagation).
+      if (
+        nextToken &&
+        nextToken.kind === 'keyword' &&
+        this.currentProfile?.code !== 'en' &&
+        isValidReference(nextNorm) &&
+        tokens.peek(1)?.kind === 'particle'
+      ) {
+        return;
+      }
+
       // Not followed by a selector, identifier, or positional keyword — revert
       tokens.reset(mark);
     }

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -2151,6 +2151,29 @@ export class SemanticParserImpl implements ISemanticParser {
   ]);
 
   /**
+   * Condition operators that join two operands inside an `if` condition
+   * expression (`I match .x`, `me contains .y`, `#m exists`). An operator can
+   * never begin a then-branch command, so the condition extraction must not
+   * truncate AT one — but in SOV languages the then-branch verb is clause-final,
+   * so a span like `match .disabled durdur` (tr) can spuriously match a verb-last
+   * command pattern and break the condition at `match`, dropping the operator and
+   * its right operand (tr if-matches; ja/ko/hi escape only because their halt
+   * pattern happens not to match the equivalent span). Checked by the token's
+   * normalized form too, so per-language `matches` keywords (ko 일치 → `matches`)
+   * are covered; the corpus also leaks these as English across every language.
+   */
+  private static readonly CONDITION_OPERATORS = new Set([
+    'matches',
+    'match',
+    'contains',
+    'exists',
+    'has',
+    'have',
+    'equals',
+    'includes',
+  ]);
+
+  /**
    * Parse a leading `if`/`unless` conditional block from the stream into a
    * ConditionalSemanticNode, consuming the whole block (condition + then/else
    * branches, up to the matching `end` or the stream end). Returns null WITHOUT
@@ -2237,7 +2260,12 @@ export class SemanticParserImpl implements ISemanticParser {
       }
       if (bodyDepth === 0 && condTokens.length > 0) {
         const prev = (blockTokens[i - 1].normalized ?? blockTokens[i - 1].value).toLowerCase();
+        const cur = (t.normalized ?? t.value).toLowerCase();
+        // A condition operator (`match`/`contains`/`exists`/…) is part of the
+        // expression, never a then-branch command head — don't truncate at it
+        // even if a verb-last SOV command pattern spuriously matches the span.
         if (
+          !SemanticParserImpl.CONDITION_OPERATORS.has(cur) &&
           !SemanticParserImpl.CONDITION_COPULAS.has(prev) &&
           this.tokensBeginCommand(blockTokens.slice(i), commandPatterns, language)
         ) {

--- a/packages/semantic/src/tokenizers/turkish.ts
+++ b/packages/semantic/src/tokenizers/turkish.ts
@@ -44,7 +44,14 @@ const POSTPOSITIONS = new Set([
   'karşı', // against, towards
   'göre', // according to
   'rağmen', // despite
-  'doğru', // towards
+  // NOTE: 'doğru' ("towards") is intentionally NOT a postposition here. It
+  // collides with the boolean literal `doğru` ("true"), which the i18n dict
+  // emits for `set @attr to true`. classifyToken checks POSTPOSITIONS before
+  // isKeyword, so listing it here misclassified the value as kind='particle'
+  // — and tokenToSemanticValue has no `particle` case, so the set patient role
+  // rejected it (set-attribute fell to the role-scrambling SOV fallback). The
+  // postpositional "towards" sense is not a hyperscript construct; the value
+  // sense is. See STRUCTURAL_ARCS_ROADMAP.md (tr set-attribute).
   'boyunca', // along, throughout
 ]);
 

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -6244,3 +6244,149 @@ describe('th add destination: positional phrase captured (R2 tails batch)', () =
     expect(bare.roles?.get('destination')).toMatchObject({ value: 'me' });
   });
 });
+
+// =============================================================================
+// R2 structural tails — batch 2 (10 → 5 execution cells). Each cell is a distinct
+// per-language mechanism; see docs-internal/STRUCTURAL_ARCS_ROADMAP.md.
+// =============================================================================
+
+import { buildAST } from '../src';
+
+/** Collect command names (the AST action set) by walking the built AST. */
+function astActions(node: unknown, acc: string[] = []): string[] {
+  if (!node || typeof node !== 'object') return acc;
+  const rec = node as Record<string, unknown>;
+  if (typeof rec.name === 'string' && (rec.type === 'command' || rec.type === 'eventHandler')) {
+    acc.push(rec.name);
+  }
+  for (const k of Object.keys(rec)) astActions(rec[k], acc);
+  return acc;
+}
+
+/** Find the first built-AST command node with the given name. */
+function findAstCommand(node: unknown, name: string): Record<string, unknown> | null {
+  if (!node || typeof node !== 'object') return null;
+  const rec = node as Record<string, unknown>;
+  if (rec.name === name && rec.type === 'command') return rec;
+  for (const k of Object.keys(rec)) {
+    const r = findAstCommand(rec[k], name);
+    if (r) return r;
+  }
+  return null;
+}
+
+describe('tr set-attribute — doğru-as-particle + dative allomorph (R2 batch 2)', () => {
+  // Two bugs dropped the value of `set @attr to true`: (1) `doğru` ("true") was a
+  // POSTPOSITION ("towards") classified before the keyword check, so it tokenized
+  // as kind='particle' which tokenToSemanticValue can't convert; (2) the dative
+  // allomorph `ya` (the i18n transformer's vowel-harmony form) wasn't a marker
+  // alternative. Both fixed → set-event-tr-sov-2role matches.
+  const corpus = 'tıklama da @disabled i doğru ya ayarla';
+
+  it('[tr] doğru tokenizes as a value, not a postposition particle', () => {
+    const toks = getTokenizer('tr').tokenize('doğru').tokens;
+    expect(toks[0].kind).not.toBe('particle');
+    expect(toks[0].normalized).toBe('true');
+  });
+
+  it('[tr] set @disabled to true captures destination + value', () => {
+    const ast = buildAST(parse(corpus, 'tr'));
+    const set = findAstCommand(ast.ast, 'set');
+    expect(set).not.toBeNull();
+    const roles = set!.semanticRoles as Record<string, { type?: string; attributeName?: string }>;
+    expect(roles.destination).toMatchObject({ type: 'attributeAccess', attributeName: 'disabled' });
+    expect(roles.event).toBeUndefined(); // not the role-scrambling SOV fallback
+  });
+});
+
+describe('ja put-content-basic — event-last SOV two-role wrapper (R2 batch 2)', () => {
+  // `"Done!" を 私 に 置く クリック で` places the event phrase AFTER the verb.
+  // Without the event-last variant it fell to the bare command pattern (runs at
+  // execute() time, before the click → invisible).
+  const corpus = '"Done!" を 私 に 置く クリック で';
+
+  it('[ja] parses as an event handler, not a bare command', () => {
+    const node = parse(corpus, 'ja') as { kind?: string; metadata?: { patternId?: string } };
+    expect(node.kind).toBe('event-handler');
+    expect(node.metadata?.patternId).toContain('event-last');
+  });
+
+  it('[ja] put captures patient "Done!" and destination me', () => {
+    const ast = buildAST(parse(corpus, 'ja'));
+    const put = findAstCommand(ast.ast, 'put');
+    const roles = put!.semanticRoles as Record<string, { value?: unknown; name?: string }>;
+    expect(roles.patient).toMatchObject({ value: 'Done!' });
+    expect(roles.destination).toMatchObject({ name: 'me' });
+  });
+});
+
+describe('id set-style — two-word possessive connector `punya` (R2 batch 2)', () => {
+  // The id dict renders "my" as `saya punya` ("I have"); the connector `punya`
+  // sits between the possessor (saya→me) and the property and must be skipped.
+  const corpus = 'pada klik atur saya punya *background ke "red"';
+
+  it('[id] set my *background captures the property-path destination', () => {
+    const ast = buildAST(parse(corpus, 'id'));
+    const set = findAstCommand(ast.ast, 'set');
+    expect(set).not.toBeNull();
+    const roles = set!.semanticRoles as Record<string, { type?: string; property?: string }>;
+    expect(roles.destination).toMatchObject({ type: 'propertyAccess', property: '*background' });
+  });
+
+  it('[id] single-word possessor (saya *background) still works', () => {
+    const set = findAstCommand(buildAST(parse('atur saya *background ke "red"', 'id')).ast, 'set');
+    expect(set).not.toBeNull();
+  });
+});
+
+describe('tr if-matches — condition not truncated at an operator (R2 batch 2)', () => {
+  // In SOV the then-verb is clause-final, so `match .disabled durdur` spuriously
+  // matched a verb-last halt pattern and truncated the condition `I match
+  // .disabled` to just `I`. CONDITION_OPERATORS guards against truncating at a
+  // condition operator.
+  const corpus = 'tıklama de eğer I match .disabled durdur yoksa .active i değiştir son';
+
+  it('[tr] condition captures the full matches expression', () => {
+    const ast = buildAST(parse(corpus, 'tr'));
+    const ifn = findAstCommand(ast.ast, 'if');
+    const cond = (ifn!.args as Array<{ type?: string; operator?: string }>)[0];
+    expect(cond).toMatchObject({ type: 'binaryExpression', operator: 'matches' });
+  });
+
+  it('[tr] then=halt, else=toggle preserved', () => {
+    expect(astActions(buildAST(parse(corpus, 'tr')).ast)).toEqual(
+      expect.arrayContaining(['halt', 'toggle'])
+    );
+  });
+});
+
+describe('hi halt-propagation — leaked `the` before a fronted patient (R2 batch 2)', () => {
+  // hi fronts the halt patient: `the घटना को क्लिक पर रोकें फिर …`. The leaked
+  // English article made the patient role grab only `the`, so the halt lost its
+  // patient (a bare halt stops the handler). skipNoiseWords now skips a leaked
+  // `the` before `the <ref-noun> <marker>`.
+  const corpus = 'the घटना को क्लिक पर रोकें फिर .active को टॉगल';
+
+  it('[hi] halt keeps its patient (the event) so the handler continues', () => {
+    const ast = buildAST(parse(corpus, 'hi'));
+    const halt = findAstCommand(ast.ast, 'halt');
+    expect((halt!.args as unknown[]).length).toBeGreaterThan(0); // NOT a bare halt
+    expect(astActions(ast.ast)).toEqual(expect.arrayContaining(['halt', 'toggle']));
+  });
+
+  it('[tr] the skip is gated to a following marker — form-submit-prevent keeps 4 actions', () => {
+    // `the olay çağır …` (the event call …) — ref noun followed by a VERB, not a
+    // marker, so `the` is NOT skipped (the §7y regression is avoided).
+    const fsp =
+      'the olay çağır validateForm() i gönder de durdur eğer sonuç dir yanlış "Invalid form" i kaydet son';
+    const acts = astActions(buildAST(parse(fsp, 'tr')).ast);
+    expect(acts).toEqual(expect.arrayContaining(['halt', 'call', 'if', 'log']));
+  });
+
+  it('[en] authored `the` before a reference noun is untouched', () => {
+    // en is excluded from the skip — `halt the event` still parses (the en
+    // reference must stay byte-identical).
+    const halt = findAstCommand(buildAST(parse('halt the event', 'en')).ast, 'halt');
+    expect((halt!.args as unknown[]).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-14T00:12:12.246Z",
-  "commit": "61ef63f8",
+  "timestamp": "2026-06-14T02:05:49.459Z",
+  "commit": "66c63361",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -13,7 +13,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["repeat-until-event", "window-scroll"],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -636,14 +636,14 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8542877757163472,
+      "avgConfidence": 0.8575345289631005,
       "avgFidelity": 0.9962121212121211,
-      "avgRoleFidelity": 0.7899211711711711,
+      "avgRoleFidelity": 0.7921734234234235,
       "avgExecutionFidelity": 0.967741935483871,
       "executionFailures": ["tabs-aria"],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -742,6 +742,10 @@
           "confidence": 1
         },
         "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "halt-propagation": {
           "success": true,
           "confidence": 1
         },
@@ -1161,10 +1165,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.5
-        },
         "call-function": {
           "success": true,
           "confidence": 0.5
@@ -1274,7 +1274,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1898,7 +1898,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2529,7 +2529,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3159,7 +3159,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3803,7 +3803,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4428,9 +4428,9 @@
       "parseRate": 1,
       "avgConfidence": 0.9560915275200976,
       "avgFidelity": 0.928030303030303,
-      "avgRoleFidelity": 0.6876126126126128,
-      "avgExecutionFidelity": 0.9354838709677419,
-      "executionFailures": ["halt-propagation", "tabs-aria"],
+      "avgRoleFidelity": 0.6893018018018019,
+      "avgExecutionFidelity": 0.967741935483871,
+      "executionFailures": ["tabs-aria"],
       "degeneratePasses": [
         "bind-auto-detect",
         "bind-explicit-property",
@@ -4451,7 +4451,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5076,19 +5076,13 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8404295051353855,
-      "avgFidelity": 0.9640522875816994,
-      "avgRoleFidelity": 0.8236070618723679,
-      "avgExecutionFidelity": 0.967741935483871,
-      "executionFailures": ["set-style"],
+      "avgFidelity": 0.9803921568627451,
+      "avgRoleFidelity": 0.8462827988338192,
+      "avgExecutionFidelity": 1,
+      "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": [
-        "input-mirror",
-        "set-opacity",
-        "set-style",
-        "set-transform",
-        "template-literal-interpolation"
-      ],
-      "bundleSize": 425708,
+      "lossyPasses": [],
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5718,7 +5712,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6341,31 +6335,19 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8399092970521543,
-      "avgFidelity": 0.941017316017316,
-      "avgRoleFidelity": 0.7586068211068213,
-      "avgExecutionFidelity": 0.9354838709677419,
-      "executionFailures": ["put-content-basic", "tabs-aria"],
+      "avgConfidence": 0.8431560502989076,
+      "avgFidelity": 0.9680735930735931,
+      "avgRoleFidelity": 0.7770752895752897,
+      "avgExecutionFidelity": 0.967741935483871,
+      "executionFailures": ["tabs-aria"],
       "degeneratePasses": [
-        "announce-screen-reader",
         "behavior-draggable",
         "behavior-removable",
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "lossyPasses": [
-        "caret-var-on-target",
-        "fetch-do-not-throw",
-        "form-disable-on-submit",
-        "get-attribute-possessive-dot",
-        "get-value-possessive-dot",
-        "input-mirror",
-        "method-call-possessive-dot",
-        "on-custom-event-receive",
-        "put-content-basic",
-        "unless-condition"
-      ],
-      "bundleSize": 425708,
+      "lossyPasses": ["fetch-do-not-throw", "form-disable-on-submit", "unless-condition"],
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6468,6 +6450,10 @@
           "confidence": 1
         },
         "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "halt-propagation": {
           "success": true,
           "confidence": 1
         },
@@ -6860,10 +6846,6 @@
           "confidence": 0.5
         },
         "repeat-times": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "halt-propagation": {
           "success": true,
           "confidence": 0.5
         },
@@ -6989,9 +6971,9 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7958977530406102,
-      "avgFidelity": 0.958874458874459,
-      "avgRoleFidelity": 0.754166666666667,
+      "avgConfidence": 0.8251185322613894,
+      "avgFidelity": 0.9588744588744588,
+      "avgRoleFidelity": 0.770382882882883,
       "avgExecutionFidelity": 0.967741935483871,
       "executionFailures": ["tabs-aria"],
       "degeneratePasses": [
@@ -7008,7 +6990,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7039,6 +7021,10 @@
           "confidence": 1
         },
         "set-style": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-content-basic": {
           "success": true,
           "confidence": 1
         },
@@ -7099,6 +7085,10 @@
           "confidence": 1
         },
         "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "halt-propagation": {
           "success": true,
           "confidence": 1
         },
@@ -7171,6 +7161,10 @@
           "confidence": 1
         },
         "dropdown-close-outside": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-mirror": {
           "success": true,
           "confidence": 1
         },
@@ -7266,6 +7260,10 @@
           "success": true,
           "confidence": 1
         },
+        "announce-screen-reader": {
+          "success": true,
+          "confidence": 1
+        },
         "set-text-possessive-dot": {
           "success": true,
           "confidence": 1
@@ -7274,7 +7272,19 @@
           "success": true,
           "confidence": 1
         },
+        "get-value-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
         "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 1
         },
@@ -7303,6 +7313,10 @@
           "confidence": 1
         },
         "send-event-to-form": {
+          "success": true,
+          "confidence": 1
+        },
+        "on-custom-event-receive": {
           "success": true,
           "confidence": 1
         },
@@ -7343,6 +7357,10 @@
           "confidence": 1
         },
         "caret-var-increment": {
+          "success": true,
+          "confidence": 1
+        },
+        "caret-var-on-target": {
           "success": true,
           "confidence": 1
         },
@@ -7426,10 +7444,6 @@
           "success": true,
           "confidence": 0.5555555555555556
         },
-        "put-content-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
         "put-before": {
           "success": true,
           "confidence": 0.5
@@ -7462,10 +7476,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.5
-        },
         "default-value": {
           "success": true,
           "confidence": 0.5
@@ -7475,10 +7485,6 @@
           "confidence": 0.5
         },
         "async-block": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "input-mirror": {
           "success": true,
           "confidence": 0.5
         },
@@ -7538,27 +7544,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "announce-screen-reader": {
-          "success": true,
-          "confidence": 0.5
-        },
         "focus-trap": {
           "success": true,
           "confidence": 0.5
         },
-        "get-value-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 0.5
-        },
         "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 0.5
         },
@@ -7571,10 +7561,6 @@
           "confidence": 0.5
         },
         "worker-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "on-custom-event-receive": {
           "success": true,
           "confidence": 0.5
         },
@@ -7595,10 +7581,6 @@
           "confidence": 0.5
         },
         "when-multiple-changes": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "caret-var-on-target": {
           "success": true,
           "confidence": 0.5
         },
@@ -7639,7 +7621,7 @@
       "executionFailures": [],
       "degeneratePasses": ["socket-basic"],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8266,7 +8248,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8896,7 +8878,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9519,7 +9501,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7161616161616162,
+      "avgConfidence": 0.7194083694083694,
       "avgFidelity": 0.9632034632034633,
       "avgRoleFidelity": 0.7616473616473615,
       "avgExecutionFidelity": 1,
@@ -9536,7 +9518,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9611,6 +9593,10 @@
           "confidence": 1
         },
         "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "halt-propagation": {
           "success": true,
           "confidence": 1
         },
@@ -9910,10 +9896,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "halt-propagation": {
-          "success": true,
-          "confidence": 0.5
-        },
         "go-url": {
           "success": true,
           "confidence": 0.5
@@ -10167,7 +10149,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10798,7 +10780,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "repeat-until-event", "set-color-variable"],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11425,7 +11407,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12056,7 +12038,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["window-scroll"],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12680,11 +12662,11 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8377425044091712,
+      "avgConfidence": 0.8442784521215895,
       "avgFidelity": 0.9635076252723311,
-      "avgRoleFidelity": 0.773922902494331,
-      "avgExecutionFidelity": 0.9032258064516129,
-      "executionFailures": ["if-matches", "set-attribute", "tabs-aria"],
+      "avgRoleFidelity": 0.7761904761904761,
+      "avgExecutionFidelity": 0.967741935483871,
+      "executionFailures": ["tabs-aria"],
       "degeneratePasses": [
         "behavior-draggable",
         "behavior-removable",
@@ -12693,7 +12675,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12716,6 +12698,10 @@
           "confidence": 1
         },
         "set-text-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "set-attribute": {
           "success": true,
           "confidence": 1
         },
@@ -12788,6 +12774,10 @@
           "confidence": 1
         },
         "repeat-for-each": {
+          "success": true,
+          "confidence": 1
+        },
+        "halt-propagation": {
           "success": true,
           "confidence": 1
         },
@@ -13163,10 +13153,6 @@
           "success": true,
           "confidence": 0.5555555555555556
         },
-        "set-attribute": {
-          "success": true,
-          "confidence": 0.5
-        },
         "put-before": {
           "success": true,
           "confidence": 0.5
@@ -13188,10 +13174,6 @@
           "confidence": 0.5
         },
         "repeat-times": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "halt-propagation": {
           "success": true,
           "confidence": 0.5
         },
@@ -13323,7 +13305,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13960,7 +13942,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14599,7 +14581,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 425708,
+      "bundleSize": 427405,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15221,7 +15203,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 425708,
+      "size": 427405,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Continues the R2 execution-tail burn-down in [`docs-internal/STRUCTURAL_ARCS_ROADMAP.md`](docs-internal/STRUCTURAL_ARCS_ROADMAP.md). Clears the **5 remaining non-S1 cells**, each a distinct per-language structural bug, probed-before-edit and verified across languages. **Only the deferred S1 `tabs-aria` ×5 cluster remains.**

- Execution failures: **10 → 5**
- avgExecutionFidelity: **0.9860 → 0.9930**
- Full `--regression` gate green (parse-rate, fidelity, correctness, execution ratchets); **zero fidelity regressions**
- Baseline regenerated against a freshly populated `patterns.db`
- 11 lock tests added; semantic **5958** tests green; typecheck clean
- All fixes semantic-only; **en reference byte-identical**

## Cells fixed (one commit each)

| Cell | Root cause | Fix |
|------|-----------|-----|
| **tr set-attribute** | `doğru`("true") was in `POSTPOSITIONS`("towards"), classified before `isKeyword` → `kind='particle'` (no `tokenToSemanticValue` case) → patient rejected. Plus the vowel-harmony dative allomorph `ya` wasn't a marker alternative. | Removed `doğru` from POSTPOSITIONS; wired the schema's `markerVariants` into the SOV two-role generators (new `resolveRoleMarker` helper); added tr dative allomorphs (e/a/ye/ya) to `set`'s patient. |
| **ja put-content-basic** (S4) | The event phrase trails the verb (`"Done!" を 私 に 置く クリック で`); no SOV variant covered event-LAST order, so it fell to the bare command (runs at execute() time, before the click → invisible). | Added `generateSOVTwoRoleEventLastEventHandlerPattern`. |
| **id set-style** (S3) | The dict renders "my" as the two-word `saya punya` ("I have"); the connector `punya` broke the possessive matcher. | Added a `connectors` field to `PossessiveConfig` (id: `punya`), skipped after the possessor keyword. |
| **tr if-matches** | In SOV the then-verb is clause-final, so `match .disabled durdur` spuriously matched a verb-last halt pattern and truncated the condition `I match .disabled` to `I`. | Added a `CONDITION_OPERATORS` guard — an operator never begins a command, so the condition isn't truncated at one. |
| **hi halt-propagation** (was §7y-blocked) | hi fronts the halt patient with a leaked English `the` (`the घटना को क्लिक पर रोकें …`); the patient role grabbed only `the`, the marker `को` failed, and the halt fell to a BARE halt (stops the handler). | `skipNoiseWords` skips a leaked `the` only before `the <ref-noun> <marker>`. The marker gate **solves the §7y tr/form-submit-prevent regression**: `the olay çağır …` has a verb (not a marker) after the ref noun, so `the` is left intact; en excluded entirely. |

## Remaining: S1 `tabs-aria` ×5 (deferred)

Confirmed the roadmap's diagnosis — the **en reference itself is lossy**: `set @aria-selected to "false" on .tab set @aria-selected to "true" on me` drops both `on <scope>` modifiers even in English. A real fix changes the en reference and **inverts the gate band**, so it's deferred to a dedicated band-inversion + full re-record (documented in `STRUCTURAL_ARCS_ROADMAP.md` and `CORRECTNESS_RELIABILITY_PLAN.md §7aa`).

## Test plan

- `npm run test:check --prefix packages/semantic` — 5958 green
- `npm run typecheck --prefix packages/semantic` — clean
- `cd packages/testing-framework && npx tsx src/multilingual/cli.ts --full --bundle browser-priority --regression` — green, zero fidelity regressions
- 11 new lock tests in `packages/semantic/test/multilingual-roadmap-fixes.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)