### PR TITLE
fix(semantic): disambiguate Hindi markers — first catch by the precision trust floor

### DIFF
--- a/packages/semantic/src/generators/profiles/hindi.ts
+++ b/packages/semantic/src/generators/profiles/hindi.ts
@@ -61,7 +61,10 @@ export const hindiProfile: LanguageProfile = {
   },
   roleMarkers: {
     patient: { primary: 'को', position: 'after' },
-    destination: { primary: 'में', alternatives: ['को', 'पर'], position: 'after' },
+    // `को` is the accusative/patient marker only — NOT a destination alternative.
+    // Listing it here made a `को`-marked patient mis-parse as a destination, the
+    // dominant source of phantom `into` commands in hi (precision audit 2026-06-15).
+    destination: { primary: 'में', alternatives: ['पर'], position: 'after' },
     source: { primary: 'से', position: 'after' },
     style: { primary: 'से', position: 'after' },
     event: { primary: 'पर', position: 'after' },
@@ -170,7 +173,9 @@ export const hindiProfile: LanguageProfile = {
     pick: { primary: 'चुनें', alternatives: [], normalized: 'pick' },
     render: { primary: 'रेंडर', alternatives: [], normalized: 'render' },
     // Modifiers
-    into: { primary: 'में', alternatives: ['को'], normalized: 'into' },
+    // `में` (locative "into") only — `को` (accusative) is not an `into` keyword.
+    // The overload made every `को`-marked patient emit a phantom `into` command.
+    into: { primary: 'में', alternatives: [], normalized: 'into' },
     before: { primary: 'से पहले', alternatives: ['पहले'], normalized: 'before' },
     after: { primary: 'के बाद', alternatives: ['बाद'], normalized: 'after' },
     until: { primary: 'तक', alternatives: [], normalized: 'until' },
@@ -202,7 +207,9 @@ export const hindiProfile: LanguageProfile = {
     // Event marker: पर (at/on), used in SOV pattern
     // Pattern: [event] पर [destination का?] [patient] को [action]
     // Example: क्लिक पर #button का .active को टॉगल
-    eventMarker: { primary: 'पर', alternatives: ['में'], position: 'after' },
+    // `में` is the locative/destination marker, NOT an event marker — listing it
+    // here made a `में`-marked destination mis-parse as a phantom event handler (`on`).
+    eventMarker: { primary: 'पर', alternatives: [], position: 'after' },
     temporalMarkers: ['जब', 'जब भी'], // temporal conjunctions (when, whenever)
   },
 };

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-15T20:51:09.831Z",
-  "commit": "cdd2af08",
+  "timestamp": "2026-06-15T21:28:36.532Z",
+  "commit": "0af855c0",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -4456,9 +4456,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9383198255378694,
-      "avgFidelity": 0.9228896103896104,
-      "avgPrecision": 0.796780600352029,
-      "avgRoleFidelity": 0.6790945540945543,
+      "avgFidelity": 0.9409271284271283,
+      "avgPrecision": 0.8129727415441702,
+      "avgRoleFidelity": 0.6818294318294321,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [
@@ -4466,7 +4466,6 @@
         "bind-explicit-property",
         "bind-non-form-display",
         "bind-two-way",
-        "install-behavior",
         "intercept-cache-strategies",
         "live-derived-value",
         "live-multiple-deps"
@@ -4476,12 +4475,8 @@
         "behavior-removable",
         "behavior-resizable",
         "behavior-sortable",
-        "breakpoint-command",
-        "event-throttle",
         "fetch-do-not-throw",
-        "fetch-json",
         "keydown-key-is-syntax",
-        "template-literal-list-build",
         "unless-condition"
       ],
       "bundleSize": 438024,


### PR DESCRIPTION
**Stacked on #433** (the R0-precision trust floor) — this is the floor's first real catch.

## The bug

The precision audit ranked **hi lowest (0.797)** with a dominant phantom: `into` ×70. Root cause = marker overloading in the Hindi profile. Hindi's two highest-frequency postpositions were each *also* claimed by a command/handler keyword:

- `को` (accusative/patient marker — on every patient) was also an `into` keyword alternative + a `destination` alternative
- `में` (locative "into") was also an `eventMarker` alternative

So a `को`-marked patient emitted a phantom `into`, and a `में`-marked destination emitted a phantom `on` handler — **dropping the real command**:

```
.active को टॉगल   ("toggle .active")   →  [into, on]      // toggle lost!  (before)
.active को टॉगल   ("toggle .active")   →  [on, toggle]    // recovered     (after)
```

## The fix

Give each high-frequency postposition one role (`hindi.ts`):
- `को` → patient only (removed from `destination.alternatives`, `into.alternatives`)
- `में` → destination/into only (removed from `eventMarker.alternatives`)

## Validated against the trust floor

| metric (hi) | Δ | new |
|---|---|---|
| avgPrecision | **+0.0162** | 0.813 |
| avgFidelity | **+0.0180** | — |
| avgRoleFidelity | +0.0027 | — |

Recall went **up** (the recovered `toggle` outweighs shifted mis-parses) — a real correctness gain, not shuffling. **No other language's baseline metrics changed** (isolated to hi). `--regression` green; hi semantic unit tests 102/102.

## Scope / follow-ups (called out, not done here)

- Not a complete fix — hi is still the lowest-precision language. The residual phantoms come from a *deeper* overload: `में` is both the `into` keyword primary **and** the `destination` roleMarker primary, so the matcher still sometimes picks "into command" over "destination marker." That's a parser-disambiguation change, separate from this profile cleanup.
- ja/ko/bn have *milder* destination↔eventMarker overlaps (0.91–0.93) that are more linguistically defensible — each needs its own audit before touching.
- Reactive/htmx verbs (`bind`/`live`/`intercept`/`eventsource`) have no Hindi keyword → unrecognized (a vocab gap, separate from phantoms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)