### PR TITLE
fix(multilingual): ja unless marker でなければ→ない限り (ja unless-condition faithful)

### DIFF
--- a/docs-internal/HANDOFF-unless-condition-tokenizer.md
+++ b/docs-internal/HANDOFF-unless-condition-tokenizer.md
@@ -30,16 +30,16 @@ when it can, the marker must first **tokenize** as a single `unless` token.
 Verified with a token probe (`tokenize(text, lang)`) over the DB translations. The
 `unless` action is lost for a **different reason in each language**:
 
-| Lang   | marker              | tokenizes as           | cause                                                                                                |
-| ------ | ------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| **tr** | `değilse`           | `unless` ✓             | clean single Latin word → **faithful (this PR)**                                                     |
-| **zh** | `除非`              | `unless` ✓             | clean token, **but still lossy** — pure **structural**: front marker, condition mid-`把 … 切换`      |
-| **ja** | `でなければ`        | `で` `で` `なければ` ✗ | the `で` particle (on/destination/style) **prefix-collides**, splitting the marker                   |
-| **ko** | `아니면`            | → `else` ✗             | marker **is** the `else` primary (`else: { primary: '아니면' }`) — collision                         |
-| **hi** | `जब_तक_नहीं`        | `जब`(when) + … ✗       | **keyword-prefix collision** (`जब`=when) + the `_` join splits                                       |
-| **vi** | (DB renders spaced) | `trừ` `khi`(on) ✗      | space split + `khi`→on (the underscore form `trừ_khi` is in the profile but the dict renders spaced) |
-| **bn** | (en `unless` leaks) | literal `unless`       | i18n dict has no `unless` entry                                                                      |
-| **he** | (en `unless` leaks) | body collapses         | **degenerate** — RTL + **untranslated English condition** `I match .disabled`; not the marker        |
+| Lang   | marker                        | tokenizes as      | cause                                                                                                |
+| ------ | ----------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------- |
+| **tr** | `değilse`                     | `unless` ✓        | clean single Latin word → **faithful (this PR)**                                                     |
+| **zh** | `除非`                        | `unless` ✓        | clean token, **but still lossy** — pure **structural**: front marker, condition mid-`把 … 切换`      |
+| **ja** | ~~`でなければ`~~ → `ない限り` | `unless` ✓        | was split by leading `で` particle; **fixed** by moving to `ない限り` (`な`-initial) → **faithful**  |
+| **ko** | ~~`아니면`~~ → `아니라면`     | `unless` ✓        | was the `else` primary (collision); **fixed** via `아니라면` + trailing-guard → **faithful**         |
+| **hi** | `जब_तक_नहीं`                  | `जब`(when) + … ✗  | **keyword-prefix collision** (`जब`=when) + the `_` join splits                                       |
+| **vi** | (DB renders spaced)           | `trừ` `khi`(on) ✗ | space split + `khi`→on (the underscore form `trừ_khi` is in the profile but the dict renders spaced) |
+| **bn** | (en `unless` leaks)           | literal `unless`  | i18n dict has no `unless` entry                                                                      |
+| **he** | (en `unless` leaks)           | body collapses    | **degenerate** — RTL + **untranslated English condition** `I match .disabled`; not the marker        |
 
 Key proof the gap is **not** keyword/dict alignment: adding `unless: でなければ` to the
 ja profile left ja at **0.67** (marker still split by `で`); zh has the keyword in
@@ -57,7 +57,7 @@ passes — only tr (which already tokenized cleanly) went faithful.
 - Baseline: tr `unless-condition` moved out of `lossyPasses` (→ faithful 1.0). Gate
   clean, parse-rate steady 3695/3696.
 
-## Follow-up landed (2026-06-21) — ko + bn via a **structural** trailing-guard
+## Follow-up landed (2026-06-21) — ko + bn + ja via a **structural** trailing-guard
 
 > This overturns _this doc's own_ "Remaining work #3 (ko)" framing the same way the
 > doc overturned the priorities handoff: **the ko collision swap was necessary but
