### PR TITLE
Multilingual gate: R0-precision trust floor (catch phantom/spurious commands)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -681,7 +681,6 @@ jobs:
       - name: Run Playwright tests
         run: npx playwright test --project=quick
         working-directory: packages/core
-        continue-on-error: true # Known failures: behaviors not fully implemented
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,7 @@ As of 2026-01-23, all CI testing has been consolidated into a single `.github/wo
 - **Parallel execution**: jobs run in parallel after build completes
 - **Two-tier job set**: full matrix on `pull_request`, slim skew-detector set on `push` to main/develop
 - **Node 24 LTS**: Active LTS release (EOL April 2028)
-- **Smart failure handling**: Known failures (behaviors, SOV/VSO languages) marked with `continue-on-error`
+- **Smart failure handling**: the multilingual job is a real fidelity-ratchet gate (no `continue-on-error`); only the perf `benchmarks` job uses `continue-on-error` (trend tracking, never a gate)
 
 **Jobs:**
 
@@ -260,8 +260,8 @@ The four PR-only jobs already ran against the merged-as-PR code, so re-running t
 
 **Known Issues:**
 
-- Behavior tests: Draggable, Sortable, Resizable not fully implemented (continue-on-error)
-- SOV/VSO languages: Japanese, Korean, Turkish have lower pass rates than SVO languages (continue-on-error)
+- Experimental behaviors (Draggable, Sortable, Resizable) still run imperative JS installers; migration to the compiled hyperscript `source` path is in progress. Curated (5) + optional (3) behaviors already run the source-compiled path and are fully tested (behaviors suite green).
+- SOV/VSO languages (Japanese, Korean, Turkish, Hindi) have lower round-trip **fidelity** than SVO languages — every non-behavior pattern parses in all 24 priority languages, but faithful command-for-command translation still lags on the hardest reorders. Tracked by the multilingual fidelity ratchet (not `continue-on-error`).
 
 ### Multilingual parse rate ≠ fidelity
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,15 +282,26 @@ the committed baseline:
   band.** See `docs-internal/CORRECTNESS_RELIABILITY_PLAN.md`.
 - **faithful** (fid = 1.0). ~3133. Cross-language `avgFidelity` ≈ 0.93.
 
-The `--regression` gate ratchets on **three** signals (each fails CI; each guarded so
-an un-regenerated baseline never retro-flags):
+The `--regression` gate ratchets on **six** signals (each fails CI; each guarded so
+an un-regenerated baseline never retro-flags — a baseline lacking a signal's field
+yields a 0 delta):
 
 1. **parse-rate** drop > 2pts.
 2. **degenerate ratchet** — a faithful baseline pass that became _degenerate_
    (tolerance 3).
-3. **correctness ratchet (R0)** — a faithful baseline pass that became _lossy_
-   (tolerance 3), **plus** a per-language **avgFidelity** drop > 0.01. This catches
-   the silent command-drops the degenerate ratchet misses (a 1.0 → 0.8 pass).
+3. **correctness ratchet (R0-recall)** — a faithful baseline pass that became _lossy_
+   (tolerance 3), **plus** a per-language **avgFidelity** drop > 0.02. Catches the
+   silent command-drops the degenerate ratchet misses (a 1.0 → 0.8 pass).
+4. **precision ratchet (R0-precision, the "trust floor")** — a per-language
+   **avgPrecision** drop > 0.02. The mirror of recall: catches a parse/render that
+   _adds_ phantom/spurious commands the source never had (a phantom `toggle` ahead of
+   a real one) — invisible to every recall-based signal above. Multiset-aware, so a
+   _duplicated_ phantom (`[toggle, toggle]`) is seen too.
+5. **role-fidelity ratchet (R1)** — a per-language **avgRoleFidelity** drop > 0.02
+   (`action.role:valueType` recall vs the en reference; catches a parse that keeps the
+   verb but drops/mistypes a role).
+6. **execution ratchet (R2)** — a curated-subset pattern whose jsdom DOM effect
+   matched the en reference and now diverges (pass→fail; tolerance 0).
 
 After an _intentional_ fidelity change, regenerate the baseline (`--save-baseline`).
 **The baseline must be regenerated against a freshly `populate`d patterns.db** — a

--- a/packages/semantic/test/lexicon-emit-mismatch.test.ts
+++ b/packages/semantic/test/lexicon-emit-mismatch.test.ts
@@ -9,15 +9,32 @@
  * (the kung/آخر/mettre/동안/wyczyść class — 30+ instances across sessions 2–4)
  * or as nothing at all.
  *
- * KNOWN_MISMATCHES is the ratchet baseline: the mismatches that existed when
- * this test landed (mostly commands with no live corpus pattern — catch,
- * pushUrl — plus tails tracked in the roadmap §10). Fixing one REMOVES its
- * entry (the test fails if an allowlisted entry disappears but is still
- * listed — keep it pruned). Introducing a NEW mismatch fails immediately.
+ * KNOWN_MISMATCHES is the ratchet baseline — the mismatches that existed when
+ * this test landed. Three guards run over it:
+ *   1. NO NEW mismatches — a fresh dict↔profile disagreement fails immediately.
+ *   2. NO STALE entries — an allowlisted entry that is no longer a real mismatch
+ *      (dict changed its emission, or the word now reads correctly) fails so the
+ *      allowlist stays pruned. (Previously promised in this comment but never
+ *      enforced; added 2026-06-15.)
+ *   3. EVERY entry is categorized — see the two buckets below.
+ *
+ * Two categories of allowlisted mismatch:
+ *   • DEAD — the action has no semantic ActionType/schema, so the semantic side
+ *     models no such command and the dict's translation can never be parsed
+ *     (harmless: never exercised by the corpus). These are `DEAD_SCHEMA_COMMANDS`
+ *     (`catch`/`pushUrl`/`replaceUrl` are real _hyperscript commands not yet
+ *     ported to the semantic schema set; `until` is only a loop sub-keyword).
+ *     They are deliberately KEPT — the translations are useful data for when the
+ *     commands gain schemas — not deleted.
+ *   • LIVE — the action IS modeled, but the dict emits a word the profile/patterns
+ *     don't read as that action: a genuine i18n↔profile gap. Fixing one is a
+ *     dict↔profile realign (the proven family) and is fidelity-affecting, so it
+ *     belongs to the fidelity track (Phase 1), not this instrumentation pass.
  */
 import { describe, it, expect } from 'vitest';
 import '../src';
 import { getPatternsForLanguage, tryGetProfile } from '../src/registry';
+import { commandSchemas } from '../src/generators/command-schemas';
 import { dictionaries } from '../../i18n/src/dictionaries';
 
 const LANGS = ['ar','bn','de','es','fr','he','hi','id','it','ja','ko','ms','pl','pt','qu','ru','sw','th','tl','tr','uk','vi','zh'];
@@ -50,7 +67,6 @@ const KNOWN_MISMATCHES = new Set([
   'hi:replaceUrl:url_बदलें',
   'hi:select:चुनें',
   'hi:unless:जब_तक_नहीं',
-  'hi:while:जब_तक',
   'id:break:hentikan',
   'id:catch:tangkap',
   'id:close:tutup',
@@ -197,4 +213,84 @@ describe('i18n dict emissions are readable as the action they translate', () => 
       expect(fresh, `new dict↔profile mismatches:\n${fresh.join('\n')}`).toEqual([]);
     });
   }
+});
+
+// Memoize readings per language for the guards below.
+const readingsCache = new Map<string, Map<string, Set<string>>>();
+function readingsForCached(lang: string): Map<string, Set<string>> {
+  let r = readingsCache.get(lang);
+  if (!r) {
+    r = readingsFor(lang);
+    readingsCache.set(lang, r);
+  }
+  return r;
+}
+
+/**
+ * Commands present in the i18n dicts but with NO semantic ActionType/schema, so
+ * the emission can never be parsed (harmless — never exercised by the corpus).
+ * `catch`/`pushUrl`/`replaceUrl` are real _hyperscript commands not yet ported to
+ * the semantic schema set; `until` is only a loop sub-keyword (`repeat until …`).
+ * Kept (not deleted) so the translations survive for when the commands gain schemas.
+ */
+const DEAD_SCHEMA_COMMANDS = new Set(['catch', 'pushUrl', 'replaceUrl', 'until']);
+
+function parseKey(key: string): { lang: string; action: string; word: string } {
+  const [lang, action, ...rest] = key.split(':');
+  return { lang, action, word: rest.join(':') };
+}
+
+describe('KNOWN_MISMATCHES stays pruned (no stale allowlist entries)', () => {
+  it('every allowlisted entry is still a real, current mismatch', () => {
+    const stale: string[] = [];
+    for (const key of KNOWN_MISMATCHES) {
+      const { lang, action, word } = parseKey(key);
+      const dict = (dictionaries as any)[lang];
+      const emitted = dict?.commands?.[action];
+      if (emitted === undefined) {
+        stale.push(`${key} — dict no longer defines commands.${action}`);
+        continue;
+      }
+      if (String(emitted) !== word) {
+        stale.push(`${key} — dict now emits "${emitted}", not "${word}"`);
+        continue;
+      }
+      const readAs = readingsForCached(lang).get(String(word).toLowerCase()) ?? new Set<string>();
+      if (readAs.has(action)) {
+        stale.push(`${key} — now reads correctly as [${[...readAs].join(',')}]; remove from allowlist`);
+      }
+    }
+    expect(
+      stale,
+      `stale KNOWN_MISMATCHES entries (fixed but still listed — prune them):\n${stale.join('\n')}`
+    ).toEqual([]);
+  });
+});
+
+describe('KNOWN_MISMATCHES entries are categorized (dead-schema vs live-gap)', () => {
+  const modeled = new Set(Object.keys(commandSchemas));
+
+  it('DEAD_SCHEMA_COMMANDS are genuinely unmodeled (no semantic schema)', () => {
+    const wronglyDead = [...DEAD_SCHEMA_COMMANDS].filter(a => modeled.has(a));
+    expect(
+      wronglyDead,
+      `listed DEAD but now HAVE a semantic schema — reclassify as a live i18n gap:\n${wronglyDead.join('\n')}`
+    ).toEqual([]);
+  });
+
+  it('every allowlisted action is either dead-listed or schema-modeled', () => {
+    const uncategorized: string[] = [];
+    for (const key of KNOWN_MISMATCHES) {
+      const { action } = parseKey(key);
+      if (!DEAD_SCHEMA_COMMANDS.has(action) && !modeled.has(action)) {
+        uncategorized.push(`${key} — action "${action}" is neither dead-listed nor schema-modeled`);
+      }
+    }
+    expect(
+      uncategorized,
+      `uncategorized allowlist entries (add the action to DEAD_SCHEMA_COMMANDS or give it a schema):\n${uncategorized.join(
+        '\n'
+      )}`
+    ).toEqual([]);
+  });
 });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-14T20:50:22.560Z",
-  "commit": "fade2a0c",
+  "timestamp": "2026-06-15T20:51:09.831Z",
+  "commit": "cdd2af08",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -8,12 +8,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8403612481675273,
       "avgFidelity": 0.9806096681096683,
+      "avgPrecision": 0.9771645021645022,
       "avgRoleFidelity": 0.8657208782208783,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "repeat-until-event", "window-scroll"],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -639,6 +640,7 @@
       "parseRate": 1,
       "avgConfidence": 0.8397628269808716,
       "avgFidelity": 0.9917929292929292,
+      "avgPrecision": 0.9143148518148518,
       "avgRoleFidelity": 0.7779662342162341,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -651,7 +653,7 @@
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1277,7 +1279,8 @@
       "parseRate": 1,
       "avgConfidence": 0.8301793444650566,
       "avgFidelity": 0.9898088023088022,
-      "avgRoleFidelity": 0.856687962937963,
+      "avgPrecision": 0.9878787878787878,
+      "avgRoleFidelity": 0.8600663413163414,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
@@ -1287,7 +1290,7 @@
         "behavior-resizable",
         "get-value"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1912,7 +1915,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2538,7 +2541,8 @@
       "parseRate": 1,
       "avgConfidence": 0.8330653473510595,
       "avgFidelity": 0.9941378066378065,
-      "avgRoleFidelity": 0.8422364234864237,
+      "avgPrecision": 0.9757575757575757,
+      "avgRoleFidelity": 0.845614801864802,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
@@ -2548,7 +2552,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3174,6 +3178,7 @@
       "parseRate": 1,
       "avgConfidence": 0.8239950525664791,
       "avgFidelity": 0.9941378066378065,
+      "avgPrecision": 0.9804112554112555,
       "avgRoleFidelity": 0.8451080451080453,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -3184,7 +3189,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3810,7 +3815,8 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8266106442577031,
       "avgFidelity": 0.9689179375453884,
-      "avgRoleFidelity": 0.8842397398519849,
+      "avgPrecision": 0.9850762527233116,
+      "avgRoleFidelity": 0.8806116219381527,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable", "unless-condition"],
@@ -3826,7 +3832,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4450,13 +4456,12 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9383198255378694,
-      "avgFidelity": 0.9200036075036074,
-      "avgRoleFidelity": 0.6770324270324272,
+      "avgFidelity": 0.9228896103896104,
+      "avgPrecision": 0.796780600352029,
+      "avgRoleFidelity": 0.6790945540945543,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [
-        "behavior-removable",
-        "behavior-sortable",
         "bind-auto-detect",
         "bind-explicit-property",
         "bind-non-form-display",
@@ -4468,7 +4473,9 @@
       ],
       "lossyPasses": [
         "behavior-draggable",
+        "behavior-removable",
         "behavior-resizable",
+        "behavior-sortable",
         "breakpoint-command",
         "event-throttle",
         "fetch-do-not-throw",
@@ -4477,7 +4484,7 @@
         "template-literal-list-build",
         "unless-condition"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5103,6 +5110,7 @@
       "parseRate": 1,
       "avgConfidence": 0.8382189239332076,
       "avgFidelity": 0.9941378066378065,
+      "avgPrecision": 0.9804112554112555,
       "avgRoleFidelity": 0.8595305032805033,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -5113,7 +5121,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5739,12 +5747,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8357452071737766,
       "avgFidelity": 0.9926948051948052,
+      "avgPrecision": 0.9715058750773035,
       "avgRoleFidelity": 0.8356791294291295,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6370,6 +6379,7 @@
       "parseRate": 1,
       "avgConfidence": 0.8253843483166787,
       "avgFidelity": 0.9816919191919193,
+      "avgPrecision": 0.9093434343434343,
       "avgRoleFidelity": 0.7920982170982173,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -6381,7 +6391,7 @@
         "form-disable-on-submit",
         "unless-condition"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7006,8 +7016,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8073468302791607,
-      "avgFidelity": 0.972492784992785,
-      "avgRoleFidelity": 0.7862374112374113,
+      "avgFidelity": 0.975378787878788,
+      "avgPrecision": 0.9263347763347766,
+      "avgRoleFidelity": 0.7872026622026623,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable", "window-scroll"],
@@ -7020,7 +7031,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7646,6 +7657,7 @@
       "parseRate": 0.974025974025974,
       "avgConfidence": 0.8312063492063471,
       "avgFidelity": 0.9791666666666666,
+      "avgPrecision": 0.9710000000000001,
       "avgRoleFidelity": 0.8610253750878751,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -7657,7 +7669,7 @@
         "last-in-collection",
         "set-color-variable"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8279,7 +8291,8 @@
       "parseRate": 1,
       "avgConfidence": 0.801814058956914,
       "avgFidelity": 0.9912518037518036,
-      "avgRoleFidelity": 0.8395108832608832,
+      "avgPrecision": 0.9817872603586888,
+      "avgRoleFidelity": 0.8445784508284507,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
@@ -8290,7 +8303,7 @@
         "behavior-sortable",
         "get-value"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8916,12 +8929,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7988455988455969,
       "avgFidelity": 0.9853896103896104,
-      "avgRoleFidelity": 0.8578720266220267,
+      "avgPrecision": 0.9731601731601732,
+      "avgRoleFidelity": 0.8612504050004051,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable"],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9547,6 +9561,7 @@
       "parseRate": 1,
       "avgConfidence": 0.7194083694083694,
       "avgFidelity": 0.9774531024531026,
+      "avgPrecision": 0.9315033451397092,
       "avgRoleFidelity": 0.7692548442548439,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -9559,7 +9574,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10185,12 +10200,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8114306328592022,
       "avgFidelity": 0.9862012987012987,
+      "avgPrecision": 0.980813234384663,
       "avgRoleFidelity": 0.8324245011745013,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "install-behavior"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10816,6 +10832,7 @@
       "parseRate": 0.9805194805194806,
       "avgConfidence": 0.7907074529591067,
       "avgFidelity": 0.9779249448123619,
+      "avgPrecision": 0.9804635761589403,
       "avgRoleFidelity": 0.8491843214257009,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -10827,7 +10844,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11450,12 +11467,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8401154401154378,
       "avgFidelity": 0.9904401154401155,
+      "avgPrecision": 0.9728354978354978,
       "avgRoleFidelity": 0.8220028845028845,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "behavior-sortable"],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12081,12 +12099,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8242099391590747,
       "avgFidelity": 0.9816919191919191,
+      "avgPrecision": 0.9771645021645022,
       "avgRoleFidelity": 0.8699587012087014,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "window-scroll"],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12712,6 +12731,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.826390595224444,
       "avgFidelity": 0.9772149600580973,
+      "avgPrecision": 0.9343500363108206,
       "avgRoleFidelity": 0.792152858479389,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -12722,7 +12742,7 @@
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13347,6 +13367,7 @@
       "parseRate": 1,
       "avgConfidence": 0.810688517831373,
       "avgFidelity": 0.9869227994227995,
+      "avgPrecision": 0.980813234384663,
       "avgRoleFidelity": 0.8218901031401032,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -13357,7 +13378,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13983,6 +14004,7 @@
       "parseRate": 1,
       "avgConfidence": 0.8037518037518019,
       "avgFidelity": 0.978625541125541,
+      "avgPrecision": 0.9706400742115028,
       "avgRoleFidelity": 0.8560137497637499,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -13997,7 +14019,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14623,6 +14645,7 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.9871667185392676,
       "avgFidelity": 0.973275236020334,
+      "avgPrecision": 0.9961873638344226,
       "avgRoleFidelity": 0.9095312850414892,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -14638,7 +14661,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 433929,
+      "bundleSize": 438024,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15260,7 +15283,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 433929,
+      "size": 438024,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/src/multilingual/cli.ts
+++ b/packages/testing-framework/src/multilingual/cli.ts
@@ -376,6 +376,17 @@ async function main(): Promise<void> {
           r => r.avgFidelityDelta < -AVG_FIDELITY_DROP_TOLERANCE
         );
 
+        // R0-precision ratchet: same semantics as the avgFidelity ratchet, on
+        // the precision signal (fraction of each parse's actions justified by the
+        // en reference). A drop means a parser/render change started injecting
+        // phantom/spurious commands — invisible to recall. Deltas are 0 unless
+        // the baseline carries avgPrecision, so an un-regenerated baseline never
+        // retro-flags.
+        const AVG_PRECISION_DROP_TOLERANCE = 0.02;
+        const precisionDrops = allResults.filter(
+          r => r.avgPrecisionDelta < -AVG_PRECISION_DROP_TOLERANCE
+        );
+
         // R1 — role-fidelity ratchet (§8): same semantics as the avgFidelity
         // ratchet, on the role-recall signal (action.role:valueType vs the en
         // reference). Deltas are 0 unless the baseline carries avgRoleFidelity,
@@ -456,6 +467,19 @@ async function main(): Promise<void> {
           );
           for (const r of fidelityDrops) {
             console.error(`   ${r.language}: ΔavgFidelity ${r.avgFidelityDelta.toFixed(4)}`);
+          }
+          console.error(`   (if intentional, regenerate the baseline with --save-baseline)`);
+          failed = true;
+        }
+
+        if (precisionDrops.length > 0) {
+          console.error(
+            `\n✗ avgPrecision dropped > ${AVG_PRECISION_DROP_TOLERANCE} in ` +
+              `${precisionDrops.length} language(s) — a parse/render started injecting ` +
+              `phantom commands the source never had:`
+          );
+          for (const r of precisionDrops) {
+            console.error(`   ${r.language}: ΔavgPrecision ${r.avgPrecisionDelta.toFixed(4)}`);
           }
           console.error(`   (if intentional, regenerate the baseline with --save-baseline)`);
           failed = true;

--- a/packages/testing-framework/src/multilingual/orchestrator.ts
+++ b/packages/testing-framework/src/multilingual/orchestrator.ts
@@ -20,7 +20,7 @@ import type {
   Reporter,
   BundleInfo,
 } from './types';
-import { computeFidelity, FIDELITY_THRESHOLD } from './fidelity';
+import { computeFidelity, computePrecision, FIDELITY_THRESHOLD } from './fidelity';
 
 const execAsync = promisify(exec);
 
@@ -254,11 +254,16 @@ export class TestOrchestrator {
 
     // codeExampleId -> English action signature (only successful en parses).
     const reference = new Map<string, string[]>();
+    // R0-precision: codeExampleId -> English action MULTISET (duplicates kept).
+    const multisetReference = new Map<string, string[]>();
     // R1: codeExampleId -> English role signature (action.role:valueType set).
     const roleReference = new Map<string, string[]>();
     for (const r of en.parseResults) {
       if (r.success && r.actionSignature && r.actionSignature.length > 0) {
         reference.set(r.pattern.codeExampleId, r.actionSignature);
+      }
+      if (r.success && r.actionMultisetSignature && r.actionMultisetSignature.length > 0) {
+        multisetReference.set(r.pattern.codeExampleId, r.actionMultisetSignature);
       }
       if (r.success && r.roleSignature && r.roleSignature.length > 0) {
         roleReference.set(r.pattern.codeExampleId, r.roleSignature);
@@ -271,6 +276,7 @@ export class TestOrchestrator {
       const degenerate: string[] = [];
       const lossy: string[] = [];
       const scores: number[] = [];
+      const precisionScores: number[] = [];
       const roleScores: number[] = [];
 
       for (const result of lang.parseResults) {
@@ -286,6 +292,17 @@ export class TestOrchestrator {
         if (fidelity < FIDELITY_THRESHOLD) degenerate.push(result.pattern.codeExampleId);
         else if (fidelity < 1) lossy.push(result.pattern.codeExampleId);
 
+        // R0-precision — fraction of THIS parse's actions justified by the en
+        // multiset reference (catches phantom/spurious commands recall misses).
+        const multisetRef = multisetReference.get(result.pattern.codeExampleId);
+        if (multisetRef && result.actionMultisetSignature) {
+          const precision = computePrecision(multisetRef, result.actionMultisetSignature);
+          if (precision !== undefined) {
+            result.precision = precision;
+            precisionScores.push(precision);
+          }
+        }
+
         // R1 — role recall vs the en role signature (role name + value type).
         const roleRef = roleReference.get(result.pattern.codeExampleId);
         if (roleRef && result.roleSignature) {
@@ -299,6 +316,10 @@ export class TestOrchestrator {
 
       lang.avgFidelity =
         scores.length > 0 ? scores.reduce((a, b) => a + b, 0) / scores.length : undefined;
+      lang.avgPrecision =
+        precisionScores.length > 0
+          ? precisionScores.reduce((a, b) => a + b, 0) / precisionScores.length
+          : undefined;
       lang.avgRoleFidelity =
         roleScores.length > 0
           ? roleScores.reduce((a, b) => a + b, 0) / roleScores.length

--- a/packages/testing-framework/src/multilingual/reporters/regression-reporter.test.ts
+++ b/packages/testing-framework/src/multilingual/reporters/regression-reporter.test.ts
@@ -327,3 +327,80 @@ describe('RegressionReporter execution ratchet — R2 (session 5)', () => {
     expect(saved.languages.ja!.executionFailures).toEqual(['was-failing']);
   });
 });
+
+describe('RegressionReporter precision ratchet — R0-precision (trust floor)', () => {
+  // LOCK: avgPrecision is the phantom-command signal recall (avgFidelity) cannot
+  // see — the fraction of each parse's actions justified by the en reference. The
+  // reporter computes avgPrecisionDelta with the SAME both-sides guard as R1/R2 (an
+  // un-regenerated baseline carries no avgPrecision, so the delta is 0 and nothing
+  // retro-flags). The CLI turns a delta < -0.02 into a CI failure.
+  let dir: string;
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function reporterWith(baseline: Baseline): RegressionReporter {
+    dir = mkdtempSync(join(tmpdir(), 'precision-'));
+    const path = join(dir, 'baseline.json');
+    writeFileSync(path, JSON.stringify(baseline));
+    return new RegressionReporter(path);
+  }
+
+  function langWithPrecision(avgPrecision: number): LanguageResults {
+    const l = lang([pass('stable')], []);
+    l.avgPrecision = avgPrecision;
+    return l;
+  }
+
+  const baseline: Baseline = {
+    timestamp: '',
+    commit: 'base',
+    languages: {
+      ja: {
+        parseSuccess: 1,
+        parseFailure: 0,
+        parseRate: 1,
+        avgConfidence: 1,
+        avgFidelity: 1,
+        avgPrecision: 1,
+        degeneratePasses: [],
+        lossyPasses: [],
+        bundleSize: undefined,
+        patterns: { stable: { success: true, confidence: 1 } },
+      },
+    },
+    bundles: {},
+  };
+
+  it('reports a negative avgPrecisionDelta when precision drops (phantom commands injected)', () => {
+    const reporter = reporterWith(baseline);
+    reporter.reportComplete(results(langWithPrecision(0.9)));
+    const r = reporter.getRegressionResults().find(x => x.language === 'ja')!;
+    expect(r.avgPrecisionDelta).toBeCloseTo(-0.1, 5);
+  });
+
+  it('reports ~0 delta when precision is unchanged', () => {
+    const reporter = reporterWith(baseline);
+    reporter.reportComplete(results(langWithPrecision(1)));
+    const r = reporter.getRegressionResults().find(x => x.language === 'ja')!;
+    expect(r.avgPrecisionDelta).toBeCloseTo(0, 5);
+  });
+
+  it('never retro-flags when the baseline has no precision data', () => {
+    const noPrecision: Baseline = structuredClone(baseline);
+    delete noPrecision.languages.ja!.avgPrecision;
+    const reporter = reporterWith(noPrecision);
+    reporter.reportComplete(results(langWithPrecision(0.1)));
+    const r = reporter.getRegressionResults().find(x => x.language === 'ja')!;
+    expect(r.avgPrecisionDelta).toBe(0);
+  });
+
+  it('persists avgPrecision when saving a baseline', () => {
+    const reporter = reporterWith(baseline);
+    const res = results(langWithPrecision(0.95));
+    reporter.reportComplete(res);
+    reporter.saveAsBaseline(res);
+    const saved = JSON.parse(readFileSync(join(dir, 'baseline.json'), 'utf-8')) as Baseline;
+    expect(saved.languages.ja!.avgPrecision).toBeCloseTo(0.95, 5);
+  });
+});

--- a/packages/testing-framework/src/multilingual/reporters/regression-reporter.ts
+++ b/packages/testing-framework/src/multilingual/reporters/regression-reporter.ts
@@ -112,6 +112,12 @@ export class RegressionReporter implements Reporter {
       const parseRateDelta = (langResult.parseRate - baselineLang.parseRate) * 100;
       const avgConfidenceDelta = langResult.avgConfidence - baselineLang.avgConfidence;
       const avgFidelityDelta = (langResult.avgFidelity ?? 0) - (baselineLang.avgFidelity ?? 0);
+      // R0-precision — both-sides guard: an un-regenerated baseline (no
+      // avgPrecision yet) must never retro-flag.
+      const avgPrecisionDelta =
+        langResult.avgPrecision !== undefined && baselineLang.avgPrecision !== undefined
+          ? langResult.avgPrecision - baselineLang.avgPrecision
+          : 0;
       // R1 — only meaningful when BOTH sides carry role data; an un-regenerated
       // baseline (no avgRoleFidelity yet) must never retro-flag.
       const avgRoleFidelityDelta =
@@ -156,6 +162,7 @@ export class RegressionReporter implements Reporter {
         parseRateDelta,
         avgConfidenceDelta,
         avgFidelityDelta,
+        avgPrecisionDelta,
         avgRoleFidelityDelta,
         avgExecutionFidelityDelta,
         bundleSizeDelta: bundleSizeDelta !== undefined ? bundleSizeDelta : undefined,
@@ -354,6 +361,9 @@ export class RegressionReporter implements Reporter {
         // Structural fidelity vs the English reference parse — tracks degenerate
         // (non-null but shallow) passes that the parse rate alone can't surface.
         avgFidelity: langResult.avgFidelity ?? undefined,
+        // R0-precision — fraction of each parse's actions justified by the en
+        // reference (phantom-command signal recall can't see). Recorded + ratcheted.
+        avgPrecision: langResult.avgPrecision ?? undefined,
         // R1 — role fidelity (role name + value type vs the en reference).
         // Recorded + ratcheted; burn-down is NOT part of the parsing-track goal.
         avgRoleFidelity: langResult.avgRoleFidelity ?? undefined,

--- a/packages/testing-framework/src/multilingual/types.ts
+++ b/packages/testing-framework/src/multilingual/types.ts
@@ -124,6 +124,13 @@ export interface ParseResult {
   actionSignature?: string[];
 
   /**
+   * R0-precision — multiset of command actions (duplicates preserved). Lets a
+   * *duplicated* spurious action (a phantom `toggle` ahead of a real one) be
+   * counted, which the deduped `actionSignature` absorbs. Set by the validator.
+   */
+  actionMultisetSignature?: string[];
+
+  /**
    * R1 — role-level signature: `action.role:valueType` for every command node
    * in the tree (`add.patient:selector`, `put.destination:reference`).
    * Cross-language comparison is by role name + value TYPE, never the value
@@ -140,6 +147,15 @@ export interface ParseResult {
    * usable English reference or this parse failed.
    */
   fidelity?: number;
+
+  /**
+   * R0-precision vs the English reference, in [0, 1]: the fraction of *this*
+   * parse's actions justified by the English reference (multiset-aware). Falls
+   * below 1.0 when the parse/render adds commands the source never had — the
+   * phantom-injection signal recall cannot see. `undefined` when this parse has
+   * no actions or there is no usable English reference.
+   */
+  precision?: number;
 
   /**
    * R1 — role fidelity vs the English reference, in [0, 1]: the fraction of the
@@ -181,6 +197,13 @@ export interface LanguageResults {
    * reference (see ParseResult.fidelity). `undefined` for English itself.
    */
   avgFidelity?: number | undefined;
+
+  /**
+   * R0-precision — mean `precision` over successful parses with an English
+   * reference. Recorded + ratcheted alongside avgFidelity: a drop means a parser
+   * change started injecting phantom/spurious commands (invisible to recall).
+   */
+  avgPrecision?: number | undefined;
 
   /**
    * R1 — mean `roleFidelity` over successful parses with an English reference.
@@ -273,6 +296,8 @@ export interface Baseline {
         avgConfidence: number;
         /** Mean structural fidelity vs the English reference parse (see ParseResult.fidelity). */
         avgFidelity?: number | undefined;
+        /** R0-precision — mean precision vs the English reference (see ParseResult.precision). */
+        avgPrecision?: number | undefined;
         /** R1 — mean role fidelity vs the English reference (see ParseResult.roleFidelity). */
         avgRoleFidelity?: number | undefined;
         /** R2 — mean execution fidelity over the curated execution subset (see LanguageResults.avgExecutionFidelity). */
@@ -308,6 +333,8 @@ export interface RegressionResult {
   avgConfidenceDelta: number; // absolute change
   /** Absolute change in avgFidelity (current − baseline). Negative = correctness drop. */
   avgFidelityDelta: number;
+  /** R0-precision — absolute change in avgPrecision (current − baseline). 0 when either side lacks data. Negative = phantom commands introduced. */
+  avgPrecisionDelta: number;
   /** R1 — absolute change in avgRoleFidelity (current − baseline). 0 when either side lacks data. */
   avgRoleFidelityDelta: number;
   /** R2 — absolute change in avgExecutionFidelity (current − baseline). 0 when either side lacks data. */

--- a/packages/testing-framework/src/multilingual/validators/parse-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/parse-validator.ts
@@ -5,7 +5,7 @@
 import { MultilingualHyperscript } from '@hyperfixi/core/multilingual';
 import type { SemanticNode } from '@lokascript/semantic';
 import type { PatternTranslation, ParseResult, Validator } from '../types';
-import { collectActions, collectRoleSignature } from '../fidelity';
+import { collectActions, collectActionsMultiset, collectRoleSignature } from '../fidelity';
 
 /**
  * Parse Validator
@@ -87,6 +87,9 @@ export class ParseValidator implements Validator<ParseResult[]> {
         parser: 'semantic',
         // Structural signature for cross-language fidelity scoring (see fidelity.ts).
         actionSignature: collectActions(semanticNode),
+        // R0-precision multiset signature — duplicates preserved so a phantom
+        // command duplicated ahead of a real one (`[toggle, toggle]`) is visible.
+        actionMultisetSignature: collectActionsMultiset(semanticNode),
         // R1 role signature (role name + value type per command) — collected here
         // because live nodes carry roles as a ReadonlyMap that serializes to {}.
         roleSignature: collectRoleSignature(semanticNode),


### PR DESCRIPTION
## Why

The multilingual fidelity gate measured **recall** (does the en reference's commands survive a translation?) but was blind to the mirror failure: a parse/render that **adds** commands the source never had — a phantom \`toggle\` ahead of a real one. Recall scores those 1.0; the translation is wrong. This PR adds the **R0-precision** signal (the "trust floor") as a fourth gate ratchet and activates it.

## What changed

- **`cdd2af08` — R0-precision wiring.** Multiset action signature → per-parse \`precision\` (via the existing \`computePrecision\`) → per-language \`avgPrecision\` → \`avgPrecisionDelta\` (both-sides guarded, like R1/R2) → CLI ratchet at −0.02. Reuses \`computePrecision\`/\`collectActionsMultiset\` already unit-tested in \`fidelity.test.ts\` (Phase 0). New \`regression-reporter.test.ts\` block covers the wiring (drop→negative delta, unchanged→~0, no-baseline→0 guard, persistence).
- **`0af855c0` — activation + docs.** Regenerated the committed browser-priority baseline against a fresh \`populate\` so it carries \`avgPrecision\` for all 23 priority languages (range 0.797–0.996). Until now the ratchet was dormant (no baseline field → 0 delta); it's now live. Fresh-populate jitter is within tolerance and mostly positive (avgFidelity +0.003 on 2 langs; avgRoleFidelity worst drop 0.0036, far inside 0.02; parse-rate unchanged). Reconciled the `CLAUDE.md` gate doc, which said "three signals" and predated R1/R2 — now lists all **six** (parse-rate, degenerate, R0-recall, R0-precision, R1, R2) and fixes a stale tolerance (0.01 → 0.02).

Also on this branch (pre-existing, ancillary): `53d0ce8a` docs(ci) stale-flag correction, `8dff4338` test(semantic) lexicon-allowlist self-pruning.

## Verification

- `--regression` against the new baseline is **green** ("✓ No regression vs baseline").
- Testing-framework multilingual suite 44/44; typecheck clean.
- `patterns.db` intentionally not committed (repo convention — CI re-populates).

## Follow-up (not in this PR)

The new signal already maps where phantom injection happens — the SOV cluster, led by **hi at 0.797 precision** (vs 0.92 recall). That residual phantom-command bug is the natural next investigation now that it's quantified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)