### PR TITLE
feat(semantic): localize event names on the render path (Phase 1b)

### DIFF
--- a/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
+++ b/docs-internal/MULTILINGUAL_BEHAVIORS_PLAN.md
@@ -200,9 +200,17 @@ Dependency shape: **Phase 0 gates 1–4 · 1→4 · 2→3 · 5 is free-floating.
 - Localized names / param-names / hover-docs for the 11 shipped behaviors
   (`packages/behaviors`). Pure data, zero parser risk, immediate broad
   understand-value. Independent of the ladder.
-- **Do not** re-localize the shipped behaviors' hyperscript `source` — they run
+- ~~**Do not** re-localize the shipped behaviors' hyperscript `source` — they run
   **imperative JS installers**, so the `source` string is near-worthless to
-  translate. Authoring value is in _user-defined_ behaviors (Phase 3).
+  translate.~~ **Superseded (2026-06-15, behaviors consolidation — see
+  [BEHAVIORS_CONSOLIDATION_PLAN.md](BEHAVIORS_CONSOLIDATION_PLAN.md)):** the curated
+  shipped behaviors no longer run imperative JS installers — they **compile their
+  hyperscript `source`** (one runtime path). So that source _is_ now meaningful to
+  translate: Toggleable/Removable translate end-to-end; the js()-core behaviors
+  (ClickOutside/Clipboard/AutoDismiss) translate their trigger surface. A live
+  showcase shipped at `examples/behaviors/multilingual.html`. Localized prose
+  metadata (names/param-docs) still wants native review before committing.
+  Authoring value remains greatest in _user-defined_ behaviors (Phase 3).
 
 ## 5. Invariants (every phase)
 
@@ -242,13 +250,30 @@ Dependency shape: **Phase 0 gates 1–4 · 1→4 · 2→3 · 5 is free-floating.
   lock `test/event-handler-render-no-phantom.test.ts` 17/17; typecheck clean. The
   fix is provably **recall-neutral** (removes only spurious commands), so the
   committed multilingual gate baseline cannot regress on its recall/R1 signals.
-- **Deferred (Phase 1b):** **event-name translation.** Event names render as
-  English (`click`, not native) — functionally correct (DOM event names;
-  round-trips fine) and **fidelity-neutral** (a value, not a command), so it does
-  not violate any invariant. Native rendering needs the _reverse_ of
-  `eventNameTranslations` (which maps native→English) plus careful handling of
-  compound (`click or keydown`), namespaced (`htmx:load`), and modifier forms —
-  scoped separately rather than rushed into Phase 1.
+- **2026-06-15: Phase 1b ✅ complete — event-name translation.** Event names now
+  render in the target language (`on click …` → es `al clic …`, ja `クリック … で`,
+  ar `على النقر …`, zh `一 点击 就 …`, ko `클릭 …`). Implementation:
+  `localizeEventName()` in `packages/semantic/src/patterns/event-handler.ts`
+  inverts `eventNameTranslations` (English→native, first-wins); `renderer.ts`
+  routes **only** the event role of an event-handler node through a new
+  `renderEventName()` (other role literals untouched). The single render-path edit
+  also covers behaviors/defs/multi-handler programs. Non-literal values (namespaced
+  `htmx:load`, unknown/custom events) and compound `a or b` triggers pass each
+  sub-name through, keeping the English `or` connector (native connectors add no
+  round-trip benefit; ja/zh/ko compound stays a pre-existing known-limitation).
+  - **Round-trip safety:** `eventNameTranslations` proved _aspirational_ — it lists
+    natives some tokenizers never register or that re-parse as other commands (de
+    `load`→`laden`→fetch; qu `submit`→`apachiy`→send; weak sw/tr handler grammars).
+    A **test-locked, evidence-based denylist** keeps English for every unsafe pair
+    (English always round-trips); the exhaustive case in
+    `test/event-name-translation.test.ts` _proves_ every native the localizer emits
+    re-parses back to the same event.
+  - **Gate-neutral** (a value, not a command): the multilingual gate scores
+    pre-synced patterns.db translations (i18n transformer), not the semantic
+    renderer — so this changes no scored output. Re-`populate`d + `--regression`
+    gate **green**, baseline byte-unchanged.
+  - Regression: new lock test (15); no-phantom lock unchanged (30); full semantic
+    suite 6096 passed / 9 skipped; build + typecheck clean.
 - **Deferred (Phase 2):** SOV trigger-marker cosmetics (ja renders `click を で`,
   slightly non-idiomatic but round-trips correctly).
 - **2026-06-14: Phase 2 in progress — doubled trigger-marker phantom fixed.**
