### PR TITLE
fix(semantic): keep handler-body commands after a nested js-bearing if

### DIFF
--- a/docs-internal/HANDOFF-transformer-behavior-fidelity.md
+++ b/docs-internal/HANDOFF-transformer-behavior-fidelity.md
@@ -1,7 +1,21 @@
 # Handoff — multilingual behavior fidelity (i18n transformer nested-body arc)
 
-> Paste into a fresh session to pick up the work. Self-contained. A **staged** arc
-> (multi-increment), not a one-shot fix.
+> **⚠️ SUPERSEDED — WRONG DIAGNOSIS (2026-06-19). Do not follow this doc's
+> root-cause.** It blames the i18n `GrammarTransformer` for "flattening nested
+> `if {…}` bodies," reproduced via `MultilingualHyperscript.translate`. But
+> `ml.translate` is `semantic.translate` = **parse→render**, a path the fidelity
+> **gate never uses**. The gate measures `patterns.db`, populated by
+> `sync:translations` → `GrammarTransformer.transform`, whose output is **faithful**
+> (precision 1.000 — it does NOT flatten the nested bodies). The real defect is
+> **pure recall in the SEMANTIC PARSER**: it drops the handler-body commands after
+> the first nested `if`/`repeat` block. First increment fixed (semantic
+> `buildEventHandler` fold-rewind + `isEndKeyword` English-`end`): removable 0.667 →
+> 0.889 across SVO langs. See **MULTILINGUAL_NEXT_STEPS.md → Track 1 item 2** for the
+> corrected diagnosis, the remaining increments (js-opaque for removable's `return`
+> artifact; sortable's `repeat`/`wait` loop-block fold; SOV head-reorder), and how
+> to reproduce the gate path correctly (`GrammarTransformer` + `maskSpans`, then
+> `parseSemantic`). The historical content below is kept only for context — it was
+> written as a self-contained staged-arc handoff before the diagnosis was corrected.
 
 ## Why this matters (read first)
 

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -130,14 +130,46 @@ x/y`, and dynamic `add { left: ${…}px }` style templating; (b) if the runtime 
    `behavior-sortable` (9 degen + 14 lossy) and the Experimental-3 source execution (item 1).
 
    > **Multilingual behavior fidelity is a PRIORITY (user, 2026-06-17).** The faithful-pass
-   > headroom above is the next behavior arc, not optional. **Root-cause triage (2026-06-19):**
-   > `behavior-removable` + `behavior-sortable` are non-faithful in **all 23 non-en langs** (the
-   > high-leverage targets; draggable/resizable are SOV-only). The defect is in the **i18n
-   > `GrammarTransformer`** (NOT the parser) — verified on **SVO Spanish**, where the translated
-   > Removable body is already mangled: nested `if {…}` bodies flattened into a then-chain (`js()`/
-   > `halt`/`transition` dropped), `init` reordered + its body dropped, `is undefined` untranslated.
-   > Staged arc handoff: [`HANDOFF-transformer-behavior-fidelity.md`](HANDOFF-transformer-behavior-fidelity.md).
-   > **This is the recommended next behavior item.**
+   > headroom above is the next behavior arc, not optional.
+   >
+   > **⚠️ DIAGNOSIS CORRECTION (2026-06-19).** The earlier triage above — and
+   > [`HANDOFF-transformer-behavior-fidelity.md`](HANDOFF-transformer-behavior-fidelity.md) — blamed
+   > the **i18n `GrammarTransformer`** ("nested `if {…}` bodies flattened into a then-chain"). That
+   > was reproduced via `MultilingualHyperscript.translate`, which is **`semantic.translate` =
+   > parse→render**, a path the **fidelity gate does not use**. The gate measures the translations in
+   > `patterns.db`, populated by `sync:translations` → the **i18n `GrammarTransformer.transform`**,
+   > whose output is in fact **faithful** (precision **1.000** in every language — no flattening, no
+   > dropped `js()`/`halt`/`transition`). The real loss is **pure recall in the SEMANTIC PARSER**:
+   > parsing the (faithful) translation drops the handler-body commands that follow the first nested
+   > `if`/`repeat` block — exactly the "body sub-parse drops `trigger`/`remove`/`halt` after the
+   > conditionals" line above. **It is a parser bug, not a transformer bug.** Do NOT spend effort on
+   > `transformer.ts` for this; the HANDOFF doc is superseded.
+   >
+   > **Increment DONE (2026-06-19, semantic parser).** Two stacked bugs in
+   > [`semantic-parser.ts`](../packages/semantic/src/parser/semantic-parser.ts) `buildEventHandler`:
+   > (a) the fused-pattern **fold-rewind guard** only saw a TOP-LEVEL conditional, but
+   > `parseBodyWithClauses` wraps a multi-statement body in a `compound` — so the fold was missed and
+   > the flat path dropped every command after the SECOND `end` (`trigger removable:removed`,
+   > `remove me`); fixed to look inside the single-`compound` wrapper. (b) `isEndKeyword` rejected the
+   > **English literal `end`** for curated langs (es `fin`, ja `終わり`, …), but a masked `js(…) … end`
+   > block restores its terminator as English `end` → the conditional's depth tracker counted the js
+   > body's `if` (+1) but not the js `end` (−1), unbalancing depth so the conditional over-consumed
+   > the rest of the body; fixed to accept English `end` universally. Result: **behavior-removable
+   > 0.667 → 0.889** across the clean SVO/other langs (es/fr/de/zh/it/id/ms/vi/ru/pl/he), per-language
+   > avgFidelity +0.0014–0.0022, avgRoleFidelity up everywhere, **gate green, zero regressions**,
+   > 6098 semantic tests pass. Regression guards in
+   > [`multilingual-roadmap-fixes.test.ts`](../packages/semantic/test/multilingual-roadmap-fixes.test.ts)
+   > ("Multi-statement handler body with a js-bearing nested if").
+   >
+   > **Still open (each its own increment):** (1) removable's last gap is the en reference parsing
+   > `return` (and a spurious `if`) from inside the raw `js(…)` body — masked in translations, so they
+   > can't match it (caps removable at 0.889, not 1.0). Fix = treat `js(…) … end` as **opaque** in the
+   > parser for ALL langs incl. en (removes `return`/js-internal-`if` from the reference → faithful).
+   > (2) **`behavior-sortable`** is unmoved — its loss is `repeat`/`wait` inside a `repeat until event
+pointerup … end` block (a loop block, NOT a conditional), so the conditional fold doesn't reach
+   > it; needs the analogous loop-block fold on the fused-event path. (3) **SOV/VSO degeneracy**
+   > (ja/ko/tr/qu/ar/tl) on both behaviors is the behavior-head/`init` reorder, a separate structural
+   > problem. **(2) is the recommended next behavior item.**
 
 3. **The actual priority — the authoring + install system for community & LLM agents:**
    - ~~**Authoring guide**~~ **DONE** (2026-06-16): `packages/behaviors/AUTHORING.md` — the

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -559,7 +559,22 @@ export class SemanticParserImpl implements ISemanticParser {
           .sort((a, b) => b.priority - a.priority);
         const bodyStream = new TokenStreamImpl(all.slice(ifIdx), language);
         const folded = this.parseBodyWithClauses(bodyStream, commandPatterns, language);
-        if (folded.some(n => n.kind === 'conditional')) {
+        // A conditional folded if it sits at the top level (body is the single
+        // `if` block) OR nested inside the single `compound` wrapper that
+        // parseBodyWithClauses returns whenever the body has >1 clause
+        // (`if confirmRemoval … end trigger … remove me`). The original guard only
+        // checked the top level, so a multi-statement handler body — exactly the
+        // removable/sortable shape — fell through to the flat path below, which
+        // captures `if` as a bare command and then drops every command after the
+        // SECOND `end` (`trigger removable:removed`, `remove me`). Looking inside
+        // the compound lets the whole faithful body (the conditional + its trailing
+        // siblings) survive, matching the English `parseBodyWithClauses` result.
+        const foldedConditional =
+          folded.some(n => n.kind === 'conditional') ||
+          (folded.length === 1 &&
+            folded[0]?.kind === 'compound' &&
+            (folded[0] as CompoundSemanticNode).statements.some(s => s.kind === 'conditional'));
+        if (foldedConditional) {
           while (!tokens.isAtEnd()) tokens.advance(); // body fully consumed by the fold
           return createEventHandler(resolvedEventValue, folded, eventModifiers, {
             sourceLanguage: language,
@@ -2154,10 +2169,18 @@ export class SemanticParserImpl implements ISemanticParser {
       qu: new Set(['tukukuy', 'tukuy', 'puchukay']),
       sw: new Set(['mwisho', 'maliza', 'tamati']),
     };
-    // See isThenKeyword: curated langs unchanged; the rest fall back to the
-    // profile's `end` form + the English literal.
+    // The English literal `end` is accepted in EVERY language, not just the
+    // profile-fallback ones: hyperscript keywords that pass through a translation
+    // untouched keep their English form, and crucially a masked `js(…) … end`
+    // block restores its terminator as the English `end`. If a curated language
+    // (es `fin`, ja `終わり`, …) rejected that literal, the depth tracker in
+    // `tryParseConditionalBlock` would count the js body's `if` (+1) but never the
+    // js block's `end` (−1) — leaving depth unbalanced so the conditional
+    // over-consumes the rest of the handler body (the removable/sortable
+    // command-drop: `trigger`, `remove`, … vanish after the js-bearing `if`).
+    // en already works because `end` is in its curated set; this aligns the rest.
     const curated = endKeywords[language];
-    if (curated) return curated.has(v);
+    if (curated) return v === 'end' || curated.has(v);
     return v === 'end' || this.profileKeywordMatches(language, 'end', v);
   }
 

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -6459,3 +6459,113 @@ describe('S1 tabs-aria — `set @attr to V on <scope>` scope capture (band inver
     expect(role).toBeUndefined();
   });
 });
+
+describe('Multi-statement handler body with a js-bearing nested if (behavior-removable shape)', () => {
+  // The removable/sortable behaviors put a nested `if … end` (containing a
+  // `js(…) … end` block) FIRST in the handler body, then trailing commands
+  // (`trigger …`, `remove me`). Two bugs dropped everything after the nested
+  // block in non-English languages:
+  //   1. buildEventHandler's fold-rewind only recognized a TOP-LEVEL conditional,
+  //      but parseBodyWithClauses wraps a multi-clause body in a `compound` — so
+  //      the fold was missed and the flat path dropped the trailing commands.
+  //   2. isEndKeyword rejected the English literal `end` for curated languages
+  //      (es `fin`, ja `終わり`, …). A masked `js(…) … end` block restores its
+  //      terminator as English `end`, so the conditional's depth tracker counted
+  //      the js body's `if` (+1) but not the js `end` (−1), unbalancing depth and
+  //      over-consuming the rest of the body into the conditional.
+  // These inputs mirror what the i18n GrammarTransformer emits for the Removable
+  // handler (the js body is masked, so its `end` stays English). Guards the
+  // `trigger`/`remove` recall that drove behavior-removable's lossy band.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const n = node as Record<string, unknown>;
+    if (typeof n.action === 'string') acc.add(n.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = n[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('[es] keeps trigger + remove after the js-bearing if (was dropped)', () => {
+    const input = [
+      'en clic de triggerEl',
+      '  si confirmRemoval',
+      '    js(me)',
+      '      if (!window.confirm("Are you sure?")) return "cancel";',
+      '    end',
+      '    si ello es "cancel"',
+      '      detener',
+      '    fin',
+      '  fin',
+      '  disparar removable:before',
+      '  si effect es "fade"',
+      '    transición opacity a 0 300ms',
+      '  fin',
+      '  disparar removable:removed',
+      '  quitar yo',
+      'fin',
+    ].join('\n');
+    const node = parse(input, 'es');
+    expect(node.action).toBe('on');
+    const a = actions(node);
+    expect(a.has('if')).toBe(true);
+    expect(a.has('halt')).toBe(true);
+    expect(a.has('trigger')).toBe(true); // disparar — dropped before the fix
+    expect(a.has('remove')).toBe(true); // quitar — dropped before the fix
+  });
+
+  it('[de] keeps trigger + remove after the js-bearing if (English js `end`)', () => {
+    // de end keyword is `ende`; the js block keeps the English `end`. Without the
+    // universal-`end` recognition the depth tracker would over-consume here too.
+    const input = [
+      'bei klick von triggerEl',
+      '  falls confirmRemoval',
+      '    js(me)',
+      '      if (!window.confirm("Are you sure?")) return "cancel";',
+      '    end',
+      '    falls es ist "cancel"',
+      '      anhalten',
+      '    ende',
+      '  ende',
+      '  auslösen removable:before',
+      '  falls effect ist "fade"',
+      '    übergang opacity zu 0 300ms',
+      '  ende',
+      '  auslösen removable:removed',
+      '  entfernen ich',
+      'ende',
+    ].join('\n');
+    const node = parse(input, 'de');
+    expect(node.action).toBe('on');
+    const a = actions(node);
+    expect(a.has('trigger')).toBe(true);
+    expect(a.has('remove')).toBe(true);
+  });
+
+  it('[en] reference keeps the full body (unchanged baseline behavior)', () => {
+    const input = [
+      'on click from triggerEl',
+      '  if confirmRemoval',
+      '    js(me)',
+      '      if (!window.confirm("Are you sure?")) return "cancel";',
+      '    end',
+      '    if it is "cancel"',
+      '      halt',
+      '    end',
+      '  end',
+      '  trigger removable:before',
+      '  if effect is "fade"',
+      '    transition opacity to 0 over 300ms',
+      '  end',
+      '  trigger removable:removed',
+      '  remove me',
+      'end',
+    ].join('\n');
+    const a = actions(parse(input, 'en'));
+    expect(a.has('trigger')).toBe(true);
+    expect(a.has('remove')).toBe(true);
+    expect(a.has('halt')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-17T18:21:50.461Z",
-  "commit": "44aaf6a6",
+  "timestamp": "2026-06-19T14:43:16.993Z",
+  "commit": "7a78cbc0",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -651,7 +651,7 @@
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1276,14 +1276,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.830921459492886,
-      "avgFidelity": 0.9920634920634922,
+      "avgFidelity": 0.9935064935064937,
       "avgPrecision": 0.993831168831169,
-      "avgRoleFidelity": 0.8543580856080857,
+      "avgRoleFidelity": 0.8568150880650881,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
       "lossyPasses": ["behavior-removable", "get-value"],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1908,7 +1908,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2533,14 +2533,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8338074623788887,
-      "avgFidelity": 0.9963924963924963,
+      "avgFidelity": 0.9978354978354977,
       "avgPrecision": 0.9817099567099568,
-      "avgRoleFidelity": 0.8400550463050463,
+      "avgRoleFidelity": 0.8425120487620488,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3165,14 +3165,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8247371675943084,
-      "avgFidelity": 0.9963924963924963,
+      "avgFidelity": 0.9978354978354977,
       "avgPrecision": 0.9804112554112555,
-      "avgRoleFidelity": 0.8429266679266679,
+      "avgRoleFidelity": 0.8453836703836703,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3797,9 +3797,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8244897959183674,
-      "avgFidelity": 0.9743506493506491,
+      "avgFidelity": 0.9765151515151513,
       "avgPrecision": 0.9851731601731601,
-      "avgRoleFidelity": 0.8817963005463006,
+      "avgRoleFidelity": 0.8848675536175536,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["unless-condition"],
@@ -3815,7 +3815,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4453,7 +4453,7 @@
         "keydown-key-is-syntax",
         "unless-condition"
       ],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5078,14 +5078,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.838961038961037,
-      "avgFidelity": 0.9963924963924963,
+      "avgFidelity": 0.9978354978354977,
       "avgPrecision": 0.979761904761905,
-      "avgRoleFidelity": 0.857349126099126,
+      "avgRoleFidelity": 0.8598061285561284,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5710,14 +5710,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8364873222016058,
-      "avgFidelity": 0.9956709956709956,
+      "avgFidelity": 0.9978354978354977,
       "avgPrecision": 0.9715638528138526,
-      "avgRoleFidelity": 0.8359176296676298,
+      "avgRoleFidelity": 0.8389888827388828,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6355,7 +6355,7 @@
         "form-disable-on-submit",
         "unless-condition"
       ],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6995,7 +6995,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7620,9 +7620,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8363327149041414,
-      "avgFidelity": 0.9826839826839826,
+      "avgFidelity": 0.9848484848484848,
       "avgPrecision": 0.9717532467532468,
-      "avgRoleFidelity": 0.8650570713070714,
+      "avgRoleFidelity": 0.8675140737640737,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["socket-basic"],
@@ -7632,7 +7632,7 @@
         "last-in-collection",
         "set-color-variable"
       ],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8264,7 +8264,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-removable", "behavior-sortable", "get-value"],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8896,7 +8896,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "behavior-removable", "behavior-resizable"],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9535,7 +9535,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10160,14 +10160,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8121727478870315,
-      "avgFidelity": 0.9891774891774893,
+      "avgFidelity": 0.9913419913419913,
       "avgPrecision": 0.980871212121212,
-      "avgRoleFidelity": 0.8326630014130014,
+      "avgRoleFidelity": 0.8357342544842546,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10805,7 +10805,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11430,9 +11430,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.840857555143267,
-      "avgFidelity": 0.9934163059163059,
+      "avgFidelity": 0.9948593073593073,
       "avgPrecision": 0.972113997113997,
-      "avgRoleFidelity": 0.8222042597042597,
+      "avgRoleFidelity": 0.823432760932761,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
@@ -11442,7 +11442,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12074,7 +12074,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12711,7 +12711,7 @@
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13342,7 +13342,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13967,9 +13967,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8044939187796312,
-      "avgFidelity": 0.9816017316017317,
+      "avgFidelity": 0.9837662337662337,
       "avgPrecision": 0.9706980519480523,
-      "avgRoleFidelity": 0.85625225000225,
+      "avgRoleFidelity": 0.8593235030735031,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
@@ -13982,7 +13982,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14607,9 +14607,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9840032982890127,
-      "avgFidelity": 0.9794011544011543,
+      "avgFidelity": 0.9808441558441557,
       "avgPrecision": 0.9962121212121211,
-      "avgRoleFidelity": 0.9111348111348111,
+      "avgRoleFidelity": 0.9135918135918135,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
@@ -14624,7 +14624,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 439528,
+      "bundleSize": 439627,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15247,7 +15247,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 439528,
+      "size": 439627,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

`behavior-removable` silently dropped `trigger`/`remove` (and similar trailing handler-body commands) in **every non-English language**. This fixes the dominant cross-language recall loss with a targeted semantic-parser change.

### Diagnosis correction
The prior [HANDOFF doc](../blob/main/docs-internal/HANDOFF-transformer-behavior-fidelity.md) blamed the **i18n `GrammarTransformer`** ("nested `if{}` bodies flattened"), reproduced via `MultilingualHyperscript.translate`. But that path is `semantic.translate` = **parse→render**, which the fidelity **gate never uses**. The gate measures `patterns.db`, populated by `sync:translations` → `GrammarTransformer.transform`, whose output is **faithful** (precision **1.000** — no flattening). The real loss is **pure recall in the semantic parser**. The HANDOFF doc is marked superseded and `MULTILINGUAL_NEXT_STEPS.md` carries the corrected diagnosis.

## The two bugs (both in `buildEventHandler`)

1. **Fold-rewind guard** only recognized a TOP-LEVEL conditional, but `parseBodyWithClauses` wraps a multi-statement body in a `compound`. So the removable/sortable shape (`if … end trigger … remove me`) missed the fold and fell through to the flat path, which drops every command after the **second** `end`. → also look inside the single-`compound` wrapper.
2. **`isEndKeyword`** rejected the English literal `end` for curated languages (es `fin`, ja `終わり`, …). A masked `js(…) … end` block restores its terminator as English `end`, so `tryParseConditionalBlock`'s depth tracker counted the js body's `if` (+1) but never the js `end` (−1) — unbalancing depth so the conditional over-consumed the rest of the body. → accept English `end` universally (en already did via its curated set).

## Results

- **behavior-removable 0.667 → 0.889** across es/fr/de/zh/it/id/ms/vi/ru/pl/he
- 11 languages up on **avgFidelity** + **avgRoleFidelity**, **0 regressions**
- `--regression` gate **green**; **6098** semantic tests pass; typecheck clean
- Baseline regenerated; `patterns.db` left uncommitted (CI repopulates)
- Regression guards added in `multilingual-roadmap-fixes.test.ts`

## Still open (separate increments, documented in `MULTILINGUAL_NEXT_STEPS.md`)

1. removable's residual `return` js-body artifact (caps it at 0.889) → make `js(…) … end` opaque in the parser for all langs incl. en
2. **behavior-sortable** unmoved — its loss is `repeat`/`wait` in a `repeat until event … end` **loop** block (not a conditional); needs the analogous loop-block fold
3. SOV/VSO degeneracy (ja/ko/tr/qu/ar/tl) is the behavior-head/`init` reorder — separate structural problem

🤖 Generated with [Claude Code](https://claude.com/claude-code)