### PR TITLE
fix(i18n): he dictionary entries for scroll/last (he last-in-collection)

### DIFF
--- a/packages/i18n/src/dictionaries/he.ts
+++ b/packages/i18n/src/dictionaries/he.ts
@@ -38,6 +38,7 @@ export const he: Dictionary = {
     render: 'רנדר',
     repeat: 'חזור',
     return: 'החזר',
+    scroll: 'גלול',
     send: 'שלח',
     set: 'קבע',
     settle: 'התייצב',
@@ -101,5 +102,7 @@ export const he: Dictionary = {
 
   attributes: {},
 
-  expressions: {},
+  expressions: {
+    last: 'אחרון',
+  },
 };

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -1954,3 +1954,26 @@ describe('Hebrew fronted accusative marker is repaired (he add-body att-fronting
     expect(he('add .error to me')).toContain('הוסף את .error');
   });
 });
+
+describe('Hebrew scroll/last command translations (he last-in-collection dict gap)', () => {
+  // `scroll` (command) and `last` (positional) were missing from the he i18n
+  // dictionary, so `scroll to last <.message/> in #chat` emitted English scroll/last
+  // that the semantic he parser dropped (last-in-collection lossy — scroll missing).
+  // Adding scroll→גלול and last→אחרון (both already recognized on the semantic side)
+  // makes it faithful. `in` is deliberately NOT translated: it would also rewrite the
+  // `for X in Y` loop iterator and break template-literal-list-build (the for-loop's
+  // English `in` already parses).
+  const he = (s: string) => new GrammarTransformer('en', 'he').transform(s);
+
+  it('[he] scroll command translates to גלול', () => {
+    expect(he('scroll to last <.message/> in #chat')).toContain('גלול');
+  });
+
+  it('[he] positional last translates to אחרון', () => {
+    expect(he('scroll to last <.message/> in #chat')).toContain('אחרון');
+  });
+
+  it('[he] for-loop `in` is left English (not rewritten — guards template-literal-list-build)', () => {
+    expect(he('for item in $items log item')).toContain(' in ');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-26T16:34:55.362Z",
-  "commit": "56babc92",
+  "timestamp": "2026-06-26T17:08:00.794Z",
+  "commit": "e047c00a",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -3792,13 +3792,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8244897959183674,
-      "avgFidelity": 0.9911255411255411,
+      "avgFidelity": 0.9943722943722944,
       "avgPrecision": 0.9835497835497835,
-      "avgRoleFidelity": 0.89878168003168,
+      "avgRoleFidelity": 0.9021600584100584,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": ["unless-condition"],
-      "lossyPasses": ["form-submit-prevent", "last-in-collection"],
+      "lossyPasses": ["form-submit-prevent"],
       "bundleSize": 444343,
       "patterns": {
         "put-content-basic": {


### PR DESCRIPTION
## Summary

Third and final fix from the `he` triage. Makes `last-in-collection` faithful for Hebrew (it was lossy in only `he` and `ms` among the 24 languages).

`scroll` (command) and `last` (positional) were missing from the he i18n dictionary, so `scroll to last <.message/> in #chat` emitted English `scroll`/`last` that the semantic he parser dropped. Both words are **already recognized on the semantic side** (profile `scroll` → גלול, tokenizer `last` → אחרון) — the dictionary just wasn't emitting them.

## Fix

Add `scroll: 'גלול'` and `last: 'אחרון'` to the he dictionary.

`in` is **deliberately not translated**: it is overloaded as the `for X in Y` loop iterator, and translating it rewrites that loop and regresses `template-literal-list-build` (a within-tolerance correctness flip I caught during gating). The for-loop's English `in` already parses, and the positional scope `in #chat` doesn't need translation for faithful action recall. A guard test locks this in.

## Results

- Priority gate: **he lossy 2 → 1** (only `form-submit-prevent` remains), **global lossy 33 → 32**
- `--regression` gate **green** — no within-tolerance flips; baseline regenerated
- New guards in `grammar.test.ts` verified failing without the fix (including the for-loop `in` guard). i18n **865** tests pass

## Scope note — `unless-condition` deferred

The triage also flagged he `unless-condition` (the one remaining he **degenerate**). I prototyped the `unless` keyword translation (`אלא`) but it is **not** a clean dictionary gap: the he transform emits a spurious accusative `את` ahead of the clause subject (`unless I match …` → `אלא את I match …`) and leaves `I match` in English. Faithful languages (de/ar) leave `I match` English and still parse, so the blocker is the spurious `את` + the control-flow body parse — the known-hard `unless-condition` cluster, not a dict gap. Left for a dedicated arc; the `unless` prototype was reverted so this PR stays focused and gate-justified.

## Series

Final of three `he`-triage PRs (#485 add att-fronting, #486 get/tell att-tolerance). Combined: **he lossy 8 → 1**, **he degenerate 1** (unless-condition, deferred above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)