### PR TITLE
fix(multilingual): clear the reactivity bareKeyword degenerate cluster (hi live + ms socket)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -425,6 +425,40 @@ at 200ms` event modifier is left untranslated and fronted by the SOV reorder. Bo
 xlate) · (3) semantic block-parser (bareKeyword blocks). Start with (1) — most leverage, cleanest
 scope.
 
+> **Increment DONE (2026-06-21 — reactivity degenerate cluster, hi live + ms socket).**
+> The "teach `block-parser.ts` the bareKeyword block shape" diagnosis above was
+> **wrong** (methodology lesson #2 — verify the layer empirically). es/ja/zh already
+> parse `live … end` / `socket … end` as a single `command` (the bareKeyword pattern
+> matches at the command stage; `collectActions` doesn't descend into the body, so the
+> dropped body costs no fidelity). The two degenerate causes were per-language and in
+> two **different** layers:
+>
+> - **hi `live-derived-value` + `live-multiple-deps` (semantic parser).** The hi
+>   bare-event pattern `event-hi-bare` (`{event}`, priority 80) runs at Stage 1 —
+>   before the command stage — and its single event role anchored the fronted `लाइव`
+>   (live) keyword, so the block parsed as a bare `on` + `put`, dropping `live`. Fix:
+>   the event-anchor guard (`pattern-matcher.tokenLooksLikeEvent`) now rejects a token
+>   whose normalized form is a bareKeyword block action (`live`/`socket`/`eventsource`/
+>   `worker`/`intercept`, derived from the schemas), so it falls through to the command
+>   stage where the `live` pattern wins. Same guard family as the existing selector/URL
+>   rejection.
+> - **ms `socket-basic` (i18n dict).** The ms dictionary was missing the `socket`
+>   command entry, so the transformer emitted English `socket`; the semantic ms profile
+>   expects native `soket`, so the token tokenized as a bare identifier and `put`
+>   (`letak`) won as the head. Fix: add `socket: 'soket'` to the ms dictionary (mirrors
+>   ja `socket: ソケット`). (The full `generate-i18n-dictionaries` regen would also pull
+>   in 7 unrelated stale ms derived entries incl. a `replace`/`replaceUrl` collision —
+>   deferred as a separate ms-dict resync.)
+>
+> Net (priority gate): degenerate **9 → 6**, hi avgFidelity 0.980 → 0.993 + avgPrecision
+> 0.837 → 0.850, ms avgFidelity/avgPrecision +0.007, zero regressions; 6134 semantic +
+> 855 i18n tests pass. Guards: `multilingual-roadmap-fixes.test.ts` "bareKeyword block
+> keyword is not mis-anchored as a bare event (hi live)" + `grammar.test.ts` "Malay
+> socket command translates to native soket" (both verified failing without the fix).
+> The remaining reactivity item is `intercept`/`eventsource`/`worker` block coverage if a
+> future corpus exercises them in a SOV/bare-event language — the same guard now protects
+> them, but they're untested in the priority corpus.
+
 ### Track 3 — R1 role-fidelity burn-down (the untouched dimension)
 
 **Why:** avgRoleFidelity **0.833** is the laggard, and it has _never had a dedicated

--- a/packages/i18n/src/dictionaries/ms.ts
+++ b/packages/i18n/src/dictionaries/ms.ts
@@ -67,6 +67,7 @@ export const malayDictionary: Dictionary = {
     close: 'tutup',
     open: 'buka',
     select: 'pilih',
+    socket: 'soket', // derived from the ms profile (socket.primary); see generate-i18n-dictionaries
   },
 
   modifiers: {

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -1406,6 +1406,25 @@ describe('Possessive Dot Notation Translation', () => {
     });
   });
 
+  // ──── Malay `socket` keyword is translated to native `soket` ────
+  // The ms dictionary was missing the `socket` command entry, so the
+  // transformer emitted the English literal `socket`. The semantic ms
+  // profile maps `socket` to its native primary `soket` (not the English
+  // form), so the untranslated `socket` token tokenized as a bare
+  // identifier and the `socket` block command was dropped — `socket-basic`
+  // parsed as a degenerate `put`. (es only worked by coincidence: its
+  // profile's socket.primary IS the English literal.) Fix: add
+  // `socket: 'soket'` to the ms dictionary, mirroring ja `socket: ソケット`.
+  describe('Malay socket command translates to native soket', () => {
+    it('(ms) emits soket, not the English literal socket', () => {
+      const result = new GrammarTransformer('en', 'ms').transform(
+        'socket ChatSocket ws://localhost:8080 on message put it into #chat end'
+      );
+      expect(result, `expected native soket in: ${result}`).toMatch(/\bsoket\b/);
+      expect(result, `English socket leaked in: ${result}`).not.toMatch(/\bsocket\b/);
+    });
+  });
+
   // ──── Block extraction for `when`, `unless`, and SOV `live` ────
   // Block-syntactic tokens are pulled out before parseStatement so
   // they don't end up as command verbs (`live` → action role) or get

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -31,6 +31,20 @@ import { isAtEndConnective } from '../patterns/put';
 import type { ConfidenceModel } from './confidence-model';
 import { defaultConfidenceModel } from './confidence-model';
 
+/**
+ * Body-bearing command keywords that front their own block (`bareKeyword` schemas:
+ * `live`/`eventsource`/`socket`/`worker`/`intercept`). The keyword leads the
+ * construct (`live put … end`, `socket Name url on message … end`) and is NEVER an
+ * event name, so it must not anchor a bare-event pattern at Stage 1 — see
+ * tokenLooksLikeEvent. Derived from the schemas so a new bareKeyword block is
+ * covered automatically.
+ */
+const BAREKEYWORD_BLOCK_ACTIONS: ReadonlySet<string> = new Set(
+  Object.values(commandSchemas)
+    .filter(s => s.bareKeyword === true)
+    .map(s => s.action)
+);
+
 // =============================================================================
 // Pattern Matcher
 // =============================================================================
@@ -1220,6 +1234,14 @@ export class PatternMatcher {
     // outranked by the per-command patient-first pattern (priority 145 > 80).
     if (/[/#@*]/.test(v)) return false;
     if (v.startsWith('"') || v.startsWith("'") || v.startsWith('`')) return false;
