### PR TITLE
fix(multilingual): Track 2 increment 1 — ms bind + hi reactivity keywords

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -145,30 +145,64 @@ curation + DX/tooling (the system). **Owner docs:** `packages/behaviors/AUTHORIN
 MULTILINGUAL_BEHAVIORS_PLAN.md, BEHAVIORS_CONSOLIDATION_PLAN.md. **Audit cmd:** grep
 `imperativeInstaller` under `packages/behaviors/src/behaviors/` — must reach 0.
 
-### Track 2 — Reactivity (htmx v4): bring the multilingual parse path up to the runtime
+### Track 2 — Reactivity: bring the multilingual parse path up to the runtime
 
-**Decision (settled): htmx v4 features, including reactivity, are in scope and must be
-supported — including in the multilingual path.** So this is not an exclusion; it's a
-parser/profile build-out.
+> **htmx v4 syntax verified (2026-06-17, against four.htmx.org).** htmx v4 reactivity is the
+> **`hx-live` extension only** — a JS-expression body re-run via a document-wide
+> `MutationObserver` + `input`/`change` events + post-swap, with a `q()` selector proxy and
+> `debounce`/`timeout`/`trigger`/`take`/`nextFrame` scope helpers — plus the separate `hx-sse`
+> / `hx-ws` streaming extensions. **htmx v4 has NO `hx-bind`, `hx-computed`, two-way binding,
+> or signals.** So of the gate's reactivity patterns, only **`live`** descends from htmx v4
+> (`hx-live` → hyperfixi's `live … end`, with a hyperscript body instead of upstream's JS — a
+> documented divergence). **`bind` / `computed` / `two-way` are hyperfixi-native reactivity
+> DSL, not htmx v4.** The old "reactivity (htmx v4)" framing conflated the two; corrected here.
+> (Possible follow-up unrelated to the gate: hyperfixi's SSE/WS compat uses the htmx-2-era
+> `sse-connect`/`ws-connect` attribute names; htmx v4 ships these as the `hx-sse`/`hx-ws`
+> extensions. Worth reconciling in the htmx-compat layer, but out of scope for the parse path.)
 
-**Why:** as of 2026-06-17 owns **all 8** remaining hard parse failures (ms `bind-*` ×4, sw
-`two-way-binding`/`computed-value`/`input-char-count`, tr `window-resize`) plus the hi degenerate
-cluster (`bind-*`/`live-*`/`intercept`).
-The hx-v4 **runtime** already handles these (`hx-live` → `live … end` block + `@hyperfixi/reactivity`,
-shipped in `hyperfixi-hx-v4.js`). The gap is purely the **semantic / multilingual parse path** —
-it doesn't yet model the reactive block shapes, so these patterns drop to hard-fail/degenerate
-when authored in non-English.
+**Decision (settled): reactivity is in scope and must be supported in the multilingual path.**
+This is a parser/profile build-out, not an exclusion.
 
-**Action:**
+> **Increment 1 DONE (2026-06-17, PR pending — `feat/track2-reactivity-ms-bind-hi-keywords`).**
+> Recon disproved the "all 8 are reactive block shapes" framing: the 8 hard fails split three
+> ways. Cleared the clean half:
+>
+> - **ms `bind`×4 (hard-fail → parse).** `bindSchema` source `markerOverride` had `ms:'to'`
+>   (stale comment "no i18n grammar profile") but ms gained the Malay grammar profile, so the
+>   transformer emits the dative `ke`. Pattern expected `to`, text had `ke` → NULL. Fixed
+>   `ms:'to'`→`'ke'` (mirrors `id`) in `command-schemas.ts`.
+> - **hi `bind`×4 + `intercept` (degenerate → faithful/improved).** The hi profile was missing
+>   `bind` and `intercept` keywords entirely (English-literal emission, like `worker`/
+>   `eventsource`); added them + a hi `bind` source marker (`में`).
+>
+> Result: parse rate **3688 → 3692/3696**, degenerate **29 → 24**, hi avgFidelity **+0.033**,
+> gate green, **zero regressions**. Semantic suite 6099 green.
 
-1. Teach the semantic parser the `bind … end` / `live … end` (and `intercept`) block shapes,
-   mirroring how the behavior/`def` blocks were added (PRs #426–#430, the structural-layer work).
-2. Add the per-language profile keywords (`bind`/`live`/`two-way`/`computed`) for the priority langs,
-   starting with the hard-fail set (ms, sw, tr) and the hi degenerate cluster.
-3. Re-baseline; expect hi precision (0.813, the outlier) and the ms/sw/tr hard fails to clear together.
+**Remaining hard fails (4) + hi block cluster — precise diagnoses (deferred, each its own arc):**
 
-**Layer:** semantic parser + per-language profiles (block-structure parsing). This is the largest
-genuine _parser_ effort remaining now that behaviors resolve mostly by curation.
+1. **sw `input-char-count` / `two-way-binding` / `computed-value` (3 hard-fail).** All three are
+   plain **`on input` event handlers** (NOT reactive commands — the names mislead). They reduce
+   to one breaker: an **`on input` / `on keyup` handler with a `set` body** → NULL in sw
+   (`kwenye ingizo seti …`). Isolation: `on input` + `add`/`put`/`log` parse; `on submit`/`on
+change` + `set` parse; standalone `set #x.y to my value` parses. So it's the
+   `(input|keyup)`-event × `set`-body interaction specifically — likely a sw event-extraction /
+   morphology-normalizer edge on `ingizo`/`kitufe_juu` adjacent to `seti`. Highest remaining
+   leverage (3 fails, one root cause).
+2. **tr `window-resize` (1 hard-fail).** `on resize from window debounced at 200ms call
+adjustLayout()` → the SOV reorder scrambles the handler
+   (`adjustLayout() i boyut_değiştir de çağır pencere den`) **and** the `debounced at 200ms`
+   modifier is left untranslated. This is an i18n-transformer SOV event-handler-reorder +
+   event-modifier-translation gap, not a semantic-parser gap.
+3. **hi `live-derived-value` / `live-multiple-deps` (degenerate); also `intercept` blocks.** The
+   genuine **reactive block-shape** work: `live`/`intercept` (and `eventsource`/`socket`/
+   `worker`) are `bareKeyword` blocks (`hasBody:true`), but `block-parser.ts` only handles
+   `behavior`/`def`. In non-English the `live … end` / `intercept … end` block parses as a bare
+   `on`, dropping the block action. Teach the block layer the bareKeyword block shape (mirrors
+   the behavior/`def` structural layer).
+
+**Layer:** (1) sw semantic parser/tokenizer · (2) i18n transformer (SOV event reorder + modifier
+xlate) · (3) semantic block-parser (bareKeyword blocks). Start with (1) — most leverage, cleanest
+scope.
 
 ### Track 3 — R1 role-fidelity burn-down (the untouched dimension)
 

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -698,7 +698,7 @@ export const bindSchema: CommandSchema = {
         de: 'zu',
         it: 'in',
         id: 'ke',
-        ms: 'to', // no i18n grammar profile: prepositions stay English in generated text
+        ms: 'ke', // Malay grammar profile now emits the dative `ke` (mirrors id)
         vi: 'vào', // generic destination preposition (matches set/put `into`), not "với"/with
         ru: 'в', // generic destination preposition (matches set/put `into`)
         uk: 'в',
@@ -714,6 +714,7 @@ export const bindSchema: CommandSchema = {
         tl: 'sa',
         bn: 'তে',
         qu: 'man',
+        hi: 'में', // SOV locative the transformer emits for the bind target
       },
     },
   ],

