### PR TITLE
fix(semantic): block depth tracking ignores marker/opener homonyms (pt para/for)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -186,8 +186,28 @@ x/y`, and dynamic `add { left: ${…}px }` style templating; (b) if the runtime 
    > sortable is a **coupled transformer+parser** arc (clean the `trigger … on me` rendering AND
    > teach the body parser the loop-block fold), not a single-defect fix. (2) **SOV/VSO degeneracy**
    > (ja/ko/tr/qu/ar/tl) on both behaviors is the behavior-head/`init` reorder, a separate structural
-   > problem (removable still degenerate in ar/qu/tl/tr). (3) **pt/sw removable** lose `on`/`remove`/
-   > `trigger` even as SVO — a distinct handler-parse gap worth its own look.
+   > problem (removable still degenerate in ar/qu/tl/tr). (3) ~~**pt/sw removable** lose `on`/`remove`/
+   > `trigger` even as SVO~~ **DONE** (see Increment 3 below).
+   >
+   > **Increment 3 DONE (2026-06-19, PR pending — block-parser marker/opener homonym).** pt/sw were
+   > the only SVO languages still lossy (0.625) on removable. Root cause: `parseBehaviorBlock`'s
+   > depth tracker mis-counted the Portuguese dative marker `para` ("to", from `set triggerEl to me`
+   > → `definir triggerEl para eu`) as the `for` LOOP opener — they share the surface form `para` in
+   > pt — so depth never returned to 0 at the init's `end` and the init segment swallowed the entire
+   > `on click` handler (`eventHandlers` empty; trigger/remove dropped). The tokenizer had already
+   > resolved the ambiguity (it normalizes the marker to its role `destination`, not `for`); the
+   > opener check ([`block-parser.ts`](../packages/semantic/src/parser/block-parser.ts) `isBlockOpener`)
+   > now trusts that normalized role over the colliding surface form. A token with no normalized form
+   > (a raw js-body `if`) still falls back to the surface match, preserving js-block depth balance.
+   > Result: **pt + sw removable now FAITHFUL (1.0)** → removable faithful in **13** languages;
+   > priority gate lossy 84→80, degenerate 22→20, avgFidelity + avgRoleFidelity up, precision flat,
+   > zero regressions; 6103 semantic tests pass. Guard:
+   > [`multilingual-roadmap-fixes.test.ts`](../packages/semantic/test/multilingual-roadmap-fixes.test.ts)
+   > "Block depth tracking ignores marker/opener homonyms".
+   >
+   > **Still open after Increment 3:** (1) **`behavior-sortable`** (coupled transformer+parser arc,
+   > above); (2) **SOV/VSO degeneracy** (ar/ja/ko/qu/tl/tr) on both behaviors — the behavior-head/
+   > `init` reorder, the remaining structural frontier.
 
 3. **The actual priority — the authoring + install system for community & LLM agents:**
    - ~~**Authoring guide**~~ **DONE** (2026-06-16): `packages/behaviors/AUTHORING.md` — the

--- a/packages/semantic/src/parser/block-parser.ts
+++ b/packages/semantic/src/parser/block-parser.ts
@@ -62,6 +62,29 @@ function tokenMatches(tok: LanguageToken, forms: Set<string>): boolean {
   return tok.normalized ? forms.has(tok.normalized.toLowerCase()) : false;
 }
 
+/** The block-opener actions whose `end` participates in depth tracking. */
+const OPENER_NORMS: ReadonlySet<string> = new Set(OPENER_ACTIONS);
+
+/**
+ * Whether a token opens a nested block (if/unless/repeat/for/while) for depth
+ * tracking — NOT a plain `tokenMatches` against the opener forms, because some
+ * languages reuse a block-keyword's surface form for a role marker: Portuguese
+ * `para` is BOTH the `for` loop keyword AND the dative "to" marker, so
+ * `set X to Y` → `definir X para Y` had its marker `para` mis-counted as a `for`
+ * opener, corrupting the behavior-body depth split (the init segment swallowed the
+ * whole handler — pt/sw behavior-removable lost on/remove/trigger). The tokenizer
+ * already resolved the ambiguity: it normalizes the marker to its ROLE
+ * (`destination`), not to `for`. So when a token carries a normalized form, trust
+ * it — count it as an opener only if that normalized form IS an opener action. A
+ * token with NO normalized form (e.g. a raw js-body `if`) falls back to the surface
+ * match, preserving the existing js-block depth balance.
+ */
+function isBlockOpener(tok: LanguageToken, openerSets: ReadonlyArray<Set<string>>): boolean {
+  const norm = tok.normalized?.toLowerCase();
+  if (norm) return OPENER_NORMS.has(norm);
+  return openerSets.some(s => tokenMatches(tok, s));
+}
+
 /**
  * Target/reference words that follow a destination `on` (`toggle .x on me`),
  * never a handler trigger. Used to tell a trigger `on` (`on click`, followed by
@@ -311,7 +334,7 @@ export function tryParseProgram(
   if (tokens.length < 2) return null;
 
   const openerSets = OPENER_ACTIONS.map(a => keywordForms(language, a));
-  const isOpener = (tok: LanguageToken): boolean => openerSets.some(s => tokenMatches(tok, s));
+  const isOpener = (tok: LanguageToken): boolean => isBlockOpener(tok, openerSets);
   const isEnd = (tok: LanguageToken): boolean => tokenMatches(tok, endForms);
 
   // Split into top-level handler segments. At depth 0: a `end` closes the current
@@ -442,7 +465,7 @@ function parseBehaviorBlock(
   const initForms = keywordForms(language, 'init');
   const endForms = keywordForms(language, 'end');
   const openerSets = OPENER_ACTIONS.map(a => keywordForms(language, a));
-  const isOpener = (tok: LanguageToken): boolean => openerSets.some(s => tokenMatches(tok, s));
+  const isOpener = (tok: LanguageToken): boolean => isBlockOpener(tok, openerSets);
   const isEnd = (tok: LanguageToken): boolean => tokenMatches(tok, endForms);
 
   // Split the body into sub-blocks by depth-aware `end` matching. Segmentation is
@@ -536,7 +559,7 @@ function parseDefBlock(
 
   const endForms = keywordForms(language, 'end');
   const openerSets = OPENER_ACTIONS.map(a => keywordForms(language, a));
-  const isOpener = (tok: LanguageToken): boolean => openerSets.some(s => tokenMatches(tok, s));
+  const isOpener = (tok: LanguageToken): boolean => isBlockOpener(tok, openerSets);
   const isEnd = (tok: LanguageToken): boolean => tokenMatches(tok, endForms);
 
   // The def body is a flat command sequence (no event handlers). Find the def's

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -6637,3 +6637,76 @@ describe('js(…) … end blocks are opaque to the body parser (no phantom JS-bo
     expect(a.has('remove')).toBe(true);
   });
 });
+
+describe('Block depth tracking ignores marker/opener homonyms (pt `para`, sw)', () => {
+  // The behavior-body splitter tracks `if/unless/repeat/for/while` openers vs `end`
+  // to find where the init block and each handler begin. Some languages reuse a
+  // block-keyword's surface form for a role marker: Portuguese `para` is BOTH the
+  // `for` loop keyword AND the dative "to" marker, so `set triggerEl to me` →
+  // `definir triggerEl para eu` had its marker `para` mis-counted as a `for` opener
+  // — the depth never returned to 0 at the init's `end`, so the init segment
+  // swallowed the whole `on click` handler (eventHandlers empty; trigger/remove
+  // dropped). pt/sw behavior-removable were the only SVO languages still lossy
+  // (0.625) after the js-opacity fix. The opener check now trusts the tokenizer's
+  // normalized role (`destination`) over the colliding surface form.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const n = node as Record<string, unknown>;
+    if (typeof n.action === 'string') acc.add(n.action);
+    for (const f of ['initBlock', 'eventHandlers', 'body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = n[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('[pt] init block with `set X para me` does not swallow the handler', () => {
+    // `para` (set's "to" marker) collides with pt `for`; before the fix it opened a
+    // phantom block and the handler was lost.
+    const input = [
+      'behavior Removable(triggerEl)',
+      '  init',
+      '    se triggerEl é indefinido',
+      '      definir triggerEl para eu',
+      '    fim',
+      '  fim',
+      '  em clique de triggerEl',
+      '    disparar removable:before',
+      '    remover eu',
+      '  fim',
+      'fim',
+    ].join('\n');
+    const node = parse(input, 'pt');
+    expect(node.action).toBe('behavior');
+    const handlers = (node as { eventHandlers?: unknown[] }).eventHandlers ?? [];
+    expect(handlers.length).toBe(1); // the `on click` handler is recognized
+    const a = actions(node);
+    expect(a.has('set')).toBe(true); // init body survives
+    expect(a.has('trigger')).toBe(true); // handler body survives…
+    expect(a.has('remove')).toBe(true); // …including the trailing remove
+  });
+
+  it('[sw] init block with `seti X kwa me` keeps the handler separate', () => {
+    const input = [
+      'behavior Removable(triggerEl)',
+      '  init',
+      '    kama triggerEl ni haijafafanuliwa',
+      '      seti triggerEl kwa mimi',
+      '    mwisho',
+      '  mwisho',
+      '  kwenye bonyeza kutoka triggerEl',
+      '    chochea removable:before',
+      '    ondoa mimi',
+      '  mwisho',
+      'mwisho',
+    ].join('\n');
+    const node = parse(input, 'sw');
+    expect(node.action).toBe('behavior');
+    const handlers = (node as { eventHandlers?: unknown[] }).eventHandlers ?? [];
+    expect(handlers.length).toBe(1);
+    const a = actions(node);
+    expect(a.has('trigger')).toBe(true);
+    expect(a.has('remove')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-19T15:29:25.196Z",
-  "commit": "ef5d34bb",
+  "timestamp": "2026-06-19T15:54:58.437Z",
+  "commit": "b1b3412a",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -651,7 +651,7 @@
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1283,7 +1283,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1908,7 +1908,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2540,7 +2540,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-sortable"],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3172,7 +3172,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-sortable"],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3814,7 +3814,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4452,7 +4452,7 @@
         "keydown-key-is-syntax",
         "unless-condition"
       ],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5084,7 +5084,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-sortable"],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5716,7 +5716,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-sortable"],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6355,7 +6355,7 @@
         "form-disable-on-submit",
         "unless-condition"
       ],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6996,7 +6996,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7628,7 +7628,7 @@
       "executionFailures": [],
       "degeneratePasses": ["socket-basic"],
       "lossyPasses": ["behavior-sortable", "last-in-collection", "set-color-variable"],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8260,7 +8260,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-sortable", "get-value"],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8885,14 +8885,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7995877138734262,
-      "avgFidelity": 0.9902597402597403,
+      "avgFidelity": 0.9985569985569985,
       "avgPrecision": 0.9791125541125543,
-      "avgRoleFidelity": 0.8589906527406528,
+      "avgRoleFidelity": 0.8658257845757846,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-sortable"],
-      "lossyPasses": ["behavior-draggable", "behavior-removable", "behavior-resizable"],
-      "bundleSize": 440215,
+      "degeneratePasses": [],
+      "lossyPasses": ["behavior-sortable"],
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9531,7 +9531,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10163,7 +10163,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["behavior-sortable"],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10788,20 +10788,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7941558441558423,
-      "avgFidelity": 0.9853896103896104,
-      "avgPrecision": 0.9792207792207791,
-      "avgRoleFidelity": 0.8618059680559681,
+      "avgFidelity": 0.9936868686868686,
+      "avgPrecision": 0.9785714285714285,
+      "avgRoleFidelity": 0.8686410998911,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-sortable"],
-      "lossyPasses": [
-        "behavior-draggable",
-        "behavior-removable",
-        "behavior-resizable",
-        "repeat-until-event",
-        "set-color-variable"
-      ],
-      "bundleSize": 440215,
+      "degeneratePasses": [],
+      "lossyPasses": ["behavior-sortable", "repeat-until-event", "set-color-variable"],
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11438,7 +11432,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12070,7 +12064,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12707,7 +12701,7 @@
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13338,7 +13332,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["behavior-removable", "behavior-sortable"],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13977,7 +13971,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14618,7 +14612,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 440215,
+      "bundleSize": 440294,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15241,7 +15235,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 440215,
+      "size": 440294,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Makes **pt + sw behavior-removable faithful (1.0)** — they were the only SVO languages still lossy (0.625) after #452 and #453. Removable is now faithful in **13 languages**.

## Root cause

`parseBehaviorBlock` splits a behavior body into its `init` block and each `on …` handler by tracking `if/unless/repeat/for/while` openers vs `end`. The Portuguese dative marker `para` ("to", from `set triggerEl to me` → `definir triggerEl para eu`) **shares its surface form with the `for` loop keyword**, so `para` was mis-counted as a `for` opener. Depth never returned to 0 at the init block's `end`, so the **init segment swallowed the entire `on click` handler** — `eventHandlers` came back empty and `trigger`/`remove` were dropped. es escapes because its "to" marker is `a`, not its `for`=`para`.

## Fix

The tokenizer had already resolved the ambiguity — it normalizes the marker to its **role** (`destination`), not `for`. The new `isBlockOpener` helper (shared across `parseBehaviorBlock` / `tryParseProgram` / `parseDefBlock`) trusts that normalized role over the colliding surface form:

- token **has** a normalized form → opener only if that form IS an opener action
- token has **no** normalized form (e.g. a raw js-body `if`) → fall back to surface match (preserves js-block depth balance)

## Results

- **pt + sw removable now FAITHFUL (1.0)** → removable faithful in **13 languages**
- Priority gate: **lossy 84 → 80, degenerate 22 → 20**, avgFidelity + avgRoleFidelity up, **precision flat**
- **Zero regressions**; 6103 semantic tests pass; typecheck clean
- Baseline regenerated; `patterns.db` left uncommitted (CI repopulates)
- Regression guard: `multilingual-roadmap-fixes.test.ts` — "Block depth tracking ignores marker/opener homonyms"

## Remaining (documented in `MULTILINGUAL_NEXT_STEPS.md`)

1. **behavior-sortable** — coupled transformer+parser arc (`trigger … on me` artifact + repeat-until loop-block fold)
2. **SOV/VSO degeneracy** (ar/ja/ko/qu/tl/tr) — the behavior-head/`init` reorder structural frontier

🤖 Generated with [Claude Code](https://claude.com/claude-code)