### PR TITLE
fix(semantic): tr load/install homonym disambiguation (tr default-value degenerate→faithful)

### DIFF
--- a/docs-internal/HANDOFF-multilingual-priorities.md
+++ b/docs-internal/HANDOFF-multilingual-priorities.md
@@ -149,10 +149,22 @@ it; greenfield headroom.
 > **Lower priority / known-hard, not in the ranked set:** `tr window-resize` (the
 > lone hard-fail) — compounded i18n underscore-split (`boyut_değiştir` → `değiştir`
 > collides with `toggle`) + an untranslated `debounced at 200ms` modifier; high-risk
-> multi-part change to the hottest path for the single lowest-ROI pattern. `ko
-window-scroll` / `tr default-value` degenerate are isolated singletons. The
+> multi-part change to the hottest path for the single lowest-ROI pattern. The
 > singleton lossy tail (`get-value`, `set-color-variable`, `tell-*`, …) is per-pattern
 > mop-up — defer behind the clusters above.
+>
+> **Update 2026-06-26.** Two of the four degenerates cleared: **he `unless-condition`**
+> (PR #490 — inline-unless-guard transformer routing + `unless: אלא` he dict/profile;
+> he now fully faithful) and **tr `default-value`** (PR #491 — `load`/`install` `yükle`
+> homonym disambiguation in the tr semantic profile; tr now fully faithful, avgFidelity
+> 1.0). `tr default-value` was NOT actually "known-hard" — it was a routine dict↔profile
+> homonym (the i18n dict already emitted `kur`/`yükle`; only the profile was misaligned).
+> The **2 remaining priority degenerates** (`ko window-scroll`, `tl behavior-resizable`)
+> have grounded, empirically-verified diagnoses + ready-to-resume scope in
+> [`HANDOFF-remaining-degenerate-singletons.md`](HANDOFF-remaining-degenerate-singletons.md).
+> Headline: ko window-scroll is the **SOV `from <source>` handler-head** (the if/else body
+> is a red herring — it parses; ablation-confirmed), the SOV mirror of the merged VSO
+> from-first fix; tl behavior-resizable is the heavy Experimental-3 behavior loop-body arc.
 
 ## How to resume (gate-faithful repro + the gate)
 