+    // A body-bearing block keyword fronting the input (`live`/`socket`/… → SOV
+    // `लाइव …`) is a command, not an event: the bare-event pattern (priority 80,
+    // Stage 1) would otherwise anchor it as the handler event before the command
+    // stage's bareKeyword pattern (Stage 2) runs, dropping the block action (hi
+    // live-derived-value/live-multiple-deps parsed as a bare `on` + `put`).
+    // Rejecting it lets the `live`/`socket` command pattern win at Stage 2.
+    const norm = token.normalized?.toLowerCase();
+    if (norm && BAREKEYWORD_BLOCK_ACTIONS.has(norm)) return false;
     return true;
   }
 

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -7121,3 +7121,35 @@ describe('Arabic VSO from-first wait clause parses (behavior-sortable)', () => {
     expect(a.has('trigger')).toBe(true);
   });
 });
+
+describe('bareKeyword block keyword is not mis-anchored as a bare event (hi live)', () => {
+  // `live`/`socket`/`eventsource`/`worker`/`intercept` are body-bearing block
+  // keywords that FRONT their construct (`live put … end`). In hi the bare-event
+  // pattern (`event-hi-bare`, priority 80) runs at Stage 1 — before the command
+  // stage — and its single `{event}` role matched the fronted `लाइव` (live)
+  // keyword, so the block parsed as a bare `on` + `put` and the `live` action was
+  // dropped (degenerate: hi live-derived-value / live-multiple-deps). es/ja/zh had
+  // no such greedy bare-event pattern, so they reached the command stage and kept
+  // `live`. Fix: the event-anchor guard (pattern-matcher.tokenLooksLikeEvent) now
+  // rejects a token whose normalized form is a bareKeyword block action, so the
+  // input falls through to the command stage where the `live` pattern wins.
+  // Corpus-shaped (the i18n transformer output stored in patterns.db).
+  const cases: Array<[string, string]> = [
+    ['hi', 'लाइव `Count: ${$count}` को रखें मैं में समाप्त'],
+    ['hi', 'लाइव `${$price * $quantity}` को रखें #total में समाप्त'],
+  ];
+  for (const [lang, input] of cases) {
+    it(`[${lang}] keeps the live block action (not a bare event-handler)`, () => {
+      const node = parse(input, lang) as { kind?: string; action?: string };
+      expect(node.kind).toBe('command');
+      expect(node.action).toBe('live');
+    });
+  }
+
+  // Guard the un-regression: a genuine bare event (an event NAME, not a block
+  // keyword) must still anchor the bare-event pattern.
+  it('[hi] a genuine bare event name still parses as an event-handler', () => {
+    const node = parse('क्लिक पर टॉगल .active', 'hi') as { kind?: string };
+    expect(node.kind).toBe('event-handler');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-21T03:18:56.534Z",
-  "commit": "3a2eafab",
+  "timestamp": "2026-06-21T03:29:07.996Z",
+  "commit": "56de00fa",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -7598,13 +7598,13 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8363327149041414,
-      "avgFidelity": 0.987012987012987,
-      "avgPrecision": 0.9717532467532468,
+      "avgConfidence": 0.8395794681508945,
+      "avgFidelity": 0.9935064935064936,
+      "avgPrecision": 0.9782467532467533,
       "avgRoleFidelity": 0.8692660380160381,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["socket-basic"],
+      "degeneratePasses": [],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
       "bundleSize": 441987,
       "patterns": {
@@ -7813,6 +7813,10 @@
           "confidence": 1
         },
         "eventsource-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "socket-basic": {
           "success": true,
           "confidence": 1
         },
@@ -8219,10 +8223,6 @@
         "pick-text-range": {
           "success": true,
           "confidence": 0.5555555555555556
-        },
-        "socket-basic": {
-          "success": true,
-          "confidence": 0.5
         }
       }
     },

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-21T02:10:59.990Z",
-  "commit": "636cf1a7",
+  "timestamp": "2026-06-21T03:18:56.534Z",
+  "commit": "3a2eafab",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3808,7 +3808,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4433,14 +4433,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.90909904631709,
-      "avgFidelity": 0.9799783549783551,
-      "avgPrecision": 0.8366587544108552,
+      "avgFidelity": 0.992965367965368,
+      "avgPrecision": 0.8496457673978681,
       "avgRoleFidelity": 0.7169609857109858,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["live-derived-value", "live-multiple-deps"],
+      "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "keydown-key-is-syntax", "unless-condition"],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5072,7 +5072,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5704,7 +5704,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6336,7 +6336,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "form-disable-on-submit", "unless-condition"],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6974,7 +6974,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7606,7 +7606,7 @@
       "executionFailures": [],
       "degeneratePasses": ["socket-basic"],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8238,7 +8238,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8870,7 +8870,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9508,7 +9508,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10140,7 +10140,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10772,7 +10772,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11409,7 +11409,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12041,7 +12041,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-resizable"],
       "lossyPasses": [],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12673,7 +12673,7 @@
       "executionFailures": [],
       "degeneratePasses": ["default-value"],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13304,7 +13304,7 @@
       "executionFailures": [],
       "degeneratePasses": ["install-behavior"],
       "lossyPasses": [],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13942,7 +13942,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14582,7 +14582,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 441851,
+      "bundleSize": 441987,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15205,7 +15205,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 441851,
+      "size": 441987,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Clears the **reactivity `bareKeyword`-block degenerate cluster** (arc #1 of `docs-internal/HANDOFF-multilingual-priorities.md`): `live-derived-value` (hi), `live-multiple-deps` (hi), `socket-basic` (ms). Priority gate **degenerate 9 → 6**, zero regressions.

### Diagnosis correction

The handoff framed this as *"teach `block-parser.ts` the bareKeyword block shape."* The gate-faithful `ml.parse`-on-DB-translation repro showed that's **wrong** — es/ja/zh already parse `live … end` / `socket … end` as a single `command` (the bareKeyword pattern matches at the command stage; `collectActions` doesn't descend into the body, so a dropped body costs no fidelity). The two degenerate causes were per-language and in **two different layers**.

### Fixes (one defect per commit)

- **`fix(semantic)` — hi `live-derived-value` + `live-multiple-deps`.** The hi bare-event pattern `event-hi-bare` (`{event}`, priority 80) runs at Stage 1 *before* the command stage and anchored the fronted `लाइव` (live) keyword, so the block parsed as a bare `on` + `put`, dropping `live`. The event-anchor guard (`pattern-matcher.tokenLooksLikeEvent`) now rejects a token whose normalized form is a `bareKeyword` block action (`live`/`socket`/`eventsource`/`worker`/`intercept`, derived from the schemas), so it falls through to the command stage where the `live` pattern wins. Same guard family as the existing selector/URL rejection.
- **`fix(i18n)` — ms `socket-basic`.** The ms dictionary was missing the `socket` command entry, so the transformer emitted English `socket` while the semantic ms profile expects native `soket` → tokenized as a bare identifier, `put` (`letak`) won as the head. Added `socket: 'soket'` to the ms dictionary (mirrors ja `socket: ソケット`).

### Verification

- Both regression guards verified **failing without the fix**: `multilingual-roadmap-fixes.test.ts` "bareKeyword block keyword is not mis-anchored as a bare event (hi live)" + `grammar.test.ts` "Malay socket command translates to native soket".
- **6134 semantic + 855 i18n** tests pass.
- `--regression` gate (browser-priority) prints **"No regression"**; baseline regenerated against a freshly `populate`d DB.
- JSON-level baseline diff confirms only **hi** (avgFidelity 0.980 → 0.993, avgPrecision 0.837 → 0.850) and **ms** (avgFidelity/avgPrecision +0.007) moved — no collateral.
- `patterns.db` not committed (CI re-populates); throwaway repro scripts removed.

### Follow-ups (not in this PR)

- The ms i18n dict is stale — a full `generate-i18n-dictionaries` regen would add 7 more derived entries but also introduces a `replace`/`replaceUrl → ganti_url` collision; deferred as its own ms-dict resync.
- `intercept`/`eventsource`/`worker` are now protected by the guard but untested in the priority corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)