### PR TITLE
fix(i18n): he inline unless guard parses faithfully (he unless-condition degenerate→faithful)

### DIFF
--- a/docs-internal/HANDOFF-unless-condition-tokenizer.md
+++ b/docs-internal/HANDOFF-unless-condition-tokenizer.md
@@ -218,9 +218,27 @@ low blast radius (`event-hi-bare` is the only bare-event pattern → effectively
    clause — the fused event pattern captures `toggle` and the mid-stream `除非 把 …`
    condition is never reattached. This is the SVO analogue of the SOV event-anchor
    work (priorities handoff item #5); shares shape with vi once vi tokenizes cleanly.
-5. **he degenerate (separate defect).** Not the marker — the **untranslated English
-   condition** in RTL context collapses the body. Belongs with the transformer
-   expression-translation / bidi work, not this cluster.
+5. **he degenerate — ✅ DONE (2026-06-26, PR #490).** Was the lone he degenerate.
+   The prior diagnosis here ("untranslated English condition collapses the body")
+   and the later handoff guess ("a spurious את before the condition subject is THE
+   blocker") were **both wrong** — verified through `ml.parse`, the את ahead of the
+   condition is a **red herring** (removing it alone changes nothing). The real cause:
+   `parseEventHandler` reads the inline `unless` guard as the action and sweeps the
+   whole `<cond> <body>` tail into one `patient` blob, which Hebrew object-marks with
+   את — and the inner toggle **loses its own את**, so the markerless `מתג .selected`
+   fails the he toggle pattern (which requires את) while the fronted את blocks the
+   `unless` pattern. Marker-less langs (de/it/ar/pl) parse the same blob faithfully,
+   so it's a Hebrew accusative-marker artifact. Fix (he-scoped): route the
+   un-terminated inline `unless` guard through the standalone block path
+   (`tryTransformEventWithUnlessGuard` → `extractBlockStructure`/`transformBlock`) so
+   the condition stays marker-free and the body keeps its את + `unless: אלא` in the he
+   dict **and** semantic profile. he transform → `ב לחיצה אלא I match .disabled מתג
+את .selected` → `[on, toggle, unless]` faithful. Priority gate degenerate 4→3,
+   lossy steady (32), zero regressions. Guards in `grammar.test.ts` + `multilingual-
+roadmap-fixes.test.ts`.
+
+The cluster is now down to the **zh structural** item (#4 above) plus the SOV/SVO
+lossy tail (qu/vi/zh `unless-condition`).
 
 ## Gate-faithful repro (recreate, then delete — not committed)
 

--- a/packages/i18n/src/dictionaries/he.ts
+++ b/packages/i18n/src/dictionaries/he.ts
@@ -24,6 +24,7 @@ export const he: Dictionary = {
     halt: 'עצור',
     hide: 'הסתר',
     if: 'אם',
+    unless: 'אלא',
     increment: 'הגדל',
     install: 'התקן',
     js: 'js',

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -1977,3 +1977,32 @@ describe('Hebrew scroll/last command translations (he last-in-collection dict ga
     expect(he('for item in $items log item')).toContain(' in ');
   });
 });
+
+describe('Hebrew event-handler inline `unless` guard (he unless-condition degenerate)', () => {
+  // `on click unless I match .disabled toggle .selected` is an inline guard with no
+  // `end`. parseEventHandler read `unless` as the action and swept the whole
+  // `<cond> <body>` tail into one patient blob; Hebrew then prefixed that blob with
+  // the accusative object marker את (`… אלא את I match .disabled מתג .selected`) and
+  // the inner toggle lost its own את. The semantic parser collapsed that (degenerate):
+  // את ahead of the condition blocks the `unless` pattern, AND the markerless `מתג
+  // .selected` fails the he toggle pattern (which requires את). Marker-less langs
+  // (de/it/ar/pl) parse the same role-blob faithfully — a Hebrew accusative-marker
+  // artifact, not a general gap. The guard now routes through the standalone block
+  // path (extractBlockStructure → transformBlock): condition kept marker-free, body
+  // command keeps its את. Needs the he dict `unless: אלא` entry too.
+  const he = (s: string) => new GrammarTransformer('en', 'he').transform(s);
+
+  it('[he] unless guard: unless translates, condition is marker-free, toggle keeps its את', () => {
+    const out = he('on click unless I match .disabled toggle .selected');
+    expect(out).toContain('אלא I match .disabled'); // unless→אלא, no fronted את before the condition
+    expect(out).not.toContain('אלא את'); // condition is NOT object-marked
+    expect(out).toContain('מתג את .selected'); // body toggle keeps its accusative marker
+    expect(out).not.toContain('unless'); // no English leak
+  });
+
+  it('[he] the event clause leads (SVO): `ב לחיצה` before the unless guard', () => {
+    const out = he('on click unless I match .disabled toggle .selected');
+    expect(out.indexOf('ב לחיצה')).toBeGreaterThanOrEqual(0);
+    expect(out.indexOf('ב לחיצה')).toBeLessThan(out.indexOf('אלא'));
+  });
+});

--- a/packages/i18n/src/grammar/transformer.ts
+++ b/packages/i18n/src/grammar/transformer.ts
@@ -1713,6 +1713,13 @@ export class GrammarTransformer {
       // across the event handler's role soup.
       const eventBlock = this.tryTransformEventWithBlockBody(input);
       if (eventBlock !== null) return eventBlock;
+
+      // Event handler whose body is an un-terminated inline `unless` guard
+      // (`on click unless I match .disabled toggle .selected`): route the guard
+      // through the standalone block path so Hebrew's accusative marker lands on
+      // the body command, not the condition. Hebrew-only; null elsewhere.
+      const eventGuard = this.tryTransformEventWithUnlessGuard(input);
+      if (eventGuard !== null) return eventGuard;
     }
 
     // Check if input has multi-line structure worth preserving
@@ -1935,6 +1942,61 @@ export class GrammarTransformer {
     // rather than substituting in place.
     const eventClause = headOut.replace(placeholder, '').replace(/\s+/g, ' ').trim();
     return [eventClause, blockOut].filter(s => s.length > 0).join(' ');
+  }
+
+  /**
+   * Transform an event handler whose body is an inline `unless` guard with NO
+   * `end` (`on <event> unless <cond> <body>` — the `unless-condition` shape).
+   *
+   * Hebrew-only. `parseEventHandler` reads `unless` as the action and sweeps the
+   * whole `<cond> <body>` tail into a single `patient` blob; Hebrew then prefixes
+   * that blob with the accusative object marker את (`… אלא את I match .disabled מתג
+   * .selected`) and the inner toggle loses its own את. The semantic parser can't
+   * recover the guard from that — את ahead of the condition blocks the `unless`
+   * pattern AND the markerless `מתג .selected` fails the he toggle pattern (which
+   * requires את) — so the body collapses (degenerate). Marker-less languages
+   * (de/it/ar/pl) tolerate the same role-blob and stay faithful, so this is a
+   * Hebrew accusative-marker artifact, not a general parse gap.
+   *
+   * The standalone `unless <cond> <body>` path already produces the correct shape
+   * (`extractBlockStructure` → `transformBlock`: condition kept marker-free, body
+   * command keeps its את — `אלא I match .disabled מתג את .selected`). So we split
+   * the event head off, transform the guard through that path, and emit the event
+   * clause first (he is SVO — event leads). Returns `null` (fall through) when the
+   * input isn't a he event handler with an un-terminated inline `unless` guard.
+   */
+  private tryTransformEventWithUnlessGuard(input: string): string | null {
+    if (this.targetProfile.code !== 'he') return null;
+
+    const tokens = tokenize(input, this.sourceProfile);
+    if (tokens.length === 0) return null;
+    if (!EVENT_KEYWORDS.has(tokens[0]?.toLowerCase())) return null;
+
+    let guardIdx = -1;
+    for (let i = 1; i < tokens.length; i++) {
+      if (tokens[i].toLowerCase() === 'unless') {
+        guardIdx = i;
+        break;
+      }
+    }
+    if (guardIdx <= 0) return null;
+    // The terminated form (`… unless … end`) is handled by
+    // tryTransformEventWithBlockBody's masking path; only take the inline guard.
+    if (tokens[tokens.length - 1].toLowerCase() === 'end') return null;
+
+    const eventHead = tokens.slice(0, guardIdx);
+    const guard = tokens.slice(guardIdx).join(' ');
+
+    // `unless` is a BLOCK_HEAD keyword, so transform() routes the guard through
+    // extractBlockStructure → transformBlock (the standalone shape that parses).
+    const guardOut = this.transform(guard);
+    if (!guardOut) return null;
+
+    const placeholder = 'EVENTGUARDPLACEHOLDER';
+    const headOut = this.transformSingle([...eventHead, placeholder].join(' '));
+    if (!headOut.includes(placeholder)) return null;
+    const eventClause = headOut.replace(placeholder, '').replace(/\s+/g, ' ').trim();
+    return [eventClause, guardOut].filter(s => s.length > 0).join(' ');
   }
 
   /**

--- a/packages/semantic/src/generators/profiles/he.ts
+++ b/packages/semantic/src/generators/profiles/he.ts
@@ -107,6 +107,7 @@ export const hebrewProfile: LanguageProfile = {
     settle: { primary: 'התייצב', normalized: 'settle' },
     // Control flow
     if: { primary: 'אם', normalized: 'if' },
+    unless: { primary: 'אלא', normalized: 'unless' },
     when: { primary: 'כאשר', alternatives: ['כש'], normalized: 'when' },
     where: { primary: 'איפה', alternatives: ['היכן'], normalized: 'where' },
     else: { primary: 'אחרת', alternatives: ['אם לא'], normalized: 'else' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -7447,6 +7447,42 @@ describe('Verb-split reserves the fronted condition (trailing-unless body patien
   }
 });
 
+describe('Hebrew leading `unless` guard (he unless-condition degenerate → faithful)', () => {
+  // he is SVO with a clause-LEADING unless marker (unlike the trailing-SOV ko/bn/ja
+  // cases above). `on click unless I match .disabled toggle .selected` was DEGENERATE
+  // in he: the i18n transformer left `unless` English and emitted a fronted accusative
+  // את ahead of the condition while the toggle lost its own את, collapsing the body.
+  // Two-part fix: (1) the i18n transformer routes the inline unless guard through the
+  // standalone block path (condition marker-free, toggle keeps את — grammar.test.ts
+  // guards that); (2) the he semantic profile gains `unless: אלא` so the leading
+  // marker recognizes as `unless` and the schema-generated `unless {condition}`
+  // pattern anchors. This guard covers (2): without `unless: אלא` in the he profile
+  // the action set drops to {on, toggle} (אלא parses as an unknown identifier).
+  const collectActions = (node: unknown, acc: string[] = []): string[] => {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.push(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => collectActions(x, acc));
+      else if (c && typeof c === 'object') collectActions(c, acc);
+    }
+    return acc;
+  };
+
+  // Corpus-shaped transformer output for `on click unless I match .disabled toggle .selected`.
+  const input = 'ב לחיצה אלא I match .disabled מתג את .selected';
+
+  it('[he] recovers the unless guard alongside the toggle body', () => {
+    expect(canParse(input, 'he')).toBe(true);
+    const actions = new Set(collectActions(parse(input, 'he')));
+    // Without `unless: אלא` in the he profile this set is {on, toggle} — guard red.
+    expect(actions.has('on')).toBe(true);
+    expect(actions.has('toggle')).toBe(true);
+    expect(actions.has('unless')).toBe(true);
+  });
+});
+
 describe('`do not throw` fetch modifier strip (fetch-do-not-throw phantom-throw)', () => {
   // `do not throw` is a fetch error-handling OPTION ("don't throw on error"), not a
   // command — en drops it (no `throw` action). The SOV grammar transform leaks the

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-26T17:08:00.794Z",
-  "commit": "e047c00a",
+  "timestamp": "2026-06-26T19:27:04.605Z",
+  "commit": "fccd8139",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -3791,13 +3791,13 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8244897959183674,
-      "avgFidelity": 0.9943722943722944,
+      "avgConfidence": 0.8237889095031952,
+      "avgFidelity": 0.9987012987012988,
       "avgPrecision": 0.9835497835497835,
-      "avgRoleFidelity": 0.9021600584100584,
+      "avgRoleFidelity": 0.9055384367884368,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["unless-condition"],
+      "degeneratePasses": [],
       "lossyPasses": ["form-submit-prevent"],
       "bundleSize": 444343,
       "patterns": {
@@ -4205,10 +4205,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "copy-to-clipboard": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -4382,6 +4378,10 @@
           "confidence": 0.7142857142857143
         },
         "if-empty": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "unless-condition": {
           "success": true,
           "confidence": 0.7142857142857143
         },


### PR DESCRIPTION
## What

`on click unless I match .disabled toggle .selected` was the **lone Hebrew degenerate** pattern in the priority multilingual gate. This makes it faithful.

## Root cause (corrected from the prior triage)

`parseEventHandler` reads the inline `unless` guard as the action and sweeps the whole `<cond> <body>` tail into one `patient` blob. Hebrew then prefixes that blob with the accusative object marker את (`… אלא את I match .disabled מתג .selected`) and the inner toggle loses its own את. The semantic parser collapses that:

- את ahead of the condition blocks the `unless` pattern, **and**
- the markerless `מתג .selected` fails the he toggle pattern (which requires את).

Marker-less languages (de/it/ar/pl) parse the same role-blob faithfully, so this is a **Hebrew accusative-marker artifact**, not a general parse gap.

> The handoff blamed a spurious את *before the condition subject*. Verifying through `ml.parse` showed that את is a **red herring** — removing it alone changes nothing. The real blockers are the dropped **toggle** marker plus the untranslated **`unless`**.

## Fix (two-part, one defect)

- **i18n** (`transformer.ts` + `dictionaries/he.ts`): route the un-terminated inline `unless` guard through the standalone block path (`extractBlockStructure` → `transformBlock`) so the condition stays marker-free and the body command keeps its את, then emit the event clause first (he is SVO). he-scoped — the existing `parseEventHandler` path is already faithful for the marker-less languages, and VSO (ar) needs the event last. Adds `unless: אלא` to the he dict.
- **semantic** (`profiles/he.ts`): add `unless: אלא` so the leading marker recognizes as `unless` and the schema-generated `unless {condition}` pattern anchors.

Result: he transform → `ב לחיצה אלא I match .disabled מתג את .selected` → `[on, toggle, unless]` faithful.

## Validation

- Priority gate: **degenerate 4→3**, lossy unchanged (32), parse-rate steady **3695/3696**, he avgFidelity → **0.999**, **zero regressions** (`--regression` green). Only band-membership change across all 24 languages: he `unless-condition` degenerate→faithful. Baseline regenerated.
- **867** i18n + **6163** semantic unit tests pass; both packages typecheck clean.
- Guards (both verified red without their enabling change):
  - `grammar.test.ts` → "Hebrew event-handler inline \`unless\` guard" (transformer/dict)
  - `multilingual-roadmap-fixes.test.ts` → "Hebrew leading \`unless\` guard" (profile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)