### PR TITLE
fix(multilingual): strip the `do not throw` fetch modifier (fetch-do-not-throw phantom-throw, SOV #5)

### DIFF
--- a/docs-internal/HANDOFF-fetch-do-not-throw.md
+++ b/docs-internal/HANDOFF-fetch-do-not-throw.md
@@ -1,0 +1,161 @@
+# Handoff — `fetch-do-not-throw`: the if-body verb-medial `set` drop (SOV #5)
+
+> Written 2026-06-22 after landing the **phantom-throw precision strip** (the
+> contained half of this cluster). This doc tees up the **remaining, harder half**:
+> the if-block body collapse that drops `set` across all 5 SOV langs. It is the
+> hottest, most regression-sensitive parser path (the priorities-handoff **#5**
+> "dedicated arc with careful guards") — read the methodology lessons in
+> [`HANDOFF-multilingual-priorities.md`](HANDOFF-multilingual-priorities.md) first
+> (reproduce through `ml.parse` on the DB translation; **verify the layer
+> empirically — the theorized root cause is usually wrong**).
+
+## The pattern
+
+```
+en rawCode:  on click fetch /api/users as JSON do not throw then if it set $users to it end
+en parse:    on → compound[ fetch, if(condition:it, then:[ set($users, it) ]) ]
+en actions:  {on, fetch, if, set}
+```
+
+`fetch-do-not-throw` is **lossy in bn, hi, ja, ko, tr** — every one of them parses to
+`{on, fetch, if}` and **drops `set`**: the `if` folds (or matches flat) with an
+**empty then-branch**. By recall that is 3/4 = lossy. (qu/vi/zh etc. are faithful here;
+this is an SOV-only failure.)
+
+## What ALREADY landed (this PR) — DO NOT redo
+
+The **phantom `throw`** is fixed. `do not throw` is a fetch error-handling OPTION, not
+a command; en drops it. The SOV transform leaks the English `do` untranslated and
+reorders the throw VERB out of the fetch clause (`… JSON do ではない 投げる それから …`),
+so in the multi-clause body it anchored a **spurious `throw` command** (precision
+defect across bn/hi/ja/ko/tr, plus phantoms in several SVO langs).
+
+- Fix: `stripDoNotThrowModifier` in `packages/semantic/src/parser/semantic-parser.ts`
+  (mirrors `stripAsyncModifier`), called right after the async strip. Removes the
+  `do … throw` span before parsing, anchored on the leaked `do` literal + a
+  `throw`-normalized verb within a small window (ja's negation `ではない` shatters into
+  `で`/`は`/`ない`, so a 2-token window misses it — the window is 5, stopping at a
+  value/conjunction).
+- Result: **avgPrecision 0.9633 → 0.9645** (the phantom was in many langs' fetch
+  pattern, not just the 5 lossy). Band steady (set still missing). Gate clean.
+- Guard: "`do not throw` fetch modifier strip" in `multilingual-roadmap-fixes.test.ts`.
+
+**The `set` drop is untouched and is what remains.** Removing the phantom throw did
+NOT recover `set` — verified: even with `do not throw` deleted from the input, `set`
+still drops. The two are independent.
+
+## The remaining defect: the if-body verb-medial `set` collapses
+
+### Empirical findings (instrumented — these are FACTS, not theory)
+
+1. **It is `set`-specific, not "verb-medial in general."** In ja, verb-medial
+   `toggle` (`.active を 切り替え`) and `put` (`それ を $users に 置く`) parse fine, but
+   verb-medial `set` (`$users を 設定 それ に` / `.active を 設定 それ に`) **fails to
+   parse at all** ("all parse stages exhausted").
+
+2. **`set`'s role markers are INVERTED vs the default SOV map.** `setSchema`
+   (`generators/command-schemas.ts`) has `markerOverride` giving the **destination**
+   the accusative marker (ja `を`, ko `를`, tr `i`, bn `কে`, hi `को`) — the marker the
+   default profile map assigns to **patient**. So `$users を 設定 それ に` =
+   `set(destination:$users, patient:it)`, but `extractRolesFromMarkedTokens`'
+   default `markerToRole` reads `を`→patient, `に`→destination (inverted). `set` and
+   `put` are special-cased in `mapRoleForCommand` (the `markerRole==='patient' &&
+!destination → 'destination'` swap), but that path is only reached when the role is
+   already taken — verify whether it actually fires for the verb-medial set.
+
+3. **ja/ko have NO hand-crafted set patterns** (`patterns/set.ts` has set-bn, set-hi,
+   …, but no set-ja/set-ko/set-tr) — they rely on schema-generated patterns. **But bn
+   and hi DO have hand-crafted set patterns and STILL drop `set` here.** So it is NOT
+   a missing-pattern problem — it is the **branch/clause parsing of the verb-medial
+   set in the if-body**.
+
+4. **`parseBranch` / `parseSOVClauseByVerbAnchoring` NEVER RUN for this if-block.**
+   Instrumented both (debug prints): zero output on the full ja event-handler parse.
+   So `tryParseConditionalBlock` is **not folding** the if-block in the event-body
+   path — the `if` is emitted FLAT (a bare `if` command, no then-branch), and the
+   verb-medial `set` body is never handed to a parser that could recover it.
+   - The standalone `もし それ $users を 設定 それ に 終わり` is a RED HERRING: at the
+     top level it's matched as a bare `if` by Stage-2 matchBest and also never reaches
+     `parseBranch`. **Always reproduce inside the event handler** (the real path).
+
+### The likely root cause to confirm
+
+The event-handler body for this shape is parsed by **`buildEventHandler`** — and for a
+fused event match it routes the body through **`parseBodyWithGrammarPatterns`** (the
+then-chain/continuation parser), NOT **`parseBodyWithClauses`** (which is where
+`tryParseConditionalBlock` lives, line ~840). So the `if` block is never offered to the
+folding path; it collapses to a flat `if`. **Confirm which body-parser path
+fetch-do-not-throw takes** (add a temp print in `buildEventHandler`'s two branches),
+then either (a) route a body containing a block opener through `parseBodyWithClauses`,
+or (b) teach `parseBodyWithGrammarPatterns` to fold a trailing `if/unless … end` block.
+Both must keep the verb-medial `set` recovery working in the then-branch — which is
+its own sub-problem (finding #1: verb-medial `set` doesn't parse even standalone).
+
+So this is **two nested fixes**: (A) get the if-block to a folding parser in the event
+body, and (B) make the verb-medial `set` then-branch actually parse (role-marker
+inversion in `parseSOVClauseByVerbAnchoring` / the generated pattern). Land them in
+whichever order lets you verify each with the gate; **one defect per PR** if they
+separate cleanly.
+
+### Generalization (why it's worth the arc)
+
+The same flat-`if`-with-dropped-body shape almost certainly explains the OTHER lossy
+if-body patterns — **`if-empty`** (he, ko) and **`input-validation`** (he, ko) are
+prime suspects, and any `… then if … <verb-medial-body> … end` SOV pattern. Confirm by
+reproducing those after the fix; one root-cause fix may clear several.
+
+## Reproduction harness (gate-faithful — recreate, delete after; NOT committed)
+
+Build deps + populate first (the gate refuses a stale DB). Then a throwaway under
+`packages/patterns-reference/scripts/` run with
+`LSP_DB_PATH="$PWD/packages/patterns-reference/data/patterns.db" npx tsx …`:
+
+```ts
+import { JSDOM } from 'jsdom';
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+Object.assign(globalThis as any, {
+  window: dom.window,
+  document: dom.window.document,
+  Element: dom.window.Element,
+  Node: dom.window.Node,
+  HTMLElement: dom.window.HTMLElement,
+});
+import { getAllPatterns, getTranslationsByLanguage } from '../src/index';
+import { MultilingualHyperscript } from '@hyperfixi/core/multilingual';
+import { collectActions } from '../../testing-framework/src/multilingual/fidelity';
+const ml = new MultilingualHyperscript();
+await ml.initialize();
+const p: any = (await getAllPatterns()).find((x: any) => x.id === 'fetch-do-not-throw');
+const en = collectActions(await ml.parse(p.rawCode, 'en')); // {on, fetch, if, set}
+for (const lang of ['bn', 'hi', 'ja', 'ko', 'tr']) {
+  const t: any = (await getTranslationsByLanguage(lang, 2000)).find(
+    (x: any) => x.codeExampleId === p.id
+  );
+  const acts = collectActions(await ml.parse(t.hyperscript, lang));
+  console.log(
+    lang,
+    'missing',
+    en.filter(a => !acts.includes(a)),
+    '|',
+    t.hyperscript
+  );
+}
+```
+
+For the instrumented dig: temp `console.error` in `buildEventHandler` (which body
+branch), in `parseBranch` (in/out), and in `parseSOVClauseByVerbAnchoring` (verb +
+extracted roles). Gate on `DBG`-style env var; restore the file from a `/tmp` backup
+after (the verb-medial-set debug from this session was removed cleanly).
+
+## Conventions (held across #445–#480)
+
+- Branch off `main`; **one defect per PR**. Hot path → gate after EVERY change.
+- Guard in `packages/semantic/test/multilingual-roadmap-fixes.test.ts`, **verified red
+  without the fix** (`git stash` the src, run `-t "<title>"`, pop).
+- `--regression` gate must print "No regression"; after an intentional fidelity change
+  re-run with `--save-baseline` and commit the baseline. Do **not** commit
+  `patterns.db` (CI re-populates — `git checkout` it). Watch **R0-recall** (set
+  recovered), **R0-precision** (no NEW phantom), **R1** (set roles correct — beware the
+  inverted markers), and **parse-rate** — this path touches every passing SOV lang.
+- If a fix proves too broad/risky for one PR, prefer landing the narrower half and
+  re-handing-off, exactly as this phantom-throw strip was split from the set drop.

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -187,7 +187,20 @@ export class SemanticParserImpl implements ISemanticParser {
     // its execution semantics across languages is Track 5 Tier 2). Gated to the
     // async keyword token, so non-async inputs are byte-identical.
     const asyncStrip = this.stripAsyncModifier(modInput, language);
-    const parseInput = asyncStrip.remainingInput ?? modInput;
+    const asyncInput = asyncStrip.remainingInput ?? modInput;
+
+    // Strip the `do [not] throw` fetch-error modifier (en `fetch … as JSON do not
+    // throw`). It is a fetch OPTION (suppress the error throw), not a command — en
+    // drops it entirely (no `throw` action). The SOV grammar transform mangles it:
+    // the English `do` leaks untranslated and the throw VERB is reordered out, so
+    // in a multi-clause body (`… 投げる それから もし …`) it anchors a spurious
+    // `throw` command (the fetch-do-not-throw phantom-throw, a precision defect in
+    // bn/hi/ja/ko/tr). Removing the `do … throw` span before parsing matches en and
+    // is a no-op on en's action set. Gated to a literal `do` followed within two
+    // tokens by a `throw`-normalized verb, so a real `throw` (no leaked `do`) and a
+    // pl/pt `do`-marker not adjacent to a throw verb are byte-identical.
+    const dntStrip = this.stripDoNotThrowModifier(asyncInput, language);
+    const parseInput = dntStrip.remainingInput ?? asyncInput;
 
     // Diagnostics accumulator (Phase 3.4)
     const diagnostics: Diagnostic[] = [];
@@ -2979,6 +2992,50 @@ export class SemanticParserImpl implements ISemanticParser {
       .trim();
     if (stripped.length === 0) return { remainingInput: null };
     return { remainingInput: stripped };
+  }
+
+  /**
+   * Strip the `do [not] throw` fetch-error modifier (see the call site for why).
+   * Anchored on the leaked English `do` literal — present in every SOV translation
+   * of the phrase — followed within two tokens by a `throw`-normalized verb (a
+   * negation may sit between: ja `ではない`, ko `아니`, hi `नहीं`, tr `değil`, bn
+   * `না`, en `not`). Removes the `do … throw` span from the source string. Returns
+   * `{ remainingInput: null }` when no such span exists, so the caller leaves the
+   * input untouched.
+   */
+  private stripDoNotThrowModifier(
+    input: string,
+    language: string
+  ): {
+    remainingInput: string | null;
+  } {
+    const allTokens = tokenizeInternal(input, language).tokens;
+    for (let i = 0; i < allTokens.length - 1; i++) {
+      if (allTokens[i].value.toLowerCase() !== 'do') continue;
+      // Scan a small window for the throw verb. The negation between `do` and
+      // `throw` may be one token (en `not`, tr `değil`) or several (ja `ではない`
+      // shatters into `で`/`は`/`ない` particles), so a 2-token window misses ja.
+      // Stop at a value / conjunction — only negation filler may separate them.
+      let throwIdx = -1;
+      for (let j = i + 1; j <= i + 5 && j < allTokens.length; j++) {
+        const tj = allTokens[j];
+        if (tj.normalized?.toLowerCase() === 'throw') {
+          throwIdx = j;
+          break;
+        }
+        const k = tj.kind as string;
+        if (k === 'selector' || k === 'literal' || k === 'reference' || k === 'conjunction') {
+          break;
+        }
+      }
+      if (throwIdx === -1) continue;
+      const start = allTokens[i].position.start;
+      const end = allTokens[throwIdx].position.end;
+      const stripped = (input.slice(0, start) + input.slice(end)).replace(/\s{2,}/g, ' ').trim();
+      if (stripped.length === 0) return { remainingInput: null };
+      return { remainingInput: stripped };
+    }
+    return { remainingInput: null };
   }
 
   /**

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -7381,3 +7381,55 @@ describe('Verb-split reserves the fronted condition (trailing-unless body patien
     });
   }
 });
+
+describe('`do not throw` fetch modifier strip (fetch-do-not-throw phantom-throw)', () => {
+  // `do not throw` is a fetch error-handling OPTION ("don't throw on error"), not a
+  // command — en drops it (no `throw` action). The SOV grammar transform leaks the
+  // English `do` untranslated and reorders the throw VERB out of the fetch clause, so
+  // in the multi-clause body (`… 投げる それから もし …`) it anchored a SPURIOUS
+  // `throw` command — a precision defect in bn/hi/ja/ko/tr (and a phantom in several
+  // SVO langs too). stripDoNotThrowModifier removes the `do … throw` span before
+  // parsing, anchored on the leaked `do` + a `throw`-normalized verb within a small
+  // window (ja's negation `ではない` shatters into `で`/`は`/`ない`). The if-body `set`
+  // drop is a SEPARATE, deferred recall defect — see the fetch-do-not-throw arc
+  // handoff (docs-internal/HANDOFF-fetch-do-not-throw.md).
+  const collectActions = (node: unknown, acc: string[] = []): string[] => {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.push(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => collectActions(x, acc));
+      else if (c && typeof c === 'object') collectActions(c, acc);
+    }
+    return acc;
+  };
+
+  it('[ja] drops the `do … 投げる` modifier — no phantom throw, fetch kept', () => {
+    const actions = new Set(
+      collectActions(
+        parse(
+          '/api/users を クリック で フェッチ JSON do ではない 投げる それから もし それ $users を 設定 それ に 終わり',
+          'ja'
+        )
+      )
+    );
+    expect(actions.has('fetch')).toBe(true);
+    expect(actions.has('throw')).toBe(false); // was a phantom throw before the strip
+  });
+
+  it('[en] is unaffected — `do not throw` never produced a throw', () => {
+    const actions = new Set(
+      collectActions(
+        parse('on click fetch /api/users as JSON do not throw then if it set it to it end', 'en')
+      )
+    );
+    expect(actions.has('fetch')).toBe(true);
+    expect(actions.has('throw')).toBe(false);
+  });
+
+  it('does not strip a genuine `throw` command (no leaked `do`)', () => {
+    const actions = new Set(collectActions(parse("throw 'boom'", 'en')));
+    expect(actions.has('throw')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-21T23:00:08.019Z",
-  "commit": "7a5fb2eb",
+  "timestamp": "2026-06-22T04:04:28.164Z",
+  "commit": "a7ee9b88",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -8,13 +8,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8368310482087561,
       "avgFidelity": 0.9954004329004328,
-      "avgPrecision": 0.9767316017316019,
+      "avgPrecision": 0.978030303030303,
       "avgRoleFidelity": 0.8735917235917239,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8495030867211314,
       "avgFidelity": 0.9983766233766234,
-      "avgPrecision": 0.9156081119316415,
+      "avgPrecision": 0.9172314885550181,
       "avgRoleFidelity": 0.782032307032307,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw"],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1272,13 +1272,13 @@
       "parseRate": 1,
       "avgConfidence": 0.830921459492886,
       "avgFidelity": 0.997835497835498,
-      "avgPrecision": 0.993831168831169,
+      "avgPrecision": 0.9951298701298701,
       "avgRoleFidelity": 0.8600318037818038,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2529,13 +2529,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
-      "avgPrecision": 0.9817099567099568,
+      "avgPrecision": 0.983008658008658,
       "avgRoleFidelity": 0.8427488614988615,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3161,13 +3161,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
-      "avgPrecision": 0.9804112554112555,
+      "avgPrecision": 0.9817099567099568,
       "avgRoleFidelity": 0.8460709335709337,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3808,7 +3808,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4434,13 +4434,13 @@
       "parseRate": 1,
       "avgConfidence": 0.90909904631709,
       "avgFidelity": 0.9951298701298701,
-      "avgPrecision": 0.8537583215104222,
+      "avgPrecision": 0.8553816981337988,
       "avgRoleFidelity": 0.7469159406659407,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "keydown-key-is-syntax"],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5066,13 +5066,13 @@
       "parseRate": 1,
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
-      "avgPrecision": 0.9799783549783551,
+      "avgPrecision": 0.9812770562770563,
       "avgRoleFidelity": 0.8604933917433917,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5698,13 +5698,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
-      "avgPrecision": 0.9715638528138526,
+      "avgPrecision": 0.9728625541125538,
       "avgRoleFidelity": 0.8397454459954462,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6330,13 +6330,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 0.9962121212121213,
-      "avgPrecision": 0.9090536214485794,
+      "avgPrecision": 0.910676998071956,
       "avgRoleFidelity": 0.7946744134244135,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["fetch-do-not-throw", "form-disable-on-submit"],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6962,13 +6962,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 0.987012987012987,
-      "avgPrecision": 0.9282246162927983,
+      "avgPrecision": 0.9298479929161748,
       "avgRoleFidelity": 0.7914090601590601,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["window-scroll"],
       "lossyPasses": ["fetch-do-not-throw", "fetch-error-handling", "if-empty", "input-validation"],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7594,13 +7594,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8395794681508945,
       "avgFidelity": 0.9935064935064936,
-      "avgPrecision": 0.9782467532467533,
+      "avgPrecision": 0.9795454545454545,
       "avgRoleFidelity": 0.8692660380160381,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8226,13 +8226,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 0.9978354978354977,
-      "avgPrecision": 0.9877976190476191,
+      "avgPrecision": 0.9890963203463203,
       "avgRoleFidelity": 0.8429629492129495,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8858,13 +8858,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7995877138734262,
       "avgFidelity": 1,
-      "avgPrecision": 0.9791125541125543,
+      "avgPrecision": 0.9804112554112555,
       "avgRoleFidelity": 0.8654483466983468,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9502,7 +9502,7 @@
         "take-class-from-siblings",
         "unless-condition"
       ],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10128,13 +10128,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8142650999793837,
       "avgFidelity": 1,
-      "avgPrecision": 0.9873647186147186,
+      "avgPrecision": 0.9886634199134199,
       "avgRoleFidelity": 0.8427971240471241,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10760,13 +10760,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7941558441558423,
       "avgFidelity": 0.9951298701298701,
-      "avgPrecision": 0.9787878787878787,
+      "avgPrecision": 0.9796536796536797,
       "avgRoleFidelity": 0.8687141124641127,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11392,7 +11392,7 @@
       "parseRate": 1,
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 0.997005772005772,
-      "avgPrecision": 0.9722943722943722,
+      "avgPrecision": 0.9735930735930735,
       "avgRoleFidelity": 0.8238491238491239,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -11403,7 +11403,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12029,13 +12029,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8216537651743292,
       "avgFidelity": 0.9942279942279942,
-      "avgPrecision": 0.9771645021645022,
+      "avgPrecision": 0.9784632034632035,
       "avgRoleFidelity": 0.8763445450945451,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-resizable"],
       "lossyPasses": [],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12661,13 +12661,13 @@
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8329265429368624,
       "avgFidelity": 0.9918300653594772,
-      "avgPrecision": 0.9336067255184901,
+      "avgPrecision": 0.9352407124465947,
       "avgRoleFidelity": 0.7987202329039063,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["default-value"],
       "lossyPasses": ["fetch-do-not-throw"],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13292,13 +13292,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8135229849515544,
       "avgFidelity": 1,
-      "avgPrecision": 0.9873647186147185,
+      "avgPrecision": 0.9886634199134197,
       "avgRoleFidelity": 0.8316484753984756,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13924,7 +13924,7 @@
       "parseRate": 1,
       "avgConfidence": 0.8044939187796312,
       "avgFidelity": 0.985930735930736,
-      "avgPrecision": 0.9706980519480523,
+      "avgPrecision": 0.9719967532467534,
       "avgRoleFidelity": 0.8600800663300664,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -13936,7 +13936,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14576,7 +14576,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 443249,
+      "bundleSize": 443841,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15199,7 +15199,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 443249,
+      "size": 443841,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

The **contained** half of the fetch-do-not-throw cluster — the phantom `throw`. (The harder if-body `set` drop is deferred with a full handoff: `docs-internal/HANDOFF-fetch-do-not-throw.md`.)

`do not throw` is a fetch error-handling **option** ("don't throw on error"), not a command — en drops it (no `throw` action). The SOV grammar transform leaks the English `do` untranslated and reorders the throw **verb** out of the fetch clause (`… JSON do ではない 投げる それから …`), so in the multi-clause body it anchored a **spurious `throw` command** — a precision defect in bn/hi/ja/ko/tr (and a phantom in several SVO langs too).

**Fix.** `stripDoNotThrowModifier` (mirrors the existing `stripAsyncModifier`), called right after the async strip: removes the `do … throw` span before parsing, anchored on the leaked `do` literal followed within a small window by a `throw`-normalized verb (ja's negation `ではない` shatters into `で`/`は`/`ない`, so the window is 5, stopping at a value/conjunction). A no-op on en's action set; a genuine `throw` (no leaked `do`) is byte-identical.

## Result

- **avgPrecision 0.9633 → 0.9645** — the phantom was in *many* langs' fetch-do-not-throw, not just the 5 lossy ones (all 24 langs' precision held or improved).
- Band steady at 48 (the if-body `set` drop is a **separate, deferred recall defect** — see the handoff).
- `--regression` gate ✓ no regression. semantic 6151 ✓ · typecheck 0.

## Verification

- Guard: *`do not throw` fetch modifier strip* — ja confirmed **red without** the strip; en + a genuine-`throw` case as no-op/regression guards.
- Verified independent of the set drop: deleting `do not throw` from the input still drops `set`, so this strip is purely the precision fix.
- Baseline regenerated; `patterns.db` not committed.

## Follow-up

`docs-internal/HANDOFF-fetch-do-not-throw.md` captures the full empirical root-cause investigation for the remaining `set`-drop arc (the if-block isn't routed to the folding parser in the event body; verb-medial `set` has inverted role markers) — ready to pick up in a fresh session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)