### PR TITLE
fix(semantic): recover juxtaposed verb-medial SOV commands in a body (clears trigger-tail)

### DIFF
--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1010,12 +1010,56 @@ export class SemanticParserImpl implements ISemanticParser {
     const clauseStream = new TokenStreamImpl(clauseTokens, language);
     const commands: SemanticNode[] = [];
 
+    // Count of commands produced by the existing paths (matchBest + the `repeat`
+    // special-case). Used to decide between per-gap recovery and the legacy
+    // whole-clause fallback below — see the `directHits === 0` branch.
+    let directHits = 0;
+
+    // Tokens matchBest could not anchor on. In SOV a *verb-medial* command
+    // (`triggerEl を 設定 私 に` = `set triggerEl to me`) doesn't match matchBest
+    // (it anchors on a selector/typed role), so when such a command is JUXTAPOSED
+    // before a matchable one (`set X to me` then `toggle .y`, no `then` between),
+    // matchBest skips the whole verb-medial command one token at a time and it is
+    // silently dropped — the all-or-nothing whole-clause fallback at the end never
+    // fired because a later command DID match. Collect each skipped run and recover
+    // verb-medial commands from it (in order, so execution semantics are kept).
+    const skipped: LanguageToken[] = [];
+    const flushSkipped = () => {
+      if (skipped.length === 0) return;
+      const run = skipped.slice();
+      skipped.length = 0;
+      // Recover only a *value-led* run (a verb-medial command always opens with
+      // its first role value — identifier/selector/literal). A keyword-led run is
+      // an event-clause leak (`스크롤 …` / `scroll …`, where the event word is also
+      // a command verb) and must NOT be turned into a command.
+      const head = run[0];
+      const headIsValue =
+        head &&
+        (head.kind === 'identifier' ||
+          head.kind === 'selector' ||
+          head.kind === 'literal' ||
+          (head.kind as string) === 'reference');
+      if (!headIsValue) return;
+      // Verb-anchoring on a *fragment* can still mis-fire on a stray marker/keyword
+      // (`from`/`into`/`or`/`until`). Keep only well-formed recoveries: a real
+      // command schema with at least one captured role.
+      for (const node of this.parseSOVClauseByVerbAnchoring(run, language)) {
+        const action = (node as { action?: string }).action;
+        const roles = (node as { roles?: unknown }).roles;
+        if (action && getSchema(action as ActionType) && roles instanceof Map && roles.size > 0) {
+          commands.push(node);
+        }
+      }
+    };
+
     while (!clauseStream.isAtEnd()) {
       // Try to match as a command
       const commandMatch = patternMatcher.matchBest(clauseStream, commandPatterns);
       if (commandMatch) {
+        flushSkipped();
         const cmd = this.buildCommand(commandMatch, language);
         commands.push(cmd);
+        directHits++;
         this.tryAttachTrailingRole(clauseStream, cmd, language);
       } else {
         // A `for`-binding loop (`repeat for <var> in <coll>`) loses its `for`
@@ -1028,6 +1072,7 @@ export class SemanticParserImpl implements ISemanticParser {
         // `repeat` loop keyword, emit the loop action directly so it survives.
         const tok = clauseStream.peek();
         if (tok && tok.normalized?.toLowerCase() === 'repeat') {
+          flushSkipped();
           commands.push(
             createCommandNode(
               'repeat' as ActionType,
@@ -1035,17 +1080,22 @@ export class SemanticParserImpl implements ISemanticParser {
               { sourceLanguage: language, confidence: 0.6 }
             )
           );
+          directHits++;
+        } else if (tok) {
+          skipped.push(tok);
         }
         // Skip unrecognized token
         clauseStream.advance();
       }
     }
+    flushSkipped();
 
-    // If pattern matching produced nothing, try verb-anchored SOV parsing.
-    // The grammar transformer often puts the verb BETWEEN roles for two-role commands:
-    //   e.g., "destination を verb patient に" instead of "destination を patient に verb"
-    // Pattern matching fails because it expects strict SOV order (verb at end).
-    if (commands.length === 0) {
+    // No command matched via matchBest or the `repeat` special-case: prefer the
+    // legacy whole-clause verb-anchoring (byte-identical to the prior behavior).
+    // It handles a single verb-FINAL command (`call updateScrollPosition()`) that
+    // the per-gap recovery would mis-split into fragments — so a clause that is one
+    // such command is parsed correctly, and any per-gap noise is discarded.
+    if (directHits === 0) {
       const sovCommands = this.parseSOVClauseByVerbAnchoring(clauseTokens, language);
       if (sovCommands.length > 0) {
         return sovCommands;

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -6938,3 +6938,52 @@ describe('Verb-medial SOV command head in a conditional body (A2a init `set` dro
     expect(acc.has('toggle')).toBe(true);
   });
 });
+
+describe('Juxtaposed verb-medial SOV command in a body (parseClause gap recovery)', () => {
+  // A verb-medial SOV command (`triggerEl を 設定 私 に` = `set triggerEl to me`)
+  // doesn't match matchBest. When JUXTAPOSED before a matchable command (`set X to
+  // me` then `toggle .y`, no `then` between), the matchBest loop skipped the whole
+  // `set` and the all-or-nothing whole-clause fallback never fired (a later command
+  // matched), so `set` was dropped. parseClause now recovers verb-medial commands
+  // from each skipped run, in order. (This also clears the behavior-sortable
+  // SOV `trigger … on me` tail.) Strings below are post-transform.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  const jux: Array<[string, string]> = [
+    ['ko', '클릭 할 때\n    triggerEl 를 설정 나 에\n    .x 를 토글\n끝'],
+    ['ja', 'クリック で\n    triggerEl を 設定 私 に\n    .x を 切り替え\n終わり'],
+    ['tr', 'tıklama de\n    triggerEl i ayarla ben e\n    .x i değiştir\nson'],
+  ];
+  for (const [lang, input] of jux) {
+    it(`[${lang}] keeps the juxtaposed verb-medial \`set\` before \`toggle\` (was dropped)`, () => {
+      const a = actions(parse(input, lang));
+      expect(a.has('set')).toBe(true); // the verb-medial command, previously skipped
+      expect(a.has('toggle')).toBe(true); // the matchBest command still there
+    });
+  }
+
+  // Regression guard: a clause that is a SINGLE verb-final command (no matchBest
+  // hit) must still go through the whole-clause fallback, not the per-gap path —
+  // the per-gap recovery could fragment it. `call updateScrollPosition()` is the
+  // canonical case (the event-throttle body).
+  const verbFinal: Array<[string, string]> = [
+    ['ko', '스크롤 할 때\n    updateScrollPosition() 를 호출\n끝'],
+    ['tr', 'kaydır de\n    updateScrollPosition() i çağır\nson'],
+  ];
+  for (const [lang, input] of verbFinal) {
+    it(`[${lang}] a single verb-final \`call\` body still parses (whole-clause path)`, () => {
+      const a = actions(parse(input, lang));
+      expect(a.has('call')).toBe(true);
+    });
+  }
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-20T13:39:59.571Z",
-  "commit": "65caf12f",
+  "timestamp": "2026-06-20T14:10:41.895Z",
+  "commit": "f7734e8f",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -19,7 +19,7 @@
         "behavior-sortable",
         "repeat-until-event"
       ],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -644,14 +644,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8495030867211314,
-      "avgFidelity": 0.9955627705627705,
-      "avgPrecision": 0.918695698241153,
+      "avgFidelity": 0.9962121212121211,
+      "avgPrecision": 0.9156081119316415,
       "avgRoleFidelity": 0.7803431178431178,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["behavior-sortable", "fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 441522,
+      "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1283,7 +1283,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-sortable", "get-value"],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1908,7 +1908,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2540,7 +2540,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3172,7 +3172,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3813,7 +3813,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4438,19 +4438,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.90909904631709,
-      "avgFidelity": 0.9793290043290043,
-      "avgPrecision": 0.8367996721892826,
-      "avgRoleFidelity": 0.7165105352605354,
+      "avgFidelity": 0.9799783549783551,
+      "avgPrecision": 0.8366587544108552,
+      "avgRoleFidelity": 0.7169609857109858,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["live-derived-value", "live-multiple-deps"],
-      "lossyPasses": [
-        "behavior-sortable",
-        "fetch-do-not-throw",
-        "keydown-key-is-syntax",
-        "unless-condition"
-      ],
-      "bundleSize": 441522,
+      "lossyPasses": ["fetch-do-not-throw", "keydown-key-is-syntax", "unless-condition"],
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5082,7 +5077,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5714,7 +5709,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6340,13 +6335,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 0.9901515151515152,
-      "avgPrecision": 0.9091007477371114,
-      "avgRoleFidelity": 0.7902503465003466,
+      "avgPrecision": 0.9084351922587217,
+      "avgRoleFidelity": 0.7907329719829721,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-sortable"],
       "lossyPasses": ["fetch-do-not-throw", "form-disable-on-submit", "unless-condition"],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6971,21 +6966,20 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8170870900194204,
-      "avgFidelity": 0.9841991341991342,
-      "avgPrecision": 0.9292207792207794,
-      "avgRoleFidelity": 0.7892694205194205,
+      "avgFidelity": 0.9848484848484848,
+      "avgPrecision": 0.9282246162927983,
+      "avgRoleFidelity": 0.789719870969871,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["window-scroll"],
       "lossyPasses": [
-        "behavior-sortable",
         "fetch-do-not-throw",
         "fetch-error-handling",
         "if-empty",
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7617,7 +7611,7 @@
       "executionFailures": [],
       "degeneratePasses": ["socket-basic"],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8249,7 +8243,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8881,7 +8875,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9507,7 +9501,7 @@
       "parseRate": 1,
       "avgConfidence": 0.7291486291486292,
       "avgFidelity": 0.986904761904762,
-      "avgPrecision": 0.9308802308802314,
+      "avgPrecision": 0.930555555555556,
       "avgRoleFidelity": 0.7716267778767776,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -9521,7 +9515,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10153,7 +10147,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10785,7 +10779,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11422,7 +11416,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12054,7 +12048,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-resizable"],
       "lossyPasses": [],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12679,14 +12673,14 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8329265429368624,
-      "avgFidelity": 0.9889978213507625,
-      "avgPrecision": 0.9344820756585462,
-      "avgRoleFidelity": 0.7965660378925684,
+      "avgFidelity": 0.9896514161220042,
+      "avgPrecision": 0.9336067255184901,
+      "avgRoleFidelity": 0.7970195526317974,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["default-value"],
-      "lossyPasses": ["behavior-sortable", "fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 441522,
+      "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13317,7 +13311,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13955,7 +13949,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14595,7 +14589,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 441522,
+      "bundleSize": 441848,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15218,7 +15212,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 441522,
+      "size": 441848,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## What

A verb-medial SOV command (`triggerEl を 設定 私 に` = `set triggerEl to me`,
`sortable:start を トリガー me に` = `trigger sortable:start on me`) doesn't match
`matchBest` — it anchors on a selector/typed role, not a bare variable / colon
event name. When such a command is **juxtaposed** before a matchable one in a body
(no `then` between), the `matchBest` loop skipped the whole verb-medial command
and the all-or-nothing whole-clause verb-anchoring fallback never fired (a later
command **did** match), so it was silently dropped.

## Fix

`parseClause` collects each `matchBest`-skipped run and recovers verb-medial
commands from it, **in order**. Guards keep it precise and zero-regression:

- **value-led only** — a keyword-led run is an event-clause leak (`스크롤 …`, where
  the event word is also a command verb) and is NOT turned into a command;
- **real command schema + ≥1 captured role** — rejects stray marker/keyword noise
  (`from`/`into`/`or`/`until`);
- **`directHits === 0` → legacy whole-clause fallback** (byte-identical) — a clause
  that is a single verb-final command (`call updateScrollPosition()`, the
  event-throttle body) the per-gap path would fragment is parsed correctly.

SOV-gated inside `parseSOVClauseByVerbAnchoring`, so non-SOV clauses are unchanged.

## Results (priority gate green, zero regressions)

- behavior-sortable SOV `trigger … on me` tail recovered → **sortable ko/tr/hi/bn
  lossy → faithful**
- Gate **lossy 61 → 57**, parse-rate unchanged (**3695/3696**), degenerate flat at
  10, avgFidelity + avgRoleFidelity up, precision flat (−0.0002, real-command
  captures the en reference itself drops)
- **6119** semantic unit tests pass; baseline regenerated

Note: an earlier broad version introduced a tolerated hi/event-throttle flip; the
narrowed version above (value-led + directHits guard) eliminates it — matches main
on throttle while still clearing the trigger-tail.

## Follow-up (separate, tracked)

qu conditional-block failure — qu still loses the init `if` entirely
(`tryParseConditionalBlock` fails for qu).

## Test

Guard `multilingual-roadmap-fixes.test.ts` → "Juxtaposed verb-medial SOV command
in a body (parseClause gap recovery)" — fails without the fix (3 jux cases),
passes with it; verb-final `call` regression guards pass both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)