### PR TITLE
fix(semantic): drop th event-role marker so trigger/send parse (th behaviors lossy→faithful)

### DIFF
--- a/packages/semantic/src/generators/profiles/thai.ts
+++ b/packages/semantic/src/generators/profiles/thai.ts
@@ -51,7 +51,13 @@ export const thaiProfile: LanguageProfile = {
     destination: { primary: 'ใน', alternatives: ['ไปยัง'], position: 'before' },
     source: { primary: 'จาก', position: 'before' },
     style: { primary: 'ด้วย', position: 'before' },
-    event: { primary: 'เมื่อ', position: 'before' },
+    // No `event` role marker: a command's event argument (`trigger foo` /
+    // `send foo`) is an UNMARKED object in Thai, like every other SVO profile
+    // (es/zh/id/…). `เมื่อ` is the temporal "when/on" marker and belongs only on
+    // the event-HANDLER head — which uses `eventHandler.eventMarker` (below),
+    // not this role marker. Carrying it here generated `ทริกเกอร์ เมื่อ {event}`,
+    // which never matched the transformer's `ทริกเกอร์ {event}` → trigger/send
+    // dropped (th behavior-draggable/removable/resizable/sortable lossy).
   },
   keywords: {
     // Class/Attribute operations

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -7647,3 +7647,26 @@ describe('Korean command-homonym event head (ko window-scroll degenerate → fai
     expect(node.action).toBe('scroll');
   });
 });
+
+describe('Thai event-argument is unmarked (th trigger/send — behavior lossy → faithful)', () => {
+  // th was the only SVO profile carrying a `roleMarkers.event` (`เมื่อ`, the temporal
+  // "when/on" marker). The generated `trigger`/`send` command pattern therefore expected
+  // `ทริกเกอร์ เมื่อ {event}`, but the transformer emits an UNMARKED object `ทริกเกอร์
+  // {event}` — so the pattern never matched and `trigger`/`send` were dropped. This made th
+  // the only language lossy across ALL FOUR behaviors (draggable/removable/resizable/
+  // sortable), each missing exactly `trigger`. Fix: drop `roleMarkers.event` so th matches
+  // its SVO peers (es/zh/id/…); `เมื่อ` stays on the event-HANDLER head via
+  // `eventHandler.eventMarker`, which is unaffected.
+  it('[th] `trigger <event>` parses (namespaced event arg)', () => {
+    expect(parse('ทริกเกอร์ resizable:start', 'th').action).toBe('trigger');
+  });
+
+  it('[th] `send <event>` parses', () => {
+    expect(parse('ส่ง foo', 'th').action).toBe('send');
+  });
+
+  it('[th] event HANDLER still parses (eventHandler.eventMarker untouched)', () => {
+    // `on click toggle .active` → th. Removing the role marker must not break the head.
+    expect(parse('เมื่อ คลิก สลับ .active', 'th').action).toBe('on');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-26T23:58:13.869Z",
-  "commit": "84bcac01",
+  "timestamp": "2026-06-27T03:12:03.708Z",
+  "commit": "e4769152",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -11376,18 +11376,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.840857555143267,
-      "avgFidelity": 0.997005772005772,
-      "avgPrecision": 0.9735930735930735,
-      "avgRoleFidelity": 0.8247500247500248,
+      "avgFidelity": 1,
+      "avgPrecision": 0.9737012987012986,
+      "avgRoleFidelity": 0.8291571791571792,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": [
-        "behavior-draggable",
-        "behavior-removable",
-        "behavior-resizable",
-        "behavior-sortable"
-      ],
+      "lossyPasses": [],
       "bundleSize": 445149,
       "patterns": {
         "toggle-class-on-other": {


### PR DESCRIPTION
Implements **Arc 1** of the lossy-tail handoff (#494) — the empirically grounded arc.

## What

th was the only language lossy across **all four** behaviors (draggable/removable/resizable/sortable), each missing exactly **`trigger`**.

Root cause: th was the **only SVO profile** carrying a `roleMarkers.event` — `เมื่อ`, the temporal "when/on" marker, positioned *before*. So the generated `trigger`/`send` command patterns expected `ทริกเกอร์ เมื่อ {event}`, but the i18n transformer emits the event as an **unmarked object** (`ทริกเกอร์ {event}`, like every other SVO language). The pattern never matched → `trigger`/`send` dropped.

| profile group | event role marker | trigger round-trips? |
|---|---|---|
| SVO (es/fr/de/it/pt/id/ms/sw/vi/zh) | **none** | ✅ |
| SOV that works (ja/ko/tr) | accusative object `を`/`을`/`i` (after) | ✅ |
| **th** | **`เมื่อ` (before)** ← anomaly | ❌ |

## Fix

Drop `roleMarkers.event` from the th profile so trigger/send generate `ทริกเกอร์ {event}` / `ส่ง {event}`, matching th's SVO peers. `เมื่อ` stays on the event-**handler** head via the separate `eventHandler.eventMarker` (untouched — handlers still parse).

## Validation

- Priority gate: **lossy 32 → 28** (all four th behaviors faithful, fid 1.000), degenerate still 0, parse-rate 3695/3696, **zero regressions**, no avg-metric drop in any language.
- 6170 semantic tests pass. Guard: `multilingual-roadmap-fixes.test.ts` "Thai event-argument is unmarked" — trigger/send **verified failing without the fix**; the event-handler regression guard holds. Baseline regenerated.

> Note: qu/bn/hi also drop `trigger` standalone — a separate **SOV** event-role/marker issue (different markers, positioned after), not this SVO fix. Tracked for a later arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)