### PR TITLE
refactor(behaviors): collapse optional 3 onto the source-compiled runtime path

### DIFF
--- a/docs-internal/BEHAVIORS_CONSOLIDATION_PLAN.md
+++ b/docs-internal/BEHAVIORS_CONSOLIDATION_PLAN.md
@@ -160,6 +160,21 @@ run (see note):
   rationale): patterns-reference populate + baseline regen (fidelity-neutral now;
   supervised op) and localized prose metadata (needs native review).
 - **Consolidation arc complete.** Curated 5 on one tested runtime path; boundary
-  documented; recipe + multilingual demos shipped. Follow-ups: convert the optional
-  3 (FocusTrap/ScrollReveal/Tabs) to source-compile; supervised patterns-reference
-  sync; native-reviewed localized metadata.
+  documented; recipe + multilingual demos shipped.
+- **2026-06-15: Optional-3 conversion ✅** (follow-up #1). FocusTrap/ScrollReveal/
+  Tabs now compile their `schema.source` (`compileSync` + `execute`) instead of a
+  synthetic node with `imperativeInstaller` — the last curated/optional fork between
+  the CDN resolver and the npm path is closed. Their web-API logic (focus model,
+  `IntersectionObserver`, ARIA/keyboard wiring) was already complete in each
+  schema's `init`-block `js()` body, so the conversion is mechanically identical to
+  the Phase-1 curated collapse. New `src/behaviors/optional-runtime.test.ts` drives
+  all three through the real core runtime under happy-dom (focus-trap wrap,
+  intersection reveal via a stubbed observer, tab ARIA/keyboard nav + cancelable
+  `tabs:change`) — the "parses ≠ works" gate. `integration.test.ts` moves the three
+  into `compiledBehaviors`; mock unit tests assert the compile path. **Only the
+  experimental 3 (Draggable/Sortable/Resizable) remain imperative** — deliberate, as
+  async components beyond the inline-scripting boundary (§3b/§3d). behaviors
+  **167 green**; typecheck + tsup build clean; dist verified (optional-3 globals
+  carry `compileSync`, `imperativeInstaller` only in the experimental-3 globals).
+- **Remaining follow-ups:** supervised patterns-reference sync; native-reviewed
+  localized metadata. Both require human/native oversight (see §4 Phase 4 notes).

--- a/packages/behaviors/README.md
+++ b/packages/behaviors/README.md
@@ -26,7 +26,8 @@ each `src/schemas/*.schema.ts`. The npm `register*()` functions, the CDN
 `resolver.browser.global.js` bundle, and `@hyperfixi/patterns-reference` all compile
 that **same source** — one runtime path, identical in the browser and Node. (The
 old imperative-JS installers were a mistaken experiment that forked a second,
-diverging path; they have been removed for the curated set.)
+diverging path; they have been removed for the curated **and optional** sets. Only
+the three experimental components still ship an imperative installer — see below.)
 
 ## Tiers
 
@@ -57,7 +58,11 @@ asserting both the effect and its lifecycle events — "parses ≠ works".
 
 `FocusTrap` · `ScrollReveal` · `Tabs`. `FocusTrap` + `ClickOutside` are the
 primitives a Modal composes from; `Tabs` is high-value but heavy (a future
-web-component candidate).
+web-component candidate). They carry their web-API logic (a focus model, an
+`IntersectionObserver`, ARIA/keyboard wiring) in an `init`-block `js()` body, but
+flow through the **same single compile path** as the curated set — no
+imperative-installer fork. Each has a real-runtime DOM test in
+[`src/behaviors/optional-runtime.test.ts`](src/behaviors/optional-runtime.test.ts).
 
 ### Experimental (3) — beyond the boundary
 

