### PR TITLE
fix(form-submit-prevent): optional call patient marker in he/zh (lossy→faithful)

### DIFF
--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -37,6 +37,16 @@ export interface RoleSpec {
    */
   readonly markerOverride?: Record<string, string>;
   /**
+   * Make this role's object marker OPTIONAL in the generated pattern (wrapped in
+   * an optional group), per language, so both the marked and unmarked surface forms
+   * parse. Used for roles whose value is sometimes an unmarked expression — e.g.
+   * `call`'s function-call patient, which the transformer leaves unmarked in a
+   * multi-command body but marks (את / 把) elsewhere. Scoped per language (only the
+   * langs that need it) so it doesn't relax marking — and role typing — everywhere.
+   * Independent of `profile.markersOptional` (which applies the same to every command).
+   */
+  readonly markerOptional?: Record<string, boolean>;
+  /**
    * Additional alternate marker keywords for this role, beyond {@link markerOverride}.
    * Used by schema-driven role inference (e.g., from `@lokascript/intent`) to
    * recognize any of the listed markers as signaling this role.
@@ -1871,6 +1881,14 @@ export const callSchema: CommandSchema = {
       description: 'The function to call',
       required: true,
       expectedTypes: ['expression', 'reference'],
+      // A function-call patient (`validateForm()`) is an expression, not a definite
+      // DOM object, so the transformer emits it UNMARKED in a multi-command body
+      // (`קרא validateForm()` / `调用 validateForm()`) — but a marked patient is
+      // still emitted elsewhere. The he/zh patient marker (את / 把) is made OPTIONAL
+      // so both forms parse; without it `call` dropped (form-submit-prevent lossy).
+      // Scoped to he/zh — SOV call (ja を / ko 을) already parses, so leaving their
+      // marker required avoids relaxing their role typing.
+      markerOptional: { he: true, zh: true },
       svoPosition: 1,
       sovPosition: 1,
     },

--- a/packages/semantic/src/generators/pattern-generator.ts
+++ b/packages/semantic/src/generators/pattern-generator.ts
@@ -704,7 +704,9 @@ function buildRoleToken(roleSpec: RoleSpec, profile: LanguageProfile): PatternTo
         : { type: 'literal', value: defaultMarker.primary };
     const pushMarker = (marker: PatternToken): void => {
       tokens.push(
-        profile.markersOptional ? { type: 'group', optional: true, tokens: [marker] } : marker
+        profile.markersOptional || roleSpec.markerOptional?.[profile.code]
+          ? { type: 'group', optional: true, tokens: [marker] }
+          : marker
       );
     };
     if (defaultMarker.position === 'before') {

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -7746,3 +7746,20 @@ describe('get keyword alignment de/pl/zh (get-value lossy → faithful)', () => 
     expect(parse('抓取 把 /api/data', 'zh').action).toBe('fetch');
   });
 });
+
+describe('Optional call patient marker he/zh (form-submit-prevent lossy → faithful)', () => {
+  // `call validateForm()` dropped in he/zh: the function-call patient is an expression,
+  // not a definite DOM object, so the transformer emits it UNMARKED in a multi-command
+  // body (`קרא validateForm()` / `调用 validateForm()`), but the he/zh patient roleMarker
+  // (את / 把) made the generated call pattern REQUIRE it → no match, `call` lost. Fix:
+  // markerOptional { he, zh } on the call patient role → the marker is an optional group,
+  // so both the unmarked (body) and marked forms parse. Scoped to he/zh (SOV call already
+  // parsed; leaving their marker required avoids relaxing role typing).
+  it('[he] unmarked function-call patient parses (`קרא validateForm()`)', () => {
+    expect(parse('קרא validateForm()', 'he').action).toBe('call');
+  });
+
+  it('[zh] unmarked function-call patient parses (`调用 validateForm()`)', () => {
+    expect(parse('调用 validateForm()', 'zh').action).toBe('call');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-27T15:07:31.416Z",
-  "commit": "9912ff7b",
+  "timestamp": "2026-06-27T16:33:41.461Z",
+  "commit": "35d1cf8a",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3792,14 +3792,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8237889095031952,
-      "avgFidelity": 0.9987012987012988,
+      "avgFidelity": 1,
       "avgPrecision": 0.9835497835497835,
-      "avgRoleFidelity": 0.9055384367884368,
+      "avgRoleFidelity": 0.9068897881397883,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["form-submit-prevent"],
-      "bundleSize": 445392,
+      "lossyPasses": [],
+      "bundleSize": 445449,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["keydown-key-is-syntax"],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["if-empty", "input-validation"],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["last-in-collection"],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["append-content", "behavior-draggable", "unless-condition"],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event"],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13278,7 +13278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13915,7 +13915,7 @@
         "render-template-with-data",
         "unless-condition"
       ],
-      "bundleSize": 445392,
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14540,19 +14540,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9840032982890127,
-      "avgFidelity": 0.9916666666666667,
+      "avgFidelity": 0.992965367965368,
       "avgPrecision": 0.9983766233766234,
-      "avgRoleFidelity": 0.929532967032967,
+      "avgRoleFidelity": 0.9308843183843183,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": [
-        "form-submit-prevent",
-        "tell-command",
-        "tell-other-element",
-        "unless-condition"
-      ],
-      "bundleSize": 445392,
+      "lossyPasses": ["tell-command", "tell-other-element", "unless-condition"],
+      "bundleSize": 445449,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15175,7 +15170,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 445392,
+      "size": 445449,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
Continues the lossy-tail work — clears `form-submit-prevent` (he/zh).

## What

`on submit halt the event call validateForm() if … end` dropped its `call` in he/zh. The `call` patient is a function-call **expression** (`validateForm()`), not a definite DOM object, so the transformer emits it **unmarked** in a multi-command body (`קרא validateForm()` / `调用 validateForm()`) — but the he/zh patient roleMarker (`את` / `把`) made the generated call pattern **require** it, so it never matched and `call` was lost.

## Fix

A per-language `markerOptional` flag on `RoleSpec`, set `{ he: true, zh: true }` on the call patient role — the object marker becomes an optional group, so both the unmarked (body) and marked forms parse.

**Scoped to he/zh** deliberately: SOV call (ja `を` / ko `을`) already parsed, so leaving their marker required avoids relaxing role typing. (An all-language `true` nudged bn/hi/ja/ko avgRoleFidelity down within tolerance; the scoped version has zero avg-metric drops.)

## Validation

- Priority gate: **lossy 20 → 18** (form-submit-prevent faithful in he/zh), degenerate still 0, parse-rate 3695/3696, **zero regressions, no avg-metric drop in any language**.
- 6176 semantic tests pass. Guard: `multilingual-roadmap-fixes.test.ts` "Optional call patient marker he/zh" (verified failing without the fix). Baseline regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)