### PR TITLE
docs: handoff for behavior-removable he/zh + skip agent boundary validator

### DIFF
--- a/docs-internal/HANDOFF-behavior-removable-he-zh.md
+++ b/docs-internal/HANDOFF-behavior-removable-he-zh.md
@@ -1,0 +1,140 @@
+# Handoff — fix `behavior-removable` hard parse failure in he + zh
+
+> Paste this into a fresh session to pick up the work. Self-contained.
+
+## Goal
+
+`behavior-removable` is the **only _curated_ behavior with hard parse failures** in the
+multilingual gate — it returns a **null parse** (not just lossy) in **he (Hebrew)** and
+**zh (Chinese)**. Because curated = the supported story, this is a real bug, not
+out-of-lane debt. Make the translated Removable source parse **non-null** in he and zh
+(degenerate→lossy→ideally faithful), then re-baseline and keep the gate green.
+
+**Acceptance:** he + zh `behavior-removable` go from hard-fail → at least a (lossy) pass;
+`avgFidelity`/precision do not regress elsewhere; baseline regenerated with
+`--save-baseline`; only dicts/profiles + baseline committed (NOT `patterns.db`).
+
+## What must parse
+
+The gate pattern's source IS the real behavior source
+([`packages/behaviors/src/schemas/removable.schema.ts`](../packages/behaviors/src/schemas/removable.schema.ts),
+registered at `packages/patterns-reference/scripts/init-db.ts:237`):
+
+```hyperscript
+behavior Removable(triggerEl, confirmRemoval, effect)
+  init
+    if triggerEl is undefined
+      set triggerEl to me
+    end
+  end
+  on click from triggerEl
+    if confirmRemoval
+      js(me)
+        if (!window.confirm("Are you sure?")) return "cancel";
+      end
+      if it is "cancel"
+        halt
+      end
+    end
+    trigger removable:before
+    if effect is "fade"
+      transition opacity to 0 over 300ms
+    end
+    trigger removable:removed
+    remove me
+  end
+end
+```
+
+This is the **hard end of the multilingual surface**: a behavior block → an
+`on click from triggerEl` handler → **nested conditionals** (`if confirmRemoval` wrapping
+a `js()` block + `halt`; `if effect is "fade"` wrapping `transition`) → trailing
+`trigger`/`remove`. It combines the known-hard "control-flow body parsing" cluster
+(`if` + bodies) with non-Latin scripts (he is RTL; zh is space-less). A null parse means
+the structural parse bails somewhere in that nesting after translation.
+
+## Reproduce (cold tree → single-language probe)
+
+```bash
+npm install                                            # bootstrap workspaces
+npm run test:multilingual:build-deps                   # ordered build (intent→framework→semantic→i18n→patterns-reference→core multilingual dist)
+npm run populate --prefix packages/patterns-reference  # rebuild patterns.db + provenance stamp (gate refuses on stale db)
+
+cd packages/testing-framework
+npx tsx src/multilingual/cli.ts --languages he,zh --full --verbose
+# look for `behavior-removable` in the he/zh output — should show a parse failure
+```
+
+To see _what_ is being parsed (the translated text) and _where_ it bails, probe the
+pieces directly (e.g. a scratch `tsx` script or the `parse_multilingual` /
+`translate_hyperscript` MCP tools):
+
+```ts
+import { MultilingualHyperscript } from '@hyperfixi/core/multilingual';
+const ml = new MultilingualHyperscript();
+await ml.initialize();
+const he = await ml.translate(REMOVABLE_SOURCE, 'en', 'he'); // inspect the translated text
+const node = await ml.parse(he, 'he'); // null? where does it stop?
+```
+
+First, **re-confirm the failure is still live** — the baseline snapshot is commit
+`0af855c0`; nothing since has targeted multilingual, but verify before digging.
+
+## Where to look
+
+- [`packages/semantic/src/parser/block-parser.ts`](../packages/semantic/src/parser/block-parser.ts)
+  — the behavior/`def` block structural parser (the Phase-3 "multilingual behavior-block
+  parsing" layer, commits `484d37d7` / `e94e01d1`). The null almost certainly originates
+  here when a nested `if`-body keyword isn't recognized in he/zh.
+- [`packages/semantic/src/explicit/renderer.ts`](../packages/semantic/src/explicit/renderer.ts)
+  — block round-trip renderer (Phase 4, `342a7f81`).
+- **Per-language keyword profiles:**
+  `packages/semantic/src/generators/profiles/he.ts` and `.../zh.ts` — the keywords the
+  block body needs (`if`, `is`, `undefined`, `from`, `trigger`, `transition`, `remove`,
+  `halt`, the `js` block delimiters). A missing/misaligned keyword for one of these in
+  he/zh is the most likely culprit.
+- **i18n transformer:** `packages/i18n/src/grammar/{transformer.ts,profiles/index.ts}`.
+  First check whether he and zh have i18n **grammar profiles** (vs. keyword substitution
+  derived from the semantic profile — `ms` famously has none). The translation path
+  differs; that changes where the break is.
+- Prior diagnosis of the cluster:
+  [`CORRECTNESS_RELIABILITY_PLAN.md`](CORRECTNESS_RELIABILITY_PLAN.md) §2 (control-flow body
+  parsing is the dominant correctness gap) and the "Key triage insight" in
+  [`MULTILINGUAL_ROADMAP.md`](MULTILINGUAL_ROADMAP.md) "Remaining work" (conditional parsing
+  breaks differently per language across three layers).
+
+## Method (proven playbook — see CLAUDE.md "Running the multilingual gate locally")
+
+1. **Edit** the semantic profile(s) `profiles/{he,zh}.ts`, `block-parser.ts`, and/or the
+   i18n transformer.
+2. **Rebuild** what you touched: `cd packages/semantic && npx tsup`; if you touched core's
+   multilingual path, `cd packages/core && npx rollup -c` (the harness parses via
+   `@hyperfixi/core/multilingual`).
+3. **Probe** the single pattern (translate + parse, above) before any full run.
+4. **Repopulate:** from `packages/patterns-reference`, `npm run db:init:force && npm run sync:translations`.
+5. **Re-baseline:** `npx tsx src/multilingual/cli.ts --full --bundle browser-priority --save-baseline`.
+6. **Verify the diff** vs HEAD baseline: only he/zh `behavior-removable` should flip; **zero
+   `↓`** elsewhere.
+7. **Restore the binary DB:** `git checkout packages/patterns-reference/data/patterns.db` —
+   do NOT commit it (CI repopulates from source; committing dicts/profiles + baseline suffices).
+
+## Gotchas
+
+- The `--regression` gate **refuses to run against a stale/unstamped `patterns.db`** —
+  always `populate` first (provenance-stamp guard).
+- `npx tsx`/`npx vitest` do **not** auto-rebuild stale dist (the "unreproducible baseline"
+  trap, roadmap §7g) — rebuild upstream deps yourself or use `npm run check:fresh`.
+- This is **not guaranteed to be a quick fix.** Behavior-block parsing in non-Latin/SOV is
+  the documented hard frontier; the fix may be one keyword alignment (cheap) or a
+  nested-conditional-body structural fix (a multi-step arc). Time-box the probe: if the
+  translated text itself is already broken, it's an **i18n transformer** problem; if the
+  text looks right but `parse` returns null, it's a **semantic block-parser/keyword** problem.
+- Keep the change minimal and language-scoped. Don't chase other languages' lossy passes in
+  the same PR — re-baseline isolates he/zh only.
+
+## Definition of done
+
+he + zh `behavior-removable` parse non-null; gate `--regression` green (no parse-rate drop
+
+> 2pts, no new degenerate/lossy/precision/role/exec regressions); baseline regenerated and
+> committed with the he/zh dict/profile changes; `patterns.db` left uncommitted.

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -100,8 +100,10 @@ x/y`, and dynamic `add { left: ${…}px }` style templating; (b) if the runtime 
    Draggable (we had it working before; richest source) as the bellwether for Sortable/Resizable.
 2. **Fix `behavior-removable` — it is CURATED, so its failures are real bugs.** 13 degen, 8 lossy,
    and the only behavior with **hard** parse failures (he/zh). It is already source-compiled, so
-   this is a parse/i18n bug, not an imperative-JS one — check the `install … Removable` block
-   parses in he/zh.
+   this is a parse/i18n bug, not an imperative-JS one — the he/zh translation of the Removable
+   block returns a **null parse**. **Handoff written:**
+   [`HANDOFF-behavior-removable-he-zh.md`](HANDOFF-behavior-removable-he-zh.md) (reproduction,
+   file pointers, method, gotchas). This is the recommended next contained behavior item.
 3. **The actual priority — the authoring + install system for community & LLM agents:**
    - ~~**Authoring guide**~~ **DONE** (2026-06-16): `packages/behaviors/AUTHORING.md` — the
      canonical "what is a behavior / boundary test / how to write one / install + resolver /
@@ -110,9 +112,10 @@ x/y`, and dynamic `add { left: ${…}px }` style templating; (b) if the runtime 
    - **Install path:** the resolver hook already works (`install X` → `_hyperscript.behaviors.resolve(X)`
      → compile-on-first-use, `packages/behaviors/src/behavior-resolver.ts`) — now documented in
      AUTHORING.md §7 as the public extension point.
-   - **LLM-agent path (the remaining gap):** AUTHORING.md §9 gives agents a boundary checklist,
-     but there is still no MCP tool / programmatic validator that _enforces_ it. Add one — schema +
-     a "stays-in-lane?" validator (reject component-shaped behaviors that need observers/async loops).
+   - **LLM-agent path (boundary _validator_) — SKIPPED for now** (decision 2026-06-16: too heavy
+     for this stage of adoption). AUTHORING.md §9 already gives agents a boundary checklist; an
+     MCP/programmatic validator that _enforces_ it (reject component-shaped behaviors) is deferred
+     until adoption justifies the weight. Revisit when there's real third-party behavior authoring.
 
 **Layer:** runtime (execute the Experimental-3 source + the Removable parse bug) + product
 curation + DX/tooling (the system). **Owner docs:** `packages/behaviors/AUTHORING.md`,
@@ -205,18 +208,18 @@ target` idiom yields null even when a match exists (`target.closest("li")` works
 
 ## Recommended sequence
 
-1. ~~**Track 1a — eliminate imperative JS**~~ **DONE** (2026-06-16, branch
-   `feat/behaviors-no-imperative-js`): Draggable/Sortable/Resizable compile from `source`;
-   `imperativeInstaller` → 0. Still open under Track 1: the curated `behavior-removable` he/zh
-   parse bug, and the three **Runtime correctness follow-ups** above.
-2. **Track 1b — behavior _system_ hardening**: the authoring guide + the resolver-as-public-API
-   docs + the missing agent/MCP "write-and-validate-a-behavior" path. The stated priority;
-   parallelizable with the parser work below.
-3. **Track 2 — reactivity (htmx v4) in the multilingual parse path**: teach the semantic parser
+1. ~~**Track 1a — eliminate imperative JS**~~ **DONE** (PRs #440–#442): Draggable/Sortable/Resizable
+   compile from `source`; `imperativeInstaller` → 0. Runtime follow-ups #1 (event-args) + #2 (inline
+   style) also **DONE** (#442); #3 (`closest`) deferred.
+2. ~~**Track 1b — authoring guide**~~ **DONE** (#443, `packages/behaviors/AUTHORING.md`). The
+   boundary **validator** is **skipped** for this stage (see item 3 above).
+3. **`behavior-removable` he/zh** — the recommended next contained behavior item; handoff ready at
+   [`HANDOFF-behavior-removable-he-zh.md`](HANDOFF-behavior-removable-he-zh.md).
+4. **Track 2 — reactivity (htmx v4) in the multilingual parse path**: teach the semantic parser
    the `bind`/`live`/`intercept` block shapes; profile keywords for ms/sw/tr/hi first. The largest
    genuine parser effort now, and required (htmx v4 is in scope).
-4. **Track 3 — R1 role-fidelity burn-down** on hi/qu/bn — greenfield headroom on the laggard dimension.
-5. **Track 4 control-flow** opportunistically; **Track 5 hygiene** continuously.
+5. **Track 3 — R1 role-fidelity burn-down** on hi/qu/bn — greenfield headroom on the laggard dimension.
+6. **Track 4 control-flow** opportunistically; **Track 5 hygiene** continuously.
 
 Re-baseline (`--save-baseline`) after each intentional fidelity change, regenerate against a
 freshly `populate`d DB, and commit only the dicts/profiles + baseline (not `patterns.db`).


### PR DESCRIPTION
## Summary

- **New [`docs-internal/HANDOFF-behavior-removable-he-zh.md`](../blob/docs/handoff-behavior-removable/docs-internal/HANDOFF-behavior-removable-he-zh.md)** — a self-contained handoff prompt for the one remaining curated-behavior bug: the Removable behavior returns a **null parse** in he + zh. Covers the goal/acceptance, the exact source that must parse, a cold-tree reproduction + single-language probe, where to look (semantic `block-parser.ts`, he/zh profiles, the i18n transformer), the proven edit→rebuild→probe→repopulate→re-baseline method, and gotchas (incl. "if the translated text is already broken it's an i18n problem; if it parses to null it's a semantic block-parser problem").
- **`MULTILINGUAL_NEXT_STEPS.md`** — records the decision to **skip the agent boundary validator** for this stage of adoption (AUTHORING.md §9 already gives agents the checklist; an enforcing MCP/programmatic validator is deferred until real third-party authoring justifies it), links the handoff, and fixes the recommended sequence.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)