--- a/packages/semantic/src/generators/profiles/hindi.ts
+++ b/packages/semantic/src/generators/profiles/hindi.ts
@@ -196,6 +196,12 @@ export const hindiProfile: LanguageProfile = {
       alternatives: ['इवेंटसोर्स'],
       normalized: 'eventsource',
     },
+    // Reactivity / service-worker commands: same English-literal emission as the
+    // streaming commands above (no i18n hi dict entry), so English primary with
+    // native transliteration alternatives. Previously absent — `bind`/`intercept`
+    // dropped to a degenerate parse in hi.
+    bind: { primary: 'bind', alternatives: ['बाइंड', 'बांधें'], normalized: 'bind' },
+    intercept: { primary: 'intercept', alternatives: ['इंटरसेप्ट'], normalized: 'intercept' },
   },
   tokenization: {
     particles: ['को', 'में', 'पर', 'से', 'का', 'की', 'के', 'तक', 'ने'],

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-17T00:54:08.487Z",
-  "commit": "18939a01",
+  "timestamp": "2026-06-17T03:48:32.337Z",
+  "commit": "21cf41b4",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -651,7 +651,7 @@
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1283,7 +1283,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
       "lossyPasses": ["behavior-removable", "get-value"],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1908,7 +1908,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2540,7 +2540,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3172,7 +3172,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3815,7 +3815,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4440,20 +4440,12 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9383198255378694,
-      "avgFidelity": 0.9424603174603177,
-      "avgPrecision": 0.8148912595341167,
+      "avgFidelity": 0.9749278499278501,
+      "avgPrecision": 0.8259302205730776,
       "avgRoleFidelity": 0.6830174330174333,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": [
-        "bind-auto-detect",
-        "bind-explicit-property",
-        "bind-non-form-display",
-        "bind-two-way",
-        "intercept-cache-strategies",
-        "live-derived-value",
-        "live-multiple-deps"
-      ],
+      "degeneratePasses": ["live-derived-value", "live-multiple-deps"],
       "lossyPasses": [
         "behavior-removable",
         "behavior-sortable",
@@ -4461,7 +4453,7 @@
         "keydown-key-is-syntax",
         "unless-condition"
       ],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5093,7 +5085,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5725,7 +5717,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6363,7 +6355,7 @@
         "form-disable-on-submit",
         "unless-condition"
       ],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7003,7 +6995,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7624,13 +7616,13 @@
       }
     },
     "ms": {
-      "parseSuccess": 150,
-      "parseFailure": 4,
-      "parseRate": 0.974025974025974,
-      "avgConfidence": 0.8312063492063471,
-      "avgFidelity": 0.9822222222222221,
-      "avgPrecision": 0.9710000000000001,
-      "avgRoleFidelity": 0.8636234714359714,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.835590599876312,
+      "avgFidelity": 0.9826839826839826,
+      "avgPrecision": 0.9717532467532468,
+      "avgRoleFidelity": 0.8673093235593236,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["socket-basic"],
@@ -7640,7 +7632,7 @@
         "last-in-collection",
         "set-color-variable"
       ],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7883,6 +7875,22 @@
           "confidence": 1
         },
         "when-multiple-changes": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-auto-detect": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-two-way": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-explicit-property": {
