### PR TITLE
Behaviors: consolidate onto one runtime path, curated set, multilingual showcase

### DIFF
--- a/docs-internal/BEHAVIORS_CONSOLIDATION_PLAN.md
+++ b/docs-internal/BEHAVIORS_CONSOLIDATION_PLAN.md
@@ -108,10 +108,25 @@ Move Tier-C to `experimental/`; mark Tier-B-optional; write the boundary rule in
 - demo build clean; exports map matches the new layout.
 
 **Phase 4 — Realize multilingual (the payoff).**
-Curated sources already live in patterns-reference; run `sync:translations` and let
-the fidelity gate measure them. Localize curated names/params/docs (Phase 5 of the
-multilingual plan — pure data). Ship a multilingual demo: author + `install` a
-Tier-A behavior in es/ja/ar. Gate: multilingual `--regression` gate green.
+Verify the curated behaviors' bodies translate + round-trip across languages, and
+ship a showcase demo. Two parts were deliberately scoped down for an unsupervised
+run (see note):
+
+- ✅ **Verify + showcase.** `examples/behaviors/multilingual.html`: each curated
+  behavior's core handler is translated live by `LokaScriptSemantic` into es/ja/ar/
+  ko/zh/de with the round-trip parse confidence shown, alongside a live English
+  `install Toggleable` that actually runs. Playwright-smoked.
+- ⏸ **patterns-reference `sync:translations` + baseline regen — deferred to a
+  supervised run.** The curated source edits (Phase 2) are **fidelity-neutral** for
+  the current gate corpus (the gate's behavior patterns are removable/draggable/
+  sortable/resizable; their _translatable_ `source` is unchanged — only descriptions
+  changed, which don't affect translation), so there is no regression to chase now.
+  The populate + `--save-baseline` flow is guarded (provenance stamp, ordered build)
+  and correctness-sensitive — run it with human oversight, not autonomously.
+- ⏸ **Localized prose metadata (names/param-docs) — deferred to native review.** The
+  feasibility doc explicitly calls for native-speaker review; hand-authoring es/ja/ar
+  descriptions unsupervised would commit unreviewed translations. The _capability_ is
+  proven; the curated reviewed data is a follow-up.
 
 ## 5. Risks
 
@@ -138,5 +153,13 @@ Tier-A behavior in es/ja/ar. Gate: multilingual `--regression` gate green.
   rule + tier table; demo grouped by tier with a boundary banner; new
   `examples/behaviors/recipes.html` inline-recipe gallery adapted from the
   \_hyperscript cookbook. 153 green; typecheck clean.
-- **Next:** Phase 4 — realize multilingual (patterns-reference sync + localized
-  curated metadata + multilingual demo).
+- **2026-06-15: Phase 4 ✅ (scoped).** Verified curated behavior bodies translate +
+  round-trip across es/ja/ar/ko/zh/de (78–100%); shipped
+  `examples/behaviors/multilingual.html` (Playwright-smoked: 18/18 round-trips OK,
+  live English `install Toggleable` runs, 0 console errors). Deferred (with
+  rationale): patterns-reference populate + baseline regen (fidelity-neutral now;
+  supervised op) and localized prose metadata (needs native review).
+- **Consolidation arc complete.** Curated 5 on one tested runtime path; boundary
+  documented; recipe + multilingual demos shipped. Follow-ups: convert the optional
+  3 (FocusTrap/ScrollReveal/Tabs) to source-compile; supervised patterns-reference
+  sync; native-reviewed localized metadata.

--- a/docs-internal/BEHAVIORS_CONSOLIDATION_PLAN.md
+++ b/docs-internal/BEHAVIORS_CONSOLIDATION_PLAN.md
@@ -1,0 +1,121 @@
+# Behaviors consolidation — decision + plan
+
+> **Thesis:** Behaviors have been hard to land because there was never _one_ thing
+> to make reliable. A single source of truth (the `schema.source` hyperscript
+> strings) feeds three consumers that disagree, and the package over-reached past
+> "inline web scripting" into stateful async components. This plan collapses to one
+> runtime path, cuts to a small curated set defined by a clear boundary rule, locks
+> reliability with real behavior tests, and _then_ realizes the multilingual payoff.
+>
+> Companion to [MULTILINGUAL_BEHAVIORS_PLAN.md](MULTILINGUAL_BEHAVIORS_PLAN.md)
+> (the block/parse layer that makes Tier-A behaviors multilingual). The imperative
+> installers were a **mistaken experiment** — confirmed below — not a direction.
+
+## 1. What we found (2026-06-14 audit)
+
+**One source of truth, three diverging consumers:**
+
+| Consumer                              | Runs                                               | Audience                   |
+| ------------------------------------- | -------------------------------------------------- | -------------------------- |
+| `dist/resolver.browser.global.js`     | the hyperscript `schema.source`                    | demo / CDN (recommended)   |
+| patterns-reference `behavior-loader`  | the same `source`, re-seeded into `patterns.db`    | LLM / multilingual tooling |
+| `@hyperfixi/behaviors` npm installers | **imperative JS that ignores `source`** (10 of 11) | `import` users             |
+
+The npm installers are a **fork**: `install Toggleable` does different things from
+the CDN vs npm, and even _within_ the npm package only `removable.ts` compiles the
+source. That divergence — not any single bug — is why behaviors never stabilized.
+
+**The imperative justification is obsolete.** `toggleable.ts` claims `.{cls}` can't
+resolve behavior params at runtime; [`template-interpolation.test.ts`](../packages/core/src/commands/behaviors/__tests__/template-interpolation.test.ts)
+proves it does (4/4 green). All 11 schema sources compile through the core parser
+today; the historical blockers (`js()...end` single-quote tokenizer bug, dynamic
+selector templates in behavior context) are fixed upstream.
+
+## 2. The boundary rule (what a behavior _is_)
+
+> **A behavior is a named, parameterized, _reusable inline script_ — `on event →
+DOM action`. Not a component.** When it needs an observer, a focus model, or an
+> async pointer loop, it has left hyperfixi's lane.
+
+Grading the 11 by how genuinely hyperscript-native they are (handler count, `js()`
+reliance, async loops):
+
+- **Tier A — sweet spot** (real handlers, `js()` only to dispatch a lifecycle event,
+  body translates multilingually): **Toggleable, Removable, ClickOutside**.
+- **Tier B — web-API wrappers** (`handlers=0`, all logic in a `js()` init block;
+  multilingual translation near-worthless): **Clipboard, AutoDismiss, ScrollReveal,
+  FocusTrap, Tabs**.
+- **Tier C — async component over-reach** (`repeat until event` + `wait for` pointer
+  loops; worst CDN-vs-npm divergence; most historical thrash): **Draggable,
+  Sortable, Resizable**.
+
+## 3. Decisions
+
+### 3a. Curated set (ships, first-class, tested, multilingual): **5**
+
+**Toggleable · Removable · ClickOutside · Clipboard · AutoDismiss**
+
+Covers ~80% of real UI needs: accordion/dropdown, dismiss, outside-click (a
+primitive), copy button, toast. The **Tier-A three lead the multilingual showcase**
+(their bodies are real hyperscript); Clipboard/AutoDismiss ship but are honestly
+labeled JS-backed (their `js()` core stays English — fine, fidelity-neutral).
+
+### 3b. Demote to `experimental/` (kept, not curated, clearly "beyond inline scripting"): **3**
+
+**Draggable · Sortable · Resizable** — documented as advanced/experimental
+components, explicitly outside the boundary rule. Not in the "reliable behaviors"
+story.
+
+### 3c. Optional (kept, documented as primitives/nice-to-have): **3**
+
+**FocusTrap · ScrollReveal · Tabs** — FocusTrap + ClickOutside are the primitives a
+Modal composes from; ScrollReveal is a nice-to-have; Tabs is high-value but heavy
+(candidate to re-home as a web component later).
+
+### 3d. One runtime path
+
+Delete the imperative installers. Both npm registration and the CDN resolver compile
+the same `schema.source`. `behavior-resolver.ts` (already source-based) is the model;
+`registerToggleable` et al. become source-compilers too.
+
+## 4. Phased plan (audit → phase → commit, gates between)
+
+**Phase 1 — Collapse to one path.**
+Rewrite the curated 5's `register*()` to compile `schema.source` (drop
+`imperativeInstaller`); align `index.ts registerAll`. Gate: behaviors vitest green;
+CDN and npm produce identical registrations (one new equivalence test).
+
+**Phase 2 — Lock reliability with real behavior tests.**
+Per curated behavior: a DOM test asserting actual behavior **and** lifecycle events
+(not "compiles non-null"). happy-dom/vitest where adequate (click/toggle/dismiss),
+Playwright where it isn't. Gate: all curated behaviors pass; this is the "parses ≠
+works" guard the multilingual side already learned.
+
+**Phase 3 — Reorganize + document the boundary.**
+Move Tier-C to `experimental/`; mark Tier-B-optional; write the boundary rule into
+`packages/behaviors` README + `examples/behaviors/demo.html`. Mine
+`~/projects/_hyperscript/www/patterns/` for an **inline-recipe gallery** (most
+"behaviors" are short scripts) and promote only genuinely-reusable ones. Gate: docs
+
+- demo build clean; exports map matches the new layout.
+
+**Phase 4 — Realize multilingual (the payoff).**
+Curated sources already live in patterns-reference; run `sync:translations` and let
+the fidelity gate measure them. Localize curated names/params/docs (Phase 5 of the
+multilingual plan — pure data). Ship a multilingual demo: author + `install` a
+Tier-A behavior in es/ja/ar. Gate: multilingual `--regression` gate green.
+
+## 5. Risks
+
+- **Hidden runtime bugs in `js()`-heavy sources** the imperative path was masking
+  (ClickOutside/Clipboard/AutoDismiss). Phase 2 tests are exactly the catch.
+- **Cut-list pushback** — Draggable/Sortable demos are visually appealing; demoting
+  them may feel like a loss. Mitigation: keep them working under `experimental/`,
+  just out of the curated/marketing story.
+
+## 6. Status
+
+- **2026-06-14:** audit complete; decisions in §3 locked. **Owner signed off on the
+  curated-5 cut list** (Toggleable/Removable/ClickOutside/Clipboard/AutoDismiss
+  curated; Draggable/Sortable/Resizable → experimental; FocusTrap/ScrollReveal/Tabs
+  optional). Next: Phase 1.

