### PR TITLE
fix(semantic): exit/end keyword collision collapsed SOV/V2 handler bodies

### DIFF
--- a/packages/semantic/src/generators/profiles/japanese.ts
+++ b/packages/semantic/src/generators/profiles/japanese.ts
@@ -137,7 +137,11 @@ export const japaneseProfile: LanguageProfile = {
     return: { primary: '戻る', alternatives: ['返す', 'リターン'], normalized: 'return' },
     then: { primary: 'それから', alternatives: ['次に', 'ならば', 'なら'], normalized: 'then' },
     and: { primary: 'また', alternatives: ['と', 'そして'], normalized: 'and' },
-    end: { primary: '終わり', alternatives: ['終了', 'おわり'], normalized: 'end' },
+    // 終了 removed: it is the i18n dict's `exit` emission (ja.ts), so listing it
+    // as an `end` alternative made an `exit` inside `if … exit … end` read as the
+    // block terminator and collapse the handler body (behavior-sortable). 終わり is
+    // the dict's `end` emission; おわり the kana variant.
+    end: { primary: '終わり', alternatives: ['おわり'], normalized: 'end' },
     // Advanced
     js: { primary: 'JS実行', alternatives: ['js'], normalized: 'js' },
     async: { primary: '非同期', alternatives: ['アシンク'], normalized: 'async' },

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -2303,18 +2303,29 @@ export class SemanticParserImpl implements ISemanticParser {
     const v = value.toLowerCase();
     const endKeywords: Record<string, Set<string>> = {
       en: new Set(['end']),
-      ja: new Set(['終わり', '終了', 'おわり']),
+      // 終了 is deliberately ABSENT: it is the i18n dict's `exit` emission
+      // (`exit: 終了`, ja.ts), and listing it as an `end` alternative made the
+      // body parser count an `exit` inside an `if … exit … end` block as the
+      // block terminator — so the real 終わり closed the whole handler body,
+      // dropping every command after the block (behavior-sortable degenerate).
+      // 終わり is the dict's `end` emission; おわり is the kana variant.
+      ja: new Set(['終わり', 'おわり']),
       // ar آخر is deliberately ABSENT: it is the positional `last` keyword;
       // listing it here chopped clauses at every positional last (ar focus-trap
       // lost its if-branch body). النهاية is what the i18n dict emits for end.
       ar: new Set(['نهاية', 'انتهى', 'النهاية']),
       es: new Set(['fin', 'final', 'terminar']),
-      ko: new Set(['끝', '종료', '마침']),
+      // 종료 is deliberately ABSENT — same exit/end collision as ja above
+      // (`exit: 종료`, ko.ts). 끝 is the dict's `end` emission; 마침 a variant.
+      ko: new Set(['끝', '마침']),
       zh: new Set(['结束', '终止', '完']),
       tr: new Set(['son', 'bitiş', 'bitti']),
       pt: new Set(['fim', 'final', 'término']),
       fr: new Set(['fin', 'terminer', 'finir']),
-      de: new Set(['ende', 'beenden', 'fertig']),
+      // beenden is deliberately ABSENT — same exit/end collision as ja above
+      // (`exit: beenden`, de.ts; the de profile's `end` alternatives are only
+      // ['ende', 'fertig'], so this hardcoded set was the lone offender).
+      de: new Set(['ende', 'fertig']),
       id: new Set(['selesai', 'akhir', 'tamat']),
       tl: new Set(['wakas', 'tapos']),
       bn: new Set(['সমাপ্ত']),

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -7032,3 +7032,53 @@ describe('Quechua word reader does not split native words at English fallbacks (
     expect(acc.has('set')).toBe(true);
   });
 });
