### PR TITLE
fix(semantic): verb-anchoring-aware then-branch boundary recovers SOV init set (A2a)

### DIFF
--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -2483,6 +2483,10 @@ export class SemanticParserImpl implements ISemanticParser {
     // Split blockTokens into condition / then-branch / else-branch. The condition
     // ends at the first depth-0 `then` keyword, or at the first depth-0 token that
     // begins a command (copula-guarded). then/else are split at depth-0 `else`.
+    // For SOV, also recognise a verb-medial command head (matchBest can't — A2a).
+    const sovProfile = tryGetProfile(language);
+    const sovVerbLookup =
+      sovProfile?.wordOrder === 'SOV' ? SemanticParserImpl.buildVerbLookup(sovProfile) : null;
     let i = 0;
     let bodyDepth = 0;
     const condTokens: LanguageToken[] = [];
@@ -2506,7 +2510,8 @@ export class SemanticParserImpl implements ISemanticParser {
         if (
           !SemanticParserImpl.CONDITION_OPERATORS.has(cur) &&
           !SemanticParserImpl.CONDITION_COPULAS.has(prev) &&
-          this.tokensBeginCommand(blockTokens.slice(i), commandPatterns, language)
+          (this.tokensBeginCommand(blockTokens.slice(i), commandPatterns, language) ||
+            this.sovCommandStartsAt(blockTokens.slice(i), sovVerbLookup))
         ) {
           break; // this token starts the then-branch
         }
@@ -2584,6 +2589,49 @@ export class SemanticParserImpl implements ISemanticParser {
     if (toks.length === 0) return false;
     const stream = new TokenStreamImpl(toks, language);
     return patternMatcher.matchBest(stream, commandPatterns) !== null;
+  }
+
+  /**
+   * Whether the token slice begins an SOV *verb-medial* command
+   * (`{value} {marker} … {verb} …`, e.g. `triggerEl を 設定 私 に` = `set triggerEl
+   * to me`). matchBest can't recognise these — it anchors on a selector/typed
+   * role — so the conditional split's {@link tokensBeginCommand} misses a
+   * verb-medial then-branch head and folds it into the condition (the A2a
+   * behavior-`init` `set` drop: the then-branch parser handles `set` fine once it
+   * *receives* it; only the boundary detection was blind to it).
+   *
+   * Mirrors the recognition {@link parseSOVClauseByVerbAnchoring} relies on: one
+   * or more `{value}{particle-marker}` role pairs followed by a command verb
+   * keyword. Conservative by construction — a bare-verb command (no leading role)
+   * already matches via matchBest, and a condition predicate (`X is empty`,
+   * `X exists`) carries copulas/operators rather than a `{value}{marker}{verb}`
+   * head, so it can't spuriously trip this.
+   */
+  private sovCommandStartsAt(
+    toks: LanguageToken[],
+    verbLookup: Map<string, string> | null
+  ): boolean {
+    if (!verbLookup) return false;
+    const isVerb = (t: LanguageToken): boolean =>
+      verbLookup.has(t.value.toLowerCase()) ||
+      (!!t.normalized && verbLookup.has(t.normalized.toLowerCase()));
+    const isValue = (t: LanguageToken): boolean =>
+      t.kind === 'identifier' ||
+      t.kind === 'selector' ||
+      t.kind === 'literal' ||
+      (t.kind as string) === 'reference';
+    let i = 0;
+    let pairs = 0;
+    while (i + 1 < toks.length) {
+      const val = toks[i];
+      const mark = toks[i + 1];
+      if (!isValue(val) || mark.kind !== 'particle') break;
+      pairs += 1;
+      i += 2;
+      const next = toks[i];
+      if (pairs >= 1 && next && isVerb(next)) return true;
+    }
+    return false;
   }
 
   /**

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -6862,3 +6862,79 @@ describe('Depth-aware end: command after a nested block in SOV bodies (A2b)', ()
     expect(a.has('toggle')).toBe(true);
   });
 });
+
+describe('Verb-medial SOV command head in a conditional body (A2a init `set` drop)', () => {
+  // The behavior `init` block `if triggerEl is undefined / set triggerEl to me /
+  // end` dropped its `set` in SOV: tryParseConditionalBlock's condition/then split
+  // located the then-branch via tokensBeginCommand (bare matchBest), which can't
+  // recognise an SOV *verb-medial* command (`triggerEl 를 설정 나 에` = `set
+  // triggerEl to me` — matchBest anchors on a selector/typed role, not a bare
+  // variable). So the `set` clause was absorbed into the condition and lost. The
+  // split now also recognises a verb-medial command head (sovCommandStartsAt). The
+  // then-branch parser already handled `set` once it received it. Strings below are
+  // the post-transform behavior with the init block + an unrelated handler.
+  function initActions(node: unknown): Set<string> {
+    const acc = new Set<string>();
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, unknown>;
+      if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+        const c = rec[f];
+        if (Array.isArray(c)) c.forEach(walk);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    const ib = (node as Record<string, unknown> | null)?.initBlock;
+    (Array.isArray(ib) ? ib : [ib]).forEach(walk);
+    return acc;
+  }
+
+  const cases: Array<[string, string]> = [
+    [
+      'ko',
+      'Foo(triggerEl) 를 behavior\n    init\n        만약 triggerEl 이다 정의안됨\n            triggerEl 를 설정 나 에\n        끝\n    끝\n    클릭 할 때\n        .x 를 토글\n    끝\n끝',
+    ],
+    [
+      'tr',
+      'Foo(triggerEl) i behavior\n    init\n        eğer triggerEl dir tanımsız\n            triggerEl i ayarla ben e\n        son\n    son\n    tıklama de\n        .x i değiştir\n    son\nson',
+    ],
+    [
+      'bn',
+      'Foo(triggerEl) কে আচরণ\n    শুরু\n        যদি triggerEl হয় অনির্ধারিত\n            triggerEl কে সেট আমি তে\n        শেষ\n    শেষ\n    ক্লিক এ\n        .x কে টগল\n    শেষ\nশেষ',
+    ],
+  ];
+  for (const [lang, input] of cases) {
+    it(`[${lang}] init keeps the verb-medial \`set\` in the if body (was dropped)`, () => {
+      const node = parse(input, lang) as Record<string, unknown>;
+      expect(node).toBeTruthy();
+      expect(node.kind).toBe('behavior');
+      const a = initActions(node);
+      expect(a.has('if')).toBe(true); // the conditional still folds
+      expect(a.has('set')).toBe(true); // …and its verb-medial body survives
+    });
+  }
+
+  // Regression guard: a conditional whose then-branch is a SELECTOR-patient
+  // command (matchBest already recognises it) is unchanged — the SOV path only
+  // adds recognition, never removes the matchBest one.
+  it('[ko] selector-patient then-branch still parses (unaffected)', () => {
+    const node = parse('클릭 할 때\n  만약 confirmRemoval\n    .y 를 토글\n  끝\n끝', 'ko') as Record<
+      string,
+      unknown
+    >;
+    const acc = new Set<string>();
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, unknown>;
+      if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+        const c = rec[f];
+        if (Array.isArray(c)) c.forEach(walk);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    expect(acc.has('toggle')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-20T03:17:56.915Z",
-  "commit": "d5b6414a",
+  "timestamp": "2026-06-20T13:39:59.571Z",
+  "commit": "65caf12f",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -19,7 +19,7 @@
         "behavior-sortable",
         "repeat-until-event"
       ],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -644,19 +644,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8495030867211314,
-      "avgFidelity": 0.9947510822510822,
+      "avgFidelity": 0.9955627705627705,
       "avgPrecision": 0.918695698241153,
-      "avgRoleFidelity": 0.7798926673926674,
+      "avgRoleFidelity": 0.7803431178431178,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": [
-        "behavior-removable",
-        "behavior-sortable",
-        "fetch-do-not-throw",
-        "unless-condition"
-      ],
-      "bundleSize": 441067,
+      "lossyPasses": ["behavior-sortable", "fetch-do-not-throw", "unless-condition"],
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1288,7 +1283,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-sortable", "get-value"],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1913,7 +1908,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2545,7 +2540,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3177,7 +3172,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3818,7 +3813,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4443,20 +4438,19 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.90909904631709,
-      "avgFidelity": 0.978517316017316,
-      "avgPrecision": 0.8377986731882837,
-      "avgRoleFidelity": 0.716060084810085,
+      "avgFidelity": 0.9793290043290043,
+      "avgPrecision": 0.8367996721892826,
+      "avgRoleFidelity": 0.7165105352605354,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["live-derived-value", "live-multiple-deps"],
       "lossyPasses": [
-        "behavior-removable",
         "behavior-sortable",
         "fetch-do-not-throw",
         "keydown-key-is-syntax",
         "unless-condition"
       ],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5088,7 +5082,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5720,7 +5714,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6345,19 +6339,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8351246080569386,
-      "avgFidelity": 0.9886904761904763,
-      "avgPrecision": 0.9107733175914994,
-      "avgRoleFidelity": 0.7890491452991454,
+      "avgFidelity": 0.9901515151515152,
+      "avgPrecision": 0.9091007477371114,
+      "avgRoleFidelity": 0.7902503465003466,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
-      "lossyPasses": [
-        "behavior-removable",
-        "fetch-do-not-throw",
-        "form-disable-on-submit",
-        "unless-condition"
-      ],
-      "bundleSize": 441067,
+      "lossyPasses": ["fetch-do-not-throw", "form-disable-on-submit", "unless-condition"],
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6982,14 +6971,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8170870900194204,
-      "avgFidelity": 0.9827380952380953,
+      "avgFidelity": 0.9841991341991342,
       "avgPrecision": 0.9292207792207794,
-      "avgRoleFidelity": 0.7888189700689701,
+      "avgRoleFidelity": 0.7892694205194205,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["window-scroll"],
       "lossyPasses": [
-        "behavior-removable",
         "behavior-sortable",
         "fetch-do-not-throw",
         "fetch-error-handling",
@@ -6997,7 +6985,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7629,7 +7617,7 @@
       "executionFailures": [],
       "degeneratePasses": ["socket-basic"],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8261,7 +8249,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8893,7 +8881,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9533,7 +9521,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10165,7 +10153,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10797,7 +10785,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11434,7 +11422,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12066,7 +12054,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-resizable"],
       "lossyPasses": [],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12691,19 +12679,14 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8329265429368624,
-      "avgFidelity": 0.9875272331154684,
-      "avgPrecision": 0.9344226579520697,
+      "avgFidelity": 0.9889978213507625,
+      "avgPrecision": 0.9344820756585462,
       "avgRoleFidelity": 0.7965660378925684,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["default-value"],
-      "lossyPasses": [
-        "behavior-removable",
-        "behavior-sortable",
-        "fetch-do-not-throw",
-        "unless-condition"
-      ],
-      "bundleSize": 441067,
+      "lossyPasses": ["behavior-sortable", "fetch-do-not-throw", "unless-condition"],
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13334,7 +13317,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13972,7 +13955,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14612,7 +14595,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 441067,
+      "bundleSize": 441522,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15235,7 +15218,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 441067,
+      "size": 441522,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## What

The behavior `init` block `if triggerEl is undefined / set triggerEl to me / end`
dropped its `set` in SOV languages (ja/ko/tr/hi/bn). `tryParseConditionalBlock`'s
condition/then split locates the then-branch via `tokensBeginCommand` (bare
`matchBest`), which **cannot recognise an SOV verb-medial command**
(`triggerEl 를 설정 나 에` = `set triggerEl to me` — matchBest anchors on a
selector/typed role, not a bare variable). So the `set` clause was absorbed into
the condition and lost (defect **A2a**).

The roadmap blamed copula normalization; triage disproved that — a
selector-patient then-branch survives even with a copula condition, and a
verb-medial `set` drops even with a trivial condition. It is purely a
boundary-detection gap; the then-branch parser handles `set` fine once it
receives it (confirmed: `set` survives in a handler body and in an `if` nested in
a handler).

## Fix

The split now also recognises a verb-medial command head via `sovCommandStartsAt`
(SOV-gated; mirrors `parseSOVClauseByVerbAnchoring`: one or more
`{value}{particle-marker}` role pairs followed by a command verb keyword).
Conservative — bare-verb commands already match via `matchBest`, and condition
predicates (`X is empty` / `X exists`) carry copulas/operators rather than a
`{value}{marker}{verb}` head, so they can't trip it.

## Results (priority gate green, zero regressions)

- behavior-removable **ja/ko/tr/hi/bn** init `set` recovered → those move out of
  the **lossy** band toward faithful
- Gate **lossy 66 → 61**, parse-rate unchanged (**3695/3696**), degenerate flat at
  10, avgFidelity + avgRoleFidelity up across SOV
- **6115** semantic unit tests pass; baseline regenerated

## Follow-ups (out of scope, scoped separately)

1. **qu** still loses the whole `if` (`tryParseConditionalBlock` fails for qu — a
   distinct conditional-block defect, not the boundary).
2. **Juxtaposed `set` + command** in a body (`set … / toggle …`, no `then`) — same
   verb-medial-matchBest family; `parseClause` runs verb-anchoring only as an
   all-or-nothing fallback.

## Test

Guard `multilingual-roadmap-fixes.test.ts` → "Verb-medial SOV command head in a
conditional body (A2a init `set` drop)" — verified it fails without the fix
(3 lang cases) and passes with it; the selector-patient control is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)