+          "success": true,
+          "confidence": 1
+        },
+        "bind-non-form-display": {
           "success": true,
           "confidence": 1
         },
@@ -8241,18 +8249,6 @@
         "socket-basic": {
           "success": true,
           "confidence": 0.5
-        },
-        "bind-auto-detect": {
-          "success": false
-        },
-        "bind-two-way": {
-          "success": false
-        },
-        "bind-explicit-property": {
-          "success": false
-        },
-        "bind-non-form-display": {
-          "success": false
         }
       }
     },
@@ -8268,7 +8264,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-removable", "behavior-sortable", "get-value"],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8900,7 +8896,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "behavior-removable", "behavior-resizable"],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9539,7 +9535,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10171,7 +10167,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10810,7 +10806,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11444,7 +11440,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12076,7 +12072,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12713,7 +12709,7 @@
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13344,7 +13340,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13984,7 +13980,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14626,7 +14622,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 438237,
+      "bundleSize": 438261,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15249,7 +15245,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 438237,
+      "size": 438261,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Track 2 — reactivity in the multilingual parse path (increment 1)

Clears **4 of 8** reactivity hard parse failures and improves the hi degenerate cluster, with zero regressions.

### htmx v4 syntax verification (requested)

Verified against **four.htmx.org**: htmx v4 reactivity is the **`hx-live` extension only** — a JS-expression body re-run via a document-wide `MutationObserver` + `input`/`change` + post-swap, with a `q()` selector proxy and `debounce`/`timeout`/`trigger`/`take`/`nextFrame` helpers — plus the separate `hx-sse`/`hx-ws` streaming extensions. **htmx v4 has no `hx-bind`, `hx-computed`, two-way binding, or signals.**

