### PR TITLE
fix(ci): track gitignored browser-test fixtures (fixes Browser Tests 25/92)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -682,13 +682,30 @@ jobs:
         run: npx playwright test --project=quick
         working-directory: packages/core
 
+      # NOTE: paths are relative to the repo root, NOT this job's
+      # working-directory. The report/traces are written under
+      # packages/core/ (the Playwright cwd), so the path must be
+      # `packages/core/...` — a bare `./core/...` resolves to a
+      # nonexistent repo-root dir and silently uploads nothing.
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report
-          path: ./core/playwright-report/
+          path: packages/core/playwright-report/
           retention-days: 3
+
+      # Traces (trace: 'on-first-retry') + error-context land in test-results/.
+      # Without this, a failing run leaves nothing to inspect — which is exactly
+      # why the semantic-bundle load flake went undiagnosed for so long.
+      - name: Upload Playwright traces
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-traces
+          path: packages/core/test-results/**
+          retention-days: 3
+          if-no-files-found: ignore
 
   # ============================================
   # Job 7: Multilingual Validation

--- a/.gitignore
+++ b/.gitignore
@@ -189,6 +189,13 @@ packages/*/html/
 !**/test-dashboard.html
 !**/test-measure-css-properties.html
 !examples/**/test-*.html
+# Playwright browser-test fixtures (load the semantic / multilingual bundles).
+# These are CI test infrastructure, not throwaway debug files — they MUST be
+# tracked, or a fresh CI checkout 404s on them and the whole semantic /
+# multilingual browser-test cluster fails with `window.LokaScriptSemantic`
+# undefined. (Regression fixed after they were silently ignored by test-*.html.)
+!**/test-browser.html
+!**/test-multilingual-e2e.html
 
 # MCP server files
 mcp-server-hyperscript/dist/

--- a/packages/core/src/compatibility/browser-tests/helpers/semantic-page.ts
+++ b/packages/core/src/compatibility/browser-tests/helpers/semantic-page.ts
@@ -6,52 +6,45 @@
  * ~906 KB IIFE bundle (`dist/browser.global.js`) and expose
  * `window.LokaScriptSemantic`.
  *
- * On resource-pressured CI runners that large, uncached asset (the webServer
- * runs `http-server -c-1`) intermittently fails to fully load/execute before
- * the test reads the global, so `window.LokaScriptSemantic` is `undefined` and
- * every assertion in the spec throws `Cannot read properties of undefined`.
- * The bundle itself is byte-identical between passing and failing runs — it is
- * purely a transient load flake, so a bounded re-navigation self-heals it
- * within the test instead of burning all of Playwright's full-test retries
- * against one bad page load.
+ * History: these specs failed 25/92 on every CI run because the fixture HTML
+ * was matched by a `test-*.html` glob in .gitignore and never tracked — so a
+ * fresh CI checkout 404'd on it, the page never loaded the bundle, and every
+ * assertion threw `Cannot read properties of undefined`. The real fix is
+ * tracking the fixture (see the .gitignore negation). This helper stays as a
+ * cheap guard: instead of an opaque `undefined` deref, it fails with a clear
+ * message — and paired with the uploaded Playwright trace, the network 404 /
+ * console error is one click away.
  */
 import type { Page } from '@playwright/test';
 
 const SEMANTIC_FIXTURE = '/packages/semantic/test-browser.html';
 
