### PR TITLE
fix(multilingual): event-anchor guard rejects bare-event mis-anchor (hi unless-condition faithful, SOV #5)

### DIFF
--- a/docs-internal/HANDOFF-unless-condition-tokenizer.md
+++ b/docs-internal/HANDOFF-unless-condition-tokenizer.md
@@ -30,16 +30,16 @@ when it can, the marker must first **tokenize** as a single `unless` token.
 Verified with a token probe (`tokenize(text, lang)`) over the DB translations. The
 `unless` action is lost for a **different reason in each language**:
 
-| Lang   | marker                        | tokenizes as      | cause                                                                                                |
-| ------ | ----------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------- |
-| **tr** | `değilse`                     | `unless` ✓        | clean single Latin word → **faithful (this PR)**                                                     |
-| **zh** | `除非`                        | `unless` ✓        | clean token, **but still lossy** — pure **structural**: front marker, condition mid-`把 … 切换`      |
-| **ja** | ~~`でなければ`~~ → `ない限り` | `unless` ✓        | was split by leading `で` particle; **fixed** by moving to `ない限り` (`な`-initial) → **faithful**  |
-| **ko** | ~~`아니면`~~ → `아니라면`     | `unless` ✓        | was the `else` primary (collision); **fixed** via `아니라면` + trailing-guard → **faithful**         |
-| **hi** | `जब_तक_नहीं`                  | `जब`(when) + … ✗  | **keyword-prefix collision** (`जब`=when) + the `_` join splits                                       |
-| **vi** | (DB renders spaced)           | `trừ` `khi`(on) ✗ | space split + `khi`→on (the underscore form `trừ_khi` is in the profile but the dict renders spaced) |
-| **bn** | (en `unless` leaks)           | literal `unless`  | i18n dict has no `unless` entry                                                                      |
-| **he** | (en `unless` leaks)           | body collapses    | **degenerate** — RTL + **untranslated English condition** `I match .disabled`; not the marker        |
+| Lang   | marker                          | tokenizes as      | cause                                                                                                                                |
+| ------ | ------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **tr** | `değilse`                       | `unless` ✓        | clean single Latin word → **faithful (this PR)**                                                                                     |
+| **zh** | `除非`                          | `unless` ✓        | clean token, **but still lossy** — pure **structural**: front marker, condition mid-`把 … 切换`                                      |
+| **ja** | ~~`でなければ`~~ → `ない限り`   | `unless` ✓        | was split by leading `で` particle; **fixed** by moving to `ない限り` (`な`-initial) → **faithful**                                  |
+| **ko** | ~~`아니면`~~ → `아니라면`       | `unless` ✓        | was the `else` primary (collision); **fixed** via `아니라면` + trailing-guard → **faithful**                                         |
+| **hi** | ~~`जब_तक_नहीं`~~ → `जब तक नहीं` | `unless` ✓        | was `जब`=when prefix + `_` split AND a bare-event mis-anchor on `I`; **fixed** via spaced marker + event-anchor guard → **faithful** |
+| **vi** | (DB renders spaced)             | `trừ` `khi`(on) ✗ | space split + `khi`→on (the underscore form `trừ_khi` is in the profile but the dict renders spaced)                                 |
+| **bn** | (en `unless` leaks)             | literal `unless`  | i18n dict has no `unless` entry                                                                                                      |
+| **he** | (en `unless` leaks)             | body collapses    | **degenerate** — RTL + **untranslated English condition** `I match .disabled`; not the marker                                        |
 
 Key proof the gap is **not** keyword/dict alignment: adding `unless: でなければ` to the
 ja profile left ja at **0.67** (marker still split by `で`); zh has the keyword in
@@ -108,7 +108,46 @@ never hit it — their last token isn't the marker).
   Pruned the now-stale `ko:unless:아니면` and `ja:unless:でなければ` entries from
   `lexicon-emit-mismatch.test.ts`.
 - Baseline: lossy band **52 → 49** (ko + bn + ja out of `lossyPasses`). Gate clean,
-  zero regressions, parse-rate steady, degenerate unchanged (he remains).
+  zero regressions, parse-rate steady, degenerate unchanged (he remains). Landed as
+  PRs **#476** (ko/bn) and **#477** (ja).
+
+## #5 event-anchor guard landed (2026-06-21) — hi via the SOV event-anchor arc
+
+> This **corrects** item #1 below, which claimed "tokenization is the ONLY remaining hi
+> work." It wasn't — hi needed the tokenization fix **plus** a structural event-anchor
+> fix. Confirmed empirically (`parseWithConfidence` diagnostics + parse-tree dumps).
+
+hi's spaced `जब तक नहीं` (item #1) tokenizes cleanly (longest-first multi-word match
+beats the `जब तक`=while prefix — the hypothesis held), **but hi still dropped `unless`.**
+Root cause is **not** tokenization: hi's SOV reorder fronts the untranslated condition
+`I match .disabled` ahead of the real `<event> पर` trigger, and the bare-event pattern
+**`event-hi-bare`** (`{event}` at position 0, the only `event-<lang>-bare` pattern)
+anchored on `I` as the event (diagnostic: `event pattern matched: event-hi-bare`),
+burying the real `क्लिक पर` (on click) mid-body. The toggle then mis-anchored on the
+fronted condition and the marker was unreachable — the priorities-handoff **#5** "fronted
+literal mistaken for the event" signature.
+
+**The fix (event-anchor guard).** In Stage 1, after a bare-event pattern matches, if the
+captured event is **not a known event** AND `trySOVEventExtraction` can recover a real
+mid-stream `<event> पर`, prefer that — it strips the true event and re-parses the body,
+where the trailing-`unless` guard fires. Additive (gated to a non-event bare capture +
+a successful SOV recovery; a genuine bare event like `क्लिक` is byte-identical), and
+low blast radius (`event-hi-bare` is the only bare-event pattern → effectively hi-only).
+
+- hi `unless-condition` → **faithful** (lossy band **49 → 48**; only hi moved, no
+  collateral).
+- **hi avgRoleFidelity 0.717 → 0.745** — the guard corrected the event role across
+  several hi patterns, not just unless-condition. hi was the **worst** R1 language; this
+  is the convergent SOV event-anchor R1 burn-down the priorities handoff (#5) predicted.
+  avgFidelity 0.993→0.995, avgPrecision 0.850→0.854; zero regressions.
+- Guard: "Bare-event mis-anchor guard (hi unless-condition — SOV event-anchor #5)" in
+  `multilingual-roadmap-fixes.test.ts` (red without the parser guard). Pruned the
+  now-stale `hi:unless:जब_तक_नहीं` lexicon entry.
+- **Residual (next #5 increment):** hi's `toggle.patient` is still mis-captured as the
+  fronted `match .disabled` (an unmarked expression) instead of the `को`-marked
+  `.selected` — `matchBest` prefers the unmarked patient-before-verb over the marked one.
+  R0 is faithful and R1 improved, but a marked-patient preference would close the
+  remaining hi role gap.
 
 ## Remaining `unless-condition` work — ranked by leverage
 
@@ -146,11 +185,13 @@ never hit it — their last token isn't the marker).
    `जब तक नहीं`) and lean on `tryMultiWordKeyword` + longest-match (longest-match also
    beats the `जब` prefix collision) — **not** to touch underscore handling. Verify with
    a token probe that the spaced marker emits one `unless` token; that is the real next
-   experiment for hi/vi. **For hi (SOV/marker-final), once `जब तक नहीं` emits a single
-   trailing `unless` token, the trailing-guard (landed 2026-06-21) recovers the clause —
-   tokenization is the ONLY remaining hi work.** For vi, first confirm marker position:
-   if it renders clause-leading (vi is SVO), the schema-generated `unless {condition}`
-   pattern handles it directly once tokenized (the guard is trailing-only).
+   experiment for hi/vi. **hi — ✅ DONE (2026-06-21):** the spaced `जब तक नहीं` tokenizes
+   cleanly, but tokenization was NOT the only remaining hi work (this line's original
+   claim was wrong) — hi also needed the event-anchor guard; see the "#5 event-anchor
+   guard landed" section above. **vi remains:** first confirm marker position — if it
+   renders clause-leading (vi is SVO), the schema-generated `unless {condition}` pattern
+   handles it directly once tokenized (the guard is trailing-only); if it renders
+   clause-final, register the spaced `trừ khi` and lean on the trailing-guard.
 
 2. **ja `でなければ` particle collision — ✅ DONE (2026-06-21).** Resolved by moving the
    marker off the `で` particle: `でなければ` → `ない限り` (i18n dict + semantic profile).

--- a/packages/i18n/src/dictionaries/hi.ts
+++ b/packages/i18n/src/dictionaries/hi.ts
@@ -19,7 +19,7 @@ export const hindiDictionary: Dictionary = {
     hide: 'छिपाएं',
     show: 'दिखाएं',
     if: 'अगर',
-    unless: 'जब_तक_नहीं',
+    unless: 'जब तक नहीं', // spaced (not जब_तक_नहीं) → one multi-word `unless` token
     repeat: 'दोहराएं',
     for: 'हेतु', // single token — के_लिए splits at _ in the hi extractor
     while: 'जब तक',

--- a/packages/semantic/src/generators/profiles/hindi.ts
+++ b/packages/semantic/src/generators/profiles/hindi.ts
@@ -142,6 +142,12 @@ export const hindiProfile: LanguageProfile = {
     // SOV for-loop).
     for: { primary: 'के लिए', alternatives: ['हेतु'], normalized: 'for' },
     while: { primary: 'जब तक', alternatives: [], normalized: 'while' },
+    // `जब तक नहीं` ("as long as not" = unless), the SPACED form so it registers as
+    // a multi-word keyword. It is a strict superset of while `जब तक`, but
+    // multiWordKeywords are matched longest-first, so the full unless phrase wins
+    // over the while prefix; tryMultiWordKeyword emits it as a single `unless`
+    // token (the underscore form `जब_तक_नहीं` shattered: `जब`=when + `_` splits).
+    unless: { primary: 'जब तक नहीं', normalized: 'unless' },
     continue: { primary: 'जारी', alternatives: [], normalized: 'continue' },
     halt: { primary: 'रोकें', alternatives: ['रोक'], normalized: 'halt' },
     throw: { primary: 'फेंकें', alternatives: ['फेंक'], normalized: 'throw' },

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -275,6 +275,43 @@ export class SemanticParserImpl implements ISemanticParser {
           'pattern-match'
         )
       );
+
+      // Event-anchor guard. A bare-event pattern (`event-<lang>-bare`: a single
+      // `{event}` token at position 0) anchors on whatever leads the stream — so a
+      // SOV reorder that fronts an untranslated condition (`I match .disabled … क्लिक
+      // पर जब तक नहीं`, hi unless-condition) makes it grab `I` as the event, burying
+      // the real `<known-event> पर` trigger mid-body where it can't be recovered (the
+      // toggle then mis-anchors on the fronted condition). When the bare capture is
+      // NOT a known event AND SOV extraction can recover a real mid-stream event,
+      // prefer that — it strips the true `<event> पर` and re-parses the body (where the
+      // trailing-`unless` guard then fires). Additive: gated to a non-event bare
+      // capture and only taken when trySOVEventExtraction actually succeeds, so a
+      // genuine bare event (`क्लिक`) or a lang without SOV markers is byte-identical.
+      if (/^event-[a-z]+-bare$/.test(eventMatch.pattern.id)) {
+        const ev = eventMatch.captured.get('event') as { raw?: string; value?: string } | undefined;
+        const evVal = (ev?.raw ?? ev?.value ?? '').toString().toLowerCase();
+        const langEvents = eventNameTranslations[language];
+        const evIsKnownEvent =
+          SemanticParserImpl.KNOWN_EVENTS.has(evVal) ||
+          (!!langEvents && Object.keys(langEvents).some(n => n.toLowerCase() === evVal));
+        if (evVal && !evIsKnownEvent) {
+          const sov = this.trySOVEventExtraction(parseInput, language, sortedPatterns);
+          if (sov) {
+            diagnostics.push(
+              parseDiagnostic(
+                `bare-event mis-anchor on "${evVal}" rejected; SOV extraction preferred`,
+                'info',
+                'stage-bare-event-guard'
+              )
+            );
+            const guarded = modifiers
+              ? this.applyModifiers(sov as EventHandlerSemanticNode, modifiers)
+              : sov;
+            return withDiagnostics(guarded, diagnostics);
+          }
+        }
+      }
+
       const handler = this.buildEventHandler(eventMatch, tokens, language);
       const result = modifiers ? this.applyModifiers(handler, modifiers) : handler;
       return withDiagnostics(result, diagnostics);

--- a/packages/semantic/test/lexicon-emit-mismatch.test.ts
+++ b/packages/semantic/test/lexicon-emit-mismatch.test.ts
@@ -66,7 +66,6 @@ const KNOWN_MISMATCHES = new Set([
   'hi:pushUrl:url_जोड़ें',
   'hi:replaceUrl:url_बदलें',
   'hi:select:चुनें',
-  'hi:unless:जब_तक_नहीं',
   'id:break:hentikan',
   'id:catch:tangkap',
   'id:close:tutup',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -7286,3 +7286,47 @@ describe('Trailing SOV `unless` guard recovery (unless-condition, ko/bn/ja)', ()
     expect(json).toContain('.selected'); // toggle patient preserved (not the condition's)
   });
 });
+
+describe('Bare-event mis-anchor guard (hi unless-condition — SOV event-anchor #5)', () => {
+  // hi's SOV reorder fronts the (untranslated) condition `I match .disabled` ahead of
+  // the real `<event> पर` trigger. The bare-event pattern `event-hi-bare` ({event} at
+  // position 0) anchored on `I`, burying the real `क्लिक पर` (on click) mid-body where
+  // it couldn't be recovered — the `unless` action dropped and the body mis-anchored
+  // (`unless-condition` was lossy in hi, and hi's avgRoleFidelity was the worst at
+  // 0.717). The event-anchor guard now rejects a bare-event capture that ISN'T a known
+  // event when SOV extraction can recover a real mid-stream event, so `क्लिक` becomes
+  // the event and the trailing-`unless` guard recovers the clause. The hi `unless`
+  // marker also had to move from the shattering underscore form `जब_तक_नहीं` to the
+  // spaced `जब तक नहीं` so it tokenizes as a single `unless` token (longest-first
+  // multi-word match beats the `जब तक`=while prefix). See
+  // docs-internal/HANDOFF-unless-condition-tokenizer.md.
+  const input = 'I match .disabled टॉगल .selected को क्लिक पर जब तक नहीं';
+  const collectActions = (node: unknown, acc: string[] = []): string[] => {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.push(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => collectActions(x, acc));
+      else if (c && typeof c === 'object') collectActions(c, acc);
+    }
+    return acc;
+  };
+
+  it('anchors on the real event (click), not the fronted condition (I)', () => {
+    const node = parse(input, 'hi') as Record<string, unknown>;
+    expect(node.action).toBe('on');
+    const ser = (o: unknown) =>
+      JSON.stringify(o, (_k, v) => (v instanceof Map ? Object.fromEntries(v) : v));
+    const evJson = ser(node.roles);
+    // Without the guard the event is the fronted `I`; with it, the real `click`.
+    expect(evJson).toContain('click');
+    expect(evJson).not.toContain('"I"');
+  });
+
+  it('recovers both toggle and unless once the event anchors correctly', () => {
+    const actions = new Set(collectActions(parse(input, 'hi')));
+    expect(actions.has('toggle')).toBe(true);
+    expect(actions.has('unless')).toBe(true); // was dropped (lossy) before the guard
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-21T16:56:50.940Z",
-  "commit": "4eba91ce",
+  "timestamp": "2026-06-21T17:50:00.366Z",
+  "commit": "e875a28d",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw"],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3808,7 +3808,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4433,14 +4433,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.90909904631709,
-      "avgFidelity": 0.992965367965368,
-      "avgPrecision": 0.8496457673978681,
-      "avgRoleFidelity": 0.7169609857109858,
+      "avgFidelity": 0.9951298701298701,
+      "avgPrecision": 0.8537583215104222,
+      "avgRoleFidelity": 0.7452267514767515,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["fetch-do-not-throw", "keydown-key-is-syntax", "unless-condition"],
-      "bundleSize": 442547,
+      "lossyPasses": ["fetch-do-not-throw", "keydown-key-is-syntax"],
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5072,7 +5072,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5704,7 +5704,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6336,7 +6336,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "form-disable-on-submit"],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6968,7 +6968,7 @@
       "executionFailures": [],
       "degeneratePasses": ["window-scroll"],
       "lossyPasses": ["fetch-do-not-throw", "fetch-error-handling", "if-empty", "input-validation"],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7600,7 +7600,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8232,7 +8232,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8864,7 +8864,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9502,7 +9502,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10134,7 +10134,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10766,7 +10766,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11403,7 +11403,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12035,7 +12035,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-resizable"],
       "lossyPasses": [],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12667,7 +12667,7 @@
       "executionFailures": [],
       "degeneratePasses": ["default-value"],
       "lossyPasses": ["fetch-do-not-throw"],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13298,7 +13298,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13936,7 +13936,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14576,7 +14576,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 442547,
+      "bundleSize": 442974,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15199,7 +15199,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 442547,
+      "size": 442974,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Starts the **SOV event-anchor arc (#5)** — the regression-sensitive R1 burn-down the priorities handoff flagged. Drives it with hi `unless-condition`, the last `unless-condition` lang amenable to a clean fix.

**Root cause (empirically traced).** hi's SOV reorder fronts the untranslated condition `I match .disabled` ahead of the real `<event> पर` trigger. The bare-event pattern `event-hi-bare` (`{event}` at position 0 — the *only* `event-<lang>-bare` pattern) anchored on `I` as the event (diagnostic: `event pattern matched: event-hi-bare`), burying the real `क्लिक पर` (on click) mid-body. The toggle then mis-anchored on the fronted condition and the `unless` marker was unreachable — the #5 "fronted literal mistaken for the event" signature. hi `unless-condition` was lossy and hi's `avgRoleFidelity` was the **worst** language at 0.717.

**Fix — Stage-1 event-anchor guard.** After a bare-event pattern matches, if the captured event is **not a known event** AND `trySOVEventExtraction` can recover a real mid-stream `<event> पर`, prefer that — it strips the true event and re-parses the body, where the trailing-`unless` guard (landed in #476) fires. Additive (gated to a non-event bare capture + a successful SOV recovery; a genuine bare event like `क्लिक` is byte-identical) and **low blast radius** — `event-hi-bare` is the only bare-event pattern, so this is effectively hi-only.

hi also needed its `unless` marker moved off the shattering underscore form `जब_तक_नहीं` to the spaced `जब तक नहीं`, which tokenizes as one `unless` token (longest-first multi-word match beats the `जब तक`=while prefix).

## Result

- hi `unless-condition` → **faithful** (lossy band **49 → 48**; only hi moved, no collateral).
- **hi avgRoleFidelity 0.717 → 0.745** — the guard corrected the event role across *several* hi patterns, not just unless-condition (the #5 R1 burn-down on the worst language). avgFidelity 0.993→0.995, avgPrecision 0.850→0.854.
- `--regression` gate: ✓ no regression (parse-rate steady, all 6 ratchets clean). semantic 6145 ✓ · i18n 857 ✓ · typechecks 0.

## Verification

- Guard added: *Bare-event mis-anchor guard (hi unless-condition — SOV event-anchor #5)* in `multilingual-roadmap-fixes.test.ts` — confirmed **red without** the parser guard (event anchors on `I`, unless dropped).
- Pruned the now-stale `hi:unless:जब_तक_नहीं` lexicon entry.
- Baseline regenerated against a freshly `populate`d DB; `patterns.db` not committed.

**Residual (next #5 increment, noted in the handoff):** hi's `toggle.patient` is still the unmarked fronted `match .disabled` instead of the `को`-marked `.selected` — `matchBest` prefers the unmarked patient-before-verb. R0 is faithful and R1 improved; a marked-patient preference would close the remaining hi role gap.

See `docs-internal/HANDOFF-unless-condition-tokenizer.md` (#5 section) for the full write-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)