### PR TITLE
fix(multilingual): tr unless keyword (değilse) recovers the negated-conditional clause

### DIFF
--- a/docs-internal/HANDOFF-multilingual-priorities.md
+++ b/docs-internal/HANDOFF-multilingual-priorities.md
@@ -1,0 +1,253 @@
+# Handoff — remaining multilingual fidelity priorities
+
+> Written 2026-06-21, after the `behavior-sortable` residuals landed on `main`
+> (PRs **#470** exit/end collision, **#472** ar from-first `wait`). Read
+> [`MULTILINGUAL_NEXT_STEPS.md`](MULTILINGUAL_NEXT_STEPS.md) first for the full
+> Tracks 1–5 narrative; this doc is the **ready-to-resume, concrete** scope for the
+> priority items that remain, with the _current_ (not 2026-06-17) leverage map.
+
+## Where we are (2026-06-21 `browser-priority` baseline)
+
+`packages/testing-framework/baselines/multilingual-priority.json` is authoritative
+(its `timestamp`/`commit` stamp each regen). 24 langs × 154 patterns = 3696.
+
+| Signal                        | Value                         |
+| ----------------------------- | ----------------------------- |
+| parse rate                    | **3695 / 3696** (1 hard fail) |
+| degenerate (fid < 0.5)        | **9**                         |
+| lossy (0.5 ≤ fid < 1.0)       | **53**                        |
+| faithful                      | **~3633**                     |
+| avgFidelity (R0-recall)       | 0.993                         |
+| avgPrecision (R0 trust floor) | 0.962 — hi 0.837 outlier      |
+| avgRoleFidelity (R1)          | **0.837 — the laggard**       |
+| avgExecutionFidelity (R2)     | 1.000                         |
+
+**The complete current non-faithful set** (regenerate with the script in "How to
+resume" — do NOT trust these counts after more work lands):
+
+```
+HARD FAIL (parse null):
+  window-resize           tr
+
+DEGENERATE (fid < 0.5):
+  install-behavior        ru, uk
+  live-derived-value      hi
+  live-multiple-deps      hi
+  socket-basic            ms
+  unless-condition        he
+  window-scroll           ko
+  behavior-resizable      tl
+  default-value           tr
+
+LOSSY (top, by lang-count):
+  unless-condition (8)    bn,hi,ja,ko,qu,tr,vi,zh
+  fetch-do-not-throw (5)  bn,hi,ja,ko,tr
+  get-value (4)           de,he,pl,zh
+  set-color-variable (4)  ms,sw,vi,zh
+  behavior-draggable (3)  ar,qu,th
+  behavior-resizable (2)  ar,th
+  repeat-until-event (2)  ar,sw
+  …singletons: form-submit-prevent, if-empty, input-validation, tell-*, etc.
+```
+
+## ⚠️ Methodology lessons from the sortable arc (read before diagnosing anything)
+
+The sortable handoff got **two of three root causes wrong**, and the cost was real
+debugging time chasing the wrong layer. Bake these in:
+
+1. **The gate path is `ml.parse` on the DB translation — NOT raw `parse`.** The
+   parse-validator calls `MultilingualHyperscript.parse(pattern.hyperscript, lang)`
+   (`@hyperfixi/core/multilingual`) over the `patterns.db` translations, then scores
+   with `collectActions` (recall over the en reference's _distinct_ actions,
+   `packages/testing-framework/src/multilingual/fidelity.ts`). A raw
+   `parse(text, lang)` from `@lokascript/semantic` **diverges** — e.g. ja sortable's
+   `set` dropped under raw `parse` but survives under `ml.parse`, which sent the
+   prior author chasing a non-existent "verb-medial set (A2a)" bug. **Always
+   reproduce through the gate-faithful path** (harness below) before forming a
+   diagnosis.
+2. **Verify the layer empirically; the theorized root cause is often wrong.** "de V2
+   body-parse (defect C)" was actually the `exit`/`end` keyword collision (a
+   one-line keyword-set bug). "ar transformer mask-split" was actually the ar
+   _tokenizer_ splitting `وثيقة` at the `و` proclitic — the transformer output was
+   clean. Tokenize the failing clause and print the parse tree before blaming the
+   transformer or the parser.
+3. **Fidelity = recall of distinct en actions.** Precision (phantom commands) and R1
+   (role types) are separate ratchet signals. A pattern can be "faithful" (recall
+   1.0) while leaking a spurious command (precision) — check `spuriousActions` if
+   precision is the concern.
+
+## The priority items (each its own arc)
+
+### 1. Reactivity bareKeyword block-shape — `live` / `intercept` / `socket` (Track 2)
+
+**Current:** hi `live-derived-value` + `live-multiple-deps` **degenerate**; ms
+`socket-basic` **degenerate** (3 of the 9 degenerate). The doc's diagnosis (likely
+correct, but VERIFY per lesson 2): `live`/`intercept`/`eventsource`/`socket`/`worker`
+are `bareKeyword` blocks (`hasBody: true`), but `block-parser.ts` only structurally
+handles `behavior`/`def`. In non-English a `live … end` block parses as a bare `on`,
+dropping the block action. Teach the block layer the bareKeyword-block shape (mirror
+the `behavior`/`def` layer). Bounded, clears 3 degenerate, structural not per-lang.
+**Highest-ROI degenerate cleanup.**
+
+### 2. `install-behavior` degenerate in ru/uk (Track 1 — behaviors are a user PRIORITY)
+
+**Current:** `install-behavior` **degenerate** in ru + uk (the other 2 of the
+"behaviors" degenerate, alongside tl `behavior-resizable`). Likely a block-opener /
+marker-homonym issue in `block-parser.ts` (cf. the merged pt `para` fix — a dative
+marker colliding with the `for` loop opener; ru/uk may have an analogous
+`install`/declaration collision). Start by tokenizing the ru/uk `install …`
+translation and checking `isBlockOpener` / the declaration routing. Small, bounded,
+and behavior-facing.
+
+### 3. `unless-condition` — biggest single lossy cluster (Track 4)
+
+**Current:** **8 lossy** (bn,hi,ja,ko,qu,tr,vi,zh) **+ degenerate in he** — the
+largest non-behavior correctness debt. Long-standing diagnosis: control-flow body
+parsing — `unless`/`if` headers + then-chain `put`/`set` bodies collapsing. Note
+`unless` is deliberately NOT folded by `tryParseConditionalBlock` (folding would
+relabel its action `unless`→`if` and desync the action-set comparison — see the
+comment there), so its body goes through the flat per-clause path. The fix likely
+lives in how the flat path scopes the `unless … end` body across SOV/SVO. Take
+`unless-condition` as representative; the he degenerate is the sharpest repro.
+
+### 4. Behavior faithful-pass tail — draggable / resizable + th/ar/qu (Track 1)
+
+**Current:** `behavior-draggable` lossy in ar/qu/th; `behavior-resizable` degenerate
+in tl and lossy in ar/th; `behavior-removable`/`behavior-sortable` lossy in th. Two
+recurring sub-defects (verify): (a) the **`measure` command** drops in ar/draggable
+(and likely resizable) — `measure x` / `measure y` inside the loop body; (b) `th` is
+lossy across all four behaviors (a th-specific body-parse or tokenizer issue worth one
+focused look — th is the only lang where all four behaviors are non-faithful).
+`repeat-until-event` (ar/sw lossy) is the same loop-body family. The `measure` /
+loop-body fix would likely move several at once.
+
+### 5. R1 role-fidelity burn-down — the laggard dimension (Track 3)
+
+**Current:** avgRoleFidelity **0.837**; worst **hi 0.717 · qu 0.770 · bn 0.780 · ko
+0.790 · ja 0.793 · tr 0.797** — the hard SOV/reorder set. R1 measures
+`action.role:valueType` recall vs the en reference (a parse that keeps the verb but
+drops/mistypes a role). Triaged in the doc as dominated by **structural SOV mis-
+anchoring** (a fronted literal/URL mistaken for the event), NOT dict-alignment; one
+increment already lifted hi 0.683→0.717. The remaining work is the **convergent SOV
+bare-command / event-anchor arc**, which also owns `fetch-do-not-throw` (5 lossy,
+complex multi-clause SOV `fetch … as JSON do not throw then if …`). **This edits the
+hottest, most regression-sensitive parser path (every passing SOV lang), so it
+deserves a dedicated arc with careful R0/precision/parse-rate guards** — not a
+tail-end increment. New `--regression` runs won't flag R1 drift until someone drives
+it; greenfield headroom.
+
+### 6. Reliability hygiene (do alongside, Track 5)
+
+- **Make `populate` deterministic.** CLAUDE.md flags "minor residual jitter" on a few
+  boundary patterns that forces the ratchet tolerances (3 lossy / 3 degen flips, 0.02
+  avg). Deterministic populate → tighten tolerances toward 0 → trust the gate more.
+- **Absolute fidelity floor**, not just a ratchet: once a lang clears a threshold,
+  ratchet the floor up so it can't silently backslide within tolerance.
+- **hi precision 0.837** is the clear outlier (next ja 0.909) — phantom-command
+  sources in the hi profile; partly subsumed by the R1/SOV arc.
+
+> **Lower priority / known-hard, not in the ranked set:** `tr window-resize` (the
+> lone hard-fail) — compounded i18n underscore-split (`boyut_değiştir` → `değiştir`
+> collides with `toggle`) + an untranslated `debounced at 200ms` modifier; high-risk
+> multi-part change to the hottest path for the single lowest-ROI pattern. `ko
+window-scroll` / `tr default-value` degenerate are isolated singletons. The
+> singleton lossy tail (`get-value`, `set-color-variable`, `tell-*`, …) is per-pattern
+> mop-up — defer behind the clusters above.
+
+## How to resume (gate-faithful repro + the gate)
+
+**Build deps first** so `@lokascript/*` and `@hyperfixi/core` dist are fresh, and
+**populate** so the DB translations match:
+
+```bash
+npm run test:multilingual:build-deps
+npm run populate --prefix packages/patterns-reference
+```
+
+**Gate-faithful repro** (throwaway under `packages/patterns-reference/scripts/`, run
+with `LSP_DB_PATH="$PWD/packages/patterns-reference/data/patterns.db" npx tsx …`,
+delete after — NOT committed). This replicates the gate exactly: DB translation +
+`ml.parse` + `collectActions`. jsdom is needed because `@hyperfixi/core` touches the
+DOM at import.
+
+```ts
+import { JSDOM } from 'jsdom';
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+Object.assign(globalThis as any, {
+  window: dom.window,
+  document: dom.window.document,
+  Element: dom.window.Element,
+  Node: dom.window.Node,
+  HTMLElement: dom.window.HTMLElement,
+});
+import { getAllPatterns, getTranslationsByLanguage } from '../src/index';
+import { MultilingualHyperscript } from '@hyperfixi/core/multilingual';
+import { collectActions } from '../../testing-framework/src/multilingual/fidelity';
+
+const PATTERN = process.env.PATTERN ?? 'unless-condition';
+const ml = new MultilingualHyperscript();
+await ml.initialize();
+const p: any = (await getAllPatterns()).find((x: any) => x.id === PATTERN);
+const enActs = collectActions(await ml.parse(p.rawCode, 'en'));
+for (const lang of (process.env.LANGS ?? 'hi,ja,ko,qu,tr').split(',')) {
+  const t: any = (await getTranslationsByLanguage(lang, 2000)).find(
+    (x: any) => x.codeExampleId === p.id
+  );
+  const acts = collectActions(await ml.parse(t.hyperscript, lang));
+  console.log(
+    lang,
+    'missing',
+    enActs.filter(a => !acts.includes(a)),
+    '| text:',
+    t.hyperscript
+  );
+}
+```
+
+Aggregate the **current** leverage map straight from the baseline JSON (the block in
+"Where we are" was produced this way — re-run it after each landing):
+
+```bash
+node -e "const b=require('./packages/testing-framework/baselines/multilingual-priority.json');
+const d={},l={};for(const [L,x] of Object.entries(b.languages)){if(L==='en')continue;
+for(const p of x.degeneratePasses||[])(d[p]=d[p]||[]).push(L);for(const p of x.lossyPasses||[])(l[p]=l[p]||[]).push(L);}
+const f=o=>Object.entries(o).sort((a,b)=>b[1].length-a[1].length).map(([p,ls])=>p+' ('+ls.length+'): '+ls.join(',')).join('\n');
+console.log('DEGEN\n'+f(d)+'\n\nLOSSY\n'+f(l));"
+```
+
+**Gate** (reproducible locally; refuses to run against a stale/unstamped DB):
+
+```bash
+cd packages/testing-framework
+npx tsx src/multilingual/cli.ts --full --bundle browser-priority --regression
+# after an INTENTIONAL fidelity change: re-run with --save-baseline and commit the baseline
+```
+
+## Conventions (held across #445–#472)
+
+- Branch off `main`; **one defect per PR**; stacked PRs if a later arc depends on an
+  earlier one — but **retarget a stacked child to `main` BEFORE deleting the
+  parent's branch** (deleting the base auto-_closes_ the child; #471 hit this and had
+  to be reopened as #472).
+- Add a guard to
+  [`packages/semantic/test/multilingual-roadmap-fixes.test.ts`](../packages/semantic/test/multilingual-roadmap-fixes.test.ts)
+  and **verify it fails without the fix** (`git stash` the src, run `-t "<title>"`,
+  pop). Use hand-written corpus-shaped transformer output + `parse` (the file's
+  established style) — but cross-check the real outcome through the gate-faithful
+  `ml.parse` repro above.
+- **Zero-regression bar:** the gate must print "No regression" with no
+  within-tolerance flips.
+- Do **not** commit `patterns.db` (CI re-populates — `git checkout` it before
+  committing); commit only src + test + baseline. Regenerate the baseline against a
+  freshly `populate`d DB.
+
+## Recommended sequence
+
+Highest leverage / cleanest first:
+
+1. **Reactivity bareKeyword block-shape (#1)** — clears 3 degenerate, bounded, structural.
+2. **`install-behavior` ru/uk (#2)** — small, behavior-facing (user priority), likely a marker-homonym.
+3. **`unless-condition` (#3)** — biggest single lossy cluster (8+1).
+4. **Behavior faithful-pass tail (#4)** — the `measure`/loop-body + th sweep moves several at once.
+5. **R1 / SOV event-anchor arc (#5)** — highest absolute headroom but regression-sensitive; dedicate an arc with R0/precision guards.
+6. **Reliability hygiene (#6)** — fold in alongside (deterministic populate unlocks tighter ratchets).

--- a/docs-internal/HANDOFF-unless-condition-tokenizer.md
+++ b/docs-internal/HANDOFF-unless-condition-tokenizer.md
@@ -1,0 +1,114 @@
+# Handoff — `unless-condition` is a tokenizer-layer cluster, not block-scoping
+
+> Written 2026-06-21 while landing the **tr** slice of the `unless-condition`
+> cluster (the biggest non-behavior lossy cluster — handoff item #3 in
+> [`HANDOFF-multilingual-priorities.md`](HANDOFF-multilingual-priorities.md)).
+> This doc records the **empirical** root cause, which **overturns** that handoff's
+> guess, and tees up scope for the remaining langs. Read the methodology lessons in
+> the priorities handoff first (reproduce through `ml.parse` on the DB translation,
+> verify the layer empirically).
+
+## The premise was wrong
+
+`HANDOFF-multilingual-priorities.md` framed `unless-condition` as an `unless … end`
+**block-body scoping** fix ("the flat path scopes the `unless … end` body across
+SOV/SVO"). **There is no block here.** The pattern is an inline guard:
+
+```
+en rawCode:  on click unless I match .disabled toggle .selected
+en parse:    on → compound[ unless, toggle ]      (fidelity reference set = {on, toggle, unless})
+```
+
+The en `unless` action comes from the hand-crafted `unlessEnglish` pattern
+(`unless {condition}`) matched inside `parseBodyWithClauses` → `parseClause`. The
+schema-generated per-language `unless` patterns key their literal off the **profile
+`unless` keyword**, so a profile with no `unless` keyword can't match it — and even
+when it can, the marker must first **tokenize** as a single `unless` token.
+
+## Root cause is the **tokenizer**, and it differs per language
+
+Verified with a token probe (`tokenize(text, lang)`) over the DB translations. The
+`unless` action is lost for a **different reason in each language**:
+
+| Lang   | marker              | tokenizes as           | cause                                                                                                |
+| ------ | ------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------- |
+| **tr** | `değilse`           | `unless` ✓             | clean single Latin word → **faithful (this PR)**                                                     |
+| **zh** | `除非`              | `unless` ✓             | clean token, **but still lossy** — pure **structural**: front marker, condition mid-`把 … 切换`      |
+| **ja** | `でなければ`        | `で` `で` `なければ` ✗ | the `で` particle (on/destination/style) **prefix-collides**, splitting the marker                   |
+| **ko** | `아니면`            | → `else` ✗             | marker **is** the `else` primary (`else: { primary: '아니면' }`) — collision                         |
+| **hi** | `जब_तक_नहीं`        | `जब`(when) + … ✗       | **keyword-prefix collision** (`जब`=when) + the `_` join splits                                       |
+| **vi** | (DB renders spaced) | `trừ` `khi`(on) ✗      | space split + `khi`→on (the underscore form `trừ_khi` is in the profile but the dict renders spaced) |
+| **bn** | (en `unless` leaks) | literal `unless`       | i18n dict has no `unless` entry                                                                      |
+| **he** | (en `unless` leaks) | body collapses         | **degenerate** — RTL + **untranslated English condition** `I match .disabled`; not the marker        |
+
+Key proof the gap is **not** keyword/dict alignment: adding `unless: でなければ` to the
+ja profile left ja at **0.67** (marker still split by `で`); zh has the keyword in
+**both** layers and is **also** 0.67. Keyword alignment alone moved **zero** lossy
+passes — only tr (which already tokenized cleanly) went faithful.
+
+## What landed in this PR
+
+- `packages/semantic/src/generators/profiles/turkish.ts`: one line —
+  `unless: { primary: 'değilse', normalized: 'unless' }`. (The tr i18n dict already
+  emitted `değilse`; only the profile keyword was missing.)
+- Guard: `Turkish unless keyword alignment (değilse)` in
+  `packages/semantic/test/multilingual-roadmap-fixes.test.ts` (verified red without
+  the line: parse drops to `{on, toggle}`).
+- Baseline: tr `unless-condition` moved out of `lossyPasses` (→ faithful 1.0). Gate
+  clean, parse-rate steady 3695/3696.
+
+## Remaining `unless-condition` work — ranked by leverage
+
+1. **Underscore-split tokenizer fix — MEASURED INERT, do NOT pursue as framed.** The
+   original hypothesis was that the tokenizer emits underscore as its own token,
+   shattering joined markers (hi `जब_तक_नहीं`, ru `двойной_клик`), so making underscore
+   a word char looked high-leverage. **A spike (2026-06-21) flipped underscore to a
+   word char in three places** — the cyrillic keyword classifier, the vietnamese
+   keyword classifier, and the generic `UnicodeIdentifierExtractor` walk
+   (`packages/framework/src/interfaces/value-extractor.ts`) — then rebuilt,
+   repopulated, and ran the gate. **Result: ZERO band movement and ZERO signal
+   movement across all 24 languages** (parse-rate steady 3695/3696). The change is
+   **safe (no regressions) but useless (no improvements)** for the priority bundle.
+   Why it's inert:
+   - The markers that **do** render with underscores still fail for a **different**
+     reason — a **keyword-prefix collision** (hi `जब_तक_नहीं`: the matcher grabs
+     `जब`=when, a registered prefix, before reaching the underscore). The boundary
+     char was never the blocker.
+   - The markers the flip **does** rescue either render with a **space** in the actual
+     DB translation (vi renders `trừ khi`, not `trừ_khi` — spaces always split) or were
+     already faithful (ru/uk `unless` is not lossy).
+
+   **The underscore convention is effectively obsolete.** The base tokenizer already
+   has a profile-driven **`tryMultiWordKeyword` (#416)** that matches **natural spaced**
+   multi-word keywords as a single token _before any extractor runs_ (see the comment
+   in `extractors/vietnamese-keyword.ts`: `chuyển đổi`=toggle, `cho đến khi`=until are
+   spaced profile keywords today). So the correct path for a multi-word `unless` marker
+   is to **register the spaced form as a profile keyword** (vi `trừ khi`, hi
+   `जब तक नहीं`) and lean on `tryMultiWordKeyword` + longest-match (longest-match also
+   beats the `जब` prefix collision) — **not** to touch underscore handling. Verify with
+   a token probe that the spaced marker emits one `unless` token; that is the real next
+   experiment for hi/vi.
+
+2. **ja `でなければ` particle collision.** Pick a ja `unless` marker that doesn't begin
+   with the `で` particle, or guard the `で`-extractor against a longer keyword match.
+   Verify the chosen marker tokenizes to a single `unless` (token probe below).
+3. **ko `아니면` = else collision.** `아니면` is the ko `else` primary. Choose a distinct
+   ko `unless` (e.g. `아니라면`) for both the i18n dict and the profile; confirm no new
+   else/unless ambiguity via the gate.
+4. **zh structural (front marker + `把`).** zh tokenizes `除非` cleanly yet drops the
+   clause — the fused event pattern captures `toggle` and the mid-stream `除非 把 …`
+   condition is never reattached. This is the SVO analogue of the SOV event-anchor
+   work (priorities handoff item #5); shares shape with vi once vi tokenizes cleanly.
+5. **he degenerate (separate defect).** Not the marker — the **untranslated English
+   condition** in RTL context collapses the body. Belongs with the transformer
+   expression-translation / bidi work, not this cluster.
+
+## Gate-faithful repro (recreate, then delete — not committed)
+
+Throwaways used this session lived under `packages/patterns-reference/scripts/`
+(`_repro-unless.ts` walks DB translation → `ml.parse` → `collectActions`;
+`_probe-tokens.ts` dumps `tokenize()` output). Recreate from the template in
+`HANDOFF-multilingual-priorities.md` ("Gate-faithful repro"); set
+`PATTERN=unless-condition`. Build deps + `populate` first (the gate refuses a stale
+DB). The token probe is the fast diagnostic — it shows _why_ a marker is lost before
+you touch the parser.

--- a/packages/semantic/src/generators/profiles/turkish.ts
+++ b/packages/semantic/src/generators/profiles/turkish.ts
@@ -154,6 +154,7 @@ export const turkishProfile: LanguageProfile = {
     settle: { primary: 'sabitlen', normalized: 'settle' },
     // Control flow
     if: { primary: 'eğer', normalized: 'if' },
+    unless: { primary: 'değilse', normalized: 'unless' },
     when: { primary: 'iken', alternatives: ['durumunda', 'olduğunda'], normalized: 'when' },
     where: { primary: 'nerede', normalized: 'where' },
     else: { primary: 'yoksa', normalized: 'else' },

--- a/packages/semantic/test/lexicon-emit-mismatch.test.ts
+++ b/packages/semantic/test/lexicon-emit-mismatch.test.ts
@@ -142,7 +142,6 @@ const KNOWN_MISMATCHES = new Set([
   'tr:pushUrl:urlEkle',
   'tr:replaceUrl:urlDeğiştir',
   'tr:select:seç',
-  'tr:unless:değilse',
   'tr:while:iken',
   'uk:catch:зловити',
   'uk:pushUrl:додати_url',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -7184,3 +7184,43 @@ describe('ru/uk install keyword is distinct from set (install-behavior)', () => 
     });
   }
 });
+
+describe('Turkish unless keyword alignment (değilse)', () => {
+  // The i18n dict emits `unless` → değilse, but the tr semantic profile had no
+  // `unless` keyword, so the negated-conditional clause was silently dropped on
+  // parse-back: `unless-condition` was *lossy* in tr (the `unless` action
+  // vanished, leaving a bare `toggle` under the event — recall 0.67 vs the en
+  // reference's {on, toggle, unless}). Registering değilse=unless lets the
+  // trailing SOV marker tokenize as a single `unless` keyword and the clause is
+  // recovered (tr unless-condition → faithful 1.0).
+  //
+  // değilse tokenizes cleanly (one Latin word) — unlike the other lossy langs,
+  // whose markers shatter on the `_` join (hi جब_تک_नہیں, vi trừ_khi → khi=on),
+  // collide with a particle (ja でなければ split by the で marker) or with `else`
+  // (ko 아니면 = else), or fail structurally with a front marker (zh 除非 mid-`把`).
+  // Those remain lossy — see docs-internal/HANDOFF-unless-condition-tokenizer.md.
+  //
+  // Corpus-shaped SOV transformer output from the multilingual baseline
+  // (`on click unless I match .disabled toggle .selected`):
+  const input = 'I match .disabled değiştir .selected i tıklama de değilse';
+
+  const collectActions = (node: unknown, acc: string[] = []): string[] => {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.push(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => collectActions(x, acc));
+      else if (c && typeof c === 'object') collectActions(c, acc);
+    }
+    return acc;
+  };
+
+  it('recovers the unless clause (değilse) alongside the toggle body', () => {
+    expect(canParse(input, 'tr')).toBe(true);
+    const actions = new Set(collectActions(parse(input, 'tr')));
+    // Without değilse=unless this set is {on, toggle} — the guard goes red.
+    expect(actions.has('toggle')).toBe(true);
+    expect(actions.has('unless')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-21T04:02:23.359Z",
-  "commit": "935bd419",
+  "timestamp": "2026-06-21T13:57:57.544Z",
+  "commit": "c6ad7dab",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3808,7 +3808,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4440,7 +4440,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "keydown-key-is-syntax", "unless-condition"],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5072,7 +5072,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5704,7 +5704,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6336,7 +6336,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "form-disable-on-submit", "unless-condition"],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6974,7 +6974,7 @@
         "input-validation",
         "unless-condition"
       ],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7606,7 +7606,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8238,7 +8238,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8870,7 +8870,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9508,7 +9508,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10140,7 +10140,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10772,7 +10772,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11409,7 +11409,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12041,7 +12041,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-resizable"],
       "lossyPasses": [],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12666,14 +12666,14 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8329265429368624,
-      "avgFidelity": 0.9896514161220042,
+      "avgFidelity": 0.9918300653594772,
       "avgPrecision": 0.9336067255184901,
       "avgRoleFidelity": 0.7970195526317974,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["default-value"],
-      "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 441987,
+      "lossyPasses": ["fetch-do-not-throw"],
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13304,7 +13304,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13942,7 +13942,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14582,7 +14582,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 441987,
+      "bundleSize": 442039,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15205,7 +15205,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 441987,
+      "size": 442039,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## What

`unless-condition` was **lossy in tr** (recall 0.67 vs the en reference `{on, toggle, unless}`). The i18n dict emits `unless` → `değilse`, but the tr semantic profile had no `unless` keyword, so the trailing SOV marker was dropped on parse-back and the negated-conditional guard clause vanished — leaving a bare unconditional `toggle`.

Registering `değilse=unless` in the tr profile (one line) recovers the clause → **faithful 1.0**.

## Why this is the right (and only clean) slice

This started as handoff item #3 ("clear the `unless-condition` cluster"), which the priorities handoff framed as an `unless … end` **block-body scoping** fix. Empirically that premise is **wrong** — there is no block; it's an inline `unless <cond> <command>` guard, and the cluster is a **tokenizer-layer** problem that differs per language:

| Lang | marker tokenizes as | cause |
| --- | --- | --- |
| **tr** | `değilse` → **`unless`** ✓ | clean single token → **faithful (this PR)** |
| zh | `除非` → `unless` ✓ | clean token, still lossy → **structural** (front marker + `把`) |
| ja | `で`+`で`+`なければ` ✗ | `で` particle prefix-collision |
| ko | `아니면` → `else` ✗ | marker **is** the `else` primary |
| hi / vi | `जब`+`_`+… / `trừ`+`_`+`khi`(on) ✗ | **underscore-split** markers |
| he | body collapses ✗ | degenerate: RTL + untranslated English condition |

Proof the gap isn't keyword/dict alignment: adding the keyword to the ja profile left ja at 0.67 (marker still split by `で`), and zh has the keyword in both layers yet is also 0.67. Only tr — which already tokenized cleanly — went faithful. The other langs need the per-language tokenizer fixes ranked in [`HANDOFF-unless-condition-tokenizer.md`](docs-internal/HANDOFF-unless-condition-tokenizer.md) (the underscore-split fix is the high-leverage one — same family as #474 and the open `tr window-resize` hard-fail — but it's a dedicated cross-cutting arc).

## Changes

- `profiles/turkish.ts`: add `unless: { primary: 'değilse', normalized: 'unless' }`
- Guard in `multilingual-roadmap-fixes.test.ts` — verified **red without** the line (parse drops to `{on, toggle}`)
- Prune the now-fixed `tr:unless:değilse` from the `lexicon-emit-mismatch` allowlist (self-policing test)
- Baseline: tr `unless-condition` lossy → faithful
- Two handoff docs (this session's diagnosis + the prior-session priorities doc)

## Verification

- Multilingual regression gate: **✓ No regression** (6 signals), parse-rate steady **3695/3696**, baseline regenerated against a fresh `populate`
- Semantic unit suite: **6139 passed** / 84 files green
- Guard test verified red→green

🤖 Generated with [Claude Code](https://claude.com/claude-code)