### PR TITLE
fix(parser): preserve whitespace in CSS object-literal values

### DIFF
--- a/packages/core/src/parser/css-object-literal-whitespace.test.ts
+++ b/packages/core/src/parser/css-object-literal-whitespace.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from './parser';
+
+/**
+ * Regression guard for `parseCSSObjectLiteral` value reconstruction.
+ *
+ * The CSS object-literal value used to be rebuilt with `valueTokens.join('')`,
+ * which discards the whitespace the tokenizer skipped. That corrupted two things:
+ *   1. `${a - b}` interpolation expressions → `${a-b}`, which then mis-tokenizes as
+ *      a single hyphenated identifier and evaluates to `undefined` (this is what
+ *      silently broke the Draggable/Sortable/Resizable behavior sources — their
+ *      `add { left: ${clientX - xoff}px }` produced `NaNpx` and never moved).
+ *   2. multi-word CSS values (`1px solid red`, `calc(100% - 2px)`) → mangled.
+ *
+ * The fix reconstructs the value verbatim from source offsets, preserving spacing.
+ */
+
+/** Walk to the first object-literal property value node. */
+function firstStyleValue(src: string): any {
+  const ast: any = parse(src);
+  const find = (o: any): any => {
+    if (!o || typeof o !== 'object') return null;
+    if (o.type === 'objectLiteral') return o.properties?.[0]?.value;
+    for (const k of Object.keys(o)) {
+      const hit = find(o[k]);
+      if (hit) return hit;
+    }
+    return null;
+  };
+  return find(ast);
+}
+
+describe('parseCSSObjectLiteral — value whitespace preservation', () => {
+  it('preserves spaces inside ${ } interpolation expressions', () => {
+    const v = firstStyleValue('add { left: ${clientX - xoff}px } to me');
+    expect(v?.type).toBe('templateLiteral');
+    expect(v.value).toBe('${clientX - xoff}px');
+  });
+
+  it('preserves spaces in a two-property style with interpolation', () => {
+    const v = firstStyleValue('add { left: ${a - b}px; top: ${c - d}px } to me');
+    expect(v.value).toBe('${a - b}px');
+  });
+
+  it('preserves spaces in multi-word CSS values', () => {
+    const v = firstStyleValue('add { border: 1px solid red } to me');
+    // join('') would have produced "1pxsolidred"
+    expect(String(v.value)).toBe('1px solid red');
+  });
+
+  it('preserves spaces inside calc()', () => {
+    const v = firstStyleValue('add { width: calc(100% - 20px) } to me');
+    expect(String(v.value)).toBe('calc(100% - 20px)');
+  });
+
+  it('still handles a simple single-token value', () => {
+    const v = firstStyleValue('add { opacity: 0.5 } to me');
+    expect(String(v.value)).toBe('0.5');
+  });
+});

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -1972,6 +1972,12 @@ export class Parser {
       const valueTokens: string[] = [];
       let hasTemplateExpression = false;
       let braceDepth = 0;
+      // Track source offsets so we can reconstruct the value verbatim (preserving
+      // internal whitespace). Joining token values discards the whitespace the
+      // tokenizer skipped, which corrupts both `${a - b}` interpolation
+      // expressions and multi-word CSS values (`1px solid red`, `calc(100% - 2px)`).
+      let valueStart = -1;
+      let valueEnd = -1;
 
       while (!this.isAtEnd()) {
         // Check for end of value (only when not inside ${})
@@ -1981,6 +1987,8 @@ export class Parser {
 
         const token = this.advance();
         valueTokens.push(token.value);
+        if (valueStart < 0 && typeof token.start === 'number') valueStart = token.start;
+        if (typeof token.end === 'number') valueEnd = token.end;
 
         // Track brace depth for ${} template expressions
         if (token.value === '$' && this.check('{')) {
@@ -1994,8 +2002,12 @@ export class Parser {
         }
       }
 
-      // Combine tokens into a single value string
-      const valueString = valueTokens.join('');
+      // Reconstruct the value verbatim from source when offsets are available
+      // (preserves internal whitespace); fall back to a tight token join.
+      const valueString =
+        this.originalInput && valueStart >= 0 && valueEnd > valueStart
+          ? this.originalInput.slice(valueStart, valueEnd)
+          : valueTokens.join('');
 
       // Create value node - if it has ${} syntax, make it a template literal
       const value: ASTNode = hasTemplateExpression


### PR DESCRIPTION
## Summary

`parseCSSObjectLiteral` rebuilt each CSS property value with `valueTokens.join('')`, which discards the whitespace the tokenizer skipped between tokens. That silently corrupted two things:

1. **Interpolation expressions** — `${a - b}` collapsed to `${a-b}`, which then mis-tokenizes as a single hyphenated identifier and evaluates to `undefined`. This is what broke the **Draggable / Sortable / Resizable** behavior sources: `add { left: ${clientX - xoff}px }` produced `NaNpx`, so the element never moved (and the behaviors fell back to imperative-JS installers).
2. **Multi-word CSS values** — `1px solid red` → `1pxsolidred`, `calc(100% - 20px)` → `calc(100%-20px)`.

The fix reconstructs each value **verbatim from source offsets** (first token start → last token end), preserving the author's exact spacing. Falls back to the previous tight token-join when offsets are unavailable.

## Why it surfaced now

While assessing whether the experimental behaviors could drop their imperative installers and run from their hyperscript `source` (the "no imperative JS in behaviors" goal), the Draggable source parsed faithfully and executed — but the element wouldn't move. Bisection traced it to this whitespace-stripping in `${…}` style values. With the fix, Draggable's source drags end-to-end (`left: 0px → 50px`).

## Tests

- New `packages/core/src/parser/css-object-literal-whitespace.test.ts` (5 cases): `${a - b}` interpolation, multi-property styles, `1px solid red`, `calc(100% - 20px)`, and the single-token case.
- No regressions: `add.test.ts`, the style-tagged sweep (125 tests), `runtime-objectliteral.test.ts`, and the curated behaviors runtime suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)