### PR TITLE
feat(behaviors): compile Draggable/Sortable/Resizable from source — no imperative JS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,11 +276,20 @@ the fraction of the English reference parse's command actions present in each
 translation. By fidelity, passes fall into three bands, each tracked per-language in
 the committed baseline:
 
-- **degenerate** (fid < 0.5 — lost most of the structure): `degeneratePasses`. ~69.
+- **degenerate** (fid < 0.5 — lost most of the structure): `degeneratePasses`. ~39.
 - **lossy** (0.5 ≤ fid < 1.0 — parses, clears the floor, but silently drops ≥1
-  command): `lossyPasses`. **~471 — the larger, previously-untracked correctness
-  band.** See `docs-internal/CORRECTNESS_RELIABILITY_PLAN.md`.
-- **faithful** (fid = 1.0). ~3133. Cross-language `avgFidelity` ≈ 0.93.
+  command): `lossyPasses`. **~113 — the larger correctness band.** See
+  `docs-internal/CORRECTNESS_RELIABILITY_PLAN.md`.
+- **faithful** (fid = 1.0). ~3534. Cross-language `avgFidelity` ≈ 0.98,
+  `avgPrecision` ≈ 0.96, `avgRoleFidelity` ≈ 0.83 (the laggard — SOV reorders).
+
+> **Figures snapshot:** the band counts and averages above are illustrative as of
+> the **2026-06-15** baseline (commit `0af855c0`, `browser-priority` bundle, 3686 /
+> 3696 patterns passing). They drift as work lands — the **authoritative** numbers
+> always live in the committed baseline,
+> `packages/testing-framework/baselines/multilingual-priority.json` (its `timestamp`
+> and `commit` fields stamp each regeneration). Treat the prose here as orientation,
+> not truth.
 
 The `--regression` gate ratchets on **six** signals (each fails CI; each guarded so
 an un-regenerated baseline never retro-flags — a baseline lacking a signal's field

--- a/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
+++ b/docs-internal/CORRECTNESS_RELIABILITY_PLAN.md
@@ -6,6 +6,16 @@
 > silently dropping commands. This plan reframes the work around **fidelity**
 > (avgFidelity 0.928 at writing; **0.9495 as of #356** — see §7) and prioritizes
 > correctness/reliability **before** behaviors (Track 2 runtime).
+>
+> **Figures snapshot (current vs. this doc's origin).** The §1 distribution below is the
+> **original assessment** that launched this campaign — kept verbatim as the starting line.
+> **Current state (2026-06-15 baseline, commit `0af855c0`, `browser-priority`):** lossy
+> **113** (was 471) · degenerate **39** (was 69) · faithful **~3534** (was 3133) ·
+> avgFidelity **0.982** (was 0.928) · avgPrecision 0.960 · avgRoleFidelity 0.831. The
+> **authoritative** numbers always live in the committed baseline,
+> `packages/testing-framework/baselines/multilingual-priority.json` (its `timestamp` +
+> `commit` fields stamp each regeneration). The §7a–§7cc session logs track the path between
+> the two; the forward plan is [MULTILINGUAL_NEXT_STEPS.md](MULTILINGUAL_NEXT_STEPS.md).
 
 ## 1. The measurement (full fidelity distribution)
 

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -78,6 +78,14 @@ Draggable/Sortable/Resizable violate this (`imperativeInstaller`); the other 8 a
 
 The fix is to **eliminate imperative JS first**, then align curation, then invest in the system:
 
+> **Status: item 1 DONE (2026-06-16, branch `feat/behaviors-no-imperative-js`).** Draggable /
+> Sortable / Resizable now compile from `source`; `imperativeInstaller` under behaviors/ = 0.
+> Required: parser CSS-interp whitespace fix (merged #440), `repeat until event … from <target>`
+> resolution fix (core `repeat.ts`), and three source-idiom swaps (Resizable `*width`, Sortable
+> `target.closest("li")`, `or pointerup` in the inner waits). Three runtime bugs surfaced en route
+> — see **Runtime correctness follow-ups** below. Items 2 (`behavior-removable`) and 3 (the system)
+> remain.
+
 1. **Resolve the Experimental 3 to hyperscript `source` — fix-vs-cut is per-behavior and
    runtime-driven, not a blanket cut.** Each already has real source; the imperative installer
    exists because the runtime historically couldn't execute the source's advanced features.
@@ -176,13 +184,31 @@ lowest-ROI remaining parse work.
    The 2026-06-15 marker-disambiguation fix lifted it +0.016; more phantom-command sources
    remain in the hi profile.
 
+## Runtime correctness follow-ups (core `_hyperscript`-compat — surfaced during Track 1a)
+
+These are general core-runtime bugs (not multilingual) found while making the behavior
+sources execute. The behaviors shipped via working idioms, so none are blocking — but each
+is a real `_hyperscript` compatibility gap worth its own focused fix + test.
+
+1. **Top-level `on event(args)` doesn't bind event args.** `on click(button)` / `on
+keydown(key)` at the top level leave the destructured args `undefined`; only the
+   _behavior_ handler path binds them (runtime-base.ts binds the `args` field but the
+   top-level handler stores `params`). Medium priority — it's a documented event-destructure
+   feature. Fix: bind `params` from event properties the same way the behavior `args` path does.
+2. **`set my style.X` resolves to the read-only _computed_ style.** `set my style.width to "50px"`
+   throws "styles are computed … read-only" instead of writing inline `element.style.width`.
+   Medium priority — natural idiom. Workaround in use: `set my *width to …`. Fix: make `my style`
+   member-write target inline `element.style`.
+3. **`closest <X/> to Y` positional returns null.** The positional `the closest <li/> to the
+target` idiom yields null even when a match exists (`target.closest("li")` works). Lower
+   priority — workaround is clean. Fix: the `closest <selector/> to <expr>` evaluator.
+
 ## Recommended sequence
 
-1. **Track 1a — eliminate imperative JS** (the hard constraint): probe the Draggable `source`
-   against the runtime; route it through `source` and delete the imperative installer if it runs
-   (then Sortable/Resizable). Cut only a behavior whose source can't execute without a too-costly
-   runtime feature. Also fix the curated `behavior-removable` parse bug (he/zh hard fails). Target:
-   `imperativeInstaller` count → 0.
+1. ~~**Track 1a — eliminate imperative JS**~~ **DONE** (2026-06-16, branch
+   `feat/behaviors-no-imperative-js`): Draggable/Sortable/Resizable compile from `source`;
+   `imperativeInstaller` → 0. Still open under Track 1: the curated `behavior-removable` he/zh
+   parse bug, and the three **Runtime correctness follow-ups** above.
 2. **Track 1b — behavior _system_ hardening**: the authoring guide + the resolver-as-public-API
    docs + the missing agent/MCP "write-and-validate-a-behavior" path. The stated priority;
    parallelizable with the parser work below.

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -1,0 +1,196 @@
+# Multilingual accuracy & reliability — next steps
+
+> **Entry point, written 2026-06-16.** This is the _current_ forward-looking plan.
+> The detailed session logs live in
+> [CORRECTNESS_RELIABILITY_PLAN.md](CORRECTNESS_RELIABILITY_PLAN.md) (§7a–§7cc, §11),
+> [MULTILINGUAL_ROADMAP.md](MULTILINGUAL_ROADMAP.md),
+> [STRUCTURAL_ARCS_ROADMAP.md](STRUCTURAL_ARCS_ROADMAP.md),
+> [MULTILINGUAL_BEHAVIORS_PLAN.md](MULTILINGUAL_BEHAVIORS_PLAN.md) and
+> [BEHAVIORS_CONSOLIDATION_PLAN.md](BEHAVIORS_CONSOLIDATION_PLAN.md). Read this first,
+> then dive into those for the per-arc detail.
+
+## Where we are (2026-06-15 baseline · commit `0af855c0` · `browser-priority`)
+
+Authoritative source: `packages/testing-framework/baselines/multilingual-priority.json`
+(its `timestamp` + `commit` fields stamp each regen). 24 langs × 154 patterns = 3696.
+
+| Signal                         | Value                   | Notes                                          |
+| ------------------------------ | ----------------------- | ---------------------------------------------- |
+| parse rate                     | **3686 / 3696 (99.7%)** | 10 hard fails                                  |
+| degenerate passes (fid < 0.5)  | **39**                  | was ~69                                        |
+| lossy passes (0.5 ≤ fid < 1.0) | **113**                 | was ~471 — the bulk of correctness debt        |
+| faithful (fid = 1.0)           | **~3534**               |                                                |
+| avgFidelity (R0-recall)        | **0.982**               | was 0.928                                      |
+| avgPrecision (R0 trust floor)  | **0.960**               | newest ratchet; hi 0.813 is the outlier        |
+| avgRoleFidelity (R1)           | **0.831**               | **the laggard dimension**                      |
+| avgExecutionFidelity (R2)      | **1.000**               | curated subset fully reproduces en DOM effects |
+
+The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recall ·
+R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
+**Direction now: stop adding gate signals; spend them down.**
+
+## The leverage map (what's actually non-faithful)
+
+Of the **162** non-faithful instances (39 degenerate + 113 lossy + 10 hard-fail),
+two clusters dominate:
+
+| Cluster                                                                         | degenerate | lossy | hard-fail |  total |   share |
+| ------------------------------------------------------------------------------- | ---------: | ----: | --------: | -----: | ------: |
+| **Behaviors** (draggable/resizable/sortable/removable + install)                |         28 |    64 |         2 | **94** | **58%** |
+| **Reactivity** (bind-\* / live-\* / two-way / computed / intercept / window-\*) |          8 |     2 |         7 | **17** |     10% |
+| **Control-flow** (`unless-condition` + then-chain bodies)                       |          1 |     8 |         0 |      9 |      6% |
+| Long tail (fetch-do-not-throw, get-value, tell-\*, set-color-variable, …)       |          2 |    39 |         1 |    ~42 |     26% |
+
+Per-pattern: `behavior-draggable` 23 lossy · `behavior-resizable` 21 lossy + 2 degen ·
+`behavior-removable` 13 degen + 8 lossy + 2 hard-fail · `behavior-sortable` 11 degen +
+12 lossy · `unless-condition` 8 lossy. The 10 hard fails: he/zh `behavior-removable`,
+ms `bind-*` ×4, sw `two-way-binding`/`computed-value`/`input-char-count`, tr `window-resize`.
+
+> **Read the behavior share through the implementation lens.** ~56 of the 94 behavior
+> instances are the **Experimental 3** (Draggable/Sortable/Resizable) — the _only_ three
+> behaviors implemented in **imperative JS** (`imperativeInstaller`) instead of compiled
+> hyperscript `source`; the other 8 are source-compiled (audited 2026-06-16). But all three
+> already ship a complete, faithful hyperscript `source` (e.g. `draggableSchema.source` is a
+> real `repeat until event pointerup` / `wait for pointermove or pointerup` / `measure` impl).
+> So this is a **runtime-capability** question, not a lane question — see Track 1.
+
+## Plan — ranked by leverage
+
+### Track 1 (top priority) — Behaviors: curate the showcase, fix the curated bug, harden the _system_
+
+**The goal is not comprehensiveness.** We are not shipping a large behavior library —
+the priority is **getting the behavior _system_ right**: a clear path for the user
+community and LLM agents to write and install new behaviors, with the curated set as a
+showcase of _what a behavior is_ and _what kinds hyperfixi enables_. The product decision
+already exists in [`packages/behaviors/src/curation.ts`](../packages/behaviors/src/curation.ts):
+
+- **Curated 5 (the supported story):** Toggleable, **Removable**, ClickOutside, Clipboard,
+  AutoDismiss — real `on event → DOM action` inline scripts (the demonstration of "what is a behavior").
+- **Optional 3:** FocusTrap, ScrollReveal, Tabs — primitives / nice-to-haves.
+- **Experimental 3:** Draggable, Sortable, Resizable — labeled "stateful async components."
+  **But each already ships a complete hyperscript `source`** and is the _only_ tier still
+  executed via an **imperative JS** `install()` that bypasses that source. So the label is
+  provisional: the boundary test is operational, not philosophical (see item 1).
+
+**Constraint (user, 2026-06-16): no behavior may be implemented in imperative JS — all must
+compile from hyperscript `source` (single source of truth).** Audit (2026-06-16): only
+Draggable/Sortable/Resizable violate this (`imperativeInstaller`); the other 8 are clean.
+
+The fix is to **eliminate imperative JS first**, then align curation, then invest in the system:
+
+1. **Resolve the Experimental 3 to hyperscript `source` — fix-vs-cut is per-behavior and
+   runtime-driven, not a blanket cut.** Each already has real source; the imperative installer
+   exists because the runtime historically couldn't execute the source's advanced features.
+   So, per behavior: (a) run its `source` and see what the runtime drops — Draggable needs
+   `repeat until event pointerup`, `wait for pointermove or pointerup from document`, `measure
+x/y`, and dynamic `add { left: ${…}px }` style templating; (b) if the runtime executes it,
+   **delete the imperative `install()` and route through `source`** (same path as the curated 8)
+   — this both honors the no-imperative-JS rule _and_ makes the multilingual fidelity follow for
+   free (parse of one source); (c) **cut only** the behavior whose source genuinely can't execute
+   without a runtime feature too costly to add — and even then, prefer fixing the feature, since
+   it's likely shared (`repeat-until-event` is already a tracked gate pattern). Start with
+   Draggable (we had it working before; richest source) as the bellwether for Sortable/Resizable.
+2. **Fix `behavior-removable` — it is CURATED, so its failures are real bugs.** 13 degen, 8 lossy,
+   and the only behavior with **hard** parse failures (he/zh). It is already source-compiled, so
+   this is a parse/i18n bug, not an imperative-JS one — check the `install … Removable` block
+   parses in he/zh.
+3. **The actual priority — the authoring + install system for community & LLM agents:**
+   - **Authoring guide:** consolidate `packages/core/BEHAVIORS.md` + the `curation.ts` boundary
+     rule into one canonical "what is a behavior / how to write one / the boundary test" doc,
+     written for humans _and_ agents.
+   - **Install path:** the resolver hook already works (`install X` → `_hyperscript.behaviors.resolve(X)`
+     → compile-on-first-use, `packages/behaviors/src/behavior-resolver.ts`). Document it as the
+     public extension point.
+   - **LLM-agent path (the gap):** there is no MCP tool / validator that lets an agent generate a
+     candidate behavior and check it against the boundary rule. Add one — schema + a
+     "stays-in-lane?" validator (reject component-shaped behaviors that need observers/async loops).
+
+**Layer:** runtime (execute the Experimental-3 source + the Removable parse bug) + product
+curation + DX/tooling (the system). **Owner docs:** MULTILINGUAL_BEHAVIORS_PLAN.md,
+BEHAVIORS_CONSOLIDATION_PLAN.md, `packages/core/BEHAVIORS.md`. **Audit cmd:** grep
+`imperativeInstaller` under `packages/behaviors/src/behaviors/` — must reach 0.
+
+### Track 2 — Reactivity (htmx v4): bring the multilingual parse path up to the runtime
+
+**Decision (settled): htmx v4 features, including reactivity, are in scope and must be
+supported — including in the multilingual path.** So this is not an exclusion; it's a
+parser/profile build-out.
+
+**Why:** owns 8 of 10 hard parse failures (ms `bind-*` ×4, sw `two-way-binding`/`computed-value`/
+`input-char-count`, tr `window-resize`) plus all 7 hi degenerate (`bind-*`/`live-*`/`intercept`).
+The hx-v4 **runtime** already handles these (`hx-live` → `live … end` block + `@hyperfixi/reactivity`,
+shipped in `hyperfixi-hx-v4.js`). The gap is purely the **semantic / multilingual parse path** —
+it doesn't yet model the reactive block shapes, so these patterns drop to hard-fail/degenerate
+when authored in non-English.
+
+**Action:**
+
+1. Teach the semantic parser the `bind … end` / `live … end` (and `intercept`) block shapes,
+   mirroring how the behavior/`def` blocks were added (PRs #426–#430, the structural-layer work).
+2. Add the per-language profile keywords (`bind`/`live`/`two-way`/`computed`) for the priority langs,
+   starting with the hard-fail set (ms, sw, tr) and the hi degenerate cluster.
+3. Re-baseline; expect hi precision (0.813, the outlier) and the ms/sw/tr hard fails to clear together.
+
+**Layer:** semantic parser + per-language profiles (block-structure parsing). This is the largest
+genuine _parser_ effort remaining now that behaviors resolve mostly by curation.
+
+### Track 3 — R1 role-fidelity burn-down (the untouched dimension)
+
+**Why:** avgRoleFidelity **0.831** is the laggard, and it has _never had a dedicated
+campaign_ — it drifted up incidentally from 0.7505 (first measured, #365) to 0.831 as a
+side effect of other work. The worst languages are the hard SOV/reorder set:
+**hi 0.682 · qu 0.769 · bn 0.778 · ko 0.787 · ja/tr 0.792**. R1 measures
+`action.role:valueType` recall — a parse that keeps the verb but drops or mistypes a role.
+
+**Action:** triage R1 on hi/qu/bn first (worst three). For each, dump the role-signature
+diff vs the en reference per pattern and find the recurring mistype/drop (likely a
+marker→role mapping or a value-type classification in the per-language profile). This is
+profile/parser work, same method as the R0 dict-alignment arcs — but targeting _roles_,
+not _presence_. New `--regression` won't flag drift here until someone drives it; this is
+greenfield headroom.
+
+### Track 4 — Control-flow + long-tail lossy
+
+**Why:** `unless-condition` (8 lossy + 1 degen) is the largest non-behavior lossy pattern;
+the docs' long-standing diagnosis is **control-flow body parsing** (`if`/`unless` headers +
+then-chain `put`/`set` bodies collapsing). The rest is a singleton long tail
+(`fetch-do-not-throw` 5, `get-value` 4, `tell-*` 4, `set-color-variable` 4).
+
+**Action:** opportunistic, lower ROI than Tracks 1–2. Take `unless-condition` as the
+representative and fix the enclosing block/then-chain collapse; the tail is per-pattern.
+Defer the per-language R2 structural arcs (STRUCTURAL_ARCS_ROADMAP.md) — explicitly the
+lowest-ROI remaining parse work.
+
+### Track 5 — Reliability hygiene (do alongside, not after)
+
+1. **Refresh stale headline numbers in the detailed docs.** CORRECTNESS_RELIABILITY_PLAN.md
+   §1 still says lossy 471 / avgFidelity 0.928; MULTILINGUAL_ROADMAP.md "Remaining work"
+   says ~159 degenerate. Reality: 113 / 0.982 / 39. (CLAUDE.md was refreshed 2026-06-16
+   with a dated snapshot note + pointer to the baseline JSON — apply the same pattern here.)
+2. **Make `populate` deterministic.** CLAUDE.md flags the "minor residual jitter" on a few
+   boundary patterns that forces the ratchet tolerances (3 lossy / 3 degen flips, 0.02 avg).
+   A deterministic populate lets us tighten those tolerances toward 0 and trust the gate more.
+3. **Consider an absolute fidelity floor**, not just a ratchet — once a language clears a
+   threshold, ratchet the floor upward so it can't silently backslide within tolerance.
+4. **hi precision follow-up.** hi avgPrecision 0.813 is a clear outlier (next-lowest ~0.91).
+   The 2026-06-15 marker-disambiguation fix lifted it +0.016; more phantom-command sources
+   remain in the hi profile.
+
+## Recommended sequence
+
+1. **Track 1a — eliminate imperative JS** (the hard constraint): probe the Draggable `source`
+   against the runtime; route it through `source` and delete the imperative installer if it runs
+   (then Sortable/Resizable). Cut only a behavior whose source can't execute without a too-costly
+   runtime feature. Also fix the curated `behavior-removable` parse bug (he/zh hard fails). Target:
+   `imperativeInstaller` count → 0.
+2. **Track 1b — behavior _system_ hardening**: the authoring guide + the resolver-as-public-API
+   docs + the missing agent/MCP "write-and-validate-a-behavior" path. The stated priority;
+   parallelizable with the parser work below.
+3. **Track 2 — reactivity (htmx v4) in the multilingual parse path**: teach the semantic parser
+   the `bind`/`live`/`intercept` block shapes; profile keywords for ms/sw/tr/hi first. The largest
+   genuine parser effort now, and required (htmx v4 is in scope).
+4. **Track 3 — R1 role-fidelity burn-down** on hi/qu/bn — greenfield headroom on the laggard dimension.
+5. **Track 4 control-flow** opportunistically; **Track 5 hygiene** continuously.
+
+Re-baseline (`--save-baseline`) after each intentional fidelity change, regenerate against a
+freshly `populate`d DB, and commit only the dicts/profiles + baseline (not `patterns.db`).

--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -1082,6 +1082,16 @@ own transformer/parser project (no shared lever remains):
 
 ## Remaining work
 
+> **Figures snapshot (2026-06-16).** The per-track counts in this section are historical
+> waypoints, not current. **Current state (2026-06-15 baseline, commit `0af855c0`,
+> `browser-priority`):** degenerate **39** (the "~159" below is stale) · lossy **113** ·
+> avgFidelity **0.982** · avgPrecision 0.960 · avgRoleFidelity 0.831 · avgExecutionFidelity
+> 1.000. The **authoritative** numbers always live in the committed baseline,
+> `packages/testing-framework/baselines/multilingual-priority.json` (its `timestamp` +
+> `commit` fields stamp each regeneration). For the forward plan, see
+> [MULTILINGUAL_NEXT_STEPS.md](MULTILINGUAL_NEXT_STEPS.md); for the correctness/fidelity
+> campaign log, [CORRECTNESS_RELIABILITY_PLAN.md](CORRECTNESS_RELIABILITY_PLAN.md).
+
 ### Track 5 — Parse fidelity (parse rate ≠ faithful) — NEW, tracked
 
 The non-behavior parse rate hit 100% (all 24 priority languages), but that metric

--- a/packages/behaviors/src/behaviors/draggable.ts
+++ b/packages/behaviors/src/behaviors/draggable.ts
@@ -1,9 +1,11 @@
 /**
- * Draggable Behavior — Imperative Implementation
+ * Draggable Behavior
  *
- * Makes elements draggable with pointer events.
- * Uses direct DOM APIs instead of compiling hyperscript source,
- * bypassing the complex repeat-until-event + wait-for async pattern.
+ * Makes elements draggable with pointer events. Compiled from its hyperscript
+ * `source` (the single source of truth shared with the CDN resolver bundle and
+ * patterns-reference) — no imperative installer. The source uses
+ * `repeat until event pointerup` + `wait for pointermove or pointerup` to run the
+ * drag loop, `measure` for the start offset, and `add { left: ${…}px }` to move.
  *
  * @example
  * ```html
@@ -27,51 +29,8 @@ export const draggableSource = draggableSchema.source;
 export const draggableMetadata = draggableSchema;
 
 /**
- * Imperative installer for Draggable behavior.
- * Called directly by the runtime when `install Draggable` is executed.
- */
-function installDraggable(element: HTMLElement, params: Record<string, any>): void {
-  // Resolve drag handle: parameter value, CSS selector, or the element itself
-  let dragHandle: HTMLElement = element;
-  if (params.dragHandle && params.dragHandle !== 'me') {
-    if (typeof params.dragHandle === 'string') {
-      const found = element.querySelector(params.dragHandle);
-      if (found instanceof HTMLElement) dragHandle = found;
-    } else if (params.dragHandle instanceof HTMLElement) {
-      dragHandle = params.dragHandle;
-    }
-  }
-
-  dragHandle.addEventListener('pointerdown', (e: PointerEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    element.dispatchEvent(new CustomEvent('draggable:start', { bubbles: true }));
-
-    const startX = element.offsetLeft;
-    const startY = element.offsetTop;
-    const xoff = e.clientX - startX;
-    const yoff = e.clientY - startY;
-
-    function onMove(ev: PointerEvent) {
-      element.style.left = `${ev.clientX - xoff}px`;
-      element.style.top = `${ev.clientY - yoff}px`;
-      element.dispatchEvent(new CustomEvent('draggable:move', { bubbles: true }));
-    }
-
-    function onUp() {
-      document.removeEventListener('pointermove', onMove);
-      document.removeEventListener('pointerup', onUp);
-      element.dispatchEvent(new CustomEvent('draggable:end', { bubbles: true }));
-    }
-
-    document.addEventListener('pointermove', onMove);
-    document.addEventListener('pointerup', onUp);
-  });
-}
-
-/**
- * Register the Draggable behavior with LokaScript.
- * Uses imperative installer via synthetic behavior node.
+ * Register the Draggable behavior with LokaScript by compiling its hyperscript
+ * source and executing the resulting behavior definition.
  */
 export async function registerDraggable(hyperfixi?: LokaScriptInstance): Promise<void> {
   const hf = hyperfixi || resolveRuntime();
@@ -82,17 +41,14 @@ export async function registerDraggable(hyperfixi?: LokaScriptInstance): Promise
     );
   }
 
-  // Register via execute() with a synthetic behavior node containing the imperative installer.
-  // The runtime detects imperativeInstaller and stores it directly in the behaviorRegistry.
-  const syntheticNode = {
-    type: 'behavior',
-    name: 'Draggable',
-    parameters: ['dragHandle'],
-    eventHandlers: [],
-    imperativeInstaller: installDraggable,
-  };
+  const result = hf.compileSync(draggableSchema.source, { traditional: true });
+
+  if (!result.ok) {
+    throw new Error(`Failed to compile Draggable behavior: ${JSON.stringify(result.errors)}`);
+  }
+
   const ctx = hf.createContext ? hf.createContext() : { locals: new Map(), globals: new Map() };
-  await hf.execute(syntheticNode, ctx);
+  await hf.execute(result.ast, ctx);
 }
 
 // Auto-register when loaded as a script tag

--- a/packages/behaviors/src/behaviors/experimental-runtime.test.ts
+++ b/packages/behaviors/src/behaviors/experimental-runtime.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment happy-dom
+/**
+ * Experimental behaviors — REAL runtime tests.
+ *
+ * Draggable / Sortable / Resizable used to run imperative JS installers. They now
+ * compile from their hyperscript `source` like every other behavior (the
+ * "no imperative JS" rule — no behavior may carry an imperative installer field).
+ * These tests are the "parses ≠ works" guard: register → install → drive pointer
+ * events → assert the DOM effect AND the documented lifecycle events.
+ *
+ * happy-dom has no PointerEvent and zero layout, so we drive `MouseEvent`s (which
+ * carry clientX/clientY) and assert deltas, which are layout-independent.
+ */
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { hyperscript } from '@hyperfixi/core';
+import { registerDraggable } from './draggable';
+import { registerSortable } from './sortable';
+import { registerResizable } from './resizable';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const hf = hyperscript as any;
+const tick = (ms = 30) => new Promise(r => setTimeout(r, ms));
+
+function pointer(type: string, x: number, y: number): MouseEvent {
+  return new MouseEvent(type, { clientX: x, clientY: y, bubbles: true, cancelable: true });
+}
+
+async function install(code: string, el: HTMLElement): Promise<void> {
+  const r = hyperscript.compileSync(code, { traditional: true });
+  if (!r.ok) throw new Error(`install compile failed: ${JSON.stringify(r.errors)}`);
+  await hyperscript.execute(r.ast, hyperscript.createContext(el));
+}
+
+beforeAll(async () => {
+  await registerDraggable(hf);
+  await registerSortable(hf);
+  await registerResizable(hf);
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('Draggable — runtime (source-compiled)', () => {
+  it('moves the element by the pointer delta and fires start/move/end', async () => {
+    const el = document.createElement('div');
+    el.style.position = 'absolute';
+    el.style.left = '0px';
+    el.style.top = '0px';
+    document.body.appendChild(el);
+
+    const ev: string[] = [];
+    el.addEventListener('draggable:start', () => ev.push('start'));
+    el.addEventListener('draggable:move', () => ev.push('move'));
+    el.addEventListener('draggable:end', () => ev.push('end'));
+
+    await install('install Draggable', el);
+
+    el.dispatchEvent(pointer('pointerdown', 10, 10));
+    await tick();
+    document.dispatchEvent(pointer('pointermove', 60, 80));
+    await tick();
+    document.dispatchEvent(pointer('pointerup', 60, 80));
+    await tick(40);
+
+    // measure x/y = 0 in happy-dom → xoff = 10, so left = 60 - 10 = 50, top = 80 - 10 = 70
+    expect(el.style.left).toBe('50px');
+    expect(el.style.top).toBe('70px');
+    expect(ev).toContain('start');
+    expect(ev).toContain('move');
+    expect(ev).toContain('end');
+  });
+});
+
+describe('Sortable — runtime (source-compiled)', () => {
+  it('toggles the drag class on the <li> and fires start/move/end', async () => {
+    const ul = document.createElement('ul');
+    ul.innerHTML = '<li id="a">A</li><li id="b">B</li>';
+    document.body.appendChild(ul);
+
+    const ev: string[] = [];
+    ul.addEventListener('sortable:start', () => ev.push('start'));
+    ul.addEventListener('sortable:move', () => ev.push('move'));
+    ul.addEventListener('sortable:end', () => ev.push('end'));
+
+    await install('install Sortable', ul);
+
+    const li = ul.querySelector('#a') as HTMLElement;
+    li.dispatchEvent(pointer('pointerdown', 0, 5));
+    await tick();
+    const classDuringDrag = li.classList.contains('sorting');
+    document.dispatchEvent(pointer('pointermove', 0, 40));
+    await tick();
+    document.dispatchEvent(pointer('pointerup', 0, 40));
+    await tick(40);
+
+    expect(classDuringDrag).toBe(true); // dragClass added on pointerdown
+    expect(li.classList.contains('sorting')).toBe(false); // removed on pointerup
+    expect(ev).toContain('start');
+    expect(ev).toContain('move');
+    expect(ev).toContain('end');
+  });
+});
+
+describe('Resizable — runtime (source-compiled)', () => {
+  it('resizes by the pointer delta and fires start/resize/end', async () => {
+    const box = document.createElement('div');
+    box.style.width = '100px';
+    box.style.height = '100px';
+    document.body.appendChild(box);
+
+    const ev: string[] = [];
+    box.addEventListener('resizable:start', () => ev.push('start'));
+    box.addEventListener('resizable:resize', () => ev.push('resize'));
+    box.addEventListener('resizable:end', () => ev.push('end'));
+
+    await install(
+      'install Resizable(minWidth: 10, minHeight: 10, maxWidth: 999, maxHeight: 999)',
+      box
+    );
+
+    box.dispatchEvent(pointer('pointerdown', 10, 10));
+    await tick();
+    document.dispatchEvent(pointer('pointermove', 60, 40));
+    await tick();
+    document.dispatchEvent(pointer('pointerup', 60, 40));
+    await tick(40);
+
+    // measure width/height = 0 in happy-dom → newWidth = 0 + 60 - 10 = 50, newHeight = 0 + 40 - 10 = 30
+    expect(box.style.width).toBe('50px');
+    expect(box.style.height).toBe('30px');
+    expect(ev).toContain('start');
+    expect(ev).toContain('resize');
+    expect(ev).toContain('end');
+  });
+});

--- a/packages/behaviors/src/behaviors/integration.test.ts
+++ b/packages/behaviors/src/behaviors/integration.test.ts
@@ -22,10 +22,11 @@ function createMockInstance(overrides: Partial<LokaScriptInstance> = {}): LokaSc
 }
 
 // Source-compiled behaviors (use compileSync + execute).
-// The curated set + the optional set (BEHAVIORS_CONSOLIDATION_PLAN.md §3) all
-// compile their hyperscript `source` — one runtime path, identical browser/npm.
-// The optional three (FocusTrap/ScrollReveal/Tabs) carry their web-API logic in
-// an `init`-block `js()` body, but still flow through the single compile path.
+// EVERY behavior compiles its hyperscript `source` — one runtime path, identical
+// browser/npm, no imperative JS installer (the "no imperative JS" rule). The optional
+// three (FocusTrap/ScrollReveal/Tabs) carry their web-API logic in an `init`-block
+// `js()` body, and the experimental three (Draggable/Sortable/Resizable) run their
+// pointer-drag loops via `repeat until event` — all through the single compile path.
 const compiledBehaviors = [
   { name: 'Removable', register: registerRemovable, source: removableSource },
   { name: 'Toggleable', register: registerToggleable, source: toggleableSource },
@@ -35,13 +36,6 @@ const compiledBehaviors = [
   { name: 'FocusTrap', register: registerFocusTrap, source: focusTrapSource },
   { name: 'ScrollReveal', register: registerScrollReveal, source: scrollRevealSource },
   { name: 'Tabs', register: registerTabs, source: tabsSource },
-] as const;
-
-// Imperative behaviors (use synthetic node with imperativeInstaller).
-// Only the Tier-C async-component over-reach (Draggable/Sortable/Resizable) stays
-// imperative — these sit beyond the inline-scripting boundary and are deliberately
-// kept as experimental components, not part of the one-runtime-path story (§3b/§3d).
-const imperativeBehaviors = [
   { name: 'Draggable', register: registerDraggable, source: draggableSource },
   { name: 'Sortable', register: registerSortable, source: sortableSource },
   { name: 'Resizable', register: registerResizable, source: resizableSource },
@@ -94,62 +88,6 @@ describe('behavior registration integration', () => {
 
           expect(mock.execute).toHaveBeenCalledWith(
             { type: 'behavior' },
-            expect.objectContaining({
-              locals: expect.any(Map),
-              globals: expect.any(Map),
-            })
-          );
-        });
-      });
-    }
-  });
-
-  describe('imperative behaviors', () => {
-    for (const { name, register } of imperativeBehaviors) {
-      describe(name, () => {
-        it('should register via synthetic node with imperativeInstaller', async () => {
-          const mock = createMockInstance();
-          await register(mock);
-
-          // Imperative behaviors do NOT call compileSync
-          expect(mock.compileSync).not.toHaveBeenCalled();
-
-          // They call execute with a synthetic node containing imperativeInstaller
-          expect(mock.execute).toHaveBeenCalledWith(
-            expect.objectContaining({
-              type: 'behavior',
-              name,
-              imperativeInstaller: expect.any(Function),
-            }),
-            expect.objectContaining({
-              locals: expect.any(Map),
-              globals: expect.any(Map),
-            })
-          );
-        });
-
-        it('should create context', async () => {
-          const mock = createMockInstance();
-          await register(mock);
-          expect(mock.createContext).toHaveBeenCalled();
-        });
-
-        it('should throw when lokascript is not available', async () => {
-          await expect(register(undefined)).rejects.toThrowError(/LokaScript not found/);
-        });
-
-        it('should fall back to manual context when createContext is missing', async () => {
-          const mock = createMockInstance();
-          delete (mock as Partial<LokaScriptInstance>).createContext;
-
-          await register(mock);
-
-          expect(mock.execute).toHaveBeenCalledWith(
-            expect.objectContaining({
-              type: 'behavior',
-              name,
-              imperativeInstaller: expect.any(Function),
-            }),
             expect.objectContaining({
               locals: expect.any(Map),
               globals: expect.any(Map),

--- a/packages/behaviors/src/behaviors/resizable.ts
+++ b/packages/behaviors/src/behaviors/resizable.ts
@@ -1,8 +1,10 @@
 /**
- * Resizable Behavior — Imperative Implementation
+ * Resizable Behavior
  *
- * Makes elements resizable by dragging edges or corners.
- * Supports minimum/maximum dimensions and resize handles.
+ * Makes elements resizable by dragging. Compiled from its hyperscript `source`
+ * (single source of truth) — no imperative installer. The source measures the
+ * start size, runs a `repeat until event pointerup` loop, clamps to
+ * min/max dimensions, and writes `*width` / `*height` inline styles.
  *
  * @example
  * ```html
@@ -21,56 +23,8 @@ export const resizableSource = resizableSchema.source;
 export const resizableMetadata = resizableSchema;
 
 /**
- * Imperative installer for Resizable behavior.
- */
-function installResizable(element: HTMLElement, params: Record<string, any>): void {
-  // Resolve handle element
-  let handleEl: HTMLElement = element;
-  if (params.handle && params.handle !== 'me') {
-    if (typeof params.handle === 'string') {
-      const found = element.querySelector(params.handle);
-      if (found instanceof HTMLElement) handleEl = found;
-    } else if (params.handle instanceof HTMLElement) {
-      handleEl = params.handle;
-    }
-  }
-
-  const minW = params.minWidth ?? 50;
-  const minH = params.minHeight ?? 50;
-  const maxW = params.maxWidth ?? 9999;
-  const maxH = params.maxHeight ?? 9999;
-
-  handleEl.addEventListener('pointerdown', (e: PointerEvent) => {
-    e.preventDefault();
-    element.dispatchEvent(new CustomEvent('resizable:start', { bubbles: true }));
-
-    const startWidth = element.offsetWidth;
-    const startHeight = element.offsetHeight;
-    const startX = e.clientX;
-    const startY = e.clientY;
-
-    function onMove(ev: PointerEvent) {
-      const newWidth = Math.max(minW, Math.min(maxW, startWidth + (ev.clientX - startX)));
-      const newHeight = Math.max(minH, Math.min(maxH, startHeight + (ev.clientY - startY)));
-
-      element.style.width = `${newWidth}px`;
-      element.style.height = `${newHeight}px`;
-      element.dispatchEvent(new CustomEvent('resizable:resize', { bubbles: true }));
-    }
-
-    function onUp() {
-      document.removeEventListener('pointermove', onMove);
-      document.removeEventListener('pointerup', onUp);
-      element.dispatchEvent(new CustomEvent('resizable:end', { bubbles: true }));
-    }
-
-    document.addEventListener('pointermove', onMove);
-    document.addEventListener('pointerup', onUp);
-  });
-}
-
-/**
- * Register the Resizable behavior with LokaScript.
+ * Register the Resizable behavior with LokaScript by compiling its hyperscript
+ * source and executing the resulting behavior definition.
  */
 export async function registerResizable(hyperfixi?: LokaScriptInstance): Promise<void> {
   const hf = hyperfixi || resolveRuntime();
@@ -81,15 +35,14 @@ export async function registerResizable(hyperfixi?: LokaScriptInstance): Promise
     );
   }
 
-  const syntheticNode = {
-    type: 'behavior',
-    name: 'Resizable',
-    parameters: [],
-    eventHandlers: [],
-    imperativeInstaller: installResizable,
-  };
+  const result = hf.compileSync(resizableSchema.source, { traditional: true });
+
+  if (!result.ok) {
+    throw new Error(`Failed to compile Resizable behavior: ${JSON.stringify(result.errors)}`);
+  }
+
   const ctx = hf.createContext ? hf.createContext() : { locals: new Map(), globals: new Map() };
-  await hf.execute(syntheticNode, ctx);
+  await hf.execute(result.ast, ctx);
 }
 
 // Auto-register when loaded as a script tag

--- a/packages/behaviors/src/behaviors/sortable.ts
+++ b/packages/behaviors/src/behaviors/sortable.ts
@@ -1,12 +1,12 @@
 /**
- * Sortable Behavior — Imperative Implementation
+ * Sortable Behavior
  *
- * Drag-and-drop reordering of list items.
- * Apply to a container element; children become sortable.
+ * Drag-and-drop reordering of list items. Apply to a container element; its
+ * `<li>` children become sortable. Compiled from its hyperscript `source` (single
+ * source of truth) — no imperative installer.
  *
- * Note: This behavior fires lifecycle events but does NOT automatically
- * reorder DOM elements. Users must handle actual reordering in their
- * `sortable:move` event handlers.
+ * Note: This behavior fires lifecycle events but does NOT automatically reorder
+ * DOM elements. Users handle actual reordering in their `sortable:move` handlers.
  *
  * @example
  * ```html
@@ -26,50 +26,8 @@ export const sortableSource = sortableSchema.source;
 export const sortableMetadata = sortableSchema;
 
 /**
- * Imperative installer for Sortable behavior.
- */
-function installSortable(element: HTMLElement, params: Record<string, any>): void {
-  const dragClass = params.dragClass || 'sorting';
-  const handleSelector = params.handle || null;
-
-  element.addEventListener('pointerdown', (e: PointerEvent) => {
-    const target = e.target as HTMLElement;
-    const item = target.closest('li');
-    if (!item || !element.contains(item)) return;
-
-    // If a handle selector is specified, only start drag from the handle
-    if (handleSelector) {
-      const handleEl = target.closest(handleSelector);
-      if (!handleEl) return;
-    }
-
-    e.preventDefault();
-    item.classList.add(dragClass);
-    element.dispatchEvent(new CustomEvent('sortable:start', { bubbles: true, detail: { item } }));
-
-    function onMove(ev: PointerEvent) {
-      element.dispatchEvent(
-        new CustomEvent('sortable:move', {
-          bubbles: true,
-          detail: { clientY: ev.clientY, item },
-        })
-      );
-    }
-
-    function onUp() {
-      document.removeEventListener('pointermove', onMove);
-      document.removeEventListener('pointerup', onUp);
-      item!.classList.remove(dragClass);
-      element.dispatchEvent(new CustomEvent('sortable:end', { bubbles: true, detail: { item } }));
-    }
-
-    document.addEventListener('pointermove', onMove);
-    document.addEventListener('pointerup', onUp);
-  });
-}
-
-/**
- * Register the Sortable behavior with LokaScript.
+ * Register the Sortable behavior with LokaScript by compiling its hyperscript
+ * source and executing the resulting behavior definition.
  */
 export async function registerSortable(hyperfixi?: LokaScriptInstance): Promise<void> {
   const hf = hyperfixi || resolveRuntime();
@@ -80,15 +38,14 @@ export async function registerSortable(hyperfixi?: LokaScriptInstance): Promise<
     );
   }
 
-  const syntheticNode = {
-    type: 'behavior',
-    name: 'Sortable',
-    parameters: ['dragClass'],
-    eventHandlers: [],
-    imperativeInstaller: installSortable,
-  };
+  const result = hf.compileSync(sortableSchema.source, { traditional: true });
+
+  if (!result.ok) {
+    throw new Error(`Failed to compile Sortable behavior: ${JSON.stringify(result.errors)}`);
+  }
+
   const ctx = hf.createContext ? hf.createContext() : { locals: new Map(), globals: new Map() };
-  await hf.execute(syntheticNode, ctx);
+  await hf.execute(result.ast, ctx);
 }
 
 // Auto-register when loaded as a script tag

--- a/packages/behaviors/src/registry.test.ts
+++ b/packages/behaviors/src/registry.test.ts
@@ -175,7 +175,7 @@ describe('registry', () => {
   });
 
   describe('registerWithRuntime', () => {
-    it('should load and call module.register (imperative behavior)', async () => {
+    it('should load and call module.register (Draggable — now source-compiled)', async () => {
       const mockInstance = {
         compileSync: vi.fn().mockReturnValue({ ok: true, ast: {} }),
         execute: vi.fn().mockResolvedValue(undefined),
@@ -185,15 +185,10 @@ describe('registry', () => {
       await loadBehavior('Draggable');
       await registerWithRuntime('Draggable', mockInstance);
 
-      // Imperative behaviors use execute with synthetic node, not compileSync
-      expect(mockInstance.execute).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'behavior',
-          name: 'Draggable',
-          imperativeInstaller: expect.any(Function),
-        }),
-        expect.objectContaining({ locals: expect.any(Map), globals: expect.any(Map) })
-      );
+      // Draggable used to install imperatively; it now compiles its hyperscript
+      // `source` like every other behavior (no imperative installer).
+      expect(mockInstance.compileSync).toHaveBeenCalled();
+      expect(mockInstance.execute).toHaveBeenCalled();
     });
 
     it('should load and call module.register (compiled behavior)', async () => {
@@ -221,7 +216,7 @@ describe('registry', () => {
 
       await loadAll();
       await registerAllWithRuntime(mockInstance);
-      // execute called for each behavior (imperative + compiled)
+      // execute called for each behavior (all source-compiled now)
       expect(mockInstance.execute.mock.calls.length).toBeGreaterThanOrEqual(10);
     });
   });

--- a/packages/behaviors/src/schemas/resizable.schema.ts
+++ b/packages/behaviors/src/schemas/resizable.schema.ts
@@ -60,15 +60,15 @@ behavior Resizable(minWidth, minHeight, maxWidth, maxHeight)
     set startX to clientX
     set startY to clientY
     repeat until event pointerup from document
-      wait for pointermove(clientX, clientY) from document
+      wait for pointermove(clientX, clientY) or pointerup(clientX, clientY) from document
       set newWidth to startWidth + clientX - startX
       set newHeight to startHeight + clientY - startY
       if newWidth < minWidth then set newWidth to minWidth end
       if newWidth > maxWidth then set newWidth to maxWidth end
       if newHeight < minHeight then set newHeight to minHeight end
       if newHeight > maxHeight then set newHeight to maxHeight end
-      set my style.width to newWidth + "px"
-      set my style.height to newHeight + "px"
+      set my *width to newWidth + "px"
+      set my *height to newHeight + "px"
       trigger resizable:resize
     end
     trigger resizable:end

--- a/packages/behaviors/src/schemas/sortable.schema.ts
+++ b/packages/behaviors/src/schemas/sortable.schema.ts
@@ -43,7 +43,7 @@ behavior Sortable(dragClass)
     end
   end
   on pointerdown(clientY) from me
-    set item to the closest <li/> to the target
+    set item to the target.closest("li")
     if item is null
       exit
     end
@@ -51,7 +51,7 @@ behavior Sortable(dragClass)
     add .{dragClass} to item
     trigger sortable:start on me
     repeat until event pointerup from document
-      wait for pointermove(clientY) from document
+      wait for pointermove(clientY) or pointerup(clientY) from document
       trigger sortable:move on me
     end
     remove .{dragClass} from item

--- a/packages/core/src/commands/control-flow/repeat.ts
+++ b/packages/core/src/commands/control-flow/repeat.ts
@@ -164,9 +164,26 @@ export class RepeatCommand implements DecoratedCommand {
       if (!eventName) throw new Error('until-event loops require an event name');
       let eventTarget: EventTarget = context.me as EventTarget;
       if (raw.args[2]) {
-        const target = await evaluator.evaluate(raw.args[2], context);
-        if (target instanceof EventTarget) eventTarget = target;
-        else if (target === 'document') eventTarget = document;
+        const targetArg = raw.args[2] as { type?: string; name?: string };
+        // `document` / `window` often arrive as bare identifiers the expression
+        // evaluator doesn't resolve to the global EventTarget in this context
+        // (which silently left the listener on `me` — so `repeat until event
+        // pointerup from document` never terminated). Resolve them by name first,
+        // then fall back to evaluating arbitrary target expressions.
+        if (targetArg?.type === 'identifier' && targetArg.name === 'document') {
+          eventTarget = document;
+        } else if (
+          targetArg?.type === 'identifier' &&
+          targetArg.name === 'window' &&
+          typeof window !== 'undefined'
+        ) {
+          eventTarget = window;
+        } else {
+          const target = await evaluator.evaluate(raw.args[2], context);
+          if (target instanceof EventTarget) eventTarget = target;
+          else if (target === 'document') eventTarget = document;
+          else if (typeof window !== 'undefined' && target === window) eventTarget = window;
+        }
       }
       return {
         type: 'until-event',


### PR DESCRIPTION
## Summary

Draggable, Sortable, and Resizable were the only three behaviors still installed via an **imperative JS** `installer` that bypassed their hyperscript `source`. They each already shipped a complete source; the installer existed because the runtime historically couldn't execute it. With the merged CSS-interpolation fix (#440) plus the runtime/idiom fixes here, the sources now run end-to-end — so the imperative installers are **deleted** and every behavior compiles from `source` (single source of truth; multilingual for free).

**Audit:** `grep imperativeInstaller packages/behaviors/src/behaviors/` → **0**.

## Commits

1. `docs(multilingual)` — refresh fidelity figures + forward plan (dated snapshots → authoritative baseline JSON; new `MULTILINGUAL_NEXT_STEPS.md`).
2. `fix(repeat)` — resolve `until event … from <target>` to the right EventTarget. Bare `document` / `window` identifiers weren't resolved, so the until-event listener stayed on `me`, the event was never seen, and the loop never terminated (drag teardown never ran). General `_hyperscript` correctness fix.
3. `feat(behaviors)` — flip the experimental 3 to source-compiled; delete imperative installers.
4. `docs(plan)` — mark Track 1a done + log 3 runtime correctness follow-ups.

## Source-idiom swaps (runtime gaps worked around)

- Resizable: `set my style.width to …` (resolved to the read-only **computed** style) → `set my *width to …` (writable inline style).
- Sortable: `the closest <li/> to the target` (positional idiom returned null) → `the target.closest("li")`.
- Sortable/Resizable inner waits gained `or pointerup(...)` so the drag loop wakes on release (Draggable already had it) and the until-event loop can exit.

## Tests

- New `experimental-runtime.test.ts`: real register → install → drive pointer events → assert the **DOM effect AND** start/move(resize)/end lifecycle for all three.
- `integration.test.ts` / `registry.test.ts` updated (the 3 moved into the source-compiled block; imperative-path assertions removed).
- Behaviors suite **173 passed**; core `repeat` + `loop-executor` **93 passed**; both packages typecheck clean.

## Follow-ups (documented in `MULTILINGUAL_NEXT_STEPS.md`, not blocking)

Three core `_hyperscript`-compat bugs surfaced en route — all have working idiom workarounds:
1. Top-level `on event(args)` doesn't bind event args (only behavior handlers do).
2. `set my style.X` targets the read-only computed style instead of inline `element.style`.
3. `closest <X/> to Y` positional returns null.

> **Note:** core's `imperativeInstaller` handling is now dead code (no behavior uses it) — left in place; safe to remove in a later cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)