@@ -94,12 +94,21 @@ never hit it — their last token isn't the marker).
   (was the bogus `event`) — a small R1 gain.
 - **Bonus: bn** also moved faithful — its English-literal `unless` leaks at the tail,
   which the same trailing-guard catches (no bn dict change needed).
-- Guard: the "Trailing SOV unless guard recovery (unless-condition, ko/bn)" describe
-  in `multilingual-roadmap-fixes.test.ts` (red without the parser change — all 3
-  cases, incl. a Map-aware structural assertion). Pruned the now-stale
-  `ko:unless:아니면` entry from `lexicon-emit-mismatch.test.ts`.
-- Baseline: lossy band **52 → 50** (ko + bn out of `lossyPasses`). Gate clean, zero
-  regressions, parse-rate steady, degenerate unchanged (he remains).
+- **ja** (second commit) moved faithful the same way once its marker was taken off the
+  `で` particle: `でなければ` → **`ない限り`** (i18n dict + semantic profile). `で` is
+  peeled by the particle extractor and shatters `でなければ` into `で`+`なければ` —
+  registering it as a keyword does NOT beat the particle extractor (a prior attempt
+  confirmed this). `ない限り` starts with `な` (not a particle), so it tokenizes as a
+  single `unless` token (the same reason else `そうでなければ` tokenizes clean), and the
+  trailing-guard recovers it. ja parse is now the most-correct form too:
+  `unless(condition:"I match .disabled") + toggle(.selected)`.
+- Guard: the "Trailing SOV unless guard recovery (unless-condition, ko/bn/ja)" describe
+  in `multilingual-roadmap-fixes.test.ts` (each case red without its enabling change —
+  parser for ko/bn, profile marker for ja; incl. a Map-aware structural assertion).
+  Pruned the now-stale `ko:unless:아니면` and `ja:unless:でなければ` entries from
+  `lexicon-emit-mismatch.test.ts`.
+- Baseline: lossy band **52 → 49** (ko + bn + ja out of `lossyPasses`). Gate clean,
+  zero regressions, parse-rate steady, degenerate unchanged (he remains).
 
 ## Remaining `unless-condition` work — ranked by leverage
 
@@ -143,12 +152,13 @@ never hit it — their last token isn't the marker).
    if it renders clause-leading (vi is SVO), the schema-generated `unless {condition}`
    pattern handles it directly once tokenized (the guard is trailing-only).
 
-2. **ja `でなければ` particle collision.** Pick a ja `unless` marker that doesn't begin
-   with the `で` particle, or guard the `で`-extractor against a longer keyword match.
-   Verify the chosen marker tokenizes to a single `unless` token (token probe below).
-   **Once it does, the trailing-`unless` guard (2026-06-21) recovers the clause
-   automatically — ja is SOV/marker-final, so no further parser work is needed.** This
-   is now the highest-leverage remaining item (one clean tokenization away).
+2. **ja `でなければ` particle collision — ✅ DONE (2026-06-21).** Resolved by moving the
+   marker off the `で` particle: `でなければ` → `ない限り` (i18n dict + semantic profile).
+   `ない限り` starts with `な` (not a particle) so it tokenizes as a single `unless`
+   token, and the trailing-guard recovers the clause. ja `unless-condition` is faithful.
+   **The pattern for hi (and any SOV laggard): the only work left is finding a marker
+   that tokenizes as ONE clause-final `unless` token — avoid particle/keyword-prefix
+   collisions; the guard does the rest.**
 3. **ko `아니면` = else collision — ✅ DONE (2026-06-21).** Resolved via the dict/profile
    swap (`아니라면`, distinct from else `아니면`) **plus** the structural trailing-guard —
    see "Follow-up landed" above. ko `unless-condition` is faithful; bn came along free.

