### PR TITLE
fix(runtime): top-level event-arg binding + inline style writes (_hyperscript compat)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -190,15 +190,14 @@ These are general core-runtime bugs (not multilingual) found while making the be
 sources execute. The behaviors shipped via working idioms, so none are blocking — but each
 is a real `_hyperscript` compatibility gap worth its own focused fix + test.
 
-1. **Top-level `on event(args)` doesn't bind event args.** `on click(button)` / `on
-keydown(key)` at the top level leave the destructured args `undefined`; only the
-   _behavior_ handler path binds them (runtime-base.ts binds the `args` field but the
-   top-level handler stores `params`). Medium priority — it's a documented event-destructure
-   feature. Fix: bind `params` from event properties the same way the behavior `args` path does.
-2. **`set my style.X` resolves to the read-only _computed_ style.** `set my style.width to "50px"`
-   throws "styles are computed … read-only" instead of writing inline `element.style.width`.
-   Medium priority — natural idiom. Workaround in use: `set my *width to …`. Fix: make `my style`
-   member-write target inline `element.style`.
+1. ~~**Top-level `on event(args)` doesn't bind event args.**~~ **DONE** (branch
+   `fix/runtime-event-args-and-style`). The top-level parser emitted the destructure names as
+   an untyped `params` field the runtime never read; now emits `args` (the field the runtime
+   binds from + the behavior parser already uses). `on click(button)` etc. now bind.
+2. ~~**`set my style.X` resolves to the read-only _computed_ style.**~~ **DONE** (same branch).
+   The set member-assignment path now targets the writable inline `element.style` for
+   `.style.<prop>` writes (reads unchanged). `set my style.width to "50px"` works; the
+   Resizable `*width` idiom remains valid (not retrofitted — `*prop` is equally canonical).
 3. **`closest <X/> to Y` positional returns null.** The positional `the closest <li/> to the
 target` idiom yields null even when a match exists (`target.closest("li")` works). Lower
    priority — workaround is clean. Fix: the `closest <selector/> to <expr>` evaluator.

--- a/packages/core/src/commands/data/__tests__/set-inline-style.test.ts
+++ b/packages/core/src/commands/data/__tests__/set-inline-style.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+/**
+ * Regression: `set my style.<prop> to V` must write the WRITABLE inline style
+ * (`element.style`), not the read-only computed style.
+ *
+ * A plain `.style` member read resolves to `getComputedStyle(element)`; assigning
+ * to it throws ("these styles are computed … read-only"). The set member-assignment
+ * path now targets `element.style` for `.style.<prop>` writes.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Runtime } from '../../../runtime/runtime';
+import { parse } from '../../../parser/parser';
+import type { ExecutionContext } from '../../../types/core';
+
+function ctx(el: HTMLElement): ExecutionContext {
+  return {
+    me: el,
+    it: null,
+    you: null,
+    result: null,
+    locals: new Map(),
+    globals: new Map(),
+    variables: new Map(),
+    events: new Map(),
+  } as unknown as ExecutionContext;
+}
+
+describe('set my style.<prop> writes inline style', () => {
+  let runtime: Runtime;
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    runtime = new Runtime();
+    document.body.innerHTML = '';
+    el = document.createElement('div');
+    document.body.appendChild(el);
+  });
+
+  it('set my style.width to "50px"', async () => {
+    const { node } = parse('set my style.width to "50px"');
+    await runtime.execute(node!, ctx(el));
+    expect(el.style.width).toBe('50px');
+  });
+
+  it('set my style.backgroundColor to "red"', async () => {
+    const { node } = parse('set my style.backgroundColor to "red"');
+    await runtime.execute(node!, ctx(el));
+    expect(el.style.backgroundColor).toBe('red');
+  });
+
+  it('does not disturb non-style member assignment (set my innerHTML)', async () => {
+    const { node } = parse('set my innerHTML to "<span>hi</span>"');
+    await runtime.execute(node!, ctx(el));
+    expect(el.innerHTML).toBe('<span>hi</span>');
+  });
+});

--- a/packages/core/src/commands/data/set.ts
+++ b/packages/core/src/commands/data/set.ts
@@ -365,7 +365,31 @@ export class SetCommand implements DecoratedCommand {
     const objectAst = firstArg.object as ASTNode | undefined;
     const computed = firstArg.computed as boolean | undefined;
     if (objectAst) {
-      const container = await evaluator.evaluate(objectAst, context);
+      // `set <el>.style.<prop> to V` must target the WRITABLE inline style
+      // (`element.style`). A plain `.style` member read resolves to the read-only
+      // computed style (`getComputedStyle`), which throws on assignment.
+      const objMember = objectAst as {
+        type?: string;
+        object?: ASTNode;
+        property?: { name?: string };
+        computed?: boolean;
+      };
+      let container: unknown;
+      if (
+        objMember.type === 'memberExpression' &&
+        !objMember.computed &&
+        objMember.property?.name === 'style' &&
+        objMember.object
+      ) {
+        const el = await evaluator.evaluate(objMember.object, context);
+        const inlineStyle =
+          el && typeof el === 'object' && 'style' in (el as object)
+            ? (el as HTMLElement).style
+            : undefined;
+        container = inlineStyle ?? (await evaluator.evaluate(objectAst, context));
+      } else {
+        container = await evaluator.evaluate(objectAst, context);
+      }
       if (container != null && typeof container === 'object') {
         const property = computed
           ? String(await evaluator.evaluate(firstArg.property as ASTNode, context))

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -2809,7 +2809,11 @@ export class Parser {
       event: eventNames.length === 1 ? eventNames[0] : eventNames.join('|'),
       events: eventNames, // Store all event names for runtime
       commands,
-      ...(eventParams.length > 0 && { params: eventParams }), // Add event parameters
+      // Event-argument destructure names (`on click(button)`). Emit as `args` —
+      // the `EventHandlerNode.args` field the runtime binds from (and the field the
+      // behavior-handler parser already uses). Previously emitted as the untyped,
+      // unread `params`, so top-level `on event(args)` never bound the names.
+      ...(eventParams.length > 0 && { args: eventParams }),
       ...(condition && { condition }), // Add condition if present
       ...(target && { target }), // Add target if present
       ...(attributeName && { attributeName }), // Add attributeName if present

--- a/packages/core/src/runtime/event-arg-binding.test.ts
+++ b/packages/core/src/runtime/event-arg-binding.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+/**
+ * Regression: top-level `on <event>(arg1, arg2)` must bind the destructured event
+ * properties as locals — the same as behavior-block handlers.
+ *
+ * The top-level parser used to emit these names as an untyped `params` field that
+ * the runtime never read (it binds from `args`), so `on click(button)` /
+ * `on pointermove(clientX, clientY)` left the names `undefined`.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Runtime } from './runtime';
+import { parse } from '../parser/parser';
+import type { ExecutionContext } from '../types/core';
+
+function freshContext(el: HTMLElement): ExecutionContext {
+  return {
+    me: el,
+    it: null,
+    you: null,
+    result: null,
+    locals: new Map(),
+    globals: new Map(),
+    variables: new Map(),
+    events: new Map(),
+  } as unknown as ExecutionContext;
+}
+
+const tick = (ms = 20) => new Promise(r => setTimeout(r, ms));
+
+describe('top-level event-arg destructuring', () => {
+  let runtime: Runtime;
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    runtime = new Runtime();
+    document.body.innerHTML = '';
+    el = document.createElement('div');
+    document.body.appendChild(el);
+  });
+
+  it('binds a single event property: on click(detail) ...', async () => {
+    const { node } = parse('on pointerdown(clientX) put `x=${clientX}` into me');
+    await runtime.execute(node!, freshContext(el));
+    await tick();
+
+    el.dispatchEvent(new MouseEvent('pointerdown', { clientX: 42, bubbles: true }));
+    await tick();
+
+    expect(el.textContent).toBe('x=42');
+  });
+
+  it('binds multiple event properties: on pointermove(clientX, clientY) ...', async () => {
+    const { node } = parse('on pointermove(clientX, clientY) put `${clientX},${clientY}` into me');
+    await runtime.execute(node!, freshContext(el));
+    await tick();
+
+    el.dispatchEvent(new MouseEvent('pointermove', { clientX: 7, clientY: 9, bubbles: true }));
+    await tick();
+
+    expect(el.textContent).toBe('7,9');
+  });
+});


### PR DESCRIPTION
## Summary

Two core `_hyperscript`-compatibility bugs surfaced while making the behavior sources run (Track 1a). Both had working idiom workarounds, neither was blocking — now fixed at the root with tests.

### 1. Top-level `on event(args)` didn't bind the destructured event properties
`on click(button)` / `on pointermove(clientX, clientY)` at the top level left the names `undefined`, while the **identical behavior-handler syntax worked**. Cause: the top-level parser emitted the names as an untyped `params` field that the runtime never reads — it binds event properties from `args` (the field `EventHandlerNode.args` declares and the behavior parser already emits). Fix: emit `args`. No core consumer read the old `params` field (verified).

### 2. `set my style.<prop> to V` wrote to the read-only computed style
`set my style.width to "50px"` threw *"these styles are computed … read-only"*. Cause: a plain `.style` member read resolves to `getComputedStyle(element)`. Fix: the set member-assignment path now targets the writable inline `element.style` for non-computed `.style.<prop>` writes; reads are unchanged and non-style member assignments (`set my innerHTML`) are untouched.

## Tests
- `runtime/event-arg-binding.test.ts` — single + multi event-property binding.
- `commands/data/__tests__/set-inline-style.test.ts` — `style.width` / `style.backgroundColor` inline writes + a non-style guard.
- Regression sweeps green: parser/events/control-flow (1638), data commands + property-target (213); core typecheck clean.

## Notes
- These were the two **medium-priority** runtime follow-ups logged in `MULTILINGUAL_NEXT_STEPS.md` (now marked done). The third — `closest <X/> to Y` returns null — is lower priority (clean workaround) and left for later.
- The Resizable behavior's `*width` idiom is **not** retrofitted to `style.width` — `*prop` is an equally canonical hyperscript style-write, and it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)