### PR TITLE
feat(r2): add announce-screen-reader to execution subset (24/24)

### DIFF
--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -1830,6 +1830,17 @@ body parse, not the scope). Adding it would need that en body-parse fix +
 per-cell trigger/`detail` support in the execution harness (a separate arc, not
 the set-scope concern). The §7g exclusion bullet is annotated RESOLVED.
 
+> **LANDED (§7cc) — and the diagnosis above was imprecise.** The deferred
+> follow-up shipped. On re-probe the body did **not** degenerate: `parseSemantic`
+> already splits it into `compound[put, set]` with all roles intact (the scope on
+> the `set`, the `event.detail.message` property path on the `put`). The real
+> en-side gap was one layer down — `buildAST` mapped the `on success` event role
+> (tokenized as an `expression`, not a recognized event keyword) to the **`click`
+> default**, so the handler bound to the wrong event and the harness's hardcoded
+> click (carrying no `detail`) produced nothing. Fixed in §7cc. The "yields no
+> effect" symptom was the event-name + missing-`detail` combination, not a body
+> split.
+
 **Lock tests:** the `S1 tabs-aria` describe-block in
 `packages/semantic/test/multilingual-roadmap-fixes.test.ts` (8 cases: en
 standalone + `on me`, es SVO, ja verb-medial event-handler + verb-last
@@ -1837,6 +1848,54 @@ standalone, ko, qu clause-final verb, and a scope-less-set no-op guard) + the
 `execute - attribute on a multi-element scope` block in
 `packages/core/src/commands/data/__tests__/set.test.ts`. Semantic 5977 green;
 core set 84 green; typechecks clean.
+
+## 7cc. Status update (announce-screen-reader — the deferred S1 follow-up: lands)
+
+**The R2 execution subset gains its first non-click, event-reading cell;
+`announce-screen-reader` PASSES 24/24.** Subset 31 → 32; avgExecutionFidelity
+stays 1.0000 across all 24 languages (empty `executionFailures` everywhere). This
+is the follow-up explicitly deferred in §7bb / #425.
+
+**Two real gaps (NOT the body split §7bb suspected):**
+
+1. **en — custom event name defaulted to `click` (`buildAST`).** `on success` is
+   not a recognized event keyword, so the tokenizer carries the event role as an
+   `expression` (`{type:'expression', raw:'success'}`), the same shape namespaced
+   events like `on htmx:afterRequest` take. `buildEventHandler`
+   (`packages/semantic/src/ast-builder/index.ts`) only handled `literal` and
+   `reference` event roles and fell through to `event = 'click'` for everything
+   else — so every custom/namespaced-event handler silently bound to `click`. Fix:
+   consolidate the event-name extraction to also read `expression.raw`, feeding the
+   same name parsing (incl. the `a or b` multi-event split). `on success` now binds
+   `success`; the latent `htmx:*` mis-binding is fixed in the same stroke. The
+   semantic PARSE was already correct (`compound[put, set]`, scope + property path
+   intact) — this is a buildAST-only change, so R0/R1 parse fidelity is untouched.
+2. **harness — no per-cell trigger / `detail` (`execution-validator.ts`).** The
+   validator hardcoded a bare `Event('click')`. Added a `PATTERN_TRIGGER` map
+   (`{event, detail?}`, default click/no-detail): with a `detail`, a `CustomEvent`
+   is dispatched so `event.detail.message` resolves. The payload is harness-supplied
+   and identical for en and every translation, so effect signatures stay comparable.
+   `#sr-announce` added to `FIXTURE_HTML` (appended last — existing positional
+   snapshot indexes unchanged). announce's trigger: `success` + `{message:'Saved
+successfully'}`.
+
+**Why 24/24 with no residuals:** the `set @attr … on <scope>` plumb (S1, §7bb) was
+the hard part and already landed; the event name (`success`) and the
+`event.detail.message` path are code, preserved verbatim across translations. So
+every language reproduces the en effect exactly: `Δ#sr-announce … role=alert …
+text[Saved successfully]`. Probed through the validator across all 24 before
+regenerating — all MATCH.
+
+**Lock tests:** `binds a custom/namespaced event name carried as an expression
+role` in `packages/semantic/test/ast-builder.test.ts` (success + htmx:afterRequest)
+
+- two cases in `execution-validator.test.ts` (the cell executes via its custom-event
+  trigger with the exact two-field signature; a click trigger does NOT fire a
+  success-only handler — trigger-routing isolation) + the membership lock bumped
+  31 → 32. Baseline regenerated against a freshly `populate`d DB (the only
+  non-metadata baseline delta is the priority bundle +33 bytes from the added
+  branch; bands/parseRate/execFid unchanged). Semantic 5977 green; testing-framework
+  validator+reporter 21 green; typechecks clean.
 
 ## 11. Next-arc handoffs (post-#416)
 