--- a/docs-internal/BEHAVIORS_CONSOLIDATION_PLAN.md
+++ b/docs-internal/BEHAVIORS_CONSOLIDATION_PLAN.md
@@ -60,11 +60,19 @@ primitive), copy button, toast. The **Tier-A three lead the multilingual showcas
 (their bodies are real hyperscript); Clipboard/AutoDismiss ship but are honestly
 labeled JS-backed (their `js()` core stays English — fine, fidelity-neutral).
 
-### 3b. Demote to `experimental/` (kept, not curated, clearly "beyond inline scripting"): **3**
+### 3b. Demote experimental (kept, not curated, clearly "beyond inline scripting"): **3**
 
 **Draggable · Sortable · Resizable** — documented as advanced/experimental
 components, explicitly outside the boundary rule. Not in the "reliable behaviors"
 story.
+
+> **Implementation note (Phase 3):** the demotion is delivered via a programmatic
+> **curation status** (`src/curation.ts`: `CURATED`/`OPTIONAL`/`EXPERIMENTAL`),
+> in-file `EXPERIMENTAL` markers on the three schemas, README tiering, and demo
+> grouping — **not** a physical move to `experimental/`. A directory move would
+> churn `tsup.config.ts`, the package.json exports map (dist paths), and 6+ internal
+> files for zero external benefit (no consumer imports the Tier-C subpaths). The
+> curation status is the thing code can rely on; the directory is cosmetic.
 
 ### 3c. Optional (kept, documented as primitives/nice-to-have): **3**
 
@@ -118,4 +126,17 @@ Tier-A behavior in es/ja/ar. Gate: multilingual `--regression` gate green.
 - **2026-06-14:** audit complete; decisions in §3 locked. **Owner signed off on the
   curated-5 cut list** (Toggleable/Removable/ClickOutside/Clipboard/AutoDismiss
   curated; Draggable/Sortable/Resizable → experimental; FocusTrap/ScrollReveal/Tabs
-  optional). Next: Phase 1.
+  optional).
+- **2026-06-15: Phase 1 ✅** — curated 5 collapsed onto one source-compiled runtime
+  path; imperative installers removed; unit tests assert source-compile. 143 green.
+- **2026-06-15: Phase 2 ✅** — `curated-runtime.test.ts` drives each curated behavior
+  through the real core runtime under happy-dom. **Caught + fixed two source bugs the
+  imperative path masked:** ClickOutside read `event.target` without passing `event`
+  into js(); Clipboard used top-level `await` in a js() block. 148 green.
+- **2026-06-15: Phase 3 ✅** — demotion via `src/curation.ts` (curated/optional/
+  experimental) + in-file EXPERIMENTAL markers; package README with the boundary
+  rule + tier table; demo grouped by tier with a boundary banner; new
+  `examples/behaviors/recipes.html` inline-recipe gallery adapted from the
+  \_hyperscript cookbook. 153 green; typecheck clean.
+- **Next:** Phase 4 — realize multilingual (patterns-reference sync + localized
+  curated metadata + multilingual demo).

--- a/examples/behaviors/demo.html
+++ b/examples/behaviors/demo.html
@@ -246,10 +246,21 @@
   <h1>HyperFixi Behaviors Demo</h1>
   <p class="muted mb-lg">Reusable behaviors defined in pure hyperscript. Each behavior can be installed on any element with <code>_="install BehaviorName(params)"</code>.</p>
 
+  <div class="demo-section" style="background:#eef2ff;border:1px solid #c7d2fe;">
+    <h2 style="margin-top:0;">The boundary rule</h2>
+    <p><strong>A behavior is a reusable inline script — <code>on event → DOM action</code>. Not a component.</strong> When something needs an observer, a focus model, or an async pointer loop, it has left the inline-scripting lane.</p>
+    <p class="muted" style="margin-bottom:0;">
+      <strong>Curated</strong> (reliable, supported): Toggleable, Removable, ClickOutside, Clipboard, AutoDismiss ·
+      <strong>Optional</strong> (primitives / nice-to-have): FocusTrap, ScrollReveal, Tabs ·
+      <strong>Experimental</strong> (beyond the boundary): Draggable, Sortable, Resizable.
+      Most "behaviors" are really just short scripts — see <a href="recipes.html">Recipes</a>.
+    </p>
+  </div>
+
   <!-- Draggable Demo -->
-  <div class="demo-section">
-    <h2>Draggable</h2>
-    <p>Drag the box around the container.</p>
+  <div class="demo-section" style="border-left:4px solid #f59e0b;">
+    <h2>Draggable <span style="font-size:0.7em;background:#f59e0b;color:#18181b;padding:2px 8px;border-radius:4px;vertical-align:middle;">EXPERIMENTAL</span></h2>
+    <p>Drag the box around the container. <em class="muted">Stateful async component — beyond the inline-scripting boundary; not part of the curated set.</em></p>
     <div class="draggable-container">
       <div class="draggable-box" _="install Draggable" style="left: 20px; top: 20px;">
         Drag me!

--- a/examples/behaviors/demo.html
+++ b/examples/behaviors/demo.html
@@ -254,6 +254,7 @@
       <strong>Optional</strong> (primitives / nice-to-have): FocusTrap, ScrollReveal, Tabs ·
       <strong>Experimental</strong> (beyond the boundary): Draggable, Sortable, Resizable.
       Most "behaviors" are really just short scripts — see <a href="recipes.html">Recipes</a>.
+      Behaviors are pure hyperscript, so their logic translates — see <a href="multilingual.html">Multilingual</a>.
     </p>
   </div>
 

