### PR TITLE
feat(semantic): multilingual behaviors — parse, harden, and translate behavior/def blocks

### DIFF
--- a/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
+++ b/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
@@ -177,4 +177,28 @@ Dependency shape: **Phase 0 gates 1–4 · 1→4 · 2→3 · 5 is free-floating.
   scoped separately rather than rushed into Phase 1.
 - **Deferred (Phase 2):** SOV trigger-marker cosmetics (ja renders `click を で`,
   slightly non-idiomatic but round-trips correctly).
-- **Next: Phase 2** — harden rung-2 SOV/VSO handler-body _parsing_.
+- **2026-06-14: Phase 2 in progress — doubled trigger-marker phantom fixed.**
+  A precision-signal round-trip probe (12 handler shapes × 16 non-SVO-Latin langs)
+  measured **85.9% clean** and surfaced a systemic defect the recall gate was
+  blind to: bn/hi/th use the **same word** for the `on` trigger keyword and the
+  event-role marker (bn `তে`, hi `पर`, th `เมื่อ`), so the generator emitted it
+  twice (`<event> তে তে`); the duplicate re-parsed as a phantom command (`তে আমি`
+  → `on me`; `เมื่อ click` → stray `click`). Root fix: `buildTokens`
+  (`packages/semantic/src/generators/pattern-generator.ts`) collapses adjacent
+  identical literals. Scan confirmed this touches **only the `on` patterns of
+  bn/hi/th** — no other command/language has adjacent duplicate literals, and
+  none are in the priority gate, so the committed baseline is untouched.
+  **Result: 85.9% → 96.9%** (th 12→0 imperfect, bn 11→2). Regression: semantic
+  6004/6004; lock test `event-handler-render-no-phantom.test.ts` extended to 27.
+- **Phase 2 tail (diagnosed, distinct per-language root causes — STRUCTURAL_ARCS):**
+  - **bn `put`** — `into #out` destination marker renders as multiple tokens that
+    re-glue into the patient (`এশেষর#out`); `"hi"` loses quotes → phantom command.
+  - **bn `wait`** — duration `200ms` (before the SOV verb) not captured into the
+    `duration` role → phantom command.
+  - **ar/id/sw `set` + possessive** — `set my textContent to "x"` renders
+    plausibly (`اضبط textContent لي إلى "x"`) but parses to an **empty body** (the
+    possessive-property target isn't matched). _ar is a priority language._
+  - **vi `increment`** — renders idiomatically as `tăng :count thêm 1`
+    ("increase by 1"); the `thêm 1` re-parses as a phantom `add` command.
+- **Next:** decide depth on the Phase-2 tail (4 separate per-language fixes), then
+  Phase 3 (general structural/block layer).

--- a/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
+++ b/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
@@ -139,11 +139,23 @@ Dependency shape: **Phase 0 gates 1–4 · 1→4 · 2→3 · 5 is free-floating.
 >   (es/ja/ko/de/fr +0.012–0.014, zh/ar/he +0.008–0.010); a few non-priority langs
 >   (tl −0.016, th −0.010, hi −0.009) drop as their incomplete behavior bodies
 >   become honestly measured. All baseline deltas are behavior-only.
-> - **Known body-content gaps (orthogonal, affect single statements too):**
->   newline-separated handler bodies capture only the first command (engine splits
->   on `then`, not newlines); `.{cls}` dynamic class selectors aren't tokenized.
->   These cap per-language behavior fidelity and are the next sub-step. `def`
->   functions / multi-handler top-level programs reuse the same layer (not yet wired).
+> - **2026-06-14: body-content fixes ✅.** A re-diagnosis corrected the earlier
+>   "newline-body" framing — **newline/space/`then`-separated multi-command bodies
+>   already parse** (`[add, remove]` for all three). The real gaps were two general
+>   single-statement issues that capped real behaviors:
+>   - **`remove me` / `remove it` (remove-self)** — threw, because the remove
+>     `patient` only accepted `selector`. Added `reference` to its expectedTypes
+>     (`command-schemas.ts`). `remove #el` / `remove .x from me` unchanged.
+>   - **`.{cls}` dynamic class interpolation** — un-tokenized (the class regex
+>     required a letter after `.`). Added a `.\{varName\}` branch to the CSS selector
+>     extractor (`tokenizers/extractors/css-selector.ts`).
+>     The real `Toggleable(cls)` / `Removable` behaviors now parse end-to-end.
+>     semantic **6041/6041**; lock test `test/behavior-body-content.test.ts`;
+>     gate green (baseline regen: only pl/uk `behavior-removable` shifts, fid −0.000 —
+>     the richer EN reference effect; corpus impact negligible, value is correctness).
+> - **Still un-tokenized / remaining body-content:** other dynamic forms as they
+>   surface; `def` functions / multi-handler top-level programs reuse the block
+>   layer (not yet wired). Phase 4 = block renderer (round-trip translation).
 
 ### Phase 4 — Block renderer + round-trip
 

--- a/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
+++ b/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
@@ -206,22 +206,29 @@ Dependency shape: **Phase 0 gates 1–4 · 1→4 · 2→3 · 5 is free-floating.
     `-at-start`) patterns for rendering only — parsing is priority-ordered in the
     matcher (not `findBestPattern`), so positional _input_ still matches via its
     literals. Same class as the Phase-1 `-event-` filter.
-- **Phase 2 tail — 2 deferred (each its own careful mini-arc):**
-  - **ar/id/sw `set` + possessive** — _framework gap, ar is PRIORITY._
-    `tryMatchPossessiveExpression` (`packages/semantic/src/parser/pattern-matcher.ts`)
-    is strictly **pre-nominal** (possessor-first: `my value` / `لي قيمة`).
-    Post-nominal (`textContent لي` / `textContent saya` / `textContent yangu`,
-    property-first — `markerPosition: 'after-object'`) isn't matched, so the set
-    body fails entirely. Scoped fix: an **additive post-nominal branch** gated on
-    `possessive.markerPosition === 'after-object'` (peek property identifier/selector,
-    then a possessor keyword → property-path). Gated so it only touches after-object
-    languages (which currently can't parse possessives at all). **Requires the full
-    gate + baseline regen** (ar priority) + cross-language verification (he/id/sw).
-  - **bn `wait`** — _deep shared body-parser, non-priority._ Standalone
-    `200ms অপেক্ষা` parses correctly (`wait{duration:200ms}`); only the
-    multi-clause **then-chain body** path drops/duplicates it (`[200ms, wait, add]`).
-    Same "control-flow body parsing" cluster tracked in
-    CORRECTNESS_RELIABILITY_PLAN; high-risk to touch for one non-priority edge case.
-- **Next:** either pick up the 2 deferred tail arcs (start with ar/id/sw
-  possessive — priority, additive, scoped above) or proceed to Phase 3 (general
-  structural/block layer).
+- **2026-06-14: ar/id/sw possessive arc ✅ DONE — fixed 7 languages.** Added a
+  **post-nominal** possessive branch (`tryMatchPostNominalPossessiveExpression` in
+  `packages/semantic/src/parser/pattern-matcher.ts`), gated on
+  `possessive.markerPosition === 'after-object'` and to property-path roles (set's
+  destination). It matches `<property> <possessor>` order (the mirror of the
+  existing pre-nominal `<possessor> <property>`).
+  - **ar/id/sw/tr**: parse-FAIL → `destination = me.textContent`.
+  - **ru/pl/uk** (bonus): were silently **lossy** (possessor dropped, destination
+    a bare `textContent` — recall-passing, role-fidelity-divergent) → possessor
+    recovered, now matches the en reference.
+  - pre-nominal langs (en/es/ms/he) unaffected; non-possessive targets
+    (`set #x to "v"`) unaffected. **qu** still fails — separate possessor-first
+    root cause (`noqa-pa textContent` not recognized), non-priority, left as tail.
+  - **Verified:** rung-2 round-trip **97.9% → 99.5%** (only bn `wait` remains);
+    semantic 6020/6020; full `--regression` gate **green**; new lock test
+    `test/post-nominal-possessive.test.ts` 12/12. The gate corpus contains no
+    `set`-possessive pattern, so corpus fidelity numbers are unchanged (the only
+    `--save-baseline` delta was bundleSize + array formatting — **not committed**,
+    gate passes against the existing baseline within tolerance).
+- **Phase 2 tail — 1 deferred (non-priority):**
+  - **bn `wait`** — _deep shared body-parser._ Standalone `200ms অপেক্ষা` parses
+    correctly (`wait{duration:200ms}`); only the multi-clause **then-chain body**
+    path drops/duplicates it (`[200ms, wait, add]`). Same "control-flow body
+    parsing" cluster tracked in CORRECTNESS_RELIABILITY_PLAN; high-risk to touch
+    for one non-priority edge case. (qu possessor-first possessive also remains.)
+- **Next:** Phase 3 — general structural/block layer (behaviors / `def` / programs).

--- a/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
+++ b/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
@@ -116,6 +116,35 @@ Dependency shape: **Phase 0 gates 1–4 · 1→4 · 2→3 · 5 is free-floating.
 - Behaviors are the **first consumer**; `def` functions and multi-handler scripts
   come essentially free.
 
+> **2026-06-14: Phase 3 first slice ✅ — `behavior … end` blocks now parse.**
+> New `parser/block-parser.ts` (`tryParseBehaviorBlock`) + `BehaviorSemanticNode`
+> kind + `createBehaviorNode` + `buildAST` `buildBehavior` → core `BehaviorNode`.
+> Hooked as **Stage 0** of `parse()` (cheap substring pre-guard; returns null fast
+> for non-block input). Decomposition is **end-delimited** (depth counts only
+> NESTED openers `if`/`unless`/`repeat`/`for`/`while`, NOT the handler trigger),
+> which is **trigger-agnostic** — works where the trigger is `on` (SVO/VSO),
+> `wenn`/when (de), the `一…就` idiom (zh), or a mid-clause SOV marker (ja/ko `で`/
+> `할 때`). Each sub-block's ORIGINAL source is sliced by token position (robust for
+> space-less scripts) and parsed by the single-statement engine.
+>
+> - **Verified** across en/es/ja/ko/ar/de/zh/tr: name + params + handler bodies
+>   preserved (`[add,remove]`), multi-handler, and nested `if` inside a handler
+>   depth-contained. buildAST → `{type:'behavior', name, parameters, eventHandlers}`.
+> - **Honesty:** a handler whose body the engine silently drops (e.g. `.{cls}`)
+>   scores the block < 0.5, not a false 1.0.
+> - semantic **6032/6032**; lock test `test/behavior-block.test.ts` 12/12; typecheck
+>   clean. **Baseline regenerated** — behaviors were trivially-faithful 1.0 before
+>   (EN + every lang dropped the body identically); now really parsed, so the gate
+>   shows true per-language fidelity. Net **improvement on priority langs**
+>   (es/ja/ko/de/fr +0.012–0.014, zh/ar/he +0.008–0.010); a few non-priority langs
+>   (tl −0.016, th −0.010, hi −0.009) drop as their incomplete behavior bodies
+>   become honestly measured. All baseline deltas are behavior-only.
+> - **Known body-content gaps (orthogonal, affect single statements too):**
+>   newline-separated handler bodies capture only the first command (engine splits
+>   on `then`, not newlines); `.{cls}` dynamic class selectors aren't tokenized.
+>   These cap per-language behavior fidelity and are the next sub-step. `def`
+>   functions / multi-handler top-level programs reuse the same layer (not yet wired).
+
 ### Phase 4 — Block renderer + round-trip
 
 - Faithful translation of whole behaviors/functions between languages (understand

--- a/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
+++ b/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
@@ -1,0 +1,180 @@
+# Multilingual behaviors — assessment + plan (correctness-first)
+
+> **Thesis:** "multilingual behaviors" is not one feature. It is the top rung of a
+> ladder whose lower rungs are cracked. An empirical spike (2026-06-14) showed the
+> semantic stack **cannot parse `behavior … end` blocks in any language** (body
+> dropped, `confidence: 1.0` — a silent success), and — more urgently — that the
+> **renderer corrupts even single event handlers** when translating into
+> high-traffic non-SVO-Latin languages (a phantom `toggle` is injected; event
+> names are left in English). So the "understand code in your language" half of the
+> goal is broken **today**, independent of behaviors.
+>
+> This plan builds **bottom-up, fidelity-gated**, and treats behaviors as the first
+> consumer of a **general structural/block layer** (which also serves `def`
+> functions and multi-handler programs), rather than as a one-off.
+>
+> Companion to [CORRECTNESS_RELIABILITY_PLAN.md](CORRECTNESS_RELIABILITY_PLAN.md)
+> (the fidelity framing this extends), [MULTILINGUAL_ROADMAP.md](MULTILINGUAL_ROADMAP.md)
+> (parse-rate vs fidelity), and [STRUCTURAL_ARCS_ROADMAP.md](STRUCTURAL_ARCS_ROADMAP.md)
+> (per-language structural arcs). Behaviors are the "Track 2 / out-of-scope" work
+> those docs repeatedly defer — this is that track.
+
+## 1. What the spike found (empirical, against built `dist`)
+
+Probes run through `@lokascript/semantic`'s built `dist` (parse / translate /
+buildAST), 2026-06-14:
+
+| Surface                                        | State                                                                                                                      | Evidence                                                                 |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `install Foo on #x` (consume)                  | ✅ works multilingually                                                                                                    | roles captured, clean AST                                                |
+| `behavior … end` (define)                      | ❌ body dropped in **all** langs incl. EN; `confidence:1.0`; `buildAST` emits a degenerate `command`, not a `BehaviorNode` | `parse()` returns `{action:'behavior', roles:{patient:Name}, body:NONE}` |
+| Multi-statement handler **parse**              | ✅ clean for SVO-Latin (es/pt/fr/de/zh)                                                                                    | round-trip fidelity 1.0                                                  |
+| Multi-statement handler **render** (translate) | ❌ phantom `toggle` injected for ja/ko/tr/ar/ru; event names untranslated (`click` stays English)                          | see §2                                                                   |
+
+**Reframe:** behavior authoring was never primarily a _translation-vocabulary_ gap
+(the `behavior`/`on`/`init`/`end` keywords are already translated in all 24
+profiles). It is (a) a **missing block/program parsing layer** in the semantic
+stack and (b) **renderer defects** on the rung below it. The only working behavior
+parse anywhere is the core _traditional_ parser's `parseBehaviorDefinition`
+(`packages/core/src/parser/parser.ts`), which the multilingual path never reaches.
+
+## 2. The acute renderer bug (highest ROI)
+
+`translate('on click add .active to me then remove .hidden from me', 'en', <lang>)`:
+
+```
+ja: click で 切り替え .active を 追加 それから 自分 から .hidden を 削除
+ar: عند click بدّل أضف .active ثم احذف .hidden من أنا
+ru: при click переключить добавить .active затем удалить .hidden из я
+```
+
+`切り替え / بدّل / переключить / 토글 / değiştir` all = **toggle** — absent from the
+source. In SOV it is _additive_ (`[toggle, add, remove]`); in ar/ru it is
+_substitutive_, eating the real first command (`if` → `[toggle]`, fidelity 0.0).
+
+- **Locus:** event-handler rendering in
+  `packages/semantic/src/explicit/renderer.ts` (body render ~L159, pattern
+  selection ~L37). These languages use the **fused event+action** event-handler
+  pattern, whose action slot renders a spurious `toggle`; the real body is then
+  appended. SVO-Latin uses a non-fused event pattern → clean.
+- **Second defect:** event names are not routed through `eventNameTranslations` /
+  `normalizeEventName` (`packages/semantic/src/patterns/event-handler.ts`) on the
+  render path, so `click`/`mouseenter` stay English.
+
+## 3. Why the gate didn't catch it — the measurement gap (Phase 0)
+
+The fidelity harness (`packages/testing-framework/src/multilingual/fidelity.ts`)
+measures **recall** (`computeFidelity`) and **role-fidelity** (`collectRoleSignature`,
+R1). Neither penalizes **spurious/extra** commands, and `collectActions` is
+Set-based, so it cannot even see a _duplicate_ phantom (`[toggle,toggle,put]` →
+`{put,toggle}`). The phantom `toggle` lives squarely in that blind spot — the
+existing test even documents it (`fidelity.test.ts`: "is recall, not precision").
+**Until a precision signal exists, every later phase flies false-green.** Hence
+Phase 0 is first.
+
+## 4. The ladder
+
+Dependency shape: **Phase 0 gates 1–4 · 1→4 · 2→3 · 5 is free-floating.**
+
+### Phase 0 — Precision-aware fidelity harness _(gates everything)_
+
+- Add to `fidelity.ts`, **without changing** the existing recall/role signals the
+  committed baseline ratchets on:
+  - `collectActionsMultiset(node)` — duplicates preserved (catches duplicate phantoms).
+  - `computePrecision(reference, candidate)` — multiset fraction of candidate
+    actions present in reference (penalizes spurious/extra commands).
+  - `spuriousActions(reference, candidate)` — the extras, for diagnostics.
+- Unit tests proving the phantom-`toggle` case scores recall 1.0 **but precision
+  < 1.0**, duplicates are visible, and a faithful reorder stays precision 1.0.
+- **Do NOT** wire into the CI ratchet or regenerate the baseline yet — that waits
+  until handler/block corpus coverage exists (Phase 2/3) and the baseline is
+  intentionally regenerated. Phase 0 ships the _capability + tests_.
+
+### Phase 1 — Fix the renderer (the "understand" bug) _(smallest, highest ROI)_
+
+- Remove the phantom `toggle` from event-handler rendering for fused-pattern
+  languages; route event names through `eventNameTranslations`.
+- Verified by the Phase-0 precision signal + lock tests. Payoff: faithful
+  single-handler translation across ja/ko/tr/ar/ru — and a hard dependency of
+  behavior-rendering (Phase 4).
+
+### Phase 2 — Harden rung-2 parsing (SOV/VSO handler bodies)
+
+- Gated by Phase 0. Isolate parser vs renderer per language; close genuine
+  body-parse defects (the ja `add`→`into` class; ar/ru first-command loss).
+- Outcome: inline multi-statement `_="on … "` handlers reliable in all priority
+  languages — the highest-_volume_ value, and the rung behaviors stand on.
+
+### Phase 3 — General structural/block layer
+
+- Block-skeleton recognizer over the already-translated `behavior`/`def`/`on`/
+  `init`/`end` + nested `if`/`repeat`/`for`/`while`; depth-aware `end` matching
+  per language; delegate leaves to the (hardened) single-statement engine;
+  assemble `BehaviorNode` / `FunctionNode` / program.
+- Fix the `confidence:1.0` silent-success: a partial/dropped-body parse must lower
+  confidence or emit a diagnostic.
+- Behaviors are the **first consumer**; `def` functions and multi-handler scripts
+  come essentially free.
+
+### Phase 4 — Block renderer + round-trip
+
+- Faithful translation of whole behaviors/functions between languages (understand
+  an arbitrary behavior, not just the curated set). Depends on Phase 1 + Phase 3.
+
+### Phase 5 — Curated localized metadata _(parallel, anytime)_
+
+- Localized names / param-names / hover-docs for the 11 shipped behaviors
+  (`packages/behaviors`). Pure data, zero parser risk, immediate broad
+  understand-value. Independent of the ladder.
+- **Do not** re-localize the shipped behaviors' hyperscript `source` — they run
+  **imperative JS installers**, so the `source` string is near-worthless to
+  translate. Authoring value is in _user-defined_ behaviors (Phase 3).
+
+## 5. Invariants (every phase)
+
+1. **Fidelity-gated, never parse-rate.** Parse-rate counts body-dropping parses as
+   passes (see MULTILINGUAL_ROADMAP.md).
+2. **No silent body-drop / no false `confidence:1.0`.**
+3. **SOV/VSO honesty** — ship SVO faithful first; mark SOV/VSO explicitly until
+   Phase 2 hardens them.
+4. **Additive to the committed baseline** — new signals/corpus land alongside the
+   existing recall + R1 ratchet; baseline regeneration is deliberate, against a
+   freshly `populate`d patterns.db (see `packages/patterns-reference/CLAUDE.md`).
+
+## 6. Status
+
+- **2026-06-14:** spike + assessment complete; decisions locked (correctness-first
+  ladder + general structural layer).
+- **2026-06-14: Phase 0 ✅ complete.** Added `collectActionsMultiset`,
+  `computePrecision`, `spuriousActions` to
+  `packages/testing-framework/src/multilingual/fidelity.ts` (additive — the
+  recall `computeFidelity` + R1 `collectRoleSignature` baseline signals are
+  byte-unchanged). 9 new unit tests (17/17 in `fidelity.test.ts`) lock the
+  phantom-`toggle` shapes: recall 1.0 but precision 0.75; duplicate phantom
+  caught by the multiset; ar/ru substitutive case scores precision 0. Typecheck
+  clean. **Not yet wired to the CI ratchet** (waits for handler/block corpus +
+  deliberate baseline regen, per invariant 4).
+- **2026-06-14: Phase 1 ✅ complete (phantom-`toggle`).** Root cause: the 'on'
+  pattern set contains fused `<command>-event-*` patterns (e.g.
+  `toggle-event-ko-sov-simple` = `<event> 할 때 토글`, prio 148) that outrank the
+  pure trigger (`on-ko-generated`, prio 100); `findBestPattern` selected one to
+  render a handler and emitted its trailing verb literal as a phantom command.
+  Fix: `findBestPattern` (`packages/semantic/src/explicit/renderer.ts`) restricts
+  event-handler rendering to pure trigger patterns (ids without the `-event-`
+  fused segment). **Verified:** EN→{ja,ko,tr,ar,ru,zh,es} round-trip now scores
+  **precision = recall = 1.0** on multi-statement handlers, conditionals, and
+  single-command handlers (incl. the genuine `toggle` case — rendered once, not
+  doubled). Regression: semantic suite 5978/5978, core multilingual 162/162, new
+  lock `test/event-handler-render-no-phantom.test.ts` 17/17; typecheck clean. The
+  fix is provably **recall-neutral** (removes only spurious commands), so the
+  committed multilingual gate baseline cannot regress on its recall/R1 signals.
+- **Deferred (Phase 1b):** **event-name translation.** Event names render as
+  English (`click`, not native) — functionally correct (DOM event names;
+  round-trips fine) and **fidelity-neutral** (a value, not a command), so it does
+  not violate any invariant. Native rendering needs the _reverse_ of
+  `eventNameTranslations` (which maps native→English) plus careful handling of
+  compound (`click or keydown`), namespaced (`htmx:load`), and modifier forms —
+  scoped separately rather than rushed into Phase 1.
+- **Deferred (Phase 2):** SOV trigger-marker cosmetics (ja renders `click を で`,
+  slightly non-idiomatic but round-trips correctly).
+- **Next: Phase 2** — harden rung-2 SOV/VSO handler-body _parsing_.

