### PR TITLE
fix(semantic): recover ar VSO from-first `wait` clause (behavior-sortable)

### DIFF
--- a/packages/semantic/src/patterns/wait.ts
+++ b/packages/semantic/src/patterns/wait.ts
@@ -73,12 +73,53 @@ function getWaitPatternsHe(): LanguagePattern[] {
   ];
 }
 
+/**
+ * Arabic (VSO) wait patterns.
+ *
+ * The grammar transformer fronts a `wait for <events> from <source>` clause's
+ * source ahead of the events for ar — `wait for pointermove or pointerup from
+ * document` → `انتظر من وثيقة pointermove أو pointerup` (`wait from document
+ * pointermove or pointerup`). The auto-generated `<verb> {duration}` pattern then
+ * can't anchor: the token right after the verb is the source particle `من`, not a
+ * duration/event. So the trailing `wait` was dropped (behavior-sortable's loop
+ * body, ar lossy). This recovers it by matching the fronted `from <source>` and
+ * capturing the first following event as the duration; the remaining `or <event>`
+ * tail is harmless trailing tokens (no command anchors on it). The natural
+ * source-last order (`انتظر … من وثيقة`) is already covered by the generated
+ * pattern, so this only adds the fronted form.
+ */
+function getWaitPatternsAr(): LanguagePattern[] {
+  return [
+    {
+      id: 'wait-ar-from-first',
+      language: 'ar',
+      command: 'wait',
+      priority: 105,
+      template: {
+        format: 'انتظر من {source} {duration}',
+        tokens: [
+          { type: 'literal', value: 'انتظر', alternatives: ['انتظري'] },
+          { type: 'literal', value: 'من' },
+          { type: 'role', role: 'source', expectedTypes: ['expression', 'reference'] },
+          { type: 'role', role: 'duration', expectedTypes: ['expression', 'literal'] },
+        ],
+      },
+      extraction: {
+        source: { position: 2 },
+        duration: { position: 3 },
+      },
+    },
+  ];
+}
+
 export function getWaitPatternsForLanguage(language: string): LanguagePattern[] {
   switch (language) {
     case 'zh':
       return getWaitPatternsZh();
     case 'he':
       return getWaitPatternsHe();
+    case 'ar':
+      return getWaitPatternsAr();
     default:
       return [];
   }

--- a/packages/semantic/src/tokenizers/extractors/arabic-proclitic.ts
+++ b/packages/semantic/src/tokenizers/extractors/arabic-proclitic.ts
@@ -54,6 +54,21 @@ const PROCLITICS = new Map<string, ProcliticMetadata>([
 ]);
 
 /**
+ * Whole words that BEGIN with a proclitic letter (و/ف/ب/ل/ك) but are NOT a
+ * proclitic + stem — splitting them destroys a real word. `isKeyword(fullWord)`
+ * already protects command keywords (بدل, etc.); this covers content words the
+ * i18n dict emits that aren't hyperscript keywords. `وثيقة` (document, `from
+ * document`) is the motivating case: split into و (`and`) + ثيقة, the spurious
+ * `and` conjunction became a clause boundary that dropped the surrounding command
+ * (ar behavior-sortable's `wait … from document` clause parsed as null). Returning
+ * null here routes the word to the identifier extractor — kept as a single
+ * `identifier` token (so a role can capture it), matching how en lexes `document`.
+ */
+const NON_PROCLITIC_WORDS = new Set<string>([
+  'وثيقة', // document
+]);
+
+/**
  * ArabicProcliticExtractor - Extracts Arabic proclitics with role metadata.
  *
  * Prevents splitting keywords by checking full word against keyword map first.
@@ -91,6 +106,11 @@ export class ArabicProcliticExtractor implements ContextAwareExtractor {
     // Check if full word is a keyword (with or without diacritics)
     if (this.context.isKeyword(fullWord)) {
       return null; // Let keyword extractor handle it
+    }
+
+    // Known content word that merely begins with a proclitic letter — keep whole.
+    if (NON_PROCLITIC_WORDS.has(fullWord)) {
+      return null; // Let the identifier extractor handle it
     }
 
     // Try multi-character proclitics first (longest match)

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -7082,3 +7082,42 @@ describe('exit/end keyword collision does not collapse the handler body (ja/de)'
     });
   }
 });
+
+describe('Arabic VSO from-first wait clause parses (behavior-sortable)', () => {
+  // VSO fronts a `wait for <events> from <source>` clause's source ahead of the
+  // events: `wait for pointermove or pointerup from document` → `انتظر من وثيقة
+  // pointermove أو pointerup` (`wait from document …`). Two breaks: (1) the ar
+  // tokenizer split وثيقة (document) into the proclitic و (`and`) + ثيقة, and the
+  // spurious `and` conjunction became a clause boundary that dropped the command;
+  // (2) the generated `wait {duration}` pattern can't anchor when the token after
+  // the verb is the source particle من. Fix: keep وثيقة whole (proclitic extractor
+  // NON_PROCLITIC_WORDS) + a hand-crafted `wait-ar-from-first` pattern.
+  function bodyActions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches', 'eventHandlers']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => bodyActions(x, acc));
+      else if (c && typeof c === 'object') bodyActions(c, acc);
+    }
+    return acc;
+  }
+
+  it('document (وثيقة) tokenizes as one identifier, not و + ثيقة', () => {
+    const r = getTokenizer('ar').tokenize('من وثيقة') as unknown;
+    const arr = Array.isArray(r) ? r : ((r as { tokens?: unknown[] }).tokens ?? []);
+    const values = (arr as Array<{ value: string }>).map(t => t.value);
+    expect(values).toEqual(['من', 'وثيقة']);
+  });
+
+  it('recovers the fronted-source wait inside a repeat-until-event loop', () => {
+    const input =
+      'من أنا عند pointerdown\n    كرر حتى حدث pointerup من وثيقة\n        انتظر من وثيقة pointermove(clientY) أو pointerup(clientY)\n        تشغيل move إلى أنا\n    النهاية\nالنهاية';
+    const a = bodyActions(parse(input, 'ar'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+    expect(a.has('wait')).toBe(true);
+    expect(a.has('trigger')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,25 +1,20 @@
 {
-  "timestamp": "2026-06-21T02:09:29.234Z",
-  "commit": "4e13b1bc",
+  "timestamp": "2026-06-21T02:10:59.990Z",
+  "commit": "636cf1a7",
   "languages": {
     "ar": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8368310482087561,
-      "avgFidelity": 0.9940295815295814,
-      "avgPrecision": 0.9767006802721089,
-      "avgRoleFidelity": 0.8726586476586478,
+      "avgFidelity": 0.9954004329004328,
+      "avgPrecision": 0.9767316017316019,
+      "avgRoleFidelity": 0.8735917235917239,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": [
-        "behavior-draggable",
-        "behavior-resizable",
-        "behavior-sortable",
-        "repeat-until-event"
-      ],
-      "bundleSize": 441793,
+      "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -651,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1283,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1908,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2540,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3172,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3813,7 +3808,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4445,7 +4440,7 @@
       "executionFailures": [],
       "degeneratePasses": ["live-derived-value", "live-multiple-deps"],
       "lossyPasses": ["fetch-do-not-throw", "keydown-key-is-syntax", "unless-condition"],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5077,7 +5072,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5709,7 +5704,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6341,7 +6336,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "form-disable-on-submit", "unless-condition"],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6979,7 +6974,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7611,7 +7606,7 @@
       "executionFailures": [],
       "degeneratePasses": ["socket-basic"],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8243,7 +8238,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8875,7 +8870,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9513,7 +9508,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10145,7 +10140,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10777,7 +10772,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11414,7 +11409,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12046,7 +12041,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-resizable"],
       "lossyPasses": [],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12678,7 +12673,7 @@
       "executionFailures": [],
       "degeneratePasses": ["default-value"],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13309,7 +13304,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13947,7 +13942,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14587,7 +14582,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 441793,
+      "bundleSize": 441851,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15210,7 +15205,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 441793,
+      "size": 441851,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
> Follow-up to #470 (now merged). This is the ar half of the SOV/structural `behavior-sortable` residuals; rebased onto `main` after #470 merged. (Supersedes #471, which GitHub auto-closed when #470's branch was deleted.)

## Summary

VSO fronts a `wait for <events> from <source>` clause's source ahead of the events:
`wait for pointermove or pointerup from document` → `انتظر من وثيقة pointermove أو pointerup` ("wait from document …"). Two breaks left `behavior-sortable` **lossy in ar** (dropped `wait`):

1. **Tokenizer split** — the ar tokenizer split `وثيقة` (document) into the proclitic `و` (`and`) + `ثيقة`; the spurious `and` conjunction became a clause boundary that dropped the command. Fixed by keeping `وثيقة` whole (proclitic-extractor `NON_PROCLITIC_WORDS`), so it lexes as one identifier like en `document`.
2. **No matching pattern** — the generated `wait {duration}` pattern can't anchor when the token after the verb is the source particle `من`. Added a hand-crafted `wait-ar-from-first` pattern (mirrors the existing zh/he `wait` patterns).

> The handoff guessed an i18n-transformer mask-split / doubled clause; the real cause is the **ar tokenizer's proclitic split of `وثيقة`** (the dict/transform output is clean), plus the missing from-first pattern. Both fixes are semantic-side.

ar `behavior-sortable` lossy→faithful — **all three sortable residuals now faithful** (ja, de via #470; ar here).

## Verification

- Priority gate (`--regression`, `browser-priority`): **No regression**; lossy **54→53**, degenerate 9.
- Full semantic unit suite green; typecheck clean.
- Regression guard added to `multilingual-roadmap-fixes.test.ts` ("Arabic VSO from-first wait clause parses") — verified to **fail without the fix**.

Resolves residual **#2 (ar)** of `docs-internal/HANDOFF-sov-sortable-residuals.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)