### PR TITLE
fix(i18n): repair fronted Hebrew accusative marker in command bodies (he add att-fronting)

### DIFF
--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -1915,3 +1915,42 @@ describe('trigger/send `on <target>` keeps its target — no spurious then (beha
     });
   }
 });
+
+describe('Hebrew fronted accusative marker is repaired (he add-body att-fronting)', () => {
+  // An event-handler body that leads with a command-modifier (`on click once add …`)
+  // or is a control block (`on blur if … add … end`) could emit the accusative
+  // marker את AHEAD of the body command's verb — `add .error to me` rendering
+  // `… את הוסף .error …` instead of the canonical `… הוסף את .error …`. את before a
+  // verb is always ungrammatical Hebrew, and the semantic parser dropped the command
+  // in every parse path (fused-event, multi-clause, conditional-body), keeping he
+  // `if-empty` / `input-validation` / `event-once` lossy. transform() now repairs the
+  // `<accusative-marker> <verb>` adjacency back to `<verb> <accusative-marker>`.
+  const he = (src: string) => new GrammarTransformer('en', 'he').transform(src);
+
+  it('[he] conditional-body add: את follows the verb (not fronted)', () => {
+    const out = he(
+      'on blur if my value is empty add .error to me put "Required" into next .error-message end'
+    );
+    expect(out).toContain('הוסף את .error');
+    expect(out).not.toContain('את הוסף');
+  });
+
+  it('[he] if/else-body add: את follows the verb', () => {
+    const out = he('on blur if my value is empty add .error to me else remove .error from me end');
+    expect(out).toContain('הוסף את .error');
+    expect(out).not.toContain('את הוסף');
+  });
+
+  it('[he] modifier-prefixed (once) body add: את follows the verb', () => {
+    const out = he('on click once add .initialized to me call setup()');
+    expect(out).toContain('הוסף את .initialized');
+    expect(out).not.toContain('את הוסף');
+  });
+
+  it('[he] a legitimate `<verb> את <obj>` form is left untouched', () => {
+    // send already emits `שלח את refresh` (verb then accusative); the repair must only
+    // swap the ungrammatical marker-then-verb adjacency, never a real `<verb> את`.
+    expect(he('send refresh to #widget')).toContain('שלח את refresh');
+    expect(he('add .error to me')).toContain('הוסף את .error');
+  });
+});