--- a/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
+++ b/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
@@ -179,6 +179,22 @@ Dependency shape: **Phase 0 gates 1–4 · 1→4 · 2→3 · 5 is free-floating.
 - Faithful translation of whole behaviors/functions between languages (understand
   an arbitrary behavior, not just the curated set). Depends on Phase 1 + Phase 3.
 
+> **2026-06-14: Phase 4 ✅ — block renderer.** The renderer was block-blind (a
+> behavior rendered to just its keyword `comportamiento`, body dropped). Added
+> `renderBehavior` / `renderDef` + a `keyword()` resolver to
+> `packages/semantic/src/explicit/renderer.ts` (dispatched from `render()` on
+> `kind`). A behavior renders to target-language source — `<behavior> Name(params)`
+>
+> - each handler (closed by `end`) + optional `init` + closing `end` — handlers and
+>   commands via the normal (Phase-1-clean) paths; `def` similarly. **Whole behaviors
+>   and functions now translate between languages and round-trip:** EN→ES
+>   `comportamiento Toggleable(cls) / al click alternar .{cls} / fin / fin` →
+>   re-parses to a behavior with `[toggle]`; EN→ja renders 振る舞い…終わり. semantic
+>   **6049/6049**; lock `test/block-renderer.test.ts`; typecheck clean. **Gate
+>   untouched** — the renderer is a separate path from the i18n transformer the gate
+>   uses (parse-only), so render-only changes are gate-neutral (baseline unmodified).
+>   SOV trigger cosmetics (ja `click を で`) carry over from Phase 2 but round-trip.
+
 ### Phase 5 — Curated localized metadata _(parallel, anytime)_
 
 - Localized names / param-names / hover-docs for the 11 shipped behaviors

--- a/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
+++ b/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
@@ -190,15 +190,38 @@ Dependency shape: **Phase 0 gates 1–4 · 1→4 · 2→3 · 5 is free-floating.
   none are in the priority gate, so the committed baseline is untouched.
   **Result: 85.9% → 96.9%** (th 12→0 imperfect, bn 11→2). Regression: semantic
   6004/6004; lock test `event-handler-render-no-phantom.test.ts` extended to 27.
