### PR TITLE
fix(semantic): recognize SOV verb-final behavior declarations (defect A)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -225,12 +225,43 @@ x/y`, and dynamic `add { left: ${…}px }` style templating; (b) if the runtime 
 <target>` keeps its target — no spurious then (behavior-sortable)". removable byte-identical
    > (its `trigger removable:before/removed` carry no `on <target>`).
    >
-   > **Still open after Increment 4:** (1) **SOV/VSO degeneracy** (ar/de/ja/qu/tl/tr on sortable;
-   > ar/qu/tl/tr on removable) — the behavior-head/`init` reorder (SOV `behavior` keyword moved
-   > block-final breaking opener detection; VSO handler-head leading with `from <target>` before
-   > `on <event>`), the remaining structural frontier. (2) sortable's **SOV trigger-drop tail**
-   > (bn/hi/th/ko still miss `trigger`) — the SOV `trigger … on me` reorder drops the trigger verb
-   > even after the SVO fix; a smaller follow-on to the same arc.
+   > **SOV/VSO arc — fully mapped (2026-06-19 deep diagnosis).** The handoff lumped this as one
+   > "behavior-head/`init` reorder," but isolation probing (each command parsed alone, then the
+   > init/handler sub-structures) shows it is **five separable defects**, NOT a deep SOV verb-final
+   > gap. Every plain SOV handler command (`set`/`trigger`/`remove`/`add`/`halt`, chained, and
+   > `trigger X on me`) parses faithfully — the loss is in **opener routing** + **control-flow body
+   > parsing**, the documented dominant cluster:
+   >
+   > - **A — SOV behavior-final opener** (ja/ko/qu/tr): the `behavior` verb reorders block-final
+   >   (`Foo(x) を behavior`), so `tryParseBlock` never routed it to `parseBehaviorBlock` →
+   >   kind=compound/event-handler, behavior+init lost. **DONE (Increment 5 below).**
+   > - **A2a — bare-`if` body command drop** (ja/ko/qu/tr): a standalone `if cond / cmd / end`
+   >   (the behavior `init`) drops its body command (`set`). `parseConditional`/body. OPEN.
+   > - **A2b — command after a nested block dropped** (ja/ko/qu/tr): the SOV analogue of the
+   >   merged #452/#453 fixes — the command right after a nested `if … end` in a handler body is
+   >   dropped (`trigger removable:before`). `parseBodyWithClauses` SOV path. OPEN.
+   > - **B — VSO/Austronesian handler-head** (ar/tl): opener IS recognized but the handler head
+   >   leads with `from <target>` before the `on <event>` marker, so the handler isn't recognized
+   >   ([`block-parser.ts`](../packages/semantic/src/parser/block-parser.ts) L509). OPEN.
+   > - **C — de (V2) sortable body collapse**: opener + handler recognized, but the V2-reordered
+   >   pointerdown body drops most commands. A separate V2 body-parse defect. OPEN.
+   >
+   > Plus sortable's **SOV trigger-drop tail** (bn/hi/th/ko miss `trigger`) — same A2b family.
+   > Making ja/ko/qu/tr faithful needs **A + A2a + A2b** (sequenced); B and C are smaller arcs.
+   >
+   > **Increment 5 DONE (2026-06-19, PR pending — SOV behavior-final opener, defect A).**
+   > [`tryParseBlock`](../packages/semantic/src/parser/block-parser.ts) now also detects a
+   > `behavior` keyword past index 0 with a PascalCase name at index 0 (the SOV verb-final
+   > declaration `Foo(x) <marker> behavior`), and `parseBehaviorBlock` takes the keyword index so
+   > the name leads and the body starts past the (verb-final) keyword. ja/ko/qu/tr now parse as
+   > `kind=behavior`: removable qu/tr **degenerate→lossy** (0.625), ja/ko lossy 0.5→0.625; sortable
+   > qu→0.889, ko/tr→0.778, qu/tr **degenerate→lossy**. Priority gate **degenerate 19→15**, lossy
+   > 68→65, parse-rate unchanged (3695/3696), execution 1.0, **zero regressions**; 6109 semantic
+   > tests pass (+4 guards). NOT yet faithful — the residual is A2a (init `set`) + A2b (handler
+   > `trigger`/`remove` after the nested blocks), the next two increments. ja sortable + ar/de/tl
+   > unaffected by A (their causes are A2b-heavy / B / C). Guard:
+   > [`multilingual-roadmap-fixes.test.ts`](../packages/semantic/test/multilingual-roadmap-fixes.test.ts)
+   > "SOV verb-final behavior declaration opener".
 
 3. **The actual priority — the authoring + install system for community & LLM agents:**
    - ~~**Authoring guide**~~ **DONE** (2026-06-16): `packages/behaviors/AUTHORING.md` — the

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -236,7 +236,16 @@ x/y`, and dynamic `add { left: ${…}px }` style templating; (b) if the runtime 
    >   (`Foo(x) を behavior`), so `tryParseBlock` never routed it to `parseBehaviorBlock` →
    >   kind=compound/event-handler, behavior+init lost. **DONE (Increment 5 below).**
    > - **A2a — bare-`if` body command drop** (ja/ko/qu/tr): a standalone `if cond / cmd / end`
-   >   (the behavior `init`) drops its body command (`set`). `parseConditional`/body. OPEN.
+   >   (the behavior `init`) drops its body command (`set`). Root cause: `tryParseConditionalBlock`'s
+   >   condition/then split (semantic-parser.ts) finds the then-branch via `tokensBeginCommand`,
+   >   which (using bare `matchBest`) fails on a SOV verb-final command with a **bare-identifier
+   >   patient** (`x を 設定 …`) — a selector patient (`.a を 追加 …`) is recognized, so `add` survives
+   >   but `set` is swallowed into the condition. OPEN. **Prototype tried + rejected (2026-06-19):** a
+   >   gated SOV copula-split (re-partition `condTokens` after the copula's predicate) is **clean
+   >   (zero gate regressions)** but only recovers **ko** — `이다` normalizes to `is`, but ja `である`
+   >   tokenizes to `で`+`ある` (and `で` IS the event marker — can't treat as copula), tr `dir`/qu
+   >   `kanqa` don't normalize to a copula. Real fix needs per-language SOV copula normalization OR
+   >   scan-from-end verb-final then-branch detection — materially larger/riskier than defect A.
    > - **A2b — command after a nested block dropped** (ja/ko/qu/tr): the SOV analogue of the
    >   merged #452/#453 fixes — the command right after a nested `if … end` in a handler body is
    >   dropped (`trigger removable:before`). `parseBodyWithClauses` SOV path. OPEN.

--- a/packages/semantic/src/parser/block-parser.ts
+++ b/packages/semantic/src/parser/block-parser.ts
@@ -231,7 +231,16 @@ export function tryParseBlock(
   if (tokens.length < 2) return null;
 
   if (tokenMatches(tokens[0], behaviorForms)) {
-    return parseBehaviorBlock(input, language, tokens, parsers);
+    return parseBehaviorBlock(input, language, tokens, parsers, 0);
+  }
+  // SOV verb-final declaration: the `behavior` keyword is reordered AFTER the
+  // name + its object marker (ja `Foo(params) を behavior`, ko `를`, qu `ta`,
+  // tr `i`), so it never lands at index 0 and the keyword-led check above misses
+  // it. Detect a `behavior` keyword token past index 0 with a PascalCase name at
+  // index 0 (the declaration head is `<Name>(params) <marker> behavior …`).
+  const sovKeywordIdx = tokens.findIndex((t, i) => i > 0 && tokenMatches(t, behaviorForms));
+  if (sovKeywordIdx > 0 && /^[A-Z][A-Za-z0-9_]*$/.test(tokens[0].value)) {
+    return parseBehaviorBlock(input, language, tokens, parsers, sovKeywordIdx);
   }
   if (tokenMatches(tokens[0], defForms)) {
     return parseDefBlock(input, language, tokens, parsers);
@@ -443,23 +452,36 @@ function flattenStatements(stmts: SemanticNode[]): SemanticNode[] {
   return out;
 }
 
-/** Parse a `behavior Name(params) … end` block into a BehaviorSemanticNode. */
+/**
+ * Parse a `behavior Name(params) … end` block into a BehaviorSemanticNode.
+ *
+ * `keywordIdx` is the token index of the `behavior` keyword: 0 for the normal
+ * keyword-led form (en/SVO/VSO/V2), or > 0 for the SOV verb-final form where the
+ * keyword is reordered after the name + object marker (`Foo(params) を behavior`).
+ */
 function parseBehaviorBlock(
   input: string,
   language: string,
   tokens: readonly LanguageToken[],
-  parsers: BlockParsers
+  parsers: BlockParsers,
+  keywordIdx: number
 ): SemanticNode | null {
-  // Behavior name — required PascalCase to avoid false positives. Skip a
-  // leading object marker (he `behavior את Foo`, zh `behavior 把 Foo`) first.
-  const nameIdx = resolveNameTokenIndex(tokens, 0, language);
+  const sovFinal = keywordIdx > 0;
+  // Behavior name — required PascalCase to avoid false positives. For the
+  // SOV verb-final form the name leads the line (index 0); otherwise it follows
+  // the keyword, skipping a leading object marker (he `behavior את Foo`, zh
+  // `behavior 把 Foo`).
+  const nameIdx = sovFinal ? 0 : resolveNameTokenIndex(tokens, keywordIdx, language);
   if (nameIdx < 0) return null;
   const nameToken = tokens[nameIdx];
   const name = nameToken.value;
   if (!/^[A-Z][A-Za-z0-9_]*$/.test(name)) return null;
 
   const { parameters, headerEnd } = parseHeader(input, nameToken);
-  let bodyStart = tokens.findIndex(t => t.position.start >= headerEnd);
+  // Body begins after the header for the keyword-led form. For the SOV verb-final
+  // form the keyword (and its preceding object marker) sit between the header and
+  // the body, so start past the keyword token instead.
+  let bodyStart = sovFinal ? keywordIdx + 1 : tokens.findIndex(t => t.position.start >= headerEnd);
   if (bodyStart <= nameIdx) bodyStart = nameIdx + 1;
 
   const initForms = keywordForms(language, 'init');

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -714,6 +714,51 @@ describe('SOV put-into verb-final reorder — ko/tr/bn (Track 5)', () => {
   });
 });
 
+describe('SOV verb-final behavior declaration opener — ja/ko/qu/tr (behavior-removable/sortable)', () => {
+  // In SOV the `behavior` verb is reordered to the end of the declaration line,
+  // after the name + its object marker: `Foo(x) を behavior` (ja), `를` (ko),
+  // `ta` (qu), `i` (tr). tryParseBlock only recognized the keyword-LED form
+  // (`behavior Foo …`), so the SOV declaration was never routed to
+  // parseBehaviorBlock — the whole block fell through to single-statement
+  // parsing (kind=compound/event-handler, the `behavior` node + init lost). This
+  // was the dominant cause of behavior-removable/sortable degeneracy in
+  // ja/ko/qu/tr. tryParseBlock now also detects a `behavior` keyword past index 0
+  // with a PascalCase name at index 0, and parseBehaviorBlock takes the keyword
+  // index so the name leads and the body starts past the (verb-final) keyword.
+  // Transformer output of `behavior Foo(x) init … on click add .a to me end end`.
+  const sovBehaviors: Array<[string, string]> = [
+    [
+      'ja',
+      'Foo(x) を behavior\n    init\n        もし x である 未定義\n            x を 設定 私 に\n        終わり\n    終わり\n    クリック で\n        .a を 追加 私 に\n    終わり\n終わり',
+    ],
+    [
+      'ko',
+      'Foo(x) 를 behavior\n    init\n        만약 x 이다 정의안됨\n            x 를 설정 나 에\n        끝\n    끝\n    클릭 할 때\n        .a 를 추가 나 에\n    끝\n끝',
+    ],
+    [
+      'qu',
+      'Foo(x) ta behavior\n    init\n        sichus x kanqa mana_riqsisqa\n            x ta noqa man churanay\n        tukuy\n    tukuy\n    ñitiy pi\n        .a ta noqa man yapay\n    tukuy\ntukuy',
+    ],
+    [
+      'tr',
+      'Foo(x) i behavior\n    init\n        eğer x dir tanımsız\n            x i ayarla ben e\n        son\n    son\n    tıklama de\n        .a i ekle ben e\n    son\nson',
+    ],
+  ];
+  for (const [lang, input] of sovBehaviors) {
+    it(`[${lang}] SOV verb-final declaration parses as a behavior block`, () => {
+      const node = parse(input, lang) as Record<string, unknown>;
+      expect(node).toBeTruthy();
+      // Routed to parseBehaviorBlock — recognized as a behavior, not a stray
+      // compound/event-handler with the keyword stranded.
+      expect(node.kind).toBe('behavior');
+      expect(node.name).toBe('Foo');
+      // The handler (with its `add`) is recovered, not swallowed by the head.
+      const handlers = node.eventHandlers as Array<unknown> | undefined;
+      expect(Array.isArray(handlers) && handlers.length).toBeGreaterThan(0);
+    });
+  }
+});
+
 describe('SOV repeat-* loop-body reorder — ko/bn/qu (Track 5)', () => {
   // For SOV languages the i18n transformer surfaces a block loop's keyword
   // (반복/পুনরাবৃত্তি/kutipay = repeat) — or a leading `while`/`for` clause — ahead of

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-19T18:32:01.880Z",
-  "commit": "ab731ac9",
+  "timestamp": "2026-06-19T20:00:00.529Z",
+  "commit": "cc089102",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-sortable"],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,7 +640,7 @@
       "parseRate": 1,
       "avgConfidence": 0.8495030867211314,
       "avgFidelity": 0.9946789321789321,
-      "avgPrecision": 0.9163195030078151,
+      "avgPrecision": 0.9167476462931012,
       "avgRoleFidelity": 0.7802199864699865,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -651,7 +651,7 @@
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1283,7 +1283,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1908,7 +1908,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2540,7 +2540,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3172,7 +3172,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3813,7 +3813,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4439,8 +4439,8 @@
       "parseRate": 1,
       "avgConfidence": 0.90909904631709,
       "avgFidelity": 0.9768217893217892,
-      "avgPrecision": 0.835932844212065,
-      "avgRoleFidelity": 0.7136525261525264,
+      "avgPrecision": 0.83773964131107,
+      "avgRoleFidelity": 0.7141351516351518,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["live-derived-value", "live-multiple-deps"],
@@ -4451,7 +4451,7 @@
         "keydown-key-is-syntax",
         "unless-condition"
       ],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5083,7 +5083,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5715,7 +5715,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6340,21 +6340,19 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8351246080569386,
-      "avgFidelity": 0.9842171717171718,
-      "avgPrecision": 0.9091372912801485,
+      "avgFidelity": 0.9872835497835499,
+      "avgPrecision": 0.9107733175914994,
       "avgRoleFidelity": 0.7872974622974624,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
       "lossyPasses": [
-        "behavior-draggable",
         "behavior-removable",
-        "behavior-resizable",
         "fetch-do-not-throw",
         "form-disable-on-submit",
         "unless-condition"
       ],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6979,16 +6977,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8170870900194204,
-      "avgFidelity": 0.9779040404040402,
-      "avgPrecision": 0.9267599464028037,
+      "avgFidelity": 0.9809704184704183,
+      "avgPrecision": 0.9292207792207794,
       "avgRoleFidelity": 0.7868940368940369,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["window-scroll"],
       "lossyPasses": [
-        "behavior-draggable",
         "behavior-removable",
-        "behavior-resizable",
         "behavior-sortable",
         "fetch-do-not-throw",
         "fetch-error-handling",
@@ -6996,7 +6992,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7628,7 +7624,7 @@
       "executionFailures": [],
       "degeneratePasses": ["socket-basic"],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8260,7 +8256,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8892,7 +8888,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9517,21 +9513,22 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7291486291486292,
-      "avgFidelity": 0.9784451659451661,
-      "avgPrecision": 0.9315033451397092,
-      "avgRoleFidelity": 0.7696440946440943,
+      "avgFidelity": 0.9852092352092352,
+      "avgPrecision": 0.9316017316017322,
+      "avgRoleFidelity": 0.7704525954525953,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-removable", "behavior-sortable"],
+      "degeneratePasses": [],
       "lossyPasses": [
         "append-content",
         "behavior-draggable",
-        "behavior-resizable",
+        "behavior-removable",
+        "behavior-sortable",
         "modal-close-escape",
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10163,7 +10160,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10795,7 +10792,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11432,7 +11429,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12064,7 +12061,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
       "lossyPasses": [],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12689,19 +12686,19 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8329265429368624,
-      "avgFidelity": 0.9781227305737109,
+      "avgFidelity": 0.9857480029048655,
       "avgPrecision": 0.9343500363108206,
-      "avgRoleFidelity": 0.7929883797230735,
+      "avgRoleFidelity": 0.7950815246733614,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-removable", "behavior-sortable", "default-value"],
+      "degeneratePasses": ["default-value"],
       "lossyPasses": [
-        "behavior-draggable",
-        "behavior-resizable",
+        "behavior-removable",
+        "behavior-sortable",
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13332,7 +13329,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["behavior-removable"],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13970,7 +13967,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14610,7 +14607,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 440294,
+      "bundleSize": 440435,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15233,7 +15230,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 440294,
+      "size": 440435,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
Supersedes #456 (closed when its stacked base #455 merged; rebased onto main).

## What

In SOV languages the `behavior` verb reorders to the **end** of the declaration line, after the name + its object marker: `Foo(x) を behavior` (ja), `를` (ko), `ta` (qu), `i` (tr). `tryParseBlock` only matched the keyword-**led** form (`behavior Foo …`) at `tokens[0]`, so the SOV declaration was never routed to `parseBehaviorBlock` — the whole block fell through to single-statement parsing (`kind=compound`/`event-handler`, the `behavior` node + init lost). This was the dominant cause of `behavior-removable`/`behavior-sortable` degeneracy in ja/ko/qu/tr.

## Fix

`tryParseBlock` now also detects a `behavior` keyword token past index 0 with a PascalCase name at index 0 (the SOV verb-final head `<Name>(params) <marker> behavior …`); `parseBehaviorBlock` takes the keyword index so the name leads (index 0) and the body starts past the verb-final keyword.

## Context — defect A of a 5-part arc

A deep diagnosis (in `MULTILINGUAL_NEXT_STEPS.md`) established the SOV/VSO behavior degeneracy is **five separable defects**, not a deep verb-final reorder gap — every plain SOV handler command parses faithfully. This is **defect A (opener routing)**. The residual ja/ko/qu/tr loss is **A2a** (bare-`if` body `set`) + **A2b** (command after a nested block). A read-only A2a prototype (copula-split) was rejected as low-yield (recovers only ko); see the doc.

## Result (gate-verified)

- ja/ko/qu/tr now parse as `kind=behavior`
- removable: qu/tr **degenerate→lossy** (0.625); ja/ko lossy 0.5→0.625
- sortable: qu→0.889, ko/tr→0.778, qu/tr **degenerate→lossy**
- priority gate: **degenerate 19→15**, lossy 68→65, parse-rate unchanged (3695/3696), execution 1.0, **zero regressions** on all six ratchets
- ar/de/tl + ja sortable unaffected (causes B / C / A2b-heavy)
- 6109 semantic tests pass (+4 guards); baseline regenerated; `patterns.db` not committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)