@@ -305,4 +330,12 @@ Dependency shape: **Phase 0 gates 1–4 · 1→4 · 2→3 · 5 is free-floating.
     path drops/duplicates it (`[200ms, wait, add]`). Same "control-flow body
     parsing" cluster tracked in CORRECTNESS_RELIABILITY_PLAN; high-risk to touch
     for one non-priority edge case. (qu possessor-first possessive also remains.)
-- **Next:** Phase 3 — general structural/block layer (behaviors / `def` / programs).
+- **2026-06-15: behaviors consolidation merged (PR #430).** The shipped curated
+  behaviors (Toggleable/Removable/ClickOutside/Clipboard/AutoDismiss) now compile
+  their hyperscript `source` on one runtime path; Phase 1's parse/render block layer
+  is exercised live by `examples/behaviors/multilingual.html` (curated bodies
+  translate + round-trip 78–100% across es/ja/ar/ko/zh/de). See
+  [BEHAVIORS_CONSOLIDATION_PLAN.md](BEHAVIORS_CONSOLIDATION_PLAN.md).
+- **Next:** native-reviewed localized metadata (Phase 5); multi-handler top-level
+  programs (feature-chain, deferred in §4); supervised patterns-reference behavior
+  corpus sync.

--- a/docs-internal/hyperscript-org-offer/README.md
+++ b/docs-internal/hyperscript-org-offer/README.md
@@ -12,7 +12,7 @@ whichever sub-doc you need.
 | 3a   | lokascript-docs patterns page: language chip grid + live-execution toggle (in shared partial, gated by `enableTranslations`) | ✅ landed in `_hyper_min` commit `80214fd`                                      |
 | 3b   | hyperfixi-docs patterns page: verify engine showcase                                                                         | 📄 verification doc ready: [hyperfixi-docs-patch.md](./hyperfixi-docs-patch.md) |
 | 4    | Drop-in integration guide for hyperscript.org's audience (lives on lokascript.org)                                           | 📄 ready: [integration-guide.md](./integration-guide.md)                        |
-| 5    | Carson hand-off message                                                                                                      | 📄 ready (two variants): [carson-handoff.md](./carson-handoff.md)               |
+| 5    | Carson hand-off message                                                                                                      | 📄 ready (two variants): [handoff.md](./handoff.md)                             |
 
 ## What's done in the monorepo (no further code work required)
 
@@ -38,4 +38,4 @@ whichever sub-doc you need.
 2. `npm publish` from `packages/hyperscript-tools-i18n/`.
 3. Apply the lokascript-docs patch, deploy, smoke-test.
 4. Deploy the integration guide page.
-5. Walk through the pre-send checklist in [carson-handoff.md](./carson-handoff.md).
+5. Walk through the pre-send checklist in [handoff.md](./handoff.md).

--- a/docs-internal/hyperscript-org-offer/handoff.md
+++ b/docs-internal/hyperscript-org-offer/handoff.md
@@ -1,55 +1,12 @@
-# Carson hand-off message
+# Hand-off message
 
-Two variants below — pick whichever matches the channel you use to reach
-Carson (GitHub issue or email). Both stay short on purpose; the integration
+The integration
 guide and live demo do the heavy lifting.
 
 ---
 
-## Variant A — GitHub issue on `bigskysoftware/_hyperscript`
-
-**Title:** `Optional plugin: write _hyperscript in 24 languages (no fork, MIT)`
-
-**Body:**
-
-> Hey Carson — the recent hyperscript.org refresh is great. Wanted to put
-> something in front of you that's been ready for a while: a runtime plugin
-> that lets visitors write `_=` attributes in any of 24 languages, and a
-> companion build-time tool for translating docs/code samples.
->
-> **Live demo:** https://lokascript.org/patterns — click a language chip to
-> flip every pattern; toggle "Live execution" and the patterns run in the
-> chosen language. Same engine; just a `getScript()` override.
->
-> **Integration guide:** https://lokascript.org/integration-guide (one
-> screen, all the install snippets and tradeoffs).
->
-> **Packages (MIT, namespace-neutral):**
->
-> - [`@hyperscript-tools/multilingual`](https://www.npmjs.com/package/@hyperscript-tools/multilingual)
->   — runtime plugin. One `<script>` tag, auto-registers.
-> - [`@hyperscript-tools/i18n`](https://www.npmjs.com/package/@hyperscript-tools/i18n)
->   — build-time CLI + Eleventy plugin for pre-translated docs.
->
-> The plugin is non-invasive: it overrides `runtime.getScript()` only, hands
-> English to your existing lexer, and falls through unchanged when parse
-> confidence is too low. No AST work. Bundle sizes range from ~140 KB
-> (single language) to ~720 KB (all 24).
->
-> No expectation of merge — happy if you just point people at it from the
-> docs, or fork the demo, or ignore it. If you'd rather we transfer the
-> packages to a `bigskysoftware`-owned scope, or co-maintain, let me know.
->
-> — _William Talcott_
-
----
-
-## Variant B — email
-
 **Subject:** `_hyperscript in 24 languages — drop-in plugin if you want it`
 
-> Hey Carson,
->
 > Site refresh looks great. Quick share in case it's useful.
 >
 > We've been running a runtime plugin that lets people write `_=` attributes
@@ -57,7 +14,7 @@ guide and live demo do the heavy lifting.
 > It overrides exactly one function (`runtime.getScript()`) and hands
 > English back to your existing lexer. No AST changes, no fork, no patches.
 >
-> Live demo: https://lokascript.org/patterns
+> Live demo: <https://lokascript.org/patterns>
 >
 > Click a chip; every pattern flips. Hit "Live execution"; they run.
 >
@@ -71,7 +28,7 @@ guide and live demo do the heavy lifting.
 > Full guide (one screen) with bundle sizes, language coverage, and the
 > build-time companion (`@hyperscript-tools/i18n` for pre-translated docs):
 >
-> https://lokascript.org/integration-guide
+> <https://lokascript.org/integration-guide>
 >
 > MIT, namespace-neutral, zero HyperFixi/LokaScript runtime dependency. If
 > you want to ship language support on hyperscript.org, the bare minimum is
@@ -81,8 +38,6 @@ guide and live demo do the heavy lifting.
 >
 > No expectation of any specific outcome. Throwing it over the fence in case
 > it's useful.
->
-> — William
 >
 > P.S. The runtime is a few hundred lines on top of a precomputed semantic
 > pattern catalog. Below-threshold input falls through unchanged, so a

--- a/docs-internal/hyperscript-org-offer/improvements-plan.md
+++ b/docs-internal/hyperscript-org-offer/improvements-plan.md
@@ -203,7 +203,7 @@ and confirm:
   auto-registers and processes a `_="alternar .active on me"` button.
 
 **Fix:** Add this as a manual step in the
-[carson-handoff.md pre-send checklist](./carson-handoff.md), or wire into a
+[handoff.md pre-send checklist](./handoff.md), or wire into a
 Playwright smoke test in `packages/multilingual-hyperscript/test/`.
 
 **Effort:** 30 minutes manual; 2 hours automated.

--- a/packages/semantic/src/explicit/renderer.ts
+++ b/packages/semantic/src/explicit/renderer.ts
@@ -20,6 +20,7 @@ import type {
 // Import from registry for tree-shaking (registry uses directly-registered patterns first)
 import { getPatternsForLanguageAndCommand, tryGetProfile } from '../registry';
 import { getSupportedLanguages as getTokenizerLanguages } from '../tokenizers';
+import { localizeEventName } from '../patterns/event-handler';
 import { renderExplicit as renderExplicitBase } from '@lokascript/framework';
 
 // =============================================================================
@@ -288,6 +289,12 @@ export class SemanticRendererImpl implements ISemanticRenderer {
           // Use default if available
           return null;
         }
+        // The event role of an event handler is the one literal we localize to
+        // the target language (Phase 1b) — scoped here so other role literals
+        // (selectors, string literals) are never touched.
+        if (token.role === 'event' && node.kind === 'event-handler') {
+          return this.renderEventName(value, language);
+        }
         return this.valueToNaturalString(value, language);
       }
 
@@ -356,6 +363,32 @@ export class SemanticRendererImpl implements ISemanticRenderer {
       default:
         return null;
     }
+  }
+
+  /**
+   * Render an event-handler's event name in the target language (Phase 1b).
+   *
+   * Only a known DOM event name arrives as a `literal`; namespaced (`htmx:load`)
+   * and unknown/custom events arrive as `expression` and pass through unchanged.
+   * Compound triggers (`click or keydown`) are one combined literal — localize
+   * each sub-name and keep the English ` or ` connector (a native connector adds
+   * no round-trip benefit, and ja/zh/ko cannot re-parse compound triggers either
+   * way — a documented pre-existing limitation).
+   */
+  private renderEventName(value: SemanticValue, language: string): string {
+    if (value.type !== 'literal' || typeof value.value !== 'string') {
+      return this.valueToNaturalString(value, language);
+    }
+    const raw = value.value;
+    const localizeOne = (name: string): string =>
+      name.includes(':') ? name : localizeEventName(name, language);
+    if (raw.includes(' or ')) {
+      return raw
+        .split(' or ')
+        .map(part => localizeOne(part.trim()))
+        .join(' or ');
+    }
+    return localizeOne(raw);
   }
 
   /**

--- a/packages/semantic/src/index.ts
+++ b/packages/semantic/src/index.ts
@@ -122,6 +122,7 @@ export {
   getEventHandlerPatternsForLanguage,
   eventNameTranslations,
   normalizeEventName,
+  localizeEventName,
 } from './patterns';
 
 // =============================================================================

--- a/packages/semantic/src/patterns/event-handler.ts
+++ b/packages/semantic/src/patterns/event-handler.ts
@@ -309,6 +309,82 @@ export function normalizeEventName(event: string, language: string): string {
 }
 
 // =============================================================================
+// Event Name Localization (English → native, render path) — Phase 1b
+// =============================================================================
+
+/**
+ * English → canonical-native event names, per language. Derived by inverting
+ * {@link eventNameTranslations} with **first-wins** per English key: the
+ * first-listed native form is the canonical one (e.g. ja `load` → `ロード`, the
+ * registered tokenizer form, not the later `読み込み`).
+ *
+ * This is the reverse of the parse-path normalization and is used only on the
+ * render/translate path to emit native event names instead of English ones.
+ */
+const eventNameLocalizations: Record<string, Record<string, string>> = Object.fromEntries(
+  Object.entries(eventNameTranslations).map(([lang, table]) => {
+    const reverse: Record<string, string> = {};
+    for (const [native, english] of Object.entries(table)) {
+      if (!(english in reverse)) reverse[english] = native; // first-wins
+    }
+    return [lang, reverse];
+  })
+);
+
+/**
+ * Round-trip-unsafe (language, English-event) pairs whose canonical native does
+ * NOT re-parse back to the same event — so we keep English for them.
+ *
+ * The source of truth for "parseable native event word" is each tokenizer's
+ * `{native, normalized}` keyword entries + the handler grammar, NOT
+ * {@link eventNameTranslations} (which is aspirational — it lists natives a
+ * tokenizer never registers, or that re-parse as a different command). This
+ * denylist is **evidence-based and test-locked**: it is exactly the failure set of
+ * the exhaustive round-trip case in `test/event-name-translation.test.ts`.
+ * Regenerate it from that test if the tokenizers or `eventNameTranslations`
+ * change; do not hand-add speculative entries.
+ *
+ * Notable classes: `de.load`→`laden` and `qu.submit`→`apachiy` re-parse as other
+ * commands (`fetch`/`send`); the weaker SOV/agglutinative handler grammars (sw,
+ * tr) reject many compounded native event words outright.
+ */
+const eventLocalizationDenylist: Record<string, ReadonlySet<string>> = {
+  ar: new Set(['mouseover']),
+  bn: new Set(['resize']),
+  de: new Set(['keydown', 'keyup', 'load', 'mouseout', 'mouseover']),
+  fr: new Set(['blur']),
+  id: new Set(['input', 'keyup', 'mouseout', 'mouseover']),
+  ja: new Set(['keypress', 'mousedown', 'mouseup', 'resize']),
+  qu: new Set(['change', 'focus', 'load', 'resize', 'submit']),
+  sw: new Set(['change', 'click', 'input', 'keydown', 'keyup', 'mouseout', 'mouseover', 'submit']),
+  tr: new Set([
+    'keydown',
+    'keyup',
+    'load',
+    'mousedown',
+    'mouseout',
+    'mouseover',
+    'mouseup',
+    'resize',
+    'scroll',
+  ]),
+  zh: new Set(['focus', 'keyup', 'mouseout', 'mouseover']),
+};
+
+/**
+ * Localize a single English event name to the target language, or return it
+ * unchanged when there is no round-trip-safe native (non-covered language,
+ * unmapped event, or a denylisted pair). Passthrough is always safe because
+ * English event names already round-trip.
+ */
+export function localizeEventName(englishEvent: string, language: string): string {
+  if (eventLocalizationDenylist[language]?.has(englishEvent)) {
+    return englishEvent;
+  }
+  return eventNameLocalizations[language]?.[englishEvent] ?? englishEvent;
+}
+
+// =============================================================================
 // Per-Language Event Handler Patterns
 // =============================================================================
 

--- a/packages/semantic/src/patterns/index.ts
+++ b/packages/semantic/src/patterns/index.ts
@@ -45,7 +45,7 @@ export { getEventHandlerPatternsForLanguage } from './event-handler';
 export { getGrammarTransformedPatternsForLanguage } from './grammar-transformed';
 
 // Event handler utilities
-export { eventNameTranslations, normalizeEventName } from './event-handler';
+export { eventNameTranslations, normalizeEventName, localizeEventName } from './event-handler';
 
 // =============================================================================
 // Registry Pattern Generator Setup

--- a/packages/semantic/test/event-name-translation.test.ts
+++ b/packages/semantic/test/event-name-translation.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Lock — event names render in the target language and round-trip (Phase 1b).
+ *
+ * Before this, `translate('on click …', 'en', lang)` left the event name English
+ * (`… click …`) even in Japanese — functionally correct but reads wrong. The
+ * renderer now localizes the event role via `localizeEventName` (renderer.ts
+ * `renderPatternToken`), emitting only round-trip-safe natives and passing
+ * everything else (namespaced/unknown events, non-covered languages, denylisted
+ * pairs) through as English — English always round-trips.
+ *
+ * See MULTILINGUAL_BEHAVIORS_PLAN.md §6 "Deferred (Phase 1b)".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse, translate, eventNameTranslations, localizeEventName } from '../src';
+
+/** The normalized (English) event name from a parsed event-handler node. */
+function eventOf(node: unknown): string | undefined {
+  const n = node as { kind?: string; roles?: Map<string, { value?: unknown }> };
+  if (!n || n.kind !== 'event-handler' || !n.roles?.get) return undefined;
+  const v = n.roles.get('event');
+  return v && 'value' in v ? String(v.value) : undefined;
+}
+
+/** Multiset of leaf command actions in a parsed semantic node tree. */
+function leafActions(node: unknown, acc: string[] = []): string[] {
+  if (!node) return acc;
+  if (Array.isArray(node)) {
+    for (const n of node) leafActions(n, acc);
+    return acc;
+  }
+  const n = node as {
+    kind?: string;
+    action?: string;
+    statements?: unknown;
+    body?: unknown;
+    thenBody?: unknown;
+    elseBody?: unknown;
+  };
+  switch (n.kind) {
+    case 'command':
+      if (n.action) acc.push(n.action);
+      break;
+    case 'compound':
+      leafActions(n.statements, acc);
+      break;
+    case 'conditional':
+      acc.push('if');
+      leafActions(n.thenBody ?? n.body, acc);
+      leafActions(n.elseBody, acc);
+      break;
+    case 'event-handler':
+      leafActions(n.body, acc);
+      break;
+  }
+  return acc;
+}
+
+const COVERED = ['ja', 'ko', 'ar', 'es', 'de', 'zh'] as const;
+
+describe('event-name translation (Phase 1b)', () => {
+  describe('single event name — localized and round-trips', () => {
+    for (const lang of COVERED) {
+      it(`${lang}: "on click add .a to me" round-trips with event=click`, () => {
+        const translated = translate('on click add .a to me', 'en', lang);
+        const reparsed = parse(translated, lang);
+        expect(leafActions(reparsed)).toEqual(['add']);
+        expect(eventOf(reparsed)).toBe('click');
+      });
+    }
+
+    it('actually emits the native name (es→clic, ar→النقر)', () => {
+      expect(translate('on click add .a to me', 'en', 'es')).toContain('clic');
+      expect(translate('on click add .a to me', 'en', 'ar')).toContain('النقر');
+      // and not the English word, for a covered language
+      expect(translate('on click add .a to me', 'en', 'es')).not.toContain('click');
+    });
+  });
+
+  describe('passthrough cases (stay English, no regression)', () => {
+    it('de: "on load …" keeps English `load` (the native `laden` is the fetch keyword)', () => {
+      const translated = translate('on load add .a to me', 'en', 'de');
+      expect(translated).toContain('load');
+      expect(eventOf(parse(translated, 'de'))).toBe('load');
+    });
+
+    it('namespaced htmx:load is left verbatim', () => {
+      for (const lang of COVERED) {
+        expect(translate('on htmx:load add .a to me', 'en', lang)).toContain('htmx:load');
+      }
+    });
+
+    it('unknown/custom event is left verbatim and round-trips', () => {
+      // es/de re-parse a bare unknown event cleanly.
+      for (const lang of ['es', 'de'] as const) {
+        const translated = translate('on customEvent add .a to me', 'en', lang);
+        expect(translated).toContain('customEvent');
+        expect(leafActions(parse(translated, lang))).toEqual(['add']);
+      }
+    });
+
+    it('non-covered languages keep the English event name', () => {
+      for (const lang of ['hi', 'ru', 'it'] as const) {
+        expect(localizeEventName('click', lang)).toBe('click');
+      }
+    });
+  });
+
+  describe('compound trigger (`click or keydown`)', () => {
+    // es/de/ar parse compound event triggers; localizing each sub-name is safe.
+    for (const lang of ['es', 'de', 'ar'] as const) {
+      it(`${lang}: compound round-trips its body`, () => {
+        const translated = translate('on click or keydown add .a to me', 'en', lang);
+        expect(leafActions(parse(translated, lang))).toEqual(['add']);
+      });
+    }
+    // ja/zh/ko cannot re-parse compound triggers (the event slot is a single
+    // token in their handler patterns) — a PRE-EXISTING limitation, not a
+    // regression from this change. Documented; intentionally not asserted.
+  });
+
+  describe('exhaustive reverse-map safety', () => {
+    it('every native this localizer emits re-parses back to the same English event', () => {
+      const failures: string[] = [];
+      for (const lang of Object.keys(eventNameTranslations)) {
+        const englishEvents = new Set(Object.values(eventNameTranslations[lang]));
+        for (const ev of englishEvents) {
+          const native = localizeEventName(ev, lang);
+          if (native === ev) continue; // passthrough (unmapped/denylisted) — English round-trips
+          const translated = translate(`on ${ev} add .a to me`, 'en', lang);
+          let got: string | undefined;
+          try {
+            got = eventOf(parse(translated, lang));
+          } catch {
+            got = undefined; // unparseable native (not registered by the tokenizer)
+          }
+          if (got !== ev) {
+            failures.push(`${lang}: ${ev}→${native} re-parsed as ${got ?? 'NONE'} ("${translated}")`);
+          }
+        }
+      }
+      expect(failures, failures.join('\n')).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## What

When translating a hyperscript event handler between languages, the event **name** stayed English (`on click …` rendered `… click …` even in Japanese). The renderer now localizes the event role to the target language:

```
on click add .active to me  →  es: al clic …    ja: クリック … で    ar: على النقر …
                                zh: 一 点击 就 …  ko: 클릭 …          fr: quand clic …
```

Implements MULTILINGUAL_BEHAVIORS_PLAN.md §6 "Deferred (Phase 1b)".

## How

- `event-handler.ts`: derive an English→native reverse map (first-wins) from the existing native→English `eventNameTranslations`, plus `localizeEventName()`.
- `renderer.ts`: in `renderPatternToken` `case 'role'`, route **only** the event role of an event-handler node through a new `renderEventName()` — other role literals (selectors, string literals) untouched. Non-literal values (namespaced `htmx:load`, unknown/custom events arrive as `expression`) and compound `a or b` triggers pass each sub-name through, keeping the English ` or ` connector. This one render-path edit also covers behaviors/defs/multi-handler programs.

## Round-trip safety

`eventNameTranslations` proved **aspirational** — it lists natives some tokenizers never register, or that re-parse as a different command (de `load`→`laden`→fetch; qu `submit`→`apachiy`→send; weak sw/tr handler grammars). A **test-locked, evidence-based denylist** keeps English for every such pair; English always round-trips. The exhaustive case in the new lock test **proves** every native the localizer emits re-parses back to the same event.

## Gate-neutral

The multilingual gate scores pre-synced `patterns.db` translations (i18n transformer), **not** the semantic renderer — so this changes no scored output. Re-`populate`d + `--regression` gate **green**, baseline byte-unchanged.

## Tests

- new `test/event-name-translation.test.ts` (15); no-phantom lock unchanged (30); full semantic suite **6096 passed / 9 skipped**; build + typecheck clean.

## Note

The docs commit (`822d317e`) bundles an unrelated `docs-internal/hyperscript-org-offer/` edit alongside the Phase-1b plan-doc update (per author request to lump pending docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)