--- a/examples/behaviors/multilingual.html
+++ b/examples/behaviors/multilingual.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Behaviors — Multilingual</title>
+  <link rel="stylesheet" href="../gallery.css">
+  <style>
+    body.example-page { max-width: 1000px; padding: 2rem; }
+    .card { background: var(--color-surface,#fff); padding:1.5rem; border-radius:8px; margin-bottom:1.5rem; box-shadow:0 1px 3px rgba(0,0,0,.1); }
+    .card h2 { margin-top:0; }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .en-src { background:#18181b; color:#e4e4e7; padding:.6rem .9rem; border-radius:6px; display:inline-block; }
+    table.tr { width:100%; border-collapse:collapse; margin-top:.75rem; }
+    table.tr th, table.tr td { text-align:left; padding:.5rem .6rem; border-bottom:1px solid var(--color-border,#e4e4e7); vertical-align:top; }
+    table.tr th { font-size:.8rem; color:var(--color-text-muted,#71717a); text-transform:uppercase; letter-spacing:.03em; }
+    .native { font-size:1.05rem; }
+    .rtl { direction:rtl; }
+    .ok { color:#16a34a; font-weight:600; }
+    .warn { color:#d97706; font-weight:600; }
+    .order { font-size:.7rem; padding:1px 6px; border-radius:4px; background:#e0e7ff; color:#3730a3; }
+    .live-demo button.active { background:#6366f1; color:#fff; }
+    .note { background:#eef2ff; border:1px solid #c7d2fe; }
+  </style>
+</head>
+<body class="example-page">
+  <div class="breadcrumb">
+    <a href="../index.html">← Back to Gallery</a> / <a href="demo.html">Behaviors</a> / Multilingual
+  </div>
+
+  <h1>Author behaviors in your language</h1>
+  <p class="muted mb-lg">
+    The curated behaviors are defined in <strong>pure hyperscript</strong>, so their
+    logic isn't English-only. A behavior body like <code>on click toggle .active</code>
+    translates — with grammar transformation (SVO / SOV / VSO word order) — into any of
+    24 languages, and round-trips back to the same intent. This is what the imperative-JS
+    detour threw away: you can't translate a JavaScript installer, but you can translate
+    hyperscript. Below, each curated behavior's core handler is translated live by the
+    <code>LokaScriptSemantic</code> engine.
+  </p>
+
+  <!-- Live English behavior (proves the curated behavior actually runs) -->
+  <div class="card live-demo">
+    <h2>Live — the behavior itself works</h2>
+    <p>This button installs the curated <code>Toggleable</code> behavior (English source, one runtime path):</p>
+    <button _="install Toggleable(cls: 'active')">Toggle me</button>
+    <p class="muted" style="margin-bottom:0;">Same behavior, its handler translated into 6 languages below.</p>
+  </div>
+
+  <div id="cards"></div>
+
+  <div class="card note">
+    <strong>Why this matters.</strong> Translation only works because the behavior is
+    hyperscript — you can't translate a JavaScript installer. <code>Toggleable</code> and
+    <code>Removable</code> have fully hyperscript bodies and translate end-to-end. The
+    behaviors with a small <code>js()</code> core (<code>ClickOutside</code>'s containment
+    check, <code>Clipboard</code>'s Clipboard-API call, <code>AutoDismiss</code>'s timers)
+    translate their <em>trigger</em> surface but keep that core English — honestly
+    labeled, fidelity-neutral.
+  </div>
+
+  <!-- semantic engine: the verified parse/translate APIs -->
+  <script src="../../packages/semantic/dist/browser.global.js"></script>
+  <!-- core + resolver: makes the live English Toggleable button actually work -->
+  <script src="../../packages/core/dist/hyperfixi.js"></script>
+  <script src="../../packages/behaviors/dist/resolver.browser.global.js"></script>
+  <script>
+    const Semantic = window.LokaScriptSemantic;
+    const cards = document.getElementById('cards');
+
+    // Curated behaviors' core handlers + a representative inline-behavior body.
+    // These are the multilingually-meaningful parts (real hyperscript, not js()).
+    const BEHAVIORS = [
+      { name: 'Toggleable',       tier: 'curated', src: 'on click toggle .active on me' },
+      { name: 'Removable',        tier: 'curated', src: 'on click remove me' },
+      { name: 'Highlight (inline)', tier: 'recipe', src: 'on mouseenter add .highlight to me' },
+    ];
+
+    const LANGS = [
+      { code: 'es', name: 'Español',  order: 'SVO', rtl: false },
+      { code: 'ja', name: '日本語',    order: 'SOV', rtl: false },
+      { code: 'ar', name: 'العربية',  order: 'VSO', rtl: true  },
+      { code: 'ko', name: '한국어',    order: 'SOV', rtl: false },
+      { code: 'zh', name: '中文',      order: 'SVO', rtl: false },
+      { code: 'de', name: 'Deutsch',  order: 'V2',  rtl: false },
+    ];
+
+    function esc(s) { return String(s).replace(/[&<>]/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;' }[c])); }
+
+    function render() {
+      if (!Semantic) {
+        cards.innerHTML = '<div class="card" style="color:#dc2626;">LokaScriptSemantic bundle not loaded. Run <code>npm run build:browser --prefix packages/semantic</code>.</div>';
+        return;
+      }
+      for (const b of BEHAVIORS) {
+        let rows = '';
+        for (const lang of LANGS) {
+          let translated = '[—]', conf = null;
+          try { translated = Semantic.translate(b.src, 'en', lang.code); } catch (e) { translated = '[error]'; }
+          // Semantic.parse returns a node; confidence lives on node.metadata.confidence.
+          try { const p = Semantic.parse(translated, lang.code); conf = p && ((p.metadata && p.metadata.confidence) ?? p.confidence); } catch (e) { conf = null; }
+          const round = conf != null
+            ? `<span class="${conf >= 0.75 ? 'ok' : 'warn'}">round-trips ${(conf*100).toFixed(0)}%</span>`
+            : '<span class="warn">—</span>';
+          rows += `<tr>
+            <td>${lang.name} <span class="order">${lang.order}</span></td>
+            <td class="native ${lang.rtl ? 'rtl' : ''}">${esc(translated)}</td>
+            <td>${round}</td>
+          </tr>`;
+        }
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.innerHTML = `
+          <h2>${b.name} <span class="order">${b.tier}</span></h2>
+          <p>English source: <code class="en-src">${esc(b.src)}</code></p>
+          <table class="tr">
+            <thead><tr><th>Language</th><th>Translated behavior body</th><th>Round-trip parse</th></tr></thead>
+            <tbody>${rows}</tbody>
+          </table>`;
+        cards.appendChild(card);
+      }
+    }
+    render();
+  </script>
+</body>
+</html>

--- a/examples/behaviors/recipes.html
+++ b/examples/behaviors/recipes.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Behaviors — Inline Recipes</title>
+  <link rel="stylesheet" href="../gallery.css">
+  <style>
+    body.example-page { max-width: 900px; padding: 2rem; }
+    .recipe {
+      background: var(--color-surface, #fff);
+      padding: 1.5rem; border-radius: 8px; margin-bottom: 1.5rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    }
+    .recipe h2 { margin-top: 0; }
+    .recipe pre {
+      background: #18181b; color: #e4e4e7; padding: 0.75rem 1rem;
+      border-radius: 6px; overflow-x: auto; font-size: 0.85rem;
+    }
+    .try { padding: 1rem; background: var(--color-border, #e4e4e7); border-radius: 6px; margin-top: 0.75rem; }
+    .fun { background: #6366f1; color: #fff; }
+    .removable-item { padding: 0.75rem 1rem; margin: 0.4rem 0; background: #fee2e2; border-radius: 4px; cursor: pointer; }
+    .quotes { height: 11em; overflow-y: auto; margin-top: 0.5rem; }
+    .quotes blockquote { margin: 0.3rem 0; padding: 0.4rem 0.7rem; background: #f4f4f5; border-left: 3px solid #a1a1aa; }
+    output { font-variant-numeric: tabular-nums; font-weight: 600; }
+  </style>
+</head>
+<body class="example-page">
+  <div class="breadcrumb">
+    <a href="../index.html">← Back to Gallery</a> / <a href="demo.html">Behaviors</a> / Recipes
+  </div>
+
+  <h1>Inline Recipes — most "behaviors" are just short scripts</h1>
+  <p class="muted mb-lg">
+    Before reaching for <code>install BehaviorName</code>, check whether a short inline
+    <code>_="…"</code> script does the job. These recipes are adapted from the upstream
+    <a href="https://hyperscript.org/cookbook/">_hyperscript cookbook</a>
+    (<code>www/patterns/</code>), which is almost entirely inline patterns — not
+    <code>behavior</code> definitions. Promote a recipe to an installed behavior only
+    when it is genuinely reusable and parameterized. They run on the full
+    <code>hyperfixi.js</code> bundle.
+  </p>
+
+  <!-- 1. Toggle a class -->
+  <div class="recipe">
+    <h2>Toggle a class</h2>
+    <p>The hello-world of inline scripting. No behavior needed.</p>
+    <pre>_="on click toggle .fun on me"</pre>
+    <div class="try">
+      <button _="on click toggle .fun on me">Click me</button>
+      <p class="muted" style="margin-bottom:0;">Reusable + parameterized? Then it's worth promoting — that's exactly <code>install Toggleable(cls)</code>.</p>
+    </div>
+  </div>
+
+  <!-- 2. Fade and remove -->
+  <div class="recipe">
+    <h2>Fade out and remove</h2>
+    <p>Transition a property, then remove the element.</p>
+    <pre>_="on click transition *opacity to 0 over 300ms then remove me"</pre>
+    <div class="try">
+      <div class="removable-item" _="on click transition *opacity to 0 over 300ms then remove me">Click to dismiss me</div>
+      <div class="removable-item" _="on click transition *opacity to 0 over 300ms then remove me">…and me</div>
+      <p class="muted" style="margin-bottom:0;">The reusable, parameterized version is <code>install Removable(effect: 'fade')</code>.</p>
+    </div>
+  </div>
+
+  <!-- 3. Character counter -->
+  <div class="recipe">
+    <h2>Character counter</h2>
+    <p>Write to a sibling <code>&lt;output/&gt;</code> on every input — no IDs, no wiring.</p>
+    <pre>_="on input put my value's length into the next &lt;output/&gt;"</pre>
+    <div class="try">
+      <input type="text" maxlength="40" placeholder="Type here…"
+             _="on input put my value's length into the next <output/>">
+      <output>0</output> / 40
+      <p class="muted" style="margin-bottom:0;">For a live reactive version (<code>bind $msg to me</code>), use the <code>hyperfixi-hx-v4.js</code> reactive bundle.</p>
+    </div>
+  </div>
+
+  <!-- 4. Filter by search -->
+  <div class="recipe">
+    <h2>Filter a list by search</h2>
+    <p>The <code>show … when</code> form filters visibility against a condition.</p>
+    <pre>_="on keyup
+    show &lt;blockquote/&gt; in the next &lt;div/&gt;
+      when its textContent contains my value"</pre>
+    <div class="try">
+      <input type="text" placeholder="Search quotes…"
+             _="on keyup show <blockquote/> in the next <div/> when its textContent contains my value">
+      <div class="quotes">
+        <blockquote>"Talk is cheap. Show me the code." — Linus Torvalds</blockquote>
+        <blockquote>"Programs must be written for people to read." — Harold Abelson</blockquote>
+        <blockquote>"Truth can only be found in one place: the code." — Robert C. Martin</blockquote>
+        <blockquote>"I'm just a good programmer with great habits." — Kent Beck</blockquote>
+      </div>
+    </div>
+  </div>
+
+  <!-- 5. When to promote to a behavior -->
+  <div class="recipe" style="border-left:4px solid #6366f1;">
+    <h2>When to promote a recipe to a behavior</h2>
+    <p>
+      A recipe earns <code>install</code> when it is (a) used in several places and
+      (b) parameterized. Outside-click dismissal is a good example — it's a reusable
+      primitive, so it ships as <code>ClickOutside</code> rather than as copy-pasted
+      inline script:
+    </p>
+    <pre>&lt;div _="install ClickOutside
+         on clickoutside add .hidden to me"&gt; … &lt;/div&gt;</pre>
+    <p class="muted" style="margin-bottom:0;">See the <a href="demo.html">curated behaviors demo</a>.</p>
+  </div>
+
+  <script src="../../packages/core/dist/hyperfixi.js"></script>
+  <script src="../../packages/behaviors/dist/resolver.browser.global.js"></script>
+</body>
+</html>

--- a/packages/behaviors/README.md
+++ b/packages/behaviors/README.md
@@ -1,0 +1,91 @@
+# @hyperfixi/behaviors
+
+Reusable hyperscript behaviors for HyperFixi / LokaScript. A behavior is installed
+on any element with `_="install BehaviorName(params)"` and is defined in **pure
+hyperscript** (its `source`), compiled on demand.
+
+```html
+<script src="hyperfixi.js"></script>
+<script src="resolver.browser.global.js"></script>
+<!-- install X just works — behaviors compile on first use -->
+<button _="install Toggleable(cls: 'active')">Toggle</button>
+```
+
+## The boundary rule — what a behavior _is_
+
+> **A behavior is a named, parameterized, _reusable inline script_ — `on event →
+DOM action`. It is not a component.** When something needs an observer, a focus
+> model, or an async pointer loop, it has left the inline-scripting lane and belongs
+> in a web component or a plain module instead.
+
+This rule is why the set is small and tiered. Most "behaviors" people reach for are
+really just short inline scripts — see [Recipes](#recipes-most-things-are-inline-scripts).
+
+A single source of truth drives every consumer: the hyperscript `source` string in
+each `src/schemas/*.schema.ts`. The npm `register*()` functions, the CDN
+`resolver.browser.global.js` bundle, and `@hyperfixi/patterns-reference` all compile
+that **same source** — one runtime path, identical in the browser and Node. (The
+old imperative-JS installers were a mistaken experiment that forked a second,
+diverging path; they have been removed for the curated set.)
+
+## Tiers
+
+Curation status (`curated` / `optional` / `experimental`) is exported
+programmatically from [`src/curation.ts`](src/curation.ts). It is orthogonal to the
+lazy-loading `tier` (core/common/optional).
+
+### Curated (5) — reliable, runtime-tested, the supported story
+
+| Behavior       | What it does                              | Notes                                   |
+| -------------- | ----------------------------------------- | --------------------------------------- |
+| `Toggleable`   | Toggle a class on click                   | accordions, dropdowns, toggle buttons   |
+| `Removable`    | Remove an element on click                | dismiss notifications; optional confirm |
+| `ClickOutside` | Fire `clickoutside` on an outside press   | a primitive (dropdown/menu dismissal)   |
+| `Clipboard`    | Copy text on click + `.copied` feedback   | JS-backed convenience (Clipboard API)   |
+| `AutoDismiss`  | Auto-remove after a delay, pause-on-hover | JS-backed convenience (timers)          |
+
+`Toggleable` / `Removable` / `ClickOutside` are genuinely hyperscript-native (real
+`on event → action` bodies) and translate meaningfully across languages.
+`Clipboard` / `AutoDismiss` ship in the curated set for their user value but are
+honestly JS-backed (their `js()` core stays English — fidelity-neutral).
+
+Each curated behavior has a real-runtime DOM test in
+[`src/behaviors/curated-runtime.test.ts`](src/behaviors/curated-runtime.test.ts)
+asserting both the effect and its lifecycle events — "parses ≠ works".
+
+### Optional (3) — kept, documented as primitives / nice-to-haves
+
+`FocusTrap` · `ScrollReveal` · `Tabs`. `FocusTrap` + `ClickOutside` are the
+primitives a Modal composes from; `Tabs` is high-value but heavy (a future
+web-component candidate).
+
+### Experimental (3) — beyond the boundary
+
+`Draggable` · `Sortable` · `Resizable` — stateful async components (`repeat until
+event` + `wait for` pointer loops). Kept working, but explicitly **outside** the
+curated/supported/marketed story. If you need robust drag/sort/resize, prefer a
+dedicated library or web component.
+
+## Recipes — most things are inline scripts
+
+Before installing a behavior, check whether a short inline script does the job. The
+upstream \_hyperscript cookbook (`www/patterns/`) is almost entirely inline patterns,
+not `behavior` definitions. See [`examples/behaviors/recipes.html`](../../examples/behaviors/recipes.html)
+for adapted recipes (toggle, fade-and-remove, character counter, …). Promote a
+recipe to an installed behavior only when it is genuinely reusable and parameterized.
+
+## API
+
+```javascript
+import { registerAll } from '@hyperfixi/behaviors';
+await registerAll(); // registers every behavior with window.hyperfixi
+
+import { registerToggleable } from '@hyperfixi/behaviors/toggleable';
+await registerToggleable(); // tree-shakeable single behavior
+
+import { CURATED_BEHAVIORS, curationStatusOf } from '@hyperfixi/behaviors';
+curationStatusOf('Draggable'); // 'experimental'
+```
+
+See [`examples/behaviors/demo.html`](../../examples/behaviors/demo.html) for a live
+demo grouped by tier.

--- a/packages/behaviors/src/behaviors/autodismiss.test.ts
+++ b/packages/behaviors/src/behaviors/autodismiss.test.ts
@@ -2,25 +2,31 @@ import { describe, it, expect, vi } from 'vitest';
 
 describe('AutoDismiss behavior', () => {
   describe('registerAutoDismiss', () => {
-    it('should register with synthetic node via execute', async () => {
-      const { registerAutoDismiss } = await import('./autodismiss');
+    it('should compile its hyperscript source and execute', async () => {
+      const { registerAutoDismiss, autoDismissSource } = await import('./autodismiss');
       const mock = {
-        compileSync: vi.fn(),
+        compileSync: vi.fn().mockReturnValue({ ok: true, ast: { type: 'behavior' } }),
         execute: vi.fn().mockResolvedValue(undefined),
         createContext: vi.fn().mockReturnValue({ locals: new Map(), globals: new Map() }),
       };
 
       await registerAutoDismiss(mock);
 
-      expect(mock.compileSync).not.toHaveBeenCalled();
+      expect(mock.compileSync).toHaveBeenCalledWith(autoDismissSource, { traditional: true });
       expect(mock.execute).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'behavior',
-          name: 'AutoDismiss',
-          imperativeInstaller: expect.any(Function),
-        }),
+        { type: 'behavior' },
         expect.objectContaining({ locals: expect.any(Map), globals: expect.any(Map) })
       );
+    });
+
+    it('should throw on compile failure', async () => {
+      const { registerAutoDismiss } = await import('./autodismiss');
+      const mock = {
+        compileSync: vi.fn().mockReturnValue({ ok: false, errors: [{ message: 'boom' }] }),
+        execute: vi.fn(),
+        createContext: vi.fn().mockReturnValue({ locals: new Map(), globals: new Map() }),
+      };
+      await expect(registerAutoDismiss(mock)).rejects.toThrowError(/Failed to compile AutoDismiss/);
     });
 
     it('should throw when no runtime available', async () => {

--- a/packages/behaviors/src/behaviors/autodismiss.ts
+++ b/packages/behaviors/src/behaviors/autodismiss.ts
@@ -1,8 +1,12 @@
 /**
- * AutoDismiss Behavior — Imperative Implementation
+ * AutoDismiss Behavior
  *
  * Auto-removes elements after a configurable delay.
- * Supports pause-on-hover and fade effect using standard setTimeout/clearTimeout.
+ * Supports pause-on-hover and fade effect using standard setTimeout/clearTimeout
+ * (in its hyperscript `source`'s js() body).
+ *
+ * Compiled from its hyperscript `source` (the single source of truth shared with
+ * the CDN resolver bundle and patterns-reference).
  */
 
 import { autoDismissSchema } from '../schemas/autodismiss.schema';
@@ -14,66 +18,8 @@ export const autoDismissSource = autoDismissSchema.source;
 export const autoDismissMetadata = autoDismissSchema;
 
 /**
- * Imperative installer for AutoDismiss behavior.
- */
-function installAutoDismiss(element: HTMLElement, params: Record<string, any>): void {
-  const delay = typeof params.delay === 'number' ? params.delay : 5000;
-  const pauseOnHover = params.pauseOnHover !== false;
-  const effect = params.effect === 'fade' ? 'fade' : 'none';
-
-  let timerId: ReturnType<typeof setTimeout> | null = null;
-  let remaining = delay;
-  let startedAt = Date.now();
-
-  function dismiss() {
-    const event = new CustomEvent('autodismiss:dismissed', {
-      bubbles: true,
-      cancelable: true,
-    });
-    element.dispatchEvent(event);
-
-    if (event.defaultPrevented) return;
-
-    if (effect === 'fade') {
-      element.style.transition = 'opacity 300ms';
-      element.style.opacity = '0';
-      setTimeout(() => element.remove(), 300);
-    } else {
-      element.remove();
-    }
-  }
-
-  function start() {
-    startedAt = Date.now();
-    timerId = setTimeout(dismiss, remaining);
-  }
-
-  // Start the countdown
-  element.dispatchEvent(new CustomEvent('autodismiss:start', { bubbles: true }));
-  start();
-
-  if (pauseOnHover) {
-    element.addEventListener('mouseenter', () => {
-      if (timerId != null) {
-        clearTimeout(timerId);
-        timerId = null;
-        remaining -= Date.now() - startedAt;
-        if (remaining < 0) remaining = 0;
-        element.dispatchEvent(new CustomEvent('autodismiss:paused', { bubbles: true }));
-      }
-    });
-
-    element.addEventListener('mouseleave', () => {
-      if (timerId == null && element.isConnected) {
-        element.dispatchEvent(new CustomEvent('autodismiss:resumed', { bubbles: true }));
-        start();
-      }
-    });
-  }
-}
-
-/**
- * Register the AutoDismiss behavior with LokaScript.
+ * Register the AutoDismiss behavior with LokaScript by compiling its
+ * hyperscript source and executing the resulting behavior definition.
  */
 export async function registerAutoDismiss(hyperfixi?: LokaScriptInstance): Promise<void> {
   const hf = hyperfixi || resolveRuntime();
@@ -84,15 +30,14 @@ export async function registerAutoDismiss(hyperfixi?: LokaScriptInstance): Promi
     );
   }
 
-  const syntheticNode = {
-    type: 'behavior',
-    name: 'AutoDismiss',
-    parameters: ['delay', 'pauseOnHover', 'effect'],
-    eventHandlers: [],
-    imperativeInstaller: installAutoDismiss,
-  };
+  const result = hf.compileSync(autoDismissSchema.source, { traditional: true });
+
+  if (!result.ok) {
+    throw new Error(`Failed to compile AutoDismiss behavior: ${JSON.stringify(result.errors)}`);
+  }
+
   const ctx = hf.createContext ? hf.createContext() : { locals: new Map(), globals: new Map() };
-  await hf.execute(syntheticNode, ctx);
+  await hf.execute(result.ast, ctx);
 }
 
 // Auto-register when loaded as a script tag

--- a/packages/behaviors/src/behaviors/clickoutside.test.ts
+++ b/packages/behaviors/src/behaviors/clickoutside.test.ts
@@ -2,24 +2,32 @@ import { describe, it, expect, vi } from 'vitest';
 
 describe('ClickOutside behavior', () => {
   describe('registerClickOutside', () => {
-    it('should register with synthetic node via execute', async () => {
-      const { registerClickOutside } = await import('./clickoutside');
+    it('should compile its hyperscript source and execute', async () => {
+      const { registerClickOutside, clickOutsideSource } = await import('./clickoutside');
       const mock = {
-        compileSync: vi.fn(),
+        compileSync: vi.fn().mockReturnValue({ ok: true, ast: { type: 'behavior' } }),
         execute: vi.fn().mockResolvedValue(undefined),
         createContext: vi.fn().mockReturnValue({ locals: new Map(), globals: new Map() }),
       };
 
       await registerClickOutside(mock);
 
-      expect(mock.compileSync).not.toHaveBeenCalled();
+      expect(mock.compileSync).toHaveBeenCalledWith(clickOutsideSource, { traditional: true });
       expect(mock.execute).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'behavior',
-          name: 'ClickOutside',
-          imperativeInstaller: expect.any(Function),
-        }),
+        { type: 'behavior' },
         expect.objectContaining({ locals: expect.any(Map), globals: expect.any(Map) })
+      );
+    });
+
+    it('should throw on compile failure', async () => {
+      const { registerClickOutside } = await import('./clickoutside');
+      const mock = {
+        compileSync: vi.fn().mockReturnValue({ ok: false, errors: [{ message: 'boom' }] }),
+        execute: vi.fn(),
+        createContext: vi.fn().mockReturnValue({ locals: new Map(), globals: new Map() }),
+      };
+      await expect(registerClickOutside(mock)).rejects.toThrowError(
+        /Failed to compile ClickOutside/
       );
     });
 

--- a/packages/behaviors/src/behaviors/clickoutside.ts
+++ b/packages/behaviors/src/behaviors/clickoutside.ts
@@ -1,8 +1,11 @@
 /**
- * ClickOutside Behavior — Imperative Implementation
+ * ClickOutside Behavior
  *
  * Fires a clickoutside event when the user clicks outside the element.
  * Uses pointerdown instead of click to avoid timing issues.
+ *
+ * Compiled from its hyperscript `source` (the single source of truth shared with
+ * the CDN resolver bundle and patterns-reference).
  */
 
 import { clickOutsideSchema } from '../schemas/clickoutside.schema';
@@ -14,36 +17,8 @@ export const clickOutsideSource = clickOutsideSchema.source;
 export const clickOutsideMetadata = clickOutsideSchema;
 
 /**
- * Imperative installer for ClickOutside behavior.
- */
-function installClickOutside(element: HTMLElement, params: Record<string, any>): void {
-  let active = params.active !== false;
-
-  function onPointerDown(e: Event) {
-    // Auto-cleanup if element has been removed from DOM
-    if (!element.isConnected) {
-      document.removeEventListener('pointerdown', onPointerDown);
-      return;
-    }
-
-    if (active && !element.contains(e.target as Node)) {
-      element.dispatchEvent(new CustomEvent('clickoutside', { bubbles: true }));
-    }
-  }
-
-  document.addEventListener('pointerdown', onPointerDown);
-
-  // Programmatic activation/deactivation via custom events
-  element.addEventListener('clickoutside:activate', () => {
-    active = true;
-  });
-  element.addEventListener('clickoutside:deactivate', () => {
-    active = false;
-  });
-}
-
-/**
- * Register the ClickOutside behavior with LokaScript.
+ * Register the ClickOutside behavior with LokaScript by compiling its
+ * hyperscript source and executing the resulting behavior definition.
  */
 export async function registerClickOutside(hyperfixi?: LokaScriptInstance): Promise<void> {
   const hf = hyperfixi || resolveRuntime();
@@ -54,15 +29,14 @@ export async function registerClickOutside(hyperfixi?: LokaScriptInstance): Prom
     );
   }
 
-  const syntheticNode = {
-    type: 'behavior',
-    name: 'ClickOutside',
-    parameters: ['active'],
-    eventHandlers: [],
-    imperativeInstaller: installClickOutside,
-  };
+  const result = hf.compileSync(clickOutsideSchema.source, { traditional: true });
+
+  if (!result.ok) {
+    throw new Error(`Failed to compile ClickOutside behavior: ${JSON.stringify(result.errors)}`);
+  }
+
   const ctx = hf.createContext ? hf.createContext() : { locals: new Map(), globals: new Map() };
-  await hf.execute(syntheticNode, ctx);
+  await hf.execute(result.ast, ctx);
 }
 
 // Auto-register when loaded as a script tag

--- a/packages/behaviors/src/behaviors/clipboard.test.ts
+++ b/packages/behaviors/src/behaviors/clipboard.test.ts
@@ -2,25 +2,31 @@ import { describe, it, expect, vi } from 'vitest';
 
 describe('Clipboard behavior', () => {
   describe('registerClipboard', () => {
-    it('should register with synthetic node via execute', async () => {
-      const { registerClipboard } = await import('./clipboard');
+    it('should compile its hyperscript source and execute', async () => {
+      const { registerClipboard, clipboardSource } = await import('./clipboard');
       const mock = {
-        compileSync: vi.fn(),
+        compileSync: vi.fn().mockReturnValue({ ok: true, ast: { type: 'behavior' } }),
         execute: vi.fn().mockResolvedValue(undefined),
         createContext: vi.fn().mockReturnValue({ locals: new Map(), globals: new Map() }),
       };
 
       await registerClipboard(mock);
 
-      expect(mock.compileSync).not.toHaveBeenCalled();
+      expect(mock.compileSync).toHaveBeenCalledWith(clipboardSource, { traditional: true });
       expect(mock.execute).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'behavior',
-          name: 'Clipboard',
-          imperativeInstaller: expect.any(Function),
-        }),
+        { type: 'behavior' },
         expect.objectContaining({ locals: expect.any(Map), globals: expect.any(Map) })
       );
+    });
+
+    it('should throw on compile failure', async () => {
+      const { registerClipboard } = await import('./clipboard');
+      const mock = {
+        compileSync: vi.fn().mockReturnValue({ ok: false, errors: [{ message: 'boom' }] }),
+        execute: vi.fn(),
+        createContext: vi.fn().mockReturnValue({ locals: new Map(), globals: new Map() }),
+      };
+      await expect(registerClipboard(mock)).rejects.toThrowError(/Failed to compile Clipboard/);
     });
 
     it('should throw when no runtime available', async () => {
@@ -31,7 +37,7 @@ describe('Clipboard behavior', () => {
     it('should fall back to manual context when createContext is missing', async () => {
       const { registerClipboard } = await import('./clipboard');
       const mock = {
-        compileSync: vi.fn(),
+        compileSync: vi.fn().mockReturnValue({ ok: true, ast: { type: 'behavior' } }),
         execute: vi.fn().mockResolvedValue(undefined),
       };
 

--- a/packages/behaviors/src/behaviors/clipboard.ts
+++ b/packages/behaviors/src/behaviors/clipboard.ts
@@ -1,8 +1,12 @@
 /**
- * Clipboard Behavior — Imperative Implementation
+ * Clipboard Behavior
  *
  * Copies text to clipboard on click with visual feedback.
- * Uses navigator.clipboard.writeText() with execCommand fallback.
+ * Uses navigator.clipboard.writeText() with execCommand fallback (in its
+ * hyperscript `source`'s js() body).
+ *
+ * Compiled from its hyperscript `source` (the single source of truth shared with
+ * the CDN resolver bundle and patterns-reference).
  */
 
 import { clipboardSchema } from '../schemas/clipboard.schema';
@@ -14,89 +18,8 @@ export const clipboardSource = clipboardSchema.source;
 export const clipboardMetadata = clipboardSchema;
 
 /**
- * Copy text to clipboard using the modern Clipboard API,
- * falling back to execCommand for older browsers.
- */
-async function copyToClipboard(text: string): Promise<void> {
-  if (navigator.clipboard?.writeText) {
-    await navigator.clipboard.writeText(text);
-    return;
-  }
-
-  // Fallback: temporary textarea + execCommand
-  const textarea = document.createElement('textarea');
-  textarea.value = text;
-  textarea.style.position = 'fixed';
-  textarea.style.opacity = '0';
-  document.body.appendChild(textarea);
-  textarea.select();
-  try {
-    document.execCommand('copy');
-  } finally {
-    document.body.removeChild(textarea);
-  }
-}
-
-/**
- * Resolve a selector parameter to an HTMLElement.
- */
-function resolveElement(element: HTMLElement, param: unknown): HTMLElement | null {
-  if (!param || param === 'me') return element;
-  if (param instanceof HTMLElement) return param;
-  if (typeof param === 'string') {
-    return (
-      (element.querySelector(param) as HTMLElement) ||
-      (document.querySelector(param) as HTMLElement) ||
-      null
-    );
-  }
-  return null;
-}
-
-/**
- * Imperative installer for Clipboard behavior.
- */
-function installClipboard(element: HTMLElement, params: Record<string, any>): void {
-  const feedbackDuration =
-    typeof params.feedbackDuration === 'number' ? params.feedbackDuration : 2000;
-
-  element.addEventListener('click', async () => {
-    // Determine text to copy
-    let copyText: string;
-    if (params.text != null) {
-      copyText = String(params.text);
-    } else {
-      const sourceEl = resolveElement(element, params.source) || element;
-      copyText = (sourceEl as HTMLInputElement).value ?? sourceEl.textContent ?? '';
-    }
-
-    try {
-      await copyToClipboard(copyText);
-
-      // Show feedback
-      const feedbackEl = resolveElement(element, params.feedback) || element;
-      feedbackEl.classList.add('copied');
-      setTimeout(() => feedbackEl.classList.remove('copied'), feedbackDuration);
-
-      element.dispatchEvent(
-        new CustomEvent('clipboard:copied', {
-          bubbles: true,
-          detail: { text: copyText },
-        })
-      );
-    } catch (error) {
-      element.dispatchEvent(
-        new CustomEvent('clipboard:error', {
-          bubbles: true,
-          detail: { error },
-        })
-      );
-    }
-  });
-}
-
-/**
- * Register the Clipboard behavior with LokaScript.
+ * Register the Clipboard behavior with LokaScript by compiling its
+ * hyperscript source and executing the resulting behavior definition.
  */
 export async function registerClipboard(hyperfixi?: LokaScriptInstance): Promise<void> {
   const hf = hyperfixi || resolveRuntime();
@@ -107,15 +30,14 @@ export async function registerClipboard(hyperfixi?: LokaScriptInstance): Promise
     );
   }
 
-  const syntheticNode = {
-    type: 'behavior',
-    name: 'Clipboard',
-    parameters: ['text', 'source', 'feedback', 'feedbackDuration'],
-    eventHandlers: [],
-    imperativeInstaller: installClipboard,
-  };
+  const result = hf.compileSync(clipboardSchema.source, { traditional: true });
+
+  if (!result.ok) {
+    throw new Error(`Failed to compile Clipboard behavior: ${JSON.stringify(result.errors)}`);
+  }
+
   const ctx = hf.createContext ? hf.createContext() : { locals: new Map(), globals: new Map() };
-  await hf.execute(syntheticNode, ctx);
+  await hf.execute(result.ast, ctx);
 }
 
 // Auto-register when loaded as a script tag

--- a/packages/behaviors/src/behaviors/curated-runtime.test.ts
+++ b/packages/behaviors/src/behaviors/curated-runtime.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment happy-dom
+/**
+ * Curated behaviors — REAL runtime behavior tests (Phase 2).
+ *
+ * These exercise each curated behavior's actual hyperscript `source` through the
+ * real @hyperfixi/core runtime: register → install on an element → drive the DOM →
+ * assert both the effect AND the documented lifecycle events. This is the
+ * "parses ≠ works" guard (BEHAVIORS_CONSOLIDATION_PLAN.md §2/§5) — the mock-based
+ * unit tests only prove `register*()` calls compileSync; these prove the js()
+ * bodies actually do the right thing at runtime.
+ *
+ * These tests already paid for themselves: they surfaced two source bugs the
+ * imperative path was masking — ClickOutside read `event.target` without passing
+ * `event` into its js() block, and Clipboard used top-level `await` (invalid in a
+ * js() block). Both are fixed in the schema sources.
+ */
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { hyperscript } from '@hyperfixi/core';
+import { registerToggleable } from './toggleable';
+import { registerRemovable } from './removable';
+import { registerClickOutside } from './clickoutside';
+import { registerClipboard } from './clipboard';
+import { registerAutoDismiss } from './autodismiss';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const hf = hyperscript as any;
+
+const tick = (ms = 30) => new Promise(r => setTimeout(r, ms));
+
+async function install(code: string, el: HTMLElement): Promise<void> {
+  const r = hyperscript.compileSync(code, { traditional: true });
+  if (!r.ok) throw new Error(`install compile failed: ${JSON.stringify(r.errors)}`);
+  await hyperscript.execute(r.ast, hyperscript.createContext(el));
+}
+
+beforeAll(async () => {
+  // Behavior registry is a runtime singleton; register the curated set once.
+  await registerToggleable(hf);
+  await registerRemovable(hf);
+  await registerClickOutside(hf);
+  await registerClipboard(hf);
+  await registerAutoDismiss(hf);
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('Toggleable — runtime', () => {
+  it('toggles the parameterized class and fires on/off lifecycle events', async () => {
+    const el = document.createElement('button');
+    document.body.appendChild(el);
+    const on = vi.fn();
+    const off = vi.fn();
+    el.addEventListener('toggleable:on', on);
+    el.addEventListener('toggleable:off', off);
+
+    await install('install Toggleable(cls: "hl")', el);
+
+    el.click();
+    await tick();
+    expect(el.classList.contains('hl')).toBe(true);
+    expect(on).toHaveBeenCalledTimes(1);
+
+    el.click();
+    await tick();
+    expect(el.classList.contains('hl')).toBe(false);
+    expect(off).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Removable — runtime', () => {
+  it('removes the element on click and fires before/removed events', async () => {
+    const el = document.createElement('div');
+    el.id = 'rm-target';
+    document.body.appendChild(el);
+    const before = vi.fn();
+    const removed = vi.fn();
+    el.addEventListener('removable:before', before);
+    document.addEventListener('removable:removed', removed, { once: true });
+
+    await install('install Removable', el);
+
+    el.click();
+    await tick();
+
+    expect(document.getElementById('rm-target')).toBeNull();
+    expect(before).toHaveBeenCalledTimes(1);
+    expect(removed).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ClickOutside — runtime', () => {
+  it('fires clickoutside for outside presses but not inside', async () => {
+    const el = document.createElement('div');
+    const outside = document.createElement('button');
+    document.body.append(el, outside);
+    const fired = vi.fn();
+    el.addEventListener('clickoutside', fired);
+
+    await install('install ClickOutside', el);
+
+    // The source passes `event` into its js() block, so dispatch sets event.target.
+    const press = (target: HTMLElement) =>
+      target.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+    press(outside);
+    await tick();
+    expect(fired).toHaveBeenCalledTimes(1);
+
+    fired.mockClear();
+    press(el);
+    await tick();
+    expect(fired).not.toHaveBeenCalled();
+  });
+});
+
+describe('Clipboard — runtime', () => {
+  it('writes literal text, adds .copied feedback, and fires clipboard:copied', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+
+    const el = document.createElement('button');
+    document.body.appendChild(el);
+    const copied = vi.fn();
+    el.addEventListener('clipboard:copied', copied);
+
+    await install('install Clipboard(text: "hello")', el);
+
+    el.click();
+    await tick();
+
+    expect(writeText).toHaveBeenCalledWith('hello');
+    expect(el.classList.contains('copied')).toBe(true);
+    expect(copied).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AutoDismiss — runtime', () => {
+  it('fires start, then removes the element after the delay and fires dismissed', async () => {
+    const el = document.createElement('div');
+    el.id = 'ad-target';
+    document.body.appendChild(el);
+    const start = vi.fn();
+    const dismissed = vi.fn();
+    el.addEventListener('autodismiss:start', start);
+    document.addEventListener('autodismiss:dismissed', dismissed, { once: true });
+
+    await install('install AutoDismiss(delay: 10)', el);
+
+    expect(start).toHaveBeenCalledTimes(1);
+
+    await tick(80);
+
+    expect(document.getElementById('ad-target')).toBeNull();
+    expect(dismissed).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/behaviors/src/behaviors/integration.test.ts
+++ b/packages/behaviors/src/behaviors/integration.test.ts
@@ -21,20 +21,24 @@ function createMockInstance(overrides: Partial<LokaScriptInstance> = {}): LokaSc
   };
 }
 
-// Source-compiled behaviors (use compileSync + execute)
+// Source-compiled behaviors (use compileSync + execute).
+// The curated set (BEHAVIORS_CONSOLIDATION_PLAN.md §3) all compile their
+// hyperscript `source` — one runtime path, identical browser/npm.
 const compiledBehaviors = [
   { name: 'Removable', register: registerRemovable, source: removableSource },
-] as const;
-
-// Imperative behaviors (use synthetic node with imperativeInstaller)
-const imperativeBehaviors = [
-  { name: 'Draggable', register: registerDraggable, source: draggableSource },
   { name: 'Toggleable', register: registerToggleable, source: toggleableSource },
-  { name: 'Sortable', register: registerSortable, source: sortableSource },
-  { name: 'Resizable', register: registerResizable, source: resizableSource },
   { name: 'Clipboard', register: registerClipboard, source: clipboardSource },
   { name: 'AutoDismiss', register: registerAutoDismiss, source: autoDismissSource },
   { name: 'ClickOutside', register: registerClickOutside, source: clickOutsideSource },
+] as const;
+
+// Imperative behaviors (use synthetic node with imperativeInstaller).
+// Tier-C over-reach (Draggable/Sortable/Resizable) + optional behaviors still
+// pending conversion (FocusTrap/ScrollReveal/Tabs) — see consolidation plan.
+const imperativeBehaviors = [
+  { name: 'Draggable', register: registerDraggable, source: draggableSource },
+  { name: 'Sortable', register: registerSortable, source: sortableSource },
+  { name: 'Resizable', register: registerResizable, source: resizableSource },
   { name: 'FocusTrap', register: registerFocusTrap, source: focusTrapSource },
   { name: 'ScrollReveal', register: registerScrollReveal, source: scrollRevealSource },
   { name: 'Tabs', register: registerTabs, source: tabsSource },

--- a/packages/behaviors/src/behaviors/toggleable.ts
+++ b/packages/behaviors/src/behaviors/toggleable.ts
@@ -1,12 +1,13 @@
 /**
- * Toggleable Behavior — Imperative Implementation
+ * Toggleable Behavior
  *
  * A behavior that toggles a CSS class on click.
  * Useful for accordions, dropdowns, and toggle buttons.
  *
- * Uses direct DOM APIs instead of compiling hyperscript source,
- * because `toggle .{cls}` template interpolation doesn't resolve
- * behavior parameters at runtime.
+ * Compiled from its hyperscript `source` (the single source of truth shared with
+ * the CDN resolver bundle and patterns-reference). The `.{cls}` dynamic class
+ * selector resolves the behavior's `cls` parameter at runtime — see
+ * `packages/core/src/commands/behaviors/__tests__/template-interpolation.test.ts`.
  *
  * @example
  * ```html
@@ -25,35 +26,8 @@ export const toggleableSource = toggleableSchema.source;
 export const toggleableMetadata = toggleableSchema;
 
 /**
- * Imperative installer for Toggleable behavior.
- * Called directly by the runtime when `install Toggleable` is executed.
- */
-function installToggleable(element: HTMLElement, params: Record<string, any>): void {
-  const cls = params.cls || 'active';
-
-  // Resolve target element
-  let targetEl: HTMLElement = element;
-  if (params.target && params.target !== 'me') {
-    if (typeof params.target === 'string') {
-      const found = document.querySelector(params.target);
-      if (found instanceof HTMLElement) targetEl = found;
-    } else if (params.target instanceof HTMLElement) {
-      targetEl = params.target;
-    }
-  }
-
-  element.addEventListener('click', () => {
-    const wasOn = targetEl.classList.contains(cls);
-    targetEl.classList.toggle(cls);
-    targetEl.dispatchEvent(
-      new CustomEvent(wasOn ? 'toggleable:off' : 'toggleable:on', { bubbles: true })
-    );
-  });
-}
-
-/**
- * Register the Toggleable behavior with LokaScript.
- * Uses imperative installer via synthetic behavior node.
+ * Register the Toggleable behavior with LokaScript by compiling its
+ * hyperscript source and executing the resulting behavior definition.
  */
 export async function registerToggleable(hyperfixi?: LokaScriptInstance): Promise<void> {
   const hf = hyperfixi || resolveRuntime();
@@ -64,15 +38,14 @@ export async function registerToggleable(hyperfixi?: LokaScriptInstance): Promis
     );
   }
 
-  const syntheticNode = {
-    type: 'behavior',
-    name: 'Toggleable',
-    parameters: ['cls', 'target'],
-    eventHandlers: [],
-    imperativeInstaller: installToggleable,
-  };
+  const result = hf.compileSync(toggleableSchema.source, { traditional: true });
+
+  if (!result.ok) {
+    throw new Error(`Failed to compile Toggleable behavior: ${JSON.stringify(result.errors)}`);
+  }
+
   const ctx = hf.createContext ? hf.createContext() : { locals: new Map(), globals: new Map() };
-  await hf.execute(syntheticNode, ctx);
+  await hf.execute(result.ast, ctx);
 }
 
 // Auto-register when loaded as a script tag

--- a/packages/behaviors/src/curation.test.ts
+++ b/packages/behaviors/src/curation.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CURATED_BEHAVIORS,
+  OPTIONAL_BEHAVIORS,
+  EXPERIMENTAL_BEHAVIORS,
+  CURATION_STATUS,
+  curationStatusOf,
+  isCurated,
+} from './curation';
+import { ALL_BEHAVIOR_NAMES } from './generated/metadata';
+
+describe('curation', () => {
+  it('partitions all behaviors into exactly one status', () => {
+    const all = [...CURATED_BEHAVIORS, ...OPTIONAL_BEHAVIORS, ...EXPERIMENTAL_BEHAVIORS];
+    // No overlaps.
+    expect(new Set(all).size).toBe(all.length);
+    // Covers exactly the known behavior set.
+    expect(new Set(all)).toEqual(new Set(ALL_BEHAVIOR_NAMES));
+  });
+
+  it('marks the curated 5', () => {
+    expect([...CURATED_BEHAVIORS].sort()).toEqual(
+      ['AutoDismiss', 'ClickOutside', 'Clipboard', 'Removable', 'Toggleable'].sort()
+    );
+  });
+
+  it('marks the experimental 3 (beyond the boundary)', () => {
+    expect([...EXPERIMENTAL_BEHAVIORS].sort()).toEqual(['Draggable', 'Resizable', 'Sortable']);
+  });
+
+  it('curationStatusOf / isCurated agree with the table', () => {
+    expect(curationStatusOf('Toggleable')).toBe('curated');
+    expect(curationStatusOf('Draggable')).toBe('experimental');
+    expect(curationStatusOf('Tabs')).toBe('optional');
+    expect(curationStatusOf('Nope')).toBeUndefined();
+    expect(isCurated('Clipboard')).toBe(true);
+    expect(isCurated('Sortable')).toBe(false);
+  });
+
+  it('every behavior has a status', () => {
+    for (const name of ALL_BEHAVIOR_NAMES) {
+      expect(CURATION_STATUS[name]).toBeDefined();
+    }
+  });
+});

--- a/packages/behaviors/src/curation.ts
+++ b/packages/behaviors/src/curation.ts
@@ -1,0 +1,58 @@
+/**
+ * Curation status — the product decision about which behaviors are first-class.
+ *
+ * This is ORTHOGONAL to {@link BehaviorTier} (core/common/optional), which is about
+ * lazy-loading priority. Curation is about support level and the boundary rule:
+ *
+ *   A behavior is a named, parameterized, *reusable inline script* — `on event →
+ *   DOM action`. Not a component. When it needs an observer, a focus model, or an
+ *   async pointer loop, it has left hyperfixi's lane.
+ *
+ * See docs-internal/BEHAVIORS_CONSOLIDATION_PLAN.md for the full rationale.
+ */
+
+export type CurationStatus = 'curated' | 'optional' | 'experimental';
+
+/**
+ * Curated set — reliable, runtime-tested, multilingual. The supported story.
+ * Real `on event → DOM action` behaviors (Tier A) plus two honestly-labeled
+ * JS-backed conveniences (Clipboard, AutoDismiss).
+ */
+export const CURATED_BEHAVIORS = [
+  'Toggleable',
+  'Removable',
+  'ClickOutside',
+  'Clipboard',
+  'AutoDismiss',
+] as const;
+
+/**
+ * Optional — useful, kept, documented as primitives / nice-to-haves.
+ * FocusTrap + ClickOutside are the primitives a Modal composes from; ScrollReveal
+ * is a nice-to-have; Tabs is high-value but heavy.
+ */
+export const OPTIONAL_BEHAVIORS = ['FocusTrap', 'ScrollReveal', 'Tabs'] as const;
+
+/**
+ * Experimental — stateful async components (drag/sort/resize). These sit *beyond*
+ * the inline-scripting boundary; kept working but explicitly outside the curated,
+ * supported, marketed story.
+ */
+export const EXPERIMENTAL_BEHAVIORS = ['Draggable', 'Sortable', 'Resizable'] as const;
+
+/** Curation status for every behavior, keyed by name. */
+export const CURATION_STATUS: Record<string, CurationStatus> = {
+  ...Object.fromEntries(CURATED_BEHAVIORS.map(n => [n, 'curated' as const])),
+  ...Object.fromEntries(OPTIONAL_BEHAVIORS.map(n => [n, 'optional' as const])),
+  ...Object.fromEntries(EXPERIMENTAL_BEHAVIORS.map(n => [n, 'experimental' as const])),
+};
+
+/** Curation status for a behavior name, or undefined if unknown. */
+export function curationStatusOf(name: string): CurationStatus | undefined {
+  return CURATION_STATUS[name];
+}
+
+/** True for the curated, supported set. */
+export function isCurated(name: string): boolean {
+  return CURATION_STATUS[name] === 'curated';
+}

--- a/packages/behaviors/src/index.ts
+++ b/packages/behaviors/src/index.ts
@@ -186,6 +186,20 @@ export {
 } from './generated/metadata';
 
 // =============================================================================
+// Curation status (curated / optional / experimental) — see curation.ts
+// =============================================================================
+
+export type { CurationStatus } from './curation';
+export {
+  CURATED_BEHAVIORS,
+  OPTIONAL_BEHAVIORS,
+  EXPERIMENTAL_BEHAVIORS,
+  CURATION_STATUS,
+  curationStatusOf,
+  isCurated,
+} from './curation';
+
+// =============================================================================
 // Convenience functions
 // =============================================================================
 

--- a/packages/behaviors/src/schemas/clickoutside.schema.ts
+++ b/packages/behaviors/src/schemas/clickoutside.schema.ts
@@ -41,7 +41,7 @@ behavior ClickOutside(active)
     end
   end
   on pointerdown from document
-    js(me, active)
+    js(me, active, event)
       if (!me.isConnected) return;
       if (active && !me.contains(event.target)) {
         me.dispatchEvent(new CustomEvent('clickoutside', { bubbles: true }));

--- a/packages/behaviors/src/schemas/clipboard.schema.ts
+++ b/packages/behaviors/src/schemas/clipboard.schema.ts
@@ -65,29 +65,32 @@ behavior Clipboard(text, source, feedback, feedbackDuration)
       set copyText to source's textContent
     end
     js(me, copyText, feedback, feedbackDuration)
-      async function copyToClipboard(t) {
-        if (navigator.clipboard && navigator.clipboard.writeText) {
-          await navigator.clipboard.writeText(t);
-          return;
+      // Wrapped in an async IIFE: hyperscript's js() block has no top-level await.
+      (async function() {
+        async function copyToClipboard(t) {
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            await navigator.clipboard.writeText(t);
+            return;
+          }
+          var ta = document.createElement('textarea');
+          ta.value = t;
+          ta.style.position = 'fixed';
+          ta.style.opacity = '0';
+          document.body.appendChild(ta);
+          ta.select();
+          try { document.execCommand('copy'); } finally { document.body.removeChild(ta); }
         }
-        var ta = document.createElement('textarea');
-        ta.value = t;
-        ta.style.position = 'fixed';
-        ta.style.opacity = '0';
-        document.body.appendChild(ta);
-        ta.select();
-        try { document.execCommand('copy'); } finally { document.body.removeChild(ta); }
-      }
-      try {
-        await copyToClipboard(copyText);
-        var feedbackEl = feedback ? (typeof feedback === 'string' ? document.querySelector(feedback) : feedback) : me;
-        if (!feedbackEl) feedbackEl = me;
-        feedbackEl.classList.add('copied');
-        me.dispatchEvent(new CustomEvent('clipboard:copied', { bubbles: true, detail: { text: copyText } }));
-        setTimeout(function() { feedbackEl.classList.remove('copied'); }, feedbackDuration);
-      } catch(err) {
-        me.dispatchEvent(new CustomEvent('clipboard:error', { bubbles: true, detail: { error: err } }));
-      }
+        try {
+          await copyToClipboard(copyText);
+          var feedbackEl = feedback ? (typeof feedback === 'string' ? document.querySelector(feedback) : feedback) : me;
+          if (!feedbackEl) feedbackEl = me;
+          feedbackEl.classList.add('copied');
+          me.dispatchEvent(new CustomEvent('clipboard:copied', { bubbles: true, detail: { text: copyText } }));
+          setTimeout(function() { feedbackEl.classList.remove('copied'); }, feedbackDuration);
+        } catch(err) {
+          me.dispatchEvent(new CustomEvent('clipboard:error', { bubbles: true, detail: { error: err } }));
+        }
+      })();
     end
   end
 end`.trim(),

--- a/packages/behaviors/src/schemas/draggable.schema.ts
+++ b/packages/behaviors/src/schemas/draggable.schema.ts
@@ -11,7 +11,8 @@ export const draggableSchema: BehaviorSchema = {
   category: 'ui',
   tier: 'core',
   version: '1.0.0',
-  description: 'Makes elements draggable with pointer events',
+  description:
+    'Makes elements draggable with pointer events (EXPERIMENTAL — stateful async component, beyond the inline-scripting boundary; not part of the curated set)',
   parameters: [
     {
       name: 'dragHandle',

--- a/packages/behaviors/src/schemas/resizable.schema.ts
+++ b/packages/behaviors/src/schemas/resizable.schema.ts
@@ -11,7 +11,8 @@ export const resizableSchema: BehaviorSchema = {
   category: 'ui',
   tier: 'optional',
   version: '1.0.0',
-  description: 'Makes elements resizable by dragging',
+  description:
+    'Makes elements resizable by dragging (EXPERIMENTAL — stateful async component, beyond the inline-scripting boundary; not part of the curated set)',
   parameters: [
     {
       name: 'minWidth',

--- a/packages/behaviors/src/schemas/sortable.schema.ts
+++ b/packages/behaviors/src/schemas/sortable.schema.ts
@@ -15,7 +15,8 @@ export const sortableSchema: BehaviorSchema = {
   category: 'ui',
   tier: 'common',
   version: '1.0.0',
-  description: 'Makes child elements reorderable via drag-and-drop',
+  description:
+    'Makes child elements reorderable via drag-and-drop (EXPERIMENTAL — stateful async component, beyond the inline-scripting boundary; not part of the curated set)',
   parameters: [
     {
       name: 'dragClass',


### PR DESCRIPTION
## Why

Behaviors have been hard to land because there was never *one* thing to make reliable. The audit found a single source of truth (the `schema.source` hyperscript strings) feeding **three consumers that disagreed**:

| Consumer | Ran | Audience |
| --- | --- | --- |
| `resolver.browser.global.js` | the hyperscript `source` | demo / CDN |
| patterns-reference `behavior-loader` | the same `source` (re-seeded) | LLM / multilingual |
| `@hyperfixi/behaviors` npm installers | **imperative JS that ignored `source`** (10 of 11) | `import` users |

The imperative installers were a **mistaken experiment** — a diverging second path, not a replacement. `install Toggleable` behaved differently on CDN vs npm. This PR collapses to one path, cuts to a small curated set defined by a clear boundary rule, locks reliability with real behavior tests, and realizes the multilingual payoff. Full rationale: [`docs-internal/BEHAVIORS_CONSOLIDATION_PLAN.md`](docs-internal/BEHAVIORS_CONSOLIDATION_PLAN.md).

## The boundary rule

> A behavior is a named, parameterized, **reusable inline script** — `on event → DOM action`. Not a component. When it needs an observer, a focus model, or an async pointer loop, it has left the inline-scripting lane.

- **Curated (5)** — Toggleable, Removable, ClickOutside, Clipboard, AutoDismiss
- **Optional (3)** — FocusTrap, ScrollReveal, Tabs
- **Experimental (3, beyond the boundary)** — Draggable, Sortable, Resizable

## What changed (commit per phase)

- **Phase 1 — one runtime path.** Curated 5 now compile their `schema.source`; imperative installers removed. Unit tests assert source-compile instead of the old plumbing.
- **Phase 2 — reliability lock.** `curated-runtime.test.ts` drives each curated behavior through the real core runtime under happy-dom, asserting DOM effect **and** lifecycle events. **It caught two real source bugs the imperative path was masking:** ClickOutside read `event.target` without passing `event` into `js()`; Clipboard used top-level `await` in a `js()` block. Both fixed in the source (repairs CDN + patterns-reference too).
- **Phase 3 — boundary + tiers.** Programmatic curation status (`src/curation.ts`), `EXPERIMENTAL` markers, package `README`, demo grouped by tier, and a new `examples/behaviors/recipes.html` inline-recipe gallery adapted from the `_hyperscript` cookbook. Demotion is via metadata + docs, **not** a risky file move (no consumer imports the Tier-C subpaths).
- **Phase 4 — multilingual showcase.** `examples/behaviors/multilingual.html` translates each curated behavior's handler live into es/ja/ar/ko/zh/de with round-trip confidence. Playwright-smoked: 18/18 round-trips 78–100%, 0 console errors, live English `install Toggleable` runs.

## Verification

- Behaviors suite **153/153 green**; typecheck clean.
- Multilingual demo Playwright-smoked (rows populate, round-trips OK, live behavior toggles, no console errors).

## Deferred (with rationale, in the plan)

- patterns-reference `sync:translations` + baseline regen — fidelity-neutral now; guarded/provenance-stamped op, run with oversight.
- Localized prose metadata — needs native-speaker review (per the feasibility doc).
- Convert the optional 3 (FocusTrap/ScrollReveal/Tabs) to source-compile the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)