### PR TITLE
fix(semantic): ko window-scroll command-homonym event head (degenerate→faithful)

### DIFF
--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -416,6 +416,36 @@ export class SemanticParserImpl implements ISemanticParser {
             : midLoop;
           return withDiagnostics(result, diagnostics);
         }
+      } else if (
+        SemanticParserImpl.KNOWN_EVENTS.has(commandMatch.pattern.command) &&
+        this.hasSOVEventMarkerHead(parseInput, language)
+      ) {
+        // SOV command-homonym event head (ko `window-scroll`): the handler's event
+        // word is also a real command (`스크롤` = scroll event AND scroll command).
+        // With no single-token event marker, ko's Stage-1 fused event pattern can't
+        // anchor once a `from <source>` clause (`창 에서`) splits the head, so Stage 2
+        // matches `스크롤` as the scroll command (absorbing `from window` as a role) and
+        // returns before Stage 3. When the matched action is itself a known event AND
+        // the input carries an SOV event-marker head (`스크롤 할 때` = "on scroll"),
+        // prefer SOV extraction — it anchors the homonym as the event and re-parses the
+        // body (the same path that already parses the non-homonym `클릭 … 창 에서 …`
+        // faithfully). trySOVEventExtraction returns null for a genuine bare command
+        // (no marker head / unparseable body), so this is additive. Mirrors the
+        // BLOCK_BODY_ACTIONS guard above.
+        const sovHomonym = this.trySOVEventExtraction(parseInput, language, sortedPatterns);
+        if (sovHomonym) {
+          diagnostics.push(
+            parseDiagnostic(
+              `SOV event extraction preferred over command-homonym event ${commandMatch.pattern.command}`,
+              'info',
+              'stage-sov-homonym'
+            )
+          );
+          const result = modifiers
+            ? this.applyModifiers(sovHomonym as EventHandlerSemanticNode, modifiers)
+            : sovHomonym;
+          return withDiagnostics(result, diagnostics);
+        }
       } else if (tryGetProfile(language)?.wordOrder === 'VSO') {
         // VSO (verb-initial: ar, tl): a *plain* leading command (not a block/loop)
         // can be followed by a mid-stream event clause — `احذف .x من .y عند نقر ثم …`
@@ -2034,6 +2064,54 @@ export class SemanticParserImpl implements ISemanticParser {
       if (phrase.every((w, j) => allTokens[startIdx + j]?.value === w)) return phrase.length;
     }
     return 0;
+  }
+
+  /**
+   * Does the input carry an SOV event-handler head — a known-event token
+   * immediately followed by this language's single-token event marker (ja で,
+   * tr de/da/te/ta, …) or multi-token marker phrase (ko 할 때)?
+   *
+   * Used to distinguish a genuine standalone command from an event handler whose
+   * verb is a command-homonym event word (scroll/resize/focus/…). With no
+   * single-token event marker (ko), the Stage-1 fused event pattern can't anchor
+   * once a `from <source>` clause (`창 에서`) splits the head, so Stage 2 matches the
+   * homonym as its literal command and returns before the SOV extraction stage. This
+   * structural cue (`<event> <marker>`) gates the Stage-2 preference for SOV
+   * extraction, so a real bare command (`스크롤 #panel` — no marker) is untouched.
+   * Returns false for languages with no SOV event-marker config.
+   */
+  private hasSOVEventMarkerHead(input: string, language: string): boolean {
+    const eventMarkers = SemanticParserImpl.SOV_EVENT_MARKERS[language];
+    if (eventMarkers === undefined) return false;
+
+    const { tokens } = tokenizeInternal(input, language);
+    const langEvents = eventNameTranslations[language];
+    const nativeEventNames = new Set<string>();
+    if (langEvents) {
+      for (const native of Object.keys(langEvents)) nativeEventNames.add(native.toLowerCase());
+    }
+
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i];
+      const value = token.value.toLowerCase();
+      const normalized = token.normalized?.toLowerCase();
+      const isEvent =
+        (!!normalized && SemanticParserImpl.KNOWN_EVENTS.has(normalized)) ||
+        SemanticParserImpl.KNOWN_EVENTS.has(value) ||
+        nativeEventNames.has(value);
+      if (!isEvent) continue;
+
+      const next = tokens[i + 1];
+      if (
+        next &&
+        (next.kind === 'particle' || next.kind === 'keyword') &&
+        eventMarkers.has(next.value)
+      ) {
+        return true;
+      }
+      if (this.matchEventMarkerPhrase(tokens, i + 1, language) > 0) return true;
+    }
+    return false;
   }
 
   /**

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -7602,3 +7602,48 @@ describe('Hebrew get/tell accusative marker tolerance (he get/tell att, Defect 2
     expect(actions.has('tell')).toBe(true);
   });
 });
+
+describe('Korean command-homonym event head (ko window-scroll degenerate → faithful)', () => {
+  // `on scroll from window if … add … else remove … end` was DEGENERATE in ko ({scroll}).
+  // ko's event word `스크롤` is ALSO the `scroll` command. With no single-token event
+  // marker, ko's Stage-1 fused event pattern can't anchor once the `from window` clause
+  // (`창 에서`) splits the handler head — so Stage 2 matched `스크롤` as the scroll command
+  // (absorbing `from window` as a role) and returned before the SOV extraction stage, losing
+  // the whole if/else body. Fix: when Stage 2 matches a command whose action is a known-event
+  // homonym AND the input carries an SOV event-marker head (`스크롤 할 때` = "on scroll"),
+  // prefer SOV extraction (hasSOVEventMarkerHead gate). The body itself always parsed — a
+  // non-homonym event (`클릭 … 창 에서 …`) was already faithful via the same path.
+  const collectActions = (node: unknown, acc: string[] = []): string[] => {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.push(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => collectActions(x, acc));
+      else if (c && typeof c === 'object') collectActions(c, acc);
+    }
+    return acc;
+  };
+
+  // Corpus-shaped transformer output for
+  // `on scroll from window if window.scrollY > 100 add .sticky to #header else remove .sticky from #header end`.
+  const input =
+    '스크롤 할 때 창 에서 만약 window.scrollY > 100 .sticky 를 추가 #header 에 아니면 .sticky 를 제거 #header 에서 끝';
+
+  it('[ko] anchors `스크롤` as the event, not the scroll command', () => {
+    const actions = new Set(collectActions(parse(input, 'ko')));
+    // Before the fix the parse anchored on the scroll command and lost the if/else body.
+    expect(actions.has('on')).toBe(true);
+    expect(actions.has('if')).toBe(true);
+    expect(actions.has('add')).toBe(true);
+    expect(actions.has('remove')).toBe(true);
+    expect(actions.has('scroll')).toBe(false);
+  });
+
+  it('[ko] a genuine bare scroll command (no event-marker head) is untouched', () => {
+    // `스크롤 #panel` has no `할 때` head, so hasSOVEventMarkerHead is false and the guard
+    // does not fire — the scroll command still parses as `scroll`.
+    const node = parse('스크롤 #panel', 'ko');
+    expect(node.action).toBe('scroll');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-26T20:08:48.626Z",
-  "commit": "b9d4d3f9",
+  "timestamp": "2026-06-26T22:53:27.390Z",
+  "commit": "ba6504c9",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["form-submit-prevent"],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["keydown-key-is-syntax"],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6952,14 +6952,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8170870900194204,
-      "avgFidelity": 0.9902597402597403,
-      "avgPrecision": 0.935800373868556,
-      "avgRoleFidelity": 0.7947874385374385,
+      "avgFidelity": 0.9967532467532467,
+      "avgPrecision": 0.9422938803620624,
+      "avgRoleFidelity": 0.8015441952941952,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
-      "degeneratePasses": ["window-scroll"],
+      "degeneratePasses": [],
       "lossyPasses": ["if-empty", "input-validation"],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["last-in-collection", "set-color-variable"],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["get-value"],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["append-content", "behavior-draggable", "unless-condition"],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event", "set-color-variable"],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11388,7 +11388,7 @@
         "behavior-resizable",
         "behavior-sortable"
       ],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12020,7 +12020,7 @@
       "executionFailures": [],
       "degeneratePasses": ["behavior-resizable"],
       "lossyPasses": [],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12652,7 +12652,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13283,7 +13283,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13921,7 +13921,7 @@
         "set-color-variable",
         "unless-condition"
       ],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14561,7 +14561,7 @@
         "tell-other-element",
         "unless-condition"
       ],
-      "bundleSize": 444376,
+      "bundleSize": 445149,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15184,7 +15184,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 444376,
+      "size": 445149,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## What

`on scroll from window if … add … else remove … end` was **degenerate** in ko (`{scroll}` only, fid 0.000) — while **ja parses the identical pattern faithfully**.

ko's event word `스크롤` is also the `scroll` command. With no single-token event marker, ko's Stage-1 fused event pattern can't anchor once the `from window` clause (`창 에서`) splits the handler head — so **Stage 2 matched `스크롤` as the scroll command** (absorbing `from window` as a role) and returned before the SOV extraction stage, dropping the whole if/else body.

The body itself always parsed: a non-homonym event (`클릭 … 창 에서 …`) was already faithful via `trySOVEventExtraction`; the sole blocker was Stage 2 short-circuiting on the command-homonym match.

## Fix

When Stage 2 matches a command whose action is a known-event homonym **AND** the input carries an SOV event-marker head (`스크롤 할 때` = "on scroll", via the new `hasSOVEventMarkerHead` gate), prefer SOV extraction. Additive — `trySOVEventExtraction` returns null for a genuine bare command (no marker head / unparseable body), and `스크롤 #panel` still parses as the scroll command. Mirrors the existing `BLOCK_BODY_ACTIONS` guard.

> Note: this corrects the handoff's hypothesis — the blocker was Stage 2 short-circuiting on the homonym, **not** `trySOVEventExtraction` needing to consume a trailing from-source (it already did).

## Validation

- Priority gate: **degenerate 2 → 1** (only tl behavior-resizable remains), lossy unchanged (32), parse-rate unchanged (3695/3696).
- ko avgFidelity 0.990→0.997, avgPrecision 0.936→0.942, avgRoleFidelity 0.795→0.802; **zero regressions**.
- 6167 semantic tests pass. Guard: `multilingual-roadmap-fixes.test.ts` "Korean command-homonym event head" — **verified failing without the fix**.
- Baseline regenerated against a freshly populated `patterns.db` (db not committed, CI repopulates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)