-/** Number of navigation attempts before giving up (1 initial + retries). */
-const MAX_ATTEMPTS = 3;
-
 /**
  * Navigate to the semantic test page and wait until the bundle's global is
- * present. Reloads (up to {@link MAX_ATTEMPTS} total) if the global hasn't
- * appeared, which recovers from a transient/truncated bundle download. Throws
- * with a clear message — not an opaque `undefined` deref — if it never loads.
+ * present, throwing a clear, trace-pointing error (not an opaque `undefined`
+ * deref) if the fixture or bundle fails to load.
  */
 export async function gotoSemanticPage(page: Page): Promise<void> {
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    if (attempt === 1) {
-      await page.goto(SEMANTIC_FIXTURE);
-    } else {
-      await page.reload();
-    }
-    try {
-      // The IIFE assigns window.LokaScriptSemantic synchronously once it
-      // executes; if the script truly loaded, this resolves immediately.
-      await page.waitForFunction(() => 'LokaScriptSemantic' in window, undefined, {
-        timeout: 10_000,
-      });
-      return;
-    } catch {
-      if (attempt === MAX_ATTEMPTS) {
-        throw new Error(
-          `window.LokaScriptSemantic never became defined after ${MAX_ATTEMPTS} ` +
-            `loads of ${SEMANTIC_FIXTURE}. The semantic browser bundle ` +
-            `(dist/browser.global.js) failed to load or execute — check the ` +
-            `Playwright trace (network + console) for the bundle request.`
-        );
-      }
-      // else: loop and reload to retry the bundle download.
-    }
+  const response = await page.goto(SEMANTIC_FIXTURE);
+  if (response && !response.ok()) {
+    throw new Error(
+      `${SEMANTIC_FIXTURE} returned HTTP ${response.status()} — the fixture is ` +
+        `not being served (is it tracked in git? it's otherwise ignored by ` +
+        `**/test-*.html). Check the Playwright trace for the failed request.`
+    );
+  }
+  try {
+    // The IIFE assigns window.LokaScriptSemantic synchronously once it
+    // executes; if the page + script loaded, this resolves immediately.
+    await page.waitForFunction(() => 'LokaScriptSemantic' in window, undefined, {
+      timeout: 8_000,
+    });
+  } catch {
+    throw new Error(
+      `window.LokaScriptSemantic never became defined after loading ` +
+        `${SEMANTIC_FIXTURE}. The semantic browser bundle ` +
+        `(dist/browser.global.js) failed to load or execute — check the ` +
+        `Playwright trace (network + console) for the bundle request.`
+    );
   }
 }

--- a/packages/core/src/compatibility/browser-tests/helpers/semantic-page.ts
+++ b/packages/core/src/compatibility/browser-tests/helpers/semantic-page.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared navigation helper for the semantic browser-bundle specs.
+ *
+ * Both `semantic-package.spec.ts` and `semantic-multilingual.spec.ts` load
+ * `/packages/semantic/test-browser.html`, whose only job is to pull in the
+ * ~906 KB IIFE bundle (`dist/browser.global.js`) and expose
+ * `window.LokaScriptSemantic`.
+ *
+ * On resource-pressured CI runners that large, uncached asset (the webServer
+ * runs `http-server -c-1`) intermittently fails to fully load/execute before
+ * the test reads the global, so `window.LokaScriptSemantic` is `undefined` and
+ * every assertion in the spec throws `Cannot read properties of undefined`.
+ * The bundle itself is byte-identical between passing and failing runs — it is
+ * purely a transient load flake, so a bounded re-navigation self-heals it
+ * within the test instead of burning all of Playwright's full-test retries
+ * against one bad page load.
+ */
+import type { Page } from '@playwright/test';
+
+const SEMANTIC_FIXTURE = '/packages/semantic/test-browser.html';
+
+/** Number of navigation attempts before giving up (1 initial + retries). */
+const MAX_ATTEMPTS = 3;
+
+/**
+ * Navigate to the semantic test page and wait until the bundle's global is
+ * present. Reloads (up to {@link MAX_ATTEMPTS} total) if the global hasn't
+ * appeared, which recovers from a transient/truncated bundle download. Throws
+ * with a clear message — not an opaque `undefined` deref — if it never loads.
+ */
+export async function gotoSemanticPage(page: Page): Promise<void> {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    if (attempt === 1) {
+      await page.goto(SEMANTIC_FIXTURE);
+    } else {
+      await page.reload();
+    }
+    try {
+      // The IIFE assigns window.LokaScriptSemantic synchronously once it
+      // executes; if the script truly loaded, this resolves immediately.
+      await page.waitForFunction(() => 'LokaScriptSemantic' in window, undefined, {
+        timeout: 10_000,
+      });
+      return;
+    } catch {
+      if (attempt === MAX_ATTEMPTS) {
+        throw new Error(
+          `window.LokaScriptSemantic never became defined after ${MAX_ATTEMPTS} ` +
+            `loads of ${SEMANTIC_FIXTURE}. The semantic browser bundle ` +
+            `(dist/browser.global.js) failed to load or execute — check the ` +
+            `Playwright trace (network + console) for the bundle request.`
+        );
+      }
+      // else: loop and reload to retry the bundle download.
+    }
+  }
+}

--- a/packages/core/src/compatibility/browser-tests/semantic-multilingual.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/semantic-multilingual.spec.ts
@@ -6,12 +6,13 @@
  */
 
 import { test, expect } from '@playwright/test';