--- a/packages/behaviors/src/behaviors/focustrap.test.ts
+++ b/packages/behaviors/src/behaviors/focustrap.test.ts
@@ -2,25 +2,31 @@ import { describe, it, expect, vi } from 'vitest';
 
 describe('FocusTrap behavior', () => {
   describe('registerFocusTrap', () => {
-    it('should register with synthetic node via execute', async () => {
-      const { registerFocusTrap } = await import('./focustrap');
+    it('should compile its hyperscript source and execute', async () => {
+      const { registerFocusTrap, focusTrapSource } = await import('./focustrap');
       const mock = {
-        compileSync: vi.fn(),
+        compileSync: vi.fn().mockReturnValue({ ok: true, ast: { type: 'behavior' } }),
         execute: vi.fn().mockResolvedValue(undefined),
         createContext: vi.fn().mockReturnValue({ locals: new Map(), globals: new Map() }),
       };
 
       await registerFocusTrap(mock);
 
-      expect(mock.compileSync).not.toHaveBeenCalled();
+      expect(mock.compileSync).toHaveBeenCalledWith(focusTrapSource, { traditional: true });
       expect(mock.execute).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'behavior',
-          name: 'FocusTrap',
-          imperativeInstaller: expect.any(Function),
-        }),
+        { type: 'behavior' },
         expect.objectContaining({ locals: expect.any(Map), globals: expect.any(Map) })
       );
+    });
+
+    it('should throw on compile failure', async () => {
+      const { registerFocusTrap } = await import('./focustrap');
+      const mock = {
+        compileSync: vi.fn().mockReturnValue({ ok: false, errors: [{ message: 'boom' }] }),
+        execute: vi.fn(),
+        createContext: vi.fn().mockReturnValue({ locals: new Map(), globals: new Map() }),
+      };
+      await expect(registerFocusTrap(mock)).rejects.toThrowError(/Failed to compile FocusTrap/);
     });
 
     it('should throw when no runtime available', async () => {

--- a/packages/behaviors/src/behaviors/focustrap.ts
+++ b/packages/behaviors/src/behaviors/focustrap.ts
@@ -1,8 +1,14 @@
 /**
- * FocusTrap Behavior — Imperative Implementation
+ * FocusTrap Behavior
  *
  * Confines Tab navigation inside an element, manages aria-modal,
- * and restores focus on deactivation.
+ * and restores focus on deactivation. The Tab-trapping / focus-model logic
+ * lives in the schema's hyperscript `source` (an `init`-block `js()` body).
+ *
+ * Compiled from its hyperscript `source` — the single source of truth shared with
+ * the CDN resolver bundle and patterns-reference. This collapses FocusTrap onto
+ * the one runtime path (no more imperative-installer fork between CDN and npm);
+ * see docs-internal/BEHAVIORS_CONSOLIDATION_PLAN.md §3d.
  */
 
 import { focusTrapSchema } from '../schemas/focustrap.schema';
@@ -13,118 +19,9 @@ import { resolveRuntime } from '../schemas/types';
 export const focusTrapSource = focusTrapSchema.source;
 export const focusTrapMetadata = focusTrapSchema;
 
-const FOCUSABLE_SELECTOR = [
-  'a[href]',
-  'button:not(:disabled)',
-  'input:not(:disabled)',
-  'select:not(:disabled)',
-  'textarea:not(:disabled)',
-  '[tabindex]:not([tabindex="-1"])',
-].join(', ');
-
 /**
- * Resolve a selector parameter to an HTMLElement within the container.
- */
-function resolveElement(container: HTMLElement, param: unknown): HTMLElement | null {
-  if (!param) return null;
-  if (param instanceof HTMLElement) return param;
-  if (typeof param === 'string') {
-    return (
-      (container.querySelector(param) as HTMLElement) ||
-      (document.querySelector(param) as HTMLElement) ||
-      null
-    );
-  }
-  return null;
-}
-
-/**
- * Imperative installer for FocusTrap behavior.
- */
-function installFocusTrap(element: HTMLElement, params: Record<string, any>): void {
-  const returnFocus = params.returnFocus !== false;
-  let isActive = false;
-  let previouslyFocused: Element | null = null;
-
-  function getFocusableElements(): HTMLElement[] {
-    return Array.from(element.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
-  }
-
-  function onKeyDown(e: KeyboardEvent) {
-    if (!isActive || e.key !== 'Tab') return;
-
-    const focusable = getFocusableElements();
-    if (focusable.length === 0) {
-      e.preventDefault();
-      return;
-    }
-
-    // Always prevent default Tab and manually manage focus.
-    // This ensures focus never escapes to elements outside the trap,
-    // even when the modal is embedded in a page with other focusable elements.
-    e.preventDefault();
-
-    const currentIndex = focusable.indexOf(document.activeElement as HTMLElement);
-
-    if (e.shiftKey) {
-      const prevIndex = currentIndex <= 0 ? focusable.length - 1 : currentIndex - 1;
-      focusable[prevIndex].focus();
-    } else {
-      const nextIndex = currentIndex >= focusable.length - 1 ? 0 : currentIndex + 1;
-      focusable[nextIndex].focus();
-    }
-  }
-
-  function activate() {
-    if (isActive) return;
-    isActive = true;
-    previouslyFocused = document.activeElement;
-
-    element.setAttribute('aria-modal', 'true');
-
-    // Focus initialFocus element or first focusable
-    const initialEl = resolveElement(element, params.initialFocus);
-    if (initialEl) {
-      initialEl.focus();
-    } else {
-      const focusable = getFocusableElements();
-      if (focusable.length > 0) {
-        focusable[0].focus();
-      }
-    }
-
-    element.dispatchEvent(new CustomEvent('focustrap:activated', { bubbles: true }));
-  }
-
-  function deactivate() {
-    if (!isActive) return;
-    isActive = false;
-
-    element.removeAttribute('aria-modal');
-
-    if (returnFocus && previouslyFocused instanceof HTMLElement) {
-      previouslyFocused.focus();
-    }
-    previouslyFocused = null;
-
-    element.dispatchEvent(new CustomEvent('focustrap:deactivated', { bubbles: true }));
-  }
-
-  // Keydown handler for Tab trapping
-  element.addEventListener('keydown', onKeyDown);
-
-  // Programmatic activation/deactivation via custom events
-  element.addEventListener('focustrap:activate', () => activate());
-  element.addEventListener('focustrap:deactivate', () => deactivate());
-
-  // Activate immediately if requested
-  if (params.active !== false) {
-    activate();
-  }
-}
-
-/**
- * Register the FocusTrap behavior with LokaScript.
+ * Register the FocusTrap behavior with LokaScript by compiling its
+ * hyperscript source and executing the resulting behavior definition.
  */
 export async function registerFocusTrap(hyperfixi?: LokaScriptInstance): Promise<void> {
   const hf = hyperfixi || resolveRuntime();
@@ -135,15 +32,14 @@ export async function registerFocusTrap(hyperfixi?: LokaScriptInstance): Promise
     );
   }
 
-  const syntheticNode = {
-    type: 'behavior',
-    name: 'FocusTrap',
-    parameters: ['active', 'initialFocus', 'returnFocus'],
-    eventHandlers: [],
-    imperativeInstaller: installFocusTrap,
-  };
+  const result = hf.compileSync(focusTrapSchema.source, { traditional: true });
+
+  if (!result.ok) {
+    throw new Error(`Failed to compile FocusTrap behavior: ${JSON.stringify(result.errors)}`);
+  }
+
   const ctx = hf.createContext ? hf.createContext() : { locals: new Map(), globals: new Map() };
-  await hf.execute(syntheticNode, ctx);
+  await hf.execute(result.ast, ctx);
 }
 
 // Auto-register when loaded as a script tag

--- a/packages/behaviors/src/behaviors/integration.test.ts
+++ b/packages/behaviors/src/behaviors/integration.test.ts
@@ -22,26 +22,29 @@ function createMockInstance(overrides: Partial<LokaScriptInstance> = {}): LokaSc
 }
 
 // Source-compiled behaviors (use compileSync + execute).
-// The curated set (BEHAVIORS_CONSOLIDATION_PLAN.md §3) all compile their
-// hyperscript `source` — one runtime path, identical browser/npm.
+// The curated set + the optional set (BEHAVIORS_CONSOLIDATION_PLAN.md §3) all
+// compile their hyperscript `source` — one runtime path, identical browser/npm.
+// The optional three (FocusTrap/ScrollReveal/Tabs) carry their web-API logic in
+// an `init`-block `js()` body, but still flow through the single compile path.
 const compiledBehaviors = [
   { name: 'Removable', register: registerRemovable, source: removableSource },
   { name: 'Toggleable', register: registerToggleable, source: toggleableSource },
   { name: 'Clipboard', register: registerClipboard, source: clipboardSource },
   { name: 'AutoDismiss', register: registerAutoDismiss, source: autoDismissSource },
   { name: 'ClickOutside', register: registerClickOutside, source: clickOutsideSource },
+  { name: 'FocusTrap', register: registerFocusTrap, source: focusTrapSource },
+  { name: 'ScrollReveal', register: registerScrollReveal, source: scrollRevealSource },
+  { name: 'Tabs', register: registerTabs, source: tabsSource },
 ] as const;
 
 // Imperative behaviors (use synthetic node with imperativeInstaller).
-// Tier-C over-reach (Draggable/Sortable/Resizable) + optional behaviors still
-// pending conversion (FocusTrap/ScrollReveal/Tabs) — see consolidation plan.
+// Only the Tier-C async-component over-reach (Draggable/Sortable/Resizable) stays
+// imperative — these sit beyond the inline-scripting boundary and are deliberately
+// kept as experimental components, not part of the one-runtime-path story (§3b/§3d).
 const imperativeBehaviors = [
   { name: 'Draggable', register: registerDraggable, source: draggableSource },
   { name: 'Sortable', register: registerSortable, source: sortableSource },
   { name: 'Resizable', register: registerResizable, source: resizableSource },
-  { name: 'FocusTrap', register: registerFocusTrap, source: focusTrapSource },
-  { name: 'ScrollReveal', register: registerScrollReveal, source: scrollRevealSource },
-  { name: 'Tabs', register: registerTabs, source: tabsSource },
 ] as const;
 
 describe('behavior registration integration', () => {

--- a/packages/behaviors/src/behaviors/optional-runtime.test.ts
+++ b/packages/behaviors/src/behaviors/optional-runtime.test.ts
@@ -1,0 +1,251 @@
+// @vitest-environment happy-dom
+/**
+ * Optional behaviors — REAL runtime behavior tests.
+ *
+ * The optional three (FocusTrap / ScrollReveal / Tabs) were converted from
+ * imperative installers onto the single source-compiled runtime path
+ * (BEHAVIORS_CONSOLIDATION_PLAN.md §3d follow-up). Like curated-runtime.test.ts,
+ * these exercise each behavior's actual hyperscript `source` through the real
+ * @hyperfixi/core runtime — register → install on an element → drive the DOM →
+ * assert both the effect AND the documented lifecycle events.
+ *
+ * This is the "parses ≠ works" guard (§2/§5): the mock-based unit tests only prove
+ * `register*()` calls compileSync; these prove the `init`-block `js()` bodies (the
+ * focus model, the IntersectionObserver, the ARIA/keyboard wiring) actually run
+ * correctly once compiled — exactly the class of bug the imperative path masked.
+ */
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { hyperscript } from '@hyperfixi/core';
+import { registerFocusTrap } from './focustrap';
+import { registerScrollReveal } from './scrollreveal';
+import { registerTabs } from './tabs';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const hf = hyperscript as any;
+
+const tick = (ms = 30) => new Promise(r => setTimeout(r, ms));
+
+async function install(code: string, el: HTMLElement): Promise<void> {
+  const r = hyperscript.compileSync(code, { traditional: true });
+  if (!r.ok) throw new Error(`install compile failed: ${JSON.stringify(r.errors)}`);
+  await hyperscript.execute(r.ast, hyperscript.createContext(el));
+}
+
+beforeAll(async () => {
+  // Behavior registry is a runtime singleton; register the optional set once.
+  await registerFocusTrap(hf);
+  await registerScrollReveal(hf);
+  await registerTabs(hf);
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('FocusTrap — runtime', () => {
+  function buildTrap(): { trap: HTMLElement; buttons: HTMLButtonElement[] } {
+    const trap = document.createElement('div');
+    const buttons = [0, 1, 2].map(i => {
+      const b = document.createElement('button');
+      b.textContent = `b${i}`;
+      trap.appendChild(b);
+      return b;
+    });
+    document.body.appendChild(trap);
+    return { trap, buttons };
+  }
+
+  it('activates on install: sets aria-modal, focuses first, fires focustrap:activated', async () => {
+    const { trap, buttons } = buildTrap();
+    const activated = vi.fn();
+    trap.addEventListener('focustrap:activated', activated);
+
+    await install('install FocusTrap', trap);
+
+    expect(trap.getAttribute('aria-modal')).toBe('true');
+    expect(activated).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it('traps Tab: wraps forward off the last element and backward off the first', async () => {
+    const { trap, buttons } = buildTrap();
+    await install('install FocusTrap', trap);
+
+    // Forward Tab from first → second.
+    buttons[0].focus();
+    trap.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    expect(document.activeElement).toBe(buttons[1]);
+
+    // Forward Tab off the last element → wraps to first.
+    buttons[2].focus();
+    trap.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    expect(document.activeElement).toBe(buttons[0]);
+
+    // Shift+Tab off the first element → wraps to last.
+    buttons[0].focus();
+    trap.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true }));
+    expect(document.activeElement).toBe(buttons[2]);
+  });
+
+  it('deactivates via custom event: removes aria-modal and fires focustrap:deactivated', async () => {
+    const { trap } = buildTrap();
+    const deactivated = vi.fn();
+    trap.addEventListener('focustrap:deactivated', deactivated);
+
+    await install('install FocusTrap', trap);
+    expect(trap.getAttribute('aria-modal')).toBe('true');
+
+    trap.dispatchEvent(new CustomEvent('focustrap:deactivate'));
+    await tick();
+
+    expect(trap.hasAttribute('aria-modal')).toBe(false);
+    expect(deactivated).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ScrollReveal — runtime', () => {
+  // happy-dom ships an IntersectionObserver that never fires its callback (no
+  // layout engine). Stub it so we can drive the intersection deterministically and
+  // assert the js() body's class/event/disconnect logic actually runs.
+  let lastCallback: ((entries: Array<{ isIntersecting: boolean }>) => void) | null = null;
+  let disconnected = false;
+  let observed: Element | null = null;
+
+  class MockIntersectionObserver {
+    constructor(cb: (entries: Array<{ isIntersecting: boolean }>) => void) {
+      lastCallback = cb;
+    }
+    observe(el: Element) {
+      observed = el;
+    }
+    disconnect() {
+      disconnected = true;
+    }
+    unobserve() {}
+    takeRecords() {
+      return [];
+    }
+  }
+
+  beforeAll(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).IntersectionObserver = MockIntersectionObserver;
+  });
+
+  afterEach(() => {
+    lastCallback = null;
+    disconnected = false;
+    observed = null;
+  });
+
+  it('observes the element and adds the class + fires enter on intersection (once)', async () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const enter = vi.fn();
+    el.addEventListener('scrollreveal:enter', enter);
+
+    await install('install ScrollReveal', el);
+
+    expect(observed).toBe(el);
+    expect(lastCallback).toBeTypeOf('function');
+
+    // Simulate the element scrolling into view.
+    lastCallback!([{ isIntersecting: true }]);
+
+    expect(el.classList.contains('revealed')).toBe(true);
+    expect(enter).toHaveBeenCalledTimes(1);
+    // once defaults to true → observer disconnects after the first reveal.
+    expect(disconnected).toBe(true);
+  });
+
+  it('honors a custom class parameter', async () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+
+    await install('install ScrollReveal(cls: "shown")', el);
+    lastCallback!([{ isIntersecting: true }]);
+
+    expect(el.classList.contains('shown')).toBe(true);
+  });
+});
+
+describe('Tabs — runtime', () => {
+  function buildTabs(): {
+    root: HTMLElement;
+    tabs: HTMLElement[];
+    panels: HTMLElement[];
+  } {
+    const root = document.createElement('div');
+    const tablist = document.createElement('div');
+    tablist.setAttribute('role', 'tablist');
+    root.appendChild(tablist);
+
+    const tabs: HTMLElement[] = [];
+    const panels: HTMLElement[] = [];
+    for (let i = 0; i < 3; i++) {
+      const tab = document.createElement('button');
+      tab.setAttribute('role', 'tab');
+      tab.textContent = `Tab ${i}`;
+      tablist.appendChild(tab);
+      tabs.push(tab);
+
+      const panel = document.createElement('div');
+      panel.setAttribute('role', 'tabpanel');
+      panel.textContent = `Panel ${i}`;
+      root.appendChild(panel);
+      panels.push(panel);
+    }
+    document.body.appendChild(root);
+    return { root, tabs, panels };
+  }
+
+  it('wires ARIA on install: first tab selected, roving tabindex, controls/labelledby', async () => {
+    const { root, tabs, panels } = buildTabs();
+
+    await install('install Tabs', root);
+
+    expect(tabs[0].getAttribute('aria-selected')).toBe('true');
+    expect(tabs[0].getAttribute('tabindex')).toBe('0');
+    expect(tabs[1].getAttribute('aria-selected')).toBe('false');
+    expect(tabs[1].getAttribute('tabindex')).toBe('-1');
+
+    // aria-controls / aria-labelledby cross-link tab[i] <-> panel[i].
+    expect(tabs[0].getAttribute('aria-controls')).toBe(panels[0].id);
+    expect(panels[0].getAttribute('aria-labelledby')).toBe(tabs[0].id);
+    expect(panels[0].getAttribute('aria-hidden')).toBe('false');
+    expect(panels[1].getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('selects a tab on click and fires tabs:changed', async () => {
+    const { root, tabs, panels } = buildTabs();
+    const changed = vi.fn();
+    root.addEventListener('tabs:changed', changed);
+
+    await install('install Tabs', root);
+
+    tabs[1].click();
+    await tick();
+
+    expect(tabs[1].getAttribute('aria-selected')).toBe('true');
+    expect(tabs[1].classList.contains('active')).toBe(true);
+    expect(tabs[0].getAttribute('aria-selected')).toBe('false');
+    expect(panels[1].getAttribute('aria-hidden')).toBe('false');
+    expect(changed).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigates with ArrowRight and is cancelable via tabs:change', async () => {
+    const { root, tabs } = buildTabs();
+    await install('install Tabs', root);
+
+    // ArrowRight on the tablist advances selection.
+    const tablist = root.querySelector('[role="tablist"]')!;
+    tablist.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(tabs[1].getAttribute('aria-selected')).toBe('true');
+
+    // preventDefault on the cancelable tabs:change blocks the next switch.
+    root.addEventListener('tabs:change', e => e.preventDefault(), { once: true });
+    tablist.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(tabs[2].getAttribute('aria-selected')).toBe('false');
+    expect(tabs[1].getAttribute('aria-selected')).toBe('true');
+  });
+});

--- a/packages/behaviors/src/behaviors/scrollreveal.test.ts
+++ b/packages/behaviors/src/behaviors/scrollreveal.test.ts
@@ -2,24 +2,32 @@ import { describe, it, expect, vi } from 'vitest';
 
 describe('ScrollReveal behavior', () => {
   describe('registerScrollReveal', () => {
-    it('should register with synthetic node via execute', async () => {
-      const { registerScrollReveal } = await import('./scrollreveal');
+    it('should compile its hyperscript source and execute', async () => {
+      const { registerScrollReveal, scrollRevealSource } = await import('./scrollreveal');
       const mock = {
-        compileSync: vi.fn(),
+        compileSync: vi.fn().mockReturnValue({ ok: true, ast: { type: 'behavior' } }),
         execute: vi.fn().mockResolvedValue(undefined),
         createContext: vi.fn().mockReturnValue({ locals: new Map(), globals: new Map() }),
       };
 
       await registerScrollReveal(mock);
 
-      expect(mock.compileSync).not.toHaveBeenCalled();
+      expect(mock.compileSync).toHaveBeenCalledWith(scrollRevealSource, { traditional: true });
       expect(mock.execute).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'behavior',
-          name: 'ScrollReveal',
-          imperativeInstaller: expect.any(Function),
-        }),
+        { type: 'behavior' },
         expect.objectContaining({ locals: expect.any(Map), globals: expect.any(Map) })
+      );
+    });
+
+    it('should throw on compile failure', async () => {
+      const { registerScrollReveal } = await import('./scrollreveal');
+      const mock = {
+        compileSync: vi.fn().mockReturnValue({ ok: false, errors: [{ message: 'boom' }] }),
+        execute: vi.fn(),
+        createContext: vi.fn().mockReturnValue({ locals: new Map(), globals: new Map() }),
+      };
+      await expect(registerScrollReveal(mock)).rejects.toThrowError(
+        /Failed to compile ScrollReveal/
       );
     });
 

--- a/packages/behaviors/src/behaviors/scrollreveal.ts
+++ b/packages/behaviors/src/behaviors/scrollreveal.ts
@@ -1,8 +1,14 @@
 /**
- * ScrollReveal Behavior — Imperative Implementation
+ * ScrollReveal Behavior
  *
  * Adds a class or fires events when the element enters or exits the viewport.
- * Uses the IntersectionObserver web standard API.
+ * Uses the IntersectionObserver web standard API (in its hyperscript `source`'s
+ * `init`-block `js()` body).
+ *
+ * Compiled from its hyperscript `source` — the single source of truth shared with
+ * the CDN resolver bundle and patterns-reference. This collapses ScrollReveal onto
+ * the one runtime path (no more imperative-installer fork between CDN and npm);
+ * see docs-internal/BEHAVIORS_CONSOLIDATION_PLAN.md §3d.
  */
 
 import { scrollRevealSchema } from '../schemas/scrollreveal.schema';
@@ -14,37 +20,8 @@ export const scrollRevealSource = scrollRevealSchema.source;
 export const scrollRevealMetadata = scrollRevealSchema;
 
 /**
- * Imperative installer for ScrollReveal behavior.
- */
-function installScrollReveal(element: HTMLElement, params: Record<string, any>): void {
-  const cls = typeof params.cls === 'string' ? params.cls : 'revealed';
-  const threshold = typeof params.threshold === 'number' ? params.threshold : 0.1;
-  const once = params.once !== false;
-  const rootMargin = typeof params.rootMargin === 'string' ? params.rootMargin : '0px';
-
-  const observer = new IntersectionObserver(
-    entries => {
-      for (const entry of entries) {
-        if (entry.isIntersecting) {
-          element.classList.add(cls);
-          element.dispatchEvent(new CustomEvent('scrollreveal:enter', { bubbles: true }));
-          if (once) {
-            observer.disconnect();
-          }
-        } else if (!once) {
-          element.classList.remove(cls);
-          element.dispatchEvent(new CustomEvent('scrollreveal:exit', { bubbles: true }));
-        }
-      }
-    },
-    { threshold, rootMargin }
-  );
-
-  observer.observe(element);
-}
-
-/**
- * Register the ScrollReveal behavior with LokaScript.
+ * Register the ScrollReveal behavior with LokaScript by compiling its
+ * hyperscript source and executing the resulting behavior definition.
  */
 export async function registerScrollReveal(hyperfixi?: LokaScriptInstance): Promise<void> {
   const hf = hyperfixi || resolveRuntime();
@@ -55,15 +32,14 @@ export async function registerScrollReveal(hyperfixi?: LokaScriptInstance): Prom
     );
   }
 
-  const syntheticNode = {
-    type: 'behavior',
-    name: 'ScrollReveal',
-    parameters: ['cls', 'threshold', 'once', 'rootMargin'],
-    eventHandlers: [],
-    imperativeInstaller: installScrollReveal,
-  };
+  const result = hf.compileSync(scrollRevealSchema.source, { traditional: true });
+
+  if (!result.ok) {
+    throw new Error(`Failed to compile ScrollReveal behavior: ${JSON.stringify(result.errors)}`);
+  }
+
   const ctx = hf.createContext ? hf.createContext() : { locals: new Map(), globals: new Map() };
-  await hf.execute(syntheticNode, ctx);
+  await hf.execute(result.ast, ctx);
 }
 
 // Auto-register when loaded as a script tag

--- a/packages/behaviors/src/behaviors/tabs.test.ts
+++ b/packages/behaviors/src/behaviors/tabs.test.ts
@@ -2,25 +2,31 @@ import { describe, it, expect, vi } from 'vitest';
 
 describe('Tabs behavior', () => {
   describe('registerTabs', () => {
-    it('should register with synthetic node via execute', async () => {
-      const { registerTabs } = await import('./tabs');
+    it('should compile its hyperscript source and execute', async () => {
+      const { registerTabs, tabsSource } = await import('./tabs');
       const mock = {
-        compileSync: vi.fn(),
+        compileSync: vi.fn().mockReturnValue({ ok: true, ast: { type: 'behavior' } }),
         execute: vi.fn().mockResolvedValue(undefined),
         createContext: vi.fn().mockReturnValue({ locals: new Map(), globals: new Map() }),
       };
 
       await registerTabs(mock);
 
-      expect(mock.compileSync).not.toHaveBeenCalled();
+      expect(mock.compileSync).toHaveBeenCalledWith(tabsSource, { traditional: true });
       expect(mock.execute).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'behavior',
-          name: 'Tabs',
-          imperativeInstaller: expect.any(Function),
-        }),
+        { type: 'behavior' },
         expect.objectContaining({ locals: expect.any(Map), globals: expect.any(Map) })
       );
+    });
+
+    it('should throw on compile failure', async () => {
+      const { registerTabs } = await import('./tabs');
+      const mock = {
+        compileSync: vi.fn().mockReturnValue({ ok: false, errors: [{ message: 'boom' }] }),
+        execute: vi.fn(),
+        createContext: vi.fn().mockReturnValue({ locals: new Map(), globals: new Map() }),
+      };
+      await expect(registerTabs(mock)).rejects.toThrowError(/Failed to compile Tabs/);
     });
 
     it('should throw when no runtime available', async () => {
@@ -31,7 +37,7 @@ describe('Tabs behavior', () => {
     it('should fall back to manual context when createContext is missing', async () => {
       const { registerTabs } = await import('./tabs');
       const mock = {
-        compileSync: vi.fn(),
+        compileSync: vi.fn().mockReturnValue({ ok: true, ast: { type: 'behavior' } }),
         execute: vi.fn().mockResolvedValue(undefined),
       };
 

--- a/packages/behaviors/src/behaviors/tabs.ts
+++ b/packages/behaviors/src/behaviors/tabs.ts
@@ -1,8 +1,15 @@
 /**
- * Tabs Behavior — Imperative Implementation
+ * Tabs Behavior
  *
  * WAI-ARIA compliant tabs with roving tabindex keyboard navigation.
- * Auto-wires role, aria-selected, aria-controls, and aria-labelledby.
+ * Auto-wires role, aria-selected, aria-controls, and aria-labelledby. The ARIA
+ * wiring / keyboard-navigation logic lives in the schema's hyperscript `source`
+ * (an `init`-block `js()` body).
+ *
+ * Compiled from its hyperscript `source` — the single source of truth shared with
+ * the CDN resolver bundle and patterns-reference. This collapses Tabs onto the one
+ * runtime path (no more imperative-installer fork between CDN and npm);
+ * see docs-internal/BEHAVIORS_CONSOLIDATION_PLAN.md §3d.
  */
 
 import { tabsSchema } from '../schemas/tabs.schema';
@@ -12,157 +19,9 @@ import { resolveRuntime } from '../schemas/types';
 export const tabsSource = tabsSchema.source;
 export const tabsMetadata = tabsSchema;
 
-let idCounter = 0;
-
-function ensureId(el: HTMLElement, prefix: string): string {
-  if (!el.id) {
-    el.id = `${prefix}-${++idCounter}`;
-  }
-  return el.id;
-}
-
 /**
- * Imperative installer for Tabs behavior.
- */
-function installTabs(element: HTMLElement, params: Record<string, any>): void {
-  const orientation = params.orientation === 'vertical' ? 'vertical' : 'horizontal';
-  const wrap = params.wrap !== false;
-  const activeClass = (params.activeClass as string) || 'active';
-  const initialIndex = typeof params.activeTab === 'number' ? params.activeTab : 0;
-
-  // Discover tabs and panels
-  const tabs = Array.from(element.querySelectorAll<HTMLElement>('[role="tab"]'));
-  const panels = Array.from(element.querySelectorAll<HTMLElement>('[role="tabpanel"]'));
-
-  if (tabs.length === 0 || panels.length === 0) return;
-
-  // Find or mark the tablist
-  const tablist = element.querySelector<HTMLElement>('[role="tablist"]') || tabs[0].parentElement;
-  if (tablist && !tablist.getAttribute('role')) {
-    tablist.setAttribute('role', 'tablist');
-  }
-  if (tablist) {
-    tablist.setAttribute('aria-orientation', orientation);
-  }
-
-  // Wire IDs, aria-controls, aria-labelledby
-  const count = Math.min(tabs.length, panels.length);
-  for (let i = 0; i < count; i++) {
-    const tabId = ensureId(tabs[i], 'tab');
-    const panelId = ensureId(panels[i], 'tabpanel');
-    tabs[i].setAttribute('aria-controls', panelId);
-    panels[i].setAttribute('aria-labelledby', tabId);
-  }
-
-  let currentIndex = -1;
-
-  function selectTab(index: number, previousIndex: number): boolean {
-    if (index === previousIndex || index < 0 || index >= count) return false;
-
-    const detail = {
-      tab: tabs[index],
-      panel: panels[index],
-      index,
-      previousIndex,
-    };
-
-    // Cancelable before-event
-    const changeEvent = new CustomEvent('tabs:change', {
-      bubbles: true,
-      cancelable: true,
-      detail,
-    });
-    element.dispatchEvent(changeEvent);
-    if (changeEvent.defaultPrevented) return false;
-
-    // Deactivate previous
-    if (previousIndex >= 0 && previousIndex < count) {
-      tabs[previousIndex].setAttribute('aria-selected', 'false');
-      tabs[previousIndex].setAttribute('tabindex', '-1');
-      tabs[previousIndex].classList.remove(activeClass);
-      panels[previousIndex].setAttribute('aria-hidden', 'true');
-      panels[previousIndex].classList.remove(activeClass);
-    }
-
-    // Activate new
-    tabs[index].setAttribute('aria-selected', 'true');
-    tabs[index].setAttribute('tabindex', '0');
-    tabs[index].classList.add(activeClass);
-    panels[index].setAttribute('aria-hidden', 'false');
-    panels[index].classList.add(activeClass);
-
-    currentIndex = index;
-
-    element.dispatchEvent(new CustomEvent('tabs:changed', { bubbles: true, detail }));
-    return true;
-  }
-
-  // Initialize all tabs as inactive, then activate initial
-  for (let i = 0; i < count; i++) {
-    tabs[i].setAttribute('aria-selected', 'false');
-    tabs[i].setAttribute('tabindex', '-1');
-    tabs[i].classList.remove(activeClass);
-    panels[i].setAttribute('aria-hidden', 'true');
-    panels[i].classList.remove(activeClass);
-  }
-
-  const clamped = Math.max(0, Math.min(initialIndex, count - 1));
-  // Directly activate without firing change event on init
-  tabs[clamped].setAttribute('aria-selected', 'true');
-  tabs[clamped].setAttribute('tabindex', '0');
-  tabs[clamped].classList.add(activeClass);
-  panels[clamped].setAttribute('aria-hidden', 'false');
-  panels[clamped].classList.add(activeClass);
-  currentIndex = clamped;
-
-  // Click handler
-  for (let i = 0; i < count; i++) {
-    tabs[i].addEventListener('click', () => {
-      selectTab(i, currentIndex);
-      tabs[i].focus();
-    });
-  }
-
-  // Keyboard handler on tablist
-  const keyTarget = tablist || element;
-  keyTarget.addEventListener('keydown', (e: KeyboardEvent) => {
-    const isHorizontal = orientation === 'horizontal';
-    const nextKey = isHorizontal ? 'ArrowRight' : 'ArrowDown';
-    const prevKey = isHorizontal ? 'ArrowLeft' : 'ArrowUp';
-
-    let nextIndex: number | null = null;
-
-    if (e.key === nextKey) {
-      nextIndex = currentIndex + 1;
-      if (nextIndex >= count) nextIndex = wrap ? 0 : null;
-    } else if (e.key === prevKey) {
-      nextIndex = currentIndex - 1;
-      if (nextIndex < 0) nextIndex = wrap ? count - 1 : null;
-    } else if (e.key === 'Home') {
-      nextIndex = 0;
-    } else if (e.key === 'End') {
-      nextIndex = count - 1;
-    }
-
-    if (nextIndex !== null) {
-      e.preventDefault();
-      if (selectTab(nextIndex, currentIndex)) {
-        tabs[nextIndex].focus();
-      }
-    }
-  });
-
-  // Programmatic tab selection
-  element.addEventListener('tabs:select', ((e: CustomEvent) => {
-    const index = e.detail?.index;
-    if (typeof index === 'number') {
-      selectTab(index, currentIndex);
-    }
-  }) as EventListener);
-}
-
-/**
- * Register the Tabs behavior with LokaScript.
+ * Register the Tabs behavior with LokaScript by compiling its
+ * hyperscript source and executing the resulting behavior definition.
  */
 export async function registerTabs(hyperfixi?: LokaScriptInstance): Promise<void> {
   const hf = hyperfixi || resolveRuntime();
@@ -173,15 +32,14 @@ export async function registerTabs(hyperfixi?: LokaScriptInstance): Promise<void
     );
   }
 
-  const syntheticNode = {
-    type: 'behavior',
-    name: 'Tabs',
-    parameters: ['orientation', 'activeTab', 'wrap', 'activeClass'],
-    eventHandlers: [],
-    imperativeInstaller: installTabs,
-  };
+  const result = hf.compileSync(tabsSchema.source, { traditional: true });
+
+  if (!result.ok) {
+    throw new Error(`Failed to compile Tabs behavior: ${JSON.stringify(result.errors)}`);
+  }
+
   const ctx = hf.createContext ? hf.createContext() : { locals: new Map(), globals: new Map() };
-  await hf.execute(syntheticNode, ctx);
+  await hf.execute(result.ast, ctx);
 }
 
 // Auto-register when loaded as a script tag


### PR DESCRIPTION
## What

Converts the **optional 3** behaviors — `FocusTrap`, `ScrollReveal`, `Tabs` — from imperative installers (`imperativeInstaller` synthetic node) onto the single source-compiled runtime path (`compileSync(schema.source) + execute`), mirroring the Phase-1 curated collapse.

This closes the last curated/optional fork between the CDN resolver bundle and the npm `register*()` path (BEHAVIORS_CONSOLIDATION_PLAN.md §3d, follow-up #1). Their web-API logic (focus model, `IntersectionObserver`, ARIA/keyboard wiring) was already complete in each schema's `init`-block `js()` body, so the conversion is mechanical.

**Only the experimental 3 (Draggable/Sortable/Resizable) remain imperative** — deliberate, as async components beyond the inline-scripting boundary (§3b).

## Tests

- New `src/behaviors/optional-runtime.test.ts` — the "parses ≠ works" gate: drives all three through the **real `@hyperfixi/core` runtime** under happy-dom (focus-trap Tab wrap, intersection reveal via stubbed observer, tab ARIA/keyboard nav + cancelable `tabs:change`).
- `integration.test.ts` moves the three into `compiledBehaviors`; mock unit tests assert the compile path.
- behaviors **167 green**; typecheck + tsup build clean; dist verified (optional-3 globals carry `compileSync`, `imperativeInstaller` only in the experimental-3 globals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)