### PR TITLE
chore: pre-approve trusted install scripts for npm 11 (allowScripts)

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,5 +125,11 @@
   "homepage": "https://github.com/codetalcott/hyperfixi#readme",
   "engines": {
     "node": ">=18.0.0"
+  },
+  "allowScripts": {
+    "better-sqlite3": true,
+    "esbuild": true,
+    "fsevents": true,
+    "nx": true
   }
 }


### PR DESCRIPTION
## Summary

npm 11 gates dependency lifecycle (`install`/`postinstall`) scripts by default and prompts for approval — contributors on npm 11 hit `npm warn allow-scripts` on a fresh install. This adds a committed `allowScripts` allowlist (root `package.json`) so build-critical and native packages run their scripts without prompting, while everything else stays gated.

## Approved (by name — patch/minor bumps won't re-trigger the gate)

| Package | Why |
|---------|-----|
| `esbuild` | platform binary; all builds run on it |
| `better-sqlite3` | native bindings (node-gyp); the `patterns.db` tooling needs it |
| `fsevents` | macOS native file-watcher (vitest/rollup watch) |
| `nx` | monorepo orchestrator postinstall (harmless `try/catch`) |

## Deliberately NOT approved

- **`puppeteer`** — its postinstall downloads Chromium. It's an **optional** peer dep, loaded lazily only for `environment: 'puppeteer'` in the testing-framework (and mocked in unit tests); this project's browser path is **Playwright** (separate `playwright install`, not a gated script). Left gated to skip the Chromium download. Run `npm approve-scripts puppeteer` if that test environment is ever needed.

## Safety

- Root package is `private`, so this is a dev/CI-install convenience with **no published-package impact**.
- npm < 11 ignores the unknown field, so it's harmless for contributors still on npm 10.
- The allowlist was generated by `npm approve-scripts --no-allow-scripts-pin …` (npm 11.16.0), not hand-written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)