### PR TITLE
fix(semantic): he accusative marker for get/tell objects (he get/tell att tolerance)

### DIFF
--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -1160,6 +1160,7 @@ export const getCommandSchema: CommandSchema = {
         ar: 'على', // Arabic preposition: احصل على #element
         tr: 'i', // Turkish accusative: #element i al
         id: '',
+        he: 'את', // Hebrew accusative: קבל את #element (the transformer marks get's object with את)
         sw: '', // Swahili SVO: pata #element (no marker)
         tl: '', // Tagalog VSO: kunin #element (no marker)
         bn: 'কে', // Bengali SOV: #element কে পান (patient marker)
@@ -1946,7 +1947,11 @@ export const tellSchema: CommandSchema = {
       expectedTypes: ['selector', 'reference'],
       svoPosition: 1,
       sovPosition: 1,
-      markerOverride: { en: '' }, // "tell #element ..." (no preposition)
+      // "tell #element ..." (no preposition in en). Hebrew: the transformer marks
+      // tell's object with the accusative את (`אמור את #element`), so the generated
+      // he pattern must expect it — without this the `את` token breaks the match and
+      // `tell` is dropped (tell-command / tell-other-element lossy).
+      markerOverride: { en: '', he: 'את' },
     },
   ],
 };

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -7498,3 +7498,34 @@ describe('`do not throw` fetch modifier strip (fetch-do-not-throw phantom-throw)
     expect(actions.has('throw')).toBe(true);
   });
 });
+
+describe('Hebrew get/tell accusative marker tolerance (he get/tell att, Defect 2)', () => {
+  // The i18n transformer marks get's source and tell's destination with the Hebrew
+  // accusative את (`קבל את #input.value`, `אמור את #modal`), but the generated he
+  // patterns had no `he` markerOverride for those roles — so the `את` token broke the
+  // match and `get`/`tell` were dropped (get-value / tell-command / tell-other-element
+  // lossy). Adding `he: 'את'` to the get-source and tell-destination markerOverride
+  // (mirroring ja を / ko 를 / bn কে / qu ta) lets the generated pattern expect it.
+  const collect = (node: unknown, acc: string[] = []): string[] => {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.push(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => collect(x, acc));
+      else if (c && typeof c === 'object') collect(c, acc);
+    }
+    return acc;
+  };
+
+  it('[he] get with accusative את: `קבל את #input.value` is recognized', () => {
+    const actions = new Set(collect(parse('ב לחיצה קבל את #input.value אז רשום את זה', 'he')));
+    expect(actions.has('get')).toBe(true);
+    expect(actions.has('log')).toBe(true);
+  });
+
+  it('[he] tell with accusative את: `אמור את #modal` is recognized', () => {
+    const actions = new Set(collect(parse('ב לחיצה אמור את #modal על הראה', 'he')));
+    expect(actions.has('tell')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-26T16:12:34.150Z",
-  "commit": "bf4f3be2",
+  "timestamp": "2026-06-26T16:34:55.362Z",
+  "commit": "56babc92",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3792,20 +3792,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8244897959183674,
-      "avgFidelity": 0.984090909090909,
+      "avgFidelity": 0.9911255411255411,
       "avgPrecision": 0.9835497835497835,
-      "avgRoleFidelity": 0.891799698049698,
+      "avgRoleFidelity": 0.89878168003168,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["unless-condition"],
-      "lossyPasses": [
-        "form-submit-prevent",
-        "get-value",
-        "last-in-collection",
-        "tell-command",
-        "tell-other-element"
-      ],
-      "bundleSize": 444307,
+      "lossyPasses": ["form-submit-prevent", "last-in-collection"],
+      "bundleSize": 444343,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4437,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["keydown-key-is-syntax"],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5069,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5701,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6333,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6965,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": ["window-scroll"],
       "lossyPasses": ["if-empty", "input-validation"],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7597,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8229,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8861,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9493,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["append-content", "behavior-draggable", "unless-condition"],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10125,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10757,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11394,7 +11388,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12026,7 +12020,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-resizable"],
       "lossyPasses": [],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12658,7 +12652,7 @@
       "executionFailures": [],
       "degeneratePasses": ["default-value"],
       "lossyPasses": [],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13289,7 +13283,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13927,7 +13921,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14567,7 +14561,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 444307,
+      "bundleSize": 444343,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15190,7 +15184,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 444307,
+      "size": 444343,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Second of the `he`-triage fixes. Clears the Hebrew **get/tell** correctness cluster: `get-value`, `tell-command`, and `tell-other-element` were lossy because the generated he patterns dropped the verb when its object carried the accusative marker `את`.

The i18n transformer marks `get`'s source and `tell`'s destination with the Hebrew accusative `את`:

- `get #input.value` → `קבל את #input.value`
- `tell #modal to show` → `אמור את #modal …`

But the `get`-source and `tell`-destination roles had **no `he` entry** in their `markerOverride` maps — while every other object-marking language does (ja `を`, ko `를`, ar `على`, bn `কে`, qu `ta`). So the stray `את` token broke the generated pattern match and `get`/`tell` were dropped.

## Fix

Add `he: 'את'` to the `get`-source and `tell`-destination `markerOverride` so the generated he pattern expects the accusative — mirroring the existing per-language overrides. Pure schema/generator change; no parser logic touched.

## Results

- Priority gate: **he lossy 5 → 2** (cleared get-value, tell-command, tell-other-element), **global lossy 36 → 33**
- `--regression` gate **green** (zero regressions); baseline regenerated
- New guards in `multilingual-roadmap-fixes.test.ts` verified **failing without the fix**
- Semantic **6162** tests pass

## Context

Builds on #485 (he add att-fronting). Combined, the two PRs take **he lossy 8 → 2**. The remaining he items are a separate dictionary-gap defect (`unless`/`match`/`last`/`in` + `scroll to`), which will be a third PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)