So of our gate's reactivity patterns, **only `live` descends from htmx v4** (`hx-live` → hyperfixi's `live … end`, with a hyperscript body instead of upstream's JS — a documented divergence). **`bind`/`computed`/`two-way` are hyperfixi-native reactivity DSL, not htmx v4.** The doc's "reactivity (htmx v4)" framing conflated them; corrected in `MULTILINGUAL_NEXT_STEPS.md`.

### Recon reframed the work

The 8 hard-fails are **not** one "reactive block shape" problem — they split three ways:

| Lang | Patterns | Root cause |
| --- | --- | --- |
| **ms** | `bind`×4 | `bindSchema` source marker `ms:'to'` but i18n emits `ke` → pattern mismatch → NULL |
| **sw** | `input-char-count`, `two-way-binding`, `computed-value` | plain `on input` handlers (names mislead); `on input`/`on keyup` + `set` body → NULL |
| **tr** | `window-resize` | SOV reorder scrambles `on resize call X()` + `debounced at` modifier untranslated |
| **hi** | `bind`×4, `intercept`, `live` (degenerate) | hi profile missing `bind`/`intercept` keywords; `live`/`intercept` blocks parse as `on` |

### Fixes in this PR (the clean half; semantic-only, translations unchanged)

- **ms `bind`×4 → parse.** `bindSchema` source `markerOverride` `ms:'to'` → `'ke'`. The comment ("no i18n grammar profile: prepositions stay English") was stale — ms gained the Malay grammar profile, so the transformer emits the dative `ke`; the generated pattern expected `to`. Now matches (mirrors `id:'ke'`).
- **hi `bind`×4 + `intercept` → faithful/improved.** Hindi profile was missing `bind` and `intercept` keywords entirely (English-literal emission, like `worker`/`eventsource`); added them + a hi `bind` source marker (`में`).

### Results

- Parse rate **3688 → 3692 / 3696** (ms +2.6%, 4 new successes).
- Degenerate passes **29 → 24** (hi `bind`×4 + `intercept` degenerate → faithful).
- hi avgFidelity **+0.033**; `--regression` gate **green**, **zero** new degenerate/lossy/precision/role/exec regressions.
- Semantic suite **6099 passed**; typecheck clean. `patterns.db` left uncommitted (CI repopulates).

### Deferred (precise diagnoses in `MULTILINGUAL_NEXT_STEPS.md` Track 2)

- **sw ×3 (hard):** `on input`/`on keyup` + `set` body → NULL (event×`set` edge; `add`/`put` and `submit`/`change`+`set` all parse). Highest remaining leverage — 3 fails, one root cause.
- **tr ×1 (hard):** i18n SOV event-handler reorder + `debounced at` modifier translation gap.
- **hi (degenerate):** `live`/`intercept` bareKeyword blocks — the genuine block-shape work (`block-parser.ts` handles only `behavior`/`def`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)