### PR TITLE
fix(semantic): recognize VSO from-first event-handler heads (defect B)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -250,8 +250,8 @@ x/y`, and dynamic `add { left: ${…}px }` style templating; (b) if the runtime 
    >   merged #452/#453 fixes — the command right after a nested `if … end` in a handler body is
    >   dropped (`trigger removable:before`). `parseBodyWithClauses` SOV path. OPEN.
    > - **B — VSO/Austronesian handler-head** (ar/tl): opener IS recognized but the handler head
-   >   leads with `from <target>` before the `on <event>` marker, so the handler isn't recognized
-   >   ([`block-parser.ts`](../packages/semantic/src/parser/block-parser.ts) L509). OPEN.
+   >   leads with `from <target>` before the `on <event>` marker, so the handler isn't recognized.
+   >   **DONE (Increment 6 below).**
    > - **C — de (V2) sortable body collapse**: opener + handler recognized, but the V2-reordered
    >   pointerdown body drops most commands. A separate V2 body-parse defect. OPEN.
    >
@@ -271,6 +271,27 @@ x/y`, and dynamic `add { left: ${…}px }` style templating; (b) if the runtime 
    > unaffected by A (their causes are A2b-heavy / B / C). Guard:
    > [`multilingual-roadmap-fixes.test.ts`](../packages/semantic/test/multilingual-roadmap-fixes.test.ts)
    > "SOV verb-final behavior declaration opener".
+   >
+   > **Increment 6 DONE (2026-06-19, PR pending — VSO from-first handler-head, defect B).** The VSO
+   > transform fronts a handler's `from <source>` clause ahead of the `on <event>` marker
+   > (`on click from triggerEl` → ar `من triggerEl عند نقر`, tl `mula_sa triggerEl kapag click`), so
+   > no event pattern anchored on the leading source marker and the whole handler + body dropped
+   > (the bare `on click` form parsed fine). The parse entry
+   > ([`semantic-parser.ts`](../packages/semantic/src/parser/semantic-parser.ts)) now detects a
+   > leading `source`-marker + a following `on`-marker (VSO-gated), moves the from-clause to AFTER
+   > the event, and re-parses the normalized `on <event> from <source>` order (the order the SVO
+   > event path already handles). The source is moved, not dropped, so role-fidelity is intact.
+   > **removable ar+tl → FAITHFUL (1.0)** (were degenerate); **sortable tl → FAITHFUL**, sortable ar
+   > degenerate→lossy 0.889 (residual: `wait` inside the repeat loop — A2b). Priority gate
+   > **degenerate 15→11**, lossy 65→66 (the one ar-sortable flip), parse-rate unchanged (3695/3696),
+   > execution 1.0, **zero regressions**; 6112 semantic tests pass (+3 guards). de sortable (C) +
+   > ja/ko/qu/tr (A2a/A2b) unaffected. Guard:
+   > [`multilingual-roadmap-fixes.test.ts`](../packages/semantic/test/multilingual-roadmap-fixes.test.ts)
+   > "VSO from-first event-handler head".
+   >
+   > **Still open after Increment 6:** **A2a** (SOV bare-`if` body `set` — prototype rejected, needs
+   > copula normalization or scan-from-end), **A2b** (SOV/VSO command after a nested block — the
+   > sortable ar `wait` + bn/hi/th/ko trigger-tail + ja sortable), **C** (de V2 sortable body).
 
 3. **The actual priority — the authoring + install system for community & LLM agents:**
    - ~~**Authoring guide**~~ **DONE** (2026-06-16): `packages/behaviors/AUTHORING.md` — the

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -216,6 +216,53 @@ export class SemanticParserImpl implements ISemanticParser {
     // Sort patterns by priority (descending)
     const sortedPatterns = [...patterns].sort((a, b) => b.priority - a.priority);
 
+    // VSO from-first event-handler head. The VSO transform fronts a handler's
+    // `from <source>` clause ahead of the `on <event>` marker (`من triggerEl عند
+    // نقر` / `mula_sa triggerEl kapag click` = `on click from triggerEl`), so no
+    // event pattern anchors on the leading source marker and the whole handler +
+    // body drop (ar/tl behavior-removable/sortable were degenerate). When the
+    // input leads with a `source` marker and an `on`-marker follows, move the
+    // leading from-clause to AFTER the event and re-parse the normalized
+    // `on <event> from <source>` order — the same order the event path already
+    // handles in SVO (es `en clic de triggerEl`). The reorder preserves the
+    // source (it is moved, not dropped), so role-fidelity is intact. Gated to VSO
+    // + this exact `<source-marker> … <on-marker> <event>` token shape and only
+    // returned when the re-parse yields an event-handler, so it can only add parses.
+    {
+      const arr = tokens.tokens as LanguageToken[];
+      if (
+        tryGetProfile(language)?.wordOrder === 'VSO' &&
+        arr.length >= 4 &&
+        arr[0]?.normalized === 'source'
+      ) {
+        const onIdx = arr.findIndex(t => t.normalized === 'on');
+        if (onIdx >= 2 && onIdx + 1 < arr.length) {
+          const fromClause = parseInput
+            .slice(arr[0].position.start, arr[onIdx].position.start)
+            .trim();
+          const eventEnd = arr[onIdx + 1].position.end;
+          const reordered =
+            parseInput.slice(arr[onIdx].position.start, eventEnd) +
+            ' ' +
+            fromClause +
+            parseInput.slice(eventEnd);
+          if (reordered !== parseInput) {
+            try {
+              const reparsed = this.parse(reordered, language);
+              if (reparsed && reparsed.kind === 'event-handler') {
+                const result = modifiers
+                  ? this.applyModifiers(reparsed as EventHandlerSemanticNode, modifiers)
+                  : reparsed;
+                return withDiagnostics(result, diagnostics);
+              }
+            } catch {
+              // fall through to the normal stages unchanged
+            }
+          }
+        }
+      }
+    }
+
     // Stage 1: Try event handler patterns first (they wrap commands)
     const eventPatterns = sortedPatterns.filter(p => p.command === 'on');
     const eventMatch = patternMatcher.matchBest(tokens, eventPatterns);

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -6755,3 +6755,50 @@ describe('Block depth tracking ignores marker/opener homonyms (pt `para`, sw)', 
     expect(a.has('remove')).toBe(true);
   });
 });