+
+describe('exit/end keyword collision does not collapse the handler body (ja/de)', () => {
+  // The i18n dict emits the `exit` command as a word that the semantic end-keyword
+  // set ALSO listed: ja `exit: 終了` (end set had 終了; real end is 終わり), de
+  // `exit: beenden` (hardcoded end set had beenden; real end is ende). Inside an
+  // `if … exit … end` block the `exit` token therefore decremented the body
+  // parser's block depth one too early, so the block's real `end` was seen at
+  // depth 0 and terminated the WHOLE handler body — dropping every command after a
+  // following nested block (behavior-sortable: ja degenerate, de lossy — the
+  // post-`repeat` `remove`/`trigger`). Fix: the exit emission is no longer read as
+  // an `end` keyword (semantic-parser.isEndKeyword + ja profile end alternatives).
+  function bodyActions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches', 'eventHandlers']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => bodyActions(x, acc));
+      else if (c && typeof c === 'object') bodyActions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped (behavior-sortable handler): `on pointerdown(clientY) from me /
+  // set item … / if item is null / exit / end / halt … / add … / repeat until … /
+  // … / end / remove … / trigger … end`. The post-`repeat` `remove`/`trigger`
+  // must survive — they were dropped while exit doubled as an end keyword.
+  const cases: Array<[string, string]> = [
+    [
+      'ja',
+      'pointerdown(clientY) で 私 から\n    item を 設定 the target.closest("li") に\n    もし item である null\n        終了\n    終わり\n    the イベント を 停止\n    .active を 追加 item に\n    まで イベント pointerup を 繰り返し ドキュメント から\n        move を 引き金 私 に\n    終わり\n    .active を 削除 item から\n    done を 引き金 私 に\n終わり',
+    ],
+    [
+      'de',
+      'bei pointerdown(clientY) von ich\n    festlegen item zu the target.closest("li")\n    falls item ist null\n        beenden\n    ende\n    anhalten the ereignis\n    hinzufügen .active zu item\n    wiederholen bis ereignis pointerup von dokument\n        auslösen move zu ich\n    ende\n    entfernen .active von item\n    auslösen done zu ich\nende',
+    ],
+  ];
+
+  for (const [lang, input] of cases) {
+    it(`[${lang}] keeps commands after the if/exit/end block + nested loop`, () => {
+      const a = bodyActions(parse(input, lang));
+      expect(a.has('on')).toBe(true);
+      // The post-`repeat` commands — the ones the collision dropped.
+      expect(a.has('remove')).toBe(true);
+      expect(a.has('trigger')).toBe(true);
+      // The pre-loop body also survives.
+      for (const action of ['halt', 'add', 'repeat']) expect(a.has(action)).toBe(true);
+    });
+  }
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-20T15:32:57.489Z",
-  "commit": "87c5c459",
+  "timestamp": "2026-06-21T02:09:29.234Z",
+  "commit": "4e13b1bc",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -19,7 +19,7 @@
         "behavior-sortable",
         "repeat-until-event"
       ],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -651,7 +651,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1276,14 +1276,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.830921459492886,
-      "avgFidelity": 0.9971861471861474,
+      "avgFidelity": 0.997835497835498,
       "avgPrecision": 0.993831168831169,
-      "avgRoleFidelity": 0.859130902880903,
+      "avgRoleFidelity": 0.8600318037818038,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["behavior-sortable", "get-value"],
-      "bundleSize": 441848,
+      "lossyPasses": ["get-value"],
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1908,7 +1908,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2540,7 +2540,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3172,7 +3172,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3813,7 +3813,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4445,7 +4445,7 @@
       "executionFailures": [],
       "degeneratePasses": ["live-derived-value", "live-multiple-deps"],
       "lossyPasses": ["fetch-do-not-throw", "keydown-key-is-syntax", "unless-condition"],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5077,7 +5077,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5709,7 +5709,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6334,14 +6334,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8351246080569386,
-      "avgFidelity": 0.9901515151515152,
-      "avgPrecision": 0.9084351922587217,
-      "avgRoleFidelity": 0.7907329719829721,
+      "avgFidelity": 0.9940476190476191,
+      "avgPrecision": 0.9090536214485794,
+      "avgRoleFidelity": 0.7929852242352243,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["behavior-sortable"],
+      "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "form-disable-on-submit", "unless-condition"],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6979,7 +6979,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7611,7 +7611,7 @@
       "executionFailures": [],
       "degeneratePasses": ["socket-basic"],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8243,7 +8243,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8875,7 +8875,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9513,7 +9513,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10145,7 +10145,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10777,7 +10777,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11414,7 +11414,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12046,7 +12046,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-resizable"],
       "lossyPasses": [],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12678,7 +12678,7 @@
       "executionFailures": [],
       "degeneratePasses": ["default-value"],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13309,7 +13309,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13947,7 +13947,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14587,7 +14587,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 441848,
+      "bundleSize": 441793,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15210,7 +15210,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 441848,
+      "size": 441793,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

The i18n dict emits the `exit` command as a word the semantic **end-keyword set also listed**:

| lang | `exit` emission | real `end` |
| ---- | --------------- | ---------- |
| ja   | `終了`          | `終わり`   |
| de   | `beenden`       | `ende`     |
| ko   | `종료`          | `끝`       |

Inside an `if … exit … end` block the `exit` token decremented the body parser's block-depth one step too early, so the block's real `end` was seen at depth 0 and **terminated the whole handler body** — dropping every command after a following nested block.

`behavior-sortable` was **degenerate in ja** (its only degenerate pass) and **lossy in de** (dropped the post-`repeat` `remove`/`trigger`). Removing the `exit` emissions from `isEndKeyword` (ja/ko/de) and the ja profile `end` alternatives makes both faithful.

Resolves residuals **#1 (ja)** and **#3 (de)** of `docs-internal/HANDOFF-sov-sortable-residuals.md`. (Residual #2, ar, is the stacked PR on top of this one.)

## Verification

- Priority gate (`--regression`, `browser-priority`): **No regression**; degenerate **10→9**, lossy **55→54**.
- Full semantic unit suite: **6131 passed**, 0 failures; typecheck clean.
- Regression guard added to `multilingual-roadmap-fixes.test.ts` ("exit/end keyword collision does not collapse the handler body (ja/de)") — verified to **fail without the fix** (git-stash checked).

## Notes

- `ko` had the same latent collision (`종료`) and is fixed too; it was already faithful, stays faithful.
- Per repo convention the regenerated `patterns.db` is not committed (CI re-populates); only src + test + baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)