### PR TITLE
docs(multilingual): mark Arc 1 done, record qu/bn/hi-trigger dead-end + qu-repeat grounding

### DIFF
--- a/docs-internal/HANDOFF-lossy-tail.md
+++ b/docs-internal/HANDOFF-lossy-tail.md
@@ -13,27 +13,31 @@
 
 ## Where we are (browser-priority, baseline `multilingual-priority.json`)
 
-The committed baseline is authoritative (`timestamp`/`commit` stamp each regen). At the time
-of writing (stamp `84bcac01`, post #492/#493):
+The committed baseline is authoritative (`timestamp`/`commit` stamp each regen).
 
-| Signal                        | Value                                                    |
+> **Update 2026-06-27 (Arc 1 DONE — #495, lossy 32 → 28).** th's four behaviors
+> (draggable/removable/resizable/sortable) are now faithful: th was the only SVO profile
+> carrying a `roleMarkers.event` (`เมื่อ`), so `trigger`/`send` command patterns expected
+> `ทริกเกอร์ เมื่อ {event}` but the transformer emits the unmarked object `ทริกเกอร์ {event}`.
+> Dropped the marker → matches the SVO peers. The numbers below are the **pre-#495** snapshot
+> (stamp `84bcac01`); the leverage map is updated. Regenerate from the baseline before use.
+
+| Signal                        | Value (post-#495)                                        |
 | ----------------------------- | -------------------------------------------------------- |
 | parse rate                    | **3695 / 3696** (1 hard fail: `tr window-resize`)        |
 | degenerate (fid < 0.5)        | **0** ✅                                                 |
-| lossy (0.5 ≤ fid < 1.0)       | **32**                                                   |
-| avgFidelity (R0-recall)       | 0.997                                                    |
-| avgPrecision (R0 trust floor) | 0.970                                                    |
+| lossy (0.5 ≤ fid < 1.0)       | **28**                                                   |
+| avgFidelity (R0-recall)       | ~0.997                                                   |
+| avgPrecision (R0 trust floor) | ~0.970                                                   |
 | avgRoleFidelity (R1)          | **0.842 — the laggard** (hi 0.750 · qu 0.779 · bn 0.784) |
 
-### The lossy leverage map (regenerate from the baseline — do NOT trust after more lands)
+### The lossy leverage map (post-#495 — regenerate from the baseline; do NOT trust after more lands)
 
 ```
 behaviors (loop-body family):
-  behavior-draggable (3)   ar,qu,th
-  behavior-resizable (2)   ar,th
+  behavior-draggable (2)   ar,qu     ← qu drops `repeat` (Arc 2; grounded below)
+  behavior-resizable (1)   ar        ← ar drops `measure` (Arc 2)
   repeat-until-event (2)   ar,sw
-  behavior-removable (1)   th
-  behavior-sortable  (1)   th
 non-behavior clusters:
   set-color-variable (4)   ms,sw,vi,zh   ← biggest non-behavior cluster
   get-value          (3)   de,pl,zh
@@ -113,10 +117,29 @@ import { MultilingualHyperscript } from '@hyperfixi/core/multilingual';
 
 ---
 
-## Arc 1 — th behaviors: `trigger`/`send` (event-category commands) don't parse [GROUNDED]
+## Arc 1 — th behaviors: `trigger`/`send` (event-category commands) don't parse [DONE — #495]
 
-**This is the recommended next arc.** th is the **only** language lossy across **all four**
-behaviors, and the loss is a **single root cause**.
+> **DONE (2026-06-27, #495 — lossy 32 → 28).** Root cause confirmed as predicted: th was the
+> only SVO profile carrying a `roleMarkers.event` (`เมื่อ`, the temporal "when/on" marker), so
+> `trigger`/`send` generated `ทริกเกอร์ เมื่อ {event}` while the transformer emits the unmarked
+> object `ทริกเกอร์ {event}`. Fix: drop `roleMarkers.event` from the th profile (handlers keep
+> `เมื่อ` via `eventHandler.eventMarker`). All four th behaviors faithful, zero regressions. The
+> grounding below is kept for provenance.
+>
+> **Sibling dead-end — qu/bn/hi standalone `trigger` (investigated 2026-06-27, NOT shipped).**
+> `trigger foo` also throws standalone in qu/bn/hi (same family: their `roleMarkers.event` is a
+> LOCATIVE — qu `pi`, bn `তে`, hi `पर` — but the transformer emits the ACCUSATIVE object marker
+> qu `ta` / bn `কে` / hi `को`, the same value as `patient`, exactly as ja を / ko 을 / tr do). BUT
+> this is **gate-invisible**: bn/hi behaviors are already faithful (their in-body trigger parses
+> via a different path), and qu's only behavior loss is `repeat`, not `trigger`. Setting
+> `roleMarkers.event = patient` was tried: it cleanly fixes **bn** but **qu** (with a destination)
+> still throws and **hi** still mis-parses as `on` — they tangle with the SOV event-anchor path
+> (the hottest, most regression-sensitive parser code). A half-working change to that path for
+> **zero gate gain** is a bad trade — reverted. Revisit only as part of a deliberate SOV
+> event-anchor arc (Arc 4 / Track 3), not as a singleton.
+
+**Original grounding (the recommended-next-arc framing, now resolved):** th is the **only**
+language lossy across **all four** behaviors, and the loss is a **single root cause**.
 
 **Verified (2026-06-27, via `ml.parse` + standalone `parse`):**
 
@@ -157,23 +180,40 @@ in one fix (and likely th `send`).
 
 ---
 
-## Arc 2 — behavior loop-body `measure` drop (ar) [VERIFY FIRST]
+## Arc 2 — behavior loop-body: SOV `repeat`-block fold (qu) + ar `measure` [PARTLY GROUNDED]
 
-**Hypothesis (from the priorities handoff — NOT yet re-verified this session):** `behavior-draggable`
-(ar) + `behavior-resizable` (ar) drop the **`measure`** command (`measure width` / `measure
-height` / `measure x/y`) inside the `repeat until event pointerup … end` loop body;
-`repeat-until-event` (ar/sw) is the same loop-body family. A `measure`/loop-body fix would likely
-move several at once.
+This is the loop-body family — `behavior-draggable` (ar drops `measure`, **qu drops `repeat`**),
+`behavior-resizable` (ar drops `measure`), `repeat-until-event` (ar/sw). The handoff says this
+arc **deserves a dedicated session** (intricate, regression-sensitive parser work).
 
-**Start here:** `PATTERN=behavior-resizable LANGS=ar` through the repro and confirm the missing
-action is `measure` (the prior handoff's note; ar resizable was 0.667→0.889 after the #493 paren
-fix, so re-check what it drops NOW). Then isolate `measure width` in ar — tokenize + parse it
-standalone, and check the ar `measure` keyword/pattern the same way Arc 1 localized th `trigger`.
-The tl paren fix (#493) already cleared the ar handler-head mangling, so the residual is narrower
-than the priorities handoff assumed — **re-localize before trusting the `measure` framing.**
+**qu `repeat` — GROUNDED (2026-06-27).** qu `behavior-draggable` drops exactly `repeat` (fid
+0.875): the SOV verb-final `repeat until event pointerup from document` loop head renders as
+`hayk_akama ruway pointerup ta qillqa manta kutipay` (`kutipay` = repeat, clause-FINAL). The body
+commands (`wait`/`add`/`trigger`) are recovered, but the `repeat` loop NODE is never created.
+Root cause: **`parseBodyWithClauses` has no loop-block fold** — it folds `if`/`unless` (via
+`tryParseConditionalBlock`) and `js` blocks, but a `repeat … end` block is handled only by
+depth-aware `end` tracking, so for an SOV verb-final opener the body flattens and `repeat` drops.
+The real fix is a `tryParseLoopBlock` analogous to the conditional fold (emit a loop node wrapping
+the body when the clause opens a `repeat`/`while`/`for` block) — **Arc-2-scale, MEDIUM risk**
+(`parseBodyWithClauses` is on the hottest body-parse path).
 
-**Risk:** MEDIUM (behavior body-parse). **Value:** likely clears ar draggable + resizable (+ maybe
-`repeat-until-event`).
+> **Prerequisite sub-fix (found, not yet shipped):** the i18n qu dict emits `until: 'hayk_akama'`,
+> which the qu tokenizer splits on `_` (`hayk`/`_`/`a`/`kama`) — only `kama` survives as `until`.
+> Aligning the dict to single-token `until: 'kama'` (the profile's primary) cleans the loop head
+> but **does not, alone, recover `repeat`** (verified — still fid 0.875: the missing fold is the
+> real blocker). Do both together in the dedicated session. (Many other qu dict words also carry
+> `_`; only the ones the profile expects single-token matter — same family as ru/uk install, tr
+> resize, hi append.)
+
+**ar `measure` — hypothesis, NOT re-verified this session.** ar `behavior-draggable`/`resizable`
+drop `measure` (`measure width`/`x`/`y`) inside the loop body. Start: `PATTERN=behavior-resizable
+LANGS=ar`, confirm the missing action is `measure` NOW (it was 0.667→0.889 after the #493 paren
+fix), then isolate `measure width` in ar (tokenize + parse standalone). **Re-localize before
+trusting the `measure` framing.**
+
+**Risk:** MEDIUM (loop-body / hottest body-parse path). **Value:** the loop-block fold likely
+clears qu `repeat` + helps ar/sw `repeat-until-event`; the ar `measure` fix clears ar draggable +
+resizable.
 
 ---
 
@@ -222,7 +262,12 @@ it a dedicated arc with careful R0/precision/parse-rate guards — not a tail-en
 
 ## Recommended sequence
 
-1. **Arc 1 (th `trigger`/`send`)** — grounded, bounded, behavior-priority, clears 4 lossy.
-2. **Arc 2 (ar `measure`)** — re-localize, then likely clears ar draggable + resizable.
-3. **Arc 3 (`set-color-variable`)** — biggest non-behavior cluster; diagnose first.
-4. **Arc 4 (R1/SOV)** — dedicate a guarded session; highest headroom, highest risk.
+1. ~~**Arc 1 (th `trigger`/`send`)**~~ **DONE (#495)** — lossy 32 → 28. (qu/bn/hi-trigger sibling
+   investigated + intentionally NOT shipped — see the Arc 1 dead-end note.)
+2. **Arc 3 (`set-color-variable`)** — biggest non-behavior cluster (4); diagnose the layer first.
+   The cleanest bounded next target.
+3. **Arc 2 (loop-body)** — the SOV `repeat`-block fold (qu, grounded) + ar `measure`; a
+   **dedicated session** (intricate, hottest body-parse path). Do the qu `until` underscore
+   prerequisite together with the `tryParseLoopBlock` fold.
+4. **Arc 4 (R1/SOV)** — dedicate a guarded session; highest headroom, highest risk. Owns the
+   qu/bn/hi-trigger SOV event-anchor residue too.


### PR DESCRIPTION
Updates `HANDOFF-lossy-tail.md` after #495 (Arc 1 done, lossy 32→28) and this session's qu investigation. **Docs only.**

## Changes

- **Arc 1 (th `trigger`/`send`) → DONE (#495).** "Where we are" + leverage map refreshed to post-#495 (lossy **28**; th behaviors removed from the loop-body cluster).
- **qu/bn/hi-trigger sibling → recorded as a dead-end** (as requested). Same family as th (event roleMarker is a *locative*, not the *accusative* the transformer emits), but **gate-invisible**: bn/hi behaviors are already faithful and qu's behavior loss is `repeat`, not trigger. The marker swap (`event = patient`) cleanly fixes bn but qu/hi tangle with the SOV event-anchor path for zero gate gain → investigated, reverted, deferred to the SOV event-anchor arc (Arc 4).
- **qu `repeat` → grounded under Arc 2.** qu `behavior-draggable` drops `repeat` because `parseBodyWithClauses` has **no loop-block fold** (folds `if`/`unless`/`js` only) — an SOV verb-final `repeat … kutipay … end` flattens its body and loses the loop node. Fix = a `tryParseLoopBlock` (Arc-2-scale, hottest body-parse path) + a prerequisite i18n qu `until` underscore sub-fix (`hayk_akama`→`kama`) that alone does **not** recover `repeat`.
- **Recommended sequence** updated: Arc 1 done; **Arc 3 (`set-color-variable`)** is the cleanest bounded next target; Arc 2 (loop-body) is a dedicated session.

## Why no code fix this turn

"qu repeat" grounded out as the **loop-body arc** (SOV verb-final `repeat`-block recognition), which the handoff says deserves a dedicated session — not a singleton. Jamming an intricate loop-fold into the hottest parser path opportunistically, for 1 lossy, is exactly what the handoff warns against. Recorded the grounding so the dedicated session starts from a verified diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)