### PR TITLE
feat(semantic): multilingual multi-handler programs (on click … on keyup …)

### DIFF
--- a/packages/core/src/multilingual/multi-handler-program.test.ts
+++ b/packages/core/src/multilingual/multi-handler-program.test.ts
@@ -22,6 +22,7 @@ describe('multilingual multi-handler program — bridge → core Program', () =>
 
   const cases = [
     ['en', 'on click toggle .active end on keyup add .x to me end'],
+    ['en', 'on click toggle .active on keyup add .x to me'], // no-end chain (Phase B)
     ['es', 'al click alternar .active fin al keyup agregar .x a me fin'],
     ['ja', 'click を で .active を 切り替え 終わり keyup を で .x を 追加 終わり'],
   ] as const;

--- a/packages/core/src/multilingual/multi-handler-program.test.ts
+++ b/packages/core/src/multilingual/multi-handler-program.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Consumer-boundary lock — multilingual multi-handler PROGRAM through the bridge.
+ *
+ * The semantic parser's multi-handler structural layer (`tryParseProgram`) splits
+ * a top-level script with ≥2 event handlers (`on click … end on keyup … end`) and
+ * buildAST maps it to a core `Program` node. This verifies the whole pipeline —
+ * parseSemantic → buildAST → SemanticGrammarBridge — resolves to a Program with
+ * one `eventHandler` statement per handler (which the runtime's executeProgram
+ * registers), across SVO/SOV word orders. Core tests resolve `@lokascript/semantic`
+ * from dist, so this also guards against the build-swallows-DTS consumer skew.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MultilingualHyperscript } from './index';
+
+describe('multilingual multi-handler program — bridge → core Program', () => {
+  let ml: MultilingualHyperscript;
+  beforeEach(async () => {
+    ml = new MultilingualHyperscript();
+    await ml.initialize();
+  });
+
+  const cases = [
+    ['en', 'on click toggle .active end on keyup add .x to me end'],
+    ['es', 'al click alternar .active fin al keyup agregar .x a me fin'],
+    ['ja', 'click を で .active を 切り替え 終わり keyup を で .x を 追加 終わり'],
+  ] as const;
+
+  for (const [lang, src] of cases) {
+    it(`${lang}: parseToAST → Program with two eventHandlers (click, keyup)`, async () => {
+      const ast = (await ml.parseToAST(src, lang)) as {
+        type: string;
+        statements: { type: string; event?: string }[];
+      } | null;
+      expect(ast).toBeTruthy();
+      expect(ast!.type).toBe('Program');
+      expect(ast!.statements).toHaveLength(2);
+      expect(ast!.statements.every(s => s.type === 'eventHandler')).toBe(true);
+      expect(ast!.statements.map(s => s.event)).toEqual(['click', 'keyup']);
+    });
+  }
+
+  it('a single handler does NOT become a Program', async () => {
+    const ast = (await ml.parseToAST('on click toggle .active on me', 'en')) as {
+      type: string;
+    } | null;
+    expect(ast).toBeTruthy();
+    expect(ast!.type).toBe('eventHandler');
+  });
+});

--- a/packages/semantic/src/ast-builder/index.ts
+++ b/packages/semantic/src/ast-builder/index.ts
@@ -457,6 +457,17 @@ export class ASTBuilder {
       };
     }
 
