### PR TITLE
fix(multilingual): verb-split reserves the fronted condition (trailing-unless body patient, SOV #5)

### DIFF
--- a/docs-internal/HANDOFF-unless-condition-tokenizer.md
+++ b/docs-internal/HANDOFF-unless-condition-tokenizer.md
@@ -143,11 +143,22 @@ low blast radius (`event-hi-bare` is the only bare-event pattern → effectively
 - Guard: "Bare-event mis-anchor guard (hi unless-condition — SOV event-anchor #5)" in
   `multilingual-roadmap-fixes.test.ts` (red without the parser guard). Pruned the
   now-stale `hi:unless:जब_तक_नहीं` lexicon entry.
-- **Residual (next #5 increment):** hi's `toggle.patient` is still mis-captured as the
-  fronted `match .disabled` (an unmarked expression) instead of the `को`-marked
-  `.selected` — `matchBest` prefers the unmarked patient-before-verb over the marked one.
-  R0 is faithful and R1 improved, but a marked-patient preference would close the
-  remaining hi role gap.
+- **Residual — ✅ FIXED (2026-06-21, verb-split).** hi's `toggle.patient` was
+  mis-captured as the fronted `match .disabled` (an unmarked expression) instead of the
+  `को`-marked `.selected` — a patient-before-verb pattern (`toggle-hi-simple` =
+  `{patient} टॉगल`) grabbing the condition's trailing selector. Fix: in the
+  trailing-`unless` guard, **reserve everything before the first command-verb keyword as
+  the condition and parse only from the verb** (`parseClause`, gated to a real command
+  verb — not an operator like `matches` — that is verb-medial). The body then sees
+  `टॉगल .selected को` and binds the real patient. Generalized across the cluster: all
+  five verb-medial langs now produce the **fully correct** parse
+  `unless(condition:"I match .disabled") + toggle(.selected)` — **tr included**, which
+  was faithful-by-luck and previously toggled the WRONG class (`.disabled`, an execution
+  bug). hi `toggle.patient` moved expression→selector (avgRoleFidelity 0.745→0.747); the
+  remaining value-level gains (tr `.disabled`→`.selected`, full conditions) are real
+  correctness the valueType-based R1 metric undercounts. Guard: "Verb-split reserves the
+  fronted condition" in `multilingual-roadmap-fixes.test.ts` (hi/tr red without it; ko a
+  regression guard). Gate clean, band steady (48), zero regressions.
 
 ## Remaining `unless-condition` work — ranked by leverage
 

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1066,6 +1066,38 @@ export class SemanticParserImpl implements ISemanticParser {
       }
     }
 
+    // Verb-split for the trailing-`unless` guard. The fronted condition (`I match
+    // .disabled`) precedes the body command's verb (ko `… 토글 .selected 를`, hi `…
+    // टॉगल .selected को`). A patient-BEFORE-verb pattern (hi `toggle-hi-simple` =
+    // `{patient} टॉगल`) otherwise grabs the condition's trailing selector
+    // (`match .disabled`) as the body patient and strands the real marked `.selected`
+    // — leaving the body faithful-by-recall but role-wrong (the hi residual). Reserve
+    // everything before the first command-verb KEYWORD as the condition and parse
+    // only from the verb, so the body command sees `टॉगल .selected को` and binds the
+    // real patient. Gated to a real command verb (not an operator like `matches`)
+    // that is verb-MEDIAL (a fronted condition before it AND tokens after it); a
+    // non-medial / verb-first body finds no split and the skip-based capture below
+    // stands (byte-identical). Already-correct verb-medial langs (ko/ja/bn) resolve
+    // to the same `[condition][verb …]` split they reached via skip-capture.
+    let presetCondition: LanguageToken[] | null = null;
+    if (trailingGuard && bodyTokens.length >= 3) {
+      const profile = tryGetProfile(language);
+      const verbLookup = profile ? SemanticParserImpl.buildVerbLookup(profile) : null;
+      if (verbLookup) {
+        for (let i = 1; i < bodyTokens.length - 1; i++) {
+          const t = bodyTokens[i];
+          const action =
+            verbLookup.get(t.value.toLowerCase()) ??
+            (t.normalized ? verbLookup.get(t.normalized.toLowerCase()) : undefined);
+          if (action && !SemanticParserImpl.CONDITION_OPERATORS.has(action)) {
+            presetCondition = bodyTokens.slice(0, i);
+            bodyTokens = bodyTokens.slice(i);
+            break;
+          }
+        }
+      }
+    }
+
     // Create a TokenStream from the (guard-stripped) clause tokens
     const clauseStream = new TokenStreamImpl(bodyTokens, language);
     const commands: SemanticNode[] = [];
@@ -1084,10 +1116,10 @@ export class SemanticParserImpl implements ISemanticParser {
     // fired because a later command DID match. Collect each skipped run and recover
     // verb-medial commands from it (in order, so execution semantics are kept).
     const skipped: LanguageToken[] = [];
-    // For a trailing-`unless` guard clause, the fronted condition surfaces as the
-    // first unmatched run before any body command — claim it as the condition
-    // (rather than trying to recover a command from it).
-    let leadingCondition: LanguageToken[] | null = null;
+    // For a trailing-`unless` guard clause, the fronted condition is either the
+    // reserved verb-split prefix (above) or — when no clean verb-medial split
+    // exists — the first unmatched run before any body command (claimed below).
+    let leadingCondition: LanguageToken[] | null = presetCondition;
     const flushSkipped = () => {
       if (skipped.length === 0) return;
       const run = skipped.slice();

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -7330,3 +7330,54 @@ describe('Bare-event mis-anchor guard (hi unless-condition — SOV event-anchor 
     expect(actions.has('unless')).toBe(true); // was dropped (lossy) before the guard
   });
 });