--- a/docs-internal/HANDOFF-remaining-degenerate-singletons.md
+++ b/docs-internal/HANDOFF-remaining-degenerate-singletons.md
@@ -1,0 +1,173 @@
+# Handoff — the 2 remaining priority degenerate singletons (ko window-scroll, tl behavior-resizable)
+
+> Written 2026-06-26, after `he unless-condition` (PR #490) and `tr default-value`
+> (PR #491) cleared two of the four degenerates. Read
+> [`MULTILINGUAL_NEXT_STEPS.md`](MULTILINGUAL_NEXT_STEPS.md) +
+> [`HANDOFF-multilingual-priorities.md`](HANDOFF-multilingual-priorities.md) first for
+> the full Tracks 1–5 narrative and the gate workflow; this doc is the **ready-to-resume,
+> grounded** scope for the two degenerates that remain. Both diagnoses below were verified
+> empirically through `ml.parse` (per the methodology lesson — the theorized root cause is
+> usually wrong).
+
+## Where we are (after PR #490 + #491, browser-priority)
+
+The committed baseline (`packages/testing-framework/baselines/multilingual-priority.json`,
+`timestamp`/`commit` stamp each regen) is authoritative — regenerate the leverage map from
+it (the one-liner in `HANDOFF-multilingual-priorities.md` "How to resume"). At the time of
+writing: **parse-rate 3695/3696**, **degenerate 2**, lossy 32.
+
+```
+DEGENERATE (fid < 0.5):
+  window-scroll       ko   ← #1 below
+  behavior-resizable  tl   ← #2 below
+```
+
+`he` and `tr` are now fully faithful. The lossy band is unchanged (still the qu/vi/zh
+`unless-condition` tail, the `set-color-variable`/`get-value` singletons, the behavior
+draggable/resizable lossy tail in ar/th/qu, etc. — see the baseline).
+
+## The gate workflow (unchanged — how #490/#491 were validated)
+
+1. `nvm use` (Node 24). On a fresh node_modules, `npm rebuild better-sqlite3` first
+   (the committed build may be for the wrong NODE_MODULE_VERSION).
+2. Build + populate (the gate REFUSES a stale dist or stale DB):
+   ```
+   npm run test:multilingual:build-deps   # or rebuild the touched packages + build:multilingual-dist in core
+   npm run populate --prefix packages/patterns-reference
+   ```
+3. Gate: `cd packages/testing-framework && npx tsx src/multilingual/cli.ts --full --bundle browser-priority --regression`
+   (must print "✓ No regression"). After an INTENTIONAL fidelity change: `--save-baseline`.
+4. Commit src + test + baseline; **`git checkout -- packages/patterns-reference/data/patterns.db`**
+   (CI repopulates — never commit it). One defect per PR, branch off main. Guards: i18n →
+   `grammar.test.ts`; semantic → `multilingual-roadmap-fixes.test.ts`; **verify the guard fails
+   without the fix** (`git stash` the src, run `-t "<title>"`, pop).
+
+Gate-faithful repro (throwaway under `packages/patterns-reference/scripts/`, delete after —
+NOT committed): the template is in `HANDOFF-multilingual-priorities.md` "Gate-faithful repro".
+jsdom is required (`@hyperfixi/core` touches the DOM at import); the package is CJS so wrap
+top-level await in an `async function main(){…}; main()`. A direct
+`GrammarTransformer.transform(raw)` + `ml.parse(text, lang)` probe (no DB) is faster for
+ablation and matched the gate exactly for both fixes this session.
+
+---
+
+## 1. ko `window-scroll` — SOV `from <source>` handler-head (NOT the if/else body)
+
+**Pattern:** `on scroll from window if window.scrollY > 100 add .sticky to #header else remove .sticky from #header end`
+(en reference action set = `{on, if, add, remove}`).
+
+**Current:** ko parses to **`{scroll}`** only — fully degenerate.
+ko transform: `스크롤 할 때 창 에서 만약 window.scrollY > 100 .sticky 를 추가 #header 에 아니면 .sticky 를 제거 #header 에서 끝`.
+
+**Empirical localization (ablation, 2026-06-26 — verified via `ml.parse`):**
+
+| variant                                                                       | ko result                              |
+| ----------------------------------------------------------------------------- | -------------------------------------- |
+| full (`from window` + if/else)                                                | `{scroll}` — degenerate                |
+| **drop `from window`**, keep if/else                                          | `{on, if, add, remove}` — **FAITHFUL** |
+| `from window`, drop the `if` (`on scroll from window add .sticky to #header`) | `{scroll}` — degenerate                |
+| drop `from window`, drop `else`                                               | `{on, if, add, remove}` — faithful     |
+| `on click … if/else … end` (no from, non-scroll event)                        | faithful                               |
+
+**So the if/else block body is a red herring — it parses fine in ko.** The sole blocker is
+the **`from <source>` modifier on the SOV handler head**. The transform renders it as
+`스크롤 할 때 창 에서` = `scroll <event-marker 할때> window <source-marker 에서>`. With the
+trailing `from`-source present, the parser fails to recognize the event-handler head and falls
+back to anchoring `스크롤` (scroll) as the **scroll command** (a real command — 스크롤 — so it
+shadows the event). Without the from-source, `스크롤 할 때` recognizes as `on scroll` and the
+body parses.
+
+**This is the SOV analogue of the merged VSO from-first handler-head fix** ("Increment 6 —
+VSO from-first event-handler head" in `MULTILINGUAL_NEXT_STEPS.md`, `semantic-parser.ts`,
+which fixed ar/tl by moving a leading `from <source>` to AFTER the event before re-parsing).
+For SOV the from-source renders _after_ the event marker (`<event> 할때 <source> 에서`), so the
+mirror fix is in the SOV event-extraction path: teach the handler-head recognition /
+`trySOVEventExtraction` (+ `SOV_EVENT_MARKERS`, `semantic-parser.ts`) to consume a trailing
+`<source> 에서` (from-source) adjacent to the event marker, so `스크롤` anchors as the event,
+not the scroll command.
+
+**Start here:** reproduce the full vs drop-from-window variants above through `ml.parse`,
+then dump the parse tree / `parseWithConfidence` diagnostics for the full case to see exactly
+where `스크롤` anchors (event vs command pattern). Confirm the `에서` source-marker is the SOV
+source marker and whether the event-extraction fallback even runs when position-0 is a
+command-homonym event word.
+
+**Risk:** MEDIUM–HIGH. This edits the SOV handler-head / event-anchor path — the hottest,
+most regression-sensitive parser code (every passing SOV language). Guard R0/precision/
+parse-rate carefully; the handoff repeatedly flags this convergent SOV arc as deserving a
+dedicated session, not a tail-end increment. The win is bounded (1 degenerate) but the fix
+likely also helps other SOV `from <source>` handlers (e.g. `on input from #x …` shapes) —
+check the lossy tail for collateral upside, and watch for collateral regressions.
+
+**Whether this generalizes beyond ko:** the same from-source-after-event shape exists in every
+SOV lang (ja/ko/tr/qu/hi/bn). window-scroll is only _degenerate_ in ko in the current corpus,
+but a fix here should be validated across all SOV langs (the gate does this automatically).
+
+---
+
+## 2. tl `behavior-resizable` — the heavy Experimental-3 behavior arc
+
+**Pattern:** `install Resizable(...)` — the behavior `source` is the rich async component
+(`packages/behaviors/src/schemas/resizable.schema.ts`):
+
+```
+behavior Resizable(minWidth, minHeight, maxWidth, maxHeight)
+  on pointerdown(clientX, clientY) from me
+    halt the event
+    trigger resizable:start
+    measure width            set startWidth to it
+    measure height           set startHeight to it
+    set startX to clientX    set startY to clientY
+    repeat until event pointerup from document
+      wait for pointermove(clientX, clientY) or pointerup(clientX, clientY) from document
+      set newWidth to startWidth + clientX - startX
+      ... 4× nested `if … then set … end` clamps ...
+      set my *width to newWidth + "px"
+      set my *height to newHeight + "px"
+      trigger resizable:resize
+    end
+    trigger resizable:end
+  end
+end
+```
+
+**Why it's its own arc, not a singleton fix.** This is one of the **Experimental-3** behaviors
+(Draggable/Sortable/Resizable) — the loop-body / `measure` / `repeat until event` / VSO-head
+family tracked in `MULTILINGUAL_NEXT_STEPS.md` **Track 1 item 4** ("Behavior faithful-pass
+tail") and `HANDOFF-multilingual-priorities.md` **#4**. Behaviors are a stated **user
+priority**. tl is the VSO/Austronesian profile — the same family as the merged VSO from-first
+handler-head work (Increment 6), and `behavior-resizable` is _also_ lossy in ar/th and the
+draggable/resizable cluster is lossy in ar/qu/th. The two recurring sub-defects the priorities
+handoff calls out (verify before trusting):
+
+- the **`measure` command** dropping inside the loop body (ar draggable/resizable);
+- a **th-wide** body-parse/tokenizer issue (th is lossy across all four behaviors).
+
+**Start here:** run the gate-faithful repro with `PATTERN=behavior-resizable`, `LANGS=tl,ar,th`,
+and diff the missing actions per lang. Expect the loss to be inside the `repeat until event
+pointerup … end` loop body (the `measure`/`wait`/`set my *width` cluster) and/or the
+`on pointerdown(...) from me` VSO handler head. A `measure` / loop-body fix would likely move
+several behaviors at once (draggable + resizable across ar/qu/th), so scope it as the behavior
+loop-body arc, not a tl-only patch. Cross-reference the merged sortable/draggable increments in
+`MULTILINGUAL_NEXT_STEPS.md` (the loop-block fold + VSO from-first head are already done — build
+on them).
+
+**Risk:** MEDIUM (behavior body-parse), but **higher value** than ko window-scroll because
+behaviors are a user priority and the fix likely clears multiple lossy behavior passes too.
+
+---
+
+## Recommended sequence
+
+Both are independent. Suggested order by value-vs-risk:
+
+1. **tl `behavior-resizable`** first — higher value (behaviors = user priority; the
+   `measure`/loop-body fix likely clears draggable/resizable lossy in ar/qu/th too), and it
+   builds directly on the already-merged behavior increments.
+2. **ko `window-scroll`** second — the SOV from-source handler-head arc. Bounded win but
+   regression-sensitive (hottest SOV path); give it a dedicated session with careful
+   R0/precision/parse-rate guards, as the priorities handoff prescribes for the SOV
+   event-anchor work.
+
+After these two, the priority degenerate band is **empty**; remaining work is the lossy tail
+(Track 4) and the R1/SOV role-fidelity burn-down (Track 3 / #5).

--- a/packages/semantic/src/generators/profiles/turkish.ts
+++ b/packages/semantic/src/generators/profiles/turkish.ts
@@ -142,6 +142,12 @@ export const turkishProfile: LanguageProfile = {
     submit: { primary: 'gönderme', normalized: 'submit' },
     input: { primary: 'giriş', alternatives: ['girdi', 'giris'], normalized: 'input' },
     change: { primary: 'değişiklik', alternatives: ['değişim', 'degisim'], normalized: 'change' },
+    // `load` event: the i18n dict emits yükle for `load`. Without this keyword the
+    // SOV reorder's mid-stream `yükle de` (on load) tokenized as the `install`
+    // command (install's primary was also yükle) and the `on load` handler dropped
+    // — `default-value` was degenerate in tr. install now keys off kur (the form
+    // the dict already emits for install), freeing yükle for the load event.
+    load: { primary: 'yükle', normalized: 'load' },
     // Navigation
     go: { primary: 'git', normalized: 'go' },
     scroll: { primary: 'kaydır', alternatives: ['kaydir'], normalized: 'scroll' },
@@ -178,7 +184,10 @@ export const turkishProfile: LanguageProfile = {
     default: { primary: 'varsayılan', normalized: 'default' },
     init: { primary: 'başlat', normalized: 'init' },
     behavior: { primary: 'davranış', normalized: 'behavior' },
-    install: { primary: 'yükle', alternatives: ['kur', 'yüklemek'], normalized: 'install' },
+    // primary is kur (the form the i18n dict emits for install); yükle is reserved
+    // for the load event (see the `load` keyword above). yüklemek stays as the
+    // infinitive surface form.
+    install: { primary: 'kur', alternatives: ['yüklemek'], normalized: 'install' },
     measure: { primary: 'ölç', normalized: 'measure' },
     beep: { primary: 'bip', normalized: 'beep' },
     break: { primary: 'dur', normalized: 'break' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -7483,6 +7483,43 @@ describe('Hebrew leading `unless` guard (he unless-condition degenerate → fait
   });
 });
 
+describe('Turkish load/install homonym disambiguation (tr default-value degenerate → faithful)', () => {
+  // `on load default my @data-count to "0"` was DEGENERATE in tr. The i18n dict
+  // emits yükle for the `load` event (and kur for install), but the tr profile's
+  // install primary was ALSO yükle. Under the SOV reorder the event surfaces
+  // mid-stream as `yükle de` (on load); the parser read that yükle as the `install`
+  // command and the whole `on load` handler dropped (parse anchored on install,
+  // {on} lost). Fix: register `load: yükle` as a tr event and move install's primary
+  // to kur (the form the dict already emits for install), freeing yükle for `load`.
+  const collectActions = (node: unknown, acc: string[] = []): string[] => {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.push(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => collectActions(x, acc));
+      else if (c && typeof c === 'object') collectActions(c, acc);
+    }
+    return acc;
+  };
+
+  // Corpus-shaped transformer output for `on load default my @data-count to "0"`.
+  const input = 'benim @data-count i yükle de varsayılan "0" e';
+
+  it('[tr] recovers the on-load handler (not mis-anchored as install)', () => {
+    const actions = new Set(collectActions(parse(input, 'tr')));
+    // Before the fix the parse anchored on `install` and lost {on}.
+    expect(actions.has('on')).toBe(true);
+    expect(actions.has('install')).toBe(false);
+  });
+
+  it('[tr] install still parses via kur — freeing yükle does not regress install', () => {
+    // `install Draggable` → SOV reorder → `Draggable i kur` (the dict emits kur).
+    const actions = new Set(collectActions(parse('Draggable i kur', 'tr')));
+    expect(actions.has('install')).toBe(true);
+  });
+});
+
 describe('`do not throw` fetch modifier strip (fetch-do-not-throw phantom-throw)', () => {
   // `do not throw` is a fetch error-handling OPTION ("don't throw on error"), not a
   // command — en drops it (no `throw` action). The SOV grammar transform leaks the

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-26T19:27:04.605Z",
-  "commit": "fccd8139",
+  "timestamp": "2026-06-26T20:08:48.626Z",
+  "commit": "b9d4d3f9",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["form-submit-prevent"],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["keydown-key-is-syntax"],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": ["window-scroll"],
       "lossyPasses": ["if-empty", "input-validation"],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["append-content", "behavior-draggable", "unless-condition"],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11388,7 +11388,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12020,7 +12020,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-resizable"],
       "lossyPasses": [],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12644,15 +12644,15 @@
       "parseSuccess": 153,
       "parseFailure": 1,
       "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8329265429368624,
-      "avgFidelity": 0.9934640522875817,
-      "avgPrecision": 0.941231997849645,
-      "avgRoleFidelity": 0.7998540197519788,
+      "avgConfidence": 0.8296585690806532,
+      "avgFidelity": 1,
+      "avgPrecision": 0.9444999717058541,
+      "avgRoleFidelity": 0.8066567408404142,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["default-value"],
+      "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12767,10 +12767,6 @@
           "confidence": 1
         },
         "log-element": {
-          "success": true,
-          "confidence": 1
-        },
-        "default-value": {
           "success": true,
           "confidence": 1
         },
@@ -13158,6 +13154,10 @@
           "success": true,
           "confidence": 0.5
         },
+        "default-value": {
+          "success": true,
+          "confidence": 0.5
+        },
         "async-block": {
           "success": true,
           "confidence": 0.5
@@ -13283,7 +13283,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13921,7 +13921,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14561,7 +14561,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 444343,
+      "bundleSize": 444376,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15184,7 +15184,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 444343,
+      "size": 444376,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## What

`on load default my @data-count to "0"` was the **lone Turkish degenerate** pattern. This makes it faithful — and tr is now **fully faithful** (avgFidelity 1.0, zero degenerate/lossy).

## Root cause

The i18n dict already disambiguates the Turkish `load`/`install` homonym (`load: yükle`, `install: kur`), but the tr **semantic profile** did not: `install`'s primary was *also* `yükle`, and tr had no `load` event keyword. Under the SOV reorder the event surfaces mid-stream as `yükle de` (on load) — the parser read that `yükle` as the **`install` command** and the whole `on load` handler dropped (parse anchored on `install`, `{on}` lost).

This is the same dict↔profile-alignment family as the prior id `toggle` / qu·tl `get` / sw `ingizo` / ms `socket` fixes.

## Fix (semantic profile only)

- Register `load: yükle` as a tr event keyword.
- Move `install`'s primary to `kur` (the form the dict already emits for install), keeping `yüklemek` as the infinitive alternative — freeing `yükle` for `load`.

No i18n change needed (the dict was already aligned).

## Validation

- `install Draggable` → SOV → `Draggable i kur` still parses as `install`, so freeing `yükle` does **not** regress install-behavior (verified before/after).
- Priority gate: **degenerate 3→2**, lossy unchanged, parse-rate steady **3695/3696**, **zero regressions** (`--regression` green). Only band-membership change across all 24 languages: tr `default-value` degenerate→faithful. tr avgFidelity → **1.0**. Baseline regenerated.
- **6165** semantic tests pass; typecheck clean.
- Guard: `multilingual-roadmap-fixes.test.ts` → "Turkish load/install homonym disambiguation" — on-load recovery is red without the fix; the install-behavior regression check stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)