-- **Phase 2 tail (diagnosed, distinct per-language root causes — STRUCTURAL_ARCS):**
-  - **bn `put`** — `into #out` destination marker renders as multiple tokens that
-    re-glue into the patient (`এশেষর#out`); `"hi"` loses quotes → phantom command.
-  - **bn `wait`** — duration `200ms` (before the SOV verb) not captured into the
-    `duration` role → phantom command.
-  - **ar/id/sw `set` + possessive** — `set my textContent to "x"` renders
-    plausibly (`اضبط textContent لي إلى "x"`) but parses to an **empty body** (the
-    possessive-property target isn't matched). _ar is a priority language._
-  - **vi `increment`** — renders idiomatically as `tăng :count thêm 1`
-    ("increase by 1"); the `thêm 1` re-parses as a phantom `add` command.
-- **Next:** decide depth on the Phase-2 tail (4 separate per-language fixes), then
-  Phase 3 (general structural/block layer).
+- **2026-06-14: Phase 2 tail — 2 of 4 fixed (vi, bn put); gate green.** Rung-2
+  round-trip now **97.9% clean** (188/192).
+  - ✅ **vi `increment`** — parser injects default `quantity: 1`; it rendered
+    everywhere, and in vi the quantity marker `thêm` _is_ the `add` keyword, so
+    `tăng :count thêm 1` re-parsed as increment + phantom `add`. Fix: the renderer
+    omits an optional role value equal to its schema default (here `quantity == 1`),
+    mirroring the existing `destination == me` skip
+    (`packages/semantic/src/explicit/renderer.ts`). Recall-neutral; explicit
+    non-default amounts (`by 5`) still render. Also cleans up es/ja increment output.
+  - ✅ **bn `put`** — the handcrafted positional `put-bn-at-end` (prio 110)
+    outranked the canonical put in **render** selection (role scoring can't see the
+    position, which is baked-in literals), emitting the verbose "at end of" form for
+    every plain put. Fix: `findBestPattern` penalizes positional (`-at-end` /
+    `-at-start`) patterns for rendering only — parsing is priority-ordered in the
+    matcher (not `findBestPattern`), so positional _input_ still matches via its
+    literals. Same class as the Phase-1 `-event-` filter.
+- **Phase 2 tail — 2 deferred (each its own careful mini-arc):**
+  - **ar/id/sw `set` + possessive** — _framework gap, ar is PRIORITY._
+    `tryMatchPossessiveExpression` (`packages/semantic/src/parser/pattern-matcher.ts`)
+    is strictly **pre-nominal** (possessor-first: `my value` / `لي قيمة`).
+    Post-nominal (`textContent لي` / `textContent saya` / `textContent yangu`,
+    property-first — `markerPosition: 'after-object'`) isn't matched, so the set
+    body fails entirely. Scoped fix: an **additive post-nominal branch** gated on
+    `possessive.markerPosition === 'after-object'` (peek property identifier/selector,
+    then a possessor keyword → property-path). Gated so it only touches after-object
+    languages (which currently can't parse possessives at all). **Requires the full
+    gate + baseline regen** (ar priority) + cross-language verification (he/id/sw).
+  - **bn `wait`** — _deep shared body-parser, non-priority._ Standalone
+    `200ms অপেক্ষা` parses correctly (`wait{duration:200ms}`); only the
+    multi-clause **then-chain body** path drops/duplicates it (`[200ms, wait, add]`).
+    Same "control-flow body parsing" cluster tracked in
+    CORRECTNESS_RELIABILITY_PLAN; high-risk to touch for one non-priority edge case.
+- **Next:** either pick up the 2 deferred tail arcs (start with ar/id/sw
+  possessive — priority, additive, scoped above) or proceed to Phase 3 (general
+  structural/block layer).

--- a/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
+++ b/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
@@ -153,9 +153,26 @@ Dependency shape: **Phase 0 gates 1–4 · 1→4 · 2→3 · 5 is free-floating.
 >     semantic **6041/6041**; lock test `test/behavior-body-content.test.ts`;
 >     gate green (baseline regen: only pl/uk `behavior-removable` shifts, fid −0.000 —
 >     the richer EN reference effect; corpus impact negligible, value is correctness).
-> - **Still un-tokenized / remaining body-content:** other dynamic forms as they
->   surface; `def` functions / multi-handler top-level programs reuse the block
->   layer (not yet wired). Phase 4 = block renderer (round-trip translation).
+> - **2026-06-14: `def` functions ✅ + multi-command body fix.** Generalized the
+>   block layer to a dispatcher (`tryParseBlock`) handling both `behavior` and
+>   `def name(params) … end` (new `DefSemanticNode` + `buildAST` → core `DefNode`).
+>   Key supporting fix: added `parseStatements()` (routes through
+>   `parseBodyWithClauses`) — the top-level `parse()` returns on the FIRST command,
+>   so a bare multi-command sequence (`add .a` ⏎ `remove .b`) was truncating to
+>   `[add]`. `def` bodies AND behavior `init` blocks now use it and keep every
+>   command. `def` keyword recognized via the English form (native-keyword
+>   translation deferred, like event-names — fidelity-neutral); body parses
+>   multilingually. semantic **6049/6049**; lock `test/def-block.test.ts`; gate
+>   green (baseline regen: behavior-draggable/-removable shift ±0.004 — richer-EN
+>   init effect; all behavior-scoped).
+> - **Multi-handler top-level programs — DEFERRED (assessed).** Two forms: the
+>   clean `end`-delimited (`on … end on … end`) is uncommon/low-value; the common
+>   no-`end` feature-chain (`on click … on keyup …`) has an `on`-marker ambiguity
+>   (trigger-`on` vs `toggle .x on me`) that risks single-handler parsing and needs
+>   its own careful design. Tangential to behaviors (which wrap handlers in
+>   `behavior…end`). Not shipped to avoid a low-value/risky version.
+> - **Remaining:** native `def`/event-name keyword translations; multi-handler
+>   programs (feature-chain); Phase 4 = block renderer (round-trip translation).
 
 ### Phase 4 — Block renderer + round-trip
 

--- a/packages/core/src/api/hyperscript-api.ts
+++ b/packages/core/src/api/hyperscript-api.ts
@@ -698,7 +698,11 @@ async function toLSECode(code: string, language?: string): Promise<string> {
     throw new Error(`Failed to parse "${code}" as ${lang} hyperscript`);
   }
 
-  return await renderExplicit(result.node);
+  // The semantic SemanticNode union now includes block kinds (`behavior`/`def`)
+  // that the intent-typed LSE renderer doesn't enumerate; the structures are
+  // otherwise compatible, so bridge the type at this boundary (block constructs
+  // aren't rendered to LSE bracket syntax).
+  return await renderExplicit(result.node as Parameters<typeof renderExplicit>[0]);
 }
 
 /**

--- a/packages/core/src/lse/index.test.ts
+++ b/packages/core/src/lse/index.test.ts
@@ -255,7 +255,9 @@ describe('LSE bridge', () => {
       const { parseSemantic } = await import('@lokascript/semantic');
       const result = parseSemantic('toggle .active', 'en');
       expect(result.node).not.toBeNull();
-      const lse = await renderExplicit(result.node!);
+      // Bridge the semantic→intent SemanticNode union gap (block kinds) — same as
+      // the toLSECode production path.
+      const lse = await renderExplicit(result.node! as Parameters<typeof renderExplicit>[0]);
       expect(lse).toContain('[');
       expect(lse).toContain('toggle');
       expect(lse).toContain('.active');

--- a/packages/semantic/src/ast-builder/index.ts
+++ b/packages/semantic/src/ast-builder/index.ts
@@ -18,6 +18,7 @@ import type {
   ConditionalSemanticNode,
   CompoundSemanticNode,
   LoopSemanticNode,
+  BehaviorSemanticNode,
   SemanticRole,
 } from '../types';
 
@@ -154,9 +155,34 @@ export class ASTBuilder {
         return this.buildCompound(node as CompoundSemanticNode);
       case 'loop':
         return this.buildLoop(node as LoopSemanticNode);
+      case 'behavior':
+        return this.buildBehavior(node as BehaviorSemanticNode);
       default:
         throw new Error(`Unknown semantic node kind: ${(node as SemanticNode).kind}`);
     }
+  }
+
+  /**
+   * Build a core-compatible BehaviorNode from a BehaviorSemanticNode.
+   * Each handler/init sub-node was parsed by the single-statement engine, so this
+   * is pure re-assembly into the `{ type: 'behavior', name, parameters,
+   * eventHandlers, initBlock? }` shape the runtime expects.
+   */
+  private buildBehavior(node: BehaviorSemanticNode): ASTNode {
+    const eventHandlers = node.eventHandlers.map(h => this.buildEventHandler(h));
+    const behaviorNode: ASTNode = {
+      type: 'behavior',
+      name: node.name,
+      parameters: [...node.parameters],
+      eventHandlers,
+    };
+    if (node.initBlock && node.initBlock.length > 0) {
+      behaviorNode.initBlock = {
+        type: 'initBlock',
+        commands: node.initBlock.map(c => this.build(c)),
+      };
+    }
+    return behaviorNode;
   }
 
   /**

--- a/packages/semantic/src/ast-builder/index.ts
+++ b/packages/semantic/src/ast-builder/index.ts
@@ -19,6 +19,7 @@ import type {
   CompoundSemanticNode,
   LoopSemanticNode,
   BehaviorSemanticNode,
+  DefSemanticNode,
   SemanticRole,
 } from '../types';
 
@@ -157,6 +158,8 @@ export class ASTBuilder {
         return this.buildLoop(node as LoopSemanticNode);
       case 'behavior':
         return this.buildBehavior(node as BehaviorSemanticNode);
+      case 'def':
+        return this.buildDef(node as DefSemanticNode);
       default:
         throw new Error(`Unknown semantic node kind: ${(node as SemanticNode).kind}`);
     }
@@ -183,6 +186,20 @@ export class ASTBuilder {
       };
     }
     return behaviorNode;
+  }
+
+  /**
+   * Build a core-compatible DefNode from a DefSemanticNode. The body sub-nodes were
+   * parsed by the single-statement engine; this re-assembles them into the
+   * `{ type: 'def', name, params, body }` shape the runtime expects.
+   */
+  private buildDef(node: DefSemanticNode): ASTNode {
+    return {
+      type: 'def',
+      name: node.name,
+      params: [...node.parameters],
+      body: node.body.map(c => this.build(c)),
+    };
   }
 
   /**

--- a/packages/semantic/src/explicit/renderer.ts
+++ b/packages/semantic/src/explicit/renderer.ts
@@ -80,7 +80,11 @@ export class SemanticRendererImpl implements ISemanticRenderer {
    * Delegates to @lokascript/framework/ir for the core logic.
    */
   renderExplicit(node: SemanticNode): string {
-    return renderExplicitBase(node);
+    // The framework IR renderer predates the `behavior` block kind and types its
+    // input to the single-statement node union. A behavior block is not rendered
+    // through the explicit IR path, so bridge the (structurally compatible) type
+    // at this boundary rather than widen the framework package's union.
+    return renderExplicitBase(node as Parameters<typeof renderExplicitBase>[0]);
   }
 
   /**

--- a/packages/semantic/src/explicit/renderer.ts
+++ b/packages/semantic/src/explicit/renderer.ts
@@ -132,6 +132,18 @@ export class SemanticRendererImpl implements ISemanticRenderer {
         }
       }
 
+      // Positional variants (`put X at end of Y`, `at start of`) are handcrafted
+      // for PARSING that specific surface form; they carry the position as baked-in
+      // literals, not a role, so role scoring can't distinguish them from the
+      // canonical `put X into Y`. Some carry a higher parse priority (e.g.
+      // `put-bn-at-end` at 110) and would otherwise win render selection, emitting
+      // the verbose positional form for every plain put. Penalize them for
+      // rendering only — parsing is priority-ordered in the matcher, not here, so
+      // positional INPUT still matches its pattern via the literals.
+      if (/-at-end|-at-start/i.test(pattern.id)) {
+        score -= 30;
+      }
+
       // For English rendering, prefer "standard" patterns over "native idiom" patterns
       // This ensures "on click" is preferred over "when clicked" for English output
       // Only apply this boost for English - other languages should use their native idioms
@@ -221,6 +233,26 @@ export class SemanticRendererImpl implements ISemanticRenderer {
             const destValue = node.roles.get('destination');
             if (destValue?.type === 'reference' && destValue.value === 'me') {
               return null; // Skip rendering default "me" destination
+            }
+          }
+        }
+
+        // For optional groups with a `quantity` role, skip when it equals the
+        // schema default (1). The parser injects `quantity: 1` for
+        // increment/decrement even when unspecified, so rendering it produces a
+        // redundant "by 1" — harmless in most languages but a real bug in vi,
+        // where the quantity marker `thêm` is also the `add` keyword, so
+        // `tăng :count thêm 1` re-parses as increment + a phantom `add`. Omitting
+        // the default-1 quantity is recall-neutral (the action set is unchanged)
+        // and renders increment/decrement naturally everywhere.
+        if (token.optional) {
+          const qtyToken = token.tokens.find(
+            (t: any) => t.type === 'role' && t.role === 'quantity'
+          );
+          if (qtyToken) {
+            const qtyValue = node.roles.get('quantity');
+            if (qtyValue?.type === 'literal' && Number(qtyValue.value) === 1) {
+              return null; // Skip rendering default quantity of 1
             }
           }
         }

--- a/packages/semantic/src/explicit/renderer.ts
+++ b/packages/semantic/src/explicit/renderer.ts
@@ -9,6 +9,8 @@ import type {
   SemanticNode,
   EventHandlerSemanticNode,
   CompoundSemanticNode,
+  BehaviorSemanticNode,
+  DefSemanticNode,
   SemanticValue,
   SemanticRenderer as ISemanticRenderer,
   LanguagePattern,
@@ -32,6 +34,14 @@ export class SemanticRendererImpl implements ISemanticRenderer {
     // Handle compound nodes specially (e.g., "cmd1 then cmd2")
     if (node.kind === 'compound') {
       return this.renderCompound(node as CompoundSemanticNode, language);
+    }
+    // Block constructs render to multi-line target-language source so a whole
+    // behavior/function round-trips between languages (Phase 4).
+    if (node.kind === 'behavior') {
+      return this.renderBehavior(node as BehaviorSemanticNode, language);
+    }
+    if (node.kind === 'def') {
+      return this.renderDef(node as DefSemanticNode, language);
     }
 
     const patterns = getPatternsForLanguageAndCommand(language, node.action);
@@ -58,6 +68,56 @@ export class SemanticRendererImpl implements ISemanticRenderer {
     const renderedStatements = node.statements.map(stmt => this.render(stmt, language));
     const chainWord = this.getChainWord(node.chainType, language);
     return renderedStatements.join(` ${chainWord} `);
+  }
+
+  /**
+   * Resolve a structural keyword (`behavior`/`def`/`init`/`end`) in the target
+   * language, falling back to the English form when the profile has no translation.
+   */
+  private keyword(language: string, action: string): string {
+    return tryGetProfile(language)?.keywords?.[action]?.primary ?? action;
+  }
+
+  /** `Name` or `Name(p1, p2)` — the parameter list renders verbatim (identifiers). */
+  private renderBlockHeader(keyword: string, name: string, parameters: readonly string[]): string {
+    return parameters.length > 0
+      ? `${keyword} ${name}(${parameters.join(', ')})`
+      : `${keyword} ${name}`;
+  }
+
+  /**
+   * Render a behavior block to target-language source:
+   * `<behavior> Name(params)` + each handler (closed by `end`) + optional `init`
+   * block + closing `end`. Handlers/commands render through the normal paths.
+   */
+  private renderBehavior(node: BehaviorSemanticNode, language: string): string {
+    const endKw = this.keyword(language, 'end');
+    const lines = [
+      this.renderBlockHeader(this.keyword(language, 'behavior'), node.name, node.parameters),
+    ];
+    for (const handler of node.eventHandlers) {
+      lines.push(`  ${this.render(handler, language)}`, `  ${endKw}`);
+    }
+    if (node.initBlock && node.initBlock.length > 0) {
+      lines.push(`  ${this.keyword(language, 'init')}`);
+      for (const cmd of node.initBlock) lines.push(`    ${this.render(cmd, language)}`);
+      lines.push(`  ${endKw}`);
+    }
+    lines.push(endKw);
+    return lines.join('\n');
+  }
+
+  /**
+   * Render a function definition to target-language source:
+   * `<def> name(params)` + body commands + closing `end`.
+   */
+  private renderDef(node: DefSemanticNode, language: string): string {
+    const lines = [
+      this.renderBlockHeader(this.keyword(language, 'def'), node.name, node.parameters),
+    ];
+    for (const cmd of node.body) lines.push(`  ${this.render(cmd, language)}`);
+    lines.push(this.keyword(language, 'end'));
+    return lines.join('\n');
   }
 
   /**

--- a/packages/semantic/src/explicit/renderer.ts
+++ b/packages/semantic/src/explicit/renderer.ts
@@ -98,8 +98,24 @@ export class SemanticRendererImpl implements ISemanticRenderer {
    * are more recognizable and closer to the original hyperscript syntax.
    */
   private findBestPattern(node: SemanticNode, patterns: LanguagePattern[]): LanguagePattern | null {
+    // Event-handler nodes carry their commands in `body`, never in roles. The
+    // 'on' pattern set also contains fused `<command>-event-*` patterns (e.g.
+    // `toggle-event-ko-sov-simple`, template `<event> 할 때 토글`) that exist to
+    // PARSE single-line fused commands. Selecting one to *render* a handler emits
+    // its trailing verb literal as a phantom command ahead of the real body — the
+    // `切り替え / 토글 / değiştir / بدّل / переключить` (toggle) injection seen in
+    // ja/ko/tr/ar/ru. At render time a handler is only ever a trigger, so restrict
+    // candidates to pure event-trigger patterns (ids without the `-event-`
+    // fused-command segment: `on-*`, `event-*`, `event-handler-*`). The fused
+    // patterns stay available for parsing.
+    let candidates = patterns;
+    if (node.kind === 'event-handler') {
+      const triggers = patterns.filter(pattern => !/-event-/i.test(pattern.id));
+      if (triggers.length > 0) candidates = triggers;
+    }
+
     // Score patterns by how well they match our roles
-    const scored = patterns.map(pattern => {
+    const scored = candidates.map(pattern => {
       let score = pattern.priority;
 
       // Check each role token in the pattern

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -352,9 +352,13 @@ export const removeSchema: CommandSchema = {
   roles: [
     {
       role: 'patient',
-      description: 'The class or attribute to remove',
+      // `remove .class from #el` / `remove @attr from #el` removes a class/attr;
+      // `remove me` / `remove it` / `remove #el` removes the ELEMENT itself, where
+      // the patient is a reference/selector. Accept references so remove-self (a
+      // core behavior pattern) parses instead of throwing.
+      description: 'The class/attribute to remove, or the element to remove',
       required: true,
-      expectedTypes: ['selector'],
+      expectedTypes: ['selector', 'reference'],
       svoPosition: 1,
       sovPosition: 2,
     },

--- a/packages/semantic/src/generators/pattern-generator.ts
+++ b/packages/semantic/src/generators/pattern-generator.ts
@@ -596,7 +596,34 @@ function buildTokens(
       tokens.push(...roleTokens);
   }
 
-  return tokens;
+  return collapseAdjacentLiterals(tokens);
+}
+
+/**
+ * Collapse adjacent identical literal tokens into one.
+ *
+ * For the event-handler trigger (`on`) schema, a handful of languages use the
+ * same word for the trigger keyword (the `on` verb) and the event role's marker —
+ * bn `তে`, hi `पर`, th `เมื่อ`. `buildTokens` then emits it twice (`<event> তে তে`),
+ * which the renderer prints verbatim; on re-parse the duplicate pairs with the
+ * following token as a phantom command (e.g. `তে আমি` → a spurious `on me`). No
+ * trigger pattern needs to match the same literal twice in a row, so fold the
+ * duplicate, preserving any `alternatives` from either side. Verified to affect
+ * only the `on` patterns of bn/hi/th — no other command/language has adjacent
+ * duplicate literals. See MULTILINGUAL_BEHAVIORS_PLAN.md Phase 2.
+ */
+function collapseAdjacentLiterals(tokens: PatternToken[]): PatternToken[] {
+  const out: PatternToken[] = [];
+  for (const tok of tokens) {
+    const prev = out[out.length - 1];
+    if (prev && prev.type === 'literal' && tok.type === 'literal' && prev.value === tok.value) {
+      const alts = [...(prev.alternatives ?? []), ...(tok.alternatives ?? [])];
+      if (alts.length) out[out.length - 1] = { ...prev, alternatives: [...new Set(alts)] };
+      continue;
+    }
+    out.push(tok);
+  }
+  return out;
 }
 
 /**

--- a/packages/semantic/src/parser/block-parser.ts
+++ b/packages/semantic/src/parser/block-parser.ts
@@ -2,20 +2,20 @@
  * Structural / block layer.
  *
  * The single-statement semantic parser cannot parse multi-line BLOCK constructs
- * (`behavior Name(params) … end`): it matches the leading keyword and drops the
- * whole body, returning a degenerate `command` node at confidence 1.0. This module
- * adds the missing layer. It does NOT re-implement statement parsing — it
- * decomposes a block into its sub-blocks (event handlers, init) using the
- * already-translated `behavior`/`on`/`init`/`end` keywords + depth-aware `end`
- * matching, slices each sub-block's ORIGINAL source text by token position (so it
- * works for space-less scripts like ja/zh), and feeds each to the ordinary
- * single-statement engine. The results are re-assembled into a `BehaviorSemanticNode`.
+ * (`behavior Name(params) … end`, `def name(params) … end`): it matches the
+ * leading keyword and drops the whole body, returning a degenerate node. This
+ * module adds the missing layer. It does NOT re-implement statement parsing — it
+ * decomposes a block into its sub-blocks using the already-translated keywords +
+ * depth-aware `end` matching, slices each sub-block's ORIGINAL source text by
+ * token position (so it works for space-less scripts like ja/zh), and feeds each
+ * to the ordinary single-statement engine. The results are re-assembled into a
+ * `BehaviorSemanticNode` / `DefSemanticNode`.
  *
  * See docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md Phase 3.
  */
 
 import type { LanguageToken, SemanticNode, EventHandlerSemanticNode } from '../types';
-import { createBehaviorNode } from '../types';
+import { createBehaviorNode, createDefNode } from '../types';
 import { tryGetProfile } from '../registry';
 import { tokenize } from '../tokenizers';
 
@@ -24,10 +24,22 @@ import { tokenize } from '../tokenizers';
  * excludes the handler-level trigger (`on`) and `init`: those are the sub-blocks
  * we are splitting INTO, and the trigger surface form is unreliable across
  * languages (de renders `wenn`/when, zh the `一…就` idiom, SOV puts the marker
- * mid-clause). Only these reliably-keyworded constructs nest inside a handler
- * body, so counting just them keeps the depth tracking trigger-agnostic.
+ * mid-clause). Only these reliably-keyworded constructs nest inside a body, so
+ * counting just them keeps the depth tracking trigger-agnostic.
  */
 const OPENER_ACTIONS = ['if', 'unless', 'repeat', 'for', 'while'] as const;
+
+/**
+ * Parsers injected to avoid a circular import with semantic-parser.
+ * - `statement` parses one statement (an `on …` clause → an event-handler node).
+ * - `body` parses a multi-command sequence into a flat statement list (def bodies,
+ *   behavior `init` blocks) — the path that splits then-chains / newlines / nested
+ *   blocks, which `statement` alone does not for a bare command sequence.
+ */
+interface BlockParsers {
+  statement: (text: string, lang: string) => SemanticNode;
+  body: (text: string, lang: string) => SemanticNode[];
+}
 
 /**
  * Build the set of surface forms (native primary + alternatives, plus the English
@@ -51,54 +63,18 @@ function tokenMatches(tok: LanguageToken, forms: Set<string>): boolean {
 }
 
 /**
- * Attempt to parse `input` as a `behavior … end` block. Returns null (fast) when
- * the input is not a behavior block, so the caller falls through to ordinary
- * single-statement parsing.
- *
- * @param parseStatement the single-statement parser (injected to avoid a circular
- *   import with semantic-parser; sub-blocks are parsed through it).
+ * Parse the block header (`<keyword> <Name>` + optional `(params)`) from source
+ * position — NOT by scanning for `on`, which fails in SOV where the handler starts
+ * with the event (`click を で …`). Returns the declared parameters and the source
+ * offset where the body begins.
  */
-export function tryParseBehaviorBlock(
+function parseHeader(
   input: string,
-  language: string,
-  parseStatement: (text: string, lang: string) => SemanticNode
-): SemanticNode | null {
-  const profile = tryGetProfile(language);
-  if (!profile) return null;
-
-  // Cheap pre-guard: skip the tokenize on the overwhelming majority of parses
-  // (ordinary statements) — only inputs mentioning the `behavior` keyword can be
-  // a behavior block.
-  const behaviorForms = keywordForms(language, 'behavior');
-  const lowerInput = input.toLowerCase();
-  if (![...behaviorForms].some(f => lowerInput.includes(f))) return null;
-
-  const stream = tokenize(input, language);
-  const tokens = stream.tokens as readonly LanguageToken[];
-  if (tokens.length < 2) return null;
-
-  const initForms = keywordForms(language, 'init');
-  const endForms = keywordForms(language, 'end');
-  const openerSets = OPENER_ACTIONS.map(a => keywordForms(language, a));
-
-  const isOpener = (tok: LanguageToken): boolean => openerSets.some(s => tokenMatches(tok, s));
-  const isEnd = (tok: LanguageToken): boolean => tokenMatches(tok, endForms);
-
-  // 1. Must start with the `behavior` keyword.
-  if (!tokenMatches(tokens[0], behaviorForms)) return null;
-
-  // 2. Behavior name — the next token, required PascalCase to avoid false positives.
-  const nameToken = tokens[1];
-  const name = nameToken.value;
-  if (!/^[A-Z][A-Za-z0-9_]*$/.test(name)) return null;
-
-  // 3. Header: `behavior <Name>` + optional `(params)`. Found by source position
-  //    (not by scanning for `on`, which fails in SOV where the handler starts with
-  //    the event, e.g. `click を で …`). The body begins after the parameter list.
+  nameToken: LanguageToken
+): { parameters: string[]; headerEnd: number } {
   const parameters: string[] = [];
   let headerEnd = nameToken.position.end;
-  const afterName = input.slice(nameToken.position.end);
-  const paren = afterName.match(/^\s*\(([^)]*)\)/);
+  const paren = input.slice(nameToken.position.end).match(/^\s*\(([^)]*)\)/);
   if (paren) {
     headerEnd = nameToken.position.end + paren[0].length;
     for (const raw of paren[1].split(/[,،、]/)) {
@@ -106,14 +82,89 @@ export function tryParseBehaviorBlock(
       if (p) parameters.push(p);
     }
   }
+  return { parameters, headerEnd };
+}
+
+/**
+ * Attempt to parse `input` as a block construct (`behavior`/`def`). Returns null
+ * (fast) for non-block input so the caller falls through to single-statement
+ * parsing. `parseStatement` parses each sub-block.
+ */
+export function tryParseBlock(
+  input: string,
+  language: string,
+  parsers: BlockParsers
+): SemanticNode | null {
+  if (!tryGetProfile(language)) return null;
+
+  // Cheap pre-guard: skip the tokenize on the overwhelming majority of parses.
+  const behaviorForms = keywordForms(language, 'behavior');
+  const defForms = keywordForms(language, 'def');
+  const lower = input.toLowerCase();
+  const mightBehavior = [...behaviorForms].some(f => lower.includes(f));
+  const mightDef =
+    /\bdef\b/.test(lower) || [...defForms].some(f => f !== 'def' && lower.includes(f));
+  if (!mightBehavior && !mightDef) return null;
+
+  const tokens = tokenize(input, language).tokens as readonly LanguageToken[];
+  if (tokens.length < 2) return null;
+
+  if (tokenMatches(tokens[0], behaviorForms)) {
+    return parseBehaviorBlock(input, language, tokens, parsers);
+  }
+  if (tokenMatches(tokens[0], defForms)) {
+    return parseDefBlock(input, language, tokens, parsers);
+  }
+  return null;
+}
+
+/** Mean of a confidence list (0 when empty). */
+function meanConfidence(confidences: number[]): number {
+  return confidences.length > 0 ? confidences.reduce((a, b) => a + b, 0) / confidences.length : 0;
+}
+
+/**
+ * Flatten a single wrapping `compound` (the body parser groups a then-chain /
+ * juxtaposed sequence under one node) into its statements, so a `def` body and an
+ * `init` block are flat command lists rather than `[CommandSequence]`.
+ */
+function flattenStatements(stmts: SemanticNode[]): SemanticNode[] {
+  const out: SemanticNode[] = [];
+  for (const s of stmts) {
+    const inner = (s as { statements?: SemanticNode[] }).statements;
+    if (s.kind === 'compound' && Array.isArray(inner)) out.push(...inner);
+    else out.push(s);
+  }
+  return out;
+}
+
+/** Parse a `behavior Name(params) … end` block into a BehaviorSemanticNode. */
+function parseBehaviorBlock(
+  input: string,
+  language: string,
+  tokens: readonly LanguageToken[],
+  parsers: BlockParsers
+): SemanticNode | null {
+  // Behavior name — required PascalCase to avoid false positives.
+  const nameToken = tokens[1];
+  const name = nameToken.value;
+  if (!/^[A-Z][A-Za-z0-9_]*$/.test(name)) return null;
+
+  const { parameters, headerEnd } = parseHeader(input, nameToken);
   let bodyStart = tokens.findIndex(t => t.position.start >= headerEnd);
   if (bodyStart < 2) bodyStart = 2;
 
-  // 4. Split the body into sub-blocks by depth-aware `end` matching. Segmentation
-  //    is END-delimited, not opener-prefixed: a sub-block runs until the `end` that
-  //    returns depth to 0. This works for SVO (handler starts with `on`), SOV
-  //    (handler starts with the event, `on`-marker mid-clause), and VSO alike. The
-  //    behavior's own closing `end` is the one reached while depth is already 0.
+  const initForms = keywordForms(language, 'init');
+  const endForms = keywordForms(language, 'end');
+  const openerSets = OPENER_ACTIONS.map(a => keywordForms(language, a));
+  const isOpener = (tok: LanguageToken): boolean => openerSets.some(s => tokenMatches(tok, s));
+  const isEnd = (tok: LanguageToken): boolean => tokenMatches(tok, endForms);
+
+  // Split the body into sub-blocks by depth-aware `end` matching. Segmentation is
+  // END-delimited, not opener-prefixed: a sub-block runs until the `end` that
+  // returns depth to 0. Works for SVO (handler starts with `on`), SOV (handler
+  // starts with the event), and VSO alike. The behavior's own closing `end` is the
+  // one reached while depth is already 0 with no content accumulated.
   const eventHandlers: EventHandlerSemanticNode[] = [];
   const initCommands: SemanticNode[] = [];
   const confidences: number[] = [];
@@ -128,22 +179,17 @@ export function tryParseBehaviorBlock(
         depth--; // closes a NESTED block (if/repeat/…) inside the current handler
         continue;
       }
-      // depth === 0: this `end` closes a handler/init sub-block — unless no content
-      // has accumulated since the last sub-block, in which case it is the
-      // behavior's own closing `end`.
       if (j === segStart) {
-        sawClosingEnd = true;
+        sawClosingEnd = true; // behavior's own closing `end`
         break;
       }
-      const isInitBlock = tokenMatches(tokens[segStart], initForms);
-      if (isInitBlock) {
-        // Drop the leading `init` keyword; parse the remaining commands.
+      if (tokenMatches(tokens[segStart], initForms)) {
         const initText = input.slice(tokens[segStart].position.end, tok.position.start).trim();
         if (initText) {
           try {
-            const node = parseStatement(initText, language);
-            initCommands.push(node);
-            confidences.push(node.metadata?.confidence ?? 0.75);
+            const stmts = flattenStatements(parsers.body(initText, language));
+            initCommands.push(...stmts);
+            confidences.push(meanConfidence(stmts.map(s => s.metadata?.confidence ?? 0.75)));
           } catch {
             confidences.push(0);
           }
@@ -151,20 +197,19 @@ export function tryParseBehaviorBlock(
       } else {
         const handlerText = input.slice(tokens[segStart].position.start, tok.position.start).trim();
         try {
-          const parsed = parseStatement(handlerText, language);
+          const parsed = parsers.statement(handlerText, language);
           if (parsed && parsed.kind === 'event-handler') {
             const handler = parsed as EventHandlerSemanticNode;
             eventHandlers.push(handler);
             // An empty handler body means the sub-parse silently dropped the
-            // commands. Don't inherit its (often misleadingly high) confidence —
-            // score it low so the block can't report a false success.
+            // commands. Don't inherit its (often misleadingly high) confidence.
             const bodyEmpty = !handler.body || handler.body.length === 0;
             confidences.push(bodyEmpty ? 0.2 : (handler.metadata?.confidence ?? 0.75));
           } else {
             confidences.push(0); // parsed, but not a handler — structural miss
           }
         } catch {
-          confidences.push(0); // sub-block failed to parse
+          confidences.push(0);
         }
       }
       segStart = j + 1;
@@ -173,16 +218,9 @@ export function tryParseBehaviorBlock(
     }
   }
 
-  // Nothing recognizable parsed — not a behavior block we can represent.
   if (eventHandlers.length === 0 && initCommands.length === 0) return null;
 
-  // Confidence reflects how faithfully the sub-blocks parsed — a dropped or failed
-  // handler pulls it down, so a partial parse no longer reports a false 1.0.
-  const avgConfidence =
-    confidences.length > 0 ? confidences.reduce((a, b) => a + b, 0) / confidences.length : 0;
-  // A missing closing `end` means the block was malformed/truncated.
-  const confidence = sawClosingEnd ? avgConfidence : avgConfidence * 0.8;
-
+  const confidence = (sawClosingEnd ? 1 : 0.8) * meanConfidence(confidences);
   return createBehaviorNode(
     name,
     parameters,
@@ -190,4 +228,64 @@ export function tryParseBehaviorBlock(
     initCommands.length > 0 ? initCommands : undefined,
     { sourceLanguage: language, confidence, sourceText: input }
   );
+}
+
+/** Parse a `def name(params) … end` block into a DefSemanticNode. */
+function parseDefBlock(
+  input: string,
+  language: string,
+  tokens: readonly LanguageToken[],
+  parsers: BlockParsers
+): SemanticNode | null {
+  // Function name — any identifier (optionally namespaced, e.g. `utils.calc`).
+  const nameToken = tokens[1];
+  const name = nameToken.value;
+  if (!/^[a-zA-Z_$][\w$]*(?:\.[a-zA-Z_$][\w$]*)*$/.test(name)) return null;
+
+  const { parameters, headerEnd } = parseHeader(input, nameToken);
+  let bodyStart = tokens.findIndex(t => t.position.start >= headerEnd);
+  if (bodyStart < 2) bodyStart = 2;
+
+  const endForms = keywordForms(language, 'end');
+  const openerSets = OPENER_ACTIONS.map(a => keywordForms(language, a));
+  const isOpener = (tok: LanguageToken): boolean => openerSets.some(s => tokenMatches(tok, s));
+  const isEnd = (tok: LanguageToken): boolean => tokenMatches(tok, endForms);
+
+  // The def body is a flat command sequence (no event handlers). Find the def's
+  // own closing `end` via depth-aware matching (nested if/repeat have their own
+  // ends), slice the body text, and parse it as one statement.
+  let depth = 0;
+  let endIdx = -1;
+  for (let j = bodyStart; j < tokens.length; j++) {
+    if (isEnd(tokens[j])) {
+      if (depth === 0) {
+        endIdx = j;
+        break;
+      }
+      depth--;
+    } else if (isOpener(tokens[j])) {
+      depth++;
+    }
+  }
+
+  const bodyStartPos = tokens[bodyStart]?.position.start ?? headerEnd;
+  const bodyEndPos = endIdx >= 0 ? tokens[endIdx].position.start : input.length;
+  const bodyText = input.slice(bodyStartPos, bodyEndPos).trim();
+  if (!bodyText) return null;
+
+  let body: SemanticNode[];
+  try {
+    body = flattenStatements(parsers.body(bodyText, language));
+  } catch {
+    return null;
+  }
+  if (body.length === 0) return null;
+  let confidence = meanConfidence(body.map(s => s.metadata?.confidence ?? 0.75));
+  if (endIdx < 0) confidence *= 0.8; // missing closing `end`
+
+  return createDefNode(name, parameters, body, {
+    sourceLanguage: language,
+    confidence,
+    sourceText: input,
+  });
 }

--- a/packages/semantic/src/parser/block-parser.ts
+++ b/packages/semantic/src/parser/block-parser.ts
@@ -1,0 +1,193 @@
+/**
+ * Structural / block layer.
+ *
+ * The single-statement semantic parser cannot parse multi-line BLOCK constructs
+ * (`behavior Name(params) … end`): it matches the leading keyword and drops the
+ * whole body, returning a degenerate `command` node at confidence 1.0. This module
+ * adds the missing layer. It does NOT re-implement statement parsing — it
+ * decomposes a block into its sub-blocks (event handlers, init) using the
+ * already-translated `behavior`/`on`/`init`/`end` keywords + depth-aware `end`
+ * matching, slices each sub-block's ORIGINAL source text by token position (so it
+ * works for space-less scripts like ja/zh), and feeds each to the ordinary
+ * single-statement engine. The results are re-assembled into a `BehaviorSemanticNode`.
+ *
+ * See docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md Phase 3.
+ */
+
+import type { LanguageToken, SemanticNode, EventHandlerSemanticNode } from '../types';
+import { createBehaviorNode } from '../types';
+import { tryGetProfile } from '../registry';
+import { tokenize } from '../tokenizers';
+
+/**
+ * NESTED block-opening keywords balanced by a matching `end`. Deliberately
+ * excludes the handler-level trigger (`on`) and `init`: those are the sub-blocks
+ * we are splitting INTO, and the trigger surface form is unreliable across
+ * languages (de renders `wenn`/when, zh the `一…就` idiom, SOV puts the marker
+ * mid-clause). Only these reliably-keyworded constructs nest inside a handler
+ * body, so counting just them keeps the depth tracking trigger-agnostic.
+ */
+const OPENER_ACTIONS = ['if', 'unless', 'repeat', 'for', 'while'] as const;
+
+/**
+ * Build the set of surface forms (native primary + alternatives, plus the English
+ * normalized form) a keyword can take in a language, for keyword matching.
+ */
+function keywordForms(language: string, action: string): Set<string> {
+  const set = new Set<string>([action]); // English normalized form
+  const profile = tryGetProfile(language);
+  const entry = profile?.keywords?.[action];
+  if (entry) {
+    if (entry.primary) set.add(entry.primary.toLowerCase());
+    for (const alt of entry.alternatives ?? []) set.add(alt.toLowerCase());
+  }
+  return set;
+}
+
+/** Does a token match any surface form in `forms` (by value or normalized form)? */
+function tokenMatches(tok: LanguageToken, forms: Set<string>): boolean {
+  if (forms.has(tok.value.toLowerCase())) return true;
+  return tok.normalized ? forms.has(tok.normalized.toLowerCase()) : false;
+}
+
+/**
+ * Attempt to parse `input` as a `behavior … end` block. Returns null (fast) when
+ * the input is not a behavior block, so the caller falls through to ordinary
+ * single-statement parsing.
+ *
+ * @param parseStatement the single-statement parser (injected to avoid a circular
+ *   import with semantic-parser; sub-blocks are parsed through it).
+ */
+export function tryParseBehaviorBlock(
+  input: string,
+  language: string,
+  parseStatement: (text: string, lang: string) => SemanticNode
+): SemanticNode | null {
+  const profile = tryGetProfile(language);
+  if (!profile) return null;
+
+  // Cheap pre-guard: skip the tokenize on the overwhelming majority of parses
+  // (ordinary statements) — only inputs mentioning the `behavior` keyword can be
+  // a behavior block.
+  const behaviorForms = keywordForms(language, 'behavior');
+  const lowerInput = input.toLowerCase();
+  if (![...behaviorForms].some(f => lowerInput.includes(f))) return null;
+
+  const stream = tokenize(input, language);
+  const tokens = stream.tokens as readonly LanguageToken[];
+  if (tokens.length < 2) return null;
+
+  const initForms = keywordForms(language, 'init');
+  const endForms = keywordForms(language, 'end');
+  const openerSets = OPENER_ACTIONS.map(a => keywordForms(language, a));
+
+  const isOpener = (tok: LanguageToken): boolean => openerSets.some(s => tokenMatches(tok, s));
+  const isEnd = (tok: LanguageToken): boolean => tokenMatches(tok, endForms);
+
+  // 1. Must start with the `behavior` keyword.
+  if (!tokenMatches(tokens[0], behaviorForms)) return null;
+
+  // 2. Behavior name — the next token, required PascalCase to avoid false positives.
+  const nameToken = tokens[1];
+  const name = nameToken.value;
+  if (!/^[A-Z][A-Za-z0-9_]*$/.test(name)) return null;
+
+  // 3. Header: `behavior <Name>` + optional `(params)`. Found by source position
+  //    (not by scanning for `on`, which fails in SOV where the handler starts with
+  //    the event, e.g. `click を で …`). The body begins after the parameter list.
+  const parameters: string[] = [];
+  let headerEnd = nameToken.position.end;
+  const afterName = input.slice(nameToken.position.end);
+  const paren = afterName.match(/^\s*\(([^)]*)\)/);
+  if (paren) {
+    headerEnd = nameToken.position.end + paren[0].length;
+    for (const raw of paren[1].split(/[,،、]/)) {
+      const p = raw.trim();
+      if (p) parameters.push(p);
+    }
+  }
+  let bodyStart = tokens.findIndex(t => t.position.start >= headerEnd);
+  if (bodyStart < 2) bodyStart = 2;
+
+  // 4. Split the body into sub-blocks by depth-aware `end` matching. Segmentation
+  //    is END-delimited, not opener-prefixed: a sub-block runs until the `end` that
+  //    returns depth to 0. This works for SVO (handler starts with `on`), SOV
+  //    (handler starts with the event, `on`-marker mid-clause), and VSO alike. The
+  //    behavior's own closing `end` is the one reached while depth is already 0.
+  const eventHandlers: EventHandlerSemanticNode[] = [];
+  const initCommands: SemanticNode[] = [];
+  const confidences: number[] = [];
+  let sawClosingEnd = false;
+
+  let depth = 0;
+  let segStart = bodyStart;
+  for (let j = bodyStart; j < tokens.length; j++) {
+    const tok = tokens[j];
+    if (isEnd(tok)) {
+      if (depth > 0) {
+        depth--; // closes a NESTED block (if/repeat/…) inside the current handler
+        continue;
+      }
+      // depth === 0: this `end` closes a handler/init sub-block — unless no content
+      // has accumulated since the last sub-block, in which case it is the
+      // behavior's own closing `end`.
+      if (j === segStart) {
+        sawClosingEnd = true;
+        break;
+      }
+      const isInitBlock = tokenMatches(tokens[segStart], initForms);
+      if (isInitBlock) {
+        // Drop the leading `init` keyword; parse the remaining commands.
+        const initText = input.slice(tokens[segStart].position.end, tok.position.start).trim();
+        if (initText) {
+          try {
+            const node = parseStatement(initText, language);
+            initCommands.push(node);
+            confidences.push(node.metadata?.confidence ?? 0.75);
+          } catch {
+            confidences.push(0);
+          }
+        }
+      } else {
+        const handlerText = input.slice(tokens[segStart].position.start, tok.position.start).trim();
+        try {
+          const parsed = parseStatement(handlerText, language);
+          if (parsed && parsed.kind === 'event-handler') {
+            const handler = parsed as EventHandlerSemanticNode;
+            eventHandlers.push(handler);
+            // An empty handler body means the sub-parse silently dropped the
+            // commands. Don't inherit its (often misleadingly high) confidence —
+            // score it low so the block can't report a false success.
+            const bodyEmpty = !handler.body || handler.body.length === 0;
+            confidences.push(bodyEmpty ? 0.2 : (handler.metadata?.confidence ?? 0.75));
+          } else {
+            confidences.push(0); // parsed, but not a handler — structural miss
+          }
+        } catch {
+          confidences.push(0); // sub-block failed to parse
+        }
+      }
+      segStart = j + 1;
+    } else if (isOpener(tok)) {
+      depth++;
+    }
+  }
+
+  // Nothing recognizable parsed — not a behavior block we can represent.
+  if (eventHandlers.length === 0 && initCommands.length === 0) return null;
+
+  // Confidence reflects how faithfully the sub-blocks parsed — a dropped or failed
+  // handler pulls it down, so a partial parse no longer reports a false 1.0.
+  const avgConfidence =
+    confidences.length > 0 ? confidences.reduce((a, b) => a + b, 0) / confidences.length : 0;
+  // A missing closing `end` means the block was malformed/truncated.
+  const confidence = sawClosingEnd ? avgConfidence : avgConfidence * 0.8;
+
+  return createBehaviorNode(
+    name,
+    parameters,
+    eventHandlers,
+    initCommands.length > 0 ? initCommands : undefined,
+    { sourceLanguage: language, confidence, sourceText: input }
+  );
+}

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -393,6 +393,18 @@ export class PatternMatcher {
         captured.set(patternToken.role, ofPossessive);
         return true;
       }
+      // Post-nominal (property-first) possessive: `textContent لي` (ar),
+      // `textContent saya` (id), `textContent yangu` (sw) — the possessor follows
+      // the property in `after-object` languages. The pre-nominal matcher below
+      // only handles possessor-first (`my value`), so these either failed to parse
+      // (ar/id/sw) or parsed lossily, dropping the possessor (ru/pl/uk). Gated to
+      // property-path roles (set's destination) so it can't misread an ordinary
+      // role value. See MULTILINGUAL_BEHAVIORS_PLAN.md Phase 2 tail.
+      const postNominalPossessive = this.tryMatchPostNominalPossessiveExpression(tokens);
+      if (postNominalPossessive) {
+        captured.set(patternToken.role, postNominalPossessive);
+        return true;
+      }
     }
 
     // Check for possessive expression (e.g., 'my value', 'its innerHTML')
@@ -955,6 +967,96 @@ export class PatternMatcher {
     // Not a valid property, revert
     tokens.reset(mark);
     return null;
+  }
+
+  /**
+   * Match a POST-NOMINAL possessive expression: `<property> <possessor>`.
+   *
+   * The pre-nominal {@link tryMatchPossessiveExpression} handles possessor-first
+   * order (`my value`, `لي قيمة`). Languages whose possessive `markerPosition` is
+   * `after-object` put the possessor AFTER the property (ar `textContent لي`,
+   * id `textContent saya`, sw `textContent yangu`), so the pre-nominal matcher
+   * never fires — `set my textContent to "x"` failed to parse (ar/id/sw) or parsed
+   * lossily with the possessor dropped (ru/pl/uk). This recovers the property-path
+   * for that order. Gated to `after-object` profiles, so possessor-first languages
+   * are untouched.
+   */
+  private tryMatchPostNominalPossessiveExpression(tokens: TokenStream): SemanticValue | null {
+    if (!this.currentProfile) return null;
+    if (this.currentProfile.possessive?.markerPosition !== 'after-object') return null;
+
+    const isPossessor = (t: { value: string; normalized?: string }): boolean => {
+      for (const cand of [t.value, t.normalized].filter(Boolean) as string[]) {
+        if (
+          getPossessiveReference(this.currentProfile!, cand) ??
+          getPossessiveReference(this.currentProfile!, cand.toLowerCase())
+        ) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    const propertyToken = tokens.peek();
+    if (!propertyToken) return null;
+
+    // The head must be a plausible property name — a bare identifier or a dot /
+    // `*` / `@` property selector — and must not itself be a possessor, structural
+    // keyword, or role-marker concept (those are handled elsewhere / are not
+    // properties).
+    const isDotSelector =
+      propertyToken.kind === 'selector' &&
+      propertyToken.value.startsWith('.') &&
+      /^\.[a-zA-Z_]\w*/.test(propertyToken.value);
+    const isPropHead =
+      (propertyToken.kind === 'identifier' &&
+        !this.isStructuralKeyword(propertyToken.value) &&
+        !(propertyToken.normalized && this.isStructuralKeyword(propertyToken.normalized)) &&
+        !(propertyToken.normalized && this.isRoleMarkerConcept(propertyToken.normalized))) ||
+      (propertyToken.kind === 'selector' &&
+        (propertyToken.value.startsWith('*') || propertyToken.value.startsWith('@'))) ||
+      isDotSelector;
+    if (!isPropHead || isPossessor(propertyToken)) return null;
+
+    const mark = tokens.mark();
+
+    let propertyName = propertyToken.value;
+    if (isDotSelector) propertyName = propertyName.substring(1);
+    tokens.advance();
+
+    // Consume chained dot-property access (`.style.display`) before the possessor.
+    let chainedProps = propertyName;
+    while (
+      tokens.peek()?.kind === 'selector' &&
+      tokens.peek()!.value.startsWith('.') &&
+      /^\.[a-zA-Z_]\w*/.test(tokens.peek()!.value)
+    ) {
+      chainedProps += tokens.peek()!.value;
+      tokens.advance();
+    }
+
+    // Now require the possessor keyword.
+    const possessorToken = tokens.peek();
+    if (!possessorToken) {
+      tokens.reset(mark);
+      return null;
+    }
+    let baseRef: string | undefined;
+    for (const cand of [possessorToken.value, possessorToken.normalized].filter(
+      Boolean
+    ) as string[]) {
+      baseRef =
+        getPossessiveReference(this.currentProfile, cand) ??
+        getPossessiveReference(this.currentProfile, cand.toLowerCase());
+      if (baseRef) break;
+    }
+    if (!baseRef) {
+      tokens.reset(mark);
+      return null;
+    }
+    tokens.advance();
+
+    return createPropertyPath(createReference(baseRef as ReferenceValue['value']), chainedProps);
   }
 
   /**

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -37,7 +37,7 @@ import {
 import { getPatternsForLanguage, tryGetProfile } from '../registry';
 import { getSchema } from '../generators/command-schemas';
 import { patternMatcher } from './pattern-matcher';
-import { tryParseBehaviorBlock } from './block-parser';
+import { tryParseBlock } from './block-parser';
 import { eventNameTranslations } from '../patterns/event-handler';
 import { isAtEndPositionNoun } from '../patterns/put';
 import { render as renderExplicitFn } from '../explicit/renderer';
@@ -154,9 +154,10 @@ export class SemanticParserImpl implements ISemanticParser {
     // into its handlers (each parsed by the single-statement path below) and
     // re-assembled — otherwise the leading keyword matches and the whole body is
     // dropped at a false confidence 1.0. Returns null (fast) for non-block input.
-    const blockNode = tryParseBehaviorBlock(input, language, (text, lang) =>
-      this.parse(text, lang)
-    );
+    const blockNode = tryParseBlock(input, language, {
+      statement: (text, lang) => this.parse(text, lang),
+      body: (text, lang) => this.parseStatements(text, lang),
+    });
     if (blockNode) return blockNode;
 
     // Extract standalone event modifiers (once, debounced, throttled) from input
@@ -420,6 +421,21 @@ export class SemanticParserImpl implements ISemanticParser {
       parseInput,
       diagnostics
     );
+  }
+
+  /**
+   * Parse a multi-command body/sequence into a flat list of statement nodes.
+   * Unlike `parse()` (which returns on the first command match), this routes
+   * through the clause splitter, so `add .a` newline `remove .b`, then-chains, and
+   * nested if-blocks all yield every statement. Used by the structural layer for
+   * `def` bodies and behavior `init` blocks.
+   */
+  parseStatements(input: string, language: string): SemanticNode[] {
+    const tokens = tokenizeInternal(input, language);
+    const commandPatterns = getPatternsForLanguage(language)
+      .filter(p => p.command !== 'on')
+      .sort((a, b) => b.priority - a.priority);
+    return this.parseBodyWithClauses(tokens, commandPatterns, language);
   }
 
   /**

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -37,6 +37,7 @@ import {
 import { getPatternsForLanguage, tryGetProfile } from '../registry';
 import { getSchema } from '../generators/command-schemas';
 import { patternMatcher } from './pattern-matcher';
+import { tryParseBehaviorBlock } from './block-parser';
 import { eventNameTranslations } from '../patterns/event-handler';
 import { isAtEndPositionNoun } from '../patterns/put';
 import { render as renderExplicitFn } from '../explicit/renderer';
@@ -149,6 +150,15 @@ export class SemanticParserImpl implements ISemanticParser {
    * Accumulates diagnostics from each fallback stage (Phase 3.4).
    */
   parse(input: string, language: string): SemanticNode {
+    // Stage 0: structural / block layer. A `behavior … end` block is decomposed
+    // into its handlers (each parsed by the single-statement path below) and
+    // re-assembled — otherwise the leading keyword matches and the whole body is
+    // dropped at a false confidence 1.0. Returns null (fast) for non-block input.
+    const blockNode = tryParseBehaviorBlock(input, language, (text, lang) =>
+      this.parse(text, lang)
+    );
+    if (blockNode) return blockNode;
+
     // Extract standalone event modifiers (once, debounced, throttled) from input
     const { modifiers, remainingInput } = this.extractStandaloneModifiers(input, language);
     const modInput = remainingInput || input;

--- a/packages/semantic/src/tokenizers/extractors/css-selector.ts
+++ b/packages/semantic/src/tokenizers/extractors/css-selector.ts
@@ -20,8 +20,13 @@ export function extractCssSelector(input: string, position: number): string | nu
     return match ? match[0] : null;
   }
 
-  // Class selector: .identifier
+  // Class selector: .identifier — or dynamic class interpolation .{varName}, where
+  // a variable resolves to the class name at runtime (used by parameterized
+  // behaviors: `toggle .{cls} on me`). Kept as one selector token so it fills the
+  // role; otherwise `.{cls}` splits into a bare `.` (mangled patient) + `{cls}`.
   if (char === '.') {
+    const dynamic = input.slice(position).match(/^\.\{[a-zA-Z_$][\w$]*\}/);
+    if (dynamic) return dynamic[0];
     const match = input.slice(position).match(/^\.[a-zA-Z_][\w-]*/);
     return match ? match[0] : null;
   }

--- a/packages/semantic/src/types.ts
+++ b/packages/semantic/src/types.ts
@@ -190,7 +190,7 @@ export interface FlagValue {
  * Semantic nodes capture the MEANING of hyperscript constructs.
  */
 export interface SemanticNode {
-  readonly kind: 'command' | 'event-handler' | 'conditional' | 'compound' | 'loop';
+  readonly kind: 'command' | 'event-handler' | 'conditional' | 'compound' | 'loop' | 'behavior';
   readonly action: ActionType;
   readonly roles: ReadonlyMap<SemanticRole, SemanticValue>;
   readonly metadata?: SemanticMetadata;
@@ -303,6 +303,26 @@ export interface LoopSemanticNode extends SemanticNode {
   readonly loopVariable?: string;
   /** Index variable name if specified (e.g., 'i' in 'for item with index i') */
   readonly indexVariable?: string;
+}
+
+/**
+ * A behavior semantic node — represents a `behavior Name(params) … end` block:
+ * a reusable, named module of event handlers (and an optional init block). Unlike
+ * the single-statement nodes above, this is a BLOCK construct decomposed by the
+ * structural layer (see `parser/block-parser.ts`); its handlers are parsed by the
+ * ordinary single-statement engine and re-assembled here.
+ */
+export interface BehaviorSemanticNode extends SemanticNode {
+  readonly kind: 'behavior';
+  readonly action: 'behavior';
+  /** Behavior name (PascalCase identifier). */
+  readonly name: string;
+  /** Declared parameter names (`behavior Toggleable(cls, target)`). */
+  readonly parameters: readonly string[];
+  /** The behavior's event handlers, each a fully-parsed event-handler node. */
+  readonly eventHandlers: EventHandlerSemanticNode[];
+  /** Commands in the optional `init … end` block. */
+  readonly initBlock?: SemanticNode[];
 }
 
 // =============================================================================
@@ -682,6 +702,33 @@ export function createEventHandler(
     (node as { additionalEvents?: readonly SemanticValue[] }).additionalEvents = additionalEvents;
   }
 
+  return node;
+}
+
+/**
+ * Create a behavior semantic node (a `behavior Name(params) … end` block).
+ */
+export function createBehaviorNode(
+  name: string,
+  parameters: string[],
+  eventHandlers: EventHandlerSemanticNode[],
+  initBlock?: SemanticNode[],
+  metadata?: SemanticMetadata
+): BehaviorSemanticNode {
+  const node: BehaviorSemanticNode = {
+    kind: 'behavior',
+    action: 'behavior',
+    roles: new Map(),
+    name,
+    parameters,
+    eventHandlers,
+  };
+  if (initBlock !== undefined && initBlock.length > 0) {
+    (node as { initBlock?: SemanticNode[] }).initBlock = initBlock;
+  }
+  if (metadata !== undefined) {
+    (node as { metadata?: SemanticMetadata }).metadata = metadata;
+  }
   return node;
 }
 

--- a/packages/semantic/src/types.ts
+++ b/packages/semantic/src/types.ts
@@ -190,7 +190,14 @@ export interface FlagValue {
  * Semantic nodes capture the MEANING of hyperscript constructs.
  */
 export interface SemanticNode {
-  readonly kind: 'command' | 'event-handler' | 'conditional' | 'compound' | 'loop' | 'behavior';
+  readonly kind:
+    | 'command'
+    | 'event-handler'
+    | 'conditional'
+    | 'compound'
+    | 'loop'
+    | 'behavior'
+    | 'def';
   readonly action: ActionType;
   readonly roles: ReadonlyMap<SemanticRole, SemanticValue>;
   readonly metadata?: SemanticMetadata;
@@ -323,6 +330,25 @@ export interface BehaviorSemanticNode extends SemanticNode {
   readonly eventHandlers: EventHandlerSemanticNode[];
   /** Commands in the optional `init … end` block. */
   readonly initBlock?: SemanticNode[];
+}
+
+/**
+ * A function-definition semantic node — represents a `def name(params) … end`
+ * block. Like {@link BehaviorSemanticNode} it is a block construct decomposed by
+ * the structural layer, but its body is a flat sequence of commands rather than
+ * event handlers.
+ */
+export interface DefSemanticNode extends SemanticNode {
+  readonly kind: 'def';
+  // `action` stays the inherited ActionType (set to 'def' via the factory) — `def`
+  // is a node KIND, not a command action, so it's kept out of the ActionType union
+  // (mirrors `compound`); discrimination is on `kind`.
+  /** Function name (may be namespaced, e.g. `utils.calculate`). */
+  readonly name: string;
+  /** Declared parameter names. */
+  readonly parameters: readonly string[];
+  /** The function body commands. */
+  readonly body: SemanticNode[];
 }
 
 // =============================================================================
@@ -726,6 +752,29 @@ export function createBehaviorNode(
   if (initBlock !== undefined && initBlock.length > 0) {
     (node as { initBlock?: SemanticNode[] }).initBlock = initBlock;
   }
+  if (metadata !== undefined) {
+    (node as { metadata?: SemanticMetadata }).metadata = metadata;
+  }
+  return node;
+}
+
+/**
+ * Create a function-definition semantic node (a `def name(params) … end` block).
+ */
+export function createDefNode(
+  name: string,
+  parameters: string[],
+  body: SemanticNode[],
+  metadata?: SemanticMetadata
+): DefSemanticNode {
+  const node: DefSemanticNode = {
+    kind: 'def',
+    action: 'def' as ActionType,
+    roles: new Map(),
+    name,
+    parameters,
+    body,
+  };
   if (metadata !== undefined) {
     (node as { metadata?: SemanticMetadata }).metadata = metadata;
   }

--- a/packages/semantic/test/behavior-block.test.ts
+++ b/packages/semantic/test/behavior-block.test.ts
@@ -121,9 +121,9 @@ describe('behavior block — multilingual', () => {
 
 describe('behavior block — honesty + non-interference', () => {
   it('reports low confidence when a handler body is silently dropped', () => {
-    // `.{cls}` (dynamic class) isn't yet parsed by the statement engine, so the
-    // handler body is empty — the block must NOT report a false 1.0.
-    const src = 'behavior Bad\n  on click add .{cls} to me\n  end\nend';
+    // An unknown command (`frobnicate`) leaves the handler body empty — the block
+    // must NOT report a false 1.0.
+    const src = 'behavior Bad\n  on click frobnicate .x\n  end\nend';
     const node = parse(src, 'en') as unknown as Behavior;
     expect(node.kind).toBe('behavior');
     expect(node.metadata?.confidence ?? 1).toBeLessThan(0.5);

--- a/packages/semantic/test/behavior-block.test.ts
+++ b/packages/semantic/test/behavior-block.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Structural / block layer — `behavior … end` parsing (Phase 3).
+ *
+ * Before this layer the semantic parser matched the leading `behavior` keyword and
+ * dropped the entire body, returning a degenerate `command` node at confidence 1.0.
+ * The block layer (parser/block-parser.ts) decomposes the block into its handlers
+ * (parsed by the single-statement engine) and re-assembles a BehaviorSemanticNode.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse, buildAST, translate } from '../src';
+
+interface SNode {
+  kind?: string;
+  action?: string;
+  body?: unknown;
+  statements?: unknown;
+  thenBranch?: unknown;
+}
+/** Multiset of leaf command actions inside a handler body. */
+function bodyActions(node: SNode, acc: string[] = []): string[] {
+  if (!node) return acc;
+  if (Array.isArray(node)) {
+    for (const n of node) bodyActions(n as SNode, acc);
+    return acc;
+  }
+  switch (node.kind) {
+    case 'command':
+      if (node.action) acc.push(node.action);
+      break;
+    case 'compound':
+      bodyActions(node.statements as SNode, acc);
+      break;
+    case 'event-handler':
+      bodyActions(node.body as SNode, acc);
+      break;
+    case 'conditional':
+      acc.push('if');
+      bodyActions(node.thenBranch as SNode, acc);
+      break;
+  }
+  return acc;
+}
+
+type Behavior = {
+  kind: string;
+  name: string;
+  parameters: string[];
+  eventHandlers: SNode[];
+  metadata?: { confidence?: number };
+};
+
+describe('behavior block — structure', () => {
+  it('parses name, parameters, and handler (body preserved, not dropped)', () => {
+    const src =
+      'behavior Removable(cls, target)\n' +
+      '  on click add .active to me then remove .hidden from me\n' +
+      '  end\n' +
+      'end';
+    const node = parse(src, 'en') as unknown as Behavior;
+    expect(node.kind).toBe('behavior');
+    expect(node.name).toBe('Removable');
+    expect(node.parameters).toEqual(['cls', 'target']);
+    expect(node.eventHandlers).toHaveLength(1);
+    expect(bodyActions(node.eventHandlers[0]).sort()).toEqual(['add', 'remove']);
+  });
+
+  it('parses multiple handlers and a nested if inside a handler', () => {
+    const src =
+      'behavior Multi\n' +
+      '  on click add .active to me\n' +
+      '  end\n' +
+      '  on mouseleave\n' +
+      '    if I match .open then remove .open from me end\n' +
+      '  end\n' +
+      'end';
+    const node = parse(src, 'en') as unknown as Behavior;
+    expect(node.eventHandlers).toHaveLength(2);
+    expect(bodyActions(node.eventHandlers[0])).toContain('add');
+    // nested if is depth-contained within the second handler
+    expect(bodyActions(node.eventHandlers[1]).sort()).toEqual(['if', 'remove']);
+  });
+
+  it('builds a core BehaviorNode with eventHandlers → commands', () => {
+    const src = 'behavior Foo\n  on click add .active to me\n  end\nend';
+    const result = buildAST(parse(src, 'en')) as { ast: Record<string, unknown> };
+    const ast = result.ast ?? result;
+    expect(ast.type).toBe('behavior');
+    expect(ast.name).toBe('Foo');
+    const handlers = ast.eventHandlers as Array<{ type: string; commands: unknown[] }>;
+    expect(handlers).toHaveLength(1);
+    expect(handlers[0].type).toBe('eventHandler');
+    expect(handlers[0].commands.length).toBeGreaterThan(0);
+  });
+});
+
+describe('behavior block — multilingual', () => {
+  // [behavior keyword, end keyword] per language (verified against profiles).
+  const KW: Record<string, [string, string]> = {
+    es: ['comportamiento', 'fin'],
+    ja: ['振る舞い', '終わり'],
+    ko: ['동작', '끝'],
+    ar: ['سلوك', 'نهاية'],
+    de: ['verhalten', 'ende'],
+    zh: ['行为', '结束'],
+    tr: ['davranış', 'son'],
+  };
+  const inner = 'on click add .active to me then remove .hidden from me';
+
+  for (const [lang, [beh, end]] of Object.entries(KW)) {
+    it(`${lang}: behavior block parses with handler body preserved`, () => {
+      const handler = translate(inner, 'en', lang);
+      const block = `${beh} Foo\n  ${handler}\n  ${end}\n${end}`;
+      const node = parse(block, lang) as unknown as Behavior;
+      expect(node.kind).toBe('behavior');
+      expect(node.eventHandlers).toHaveLength(1);
+      expect(bodyActions(node.eventHandlers[0]).sort()).toEqual(['add', 'remove']);
+    });
+  }
+});
+
+describe('behavior block — honesty + non-interference', () => {
+  it('reports low confidence when a handler body is silently dropped', () => {
+    // `.{cls}` (dynamic class) isn't yet parsed by the statement engine, so the
+    // handler body is empty — the block must NOT report a false 1.0.
+    const src = 'behavior Bad\n  on click add .{cls} to me\n  end\nend';
+    const node = parse(src, 'en') as unknown as Behavior;
+    expect(node.kind).toBe('behavior');
+    expect(node.metadata?.confidence ?? 1).toBeLessThan(0.5);
+  });
+
+  it('leaves ordinary single statements unaffected', () => {
+    expect((parse('toggle .active on #btn', 'en') as SNode).kind).toBe('command');
+    expect((parse('on click add .active to me', 'en') as SNode).kind).toBe('event-handler');
+  });
+});

--- a/packages/semantic/test/behavior-body-content.test.ts
+++ b/packages/semantic/test/behavior-body-content.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Behavior body-content parsing (Phase 3) — the two gaps that capped real
+ * behavior fidelity once block decomposition worked:
+ *   1. `remove me` / `remove it` — remove-self (element as patient), previously
+ *      threw because the remove patient only accepted `selector`.
+ *   2. `.{cls}` — dynamic class interpolation, previously un-tokenized (the class
+ *      regex required a letter after `.`).
+ * Both are general single-statement fixes that unblock parameterized behaviors.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse } from '../src';
+
+interface SNode {
+  kind?: string;
+  action?: string;
+  body?: unknown;
+  roles?: unknown;
+}
+function roles(n: SNode): Record<string, { type?: string; value?: string }> {
+  const r = n.roles instanceof Map ? Object.fromEntries(n.roles) : (n.roles as object);
+  return (r ?? {}) as never;
+}
+function leaves(n: SNode, acc: string[] = []): string[] {
+  if (!n) return acc;
+  if (Array.isArray(n)) {
+    for (const x of n) leaves(x as SNode, acc);
+    return acc;
+  }
+  if (n.kind === 'command' && n.action) acc.push(n.action);
+  else if (n.kind === 'event-handler') leaves(n.body as SNode, acc);
+  else if (n.kind === 'compound') leaves((n as { statements?: unknown }).statements as SNode, acc);
+  return acc;
+}
+
+describe('remove-self (element as patient)', () => {
+  for (const ref of ['me', 'it']) {
+    it(`parses \`remove ${ref}\` with the element as patient`, () => {
+      const node = parse(`remove ${ref}`, 'en') as SNode;
+      expect(node.action).toBe('remove');
+      expect(roles(node).patient?.value).toBe(ref);
+    });
+  }
+
+  it('still parses `remove .class from me` (class removal unchanged)', () => {
+    const node = parse('remove .x from me', 'en') as SNode;
+    expect(roles(node).patient?.value).toBe('.x');
+    expect(roles(node).source?.value).toBe('me');
+  });
+
+  it('captures `remove me` after another command in a handler body', () => {
+    const node = parse('on click add .highlight to me then remove me', 'en') as SNode;
+    expect(leaves(node).sort()).toEqual(['add', 'remove']);
+  });
+});
+
+describe('dynamic class interpolation .{cls}', () => {
+  for (const cmd of ['toggle', 'add', 'remove']) {
+    const code =
+      cmd === 'toggle'
+        ? 'toggle .{cls} on me'
+        : cmd === 'add'
+          ? 'add .{cls} to me'
+          : 'remove .{cls} from me';
+    it(`tokenizes \`.{cls}\` as a class selector in \`${cmd}\``, () => {
+      const node = parse(code, 'en') as SNode;
+      expect(node.action).toBe(cmd);
+      const p = roles(node).patient as { type?: string; value?: string; selectorKind?: string };
+      expect(p.value).toBe('.{cls}');
+      expect(p.type).toBe('selector');
+    });
+  }
+
+  it('does not disturb a literal class selector', () => {
+    expect((parse('toggle .active on me', 'en') as SNode).action).toBe('toggle');
+    expect(roles(parse('toggle .active on me', 'en') as SNode).patient?.value).toBe('.active');
+  });
+
+  it('parses the real Toggleable(cls) behavior end to end', () => {
+    const src = 'behavior Toggleable(cls)\n  on click\n    toggle .{cls} on me\n  end\nend';
+    const node = parse(src, 'en') as unknown as {
+      kind: string;
+      parameters: string[];
+      eventHandlers: SNode[];
+      metadata?: { confidence?: number };
+    };
+    expect(node.kind).toBe('behavior');
+    expect(node.parameters).toEqual(['cls']);
+    expect(leaves(node.eventHandlers[0])).toEqual(['toggle']);
+    expect(node.metadata?.confidence).toBeGreaterThan(0.7);
+  });
+});

--- a/packages/semantic/test/block-renderer.test.ts
+++ b/packages/semantic/test/block-renderer.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Block renderer (Phase 4) — render whole behavior/def blocks to target-language
+ * source, so a behavior authored in one language round-trips to another. The
+ * renderer was block-blind before: a behavior rendered to just its keyword
+ * (`comportamiento`), dropping the body.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse, render } from '../src';
+
+interface SNode {
+  kind?: string;
+  action?: string;
+  name?: string;
+  parameters?: string[];
+  body?: unknown;
+  eventHandlers?: SNode[];
+  statements?: unknown;
+  thenBranch?: unknown;
+}
+function leaves(node: SNode, acc: string[] = []): string[] {
+  if (!node) return acc;
+  if (Array.isArray(node)) {
+    for (const n of node) leaves(n as SNode, acc);
+    return acc;
+  }
+  switch (node.kind) {
+    case 'command':
+      if (node.action) acc.push(node.action);
+      break;
+    case 'compound':
+      leaves(node.statements as SNode, acc);
+      break;
+    case 'event-handler':
+    case 'def':
+      leaves(node.body as SNode, acc);
+      break;
+    case 'behavior':
+      leaves(node.eventHandlers as SNode, acc);
+      break;
+    case 'conditional':
+      acc.push('if');
+      leaves(node.thenBranch as SNode, acc);
+      break;
+  }
+  return acc;
+}
+
+const BEHAVIOR = 'behavior Toggleable(cls)\n  on click\n    toggle .{cls} on me\n  end\nend';
+
+describe('block renderer — behavior', () => {
+  it('renders the keyword, name, params, handler body, and closing end (ES)', () => {
+    const out = render(parse(BEHAVIOR, 'en'), 'es');
+    expect(out).toContain('comportamiento Toggleable(cls)'); // behavior keyword + header
+    expect(out).toContain('alternar'); // toggle, translated
+    expect(out).toContain('.{cls}'); // dynamic class preserved verbatim
+    expect(out.trimEnd().endsWith('fin')).toBe(true); // closing end, translated
+  });
+
+  it('renders the behavior keyword and end in the target language (ja, SOV)', () => {
+    const out = render(parse(BEHAVIOR, 'en'), 'ja');
+    expect(out).toContain('振る舞い Toggleable(cls)');
+    expect(out).toContain('切り替え'); // toggle
+    expect(out).toContain('終わり'); // end
+  });
+
+  it('round-trips EN → ES → parse with structure + body preserved', () => {
+    const back = parse(render(parse(BEHAVIOR, 'en'), 'es'), 'es') as unknown as {
+      kind: string;
+      name: string;
+      parameters: string[];
+      eventHandlers: SNode[];
+    };
+    expect(back.kind).toBe('behavior');
+    expect(back.name).toBe('Toggleable');
+    expect(back.parameters).toEqual(['cls']);
+    expect(back.eventHandlers).toHaveLength(1);
+    expect(leaves(back.eventHandlers[0])).toEqual(['toggle']);
+  });
+
+  it('renders multiple handlers, each closed by its own end', () => {
+    const src =
+      'behavior Multi\n  on click add .a to me\n  end\n  on mouseleave remove .b from me\n  end\nend';
+    const out = render(parse(src, 'en'), 'es');
+    const back = parse(out, 'es') as unknown as { eventHandlers: SNode[] };
+    expect(back.eventHandlers).toHaveLength(2);
+  });
+});
+
+describe('block renderer — def', () => {
+  it('renders def header, body, and end; round-trips', () => {
+    const out = render(parse('def greet(name)\n  log name\nend', 'en'), 'es');
+    expect(out).toContain('greet(name)');
+    expect(out).toContain('registrar'); // log, translated
+    const back = parse(out, 'es') as unknown as { kind: string; name: string; body: SNode[] };
+    expect(back.kind).toBe('def');
+    expect(back.name).toBe('greet');
+    expect(leaves({ kind: 'def', body: back.body })).toEqual(['log']);
+  });
+});

--- a/packages/semantic/test/def-block.test.ts
+++ b/packages/semantic/test/def-block.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Structural layer — `def name(params) … end` function definitions (Phase 3).
+ *
+ * The block layer (parser/block-parser.ts) decomposes a def block and parses its
+ * body as a flat command sequence via `parseStatements` (the clause splitter), so
+ * multi-command bodies — which the top-level `parse()` would truncate to the first
+ * command — yield every statement. The `def` keyword is recognized in any language
+ * context (English form); the body parses multilingually.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse, buildAST, translate } from '../src';
+
+interface SNode {
+  kind?: string;
+  action?: string;
+  body?: unknown;
+  statements?: unknown;
+  thenBranch?: unknown;
+  eventHandlers?: unknown;
+  initBlock?: unknown;
+}
+function leaves(node: SNode, acc: string[] = []): string[] {
+  if (!node) return acc;
+  if (Array.isArray(node)) {
+    for (const n of node) leaves(n as SNode, acc);
+    return acc;
+  }
+  switch (node.kind) {
+    case 'command':
+      if (node.action) acc.push(node.action);
+      break;
+    case 'compound':
+      leaves(node.statements as SNode, acc);
+      break;
+    case 'event-handler':
+    case 'def':
+      leaves(node.body as SNode, acc);
+      break;
+    case 'behavior':
+      leaves(node.eventHandlers as SNode, acc);
+      leaves(node.initBlock as SNode, acc);
+      break;
+    case 'conditional':
+      acc.push('if');
+      leaves(node.thenBranch as SNode, acc);
+      break;
+  }
+  return acc;
+}
+
+type Def = { kind: string; name: string; parameters: string[]; body: SNode[] };
+
+describe('def block — structure', () => {
+  it('parses name, parameters, and a single-command body', () => {
+    const node = parse('def toggleIt()\n  toggle .active on me\nend', 'en') as unknown as Def;
+    expect(node.kind).toBe('def');
+    expect(node.name).toBe('toggleIt');
+    expect(node.parameters).toEqual([]);
+    expect(leaves(node)).toEqual(['toggle']);
+  });
+
+  it('parses parameters and a MULTI-command body (every statement kept)', () => {
+    const src = 'def f(name)\n  add .a to me\n  remove .b from me\n  log name\nend';
+    const node = parse(src, 'en') as unknown as Def;
+    expect(node.parameters).toEqual(['name']);
+    expect(leaves(node)).toEqual(['add', 'remove', 'log']);
+  });
+
+  it('builds a core DefNode with a flat command body', () => {
+    const result = buildAST(parse('def f()\n  add .a to me\n  remove .b from me\nend', 'en')) as {
+      ast: { type: string; name: string; params: string[]; body: Array<{ type: string }> };
+    };
+    const ast = result.ast ?? (result as never);
+    expect(ast.type).toBe('def');
+    expect(ast.body.map(c => c.type)).toEqual(['command', 'command']);
+  });
+});
+
+describe('def block — multilingual body', () => {
+  const KW: Record<string, string> = { es: 'fin', ja: '終わり', ko: '끝' };
+  for (const [lang, end] of Object.entries(KW)) {
+    it(`${lang}: def body parses multilingually`, () => {
+      const body = translate('add .active to me', 'en', lang);
+      const node = parse(`def f()\n  ${body}\n${end}`, lang) as unknown as Def;
+      expect(node.kind).toBe('def');
+      expect(leaves(node)).toContain('add');
+    });
+  }
+});
+
+describe('structural layer — non-interference', () => {
+  it('behavior init blocks now keep every command', () => {
+    const src = 'behavior B\n  init\n    add .a to me\n    log "x"\n  end\nend';
+    const node = parse(src, 'en') as unknown as { kind: string };
+    expect(node.kind).toBe('behavior');
+    expect(leaves(node as SNode)).toEqual(['add', 'log']);
+  });
+
+  it('still parses behaviors and single statements', () => {
+    expect((parse('behavior Foo\n  on click add .a to me\n  end\nend', 'en') as SNode).kind).toBe(
+      'behavior'
+    );
+    expect((parse('toggle .active', 'en') as SNode).kind).toBe('command');
+  });
+});

--- a/packages/semantic/test/event-handler-render-no-phantom.test.ts
+++ b/packages/semantic/test/event-handler-render-no-phantom.test.ts
@@ -132,3 +132,37 @@ describe('event-handler render — no duplicated trigger marker (Phase 2)', () =
     }
   });
 });
+
+describe('render — default quantity (Phase 2 tail: vi increment)', () => {
+  // The parser injects `quantity: 1` for increment/decrement even when
+  // unspecified; rendering it produced a redundant amount. In vi the quantity
+  // marker `thêm` is also the `add` keyword, so `tăng :count thêm 1` re-parsed as
+  // increment + a phantom `add`. The renderer now omits a default-1 quantity.
+  it('omits the default quantity of 1 (no phantom add in vi)', () => {
+    const ref = sorted(leafActions(parse('on click increment :count then log :count', 'en')));
+    for (const lang of ['vi', 'es', 'ja', 'en']) {
+      const translated = translate('on click increment :count then log :count', 'en', lang);
+      expect(sorted(leafActions(parse(translated, lang)))).toEqual(ref);
+    }
+    expect(translate('increment :count', 'en', 'vi')).not.toContain('thêm');
+  });
+
+  it('still renders an explicit non-default quantity', () => {
+    expect(translate('increment :count by 5', 'en', 'vi')).toContain('5');
+    expect(translate('increment :count by 5', 'en', 'vi')).toContain('thêm');
+  });
+});
+
+describe('render — canonical put over positional variant (Phase 2 tail: bn put)', () => {
+  // `put-bn-at-end` (a handcrafted "at end of" pattern, priority 110) outranked
+  // the canonical put and rendered every plain `put X into Y` as the verbose
+  // positional form, which re-parsed into a scrambled patient + phantom. The
+  // renderer now penalizes positional (`-at-end`/`-at-start`) patterns.
+  it('bn renders plain put canonically and round-trips to [put]', () => {
+    const ref = sorted(leafActions(parse('on click put "hi" into #out', 'en')));
+    expect(ref).toEqual(['put']);
+    const translated = translate('on click put "hi" into #out', 'en', 'bn');
+    expect(translated).not.toContain('শেষ'); // no spurious "end" token
+    expect(sorted(leafActions(parse(translated, 'bn')))).toEqual(['put']);
+  });
+});

--- a/packages/semantic/test/event-handler-render-no-phantom.test.ts
+++ b/packages/semantic/test/event-handler-render-no-phantom.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression lock — event-handler rendering must not inject a phantom command.
+ *
+ * Bug (MULTILINGUAL_BEHAVIORS_PLAN.md Phase 1): the 'on' pattern set contains
+ * fused `<command>-event-*` patterns (e.g. `toggle-event-ko-sov-simple`,
+ * `<event> 할 때 토글`) used to PARSE single-line fused commands. The renderer
+ * selected one to render a multi-statement handler, emitting its trailing verb
+ * literal as a phantom `toggle` ahead of the real body — `切り替え / 토글 /
+ * değiştir / بدّل / переключить`. The fix restricts event-handler rendering to
+ * pure trigger patterns (renderer.ts `findBestPattern`).
+ *
+ * These languages were the affected (non-SVO-Latin) set.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse, translate } from '../src';
+
+const AFFECTED = ['ja', 'ko', 'tr', 'ar', 'ru'] as const;
+
+/** Multiset of leaf command actions in a parsed semantic node tree. */
+function leafActions(node: unknown, acc: string[] = []): string[] {
+  if (!node) return acc;
+  if (Array.isArray(node)) {
+    for (const n of node) leafActions(n, acc);
+    return acc;
+  }
+  const n = node as {
+    kind?: string;
+    action?: string;
+    statements?: unknown;
+    body?: unknown;
+    thenBody?: unknown;
+    elseBody?: unknown;
+  };
+  switch (n.kind) {
+    case 'command':
+      if (n.action) acc.push(n.action);
+      break;
+    case 'compound':
+      leafActions(n.statements, acc);
+      break;
+    case 'conditional':
+      acc.push('if');
+      leafActions(n.thenBody ?? n.body, acc);
+      leafActions(n.elseBody, acc);
+      break;
+    case 'loop':
+      acc.push('repeat');
+      leafActions(n.body, acc);
+      break;
+    case 'event-handler':
+      leafActions(n.body, acc);
+      break;
+  }
+  return acc;
+}
+
+const sorted = (xs: string[]) => [...xs].sort();
+
+describe('event-handler render — no phantom command', () => {
+  const cases = [
+    'on click add .active to me then remove .hidden from me',
+    'on mouseenter add .hover to me',
+    'on click if I match .open then remove .open from me end',
+  ];
+
+  for (const code of cases) {
+    const reference = sorted(leafActions(parse(code, 'en')));
+
+    for (const lang of AFFECTED) {
+      it(`${lang}: "${code}" round-trips with no added/dropped command`, () => {
+        const translated = translate(code, 'en', lang);
+        const roundTripped = sorted(leafActions(parse(translated, lang)));
+        // Multiset equality catches BOTH a phantom add and a silent drop.
+        expect(roundTripped).toEqual(reference);
+      });
+    }
+  }
+
+  it('does not emit the native toggle verb when the source has no toggle', () => {
+    // The exact phantom literals from the bug, per language.
+    const toggleVerb: Record<string, string> = {
+      ja: '切り替え',
+      ko: '토글',
+      tr: 'değiştir',
+      ar: 'بدّل',
+      ru: 'переключить',
+    };
+    const code = 'on click add .active to me';
+    for (const lang of AFFECTED) {
+      expect(translate(code, 'en', lang)).not.toContain(toggleVerb[lang]);
+    }
+  });
+
+  it('still renders a genuine single toggle exactly once (no double-toggle)', () => {
+    const reference = sorted(leafActions(parse('on click toggle .active', 'en')));
+    expect(reference).toEqual(['toggle']);
+    for (const lang of AFFECTED) {
+      const translated = translate('on click toggle .active', 'en', lang);
+      expect(sorted(leafActions(parse(translated, lang)))).toEqual(['toggle']);
+    }
+  });
+});

--- a/packages/semantic/test/event-handler-render-no-phantom.test.ts
+++ b/packages/semantic/test/event-handler-render-no-phantom.test.ts
@@ -101,3 +101,34 @@ describe('event-handler render — no phantom command', () => {
     }
   });
 });
+
+describe('event-handler render — no duplicated trigger marker (Phase 2)', () => {
+  // bn (তে), hi (पर), th (เมื่อ) use the same word for the trigger keyword and the
+  // event role marker, so the generator emitted it twice (`<event> তে তে`). The
+  // duplicate paired with the following token as a phantom command (`তে আমি` →
+  // `on me`; `เมื่อ click` → a stray `click` command). `buildTokens` now collapses
+  // adjacent identical literals.
+  const DOUBLED = ['bn', 'hi', 'th'] as const;
+  const cases = [
+    'on click add .active to me',
+    'on click toggle .open on #panel',
+    'on click add .a to me then remove .b from me',
+  ];
+
+  for (const code of cases) {
+    const reference = sorted(leafActions(parse(code, 'en')));
+    for (const lang of DOUBLED) {
+      it(`${lang}: "${code}" — no phantom trigger command`, () => {
+        const translated = translate(code, 'en', lang);
+        expect(sorted(leafActions(parse(translated, lang)))).toEqual(reference);
+      });
+    }
+  }
+
+  it('does not render the trigger marker twice in a row', () => {
+    const doubled: Record<string, string> = { bn: 'তে তে', hi: 'पर पर', th: 'เมื่อ เมื่อ' };
+    for (const lang of DOUBLED) {
+      expect(translate('on click add .active to me', 'en', lang)).not.toContain(doubled[lang]);
+    }
+  });
+});

--- a/packages/semantic/test/post-nominal-possessive.test.ts
+++ b/packages/semantic/test/post-nominal-possessive.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression lock — post-nominal (property-first) possessive parsing.
+ *
+ * `tryMatchPossessiveExpression` only handled possessor-first order (`my value`).
+ * Languages whose possessive `markerPosition` is `after-object` put the possessor
+ * AFTER the property (ar `textContent لي`, id `textContent saya`, sw
+ * `textContent yangu`), so `set my textContent to "x"` either failed to parse
+ * (ar/id/sw/tr) or parsed lossily with the possessor dropped — destination became
+ * a bare `textContent` instead of `me.textContent` (ru/pl/uk). The post-nominal
+ * branch in `tryMatchPossessiveExpression`'s caller recovers the property-path.
+ * See MULTILINGUAL_BEHAVIORS_PLAN.md Phase 2 tail.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse, translate } from '../src';
+
+type Node = { roles?: unknown };
+function destinationOf(node: Node): { type?: string; object?: { value?: string }; property?: string } {
+  const roles =
+    node.roles instanceof Map
+      ? Object.fromEntries(node.roles as Map<string, unknown>)
+      : (node.roles as Record<string, unknown>);
+  return (roles?.destination ?? {}) as never;
+}
+
+const SRC = 'set my textContent to "x"';
+
+describe('post-nominal possessive (after-object languages)', () => {
+  // ar/id/sw failed to parse; tr also failed; ru/pl/uk parsed lossily (possessor
+  // dropped). All must now recover destination = me.textContent.
+  const postNominal = ['ar', 'id', 'sw', 'ru', 'pl', 'uk', 'tr'] as const;
+
+  for (const lang of postNominal) {
+    it(`${lang}: "${SRC}" → destination property-path me.textContent`, () => {
+      const translated = translate(SRC, 'en', lang);
+      const dest = destinationOf(parse(translated, lang) as Node);
+      expect(dest.type).toBe('property-path');
+      expect(dest.object?.value).toBe('me');
+      expect(dest.property).toBe('textContent');
+    });
+  }
+
+  // Possessor-first (pre-nominal) languages must be unaffected by the new branch.
+  const preNominal = ['en', 'es', 'ms', 'he'] as const;
+  for (const lang of preNominal) {
+    it(`${lang}: pre-nominal possessive still resolves to me.textContent`, () => {
+      const translated = translate(SRC, 'en', lang);
+      const dest = destinationOf(parse(translated, lang) as Node);
+      expect(dest.type).toBe('property-path');
+      expect(dest.object?.value).toBe('me');
+      expect(dest.property).toBe('textContent');
+    });
+  }
+
+  it('does not misread a non-possessive set target (ar `set #x to "v"`)', () => {
+    const translated = translate('set #x to "v"', 'en', 'ar');
+    const dest = destinationOf(parse(translated, 'ar') as Node);
+    // #x is a selector, not a possessive property-path.
+    expect(dest.type).toBe('selector');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,19 +1,19 @@
 {
-  "timestamp": "2026-06-14T20:21:03.893Z",
-  "commit": "484d37d7",
+  "timestamp": "2026-06-14T20:50:22.560Z",
+  "commit": "fade2a0c",
   "languages": {
     "ar": {
-      "parseSuccess": 153,
-      "parseFailure": 1,
-      "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8425858314888838,
-      "avgFidelity": 0.9848402323892521,
-      "avgRoleFidelity": 0.870308489696245,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.8403612481675273,
+      "avgFidelity": 0.9806096681096683,
+      "avgRoleFidelity": 0.8657208782208783,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-resizable", "behavior-sortable"],
+      "degeneratePasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "repeat-until-event", "window-scroll"],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -616,7 +616,8 @@
           "confidence": 0.5
         },
         "behavior-removable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-draggable": {
           "success": true,
@@ -637,19 +638,20 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8397628269808716,
-      "avgFidelity": 0.9926046176046175,
-      "avgRoleFidelity": 0.7776006088506087,
+      "avgFidelity": 0.9917929292929292,
+      "avgRoleFidelity": 0.7779662342162341,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [
+        "behavior-draggable",
         "behavior-removable",
         "behavior-resizable",
         "behavior-sortable",
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1274,13 +1276,18 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8301793444650566,
-      "avgFidelity": 0.9898989898989898,
-      "avgRoleFidelity": 0.8545731858231858,
+      "avgFidelity": 0.9898088023088022,
+      "avgRoleFidelity": 0.856687962937963,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
-      "lossyPasses": ["behavior-removable", "behavior-resizable", "get-value"],
-      "bundleSize": 432430,
+      "lossyPasses": [
+        "behavior-draggable",
+        "behavior-removable",
+        "behavior-resizable",
+        "get-value"
+      ],
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1905,7 +1912,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,13 +2537,18 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8330653473510595,
-      "avgFidelity": 0.994227994227994,
-      "avgRoleFidelity": 0.8399929462429464,
+      "avgFidelity": 0.9941378066378065,
+      "avgRoleFidelity": 0.8422364234864237,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 432430,
+      "lossyPasses": [
+        "behavior-draggable",
+        "behavior-removable",
+        "behavior-resizable",
+        "behavior-sortable"
+      ],
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3161,13 +3173,18 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8239950525664791,
-      "avgFidelity": 0.994227994227994,
-      "avgRoleFidelity": 0.842864567864568,
+      "avgFidelity": 0.9941378066378065,
+      "avgRoleFidelity": 0.8451080451080453,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 432430,
+      "lossyPasses": [
+        "behavior-draggable",
+        "behavior-removable",
+        "behavior-resizable",
+        "behavior-sortable"
+      ],
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3793,7 +3810,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8266106442577031,
       "avgFidelity": 0.9689179375453884,
-      "avgRoleFidelity": 0.884174952032095,
+      "avgRoleFidelity": 0.8842397398519849,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable", "unless-condition"],
@@ -3809,7 +3826,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4433,8 +4450,8 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9383198255378694,
-      "avgFidelity": 0.9208152958152958,
-      "avgRoleFidelity": 0.6784823284823287,
+      "avgFidelity": 0.9200036075036074,
+      "avgRoleFidelity": 0.6770324270324272,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [
@@ -4450,6 +4467,7 @@
         "live-multiple-deps"
       ],
       "lossyPasses": [
+        "behavior-draggable",
         "behavior-resizable",
         "breakpoint-command",
         "event-throttle",
@@ -4459,7 +4477,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5084,13 +5102,18 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8382189239332076,
-      "avgFidelity": 0.994227994227994,
-      "avgRoleFidelity": 0.857287026037026,
+      "avgFidelity": 0.9941378066378065,
+      "avgRoleFidelity": 0.8595305032805033,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 432430,
+      "lossyPasses": [
+        "behavior-draggable",
+        "behavior-removable",
+        "behavior-resizable",
+        "behavior-sortable"
+      ],
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5715,13 +5738,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8357452071737766,
-      "avgFidelity": 0.9919733044733045,
-      "avgRoleFidelity": 0.833723764973765,
+      "avgFidelity": 0.9926948051948052,
+      "avgRoleFidelity": 0.8356791294291295,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6347,7 +6370,7 @@
       "parseRate": 1,
       "avgConfidence": 0.8253843483166787,
       "avgFidelity": 0.9816919191919193,
-      "avgRoleFidelity": 0.7914117414117416,
+      "avgRoleFidelity": 0.7920982170982173,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable"],
@@ -6358,7 +6381,7 @@
         "form-disable-on-submit",
         "unless-condition"
       ],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6984,7 +7007,7 @@
       "parseRate": 1,
       "avgConfidence": 0.8073468302791607,
       "avgFidelity": 0.972492784992785,
-      "avgRoleFidelity": 0.7855509355509358,
+      "avgRoleFidelity": 0.7862374112374113,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable", "window-scroll"],
@@ -6997,7 +7020,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7622,8 +7645,8 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.8312063492063471,
-      "avgFidelity": 0.9784259259259261,
-      "avgRoleFidelity": 0.8589826261701262,
+      "avgFidelity": 0.9791666666666666,
+      "avgRoleFidelity": 0.8610253750878751,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "socket-basic"],
@@ -7634,7 +7657,7 @@
         "last-in-collection",
         "set-color-variable"
       ],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8255,13 +8278,19 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.801814058956914,
-      "avgFidelity": 0.990530303030303,
-      "avgRoleFidelity": 0.8375043312543313,
+      "avgFidelity": 0.9912518037518036,
+      "avgRoleFidelity": 0.8395108832608832,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-removable"],
-      "lossyPasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable", "get-value"],
-      "bundleSize": 432430,
+      "degeneratePasses": [],
+      "lossyPasses": [
+        "behavior-draggable",
+        "behavior-removable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "get-value"
+      ],
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8887,12 +8916,12 @@
       "parseRate": 1,
       "avgConfidence": 0.7988455988455969,
       "avgFidelity": 0.9853896103896104,
-      "avgRoleFidelity": 0.8571422383922385,
+      "avgRoleFidelity": 0.8578720266220267,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable"],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9518,7 +9547,7 @@
       "parseRate": 1,
       "avgConfidence": 0.7194083694083694,
       "avgFidelity": 0.9774531024531026,
-      "avgRoleFidelity": 0.7689535689535686,
+      "avgRoleFidelity": 0.7692548442548439,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable"],
@@ -9530,7 +9559,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10155,13 +10184,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8114306328592022,
-      "avgFidelity": 0.985479797979798,
-      "avgRoleFidelity": 0.8304691367191368,
+      "avgFidelity": 0.9862012987012987,
+      "avgRoleFidelity": 0.8324245011745013,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "install-behavior"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10787,7 +10816,7 @@
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.7907074529591067,
       "avgFidelity": 0.9779249448123619,
-      "avgRoleFidelity": 0.8484394341290895,
+      "avgRoleFidelity": 0.8491843214257009,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable"],
@@ -10798,7 +10827,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11420,13 +11449,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8401154401154378,
-      "avgFidelity": 0.9897186147186147,
-      "avgRoleFidelity": 0.820079695079695,
+      "avgFidelity": 0.9904401154401155,
+      "avgRoleFidelity": 0.8220028845028845,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12051,13 +12080,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8242099391590747,
-      "avgFidelity": 0.9816919191919193,
-      "avgRoleFidelity": 0.8694541382041383,
+      "avgFidelity": 0.9816919191919191,
+      "avgRoleFidelity": 0.8699587012087014,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "window-scroll"],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12683,7 +12712,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.826390595224444,
       "avgFidelity": 0.9772149600580973,
-      "avgRoleFidelity": 0.7914617128902844,
+      "avgRoleFidelity": 0.792152858479389,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable", "default-value"],
@@ -12693,7 +12722,7 @@
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13317,13 +13346,18 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.810688517831373,
-      "avgFidelity": 0.9862012987012987,
-      "avgRoleFidelity": 0.8198835511335512,
+      "avgFidelity": 0.9869227994227995,
+      "avgRoleFidelity": 0.8218901031401032,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-removable", "install-behavior"],
-      "lossyPasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 432430,
+      "degeneratePasses": ["install-behavior"],
+      "lossyPasses": [
+        "behavior-draggable",
+        "behavior-removable",
+        "behavior-resizable",
+        "behavior-sortable"
+      ],
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13948,8 +13982,8 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8037518037518019,
-      "avgFidelity": 0.9779040404040404,
-      "avgRoleFidelity": 0.8540583853083853,
+      "avgFidelity": 0.978625541125541,
+      "avgRoleFidelity": 0.8560137497637499,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable"],
@@ -13963,7 +13997,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14589,7 +14623,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9871667185392676,
       "avgFidelity": 0.973275236020334,
-      "avgRoleFidelity": 0.9094664972215992,
+      "avgRoleFidelity": 0.9095312850414892,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
@@ -14604,7 +14638,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 432430,
+      "bundleSize": 433929,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15226,7 +15260,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 432430,
+      "size": 433929,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,19 +1,19 @@
 {
-  "timestamp": "2026-06-14T12:22:40.322Z",
-  "commit": "776e46c3",
+  "timestamp": "2026-06-14T19:16:04.268Z",
+  "commit": "87f4cd05",
   "languages": {
     "ar": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8425858314888838,
-      "avgFidelity": 0.9771241830065359,
-      "avgRoleFidelity": 0.8616456106252026,
+      "avgFidelity": 0.9849310094408135,
+      "avgRoleFidelity": 0.868747352420822,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": ["repeat-until-event", "window-scroll"],
-      "bundleSize": 428347,
+      "degeneratePasses": ["behavior-resizable", "behavior-sortable"],
+      "lossyPasses": ["behavior-draggable", "repeat-until-event", "window-scroll"],
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -637,13 +637,19 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8397628269808716,
-      "avgFidelity": 0.9962121212121211,
-      "avgRoleFidelity": 0.7971283783783784,
+      "avgFidelity": 0.9922438672438672,
+      "avgRoleFidelity": 0.7811868874368872,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 428347,
+      "lossyPasses": [
+        "behavior-removable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "fetch-do-not-throw",
+        "unless-condition"
+      ],
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1264,17 +1270,17 @@
       }
     },
     "de": {
-      "parseSuccess": 153,
-      "parseFailure": 1,
-      "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8323373793962008,
-      "avgFidelity": 0.9782135076252723,
-      "avgRoleFidelity": 0.8443553611920959,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.8301793444650566,
+      "avgFidelity": 0.9898088023088022,
+      "avgRoleFidelity": 0.8524162211662212,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": ["get-value"],
-      "bundleSize": 428347,
+      "degeneratePasses": ["behavior-sortable"],
+      "lossyPasses": ["behavior-removable", "behavior-resizable", "get-value"],
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1877,7 +1883,8 @@
           "confidence": 0.5555555555555556
         },
         "behavior-removable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-draggable": {
           "success": true,
@@ -1898,7 +1905,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 428347,
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2519,17 +2526,17 @@
       }
     },
     "es": {
-      "parseSuccess": 153,
-      "parseFailure": 1,
-      "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8352422450461645,
-      "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8288710722384194,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.8330653473510595,
+      "avgFidelity": 0.9935966810966811,
+      "avgRoleFidelity": 0.8370736808236809,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": [],
-      "bundleSize": 428347,
+      "degeneratePasses": [],
+      "lossyPasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3132,7 +3139,8 @@
           "confidence": 0.5555555555555556
         },
         "behavior-removable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-draggable": {
           "success": true,
@@ -3149,17 +3157,17 @@
       }
     },
     "fr": {
-      "parseSuccess": 153,
-      "parseFailure": 1,
-      "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8261126672891358,
-      "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8317622287010044,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.8239950525664791,
+      "avgFidelity": 0.9935966810966811,
+      "avgRoleFidelity": 0.8399453024453026,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": [],
-      "bundleSize": 428347,
+      "degeneratePasses": [],
+      "lossyPasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3762,7 +3770,8 @@
           "confidence": 0.5555555555555556
         },
         "behavior-removable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-draggable": {
           "success": true,
@@ -3783,17 +3792,14 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8266106442577031,
-      "avgFidelity": 0.9589324618736381,
-      "avgRoleFidelity": 0.8751943634596696,
+      "avgFidelity": 0.9690087145969497,
+      "avgRoleFidelity": 0.8843144950287809,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": [
+      "degeneratePasses": ["behavior-sortable", "unless-condition"],
+      "lossyPasses": [
         "behavior-draggable",
         "behavior-resizable",
-        "behavior-sortable",
-        "unless-condition"
-      ],
-      "lossyPasses": [
         "event-once",
         "form-submit-prevent",
         "get-value",
@@ -3803,7 +3809,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 428347,
+      "bundleSize": 432328,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4427,11 +4433,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9383198255378694,
-      "avgFidelity": 0.9301948051948052,
-      "avgRoleFidelity": 0.6942567567567569,
+      "avgFidelity": 0.9213564213564214,
+      "avgRoleFidelity": 0.6771569646569648,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [
+        "behavior-removable",
+        "behavior-sortable",
         "bind-auto-detect",
         "bind-explicit-property",
         "bind-non-form-display",
@@ -4442,6 +4450,7 @@
         "live-multiple-deps"
       ],
       "lossyPasses": [
+        "behavior-resizable",
         "breakpoint-command",
         "event-throttle",
         "fetch-do-not-throw",
@@ -4450,7 +4459,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 428347,
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5071,17 +5080,17 @@
       }
     },
     "id": {
-      "parseSuccess": 153,
-      "parseFailure": 1,
-      "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8404295051353855,
-      "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8462827988338192,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.8382189239332076,
+      "avgFidelity": 0.9935966810966811,
+      "avgRoleFidelity": 0.8543677606177607,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": [],
-      "bundleSize": 428347,
+      "degeneratePasses": [],
+      "lossyPasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5684,7 +5693,8 @@
           "confidence": 0.5555555555555556
         },
         "behavior-removable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-draggable": {
           "success": true,
@@ -5701,17 +5711,17 @@
       }
     },
     "it": {
-      "parseSuccess": 153,
-      "parseFailure": 1,
-      "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8379396202925594,
-      "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8248380304502754,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.8357452071737766,
+      "avgFidelity": 0.9919733044733045,
+      "avgRoleFidelity": 0.8320432382932383,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": [],
-      "bundleSize": 428347,
+      "degeneratePasses": ["behavior-removable"],
+      "lossyPasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6314,7 +6324,8 @@
           "confidence": 0.5555555555555556
         },
         "behavior-removable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-draggable": {
           "success": true,
@@ -6335,18 +6346,19 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8253843483166787,
-      "avgFidelity": 0.9680735930735931,
-      "avgRoleFidelity": 0.7806788931788933,
+      "avgFidelity": 0.9820526695526696,
+      "avgRoleFidelity": 0.7900863775863778,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": [
+      "degeneratePasses": ["behavior-removable", "behavior-sortable"],
+      "lossyPasses": [
         "behavior-draggable",
-        "behavior-removable",
         "behavior-resizable",
-        "behavior-sortable"
+        "fetch-do-not-throw",
+        "form-disable-on-submit",
+        "unless-condition"
       ],
-      "lossyPasses": ["fetch-do-not-throw", "form-disable-on-submit", "unless-condition"],
-      "bundleSize": 428347,
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6971,25 +6983,21 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8073468302791607,
-      "avgFidelity": 0.9588744588744588,
-      "avgRoleFidelity": 0.7753378378378379,
+      "avgFidelity": 0.9728535353535352,
+      "avgRoleFidelity": 0.784225571725572,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": [
-        "behavior-draggable",
-        "behavior-removable",
-        "behavior-resizable",
-        "behavior-sortable",
-        "window-scroll"
-      ],
+      "degeneratePasses": ["behavior-removable", "behavior-sortable", "window-scroll"],
       "lossyPasses": [
+        "behavior-draggable",
+        "behavior-resizable",
         "fetch-do-not-throw",
         "fetch-error-handling",
         "if-empty",
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 428347,
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7614,13 +7622,19 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.8312063492063471,
-      "avgFidelity": 0.9866666666666667,
-      "avgRoleFidelity": 0.8714368386243386,
+      "avgFidelity": 0.9784259259259259,
+      "avgRoleFidelity": 0.8567924552299553,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["socket-basic"],
-      "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 428347,
+      "degeneratePasses": ["behavior-removable", "socket-basic"],
+      "lossyPasses": [
+        "behavior-draggable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "last-in-collection",
+        "set-color-variable"
+      ],
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8237,17 +8251,23 @@
       }
     },
     "pl": {
-      "parseSuccess": 153,
-      "parseFailure": 1,
-      "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8037866998651292,
-      "avgFidelity": 0.9782135076252723,
-      "avgRoleFidelity": 0.8280774214447684,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.801814058956914,
+      "avgFidelity": 0.9906204906204905,
+      "avgRoleFidelity": 0.8359364171864172,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": ["get-value"],
-      "bundleSize": 428347,
+      "degeneratePasses": [],
+      "lossyPasses": [
+        "behavior-draggable",
+        "behavior-removable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "get-value"
+      ],
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,7 +8870,8 @@
           "confidence": 0.5555555555555556
         },
         "behavior-removable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-draggable": {
           "success": true,
@@ -8867,17 +8888,17 @@
       }
     },
     "pt": {
-      "parseSuccess": 153,
-      "parseFailure": 1,
-      "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8007988380537381,
-      "avgFidelity": 0.9803921568627451,
-      "avgRoleFidelity": 0.8517249757045676,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.7988455988455969,
+      "avgFidelity": 0.9856601731601731,
+      "avgRoleFidelity": 0.855704261954262,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": [],
-      "bundleSize": 428347,
+      "degeneratePasses": ["behavior-removable", "behavior-sortable"],
+      "lossyPasses": ["behavior-draggable", "behavior-resizable"],
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9480,7 +9501,8 @@
           "confidence": 0.5555555555555556
         },
         "behavior-removable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-draggable": {
           "success": true,
@@ -9501,23 +9523,20 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7194083694083694,
-      "avgFidelity": 0.9632034632034633,
-      "avgRoleFidelity": 0.7618725868725866,
+      "avgFidelity": 0.977994227994228,
+      "avgRoleFidelity": 0.7741164241164238,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": [
-        "behavior-draggable",
-        "behavior-removable",
-        "behavior-resizable",
-        "behavior-sortable"
-      ],
+      "degeneratePasses": ["behavior-removable", "behavior-sortable"],
       "lossyPasses": [
         "append-content",
+        "behavior-draggable",
+        "behavior-resizable",
         "modal-close-escape",
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 428347,
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10142,13 +10161,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8114306328592022,
-      "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.8440395752895754,
+      "avgFidelity": 0.985479797979798,
+      "avgRoleFidelity": 0.8287886100386102,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["install-behavior"],
-      "lossyPasses": [],
-      "bundleSize": 428347,
+      "degeneratePasses": ["behavior-removable", "install-behavior"],
+      "lossyPasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10769,17 +10788,23 @@
       }
     },
     "sw": {
-      "parseSuccess": 150,
-      "parseFailure": 4,
-      "parseRate": 0.974025974025974,
-      "avgConfidence": 0.7926455026455007,
-      "avgFidelity": 0.9727777777777777,
-      "avgRoleFidelity": 0.8428488756613759,
+      "parseSuccess": 151,
+      "parseFailure": 3,
+      "parseRate": 0.9805194805194806,
+      "avgConfidence": 0.7907074529591067,
+      "avgFidelity": 0.9782008830022074,
+      "avgRoleFidelity": 0.8469717064544653,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "lossyPasses": ["event-debounce", "repeat-until-event", "set-color-variable"],
-      "bundleSize": 428347,
+      "degeneratePasses": ["behavior-removable", "behavior-sortable"],
+      "lossyPasses": [
+        "behavior-draggable",
+        "behavior-resizable",
+        "event-debounce",
+        "repeat-until-event",
+        "set-color-variable"
+      ],
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11379,7 +11404,8 @@
           "success": false
         },
         "behavior-removable": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "behavior-draggable": {
           "success": true,
@@ -11400,13 +11426,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8401154401154378,
-      "avgFidelity": 1,
-      "avgRoleFidelity": 0.8412966537966537,
+      "avgFidelity": 0.9896284271284271,
+      "avgRoleFidelity": 0.8240038115038115,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": [],
-      "lossyPasses": [],
-      "bundleSize": 428347,
+      "degeneratePasses": ["behavior-removable"],
+      "lossyPasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12031,13 +12057,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8242099391590747,
-      "avgFidelity": 0.9983766233766234,
-      "avgRoleFidelity": 0.8884250321750323,
+      "avgFidelity": 0.9820526695526696,
+      "avgRoleFidelity": 0.868102786852787,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": [],
-      "lossyPasses": ["window-scroll"],
-      "bundleSize": 428347,
+      "degeneratePasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
+      "lossyPasses": ["behavior-draggable", "window-scroll"],
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12662,19 +12688,18 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.826390595224444,
-      "avgFidelity": 0.9635076252723311,
-      "avgRoleFidelity": 0.7811791383219955,
+      "avgFidelity": 0.9775780682643427,
+      "avgRoleFidelity": 0.7901273329844759,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": [
+      "degeneratePasses": ["behavior-removable", "behavior-sortable", "default-value"],
+      "lossyPasses": [
         "behavior-draggable",
-        "behavior-removable",
         "behavior-resizable",
-        "behavior-sortable",
-        "default-value"
+        "fetch-do-not-throw",
+        "unless-condition"
       ],
-      "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 428347,
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13298,13 +13323,18 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.810688517831373,
-      "avgFidelity": 0.9935064935064936,
-      "avgRoleFidelity": 0.8328909266409267,
+      "avgFidelity": 0.9862914862914862,
+      "avgRoleFidelity": 0.8183156370656371,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
-      "lossyPasses": [],
-      "bundleSize": 428347,
+      "lossyPasses": [
+        "behavior-draggable",
+        "behavior-removable",
+        "behavior-resizable",
+        "behavior-sortable"
+      ],
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13929,19 +13959,22 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8037518037518019,
-      "avgFidelity": 0.985930735930736,
-      "avgRoleFidelity": 0.8666264478764479,
+      "avgFidelity": 0.9779040404040404,
+      "avgRoleFidelity": 0.8523778586278586,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": [],
+      "degeneratePasses": ["behavior-removable"],
       "lossyPasses": [
+        "behavior-draggable",
+        "behavior-resizable",
+        "behavior-sortable",
         "input-mirror",
         "morph-with-template",
         "render-template-with-data",
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 428347,
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14566,12 +14599,14 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9871667185392676,
-      "avgFidelity": 0.9632897603485838,
-      "avgRoleFidelity": 0.9004859086491739,
+      "avgFidelity": 0.9733660130718953,
+      "avgRoleFidelity": 0.9096060402182852,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
+      "degeneratePasses": ["behavior-sortable"],
       "lossyPasses": [
+        "behavior-draggable",
+        "behavior-resizable",
         "form-submit-prevent",
         "get-value",
         "set-color-variable",
@@ -14580,7 +14615,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 428347,
+      "bundleSize": 432328,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15202,7 +15237,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 428347,
+      "size": 432328,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,19 +1,19 @@
 {
-  "timestamp": "2026-06-14T19:16:04.268Z",
-  "commit": "87f4cd05",
+  "timestamp": "2026-06-14T20:21:03.893Z",
+  "commit": "484d37d7",
   "languages": {
     "ar": {
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8425858314888838,
-      "avgFidelity": 0.9849310094408135,
-      "avgRoleFidelity": 0.868747352420822,
+      "avgFidelity": 0.9848402323892521,
+      "avgRoleFidelity": 0.870308489696245,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "repeat-until-event", "window-scroll"],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -637,8 +637,8 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8397628269808716,
-      "avgFidelity": 0.9922438672438672,
-      "avgRoleFidelity": 0.7811868874368872,
+      "avgFidelity": 0.9926046176046175,
+      "avgRoleFidelity": 0.7776006088506087,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
@@ -649,7 +649,7 @@
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1274,13 +1274,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8301793444650566,
-      "avgFidelity": 0.9898088023088022,
-      "avgRoleFidelity": 0.8524162211662212,
+      "avgFidelity": 0.9898989898989898,
+      "avgRoleFidelity": 0.8545731858231858,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
       "lossyPasses": ["behavior-removable", "behavior-resizable", "get-value"],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1905,7 +1905,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,13 +2530,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8330653473510595,
-      "avgFidelity": 0.9935966810966811,
-      "avgRoleFidelity": 0.8370736808236809,
+      "avgFidelity": 0.994227994227994,
+      "avgRoleFidelity": 0.8399929462429464,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3161,13 +3161,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8239950525664791,
-      "avgFidelity": 0.9935966810966811,
-      "avgRoleFidelity": 0.8399453024453026,
+      "avgFidelity": 0.994227994227994,
+      "avgRoleFidelity": 0.842864567864568,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3792,8 +3792,8 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8266106442577031,
-      "avgFidelity": 0.9690087145969497,
-      "avgRoleFidelity": 0.8843144950287809,
+      "avgFidelity": 0.9689179375453884,
+      "avgRoleFidelity": 0.884174952032095,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable", "unless-condition"],
@@ -3809,7 +3809,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4433,8 +4433,8 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9383198255378694,
-      "avgFidelity": 0.9213564213564214,
-      "avgRoleFidelity": 0.6771569646569648,
+      "avgFidelity": 0.9208152958152958,
+      "avgRoleFidelity": 0.6784823284823287,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [
@@ -4459,7 +4459,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5084,13 +5084,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8382189239332076,
-      "avgFidelity": 0.9935966810966811,
-      "avgRoleFidelity": 0.8543677606177607,
+      "avgFidelity": 0.994227994227994,
+      "avgRoleFidelity": 0.857287026037026,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5716,12 +5716,12 @@
       "parseRate": 1,
       "avgConfidence": 0.8357452071737766,
       "avgFidelity": 0.9919733044733045,
-      "avgRoleFidelity": 0.8320432382932383,
+      "avgRoleFidelity": 0.833723764973765,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6346,8 +6346,8 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8253843483166787,
-      "avgFidelity": 0.9820526695526696,
-      "avgRoleFidelity": 0.7900863775863778,
+      "avgFidelity": 0.9816919191919193,
+      "avgRoleFidelity": 0.7914117414117416,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable"],
@@ -6358,7 +6358,7 @@
         "form-disable-on-submit",
         "unless-condition"
       ],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6983,8 +6983,8 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8073468302791607,
-      "avgFidelity": 0.9728535353535352,
-      "avgRoleFidelity": 0.784225571725572,
+      "avgFidelity": 0.972492784992785,
+      "avgRoleFidelity": 0.7855509355509358,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable", "window-scroll"],
@@ -6997,7 +6997,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7622,8 +7622,8 @@
       "parseFailure": 4,
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.8312063492063471,
-      "avgFidelity": 0.9784259259259259,
-      "avgRoleFidelity": 0.8567924552299553,
+      "avgFidelity": 0.9784259259259261,
+      "avgRoleFidelity": 0.8589826261701262,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "socket-basic"],
@@ -7634,7 +7634,7 @@
         "last-in-collection",
         "set-color-variable"
       ],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8255,19 +8255,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.801814058956914,
-      "avgFidelity": 0.9906204906204905,
-      "avgRoleFidelity": 0.8359364171864172,
+      "avgFidelity": 0.990530303030303,
+      "avgRoleFidelity": 0.8375043312543313,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": [],
-      "lossyPasses": [
-        "behavior-draggable",
-        "behavior-removable",
-        "behavior-resizable",
-        "behavior-sortable",
-        "get-value"
-      ],
-      "bundleSize": 432328,
+      "degeneratePasses": ["behavior-removable"],
+      "lossyPasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable", "get-value"],
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8892,13 +8886,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7988455988455969,
-      "avgFidelity": 0.9856601731601731,
-      "avgRoleFidelity": 0.855704261954262,
+      "avgFidelity": 0.9853896103896104,
+      "avgRoleFidelity": 0.8571422383922385,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable"],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9523,8 +9517,8 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7194083694083694,
-      "avgFidelity": 0.977994227994228,
-      "avgRoleFidelity": 0.7741164241164238,
+      "avgFidelity": 0.9774531024531026,
+      "avgRoleFidelity": 0.7689535689535686,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable"],
@@ -9536,7 +9530,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10162,12 +10156,12 @@
       "parseRate": 1,
       "avgConfidence": 0.8114306328592022,
       "avgFidelity": 0.985479797979798,
-      "avgRoleFidelity": 0.8287886100386102,
+      "avgRoleFidelity": 0.8304691367191368,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "install-behavior"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10792,8 +10786,8 @@
       "parseFailure": 3,
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.7907074529591067,
-      "avgFidelity": 0.9782008830022074,
-      "avgRoleFidelity": 0.8469717064544653,
+      "avgFidelity": 0.9779249448123619,
+      "avgRoleFidelity": 0.8484394341290895,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable"],
@@ -10804,7 +10798,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11426,13 +11420,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8401154401154378,
-      "avgFidelity": 0.9896284271284271,
-      "avgRoleFidelity": 0.8240038115038115,
+      "avgFidelity": 0.9897186147186147,
+      "avgRoleFidelity": 0.820079695079695,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12057,13 +12051,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8242099391590747,
-      "avgFidelity": 0.9820526695526696,
-      "avgRoleFidelity": 0.868102786852787,
+      "avgFidelity": 0.9816919191919193,
+      "avgRoleFidelity": 0.8694541382041383,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "window-scroll"],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12688,8 +12682,8 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.826390595224444,
-      "avgFidelity": 0.9775780682643427,
-      "avgRoleFidelity": 0.7901273329844759,
+      "avgFidelity": 0.9772149600580973,
+      "avgRoleFidelity": 0.7914617128902844,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable", "default-value"],
@@ -12699,7 +12693,7 @@
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13323,18 +13317,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.810688517831373,
-      "avgFidelity": 0.9862914862914862,
-      "avgRoleFidelity": 0.8183156370656371,
+      "avgFidelity": 0.9862012987012987,
+      "avgRoleFidelity": 0.8198835511335512,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["install-behavior"],
-      "lossyPasses": [
-        "behavior-draggable",
-        "behavior-removable",
-        "behavior-resizable",
-        "behavior-sortable"
-      ],
-      "bundleSize": 432328,
+      "degeneratePasses": ["behavior-removable", "install-behavior"],
+      "lossyPasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13960,7 +13949,7 @@
       "parseRate": 1,
       "avgConfidence": 0.8037518037518019,
       "avgFidelity": 0.9779040404040404,
-      "avgRoleFidelity": 0.8523778586278586,
+      "avgRoleFidelity": 0.8540583853083853,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable"],
@@ -13974,7 +13963,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14599,8 +14588,8 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9871667185392676,
-      "avgFidelity": 0.9733660130718953,
-      "avgRoleFidelity": 0.9096060402182852,
+      "avgFidelity": 0.973275236020334,
+      "avgRoleFidelity": 0.9094664972215992,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
@@ -14615,7 +14604,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 432328,
+      "bundleSize": 432430,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15237,7 +15226,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 432328,
+      "size": 432430,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/src/multilingual/fidelity.test.ts
+++ b/packages/testing-framework/src/multilingual/fidelity.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { collectActions, computeFidelity, FIDELITY_THRESHOLD } from './fidelity';
+import {
+  collectActions,
+  collectActionsMultiset,
+  computeFidelity,
+  computePrecision,
+  spuriousActions,
+  FIDELITY_THRESHOLD,
+} from './fidelity';
 
 describe('collectActions', () => {
   it('collects distinct actions across a nested event-handler tree', () => {
@@ -55,5 +62,75 @@ describe('computeFidelity', () => {
 
   it('returns undefined when there is no reference to score against', () => {
     expect(computeFidelity([], ['on'])).toBeUndefined();
+  });
+});
+
+describe('collectActionsMultiset', () => {
+  it('preserves duplicate actions the Set-based collector drops', () => {
+    // The ja/ko/tr round-trip of `on click toggle .open then put "hi" into #out`
+    // renders a phantom `toggle` ahead of the real one: [on, toggle, toggle, put].
+    const node = {
+      kind: 'event-handler',
+      action: 'on',
+      body: [
+        { kind: 'command', action: 'toggle' }, // phantom, injected by the renderer
+        { kind: 'command', action: 'toggle' }, // the real one
+        { kind: 'command', action: 'put' },
+      ],
+    };
+    expect(collectActionsMultiset(node)).toEqual(['on', 'put', 'toggle', 'toggle']);
+    // The existing Set-based collector cannot see the duplicate:
+    expect(collectActions(node)).toEqual(['on', 'put', 'toggle']);
+  });
+
+  it('still excludes the structural `compound` wrapper', () => {
+    const node = { action: 'compound', statements: [{ action: 'toggle' }, { action: 'toggle' }] };
+    expect(collectActionsMultiset(node)).toEqual(['toggle', 'toggle']);
+  });
+});
+
+describe('computePrecision', () => {
+  it('scores a faithful (reordered) parse 1.0', () => {
+    const en = ['focus', 'halt', 'if', 'on'];
+    expect(computePrecision(en, ['on', 'if', 'halt', 'focus'])).toBe(1);
+  });
+
+  it('catches the phantom `toggle` recall is blind to (the renderer bug)', () => {
+    // Real shape: EN `on click add .x then remove .y` round-tripped through ja
+    // renders as [on, toggle, add, remove] — recall stays 1.0, precision drops.
+    const en = ['add', 'on', 'remove'];
+    const ja = ['add', 'on', 'remove', 'toggle'];
+    expect(computeFidelity(en, ja)).toBe(1); // recall is fooled
+    expect(computePrecision(en, ja)).toBeCloseTo(3 / 4); // precision is not
+  });
+
+  it('penalizes a duplicated spurious action (multiset)', () => {
+    // [toggle, toggle, put] vs reference [put, toggle]: one toggle is spurious.
+    expect(computePrecision(['put', 'toggle'], ['put', 'toggle', 'toggle'])).toBeCloseTo(2 / 3);
+  });
+
+  it('scores 0 when every candidate action is spurious (ar/ru substitutive case)', () => {
+    // ar `on click if … end` collapsed to just a phantom [toggle].
+    expect(computePrecision(['if', 'on'], ['toggle'])).toBe(0);
+  });
+
+  it('returns undefined when there is no candidate to score', () => {
+    expect(computePrecision(['on'], [])).toBeUndefined();
+  });
+});
+
+describe('spuriousActions', () => {
+  it('lists the hallucinated commands a render/parse introduced', () => {
+    expect(spuriousActions(['add', 'on', 'remove'], ['add', 'on', 'remove', 'toggle'])).toEqual([
+      'toggle',
+    ]);
+  });
+
+  it('counts duplicates as spurious beyond the reference multiset', () => {
+    expect(spuriousActions(['put', 'toggle'], ['put', 'toggle', 'toggle'])).toEqual(['toggle']);
+  });
+
+  it('is empty for a faithful subset/reorder', () => {
+    expect(spuriousActions(['focus', 'halt', 'if', 'on'], ['on', 'if', 'focus'])).toEqual([]);
   });
 });

--- a/packages/testing-framework/src/multilingual/fidelity.ts
+++ b/packages/testing-framework/src/multilingual/fidelity.ts
@@ -55,6 +55,47 @@ function walk(node: unknown, acc: Set<string>, depth: number): void {
 }
 
 /**
+ * Like {@link collectActions} but **multiset**: duplicates are preserved (sorted,
+ * not deduped). Needed for precision — a *duplicate* spurious command (e.g. a
+ * renderer that injects a phantom `toggle` ahead of a real `toggle`, yielding
+ * `[toggle, toggle, put]`) is invisible to the Set-based `collectActions`.
+ *
+ * Kept as a parallel walk rather than refactoring `collectActions`: the latter
+ * feeds the committed regression baseline, so its traversal stays byte-identical.
+ */
+export function collectActionsMultiset(node: unknown): string[] {
+  const acc: string[] = [];
+  walkMultiset(node, acc, 0);
+  return acc.sort();
+}
+
+function walkMultiset(node: unknown, acc: string[], depth: number): void {
+  if (depth > 64 || node === null || typeof node !== 'object') return;
+
+  const rec = node as Record<string, unknown>;
+  const action = rec.action;
+  if (typeof action === 'string' && !STRUCTURAL_ACTIONS.has(action)) {
+    acc.push(action);
+  }
+
+  for (const field of CHILD_FIELDS) {
+    const child = rec[field];
+    if (Array.isArray(child)) {
+      for (const c of child) walkMultiset(c, acc, depth + 1);
+    } else if (child && typeof child === 'object') {
+      walkMultiset(child, acc, depth + 1);
+    }
+  }
+}
+
+/** Build a multiset count map from an action list. */
+function actionCounts(items: readonly string[]): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const it of items) m.set(it, (m.get(it) ?? 0) + 1);
+  return m;
+}
+
+/**
  * Structural fidelity in [0, 1]: the fraction of the reference (English) actions
  * also present in the candidate (recall). Returns `undefined` when the reference
  * has no actions to compare against.
@@ -70,6 +111,57 @@ export function computeFidelity(
     if (cand.has(a)) hits++;
   }
   return hits / reference.length;
+}
+
+/**
+ * Structural **precision** in [0, 1]: the fraction of the *candidate's* actions
+ * that are justified by the reference (multiset-aware). The complement of
+ * {@link computeFidelity}'s recall — it falls below 1.0 when a parse/render adds
+ * commands the source never had.
+ *
+ * This is the signal recall + role-fidelity (R1) cannot see: a renderer that
+ * injects a phantom `toggle` (ja/ko/tr/ar/ru event-handler rendering) keeps recall
+ * 1.0 while precision drops. Pass multisets (see {@link collectActionsMultiset})
+ * so a *duplicated* spurious action is counted, not absorbed.
+ *
+ * Returns `undefined` when the candidate has no actions to score.
+ */
+export function computePrecision(
+  reference: readonly string[],
+  candidate: readonly string[]
+): number | undefined {
+  if (candidate.length === 0) return undefined;
+  const ref = actionCounts(reference);
+  let matched = 0;
+  for (const a of candidate) {
+    const remaining = ref.get(a) ?? 0;
+    if (remaining > 0) {
+      matched++;
+      ref.set(a, remaining - 1);
+    }
+  }
+  return matched / candidate.length;
+}
+
+/**
+ * The candidate actions **not** justified by the reference (multiset difference,
+ * sorted) — i.e. the spurious/hallucinated commands a parse or render introduced.
+ * Empty when the candidate is a structural subset of the reference. Use for
+ * diagnostics ("which command was hallucinated?"), complementing the
+ * {@link computePrecision} score.
+ */
+export function spuriousActions(
+  reference: readonly string[],
+  candidate: readonly string[]
+): string[] {
+  const ref = actionCounts(reference);
+  const extras: string[] = [];
+  for (const a of candidate) {
+    const remaining = ref.get(a) ?? 0;
+    if (remaining > 0) ref.set(a, remaining - 1);
+    else extras.push(a);
+  }
+  return extras.sort();
 }
 
 /**

--- a/packages/testing-framework/src/multilingual/fidelity.ts
+++ b/packages/testing-framework/src/multilingual/fidelity.ts
@@ -20,8 +20,16 @@ export const FIDELITY_THRESHOLD = 0.5;
 /** The structural `compound` wrapper is not a command; never counts as an action. */
 const STRUCTURAL_ACTIONS = new Set(['compound']);
 
-/** Node-array fields the walk recurses into (event/loop/conditional bodies). */
-const CHILD_FIELDS = ['body', 'statements', 'thenBranch', 'elseBranch', 'branches'] as const;
+/** Node-array fields the walk recurses into (event/loop/conditional/behavior bodies). */
+const CHILD_FIELDS = [
+  'body',
+  'statements',
+  'thenBranch',
+  'elseBranch',
+  'branches',
+  'eventHandlers',
+  'initBlock',
+] as const;
 
 /**
  * Collect the distinct command actions anywhere in a parsed semantic node tree


### PR DESCRIPTION
## Multilingual behaviors — write *and* understand behaviors in your preferred language

Authoring a `behavior … end` block in a non-English language previously dropped the
entire body at `confidence: 1.0` (a silent success), and translating even a single
event handler injected phantom commands. This PR builds the missing **correctness-first
ladder** so behaviors (and `def` functions) can be authored, parsed faithfully, and
translated between any of the supported languages, end to end.

Full design + per-phase notes: [`docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md`](docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md).

### The ladder (built bottom-up, fidelity-gated)

| Phase | What it does |
| --- | --- |
| **0 — Precision fidelity signal** | The fidelity harness measured only recall (and was Set-based), so a phantom/duplicate command scored 1.0. Added `computePrecision` / `collectActionsMultiset` / `spuriousActions` — the blind spot that was hiding everything. Additive; existing recall + R1 ratchets unchanged. |
| **1 — Renderer phantom-`toggle`** | Translating a handler into ja/ko/tr/ar/ru injected a phantom `toggle` (a fused parse-only pattern winning *render* selection). Restricted handler rendering to pure trigger patterns. Faithful single-handler translation across all affected langs. |
| **2 — Rung-2 SOV/VSO parsing (85.9% → 99.5%)** | Doubled trigger marker (bn/hi/th), vi `increment` idiom collision, bn `put` positional-pattern render, and **post-nominal possessives** (`set my textContent` → fixed in ar/id/sw + recovered a silently-lossy drop in ru/pl/uk/tr). |
| **3 — Structural / block layer** | `behavior … end` now parses into a real `BehaviorSemanticNode` (8 langs: en/es/ja/ko/ar/de/zh/tr) with multi-handler + nested-`if` support; `def name(params) … end` functions; `remove me` (remove-self) and `.{cls}` (dynamic class); multi-command bodies. Decomposition is **trigger-agnostic** (end-delimited, depth on nested openers only) so it works across SVO/SOV/VSO/V2. The `confidence:1.0` silent-success is fixed — a dropped body scores < 0.5. |
| **4 — Block renderer** | Whole behaviors/functions render to target-language source and **round-trip**: `EN behavior → comportamiento Toggleable(cls) / al click alternar .{cls} / fin / fin → re-parses to a behavior`. |

### Verification

- **semantic: 6049/6049** unit tests passing; typecheck clean.
- New lock tests: `event-handler-render-no-phantom`, `post-nominal-possessive`, `behavior-block`, `behavior-body-content`, `def-block`, `block-renderer`, plus `fidelity` precision tests.
- **Full multilingual `--regression` gate: green** across all 24 languages (run repeatedly throughout). Baseline regenerated only for **intentional** behavior-fidelity changes — behaviors were trivially-faithful 1.0 before (every language dropped the body identically) and are now really measured; net improvement on priority languages, all deltas behavior-scoped. Phase 4 is render-only and gate-neutral.

### Scope notes / deferred (documented in the plan)

- **Deferred tails:** bn `wait` (then-chain body-parser, non-priority), qu possessive, native `def`/event-name keyword translations (fidelity-neutral), and multi-handler feature-chain programs (`on click … on keyup …` has an `on`-marker ambiguity needing its own design).
- **Not in this PR:** wiring into `@hyperfixi/behaviors` package *consumption* (curated behaviors still run imperative installers), and Phase 5 curated localized metadata.
- The regenerated `patterns.db` is intentionally **not** committed (CI re-populates it); only the dicts/profiles + baseline are tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
