### PR TITLE
fix(semantic): treat js(…) … end blocks as opaque in body parsing

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -161,15 +161,33 @@ x/y`, and dynamic `add { left: ${…}px }` style templating; (b) if the runtime 
    > [`multilingual-roadmap-fixes.test.ts`](../packages/semantic/test/multilingual-roadmap-fixes.test.ts)
    > ("Multi-statement handler body with a js-bearing nested if").
    >
-   > **Still open (each its own increment):** (1) removable's last gap is the en reference parsing
-   > `return` (and a spurious `if`) from inside the raw `js(…)` body — masked in translations, so they
-   > can't match it (caps removable at 0.889, not 1.0). Fix = treat `js(…) … end` as **opaque** in the
-   > parser for ALL langs incl. en (removes `return`/js-internal-`if` from the reference → faithful).
-   > (2) **`behavior-sortable`** is unmoved — its loss is `repeat`/`wait` inside a `repeat until event
-pointerup … end` block (a loop block, NOT a conditional), so the conditional fold doesn't reach
-   > it; needs the analogous loop-block fold on the fused-event path. (3) **SOV/VSO degeneracy**
+   > **Increment 2 DONE (2026-06-19, PR pending — js-block opacity).** Removed removable's last
+   > non-SOV gap: the en reference parsed a phantom `return` (and a surplus `if`) from inside the raw
+   > `js(me) … if (…) return "cancel"; … end` body — masked in translations, so they could never
+   > match it (capped removable at 0.889). A standalone `js(…) … end` already parsed clean (the main
+   > parser stops after the first command), but **nested** in a handler/conditional body the clause
+   > loop split the block at its internal `end` and re-parsed the JS body through the command
+   > patterns. Fix: `parseBodyWithClauses` now consumes a `js(…) … end` block as one opaque `js`
+   > command (`consumeJsBlock` — first `end` closes it, same heuristic as the i18n js-mask), built
+   > directly so the JS body never reaches `matchBest`. Applies to en + every translation (the `js`
+   > keyword survives translation verbatim). Result: **behavior-removable now FAITHFUL (1.0) in 11
+   > languages** (es/fr/de/it/id/ms/zh/vi/ru/pl/he); priority gate **lossy 93→84, degenerate 24→22**,
+   > avgFidelity + avgRoleFidelity up, precision flat, **zero regressions** across all 8 js-using
+   > behaviors; 6101 semantic tests pass. Guard:
+   > [`multilingual-roadmap-fixes.test.ts`](../packages/semantic/test/multilingual-roadmap-fixes.test.ts)
+   > "js(…) … end blocks are opaque to the body parser".
+   >
+   > **Still open (each its own increment):** (1) **`behavior-sortable`** is unmoved — its loss is
+   > `repeat`/`wait` inside a `repeat until event pointerup … end` block, BUT triage (2026-06-19)
+   > shows the real blocker is the i18n transformer rendering `trigger sortable:start on me` as
+   > `disparar sortable:start entonces en yo` (a spurious `then` + a stray `en yo` = "on me") right
+   > before the loop block — the exact `trigger … on me` artifact `ON_TARGET_COMMANDS`
+   > ([`transformer.ts`](../packages/i18n/src/grammar/transformer.ts)) deliberately leaves split. So
+   > sortable is a **coupled transformer+parser** arc (clean the `trigger … on me` rendering AND
+   > teach the body parser the loop-block fold), not a single-defect fix. (2) **SOV/VSO degeneracy**
    > (ja/ko/tr/qu/ar/tl) on both behaviors is the behavior-head/`init` reorder, a separate structural
-   > problem. **(2) is the recommended next behavior item.**
+   > problem (removable still degenerate in ar/qu/tl/tr). (3) **pt/sw removable** lose `on`/`remove`/
+   > `trigger` even as SVO — a distinct handler-parse gap worth its own look.
 
 3. **The actual priority — the authoring + install system for community & LLM agents:**
    - ~~**Authoring guide**~~ **DONE** (2026-06-16): `packages/behaviors/AUTHORING.md` — the

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -771,6 +771,22 @@ export class SemanticParserImpl implements ISemanticParser {
       // null without consuming when the head isn't a usable conditional — so a
       // non-conditional clause is byte-identical to the previous behavior.
       if (currentClauseTokens.length === 0) {
+        // A `js(…) … end` block is raw JavaScript and must stay OPAQUE. Its body
+        // tokens (`if (…) return …;`) look like hyperscript keywords, so if the
+        // clause loop splits the block at its internal `end`, parseClause re-parses
+        // the body and emits phantom `if`/`return`/… commands — the spurious
+        // `return` the en reference extracted from behavior-removable's js body,
+        // which capped it at fid 0.889 (translations mask the js body, so they
+        // never reproduced it). Consume the whole block — up to and including its
+        // first `end` — and parse it as one unit, so matchBest matches the single
+        // `js` command (as it already does for a standalone block) and the JS body
+        // never reaches the command patterns.
+        const jsNode = this.consumeJsBlock(tokens, language);
+        if (jsNode) {
+          clauses.push(jsNode);
+          continue;
+        }
+
         const conditional = this.tryParseConditionalBlock(tokens, commandPatterns, language);
         if (conditional) {
           clauses.push(conditional);
@@ -2182,6 +2198,72 @@ export class SemanticParserImpl implements ISemanticParser {
     const curated = endKeywords[language];
     if (curated) return v === 'end' || curated.has(v);
     return v === 'end' || this.profileKeywordMatches(language, 'end', v);
+  }
+
+  /**
+   * Whether a token opens a `js` block. The `js` command keyword survives
+   * translation verbatim (the i18n transformer masks the whole block, so the
+   * keyword stays English), so the English literal is the reliable signal; the
+   * profile form is also accepted for completeness.
+   */
+  private isJsKeyword(token: LanguageToken): boolean {
+    const v = (token.normalized ?? token.value).toLowerCase();
+    return v === 'js' || this.profileKeywordMatches('en', 'js', v);
+  }
+
+  /**
+   * Consume a `js(…) … end` block from the stream as one opaque unit and return a
+   * single `js` command node. The FIRST `end` after the `js` keyword closes the
+   * block — the same heuristic the i18n transformer's js-masking uses (raw JS never
+   * carries a bare hyperscript `end` token). Returns null without consuming when
+   * the head isn't a js keyword or the block has no closing `end` (malformed —
+   * leave it to the normal path).
+   *
+   * The node is built directly rather than re-parsed: `matchBest` in `parseClause`
+   * would match the `js` head and then keep matching the raw JS body (`if`,
+   * `return`, …) as sibling commands — the exact phantom actions this skip exists
+   * to suppress. Emitting `{ action: 'js', roles: { patient: expression } }`
+   * mirrors the shape a standalone `js(…)` parse produces, and applies uniformly to
+   * English and every translation (the keyword survives translation verbatim), so
+   * the reference and candidate js nodes stay identical for fidelity scoring.
+   */
+  private consumeJsBlock(
+    tokens: ReturnType<typeof tokenizeInternal>,
+    language: string
+  ): SemanticNode | null {
+    const head = tokens.peek();
+    if (!head || !this.isJsKeyword(head)) return null;
+
+    const startMark = tokens.mark();
+    const bodyTokens: LanguageToken[] = [];
+    tokens.advance(); // consume `js`
+
+    let sawEnd = false;
+    while (!tokens.isAtEnd()) {
+      const t = tokens.peek();
+      if (!t) break;
+      tokens.advance();
+      if (this.isEndKeyword(t.value, language)) {
+        sawEnd = true;
+        break;
+      }
+      bodyTokens.push(t);
+    }
+
+    if (!sawEnd) {
+      tokens.reset(startMark);
+      return null;
+    }
+
+    const raw = bodyTokens
+      .map(t => t.value)
+      .join(' ')
+      .trim();
+    return createCommandNode(
+      'js' as ActionType,
+      { patient: { type: 'expression', raw: raw || '()' } },
+      { sourceLanguage: language, patternId: `js-opaque-${language}`, confidence: 1 }
+    );
   }
 
   /**

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -6569,3 +6569,71 @@ describe('Multi-statement handler body with a js-bearing nested if (behavior-rem
     expect(a.has('halt')).toBe(true);
   });
 });
+
+describe('js(…) … end blocks are opaque to the body parser (no phantom JS-body commands)', () => {
+  // A `js(…) … end` block's body is raw JavaScript. When the block is nested in a
+  // handler/conditional body, the clause loop used to split it at its internal
+  // `end` and re-parse the JS body through the command patterns, emitting phantom
+  // `return`/`if`/… commands. behavior-removable's `js(me) … if (…) return "cancel";
+  // … end` injected a spurious `return` into the EN reference action set — which
+  // translations (whose js body is masked) could never reproduce, capping removable
+  // at fidelity 0.889. The body parser now consumes the whole block as one opaque
+  // `js` command, so the JS body never reaches the command patterns. A STANDALONE
+  // js block already parsed clean (the main parser stops after the first command);
+  // this guards the NESTED case.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const n = node as Record<string, unknown>;
+    if (typeof n.action === 'string') acc.add(n.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = n[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  const NESTED_JS = [
+    'on click',
+    '  if confirmRemoval',
+    '    js(me)',
+    '      if (!window.confirm("Are you sure?")) return "cancel";',
+    '    end',
+    '    if it is "cancel"',
+    '      halt',
+    '    end',
+    '  end',
+    '  remove me',
+    'end',
+  ].join('\n');
+
+  it('[en] does not extract `return` from a nested js body', () => {
+    const a = actions(parse(NESTED_JS, 'en'));
+    expect(a.has('js')).toBe(true); // the block itself is captured
+    expect(a.has('return')).toBe(false); // …but its raw-JS body is opaque
+    expect(a.has('halt')).toBe(true); // real commands after the js block survive
+    expect(a.has('remove')).toBe(true);
+  });
+
+  it('[es] keeps the js block opaque too (keyword survives translation)', () => {
+    // The i18n transformer masks the js body, so the keyword stays English `js`.
+    const input = [
+      'en clic',
+      '  si confirmRemoval',
+      '    js(me)',
+      '      if (!window.confirm("Are you sure?")) return "cancel";',
+      '    end',
+      '    si ello es "cancel"',
+      '      detener',
+      '    fin',
+      '  fin',
+      '  quitar yo',
+      'fin',
+    ].join('\n');
+    const a = actions(parse(input, 'es'));
+    expect(a.has('js')).toBe(true);
+    expect(a.has('return')).toBe(false);
+    expect(a.has('halt')).toBe(true);
+    expect(a.has('remove')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,20 +1,20 @@
 {
-  "timestamp": "2026-06-19T14:43:16.993Z",
-  "commit": "7a78cbc0",
+  "timestamp": "2026-06-19T15:29:25.196Z",
+  "commit": "ef5d34bb",
   "languages": {
     "ar": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8368310482087561,
-      "avgFidelity": 0.9860209235209235,
+      "avgFidelity": 0.9862914862914862,
       "avgPrecision": 0.9771645021645022,
-      "avgRoleFidelity": 0.8650728775728778,
+      "avgRoleFidelity": 0.8654823779823783,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 439627,
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -639,9 +639,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8495030867211314,
-      "avgFidelity": 0.994047619047619,
+      "avgFidelity": 0.9946789321789321,
       "avgPrecision": 0.9163195030078151,
-      "avgRoleFidelity": 0.779673985923986,
+      "avgRoleFidelity": 0.7802199864699865,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
@@ -651,7 +651,7 @@
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 439627,
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1276,14 +1276,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.830921459492886,
-      "avgFidelity": 0.9935064935064937,
+      "avgFidelity": 0.9942279942279945,
       "avgPrecision": 0.993831168831169,
-      "avgRoleFidelity": 0.8568150880650881,
+      "avgRoleFidelity": 0.8574293386793388,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
-      "lossyPasses": ["behavior-removable", "get-value"],
-      "bundleSize": 439627,
+      "lossyPasses": ["get-value"],
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1908,7 +1908,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 439627,
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2533,14 +2533,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8338074623788887,
-      "avgFidelity": 0.9978354978354977,
+      "avgFidelity": 0.9985569985569985,
       "avgPrecision": 0.9817099567099568,
-      "avgRoleFidelity": 0.8425120487620488,
+      "avgRoleFidelity": 0.8431262993762995,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 439627,
+      "lossyPasses": ["behavior-sortable"],
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3165,14 +3165,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8247371675943084,
-      "avgFidelity": 0.9978354978354977,
+      "avgFidelity": 0.9985569985569985,
       "avgPrecision": 0.9804112554112555,
-      "avgRoleFidelity": 0.8453836703836703,
+      "avgRoleFidelity": 0.845997920997921,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 439627,
+      "lossyPasses": ["behavior-sortable"],
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3797,14 +3797,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8244897959183674,
-      "avgFidelity": 0.9765151515151513,
+      "avgFidelity": 0.977236652236652,
       "avgPrecision": 0.9851731601731601,
-      "avgRoleFidelity": 0.8848675536175536,
+      "avgRoleFidelity": 0.8860960548460549,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["unless-condition"],
       "lossyPasses": [
-        "behavior-removable",
         "behavior-sortable",
         "event-once",
         "form-submit-prevent",
@@ -3815,7 +3814,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 439627,
+      "bundleSize": 440215,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4440,9 +4439,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.90909904631709,
-      "avgFidelity": 0.9749278499278501,
+      "avgFidelity": 0.975378787878788,
       "avgPrecision": 0.8356704803133375,
-      "avgRoleFidelity": 0.7128597753597756,
+      "avgRoleFidelity": 0.7131327756327759,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["live-derived-value", "live-multiple-deps"],
@@ -4453,7 +4452,7 @@
         "keydown-key-is-syntax",
         "unless-condition"
       ],
-      "bundleSize": 439627,
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5078,14 +5077,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.838961038961037,
-      "avgFidelity": 0.9978354978354977,
+      "avgFidelity": 0.9985569985569985,
       "avgPrecision": 0.979761904761905,
-      "avgRoleFidelity": 0.8598061285561284,
+      "avgRoleFidelity": 0.8604203791703791,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 439627,
+      "lossyPasses": ["behavior-sortable"],
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5710,14 +5709,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8364873222016058,
-      "avgFidelity": 0.9978354978354977,
+      "avgFidelity": 0.9985569985569985,
       "avgPrecision": 0.9715638528138526,
-      "avgRoleFidelity": 0.8389888827388828,
+      "avgRoleFidelity": 0.8396031333531335,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 439627,
+      "lossyPasses": ["behavior-sortable"],
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6342,20 +6341,21 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8351246080569386,
-      "avgFidelity": 0.9838564213564215,
+      "avgFidelity": 0.9842171717171718,
       "avgPrecision": 0.9091372912801485,
-      "avgRoleFidelity": 0.7870244620244622,
+      "avgRoleFidelity": 0.7872974622974624,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-removable", "behavior-sortable"],
+      "degeneratePasses": ["behavior-sortable"],
       "lossyPasses": [
         "behavior-draggable",
+        "behavior-removable",
         "behavior-resizable",
         "fetch-do-not-throw",
         "form-disable-on-submit",
         "unless-condition"
       ],
-      "bundleSize": 439627,
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6980,14 +6980,15 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8170870900194204,
-      "avgFidelity": 0.9761002886002886,
+      "avgFidelity": 0.976461038961039,
       "avgPrecision": 0.926489383632241,
-      "avgRoleFidelity": 0.7855815355815355,
+      "avgRoleFidelity": 0.7858545358545359,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-removable", "behavior-sortable", "window-scroll"],
+      "degeneratePasses": ["behavior-sortable", "window-scroll"],
       "lossyPasses": [
         "behavior-draggable",
+        "behavior-removable",
         "behavior-resizable",
         "fetch-do-not-throw",
         "fetch-error-handling",
@@ -6995,7 +6996,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 439627,
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7620,19 +7621,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8363327149041414,
-      "avgFidelity": 0.9848484848484848,
+      "avgFidelity": 0.9855699855699855,
       "avgPrecision": 0.9717532467532468,
-      "avgRoleFidelity": 0.8675140737640737,
+      "avgRoleFidelity": 0.868742574992575,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["socket-basic"],
-      "lossyPasses": [
-        "behavior-removable",
-        "behavior-sortable",
-        "last-in-collection",
-        "set-color-variable"
-      ],
-      "bundleSize": 439627,
+      "lossyPasses": ["behavior-sortable", "last-in-collection", "set-color-variable"],
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8257,14 +8253,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8025561739847434,
-      "avgFidelity": 0.9956709956709956,
+      "avgFidelity": 0.9963924963924963,
       "avgPrecision": 0.9877976190476191,
-      "avgRoleFidelity": 0.842206385956386,
+      "avgRoleFidelity": 0.8428206365706367,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["behavior-removable", "behavior-sortable", "get-value"],
-      "bundleSize": 439627,
+      "lossyPasses": ["behavior-sortable", "get-value"],
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8889,14 +8885,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7995877138734262,
-      "avgFidelity": 0.9898088023088022,
+      "avgFidelity": 0.9902597402597403,
       "avgPrecision": 0.9791125541125543,
-      "avgRoleFidelity": 0.8590589028089028,
+      "avgRoleFidelity": 0.8589906527406528,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "behavior-removable", "behavior-resizable"],
-      "bundleSize": 439627,
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9521,9 +9517,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7291486291486292,
-      "avgFidelity": 0.9781746031746034,
+      "avgFidelity": 0.9784451659451661,
       "avgPrecision": 0.9315033451397092,
-      "avgRoleFidelity": 0.7698488448488445,
+      "avgRoleFidelity": 0.7696440946440943,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable"],
@@ -9535,7 +9531,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 439627,
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10160,14 +10156,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8121727478870315,
-      "avgFidelity": 0.9913419913419913,
+      "avgFidelity": 0.992063492063492,
       "avgPrecision": 0.980871212121212,
-      "avgRoleFidelity": 0.8357342544842546,
+      "avgRoleFidelity": 0.8363485050985052,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
-      "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 439627,
+      "lossyPasses": ["behavior-sortable"],
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10792,9 +10788,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7941558441558423,
-      "avgFidelity": 0.9849386724386724,
+      "avgFidelity": 0.9853896103896104,
       "avgPrecision": 0.9792207792207791,
-      "avgRoleFidelity": 0.8618742181242182,
+      "avgRoleFidelity": 0.8618059680559681,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
@@ -10805,7 +10801,7 @@
         "repeat-until-event",
         "set-color-variable"
       ],
-      "bundleSize": 439627,
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11430,9 +11426,9 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.840857555143267,
-      "avgFidelity": 0.9948593073593073,
+      "avgFidelity": 0.9954906204906204,
       "avgPrecision": 0.972113997113997,
-      "avgRoleFidelity": 0.823432760932761,
+      "avgRoleFidelity": 0.8236375111375112,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
@@ -11442,7 +11438,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 439627,
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12067,14 +12063,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8216537651743292,
-      "avgFidelity": 0.9855699855699855,
+      "avgFidelity": 0.9858405483405485,
       "avgPrecision": 0.9771645021645022,
-      "avgRoleFidelity": 0.8683083245583247,
+      "avgRoleFidelity": 0.8687178249678251,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 439627,
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12699,9 +12695,9 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8329265429368624,
-      "avgFidelity": 0.9779411764705882,
+      "avgFidelity": 0.9781227305737109,
       "avgPrecision": 0.9343500363108206,
-      "avgRoleFidelity": 0.792713522305359,
+      "avgRoleFidelity": 0.7929883797230735,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable", "default-value"],
@@ -12711,7 +12707,7 @@
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 439627,
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13335,14 +13331,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8114306328592024,
-      "avgFidelity": 0.98989898989899,
+      "avgFidelity": 0.9904401154401155,
       "avgPrecision": 0.980871212121212,
-      "avgRoleFidelity": 0.8221286033786035,
+      "avgRoleFidelity": 0.8221968534468536,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 439627,
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13967,14 +13963,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8044939187796312,
-      "avgFidelity": 0.9837662337662337,
+      "avgFidelity": 0.9844877344877345,
       "avgPrecision": 0.9706980519480523,
-      "avgRoleFidelity": 0.8593235030735031,
+      "avgRoleFidelity": 0.8599377536877537,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [
-        "behavior-removable",
         "behavior-sortable",
         "input-mirror",
         "morph-with-template",
@@ -13982,7 +13977,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 439627,
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14607,14 +14602,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9840032982890127,
-      "avgFidelity": 0.9808441558441557,
+      "avgFidelity": 0.9815656565656565,
       "avgPrecision": 0.9962121212121211,
-      "avgRoleFidelity": 0.9135918135918135,
+      "avgRoleFidelity": 0.9181986931986931,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [
-        "behavior-removable",
         "behavior-sortable",
         "form-submit-prevent",
         "get-value",
@@ -14624,7 +14618,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 439627,
+      "bundleSize": 440215,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15247,7 +15241,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 439627,
+      "size": 440215,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Completes **behavior-removable to faithful (1.0) in 11 languages**. Follow-up to #452.

A `js(…) … end` block's body is raw JavaScript. When **nested** in a handler/conditional body, the clause loop split it at its internal `end` and re-parsed the JS body through the command patterns — emitting phantom `return`/`if` commands. behavior-removable's `js(me) … if (…) return "cancel"; … end` injected a spurious `return` into the **EN reference** action set that translations (whose js body is masked by the i18n transformer) could never reproduce, capping removable at fidelity **0.889**.

## Fix

`parseBodyWithClauses` now consumes a `js(…) … end` block as one opaque `js` command via `consumeJsBlock` (first `end` closes it — the same heuristic the i18n js-mask uses), building the node directly so the raw JS body never reaches `matchBest`. A **standalone** js block already parsed clean (the main parser stops after the first command); this fixes the **nested** case. Applies to en and every translation (the `js` keyword survives translation verbatim), so reference and candidate js nodes stay identical for fidelity scoring.

## Results

- **behavior-removable now FAITHFUL (1.0) in 11 languages**: es/fr/de/it/id/ms/zh/vi/ru/pl/he
- Priority gate: **lossy 93 → 84, degenerate 24 → 22**, avgFidelity + avgRoleFidelity up, **precision flat**
- **Zero regressions** across all 8 js-using behaviors (gate-verified); **6101** semantic tests pass; typecheck clean
- Baseline regenerated; `patterns.db` left uncommitted (CI repopulates)
- Regression guard added: `multilingual-roadmap-fixes.test.ts` — "js(…) … end blocks are opaque to the body parser"

## Still open (documented in `MULTILINGUAL_NEXT_STEPS.md`)

1. **behavior-sortable** — triage shows it's a *coupled transformer+parser* arc, not a clean single-defect fix: the i18n transformer renders `trigger sortable:start on me` as `disparar sortable:start entonces en yo` (spurious `then` + stray `en yo`) right before its `repeat until event … end` loop block. Needs the `trigger … on me` rendering cleaned up **and** a loop-block fold.
2. SOV/VSO head-reorder degeneracy (ja/ko/tr/qu/ar/tl)
3. pt/sw removable handler-parse gap (lose on/remove/trigger even as SVO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)