+import { gotoSemanticPage } from './helpers/semantic-page';
 
 test.describe('Semantic Multilingual Parser', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to the semantic package test page
-    // page.goto waits for 'load' event, so the bundle should be ready after this
-    await page.goto('/packages/semantic/test-browser.html');
+    // Navigate to the semantic package test page, waiting for the bundle's
+    // global and reloading to recover from a transient CI bundle-load flake.
+    await gotoSemanticPage(page);
   });
 
   test('bundle loads and exposes LokaScriptSemantic global @quick', async ({ page }) => {

--- a/packages/core/src/compatibility/browser-tests/semantic-multilingual.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/semantic-multilingual.spec.ts
@@ -11,7 +11,7 @@ import { gotoSemanticPage } from './helpers/semantic-page';
 test.describe('Semantic Multilingual Parser', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to the semantic package test page, waiting for the bundle's
-    // global and reloading to recover from a transient CI bundle-load flake.
+    // global and failing with a clear, trace-pointing error if it 404s.
     await gotoSemanticPage(page);
   });
 

--- a/packages/core/src/compatibility/browser-tests/semantic-package.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/semantic-package.spec.ts
@@ -10,10 +10,13 @@
  */
 
 import { test, expect } from '@playwright/test';
+import { gotoSemanticPage } from './helpers/semantic-page';
 
 test.describe('HyperFixi Semantic Parser Bundle', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/packages/semantic/test-browser.html');
+    // Loads the ~906 KB semantic bundle and waits for window.LokaScriptSemantic,
+    // reloading to recover from a transient CI bundle-load flake.
+    await gotoSemanticPage(page);
   });
 
   test('bundle loads and exposes LokaScriptSemantic global @quick', async ({ page }) => {

--- a/packages/core/src/compatibility/browser-tests/semantic-package.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/semantic-package.spec.ts
@@ -14,8 +14,8 @@ import { gotoSemanticPage } from './helpers/semantic-page';
 
 test.describe('HyperFixi Semantic Parser Bundle', () => {
   test.beforeEach(async ({ page }) => {
-    // Loads the ~906 KB semantic bundle and waits for window.LokaScriptSemantic,
-    // reloading to recover from a transient CI bundle-load flake.
+    // Loads the fixture + ~906 KB semantic bundle and waits for
+    // window.LokaScriptSemantic, failing with a clear, trace-pointing error.
     await gotoSemanticPage(page);
   });
 

--- a/packages/core/test-multilingual-e2e.html
+++ b/packages/core/test-multilingual-e2e.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Multilingual E2E Test</title>
+</head>
+<body>
+  <div id="test-element"></div>
+  <button id="test-button">Click</button>
+
+  <!-- Load semantic bundle first (absolute path) -->
+  <script src="/packages/semantic/dist/browser.global.js"></script>
+
+  <!-- Then load multilingual bundle (absolute path) -->
+  <script src="/packages/core/dist/lokascript-multilingual.js"></script>
+
+  <script>
+    // Mark bundles as ready
+    window.bundlesReady = false;
+    if (typeof window.LokaScriptSemantic !== 'undefined' && typeof window.lokascript !== 'undefined') {
+      window.bundlesReady = true;
+      console.log('Both bundles loaded successfully');
+    } else {
+      console.error('Bundle loading failed:', {
+        semantic: typeof window.LokaScriptSemantic !== 'undefined',
+        hyperfixi: typeof window.lokascript !== 'undefined'
+      });
+    }
+  </script>
+</body>
+</html>

--- a/packages/semantic/test-browser.html
+++ b/packages/semantic/test-browser.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Semantic Parser - Browser Test Page</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            padding: 20px;
+            background: #1a1a2e;
+            color: #e0e0e0;
+        }
+        .status {
+            padding: 10px 15px;
+            border-radius: 8px;
+            margin: 10px 0;
+        }
+        .status.success {
+            background: rgba(40, 167, 69, 0.2);
+            border: 1px solid #28a745;
+        }
+        .status.error {
+            background: rgba(220, 53, 69, 0.2);
+            border: 1px solid #dc3545;
+        }
+        code {
+            background: #2d2d3d;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-family: 'Monaco', 'Menlo', monospace;
+        }
+    </style>
+</head>
+<body>
+    <h1>Semantic Parser - Browser Test Page</h1>
+    <p>This page loads the LokaScriptSemantic bundle for Playwright browser tests.</p>
+
+    <div id="status">Loading bundle...</div>
+    <div id="api-check"></div>
+
+    <!-- Load the semantic browser bundle -->
+    <script src="./dist/browser.global.js"></script>
+    <script>
+        const statusEl = document.getElementById('status');
+        const apiCheckEl = document.getElementById('api-check');
+
+        // Check if bundle loaded
+        if (typeof window.LokaScriptSemantic !== 'undefined') {
+            statusEl.className = 'status success';
+            statusEl.innerHTML = 'Bundle loaded successfully! <code>window.LokaScriptSemantic</code> is available.';
+
+            // Check available API
+            const S = window.LokaScriptSemantic;
+            const api = [
+                ['parse', typeof S.parse],
+                ['translate', typeof S.translate],
+                ['toExplicit', typeof S.toExplicit],
+                ['fromExplicit', typeof S.fromExplicit],
+                ['canParse', typeof S.canParse],
+                ['getSupportedLanguages', typeof S.getSupportedLanguages],
+                ['createSemanticAnalyzer', typeof S.createSemanticAnalyzer],
+                ['tokenize', typeof S.tokenize],
+                ['getAllTranslations', typeof S.getAllTranslations],
+                ['roundTrip', typeof S.roundTrip],
+                ['isExplicitSyntax', typeof S.isExplicitSyntax],
+            ];
+
+            let apiHtml = '<h2>API Check</h2><ul>';
+            for (const [name, type] of api) {
+                const ok = type === 'function';
+                apiHtml += `<li><code>${name}</code>: ${ok ? 'function' : type}</li>`;
+            }
+            apiHtml += '</ul>';
+
+            // Check supported languages
+            if (typeof S.getSupportedLanguages === 'function') {
+                const langs = S.getSupportedLanguages();
+                apiHtml += `<h2>Supported Languages (${langs.length})</h2>`;
+                apiHtml += `<p>${langs.join(', ')}</p>`;
+            }
+
+            apiCheckEl.innerHTML = apiHtml;
+
+        } else {
+            statusEl.className = 'status error';
+            statusEl.innerHTML = 'Bundle failed to load! <code>window.LokaScriptSemantic</code> is undefined.';
+            apiCheckEl.innerHTML = '<p>Run <code>npm run build:browser --prefix packages/semantic</code> to build the bundle.</p>';
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Real root cause (corrected)

Browser Tests failed **25/92 on every PR run** — semantic-package, semantic-multilingual,
and multilingual-e2e specs. Not flaky; not the bundle.

The downloaded Playwright trace from a failing run shows the **fixture HTML itself 404ing**:
`GET /packages/core/test-multilingual-e2e.html → 404`. The page therefore never loaded any
bundle, so `window.LokaScriptSemantic` / `window.hyperfixi` were `undefined` and every
assertion threw `Cannot read properties of undefined`.

Cause: both fixtures are matched by the `test-*.html` glob in `.gitignore` and were **never
tracked**, so a fresh CI checkout doesn't have them (global-setup doesn't generate them;
build-artifacts don't include them). Both sampled runs end with
`##[error]Process completed with exit code 1` — consistent. The original "flaky /
byte-identical bundle / runner regression" framing (and the handoff doc's "fixture is
git-tracked") was wrong, traced to unreliable `gh` job-conclusion output.

## Fix

1. **Track the two fixtures** (`packages/semantic/test-browser.html`,
   `packages/core/test-multilingual-e2e.html`) via `.gitignore` negations — matching the
   existing `!**/test-runner.html` convention. Their `<script>` srcs already resolve to
   build-artifact dist files (incl. the `lokascript-*` alias).
2. **Make traces retrievable** — fix the report path (`./core/...` → `packages/core/...`)
   and add a `playwright-traces` upload of `packages/core/test-results/**`. This is what
   surfaced the 404 and made the bug diagnosable.
3. Replace the (mis-diagnosed) reload-loop with a `goto` + `waitForFunction` guard that
   fails with a clear, trace-pointing message instead of an opaque `undefined` deref.

## Verification

`npx playwright test --project=quick multilingual-e2e.spec.ts semantic-package.spec.ts
semantic-multilingual.spec.ts` → **25/25 pass**. The CI-specific part (fixtures now in a
fresh checkout) is verified by CI on this PR.

## Commits
- `fc40de28` — trace-upload fix + (mis-diagnosed) reload-loop. Keep the trace-upload half.
- `f869d723` — real fix: track the gitignored fixtures; replace the reload-loop with a
  clear-error guard. *Squashable on merge.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)