### PR TITLE
fix(multilingual): fold fused-event trailing if-block to recover verb-medial set (fetch-do-not-throw set-drop, SOV #5)

### DIFF
--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1461,6 +1461,16 @@ export class SemanticParserImpl implements ISemanticParser {
 
       for (let i = pos; i < clauseTokens.length; i++) {
         const token = clauseTokens[i];
+        // A known postpositional ROLE MARKER (を/に/를/에/i/কে/…) is NEVER a command
+        // verb, even when its surface form doubles as a verb keyword alternative:
+        // ja's `に` is both the `set`-value destination marker AND an `into`
+        // alternative, so anchoring the trailing `それ に` of `set $users to it`
+        // emitted a phantom `into` command (R0-precision). Gate on markerToRole,
+        // NOT on `kind==='particle'`: a clause-final loop keyword like tr `için` /
+        // bn `জন্য` (`for`) also tokenizes as a particle but is NOT a role marker,
+        // and the verb-anchoring fallback must still find it as the `for` verb (else
+        // template-literal-list-build drops its loop). See buildVerbLookup's `for` note.
+        if (markerToRole.has(token.value)) continue;
         const byValue = verbLookup.get(token.value.toLowerCase());
         const byNormalized = token.normalized
           ? verbLookup.get(token.normalized.toLowerCase())
@@ -1489,8 +1499,12 @@ export class SemanticParserImpl implements ISemanticParser {
           break;
         }
         // Stop at the next verb (start of new command) — but only if preceded by a marker
-        // This prevents stopping at "value" tokens that happen to match a verb name
-        if (i > verbIdx + 1) {
+        // This prevents stopping at "value" tokens that happen to match a verb name.
+        // A known role marker is not a verb (see the verb-find guard above): without
+        // this exclusion `に` (set's value marker, also an `into` alt) ends the `set`
+        // clause one token early, stranding its `it` patient. A non-marker loop
+        // keyword (tr `için` / bn `জন্য`) still legitimately stops the clause.
+        if (i > verbIdx + 1 && !markerToRole.has(t.value)) {
           const nextAction =
             verbLookup.get(t.value.toLowerCase()) ||
             (t.normalized ? verbLookup.get(t.normalized.toLowerCase()) : undefined);
@@ -1773,6 +1787,37 @@ export class SemanticParserImpl implements ISemanticParser {
         }
       }
 
+      // Fold a leading `if … end` block into a conditional, mirroring the
+      // clause-boundary fold in parseBodyWithClauses. A fused SOV/VSO event
+      // pattern captures the FIRST body command (`fetch`) as the action and
+      // routes the trailing `then if it set $users to it end` here — but this
+      // body walker only ran matchBest, where the schema-generated bare-`if`
+      // pattern (`if-ja-generated-verb-first`) captures the if-keyword and
+      // swallows the whole block as a flat `if` with NO condition and an empty
+      // then-branch, silently dropping the block body (the verb-medial `set` of
+      // fetch-do-not-throw — lossy across bn/hi/ja/ko/tr). The if-keyword itself
+      // marks a sub-clause boundary, so flush any pending tokens first: in
+      // hi/ko/tr a leaked `as` remnant (के रूप में / 로 / olarak) strands between
+      // `then` and `if`, and without the flush skippedClauseTokens stays
+      // non-empty (the flush recovers a real pending verb-medial command and
+      // harmlessly discards non-command junk). Gated on `!clauseHadMatch` so a
+      // juxtaposed `<cmd> if` mid-clause is untouched. tryParseConditionalBlock
+      // folds `if` only and returns null without consuming when the head isn't a
+      // usable conditional, so a non-`if` clause is byte-identical to before.
+      if (
+        current &&
+        !clauseHadMatch &&
+        this.isIfKeyword((current.normalized ?? current.value).toLowerCase(), language)
+      ) {
+        flushClause();
+        const conditional = this.tryParseConditionalBlock(tokens, commandPatterns, language);
+        if (conditional) {
+          commands.push(conditional);
+          clauseHadMatch = true;
+          continue;
+        }
+      }
+
       let matched = false;
 
       // Try grammar-transformed continuation patterns first
@@ -1814,8 +1859,38 @@ export class SemanticParserImpl implements ISemanticParser {
 
       // Try regular command patterns
       if (!matched) {
+        const preMatch = tokens.mark();
         const commandMatch = patternMatcher.matchBest(tokens, commandPatterns);
         if (commandMatch) {
+          // A schema-generated bare-`if` pattern (`if-tr-generated`,
+          // `if-ja-generated-verb-first`, …) matches the if-keyword and yields a
+          // flat `if` with no condition and an EMPTY then-branch — dropping the
+          // block body (the verb-medial `set` of fetch-do-not-throw). It can even
+          // swallow a leaked `as` remnant just ahead of the if (tr `olarak eğer`),
+          // so the clause-head fold guard above never sees the if as the head.
+          // Whenever matchBest yields a flat `if` here, rewind, skip any non-`if`
+          // junk to the if-keyword, and fold the whole `if … end` block instead —
+          // flushing first so a pending verb-medial command is recovered, not lost.
+          // A folded `if` strictly dominates the bare one for recall (same `if`
+          // action plus the recovered branch); if the block isn't foldable
+          // (no `end`), restore the post-match position and keep the bare `if`.
+          if ((commandMatch.pattern.command as string) === 'if') {
+            const afterMatch = tokens.mark();
+            tokens.reset(preMatch);
+            while (!tokens.isAtEnd()) {
+              const h = tokens.peek();
+              if (!h || this.isIfKeyword((h.normalized ?? h.value).toLowerCase(), language)) break;
+              tokens.advance();
+            }
+            const conditional = this.tryParseConditionalBlock(tokens, commandPatterns, language);
+            if (conditional) {
+              flushClause();
+              commands.push(conditional);
+              clauseHadMatch = true;
+              continue;
+            }
+            tokens.reset(afterMatch);
+          }
           const cmd = this.buildCommand(commandMatch, language);
           commands.push(cmd);
           // Reclaim a trailing post-verb source/destination phrase the matched

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -431,6 +431,71 @@ describe('if/else block-body in event handlers — Track 5 Tier 1', () => {
   });
 });
 
+describe('fused-event trailing `if … end` folds + verb-medial set (fetch-do-not-throw, SOV)', () => {
+  // `on click fetch /api/users as JSON do not throw then if it set $users to it end`.
+  // A fused SOV event pattern captures `fetch` as the handler action and routes the
+  // trailing `then if … end` through parseBodyWithGrammarPatterns — where a
+  // schema-generated bare-`if` pattern (`if-ja-generated-verb-first`, `if-tr-generated`)
+  // swallowed the whole block as a flat `if` with an empty then-branch, dropping the
+  // verb-medial `set`. The body walker now folds that `if … end` block (mirroring
+  // parseBodyWithClauses), recovering the `set` in its then-branch. Flips
+  // fetch-do-not-throw bn/hi/ja/ko/tr lossy→faithful (and generalizes to
+  // fetch-error-handling, form-disable-on-submit, modal-close-escape). See
+  // docs-internal/HANDOFF-fetch-do-not-throw.md.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const n = node as Record<string, unknown>;
+    if (typeof n.action === 'string') acc.add(n.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = n[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped transformer output (en → lang) for fetch-do-not-throw.
+  const cases: Array<[string, string]> = [
+    ['bn', '/api/users কে ক্লিক এ আনুন JSON do না নিক্ষেপ তারপর যদি এটি $users কে সেট এটি তে শেষ'],
+    [
+      'hi',
+      '/api/users को क्लिक पर लाएं JSON do नहीं फेंकें फिर के रूप में अगर यह $users को सेट यह में समाप्त',
+    ],
+    ['ja', '/api/users を クリック で フェッチ JSON do ではない 投げる それから もし それ $users を 設定 それ に 終わり'],
+    ['ko', '/api/users 를 클릭 할 때 가져오기 JSON do 아니 던지다 그러면 로 만약 그것 $users 를 설정 그것 에 끝'],
+    ['tr', '/api/users i tıklama de getir JSON do değil fırlat sonra olarak eğer o $users i ayarla o e son'],
+  ];
+
+  for (const [lang, input] of cases) {
+    it(`[${lang}] folds the if-block and keeps fetch + if + set`, () => {
+      const node = parse(input, lang);
+      expect(node.action).toBe('on');
+      const a = actions(node);
+      expect(a.has('fetch')).toBe(true);
+      expect(a.has('if')).toBe(true);
+      expect(a.has('set')).toBe(true); // the recovered verb-medial then-branch set
+      // Precision: the `do not throw` strip leaves no phantom `throw`, and the set's
+      // value marker (ja に / ko 에) must not anchor a phantom `into` command.
+      expect(a.has('throw')).toBe(false);
+      expect(a.has('into')).toBe(false);
+    });
+  }
+
+  it('[tr] a non-marker clause-final loop keyword (`için`) still anchors `for`', () => {
+    // The verb-anchoring particle guard that suppresses the phantom `into` is scoped
+    // to KNOWN role markers (markerToRole), NOT all particles — else a clause-final
+    // loop keyword like tr `için` (a particle, but not a role marker) would be
+    // skipped and the `for` dropped (the template-literal-list-build regression caught
+    // by the multilingual gate). Corpus shape of `on click set $total to 0 then for
+    // item in $items set $total to $total end`.
+    const input =
+      '$total i tıklama de ayarla 0 e sonra item içinde $items i için $total i ayarla $total son';
+    const a = actions(parse(input, 'tr'));
+    expect(a.has('for')).toBe(true);
+    expect(a.has('set')).toBe(true);
+  });
+});
+
 describe('async modifier transparency — Track 5 Async Tier 1', () => {
   // `async` marks the *following* command for async execution — it is a modifier,
   // not a command verb. The grammar transformer reorders it as a verb, so a fused

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-22T04:04:28.164Z",
-  "commit": "a7ee9b88",
+  "timestamp": "2026-06-22T04:44:08.728Z",
+  "commit": "2d69207e",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9,12 +9,12 @@
       "avgConfidence": 0.8368310482087561,
       "avgFidelity": 0.9954004329004328,
       "avgPrecision": 0.978030303030303,
-      "avgRoleFidelity": 0.8735917235917239,
+      "avgRoleFidelity": 0.8758439758439762,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -639,14 +639,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8495030867211314,
-      "avgFidelity": 0.9983766233766234,
-      "avgPrecision": 0.9172314885550181,
-      "avgRoleFidelity": 0.782032307032307,
+      "avgFidelity": 1,
+      "avgPrecision": 0.9231838695073992,
+      "avgRoleFidelity": 0.7842845592845592,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["fetch-do-not-throw"],
-      "bundleSize": 443841,
+      "lossyPasses": [],
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.830921459492886,
       "avgFidelity": 0.997835497835498,
       "avgPrecision": 0.9951298701298701,
-      "avgRoleFidelity": 0.8600318037818038,
+      "avgRoleFidelity": 0.8609327046827048,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
       "avgPrecision": 0.983008658008658,
-      "avgRoleFidelity": 0.8427488614988615,
+      "avgRoleFidelity": 0.8436497623997625,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
       "avgPrecision": 0.9817099567099568,
-      "avgRoleFidelity": 0.8460709335709337,
+      "avgRoleFidelity": 0.8469718344718347,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3808,7 +3808,7 @@
         "tell-command",
         "tell-other-element"
       ],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4433,14 +4433,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.90909904631709,
-      "avgFidelity": 0.9951298701298701,
-      "avgPrecision": 0.8553816981337988,
-      "avgRoleFidelity": 0.7469159406659407,
+      "avgFidelity": 0.9967532467532467,
+      "avgPrecision": 0.9165363046044861,
+      "avgRoleFidelity": 0.7502943190443191,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["fetch-do-not-throw", "keydown-key-is-syntax"],
-      "bundleSize": 443841,
+      "lossyPasses": ["keydown-key-is-syntax"],
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5067,12 +5067,12 @@
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
       "avgPrecision": 0.9812770562770563,
-      "avgRoleFidelity": 0.8604933917433917,
+      "avgRoleFidelity": 0.8602681665181665,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5699,12 +5699,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.9728625541125538,
-      "avgRoleFidelity": 0.8397454459954462,
+      "avgRoleFidelity": 0.8406463468963471,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6329,14 +6329,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8351246080569386,
-      "avgFidelity": 0.9962121212121213,
-      "avgPrecision": 0.910676998071956,
-      "avgRoleFidelity": 0.7946744134244135,
+      "avgFidelity": 1,
+      "avgPrecision": 0.9422938803620623,
+      "avgRoleFidelity": 0.7953987641487641,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["fetch-do-not-throw", "form-disable-on-submit"],
-      "bundleSize": 443841,
+      "lossyPasses": [],
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6961,14 +6961,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8170870900194204,
-      "avgFidelity": 0.987012987012987,
-      "avgPrecision": 0.9298479929161748,
-      "avgRoleFidelity": 0.7914090601590601,
+      "avgFidelity": 0.9902597402597403,
+      "avgPrecision": 0.935800373868556,
+      "avgRoleFidelity": 0.7947874385374385,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["window-scroll"],
-      "lossyPasses": ["fetch-do-not-throw", "fetch-error-handling", "if-empty", "input-validation"],
-      "bundleSize": 443841,
+      "lossyPasses": ["if-empty", "input-validation"],
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7595,12 +7595,12 @@
       "avgConfidence": 0.8395794681508945,
       "avgFidelity": 0.9935064935064936,
       "avgPrecision": 0.9795454545454545,
-      "avgRoleFidelity": 0.8692660380160381,
+      "avgRoleFidelity": 0.8690408127908131,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8227,12 +8227,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 0.9978354978354977,
       "avgPrecision": 0.9890963203463203,
-      "avgRoleFidelity": 0.8429629492129495,
+      "avgRoleFidelity": 0.8438638501138503,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8859,12 +8859,12 @@
       "avgConfidence": 0.7995877138734262,
       "avgFidelity": 1,
       "avgPrecision": 0.9804112554112555,
-      "avgRoleFidelity": 0.8654483466983468,
+      "avgRoleFidelity": 0.8663492475992477,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9489,20 +9489,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7316532673675531,
-      "avgFidelity": 0.988365800865801,
-      "avgPrecision": 0.9311969415865524,
-      "avgRoleFidelity": 0.7701570389070387,
+      "avgFidelity": 0.9937770562770564,
+      "avgPrecision": 0.942019452409063,
+      "avgRoleFidelity": 0.7786029848529846,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": [
-        "append-content",
-        "behavior-draggable",
-        "modal-close-escape",
-        "take-class-from-siblings",
-        "unless-condition"
-      ],
-      "bundleSize": 443841,
+      "lossyPasses": ["append-content", "behavior-draggable", "unless-condition"],
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10129,12 +10123,12 @@
       "avgConfidence": 0.8142650999793837,
       "avgFidelity": 1,
       "avgPrecision": 0.9886634199134199,
-      "avgRoleFidelity": 0.8427971240471241,
+      "avgRoleFidelity": 0.8436980249480251,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10761,12 +10755,12 @@
       "avgConfidence": 0.7941558441558423,
       "avgFidelity": 0.9951298701298701,
       "avgPrecision": 0.9796536796536797,
-      "avgRoleFidelity": 0.8687141124641127,
+      "avgRoleFidelity": 0.8673627611127612,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11393,7 +11387,7 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 0.997005772005772,
       "avgPrecision": 0.9735930735930735,
-      "avgRoleFidelity": 0.8238491238491239,
+      "avgRoleFidelity": 0.8247500247500248,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
@@ -11403,7 +11397,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12030,12 +12024,12 @@
       "avgConfidence": 0.8216537651743292,
       "avgFidelity": 0.9942279942279942,
       "avgPrecision": 0.9784632034632035,
-      "avgRoleFidelity": 0.8763445450945451,
+      "avgRoleFidelity": 0.8785967973467976,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["behavior-resizable"],
       "lossyPasses": [],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12660,14 +12654,14 @@
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
       "avgConfidence": 0.8329265429368624,
-      "avgFidelity": 0.9918300653594772,
-      "avgPrecision": 0.9352407124465947,
-      "avgRoleFidelity": 0.7987202329039063,
+      "avgFidelity": 0.9934640522875817,
+      "avgPrecision": 0.941231997849645,
+      "avgRoleFidelity": 0.7998540197519788,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["default-value"],
-      "lossyPasses": ["fetch-do-not-throw"],
-      "bundleSize": 443841,
+      "lossyPasses": [],
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13293,12 +13287,12 @@
       "avgConfidence": 0.8135229849515544,
       "avgFidelity": 1,
       "avgPrecision": 0.9886634199134197,
-      "avgRoleFidelity": 0.8316484753984756,
+      "avgRoleFidelity": 0.8325493762993766,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13925,7 +13919,7 @@
       "avgConfidence": 0.8044939187796312,
       "avgFidelity": 0.985930735930736,
       "avgPrecision": 0.9719967532467534,
-      "avgRoleFidelity": 0.8600800663300664,
+      "avgRoleFidelity": 0.8598548411048412,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
@@ -13936,7 +13930,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14576,7 +14570,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 443841,
+      "bundleSize": 444307,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15199,7 +15193,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 443841,
+      "size": 444307,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Lands the **remaining harder half** of the `fetch-do-not-throw` cluster (the
phantom-`throw` strip shipped in #480): the if-block body collapse that drops
`set` across all 5 SOV langs. Implements the plan in
[`docs-internal/HANDOFF-fetch-do-not-throw.md`](docs-internal/HANDOFF-fetch-do-not-throw.md).

`on click fetch /api/users as JSON do not throw then if it set $users to it end`
was **lossy in bn/hi/ja/ko/tr** — each parsed to `{on, fetch, if}` and dropped
`set`. The fused SOV event pattern captures `fetch` as the handler action and
routes the trailing `then if … end` through `parseBodyWithGrammarPatterns`, where
a schema-generated bare-`if` pattern (`if-ja-generated-verb-first`,
`if-tr-generated`) swallowed the whole block as a flat `if` with an empty
then-branch — silently dropping the verb-medial `set`.

## The fix (two nested halves, both in `semantic-parser.ts`)

1. **Fold the trailing `if … end` block** instead of leaving it as a flat bare
   `if`, mirroring `parseBodyWithClauses`. Two complementary paths:
   - a **clause-head guard** when the if-keyword is the clause head (ja/ko/bn/hi);
   - a **rewind-on-flat-`if`** when `matchBest` swallows a leaked `as` remnant
     just ahead of the if (tr `olarak eğer`).
   Both flush pending tokens first, so a real verb-medial command in the clause is
   recovered, not lost. A folded `if` strictly dominates the bare one for recall;
   an unfoldable block (no `end`) falls back to the bare `if` unchanged.

2. **Scope the verb-anchoring particle guard to role markers.** A known
   postpositional role marker (`markerToRole`) is never a command verb, so the
   trailing `それ に` of `set $users to it` no longer anchors a phantom `into`
   (ja `に` doubles as the set-value marker *and* an `into` alternative — R0
   precision). Gated on `markerToRole`, **not** `kind==='particle'`, so a
   non-marker clause-final loop keyword (tr `için` / bn `জন্য` = `for`) still
   anchors `for` (caught a `template-literal-list-build` regression mid-arc).

## Verification

- **Multilingual `--regression` gate clean**; baseline regenerated (the change is
  an intentional fidelity improvement). **lossy 48 → 39**, degenerate unchanged.
  - `fetch-do-not-throw`: **5 → 0** lossy (target — all SOV langs faithful)
  - generalizes (one root-cause clears several): `fetch-error-handling` 1→0,
    `form-disable-on-submit` 1→0, `modal-close-escape` 1→0,
    `take-class-from-siblings` 2→1
- Guard tests in `multilingual-roadmap-fixes.test.ts`, **verified red without the
  fix**; a `for`-preservation guard locks the particle-marker scoping.
- Full semantic suite green (6157 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)