### PR TITLE
fix(multilingual): recover trailing SOV `unless` guard (ko/bn unless-condition faithful)

### DIFF
--- a/docs-internal/HANDOFF-unless-condition-tokenizer.md
+++ b/docs-internal/HANDOFF-unless-condition-tokenizer.md
@@ -57,7 +57,57 @@ passes — only tr (which already tokenized cleanly) went faithful.
 - Baseline: tr `unless-condition` moved out of `lossyPasses` (→ faithful 1.0). Gate
   clean, parse-rate steady 3695/3696.
 
+## Follow-up landed (2026-06-21) — ko + bn via a **structural** trailing-guard
+
+> This overturns _this doc's own_ "Remaining work #3 (ko)" framing the same way the
+> doc overturned the priorities handoff: **the ko collision swap was necessary but
+> NOT sufficient.** Verified empirically (raw parse-tree dumps through `ml.parse`).
+
+**What the ko swap alone did and didn't do.** Renaming ko `unless` `아니면`→`아니라면`
+(i18n dict + semantic profile, distinct from else `아니면`) made the marker tokenize
+cleanly as a single `unless` token (probe-confirmed) and fixed the toggle patient —
+**but ko still dropped the `unless` action.** Root cause is **not** the tokenizer:
+the `unless` schema's `condition` role is **required**, and under the verb-final
+reorder the marker renders **clause-FINAL** (`… 토글 .selected 를 아니라면`) with its
+condition **fronted** ahead of the guarded command. `tryParseConditionalBlock` only
+folds a **leading** marker, so the trailing marker never anchored and the fronted
+condition was orphaned.
+
+**tr was faithful-by-luck.** Its "faithful" parse was structurally wrong —
+`toggle.patient = .disabled` (the _condition's_ selector) and `unless` carrying a
+bogus `event:.selected` role — but it happened to emit the action _names_
+`{on,toggle,unless}`, so recall-fidelity read 1.0. (Reminder: parse-rate/recall ≠
+correctness.)
+
+**The fix (structural, general).** `parseClause`
+(`packages/semantic/src/parser/semantic-parser.ts`) now detects a **clause-final
+`unless` marker**, strips it, parses the body without it (ko's toggle stays correct),
+captures the **fronted condition** from the clause head, and re-emits
+`[unless(condition), …body]` — en-parity. `unless`-only (an `if` would relabel to a
+conditional node and desync the action set); fires only when a real body command
+parsed **and** a condition was captured (precision-safe — can't inject a phantom
+`unless`). Behavior is byte-identical when no trailing marker is present (SVO/en
+never hit it — their last token isn't the marker).
+
+- ko parse is now the **most correct of the three**: `unless(condition:"I match
+.disabled") + toggle(.selected)`. tr's `unless` also gained a real `condition` role
+  (was the bogus `event`) — a small R1 gain.
+- **Bonus: bn** also moved faithful — its English-literal `unless` leaks at the tail,
+  which the same trailing-guard catches (no bn dict change needed).
+- Guard: the "Trailing SOV unless guard recovery (unless-condition, ko/bn)" describe
+  in `multilingual-roadmap-fixes.test.ts` (red without the parser change — all 3
+  cases, incl. a Map-aware structural assertion). Pruned the now-stale
+  `ko:unless:아니면` entry from `lexicon-emit-mismatch.test.ts`.
+- Baseline: lossy band **52 → 50** (ko + bn out of `lossyPasses`). Gate clean, zero
+  regressions, parse-rate steady, degenerate unchanged (he remains).
+
 ## Remaining `unless-condition` work — ranked by leverage
+
+> **Updated 2026-06-21 (post ko/bn):** the **trailing-`unless` guard now exists** in
+> `parseClause`. So for any lang whose marker renders/tokenizes as a **single
+> clause-final `unless` token**, the guard recovers it automatically — these langs
+> now need **only** clean tokenization, not parser work. zh (front marker) and he
+> (degenerate) are unaffected by the guard (it handles **trailing** markers only).
 
 1. **Underscore-split tokenizer fix — MEASURED INERT, do NOT pursue as framed.** The
    original hypothesis was that the tokenizer emits underscore as its own token,
@@ -87,14 +137,21 @@ passes — only tr (which already tokenized cleanly) went faithful.
    `जब तक नहीं`) and lean on `tryMultiWordKeyword` + longest-match (longest-match also
    beats the `जब` prefix collision) — **not** to touch underscore handling. Verify with
    a token probe that the spaced marker emits one `unless` token; that is the real next
-   experiment for hi/vi.
+   experiment for hi/vi. **For hi (SOV/marker-final), once `जब तक नहीं` emits a single
+   trailing `unless` token, the trailing-guard (landed 2026-06-21) recovers the clause —
+   tokenization is the ONLY remaining hi work.** For vi, first confirm marker position:
+   if it renders clause-leading (vi is SVO), the schema-generated `unless {condition}`
+   pattern handles it directly once tokenized (the guard is trailing-only).
 
 2. **ja `でなければ` particle collision.** Pick a ja `unless` marker that doesn't begin
    with the `で` particle, or guard the `で`-extractor against a longer keyword match.
-   Verify the chosen marker tokenizes to a single `unless` (token probe below).
-3. **ko `아니면` = else collision.** `아니면` is the ko `else` primary. Choose a distinct
-   ko `unless` (e.g. `아니라면`) for both the i18n dict and the profile; confirm no new
-   else/unless ambiguity via the gate.
+   Verify the chosen marker tokenizes to a single `unless` token (token probe below).
+   **Once it does, the trailing-`unless` guard (2026-06-21) recovers the clause
+   automatically — ja is SOV/marker-final, so no further parser work is needed.** This
+   is now the highest-leverage remaining item (one clean tokenization away).
+3. **ko `아니면` = else collision — ✅ DONE (2026-06-21).** Resolved via the dict/profile
+   swap (`아니라면`, distinct from else `아니면`) **plus** the structural trailing-guard —
+   see "Follow-up landed" above. ko `unless-condition` is faithful; bn came along free.
 4. **zh structural (front marker + `把`).** zh tokenizes `除非` cleanly yet drops the
    clause — the fused event pattern captures `toggle` and the mid-stream `除非 把 …`
    condition is never reattached. This is the SVO analogue of the SOV event-anchor

--- a/packages/i18n/src/dictionaries/ko.ts
+++ b/packages/i18n/src/dictionaries/ko.ts
@@ -19,7 +19,7 @@ export const ko: Dictionary = {
     hide: '숨기다',
     show: '보이다',
     if: '만약',
-    unless: '아니면',
+    unless: '아니라면', // distinct from else `아니면` (line ~131) — was a homonym
     repeat: '반복',
     for: '각각', // profile's for word — 동안 is while (collision)
     while: '동안',

--- a/packages/semantic/src/generators/profiles/korean.ts
+++ b/packages/semantic/src/generators/profiles/korean.ts
@@ -118,6 +118,11 @@ export const koreanProfile: LanguageProfile = {
     when: { primary: '때', normalized: 'when' },
     where: { primary: '어디', normalized: 'where' },
     else: { primary: '아니면', normalized: 'else' },
+    // `아니라면` ("if it isn't"), deliberately distinct from else `아니면`. The
+    // i18n dict previously rendered unless as `아니면` too, so the marker
+    // tokenized as `else` (homonym collision) and the `unless` action dropped.
+    // Longest-match beats the `아니` (not) prefix, so this tokenizes clean.
+    unless: { primary: '아니라면', normalized: 'unless' },
     repeat: { primary: '반복', normalized: 'repeat' },
     for: { primary: '각각', normalized: 'for' }, // "each" — avoids collision with while 동안
     while: { primary: '동안', normalized: 'while' },

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1006,8 +1006,31 @@ export class SemanticParserImpl implements ISemanticParser {
       return [];
     }
 
-    // Create a TokenStream from the clause tokens
-    const clauseStream = new TokenStreamImpl(clauseTokens, language);
+    // SOV/postpositional trailing `unless` guard. The leading-fold path
+    // (tryParseConditionalBlock) only fires when the block marker is the clause
+    // HEAD, but a verb-final reorder renders the negated-conditional marker
+    // clause-FINAL (ko `… 토글 .selected 를 아니라면`, tr `… değiştir .selected i
+    // değilse`) with its condition fronted ahead of the guarded command. That
+    // leaves the `unless` action unparsed and the fronted condition orphaned — the
+    // dominant `unless-condition` lossy cluster. Detect the trailing marker, parse
+    // the body without it, then re-emit `unless` carrying the recovered fronted
+    // condition, mirroring en's flat `[unless(cond), toggle]` compound. Only
+    // `unless` is handled here: `if` keeps its existing leading-fold semantics, and
+    // a conditional node would relabel the action `unless`→`if` (see
+    // tryParseConditionalBlock), desyncing the cross-language action set.
+    let trailingGuard: ActionType | null = null;
+    let bodyTokens = clauseTokens;
+    const lastTok = clauseTokens[clauseTokens.length - 1];
+    if (lastTok && clauseTokens.length >= 2) {
+      const lv = (lastTok.normalized ?? lastTok.value).toLowerCase();
+      if (this.isUnlessKeyword(lv, language)) {
+        trailingGuard = 'unless' as ActionType;
+        bodyTokens = clauseTokens.slice(0, -1);
+      }
+    }
+
+    // Create a TokenStream from the (guard-stripped) clause tokens
+    const clauseStream = new TokenStreamImpl(bodyTokens, language);
     const commands: SemanticNode[] = [];
 
     // Count of commands produced by the existing paths (matchBest + the `repeat`
@@ -1024,10 +1047,18 @@ export class SemanticParserImpl implements ISemanticParser {
     // fired because a later command DID match. Collect each skipped run and recover
     // verb-medial commands from it (in order, so execution semantics are kept).
     const skipped: LanguageToken[] = [];
+    // For a trailing-`unless` guard clause, the fronted condition surfaces as the
+    // first unmatched run before any body command — claim it as the condition
+    // (rather than trying to recover a command from it).
+    let leadingCondition: LanguageToken[] | null = null;
     const flushSkipped = () => {
       if (skipped.length === 0) return;
       const run = skipped.slice();
       skipped.length = 0;
+      if (trailingGuard && commands.length === 0 && leadingCondition === null) {
+        leadingCondition = run;
+        return;
+      }
       // Recover only a *value-led* run (a verb-medial command always opens with
       // its first role value — identifier/selector/literal). A keyword-led run is
       // an event-clause leak (`스크롤 …` / `scroll …`, where the event word is also
@@ -1090,19 +1121,43 @@ export class SemanticParserImpl implements ISemanticParser {
     }
     flushSkipped();
 
+    let bodyCommands = commands;
     // No command matched via matchBest or the `repeat` special-case: prefer the
     // legacy whole-clause verb-anchoring (byte-identical to the prior behavior).
     // It handles a single verb-FINAL command (`call updateScrollPosition()`) that
     // the per-gap recovery would mis-split into fragments — so a clause that is one
     // such command is parsed correctly, and any per-gap noise is discarded.
     if (directHits === 0) {
-      const sovCommands = this.parseSOVClauseByVerbAnchoring(clauseTokens, language);
+      const sovCommands = this.parseSOVClauseByVerbAnchoring(bodyTokens, language);
       if (sovCommands.length > 0) {
-        return sovCommands;
+        bodyCommands = sovCommands;
       }
     }
 
-    return commands;
+    // Re-emit a stripped trailing `unless` guard ahead of its body, carrying the
+    // fronted condition recovered from the clause head. Conservative: fires only
+    // when a real body command parsed AND a fronted condition was captured — a bare
+    // trailing marker with no condition is left unparsed rather than fabricated, so
+    // this can't inject a phantom `unless` (precision-safe).
+    // `leadingCondition` is only assigned inside the `flushSkipped` closure, which
+    // TS's flow analysis can't see — the cast restores its declared union so the
+    // truthiness guard narrows correctly.
+    const cond = leadingCondition as LanguageToken[] | null;
+    if (trailingGuard && bodyCommands.length > 0 && cond && cond.length > 0) {
+      const guardNode = createCommandNode(
+        trailingGuard,
+        { condition: { type: 'expression', raw: this.joinTokenText(cond) } },
+        {
+          sourceLanguage: language,
+          patternId: `${trailingGuard}-${language}-trailing-guard`,
+          confidence: 0.85,
+        }
+      );
+      // Mirror en's flat `[unless(cond), toggle]` order: guard first, then body.
+      return [guardNode, ...bodyCommands];
+    }
+
+    return bodyCommands;
   }
 
   /**

--- a/packages/semantic/test/lexicon-emit-mismatch.test.ts
+++ b/packages/semantic/test/lexicon-emit-mismatch.test.ts
@@ -87,7 +87,6 @@ const KNOWN_MISMATCHES = new Set([
   'ko:pushUrl:URL푸시',
   'ko:replaceUrl:URL교체',
   'ko:select:선택',
-  'ko:unless:아니면',
   'ms:break:henti',
   'ms:catch:tangkap',
   'ms:pushUrl:tolak_url',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -7224,3 +7224,61 @@ describe('Turkish unless keyword alignment (değilse)', () => {
     expect(actions.has('unless')).toBe(true);
   });
 });
+
+describe('Trailing SOV `unless` guard recovery (unless-condition, ko/bn)', () => {
+  // tr (above) tokenizes its trailing `unless` marker cleanly but only RECALLED
+  // the action via a structurally-wrong parse (toggle.patient = the condition's
+  // .disabled, unless carrying a bogus event role). The deeper defect: the
+  // negated-conditional marker renders CLAUSE-FINAL under the verb-final reorder
+  // (ko `… 토글 .selected 를 아니라면`) — or leaks the English literal at the tail
+  // (bn) — with its condition FRONTED ahead of the guarded command. The
+  // leading-fold path (tryParseConditionalBlock) only fires on a *leading* marker,
+  // so the trailing marker was dropped and its fronted condition orphaned:
+  // `unless-condition` was lossy (recall 0.67, a bare `toggle` under the event).
+  // parseClause now detects a trailing `unless` marker, parses the body without it,
+  // and re-emits `unless` carrying the fronted condition recovered from the clause
+  // head — en-parity `[unless(cond), toggle]`, with the toggle patient kept correct
+  // (a *structural* fix, not a bare action-name recovery). ko additionally needed
+  // its profile + i18n dict `unless` keyword disambiguated from `else` (아니면 →
+  // 아니라면) so the marker tokenizes as `unless` rather than `else`.
+  // See docs-internal/HANDOFF-unless-condition-tokenizer.md.
+  const collectActions = (node: unknown, acc: string[] = []): string[] => {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.push(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => collectActions(x, acc));
+      else if (c && typeof c === 'object') collectActions(c, acc);
+    }
+    return acc;
+  };
+
+  // Corpus-shaped transformer output from the multilingual baseline for
+  // `on click unless I match .disabled toggle .selected`:
+  const cases: Array<[string, string]> = [
+    ['ko', 'I match .disabled 토글 .selected 를 클릭 할 때 아니라면'],
+    ['bn', 'I match .disabled টগল .selected কে ক্লিক এ unless'],
+  ];
+
+  for (const [lang, input] of cases) {
+    it(`[${lang}] recovers the trailing unless clause alongside the toggle body`, () => {
+      expect(canParse(input, lang)).toBe(true);
+      const actions = new Set(collectActions(parse(input, lang)));
+      // Without the trailing-guard recovery this set is {on, toggle} — guard red.
+      expect(actions.has('toggle')).toBe(true);
+      expect(actions.has('unless')).toBe(true);
+    });
+  }
+
+  it('[ko] is structural: the recovered unless keeps its fronted condition and the toggle its patient', () => {
+    // `roles` is a Map — a plain JSON.stringify would drop its contents, so use a
+    // Map-aware replacer to assert on the captured role values.
+    const ser = (o: unknown) =>
+      JSON.stringify(o, (_k, v) => (v instanceof Map ? Object.fromEntries(v) : v));
+    const json = ser(parse('I match .disabled 토글 .selected 를 클릭 할 때 아니라면', 'ko'));
+    expect(json).toContain('"action":"unless"');
+    expect(json).toContain('.disabled'); // fronted condition selector preserved
+    expect(json).toContain('.selected'); // toggle patient preserved (not the condition's)
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-21T13:57:57.544Z",
-  "commit": "c6ad7dab",
+  "timestamp": "2026-06-21T16:43:26.983Z",
+  "commit": "b0b9138b",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -639,14 +639,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8495030867211314,
-      "avgFidelity": 0.9962121212121211,
+      "avgFidelity": 0.9983766233766234,
       "avgPrecision": 0.9156081119316415,
-      "avgRoleFidelity": 0.7803431178431178,
+      "avgRoleFidelity": 0.782032307032307,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["fetch-do-not-throw", "unless-condition"],
-      "bundleSize": 442039,
+      "lossyPasses": ["fetch-do-not-throw"],
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3808,7 +3808,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4440,7 +4440,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "keydown-key-is-syntax", "unless-condition"],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5072,7 +5072,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5704,7 +5704,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6336,7 +6336,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "form-disable-on-submit", "unless-condition"],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6961,20 +6961,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8170870900194204,
-      "avgFidelity": 0.9848484848484848,
+      "avgFidelity": 0.987012987012987,
       "avgPrecision": 0.9282246162927983,
-      "avgRoleFidelity": 0.789719870969871,
+      "avgRoleFidelity": 0.7914090601590601,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["window-scroll"],
-      "lossyPasses": [
-        "fetch-do-not-throw",
-        "fetch-error-handling",
-        "if-empty",
-        "input-validation",
-        "unless-condition"
-      ],
-      "bundleSize": 442039,
+      "lossyPasses": ["fetch-do-not-throw", "fetch-error-handling", "if-empty", "input-validation"],
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7606,7 +7600,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8238,7 +8232,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8870,7 +8864,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9508,7 +9502,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10140,7 +10134,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10772,7 +10766,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11409,7 +11403,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12041,7 +12035,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-resizable"],
       "lossyPasses": [],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12668,12 +12662,12 @@
       "avgConfidence": 0.8329265429368624,
       "avgFidelity": 0.9918300653594772,
       "avgPrecision": 0.9336067255184901,
-      "avgRoleFidelity": 0.7970195526317974,
+      "avgRoleFidelity": 0.7987202329039063,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["default-value"],
       "lossyPasses": ["fetch-do-not-throw"],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13304,7 +13298,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13942,7 +13936,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14582,7 +14576,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 442039,
+      "bundleSize": 442483,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15205,7 +15199,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 442039,
+      "size": 442483,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

`unless-condition` was the largest non-behavior lossy cluster. The prior handoff framed ko/ja as **clean marker swaps** — empirically (raw parse-tree dumps through `ml.parse`) that premise was **wrong**: the swap is necessary but not sufficient.

**Real defect.** The `unless` marker renders **clause-final** under the SOV reorder (`… 토글 .selected 를 아니라면`) with its condition **fronted** ahead of the guarded command. `tryParseConditionalBlock` only folds a **leading** marker, so the trailing marker was dropped and the condition orphaned (recall 0.67 — a bare `toggle` under the event).

**Fix.** `parseClause` now detects a clause-final `unless` marker, strips it, parses the body without it, captures the fronted condition from the clause head, and re-emits `[unless(condition), …body]` — en-parity. `unless`-only (an `if` would relabel to a conditional node and desync the action set); fires only when a real body command parsed **and** a condition was captured (precision-safe — no phantom `unless`); byte-identical when no trailing marker is present (SVO/en never hit it).

ko also needed its profile + i18n dict `unless` keyword disambiguated from `else` (`아니면` → `아니라면`) so the marker tokenizes as `unless`, not `else`. ko's parse is now the **most-correct of the cluster**: `unless(condition:"I match .disabled") + toggle(.selected)`. **bn** came along free (its English `unless` literal leaks at the tail). **tr** even gained a real `condition` role (was a bogus `event` role) — a small R1 gain.

## Result

- **Lossy band 52 → 50** (ko + bn out of `lossyPasses`).
- `--regression` gate: ✓ no regression (parse-rate steady, all 6 ratchets clean).
- semantic suite 6142 ✓ · i18n 857 ✓ · typechecks 0.

## Verification

- Guard added: *Trailing SOV unless guard recovery (unless-condition, ko/bn)* in `multilingual-roadmap-fixes.test.ts` — confirmed **red without** the parser change (all cases, incl. a Map-aware structural assertion).
- Pruned the now-stale `ko:unless:아니면` entry from `lexicon-emit-mismatch.test.ts`.
- Baseline regenerated against a freshly `populate`d DB; `patterns.db` not committed (CI re-populates).

See `docs-internal/HANDOFF-unless-condition-tokenizer.md` for the full empirical write-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)