--- a/packages/i18n/src/dictionaries/ja.ts
+++ b/packages/i18n/src/dictionaries/ja.ts
@@ -19,7 +19,7 @@ export const ja: Dictionary = {
     hide: '隠す',
     show: '表示',
     if: 'もし',
-    unless: 'でなければ',
+    unless: 'ない限り', // not でなければ — leading で particle shatters the marker
     repeat: '繰り返し',
     for: 'ために',
     while: 'の間',

--- a/packages/semantic/src/generators/profiles/japanese.ts
+++ b/packages/semantic/src/generators/profiles/japanese.ts
@@ -127,6 +127,14 @@ export const japaneseProfile: LanguageProfile = {
     when: { primary: 'とき', alternatives: ['ときに'], normalized: 'when' },
     where: { primary: 'どこ', normalized: 'where' },
     else: { primary: 'そうでなければ', alternatives: ['それ以外'], normalized: 'else' },
+    // `ない限り` ("as long as not" = unless). Deliberately NOT `でなければ`: that
+    // begins with the `で` particle, which the tokenizer peels off the front
+    // (`で`+`なければ`), shattering the marker — registering it as a keyword does
+    // NOT win against the particle extractor. `ない限り` starts with `な` (not a
+    // particle), so it tokenizes as a single `unless` token (the same reason else
+    // `そうでなければ` tokenizes clean), and the trailing-`unless` guard recovers the
+    // clause. See docs-internal/HANDOFF-unless-condition-tokenizer.md.
+    unless: { primary: 'ない限り', normalized: 'unless' },
     repeat: { primary: '繰り返し', alternatives: ['繰り返す', 'リピート'], normalized: 'repeat' },
     for: { primary: 'ために', alternatives: ['各'], normalized: 'for' },
     while: { primary: 'の間', alternatives: ['間'], normalized: 'while' },

--- a/packages/semantic/test/lexicon-emit-mismatch.test.ts
+++ b/packages/semantic/test/lexicon-emit-mismatch.test.ts
@@ -81,7 +81,6 @@ const KNOWN_MISMATCHES = new Set([
   'ja:pushUrl:URLプッシュ',
   'ja:replaceUrl:URL置換',
   'ja:select:選択',
-  'ja:unless:でなければ',
   'ko:catch:잡다',
   'ko:exit:종료',
   'ko:pushUrl:URL푸시',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -7225,7 +7225,7 @@ describe('Turkish unless keyword alignment (değilse)', () => {
   });
 });
 
-describe('Trailing SOV `unless` guard recovery (unless-condition, ko/bn)', () => {
+describe('Trailing SOV `unless` guard recovery (unless-condition, ko/bn/ja)', () => {
   // tr (above) tokenizes its trailing `unless` marker cleanly but only RECALLED
   // the action via a structurally-wrong parse (toggle.patient = the condition's
   // .disabled, unless carrying a bogus event role). The deeper defect: the
@@ -7240,7 +7240,10 @@ describe('Trailing SOV `unless` guard recovery (unless-condition, ko/bn)', () =>
   // head — en-parity `[unless(cond), toggle]`, with the toggle patient kept correct
   // (a *structural* fix, not a bare action-name recovery). ko additionally needed
   // its profile + i18n dict `unless` keyword disambiguated from `else` (아니면 →
-  // 아니라면) so the marker tokenizes as `unless` rather than `else`.
+  // 아니라면) so the marker tokenizes as `unless` rather than `else`. ja needed its
+  // marker moved off the `で` particle (でなければ → ない限り): `で` is peeled by the
+  // particle extractor and shatters the marker, but `ない限り` starts with `な` (not a
+  // particle) so it tokenizes as a single `unless` token — then the guard recovers it.
   // See docs-internal/HANDOFF-unless-condition-tokenizer.md.
   const collectActions = (node: unknown, acc: string[] = []): string[] => {
     if (!node || typeof node !== 'object') return acc;
@@ -7259,6 +7262,7 @@ describe('Trailing SOV `unless` guard recovery (unless-condition, ko/bn)', () =>
   const cases: Array<[string, string]> = [
     ['ko', 'I match .disabled 토글 .selected 를 클릭 할 때 아니라면'],
     ['bn', 'I match .disabled টগল .selected কে ক্লিক এ unless'],
+    ['ja', 'I match .disabled 切り替え .selected を クリック で ない限り'],
   ];
 
   for (const [lang, input] of cases) {

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-21T16:43:26.983Z",
-  "commit": "b0b9138b",
+  "timestamp": "2026-06-21T16:56:50.940Z",
+  "commit": "4eba91ce",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw"],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3808,7 +3808,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4440,7 +4440,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "keydown-key-is-syntax", "unless-condition"],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5072,7 +5072,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5704,7 +5704,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6329,14 +6329,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8351246080569386,
-      "avgFidelity": 0.9940476190476191,
+      "avgFidelity": 0.9962121212121213,
       "avgPrecision": 0.9090536214485794,
-      "avgRoleFidelity": 0.7929852242352243,
+      "avgRoleFidelity": 0.7946744134244135,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["fetch-do-not-throw", "form-disable-on-submit", "unless-condition"],
-      "bundleSize": 442483,
+      "lossyPasses": ["fetch-do-not-throw", "form-disable-on-submit"],
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6968,7 +6968,7 @@
       "executionFailures": [],
       "degeneratePasses": ["window-scroll"],
       "lossyPasses": ["fetch-do-not-throw", "fetch-error-handling", "if-empty", "input-validation"],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7600,7 +7600,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8232,7 +8232,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8864,7 +8864,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9502,7 +9502,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10134,7 +10134,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10766,7 +10766,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11403,7 +11403,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12035,7 +12035,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-resizable"],
       "lossyPasses": [],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12667,7 +12667,7 @@
       "executionFailures": [],
       "degeneratePasses": ["default-value"],
       "lossyPasses": ["fetch-do-not-throw"],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13298,7 +13298,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13936,7 +13936,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14576,7 +14576,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 442483,
+      "bundleSize": 442547,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15199,7 +15199,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 442483,
+      "size": 442547,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

> **Stacked on #476** (base = `fix/unless-condition-ko-bn-trailing-guard`). The diff shown here is the single ja commit; it relies on the trailing-`unless` guard introduced in #476. **Retarget this PR to `main` before #476's branch is deleted** (deleting the base auto-closes the child — see the arc conventions).

With the trailing-guard in place (#476), ja was **one tokenization away**. Its i18n marker `でなければ` begins with the `で` particle, which the tokenizer peels off the front (`で`+`なければ`), shattering the marker — and registering `でなければ` as a profile keyword does **not** beat the particle extractor (a prior attempt confirmed this). So the `unless` action was dropped (recall 0.67).

**Fix.** Move the ja marker to `ない限り` ("as long as not" = unless) in both the i18n dict and the semantic profile. `ない限り` starts with `な` (not a particle), so it tokenizes as a **single `unless` token** — the same reason else `そうでなければ` tokenizes clean. The trailing-guard then recovers the clause. ja's parse is now the most-correct form: `unless(condition:"I match .disabled") + toggle(.selected)`.

## Result

- **Lossy band 50 → 49** (ja out of `lossyPasses`); avgFidelity 0.994 → 0.996, R1 0.793 → 0.795.
- `--regression` gate: ✓ no regression.
- semantic suite 6143 ✓ · i18n 857 ✓ · typechecks 0.

## Verification

- Extended the trailing-guard guard with a ja case — confirmed **red without** the profile marker change.
- Pruned the now-stale `ja:unless:でなければ` entry from `lexicon-emit-mismatch.test.ts`.
- Baseline regenerated against a freshly `populate`d DB; `patterns.db` not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)