### PR TITLE
fix(semantic): qu word reader keeps native words whole at English fallbacks (init)

### DIFF
--- a/packages/semantic/src/tokenizers/extractors/quechua-keyword.ts
+++ b/packages/semantic/src/tokenizers/extractors/quechua-keyword.ts
@@ -64,6 +64,33 @@ const POSTPOSITIONS = new Set([
 ]);
 
 /**
+ * Standalone (unhyphenated) Quechua case-marker forms that legitimately
+ * agglutinate onto a stem — used by the word reader to decide where to break.
+ * Derived from {@link SUFFIXES}/{@link POSTPOSITIONS} (hyphen stripped, plus the
+ * `rayku` postposition the suffix set lists only hyphenated).
+ */
+const AGGLUTINATIVE_MARKERS: ReadonlySet<string> = new Set(
+  [...SUFFIXES, ...POSTPOSITIONS].map(s => (s.startsWith('-') ? s.slice(1) : s))
+);
+
+/**
+ * Whether a Quechua case-marker suffix starts at `pos` and ends at a word
+ * boundary (end of input or a non-Quechua-letter). Unlike a generic
+ * isKeywordStart check, this never fires on the English canonical fallbacks
+ * injected into the keyword table, so native words containing `it`/`me`/… are
+ * not split (`init`, `ñit'iy`).
+ */
+function quechuaSuffixStartsAt(input: string, pos: number): boolean {
+  const remaining = input.slice(pos);
+  for (const marker of AGGLUTINATIVE_MARKERS) {
+    if (!remaining.startsWith(marker)) continue;
+    const after = input[pos + marker.length];
+    if (after === undefined || !isQuechuaLetter(after)) return true;
+  }
+  return false;
+}
+
+/**
  * QuechuaKeywordExtractor - Context-aware extractor for Quechua words.
  *
  * Handles:
@@ -176,12 +203,15 @@ export class QuechuaKeywordExtractor implements ContextAwareExtractor {
     let pos = position;
 
     while (pos < input.length && isQuechuaLetter(input[pos])) {
-      // Break for an attached keyword (agglutinative suffix like `-ta`, `-man`)
-      // only when the match ends at a word boundary. A raw isKeywordStart check
-      // splits native words around embedded English-fallback keywords (me, it,
-      // you, … are injected for every language): ñit'iy → ñ + it + 'iy.
-      // isQuechuaLetter keeps the glottal apostrophe inside the word.
-      if (word.length > 0 && this.context.isKeywordStartAtBoundary?.(input, pos, isQuechuaLetter)) {
+      // Break for an attached agglutinative case-marker suffix (`-ta`, `-man`,
+      // `-pi`, …) at a word boundary. Restricted to the Quechua suffix set — a
+      // generic isKeywordStart(AtBoundary) check also fires on the English
+      // canonical fallbacks (me, it, you, …) injected into every language's
+      // keyword table, splitting native words around them: `init` → `in` + `it`
+      // (which silently dropped the behavior `init` block — the parser saw `in`,
+      // not the `init` keyword), `ñit'iy` → `ñ` + `it` + `'iy`. Only real case
+      // markers legitimately agglutinate onto a stem; English fallbacks never do.
+      if (word.length > 0 && quechuaSuffixStartsAt(input, pos)) {
         break;
       }
       word += input[pos];

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -6987,3 +6987,48 @@ describe('Juxtaposed verb-medial SOV command in a body (parseClause gap recovery
     });
   }
 });
+
+describe('Quechua word reader does not split native words at English fallbacks (init)', () => {
+  // The qu word reader broke a word at any embedded keyword-at-boundary, which
+  // includes the English canonical fallbacks (me/it/you/…) injected into every
+  // language's keyword table: `init` → `in` + `it`. The behavior `init` block
+  // keyword was therefore never recognised (the block-parser saw `in`), so the
+  // whole init body — `if triggerEl is undefined / set triggerEl to me / end` —
+  // was treated as a handler and dropped (qu behavior-removable/sortable lost the
+  // init `set`). The reader now breaks only on real Quechua case-marker suffixes.
+  function tokens(input: string): string[] {
+    const r = getTokenizer('qu').tokenize(input) as unknown;
+    const arr = Array.isArray(r) ? r : ((r as { tokens?: unknown[] }).tokens ?? []);
+    return (arr as Array<{ value: string }>).map(t => t.value);
+  }
+
+  it('tokenizes `init` as a single word (was `in` + `it`)', () => {
+    expect(tokens('init')).toEqual(['init']);
+  });
+
+  it('still splits a real agglutinated case marker (`triggerElta` → stem + `ta`)', () => {
+    expect(tokens('triggerElta')).toEqual(['triggerEl', 'ta']);
+  });
+
+  it('recovers the behavior `init` block body (if + set)', () => {
+    const input =
+      'Foo(triggerEl) ta behavior\n    init\n        sichus triggerEl kanqa mana_riqsisqa\n            triggerEl ta noqa man churanay\n        tukuy\n    tukuy\n    ñitiy pi\n        .x ta tikray\n    tukuy\ntukuy';
+    const node = parse(input, 'qu') as Record<string, unknown>;
+    expect(node.kind).toBe('behavior');
+    const acc = new Set<string>();
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, unknown>;
+      if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+        const c = rec[f];
+        if (Array.isArray(c)) c.forEach(walk);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    const ib = node.initBlock;
+    (Array.isArray(ib) ? ib : [ib]).forEach(walk);
+    expect(acc.has('if')).toBe(true);
+    expect(acc.has('set')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-20T14:10:41.895Z",
-  "commit": "f7734e8f",
+  "timestamp": "2026-06-20T15:32:57.489Z",
+  "commit": "87c5c459",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9499,18 +9499,16 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7291486291486292,
-      "avgFidelity": 0.986904761904762,
-      "avgPrecision": 0.930555555555556,
-      "avgRoleFidelity": 0.7716267778767776,
+      "avgConfidence": 0.7316532673675531,
+      "avgFidelity": 0.988365800865801,
+      "avgPrecision": 0.9311969415865524,
+      "avgRoleFidelity": 0.7701570389070387,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [
         "append-content",
         "behavior-draggable",
-        "behavior-removable",
-        "behavior-sortable",
         "modal-close-escape",
         "take-class-from-siblings",
         "unless-condition"
@@ -9789,6 +9787,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "trigger-event": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -9886,10 +9888,6 @@
           "confidence": 0.5
         },
         "append-content": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "trigger-event": {
           "success": true,
           "confidence": 0.5
         },


### PR DESCRIPTION
## What

The Quechua word reader (`quechua-keyword.ts`) broke a word at **any** embedded
keyword-at-boundary. The keyword table includes the English canonical fallbacks
(me/it/you/…) injected into every language, so `init` split into `in` + `it`. The
behavior `init` block keyword was then never recognised — the block-parser saw
`in`, treated the whole `init` segment as a handler, and dropped its body — so qu
behavior-removable/sortable lost the init `set`. qu was the **only SOV language
still non-faithful on both** after the A2a / A2b / juxtaposed-body fixes.

## Fix

Break the word only on a real Quechua agglutinative case-marker suffix
(`-ta`/`-man`/`-pi`/… via `quechuaSuffixStartsAt`), never on an arbitrary keyword.
English fallbacks never agglutinate onto a stem; real case markers do — so
`triggerElta` → `triggerEl` + `ta` still splits, while `init` / `ñit'iy` stay
whole.

## Results (priority gate green, zero regressions)

- qu behavior-removable + behavior-sortable init `set` recovered → **both faithful**
- Gate **lossy 57 → 55**, parse-rate unchanged (**3695/3696**), degenerate flat at
  10, precision + fidelity flat
- **6124** semantic unit tests pass; baseline regenerated

## Test

Guard `multilingual-roadmap-fixes.test.ts` → "Quechua word reader does not split
native words at English fallbacks (init)" — `init` tokenizes whole, agglutination
still splits (`triggerElta`→`triggerEl`+`ta`), behavior init recovers if+set.
Fails without the fix (init split + behavior init), passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)