+
+describe('VSO from-first event-handler head — ar/tl (behavior-removable/sortable)', () => {
+  // In VSO the handler's `from <source>` clause is fronted ahead of the
+  // `on <event>` marker: `on click from triggerEl` → `من triggerEl عند نقر` (ar) /
+  // `mula_sa triggerEl kapag click` (tl). No event pattern anchors on the leading
+  // source marker, so the whole handler + body dropped (ar/tl behavior-removable
+  // were degenerate; the bare `on click` form parsed fine). The parser now detects
+  // a leading source marker + a following `on`-marker (VSO-gated), moves the
+  // from-clause to after the event, and re-parses the normalized
+  // `on <event> from <source>` order. Strings below are post-transform output of
+  // `on click from triggerEl / add .a to me / end`.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  const cases: Array<[string, string]> = [
+    ['ar', 'من triggerEl عند نقر\n    أضف .a إلى أنا\nالنهاية'],
+    ['tl', 'mula_sa triggerEl kapag click\n    idagdag .a sa ako\nwakas'],
+  ];
+  for (const [lang, input] of cases) {
+    it(`[${lang}] VSO from-first head parses as an event handler with its body`, () => {
+      const node = parse(input, lang) as Record<string, unknown>;
+      expect(node).toBeTruthy();
+      expect(node.kind).toBe('event-handler');
+      const a = actions(node);
+      expect(a.has('on')).toBe(true);
+      expect(a.has('add')).toBe(true); // body recovered, not dropped with the head
+    });
+  }
+
+  // Regression guard: a VSO handler with NO from-clause (bare `on click`) must
+  // still parse via the normal event path — the reorder only fires on a leading
+  // source marker, so this is untouched.
+  it('[ar] bare `on click` head (no from-clause) is unaffected', () => {
+    const a = actions(parse('عند نقر\n    أضف .a إلى أنا\nالنهاية', 'ar'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('add')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,20 +1,25 @@
 {
-  "timestamp": "2026-06-19T20:00:00.529Z",
-  "commit": "cc089102",
+  "timestamp": "2026-06-19T23:09:33.956Z",
+  "commit": "fba720ca",
   "languages": {
     "ar": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8368310482087561,
-      "avgFidelity": 0.9862914862914862,
-      "avgPrecision": 0.9771645021645022,
-      "avgRoleFidelity": 0.8654823779823783,
+      "avgFidelity": 0.9939574314574313,
+      "avgPrecision": 0.9765741833923653,
+      "avgRoleFidelity": 0.8731053856053858,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-removable", "behavior-sortable"],
-      "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 440435,
+      "degeneratePasses": [],
+      "lossyPasses": [
+        "behavior-draggable",
+        "behavior-resizable",
+        "behavior-sortable",
+        "repeat-until-event"
+      ],
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -651,7 +656,7 @@
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1283,7 +1288,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
       "lossyPasses": ["get-value"],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1908,7 +1913,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2540,7 +2545,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3172,7 +3177,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3813,7 +3818,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4451,7 +4456,7 @@
         "keydown-key-is-syntax",
         "unless-condition"
       ],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5083,7 +5088,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5715,7 +5720,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6352,7 +6357,7 @@
         "form-disable-on-submit",
         "unless-condition"
       ],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6992,7 +6997,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7624,7 +7629,7 @@
       "executionFailures": [],
       "degeneratePasses": ["socket-basic"],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8256,7 +8261,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8888,7 +8893,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9528,7 +9533,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10160,7 +10165,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10792,7 +10797,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11429,7 +11434,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12054,14 +12059,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8216537651743292,
-      "avgFidelity": 0.9858405483405485,
+      "avgFidelity": 0.9942279942279942,
       "avgPrecision": 0.9771645021645022,
-      "avgRoleFidelity": 0.8687178249678251,
+      "avgRoleFidelity": 0.8768605831105833,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-removable", "behavior-resizable", "behavior-sortable"],
+      "degeneratePasses": ["behavior-resizable"],
       "lossyPasses": [],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12698,7 +12703,7 @@
         "fetch-do-not-throw",
         "unless-condition"
       ],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13329,7 +13334,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": ["behavior-removable"],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13967,7 +13972,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14607,7 +14612,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 440435,
+      "bundleSize": 440852,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15230,7 +15235,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 440435,
+      "size": 440852,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## What

In VSO the handler's `from <source>` clause is fronted ahead of the `on <event>` marker: `on click from triggerEl` → ar `من triggerEl عند نقر`, tl `mula_sa triggerEl kapag click`. No event pattern anchors on the leading source marker, so the **whole handler + body dropped** — ar/tl `behavior-removable`/`behavior-sortable` were degenerate, even though the bare `on click` form parsed fine.

## Fix

The parse entry now detects a leading `source`-marker followed by an `on`-marker (VSO-gated, on the exact `<source-marker> … <on-marker> <event>` token shape), moves the from-clause to **after** the event, and re-parses the normalized `on <event> from <source>` order — the same order the SVO event path already handles (es `en clic de triggerEl`). The source is **moved, not dropped** (role-fidelity intact), and it returns only when the re-parse yields an event-handler, so it can only add parses.

## Context — defect B of the 5-part SOV/VSO arc

The SOV/VSO behavior degeneracy is five separable defects (see `MULTILINGUAL_NEXT_STEPS.md`). This is **defect B (VSO handler-head)**. It was prototyped read-only first and measured clean before landing.

## Result (gate-verified)

- **removable ar+tl → faithful (1.0)** (were degenerate)
- **sortable tl → faithful**; sortable ar degenerate→lossy 0.889 (residual: `wait` inside the repeat loop — defect A2b)
- priority gate: **degenerate 15→11**, lossy 65→66, parse-rate unchanged (3695/3696), execution 1.0, **zero regressions** on all six ratchets
- de sortable (C) + ja/ko/qu/tr (A2a/A2b) unaffected
- 6112 semantic tests pass (+3 guards); baseline regenerated; `patterns.db` not committed

## Still open

A2a (SOV bare-`if` body `set`), A2b (command after a nested block — sortable ar `wait`, bn/hi/th/ko trigger-tail, ja sortable), C (de V2 sortable body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)