--- a/packages/i18n/src/grammar/transformer.ts
+++ b/packages/i18n/src/grammar/transformer.ts
@@ -51,6 +51,36 @@ function getCommandKeywordsForLocale(locale: string): Set<string> {
 }
 
 /**
+ * Repair a FRONTED Hebrew accusative marker in transformed output.
+ *
+ * When an event-handler body leads with a command-modifier (`on click once add …`,
+ * via {@link GrammarTransformer.tryTransformEventWithModifierBody}) or is a control
+ * block (`on blur if … add … end`, via `tryTransformEventWithBlockBody`), the body
+ * command's accusative marker את can be emitted AHEAD of its verb — `add .error to me`
+ * renders `… את הוסף .error …` instead of the canonical `… הוסף את .error …`. את before
+ * a verb is always ungrammatical Hebrew (it only ever marks a FOLLOWING definite
+ * object), and the semantic parser drops the command in every parse path (fused-event,
+ * multi-clause, conditional-body) when the marker is fronted but parses it when the
+ * marker follows the verb. So an `<accusative-marker> <command-verb>` adjacency is a
+ * pure transformer artifact: swap it back. Idempotent and safe — only touches `את
+ * <verb>`, never the ~40 generated `<verb> את {patient}` patterns that embed את legitimately.
+ */
+function repairHebrewFrontedAccusative(text: string): string {
+  const ACC = 'את'; // hebrewProfile.markers patient marker
+  const verbs = getCommandKeywordsForLocale('he');
+  const tokens = text.split(/\s+/);
+  let changed = false;
+  for (let i = 0; i + 1 < tokens.length; i++) {
+    if (tokens[i] === ACC && verbs.has(tokens[i + 1].toLowerCase())) {
+      [tokens[i], tokens[i + 1]] = [tokens[i + 1], tokens[i]];
+      changed = true;
+      i++; // skip the marker we just moved
+    }
+  }
+  return changed ? tokens.join(' ') : text;
+}
+
+/**
  * Split a compound statement into parts at "then" boundaries, newlines,
  * AND command keyword boundaries.
  *
@@ -1641,6 +1671,14 @@ export class GrammarTransformer {
    * For multi-line input, preserves line structure (indentation, blank lines).
    */
   transform(input: string): string {
+    const out = this.transformInternal(input);
+    // Hebrew: repair a fronted accusative marker the body-split heuristics can emit
+    // (`… את הוסף .x …` → `… הוסף את .x …`). Applied to the assembled output; idempotent
+    // across the internal recursion. See repairHebrewFrontedAccusative.
+    return this.targetProfile.code === 'he' ? repairHebrewFrontedAccusative(out) : out;
+  }
+
+  private transformInternal(input: string): string {
     // Caret-scoped variable reads (`^name on <selector>`) carry a second,
     // overloaded `on` that the splitter/event-parser would mistake for an event
     // or command boundary — mangling `put ^count on #host into me`. Mask the

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-22T04:44:08.728Z",
-  "commit": "2d69207e",
+  "timestamp": "2026-06-26T16:12:34.150Z",
+  "commit": "bf4f3be2",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -3792,18 +3792,15 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8244897959183674,
-      "avgFidelity": 0.9786796536796535,
-      "avgPrecision": 0.9851731601731601,
-      "avgRoleFidelity": 0.8861690674190673,
+      "avgFidelity": 0.984090909090909,
+      "avgPrecision": 0.9835497835497835,
+      "avgRoleFidelity": 0.891799698049698,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["unless-condition"],
       "lossyPasses": [
-        "event-once",
         "form-submit-prevent",
         "get-value",
-        "if-empty",
-        "input-validation",
         "last-in-collection",
         "tell-command",
         "tell-other-element"


### PR DESCRIPTION
## Summary

Clears the Hebrew **add-in-body** correctness cluster surfaced by a `he` fidelity triage: `if-empty`, `input-validation`, and `event-once` were all lossy because the i18n transformer fronted the accusative marker `את` ahead of the body command's verb.

When an event-handler body leads with a command-modifier (`on click once add …`) or is a control block (`on blur if … add … end`), `GrammarTransformer` emitted `… את הוסף .error …` instead of the canonical `… הוסף את .error …`. `את` before a verb is always ungrammatical Hebrew (it only ever marks a **following** definite object), and the semantic parser drops the command in **every** parse path (fused-event, multi-clause, conditional-body) when the marker is fronted — but parses it cleanly when the marker follows the verb.

## Fix

A `he`-scoped post-pass in `GrammarTransformer.transform` swaps the ungrammatical `<accusative-marker> <verb>` adjacency back to `<verb> <accusative-marker>`. It is:

- **Idempotent** (safe across the transformer's internal recursion).
- **Tightly scoped** — only touches `את <command-verb>`; never the ~40 generated `<verb> את {patient}` patterns that embed `את` legitimately. Verified: `send refresh to #widget` → `שלח את refresh` and isolated `add .error to me` → `הוסף את .error` are unchanged.

Why the transformer and not the parser: the canonical `verb את obj` form already parses in all three semantic paths; only the fronted form fails. Fixing the single emission point is cleaner and lower-risk than teaching the hot, regression-sensitive parser paths to tolerate an ungrammatical adjacency.

## Results

- Priority gate: **he lossy 8 → 5**, **global lossy 39 → 36**
- `--regression` gate **green** (zero regressions); baseline regenerated
- New guards in `grammar.test.ts` verified **failing without the fix**
- i18n **861** + semantic **6160** tests pass

## Notes

- Per repo convention, `patterns.db` is not committed (CI re-populates); only the transformer fix, the guard test, and the regenerated baseline are included.
- This is the first of three fixes from the `he` triage. The remaining two (get/tell `את`-tolerance; dictionary gaps for `unless`/`match`/`last`/`in` + `scroll to`) are separate, independent defects and will be separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)