+    // A compound whose every child is a top-level event handler is a multi-handler
+    // PROGRAM (`on click … on keyup …`), not a then-chained command sequence. Emit
+    // a Program node so the runtime's executeProgram registers each handler;
+    // CommandSequence would execute them as ordered commands instead. Only the
+    // multi-handler structural layer (tryParseProgram) produces such a compound —
+    // then-chains contain commands, never event handlers — so this never reroutes
+    // an ordinary then-chain.
+    if (statements.every(s => s.type === 'eventHandler')) {
+      return { type: 'Program', statements };
+    }
+
     // Convert to CommandSequence for runtime compatibility
     // Runtime handles 'CommandSequence' type in executeCommandSequence()
     const result: CommandSequenceNode = {

--- a/packages/semantic/src/explicit/renderer.ts
+++ b/packages/semantic/src/explicit/renderer.ts
@@ -65,6 +65,20 @@ export class SemanticRendererImpl implements ISemanticRenderer {
    * Render a compound node (multiple statements chained with then/and).
    */
   private renderCompound(node: CompoundSemanticNode, language: string): string {
+    // A compound whose every statement is an event handler is a multi-handler
+    // PROGRAM (produced by tryParseProgram), not a then-chain. Render each handler
+    // closed by `end` — the end-delimited form tryParseProgram splits on — so it
+    // round-trips. Joining handlers with the chain word instead collapses them
+    // back into a single handler with a merged body on re-parse. Mirrors
+    // renderBehavior's handler loop (no indent — these are top-level features).
+    if (node.statements.length > 1 && node.statements.every(s => s.kind === 'event-handler')) {
+      const endKw = this.keyword(language, 'end');
+      const lines: string[] = [];
+      for (const handler of node.statements) {
+        lines.push(this.render(handler, language), endKw);
+      }
+      return lines.join('\n');
+    }
     const renderedStatements = node.statements.map(stmt => this.render(stmt, language));
     const chainWord = this.getChainWord(node.chainType, language);
     return renderedStatements.join(` ${chainWord} `);

--- a/packages/semantic/src/parser/block-parser.ts
+++ b/packages/semantic/src/parser/block-parser.ts
@@ -63,6 +63,56 @@ function tokenMatches(tok: LanguageToken, forms: Set<string>): boolean {
 }
 
 /**
+ * Target/reference words that follow a destination `on` (`toggle .x on me`),
+ * never a handler trigger. Used to tell a trigger `on` (`on click`, followed by
+ * an EVENT) from a target `on` (followed by one of these or a selector). Listed
+ * by their NORMALIZED form — non-English tokenizers normalize the native word
+ * (es `me`, ja `自分`, ko `나`) to these English bases.
+ */
+const TARGET_REFERENCES = new Set([
+  'me',
+  'it',
+  'you',
+  'the',
+  'body',
+  'window',
+  'document',
+  'its',
+  'event',
+  'result',
+  'target',
+  'self',
+  'this',
+  'them',
+  'parent',
+  'next',
+  'previous',
+  'closest',
+  'first',
+  'last',
+]);
+
+/** Role-concept normalized forms a token can carry — markers, not event names. */
+const ROLE_CONCEPTS = new Set(['destination', 'source', 'style', 'patient', 'on', 'from', 'to']);
+
+/**
+ * Does `tok` look like an EVENT name — meaning the `on`-marker before it begins a
+ * handler TRIGGER — as opposed to a target reference/selector that makes the
+ * `on` a destination marker (`toggle .x on me`)? Selectors (`.x`/`#y`/`<…>`),
+ * known reference words (me/it/the/…), and role-marker concepts are targets;
+ * anything else (click, keyup, a custom event name) reads as an event.
+ */
+function looksLikeEvent(tok: LanguageToken | undefined): boolean {
+  if (!tok) return false;
+  if (tok.kind === 'selector') return false;
+  const norm = (tok.normalized ?? tok.value).toLowerCase();
+  const val = tok.value.toLowerCase();
+  if (TARGET_REFERENCES.has(norm) || TARGET_REFERENCES.has(val)) return false;
+  if (ROLE_CONCEPTS.has(norm)) return false;
+  return true;
+}
+
+/**
  * Parse the block header (`<keyword> <Name>` + optional `(params)`) from source
  * position — NOT by scanning for `on`, which fails in SOV where the handler starts
  * with the event (`click を で …`). Returns the declared parameters and the source
@@ -126,37 +176,72 @@ export function tryParseBlock(
  * rest into its body (the trailing `on keyup …` is swallowed as a compound
  * command), so a script with N>1 top-level handlers silently loses all but the
  * first — broken in every language. This splits the input into its top-level
- * handler segments using the SAME end-delimited, trigger-AGNOSTIC technique as
- * {@link parseBehaviorBlock}'s body split: depth counts only nested openers
- * (if/unless/repeat/for/while), the handler trigger is never counted, so it works
- * regardless of how a language surfaces the trigger (`on`, de `wenn`, zh idiom,
- * SOV mid-clause marker). Each segment is parsed by the ordinary single-statement
- * engine and the handlers are re-assembled into a `compound` (which buildAST maps
- * to a core `Program`, so the runtime registers each handler).
+ * handler segments by two complementary boundaries, both at depth 0 (depth counts
+ * only nested if/unless/repeat/for/while openers, never the handler trigger):
+ *
+ *  - **end-delimited** (Phase A) — a depth-0 `end` closes a handler. Trigger-
+ *    AGNOSTIC, so it works however a language surfaces the trigger (`on`, de
+ *    `wenn`, zh idiom, SOV mid-clause marker). This is the common, unambiguous
+ *    form (`on click … end on keyup … end`).
+ *  - **trigger-delimited** (Phase B) — a depth-0 `on`-marker that begins a NEW
+ *    handler starts a segment, for the no-`end` feature chain (`on click … on
+ *    keyup …`). The `on` marker is matched by its surface form (en `on`, es `al`,
+ *    …) and disambiguated from a destination `on` (`toggle .x on me`) by event-
+ *    name lookahead: the next token must look like an EVENT, not a target
+ *    reference/selector. This is inherently marker-dependent, so SOV chains with
+ *    no trigger marker (ja `… 切り替え keyup を …`) are NOT split — they rely on
+ *    the end-delimited form.
+ *
+ * Each segment is parsed by the ordinary single-statement engine and re-assembled
+ * into a `compound` (which buildAST maps to a core `Program`, so the runtime
+ * registers each handler).
  *
  * Returns null (fast) unless it finds ≥2 segments that ALL parse as event
  * handlers — so single handlers, single commands, and conditionals fall straight
  * through to single-statement parsing unchanged.
- *
- * NOTE: the no-`end` feature chain (`on click … on keyup …`, no delimiters) is
- * deliberately NOT split here. Distinguishing a trigger `on` from a target `on`
- * (`toggle .x on me`) needs event-name lookahead and is language-sensitive — a
- * separate follow-up. The end-delimited form is the common, unambiguous case.
  */
 export function tryParseProgram(
   input: string,
   language: string,
   parsers: BlockParsers
 ): SemanticNode | null {
-  if (!tryGetProfile(language)) return null;
+  const profile = tryGetProfile(language);
+  if (!profile) return null;
 
-  // Cheap pre-guard: the end-delimited multi-handler form needs ≥1 `end`
-  // keyword. Skip the tokenize for the overwhelming majority of single-statement
-  // inputs that contain no `end` form at all. (A substring hit on `end` inside
-  // `append`/`send` only costs a tokenize that then yields <2 segments → null.)
+  // The no-`end` trigger split uses FORWARD event-name lookahead (`<on> <event>`),
+  // which only holds where the `on` marker PRECEDES the event — SVO/VSO/V2 (en
+  // `on click`, es `al click`, ar `على click`, de `bei click`). SOV languages are
+  // POSTPOSITIONAL: the marker follows the event (`click पर`, `click を で`) and
+  // is typically homonymous with the locative/destination marker (hi `पर`, ja
+  // `で`), so a forward lookahead both misses the real boundary and mis-fires on
+  // `<target> <marker> <verb>`. SOV no-`end` chains are therefore NOT trigger-
+  // split; they rely on the end-delimited form (Phase A), which is word-order
+  // agnostic. (The end split below still runs for SOV.)
+  const triggerSplit = profile.wordOrder !== 'SOV';
+
+  // Cheap pre-guard: a multi-handler program needs either ≥1 `end` keyword (the
+  // end-delimited form) or — for trigger-split languages — ≥2 `on`-trigger surface
+  // forms (the no-`end` chain). Skip the tokenize for the overwhelming majority of
+  // single-statement inputs that have neither. Over-counting only costs a tokenize
+  // that then yields <2 segments → null; under-counting would miss a real program,
+  // so this errs toward proceeding.
   const endForms = keywordForms(language, 'end');
+  const onForms = keywordForms(language, 'on');
   const lower = input.toLowerCase();
-  if (![...endForms].some(f => lower.includes(f))) return null;
+  const hasEnd = [...endForms].some(f => lower.includes(f));
+  const hasMultiTrigger =
+    triggerSplit &&
+    (() => {
+      let hits = 0;
+      for (const f of onForms) {
+        if (!f) continue;
+        for (let i = lower.indexOf(f); i >= 0; i = lower.indexOf(f, i + f.length)) {
+          if (++hits >= 2) return true;
+        }
+      }
+      return false;
+    })();
+  if (!hasEnd && !hasMultiTrigger) return null;
 
   const tokens = tokenize(input, language).tokens as readonly LanguageToken[];
   if (tokens.length < 2) return null;
@@ -165,9 +250,11 @@ export function tryParseProgram(
   const isOpener = (tok: LanguageToken): boolean => openerSets.some(s => tokenMatches(tok, s));
   const isEnd = (tok: LanguageToken): boolean => tokenMatches(tok, endForms);
 
-  // Split into top-level handler segments by depth-aware `end` matching: a `end`
-  // at depth > 0 closes a NESTED if/repeat (decrement only); a depth-0 `end`
-  // closes a handler segment. A final handler with no trailing `end` is the tail.
+  // Split into top-level handler segments. At depth 0: a `end` closes the current
+  // handler (end-delimited form); an `on`-marker that BEGINS a new handler (its
+  // lookahead is an event, not a target) starts a new segment (no-`end` chain). A
+  // `end` at depth > 0 closes a NESTED if/repeat (decrement only). A final handler
+  // with no trailing `end` is the tail segment.
   const segments: string[] = [];
   let depth = 0;
   let segStart = 0;
@@ -183,6 +270,17 @@ export function tryParseProgram(
       segStart = j + 1;
     } else if (isOpener(tok)) {
       depth++;
+    } else if (
+      triggerSplit &&
+      depth === 0 &&
+      j > segStart &&
+      tokenMatches(tok, onForms) &&
+      looksLikeEvent(tokens[j + 1])
+    ) {
+      // A new handler trigger at top level ends the previous (un-`end`ed) handler.
+      const text = input.slice(tokens[segStart].position.start, tok.position.start).trim();
+      if (text) segments.push(text);
+      segStart = j;
     }
   }
   if (segStart < tokens.length) {

--- a/packages/semantic/src/parser/block-parser.ts
+++ b/packages/semantic/src/parser/block-parser.ts
@@ -15,7 +15,7 @@
  */
 
 import type { LanguageToken, SemanticNode, EventHandlerSemanticNode } from '../types';
-import { createBehaviorNode, createDefNode } from '../types';
+import { createBehaviorNode, createDefNode, createCompoundNode } from '../types';
 import { tryGetProfile } from '../registry';
 import { tokenize } from '../tokenizers';
 
@@ -116,6 +116,108 @@ export function tryParseBlock(
     return parseDefBlock(input, language, tokens, parsers);
   }
   return null;
+}
+
+/**
+ * Attempt to parse `input` as a multi-handler PROGRAM — a top-level "feature"
+ * script with two or more event handlers (`on click … end on keyup … end`).
+ *
+ * The single-statement parser matches only the FIRST handler and absorbs the
+ * rest into its body (the trailing `on keyup …` is swallowed as a compound
+ * command), so a script with N>1 top-level handlers silently loses all but the
+ * first — broken in every language. This splits the input into its top-level
+ * handler segments using the SAME end-delimited, trigger-AGNOSTIC technique as
+ * {@link parseBehaviorBlock}'s body split: depth counts only nested openers
+ * (if/unless/repeat/for/while), the handler trigger is never counted, so it works
+ * regardless of how a language surfaces the trigger (`on`, de `wenn`, zh idiom,
+ * SOV mid-clause marker). Each segment is parsed by the ordinary single-statement
+ * engine and the handlers are re-assembled into a `compound` (which buildAST maps
+ * to a core `Program`, so the runtime registers each handler).
+ *
+ * Returns null (fast) unless it finds ≥2 segments that ALL parse as event
+ * handlers — so single handlers, single commands, and conditionals fall straight
+ * through to single-statement parsing unchanged.
+ *
+ * NOTE: the no-`end` feature chain (`on click … on keyup …`, no delimiters) is
+ * deliberately NOT split here. Distinguishing a trigger `on` from a target `on`
+ * (`toggle .x on me`) needs event-name lookahead and is language-sensitive — a
+ * separate follow-up. The end-delimited form is the common, unambiguous case.
+ */
+export function tryParseProgram(
+  input: string,
+  language: string,
+  parsers: BlockParsers
+): SemanticNode | null {
+  if (!tryGetProfile(language)) return null;
+
+  // Cheap pre-guard: the end-delimited multi-handler form needs ≥1 `end`
+  // keyword. Skip the tokenize for the overwhelming majority of single-statement
+  // inputs that contain no `end` form at all. (A substring hit on `end` inside
+  // `append`/`send` only costs a tokenize that then yields <2 segments → null.)
+  const endForms = keywordForms(language, 'end');
+  const lower = input.toLowerCase();
+  if (![...endForms].some(f => lower.includes(f))) return null;
+
+  const tokens = tokenize(input, language).tokens as readonly LanguageToken[];
+  if (tokens.length < 2) return null;
+
+  const openerSets = OPENER_ACTIONS.map(a => keywordForms(language, a));
+  const isOpener = (tok: LanguageToken): boolean => openerSets.some(s => tokenMatches(tok, s));
+  const isEnd = (tok: LanguageToken): boolean => tokenMatches(tok, endForms);
+
+  // Split into top-level handler segments by depth-aware `end` matching: a `end`
+  // at depth > 0 closes a NESTED if/repeat (decrement only); a depth-0 `end`
+  // closes a handler segment. A final handler with no trailing `end` is the tail.
+  const segments: string[] = [];
+  let depth = 0;
+  let segStart = 0;
+  for (let j = 0; j < tokens.length; j++) {
+    const tok = tokens[j];
+    if (isEnd(tok)) {
+      if (depth > 0) {
+        depth--;
+        continue;
+      }
+      const text = input.slice(tokens[segStart].position.start, tok.position.start).trim();
+      if (text) segments.push(text);
+      segStart = j + 1;
+    } else if (isOpener(tok)) {
+      depth++;
+    }
+  }
+  if (segStart < tokens.length) {
+    const text = input.slice(tokens[segStart].position.start).trim();
+    if (text) segments.push(text);
+  }
+
+  if (segments.length < 2) return null;
+
+  // Every segment must parse as an event handler; otherwise this isn't a
+  // multi-handler program (it may be a single conditional, a command sequence, a
+  // mixed init/def program) and we defer to the existing single-statement path.
+  const handlers: SemanticNode[] = [];
+  const confidences: number[] = [];
+  for (const seg of segments) {
+    let parsed: SemanticNode;
+    try {
+      parsed = parsers.statement(seg, language);
+    } catch {
+      return null;
+    }
+    if (!parsed || parsed.kind !== 'event-handler') return null;
+    const handler = parsed as EventHandlerSemanticNode;
+    handlers.push(handler);
+    // An empty handler body means the sub-parse silently dropped its commands —
+    // don't inherit a misleadingly high confidence (mirrors parseBehaviorBlock).
+    const bodyEmpty = !handler.body || handler.body.length === 0;
+    confidences.push(bodyEmpty ? 0.2 : (handler.metadata?.confidence ?? 0.75));
+  }
+
+  return createCompoundNode(handlers, 'then', {
+    sourceLanguage: language,
+    confidence: meanConfidence(confidences),
+    sourceText: input,
+  });
 }
 
 /** Mean of a confidence list (0 when empty). */

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -37,7 +37,7 @@ import {
 import { getPatternsForLanguage, tryGetProfile } from '../registry';
 import { getSchema } from '../generators/command-schemas';
 import { patternMatcher } from './pattern-matcher';
-import { tryParseBlock } from './block-parser';
+import { tryParseBlock, tryParseProgram } from './block-parser';
 import { eventNameTranslations } from '../patterns/event-handler';
 import { isAtEndPositionNoun } from '../patterns/put';
 import { render as renderExplicitFn } from '../explicit/renderer';
@@ -159,6 +159,18 @@ export class SemanticParserImpl implements ISemanticParser {
       body: (text, lang) => this.parseStatements(text, lang),
     });
     if (blockNode) return blockNode;
+
+    // Stage 0.5: multi-handler PROGRAM layer. A top-level script with ≥2 event
+    // handlers (`on click … end on keyup … end`) otherwise matches only the first
+    // handler at Stage 1 and silently absorbs the rest into its body. This splits
+    // the input into top-level handler segments (end-delimited, trigger-agnostic)
+    // and re-assembles them. Returns null (fast) unless ≥2 segments all parse as
+    // handlers, so single statements fall through unchanged.
+    const programNode = tryParseProgram(input, language, {
+      statement: (text, lang) => this.parse(text, lang),
+      body: (text, lang) => this.parseStatements(text, lang),
+    });
+    if (programNode) return programNode;
 
     // Extract standalone event modifiers (once, debounced, throttled) from input
     const { modifiers, remainingInput } = this.extractStandaloneModifiers(input, language);

--- a/packages/semantic/test/multi-handler-program.test.ts
+++ b/packages/semantic/test/multi-handler-program.test.ts
@@ -74,6 +74,70 @@ describe('multi-handler program — parse (end-delimited)', () => {
   });
 });
 
+describe('multi-handler program — parse (no-end feature chain, Phase B)', () => {
+  it('splits a no-end chain at the trigger boundary (EN)', () => {
+    const node = parse('on click toggle .active on keyup add .x to me', 'en') as SNode;
+    expect(node.kind).toBe('compound');
+    expect(node.statements).toHaveLength(2);
+    expect(node.statements!.map(eventOf)).toEqual(['click', 'keyup']);
+    expect(actionsOf(node.statements![0])).toEqual(['toggle']);
+    expect(actionsOf(node.statements![1])).toEqual(['add']);
+  });
+
+  it('splits a three-handler no-end chain', () => {
+    const node = parse(
+      'on click add .a to me on mouseenter remove .b from me on mouseleave toggle .c',
+      'en'
+    ) as SNode;
+    expect(node.statements).toHaveLength(3);
+    expect(node.statements!.map(eventOf)).toEqual(['click', 'mouseenter', 'mouseleave']);
+  });
+
+  it('mixes a no-end handler followed by an end-delimited one', () => {
+    const node = parse('on click toggle .a on keyup add .b end', 'en') as SNode;
+    expect(node.statements).toHaveLength(2);
+    expect(node.statements!.map(eventOf)).toEqual(['click', 'keyup']);
+  });
+
+  // The on-trigger / on-target ambiguity — these must NOT split.
+  it('does not split a single handler whose body ends in an `on`-target', () => {
+    expect((parse('on click toggle .active on me', 'en') as SNode).kind).toBe('event-handler');
+  });
+
+  it('does not split on `on me` inside a then-chained body', () => {
+    // `to me` and `on me` are both destinations here, not new triggers.
+    expect(
+      (parse('on click add .a to me then toggle .b on me', 'en') as SNode).kind
+    ).toBe('event-handler');
+  });
+
+  it('splits no-end chains in trigger-prepositional languages (es SVO, de V2, ar VSO)', () => {
+    const cases: Record<string, string> = {
+      es: 'al click alternar .active al keyup agregar .x',
+      de: 'bei click umschalten .active bei keyup hinzufügen .x',
+      ar: 'على click بدّل .active على keyup أضف .x',
+    };
+    for (const [lang, src] of Object.entries(cases)) {
+      const node = parse(src, lang) as SNode;
+      expect(node.kind, lang).toBe('compound');
+      expect(node.statements, lang).toHaveLength(2);
+      expect(node.statements!.map(eventOf), lang).toEqual(['click', 'keyup']);
+    }
+  });
+
+  it('does NOT trigger-split SOV chains (postpositional marker) — stays one handler', () => {
+    // SOV `on` markers are postpositional and homonymous with the locative, so a
+    // forward event lookahead can't split safely; these rely on the end-delimited
+    // form (Phase A). A single SOV handler must remain a single handler.
+    expect(
+      (parse('click पर .open को #panel पर टॉगल', 'hi') as SNode).kind
+    ).toBe('event-handler');
+    expect(
+      (parse('click を で .active を 切り替え keyup を で .x を 追加', 'ja') as SNode).kind
+    ).toBe('event-handler');
+  });
+});
+
 describe('multi-handler program — buildAST → core Program', () => {
   it('emits a Program node with one eventHandler statement per handler', () => {
     const ast = astOf(parse('on click toggle .active end on keyup add .x to me end', 'en') as SNode);

--- a/packages/semantic/test/multi-handler-program.test.ts
+++ b/packages/semantic/test/multi-handler-program.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Multi-handler PROGRAM layer — a top-level "feature" script with two or more
+ * event handlers (`on click … end on keyup … end`).
+ *
+ * The single-statement parser matched only the FIRST handler and silently
+ * absorbed the rest into its body (the trailing `on keyup …` was swallowed as a
+ * compound command) — broken in every language. `tryParseProgram` splits the
+ * input into its top-level handler segments using the SAME end-delimited,
+ * trigger-agnostic technique as the behavior-block body split (depth counts only
+ * nested if/repeat/…; the trigger is never counted), re-assembles them into a
+ * `compound`, and buildAST maps an all-handler compound to a core `Program` node
+ * so the runtime's executeProgram registers every handler. The renderer renders
+ * such a compound as `end`-delimited handlers (not a then-chain) so it round-trips.
+ *
+ * See docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md (deferred tails: multi-handler).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse, buildAST, render } from '../src';
+
+interface SNode {
+  kind?: string;
+  action?: string;
+  body?: SNode[];
+  statements?: SNode[];
+  roles?: Map<string, { value?: string }>;
+}
+const eventOf = (h: SNode): string | undefined => h.roles?.get?.('event')?.value;
+const actionsOf = (h: SNode): string[] => (h.body ?? []).map(b => b.action ?? b.kind ?? '?');
+
+/** buildAST returns a `{ ast }` wrapper; normalize to the AST node. */
+function astOf(node: SNode): { type?: string; statements?: { type: string; event?: string }[] } {
+  const built = buildAST(node as never) as { ast?: unknown };
+  return (built.ast ?? built) as never;
+}
+
+describe('multi-handler program — parse (end-delimited)', () => {
+  it('splits two top-level handlers into a compound of event handlers (EN)', () => {
+    const node = parse('on click toggle .active end on keyup add .x to me end', 'en') as SNode;
+    expect(node.kind).toBe('compound');
+    expect(node.statements).toHaveLength(2);
+    expect(node.statements!.every(s => s.kind === 'event-handler')).toBe(true);
+    expect(eventOf(node.statements![0])).toBe('click');
+    expect(actionsOf(node.statements![0])).toEqual(['toggle']);
+    expect(eventOf(node.statements![1])).toBe('keyup');
+    expect(actionsOf(node.statements![1])).toEqual(['add']);
+  });
+
+  it('splits three handlers', () => {
+    const node = parse(
+      'on click add .a to me end on mouseenter add .b to me end on mouseleave remove .c from me end',
+      'en'
+    ) as SNode;
+    expect(node.statements).toHaveLength(3);
+    expect(node.statements!.map(eventOf)).toEqual(['click', 'mouseenter', 'mouseleave']);
+  });
+
+  it('contains a nested if inside a handler body without mis-splitting (depth-aware)', () => {
+    const node = parse(
+      'on click if me matches .x then toggle .a end end on mouseenter add .b to me end',
+      'en'
+    ) as SNode;
+    expect(node.kind).toBe('compound');
+    expect(node.statements).toHaveLength(2);
+    expect(eventOf(node.statements![0])).toBe('click');
+    expect(eventOf(node.statements![1])).toBe('mouseenter');
+  });
+
+  it('handles a final handler with no trailing end', () => {
+    const node = parse('on click toggle .a end on keyup add .b to me', 'en') as SNode;
+    expect(node.kind).toBe('compound');
+    expect(node.statements).toHaveLength(2);
+    expect(node.statements!.map(eventOf)).toEqual(['click', 'keyup']);
+  });
+});
+
+describe('multi-handler program — buildAST → core Program', () => {
+  it('emits a Program node with one eventHandler statement per handler', () => {
+    const ast = astOf(parse('on click toggle .active end on keyup add .x to me end', 'en') as SNode);
+    expect(ast.type).toBe('Program');
+    expect(ast.statements).toHaveLength(2);
+    expect(ast.statements!.every(s => s.type === 'eventHandler')).toBe(true);
+    expect(ast.statements!.map(s => s.event)).toEqual(['click', 'keyup']);
+  });
+});
+
+describe('multi-handler program — does NOT mis-fire on single statements', () => {
+  it('a single handler with an `on`-target stays one handler (not a program)', () => {
+    // `on me` is a destination here, not a second trigger.
+    const node = parse('on click toggle .active on me', 'en') as SNode;
+    expect(node.kind).toBe('event-handler');
+  });
+
+  it('a single handler closed by end is not a program', () => {
+    const node = parse('on click toggle .active end', 'en') as SNode;
+    expect(node.kind).toBe('event-handler');
+  });
+
+  it('a single conditional (if … end) is not a program', () => {
+    const node = parse('if me matches .x then toggle .a end', 'en') as SNode;
+    expect(node.kind).not.toBe('compound');
+  });
+
+  it('a then-chain of commands is a CommandSequence, never a Program', () => {
+    const ast = astOf(parse('toggle .a then add .b to me', 'en') as SNode);
+    expect(ast.type).not.toBe('Program');
+  });
+});
+
+describe('multi-handler program — round-trips across word orders', () => {
+  const SRC = 'on click toggle .active end on keyup add .red to me end';
+  // SVO (es), SOV (ja, ko), V2 (de), VSO (ar).
+  for (const lang of ['es', 'ja', 'ko', 'de', 'ar'] as const) {
+    it(`EN → ${lang} → parse preserves both handlers + their first command`, () => {
+      const back = parse(render(parse(SRC, 'en'), lang), lang) as SNode;
+      expect(back.kind).toBe('compound');
+      expect(back.statements).toHaveLength(2);
+      expect(eventOf(back.statements![0])).toBe('click');
+      expect(actionsOf(back.statements![0])).toEqual(['toggle']);
+      expect(eventOf(back.statements![1])).toBe('keyup');
+      expect(actionsOf(back.statements![1])).toEqual(['add']);
+    });
+  }
+
+  it('renders each handler closed by its own end (ES), not a then-chain', () => {
+    const out = render(parse(SRC, 'en'), 'es');
+    // Two `fin` (end) delimiters, and NOT joined by the chain word `entonces`.
+    expect(out.match(/\bfin\b/g)).toHaveLength(2);
+    expect(out).not.toContain('entonces');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes multi-handler **programs** on the semantic/multilingual parse path: a top-level script with ≥2 event handlers (`on click … on keyup …`) previously parsed to **only the first handler** in every language — the rest were silently absorbed into the first handler's body. This is the `multi-handler feature-chain programs` tail deferred from the multilingual-behaviors arc ([#427](https://github.com/codetalcott/hyperfixi/pull/427)).

> Note: English multi-handler already worked via core's *traditional* parser (`createProgramNode`). This PR fixes the **semantic** parser used for the multilingual path.

## Approach

New `tryParseProgram` (block-parser **Stage 0.5**) splits a script into top-level handler segments, parses each with the ordinary single-statement engine, and re-assembles them into a `compound`. `buildAST` maps an all-`eventHandler` compound → core **`Program`** node, so the runtime's `executeProgram` registers each handler. The renderer renders such a compound as `end`-delimited handlers (not a `then`-chain) so it round-trips.

Two complementary split boundaries, both at depth 0 (depth counts only nested `if`/`unless`/`repeat`/`for`/`while`, never the trigger):

- **Phase A — end-delimited** (`on click … end on keyup … end`): a depth-0 `end` closes a handler. **Trigger-agnostic**, so it works for every word order (reuses the proven behavior-block split technique).
- **Phase B — trigger-delimited** (`on click … on keyup …`, no delimiters): an `on`-marker that *begins* a new handler. Trigger-vs-target `on` (`toggle .x on me`) is disambiguated by **forward event-name lookahead** — the token after the marker must look like an event, not a selector/reference. **Gated to non-SOV** word order: SVO/VSO/V2 are prepositional (`on click`, es `al click`, ar `على click`); SOV is postpositional and homonymous with the locative (`click पर … #panel पर`), so a forward lookahead can't split it safely.

### Design notes
- **Reused the existing `compound` kind** — no new `SemanticNode.kind`, so there's no INTENT-package union boundary break (the CI fix `3c9e03d6` from the prior arc). Core typecheck confirms clean.
- **Remaining limitation (deferred):** SOV no-`end` chains (`click を で … keyup を で …`) have no reliable delimiter without backward/verb-aware analysis; they work in the end-delimited form.

## Test plan

- Round-trip EN → {es, ja, ko, de, ar} → parse preserves both handlers (SVO/SOV/V2/VSO)
- no-`end` chains split in en/es/de/ar → N handlers; hi/ja SOV correctly stay single; single-handler `on me` and `then … on me` bodies never false-split
- Semantic **6069/6069** + new 22-case lock (`packages/semantic/test/multi-handler-program.test.ts`)
- Core **5/5** consumer-boundary lock (`packages/core/src/multilingual/multi-handler-program.test.ts` — `parseToAST` → `Program` through the bridge, against fresh semantic dist)
- semantic + core typecheck clean
- Multilingual `--regression` gate **green, baseline unchanged** (no corpus entry is multi-handler; renderer change is gate-neutral)

🤖 Generated with [Claude Code](https://claude.com/claude-code)