@@ -1856,6 +1915,11 @@ S2+S6+qu, parse ship line held). The next work is decomposed into focused handof
   `set @attr to V on <scope>` scope plumb; band inversion absorbed in-PR; all 24
   langs reproduce the scoped reference; avgExecutionFidelity → 1.0000. **R2
   execution tail fully cleared (0 cells).**
+- ✅ **announce-screen-reader — the deferred S1 follow-up:** DONE (§7cc). Subset
+  31 → 32 (first non-click, event-reading cell); 24/24 pass, execFid stays 1.0000.
+  Fixes were a buildAST custom-event-name default (`success`/`htmx:*` → `click`)
+  and a per-cell trigger/`detail` harness gap — NOT the body split §7bb suspected
+  (the parse was already `compound[put, set]`).
 - **Per-language structural arcs (the R2 tail):**
   [STRUCTURAL_ARCS_ROADMAP.md](STRUCTURAL_ARCS_ROADMAP.md). Every remaining R2 cell
   mapped to an arc, with a triage rubric (yield · leverage · confidence · risk ·

--- a/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
+++ b/docs-internal/STRUCTURAL_ARCS_ROADMAP.md
@@ -1,5 +1,17 @@
 # Per-language structural arcs roadmap (R2 execution tail)
 
+> **Progress (announce-screen-reader — the deferred S1 follow-up — LANDED):**
+> the R2 subset gains its first non-click, event-reading cell and it passes
+> 24/24 on arrival (subset 31 → 32, avgExecutionFidelity stays 1.0000). This was
+> an EXPANSION, not a tail-clearing — the tail was already 0 (§7bb). Two fixes,
+> neither the body split §7bb suspected: (1) `buildAST` bound the custom `on
+success` event (carried as an `expression` role, like `htmx:*`) to the `click`
+> default — now reads `expression.raw`; (2) the execution validator gained a
+> per-cell `PATTERN_TRIGGER` ({event, detail?}) so a `success` `CustomEvent` with
+> `event.detail.message` can fire the handler. The `set @attr … on <scope>` plumb
+> (S1) did the heavy lifting; the event name + property path are code, preserved
+> verbatim across all 24 languages. See CORRECTNESS_RELIABILITY_PLAN.md §7cc.
+
 > **Progress (S1 tabs-aria ×5 — 5 → 0 — ARC COMPLETE):** the deferred
 > en-reference band-inversion arc is done. `set @attr to V on <scope>` now
 > captures the `on`-scope across the whole stack: a new `scope` SemanticRole +

--- a/packages/semantic/src/ast-builder/index.ts
+++ b/packages/semantic/src/ast-builder/index.ts
@@ -263,24 +263,33 @@ export class ASTBuilder {
    * Build an EventHandlerNode from an EventHandlerSemanticNode.
    */
   private buildEventHandler(node: EventHandlerSemanticNode): EventHandlerNode {
-    // Extract event name(s)
+    // Extract event name(s).
     const eventValue = node.roles.get('event');
-    let event: string;
+    let event = 'click'; // Default when the event role is absent or opaque.
     let events: string[] | undefined;
 
-    if (eventValue?.type === 'literal') {
-      const eventStr = String(eventValue.value);
-      // Handle "click or keydown" syntax
+    // A recognized event keyword (`on click`) tokenizes as a literal; a custom
+    // or namespaced event name (`on success`, `on htmx:afterRequest`) is not a
+    // keyword, so it tokenizes as an expression whose `raw` IS the event name.
+    // Both feed the same name parsing (including the `click or keydown`
+    // multi-event split). Without the expression branch, every custom-event
+    // handler silently bound to `click` instead.
+    const eventStr =
+      eventValue?.type === 'literal'
+        ? String(eventValue.value)
+        : eventValue?.type === 'expression'
+          ? eventValue.raw
+          : eventValue?.type === 'reference'
+            ? eventValue.value
+            : undefined;
+
+    if (eventStr !== undefined) {
       if (eventStr.includes('|') || eventStr.includes(' or ')) {
         events = eventStr.split(/\s+or\s+|\|/).map(e => e.trim());
         event = events[0];
       } else {
         event = eventStr;
       }
-    } else if (eventValue?.type === 'reference') {
-      event = eventValue.value;
-    } else {
-      event = 'click'; // Default event
     }
 
     // Build body commands recursively

--- a/packages/semantic/test/ast-builder.test.ts
+++ b/packages/semantic/test/ast-builder.test.ts
@@ -324,6 +324,29 @@ describe('ASTBuilder', () => {
       expect((result as any).event).toBe('click');
       expect((result as any).commands).toHaveLength(1);
     });
+
+    it('binds a custom/namespaced event name carried as an expression role', () => {
+      // `on success` / `on htmx:afterRequest` are not recognized event
+      // keywords, so the tokenizer emits the event role as an expression whose
+      // `raw` IS the event name. Without the expression branch in
+      // buildEventHandler these silently bound to the `click` default.
+      for (const name of ['success', 'htmx:afterRequest']) {
+        const node: EventHandlerSemanticNode = {
+          kind: 'event-handler',
+          roles: new Map([['event', { type: 'expression', raw: name }]]),
+          body: [
+            {
+              kind: 'command',
+              action: 'toggle',
+              roles: new Map([
+                ['patient', { type: 'selector', value: '.active', selectorKind: 'class' }],
+              ]),
+            },
+          ],
+        };
+        expect((builder.build(node) as any).event).toBe(name);
+      }
+    });
   });
 
   describe('build conditional', () => {

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-14T04:56:51.147Z",
-  "commit": "08393962",
+  "timestamp": "2026-06-14T12:22:40.322Z",
+  "commit": "776e46c3",
   "languages": {
     "ar": {
       "parseSuccess": 153,
@@ -13,7 +13,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["repeat-until-event", "window-scroll"],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -643,7 +643,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1274,7 +1274,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1898,7 +1898,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2529,7 +2529,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3159,7 +3159,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3803,7 +3803,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4450,7 +4450,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5081,7 +5081,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5711,7 +5711,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6346,7 +6346,7 @@
         "behavior-sortable"
       ],
       "lossyPasses": ["fetch-do-not-throw", "form-disable-on-submit", "unless-condition"],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6989,7 +6989,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7620,7 +7620,7 @@
       "executionFailures": [],
       "degeneratePasses": ["socket-basic"],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8247,7 +8247,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8877,7 +8877,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9517,7 +9517,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10148,7 +10148,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10779,7 +10779,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["event-debounce", "repeat-until-event", "set-color-variable"],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11406,7 +11406,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12037,7 +12037,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["window-scroll"],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12674,7 +12674,7 @@
         "default-value"
       ],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13304,7 +13304,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13941,7 +13941,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14580,7 +14580,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 428314,
+      "bundleSize": 428347,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15202,7 +15202,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 428314,
+      "size": 428347,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
@@ -19,7 +19,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { ExecutionValidator, EXECUTION_SUBSET, loadExecutionSubset } from './execution-validator';
 
 describe('R2 execution subset (lock)', () => {
-  it('contains exactly the 31 curated patterns', () => {
+  it('contains exactly the 32 curated patterns', () => {
     // Changing this list recalibrates avgExecutionFidelity for every language.
     // If you expand the subset, regenerate the baseline (--save-baseline) in
     // the SAME PR and update this lock.
@@ -82,6 +82,12 @@ describe('R2 execution subset (lock)', () => {
         // + contextReference body. The last R2 candidate excluded for an
         // unusable en reference is now in.
         'make-toast-element',
+        // Expansion wave 4 (the deferred S1 follow-up): the first non-click,
+        // event-reading cell. buildEventHandler binds the custom `success`
+        // event (carried as an expression role) instead of defaulting to click;
+        // PATTERN_TRIGGER dispatches a CustomEvent whose detail.message the
+        // handler reads. set @role on the #sr-announce scope landed in S1.
+        'announce-screen-reader',
       ].sort()
     );
   });
@@ -152,6 +158,37 @@ describe('R2 execution validator (lock)', () => {
     );
     expect(backdrop.error).toBeUndefined();
     expect(backdrop.effects.length).toBeGreaterThan(0);
+  });
+
+  it('the announce-screen-reader cell executes via its custom-event trigger', async () => {
+    // First non-click cell: `on success put event.detail.message into
+    // #sr-announce set @role to "alert" on #sr-announce`. PATTERN_TRIGGER
+    // dispatches a `success` CustomEvent carrying detail.message; the handler
+    // writes that text into #sr-announce and sets role=alert on it. Locks both
+    // the per-cell trigger wiring and the two-line effect signature.
+    const res = await validator.execute(
+      'announce-screen-reader',
+      'on success put event.detail.message into #sr-announce set @role to "alert" on #sr-announce',
+      'en'
+    );
+    expect(res.error).toBeUndefined();
+    expect(res.effects).toEqual([
+      'Δ#sr-announce cls[] attr[id=sr-announce,role=alert] style[] text[Saved successfully]',
+    ]);
+  });
+
+  it('a click trigger does not fire the success-only handler (trigger isolation)', async () => {
+    // The default click dispatch must NOT execute a handler bound to a custom
+    // event — proves PATTERN_TRIGGER actually routes the event name, rather than
+    // the handler firing on any event.
+    const clickOnly = await validator.execute(
+      'toggle-class-basic', // a click cell, but force the wrong source text:
+      'on success add .x to me',
+      'en'
+    );
+    // No PATTERN_TRIGGER for toggle-class-basic → click dispatched → success
+    // handler never runs → empty signature.
+    expect(clickOnly.effects).toEqual([]);
   });
 
   it('a parse failure comes back as an error, never a throw', async () => {

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.ts
@@ -116,6 +116,15 @@ export const EXECUTION_SUBSET: readonly string[] = [
   // keys, and contextReference body/document/window resolve. The en
   // reference appends the toast at end of body: one clean effect line.
   'make-toast-element',
+  // Expansion wave 4 (the deferred S1 follow-up): the first non-click,
+  // event-reading cell. `on success put event.detail.message into #sr-announce
+  // set @role to "alert" on #sr-announce` exercises (1) a custom event name
+  // carried as an expression role — buildEventHandler now binds it instead of
+  // defaulting to `click`; (2) the `set @attr … on <scope>` plumb landed in S1;
+  // (3) per-cell trigger support (PATTERN_TRIGGER) dispatching a CustomEvent
+  // with a `detail` payload. The en reference writes the announcement text into
+  // #sr-announce and sets role=alert on it: two clean effect lines.
+  'announce-screen-reader',
 ];
 
 /**
@@ -139,6 +148,7 @@ const FIXTURE_HTML = `<!DOCTYPE html><html><body>
   <div class="accordion-item open"></div>
   <div id="container"></div>
   <div class="dropdown-menu"></div>
+  <div id="sr-announce"></div>
 </body></html>`;
 
 /** Per-pattern fixture preconditions (applied identically for every language). */
@@ -163,6 +173,27 @@ const PATTERN_SETUP: Record<string, (doc: Document) => void> = {
     doc.querySelector('.card')!.classList.add('modal');
     doc.body.classList.add('modal-open');
   },
+};
+
+/**
+ * Per-pattern trigger override. The subset is overwhelmingly `on click`, so the
+ * default (dispatched in `executeInner`) is a bare `Event('click')`. A handler
+ * that listens for a different event — or that READS the triggering event (e.g.
+ * `on success put event.detail.message …`) — declares the event name and, when
+ * needed, a `detail` payload here. With a `detail`, a `CustomEvent` is
+ * dispatched so `event.detail.*` resolves; the payload is identical for the en
+ * reference and every translation (it is harness-supplied, not translated), so
+ * effect signatures stay comparable across languages.
+ */
+interface PatternTrigger {
+  readonly event: string;
+  readonly detail?: unknown;
+}
+const PATTERN_TRIGGER: Record<string, PatternTrigger> = {
+  // `on success put event.detail.message into #sr-announce set @role to "alert"
+  // on #sr-announce` — a custom event carrying the announcement text. The fixed
+  // message lands in #sr-announce's text; role=alert is set on the same node.
+  'announce-screen-reader': { event: 'success', detail: { message: 'Saved successfully' } },
 };
 
 /** Result of executing one pattern translation. */
@@ -348,7 +379,12 @@ export class ExecutionValidator {
       await runtime.execute(built.ast, ctx);
 
       const before = snapshot(document);
-      btn.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+      const trigger = PATTERN_TRIGGER[codeExampleId];
+      const triggerEvent =
+        trigger?.detail !== undefined
+          ? new dom.window.CustomEvent(trigger.event, { bubbles: true, detail: trigger.detail })
+          : new dom.window.Event(trigger?.event ?? 'click', { bubbles: true });
+      btn.dispatchEvent(triggerEvent);
       await new Promise(r => setTimeout(r, SETTLE_MS));
       const after = snapshot(document);
 


### PR DESCRIPTION
## Summary

The deferred S1 follow-up (#425): the R2 execution subset gains its first **non-click, event-reading** cell. `announce-screen-reader` — `on success put event.detail.message into #sr-announce set @role to "alert" on #sr-announce` — now passes **24/24**; `avgExecutionFidelity` stays **1.0000** (empty `executionFailures` across all languages). Subset 31 → 32.

## The real gap was NOT the body split

The #425 brief suspected the body "degenerates to a bare compound (the `on success` + `event.detail` put/set juxtaposition doesn't split)." Re-probed against the parent commit — the body **does** split, and that was never the blocker:

```
1) parseSemantic body[0] = compound{ statements: ['put', 'set'] }   ← parser, byte-identical to parent
2) PRE-FIX buildAST event = click                                   ← the actual bug
3) PRE-FIX, bare click (old harness, no detail) → text="" role=alert ← the "#425 no effect"
4) PRE-FIX, click WITH detail → text="Saved successfully" role=alert ← BODY executes fully
5) PRE-FIX, success+detail → text="" role=null                       ← bound to click, not success
```

Line 4 is the proof: when the click-bound handler is given a `detail`, the compound `[put, set]` executes completely. The "no effect" symptom was two layers down.

## Two fixes

1. **en — custom event name defaulted to `click` (`buildAST`).** `on success` isn't a recognized event keyword, so the tokenizer carries the event role as an `expression` (`raw: 'success'`) — the same shape namespaced events (`on htmx:afterRequest`) take. `buildEventHandler` only handled `literal`/`reference` roles and fell through to `event = 'click'`, so every custom/namespaced-event handler silently bound to `click`. Consolidated the event-name extraction to also read `expression.raw` (feeding the same `a or b` multi-event split). Fixes the latent `htmx:*`→click mis-binding in the same stroke. **buildAST-only — R0/R1 parse fidelity untouched** (parser byte-identical to parent).
2. **harness — no per-cell trigger/detail (`execution-validator`).** Added a `PATTERN_TRIGGER` map (`{event, detail?}`, default click/no-detail): with a `detail`, a `CustomEvent` is dispatched so `event.detail.message` resolves. The payload is harness-supplied and identical for en and every translation, so effect signatures stay comparable. `#sr-announce` appended last in `FIXTURE_HTML` (existing positional snapshot indexes unchanged).

## Baseline

Regenerated against a freshly populated DB (reproduces clean vs a fresh `--regression`). Only non-metadata delta is the priority bundle **+33 bytes** from the added branch; bands/parseRate/execFid unchanged. Per convention the regenerated `patterns.db` is **not** committed (CI re-populates it).

## Tests

- `binds a custom/namespaced event name carried as an expression role` (`ast-builder.test.ts`: success + htmx:afterRequest)
- the cell executes via its custom-event trigger; a click trigger does **not** fire a success-only handler — trigger-routing isolation (`execution-validator.test.ts`)
- membership lock 31 → 32

Semantic 5977 green; testing-framework 177 green; typechecks clean.

Docs: `CORRECTNESS_RELIABILITY_PLAN` §7cc + §7bb/§11 annotations (correcting the earlier diagnosis), `STRUCTURAL_ARCS_ROADMAP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)