+
+describe('Verb-split reserves the fronted condition (trailing-unless body patient — SOV #5)', () => {
+  // With a trailing-`unless` guard the body command's verb is verb-medial
+  // (`… टॉगल .selected को`). A patient-BEFORE-verb pattern (hi `toggle-hi-simple`)
+  // would grab the fronted condition's trailing `.disabled` as the toggle patient,
+  // stranding the real को-marked `.selected`. The verb-split reserves everything
+  // before the first command-verb keyword as the condition, so the body binds the
+  // real `.selected`. This is a *value* correctness fix the valueType-based R1 metric
+  // undercounts — yet it's a real execution bug: tr previously toggled `.disabled`
+  // (the wrong class), now `.selected`; hi's patient went expression→selector. The
+  // unless condition also captures the full `I match .disabled`, not a truncated `I`.
+  const findRole = (node: unknown, action: string, role: string): unknown => {
+    let found: unknown;
+    const walk = (n: unknown) => {
+      if (found !== undefined || !n || typeof n !== 'object') return;
+      const rec = n as Record<string, unknown>;
+      if (rec.action === action) {
+        const roles = rec.roles instanceof Map ? rec.roles : new Map(Object.entries(rec.roles ?? {}));
+        if (roles.has(role)) {
+          found = roles.get(role);
+          return;
+        }
+      }
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+        const c = rec[f];
+        if (Array.isArray(c)) c.forEach(walk);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return found;
+  };
+
+  // Corpus-shaped transformer output (`on click unless I match .disabled toggle .selected`).
+  const cases: Array<[string, string]> = [
+    ['hi', 'I match .disabled टॉगल .selected को क्लिक पर जब तक नहीं'],
+    ['ko', 'I match .disabled 토글 .selected 를 클릭 할 때 아니라면'],
+    ['tr', 'I match .disabled değiştir .selected i tıklama de değilse'],
+  ];
+
+  for (const [lang, input] of cases) {
+    it(`[${lang}] toggle binds the marked .selected, not the condition's .disabled`, () => {
+      const node = parse(input, lang);
+      const patient = findRole(node, 'toggle', 'patient') as { value?: string } | undefined;
+      expect(patient?.value).toBe('.selected');
+      // The fronted condition is reserved on the unless, not consumed by the body.
+      const cond = findRole(node, 'unless', 'condition') as { raw?: string } | undefined;
+      expect(cond?.raw).toContain('.disabled');
+    });
+  }
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-21T17:50:00.366Z",
-  "commit": "e875a28d",
+  "timestamp": "2026-06-21T23:00:08.019Z",
+  "commit": "7a5fb2eb",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw"],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3808,7 +3808,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4435,12 +4435,12 @@
       "avgConfidence": 0.90909904631709,
       "avgFidelity": 0.9951298701298701,
       "avgPrecision": 0.8537583215104222,
-      "avgRoleFidelity": 0.7452267514767515,
+      "avgRoleFidelity": 0.7469159406659407,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "keydown-key-is-syntax"],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5072,7 +5072,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5704,7 +5704,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6336,7 +6336,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "form-disable-on-submit"],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6968,7 +6968,7 @@
       "executionFailures": [],
       "degeneratePasses": ["window-scroll"],
       "lossyPasses": ["fetch-do-not-throw", "fetch-error-handling", "if-empty", "input-validation"],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7600,7 +7600,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8232,7 +8232,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8864,7 +8864,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9502,7 +9502,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10134,7 +10134,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10766,7 +10766,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11403,7 +11403,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12035,7 +12035,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-resizable"],
       "lossyPasses": [],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12667,7 +12667,7 @@
       "executionFailures": [],
       "degeneratePasses": ["default-value"],
       "lossyPasses": ["fetch-do-not-throw"],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13298,7 +13298,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13936,7 +13936,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14576,7 +14576,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 442974,
+      "bundleSize": 443249,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15199,7 +15199,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 442974,
+      "size": 443249,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Second #5 increment — closes the residual from #478. With a trailing-`unless` guard the body command's verb is verb-medial (`… टॉगल .selected को`). A patient-**before**-verb pattern (hi `toggle-hi-simple` = `{patient} टॉगल`) grabbed the fronted condition's trailing `.disabled` selector as the toggle patient, stranding the real `को`-marked `.selected`. The body was faithful-by-recall but **role-wrong** — and tr was even toggling the **wrong class** (`.disabled`), a real execution bug masked by the recall-based metric.

**Fix.** In `parseClause`'s trailing-`unless` guard, reserve everything before the first command-verb **keyword** as the condition and parse only from the verb. Gated to a real command verb (not an operator like `matches` — excluded via `CONDITION_OPERATORS`) that is verb-**medial** (a fronted condition before it AND a patient after it); a non-medial / verb-first body finds no split and the existing skip-based capture stands **byte-identical**.

## Result

All five verb-medial trailing-`unless` langs now produce the **fully correct** parse `unless(condition:"I match .disabled") + toggle(.selected)`:

| lang | before | after |
|------|--------|-------|
| hi | `toggle.patient = match.disabled` (expression) | `.selected` (selector) — the target |
| tr | `toggle.patient = .disabled` (**wrong class** — exec bug) | `.selected` |
| ko/ja/bn | `.selected`, condition truncated to `I` | `.selected`, full `I match .disabled` |

- hi avgRoleFidelity **0.745 → 0.747** (the expression→selector type change). The remaining value-level gains (tr `.disabled`→`.selected`, full conditions) are **real correctness the valueType-based R1 metric undercounts** — R1 scores `patient:selector`, which can't see `.disabled` vs `.selected`.
- `--regression` gate: ✓ no regression. Band steady (48). semantic 6148 ✓ · typecheck 0.

## Verification

- Guard added: *Verb-split reserves the fronted condition (trailing-unless body patient — SOV #5)* — hi/tr confirmed **red without** the fix; ko included as a regression guard. Baseline regenerated.
- Parser-only change (no dict/profile), scoped to the trailing-`unless` guard path.

See `docs-internal/HANDOFF-unless-condition-tokenizer.md` (#5 section, "Residual — FIXED").

🤖 Generated with [Claude Code](https://claude.com/claude-code)