### PR TITLE
fix(unless-condition): qu/vi/zh unless keyword + zh ba-guard (lossy→faithful)

### DIFF
--- a/docs-internal/HANDOFF-lossy-tail.md
+++ b/docs-internal/HANDOFF-lossy-tail.md
@@ -36,12 +36,38 @@ The committed baseline is authoritative (`timestamp`/`commit` stamp each regen).
 > session — every theorized cause was wrong until `ml.parse` corrected it). Regenerate the
 > leverage map + signals below from the committed baseline before starting.
 
-| Signal                        | Value (post-#499, stamp `35d1cf8a`)                      |
+> **Update 2026-06-27 (next session — lossy 18 → 15; `unless-condition` cleared).** Sequence
+> item 3 (`unless-condition` qu/vi/zh) is **DONE**. The "control-flow body-parse / how that path
+> scopes the `unless … end` body" framing was — as the doc warned — **the trap**: the en
+> reference parses `unless I match .disabled` as a **flat sibling statement** (just a `condition`,
+> no nested body), so there is no body to scope. `ml.parse` showed **three unrelated
+> keyword/transform causes**, one per language:
+>
+> - **vi** — semantic profile `unless` primary was `trừ_khi` (underscore) but the transformer
+>   emits the spaced `trừ khi`; the bare `khi` (=on/when) was mis-read as a second event handler.
+>   Profile primary → `trừ khi` (the BaseTokenizer multi-word matcher catches it longest-first).
+> - **qu** — quechua profile had **no `unless`** at all, and the dict's `mana_sichus` `_`-split to
+>   `mana`(=false)+`sichus`(=if), so the clause parsed as **`if`**. Added
+>   `unless: 'mana sichus'` (spaced, multi-word) + realigned the i18n dict to `mana sichus`
+>   (transformer keeps the phrase contiguous clause-final).
+> - **zh** — purely a **transform** artifact: `parseEventHandler` swept the whole `unless` tail
+>   into one `patient` blob, so the BA particle `把` landed ahead of the _condition_
+>   (`除非 把 I match …`, `unless` dropped) instead of on the toggle patient. The existing
+>   **Hebrew-only** `tryTransformEventWithUnlessGuard` (which routes the guard through the
+>   standalone block path) was the same את/把 object-marker artifact — widened to `{he, zh}`.
+>
+> Guards: semantic `multilingual-roadmap-fixes.test.ts` (vi/qu/zh parse) + i18n `grammar.test.ts`
+> (zh/he marker placement, qu dict form), both verified fail-without-fix; pruned two now-stale
+> `lexicon-emit-mismatch` allowlist entries (`qu:unless`, `vi:unless`). `--regression` green,
+> baseline regenerated. **What's left (15) is the loop-body family + singleton tail** — unchanged
+> below.
+
+| Signal                        | Value (post-unless-condition, stamp `ea271f4b`)          |
 | ----------------------------- | -------------------------------------------------------- |
 | parse rate                    | **3695 / 3696** (1 hard fail: `tr window-resize`)        |
 | degenerate (fid < 0.5)        | **0** ✅                                                 |
-| lossy (0.5 ≤ fid < 1.0)       | **18**                                                   |
-| avgFidelity (R0-recall)       | 0.998                                                    |
+| lossy (0.5 ≤ fid < 1.0)       | **15** (was 18; `unless-condition` qu/vi/zh cleared)     |
+| avgFidelity (R0-recall)       | 0.999                                                    |
 | avgPrecision (R0 trust floor) | 0.970                                                    |
 | avgRoleFidelity (R1)          | **0.843 — the laggard** (hi 0.750 · qu 0.779 · bn 0.784) |
 
@@ -49,7 +75,7 @@ The committed baseline is authoritative (`timestamp`/`commit` stamp each regen).
 
 ```text
 control-flow body-parse:
-  unless-condition   (3)   qu,vi,zh   ← was the biggest; he cleared (#490). Body-parse arc.
+  unless-condition   (0)   ✅ DONE     ← qu/vi/zh cleared (keyword + transform; NOT body-parse).
 loop-body family:
   behavior-draggable (2)   ar,qu      ← qu drops `repeat` (no tryParseLoopBlock; grounded below)
   repeat-until-event (2)   ar,sw
@@ -286,13 +312,14 @@ The localized-alignment band is **done** (lossy 32 → 18):
 2. ~~**Arc 3 (`set-color-variable`)**~~ **DONE (#497)**; **`get-value`** (#498) + **`form-submit-prevent`**
    (#499) also cleared — see the Arc 3 DONE block.
 
-**The remaining 18 are the body-parse residue — each its own FRESH, ground-from-scratch session:**
+3. ~~**`unless-condition` (qu,vi,zh)**~~ **DONE** (lossy 18 → 15). NOT body-parse, as the framing
+   warned — three independent keyword/transform causes: vi profile `trừ_khi`→`trừ khi`; qu added
+   `unless: 'mana sichus'` + dict realign; zh widened the Hebrew-only `tryTransformEventWithUnlessGuard`
+   to `{he, zh}` (the `把`/את object-marker on the swept condition blob). See the 2026-06-27 update
+   block at the top.
 
-3. **`unless-condition` (qu,vi,zh)** — control-flow body parsing. `unless` is deliberately NOT
-   folded by `tryParseConditionalBlock` (folding relabels its action `unless`→`if` and desyncs the
-   action-set comparison), so its body goes through the flat per-clause path; the loss is how that
-   path scopes the `unless … end` body across qu/vi/zh. **Re-ground from scratch** (don't trust this
-   framing — it's the trap). Bounded-ish (3) but genuinely body-parse, not a dict tweak.
+**The remaining 15 are the loop-body residue + singleton tail — each its own FRESH, ground-from-scratch session:**
+
 4. **Arc 2 (loop-body)** — the SOV `repeat`-block fold (qu, grounded below: no `tryParseLoopBlock`
    in `parseBodyWithClauses`) + ar `measure` + `repeat-until-event` (ar/sw). Dedicated session,
    hottest body-parse path. Do the qu `until` underscore prerequisite together with the fold.

--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -25,7 +25,7 @@ export const qu: Dictionary = {
     hide: 'pakay',
     show: 'rikuchiy',
     if: 'sichus',
-    unless: 'mana_sichus',
+    unless: 'mana sichus', // spaced phrase ("if not"); `_` form split to `mana`+`sichus`(=if) at parse time
     repeat: 'kutipay',
     for: 'sapankaq', // profile's for word — rayku doubles as `by`
     while: 'kay_kaq',

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -576,6 +576,39 @@ describe('GrammarTransformer', () => {
   });
 });
 
+describe('Inline `unless` guard in an event handler (no object marker on condition)', () => {
+  // `on click unless I match .disabled toggle .selected`: the event-handler body
+  // is a bare `unless <cond> <verb>` guard (no `end`). parseEventHandler sweeps the
+  // whole tail into one `patient` blob, so an object-marking SVO target used to
+  // front the *condition* with its marker (he את / zh 把) and strip the marker off
+  // the real toggle — the semantic parser then dropped `unless`.
+  // tryTransformEventWithUnlessGuard routes the guard through the standalone block
+  // path so the marker lands on the toggle patient, not the condition.
+  // See docs-internal/HANDOFF-lossy-tail.md (unless-condition arc).
+  const en = 'on click unless I match .disabled toggle .selected';
+
+  it('zh: 把 marks the toggle patient, not the unless condition', () => {
+    const result = new GrammarTransformer('en', 'zh').transform(en);
+    expect(result).toContain('除非'); // unless
+    expect(result).toContain('切换'); // toggle
+    expect(result).toContain('切换 把 .selected'); // 把 on the toggle patient
+    expect(result).not.toContain('除非 把'); // never on the condition
+  });
+
+  it('he: את marks the toggle patient, not the unless condition (unchanged)', () => {
+    const result = new GrammarTransformer('en', 'he').transform(en);
+    expect(result).toContain('אלא'); // unless
+    expect(result).toContain('מתג את .selected'); // את on the toggle patient
+    expect(result).not.toContain('אלא את'); // never on the condition
+  });
+
+  it('qu: dict emits the spaced `mana sichus`, not the `_`-split form', () => {
+    const result = new GrammarTransformer('en', 'qu').transform(en);
+    expect(result).toContain('mana sichus');
+    expect(result).not.toContain('mana_sichus');
+  });
+});
+
 // =============================================================================
 // Convenience Function Tests
 // =============================================================================

--- a/packages/i18n/src/grammar/transformer.ts
+++ b/packages/i18n/src/grammar/transformer.ts
@@ -498,6 +498,16 @@ const BLOCK_HEAD_KEYWORDS = new Set(['live', 'when', 'unless']);
  */
 const BLOCK_BODY_KEYWORDS = new Set(['if', 'repeat', 'unless', 'while', 'for']);
 
+/**
+ * SVO targets that mark the object/patient with a particle (he את, zh 把) and so
+ * mangle an inline `on <event> unless <cond> <body>` guard — the unless tail is
+ * swept into one patient blob and the marker lands ahead of the condition. These
+ * route through `tryTransformEventWithUnlessGuard`. SOV/VSO object-markers
+ * (ja/ko/tr/ar) are excluded: their event does not lead, so the SVO event-first
+ * emission there would be wrong (and they don't exhibit the artifact today).
+ */
+const UNLESS_GUARD_OBJECT_MARKING_LOCALES = new Set(['he', 'zh']);
+
 function splitOnCommandBoundaries(input: string, sourceLocale: string): string[] {
   const commandKeywords = getCommandKeywordsForLocale(sourceLocale);
   const boundaryModifiers = getBoundaryModifiersForLocale(sourceLocale);
@@ -1965,25 +1975,31 @@ export class GrammarTransformer {
    * Transform an event handler whose body is an inline `unless` guard with NO
    * `end` (`on <event> unless <cond> <body>` — the `unless-condition` shape).
    *
-   * Hebrew-only. `parseEventHandler` reads `unless` as the action and sweeps the
-   * whole `<cond> <body>` tail into a single `patient` blob; Hebrew then prefixes
-   * that blob with the accusative object marker את (`… אלא את I match .disabled מתג
-   * .selected`) and the inner toggle loses its own את. The semantic parser can't
-   * recover the guard from that — את ahead of the condition blocks the `unless`
-   * pattern AND the markerless `מתג .selected` fails the he toggle pattern (which
-   * requires את) — so the body collapses (degenerate). Marker-less languages
-   * (de/it/ar/pl) tolerate the same role-blob and stay faithful, so this is a
-   * Hebrew accusative-marker artifact, not a general parse gap.
+   * Object-marking SVO targets (he, zh). `parseEventHandler` reads `unless` as the
+   * action and sweeps the whole `<cond> <body>` tail into a single `patient` blob;
+   * the target then prefixes that blob with its object marker — Hebrew's accusative
+   * את (`… אלא את I match .disabled מתג .selected`) or Chinese's BA particle 把
+   * (`… 除非 把 I match .disabled 切换 .selected`) — and the inner toggle loses its
+   * own marker. The semantic parser can't recover the guard from that: the marker
+   * ahead of the condition blocks the `unless` pattern AND the now-markerless body
+   * command fails its object-marked toggle pattern, so the body collapses (`unless`
+   * dropped). Marker-less languages (de/it/ar/pl) tolerate the same role-blob and
+   * stay faithful, so this is an object-marker artifact, not a general parse gap.
    *
    * The standalone `unless <cond> <body>` path already produces the correct shape
    * (`extractBlockStructure` → `transformBlock`: condition kept marker-free, body
-   * command keeps its את — `אלא I match .disabled מתג את .selected`). So we split
-   * the event head off, transform the guard through that path, and emit the event
-   * clause first (he is SVO — event leads). Returns `null` (fall through) when the
-   * input isn't a he event handler with an un-terminated inline `unless` guard.
+   * command keeps its marker — he `אלא I match .disabled מתג את .selected`, zh
+   * `除非 I match .disabled 切换 把 .selected`). So we split the event head off,
+   * transform the guard through that path, and emit the event clause first (he and
+   * zh are both SVO — event leads). Returns `null` (fall through) when the input
+   * isn't an object-marking event handler with an un-terminated inline `unless`
+   * guard.
    */
   private tryTransformEventWithUnlessGuard(input: string): string | null {
-    if (this.targetProfile.code !== 'he') return null;
+    // SVO object-marking targets only — these front the unless tail with an object
+    // marker (he את / zh 把) that breaks the parse. Event-leads emission below
+    // assumes SVO, so SOV/VSO object-markers (ja/ko/tr/ar) are intentionally out.
+    if (!UNLESS_GUARD_OBJECT_MARKING_LOCALES.has(this.targetProfile.code)) return null;
 
     const tokens = tokenize(input, this.sourceProfile);
     if (tokens.length === 0) return null;

--- a/packages/semantic/src/generators/profiles/quechua.ts
+++ b/packages/semantic/src/generators/profiles/quechua.ts
@@ -107,6 +107,12 @@ export const quechuaProfile: LanguageProfile = {
     fetch: { primary: 'apamuy', alternatives: ['taripakaramuy'], normalized: 'fetch' },
     settle: { primary: 'tiyakuy', normalized: 'settle' },
     if: { primary: 'sichus', normalized: 'if' },
+    // `mana sichus` = "if not" (Quechua has no single-word "unless"). Spaced phrase
+    // so the BaseTokenizer multi-word matcher catches it longest-first — otherwise
+    // the tokenizer splits it into `mana`(=false) + `sichus`(=if) and the clause
+    // mis-parses as `if`. The i18n qu dict emits the same spaced form (was
+    // `mana_sichus`, whose `_`-split caused exactly that drop).
+    unless: { primary: 'mana sichus', normalized: 'unless' },
     when: { primary: 'maykama', normalized: 'when' },
     where: { primary: 'maypi', normalized: 'where' },
     else: { primary: 'manachus', alternatives: ['hukniraq'], normalized: 'else' },

--- a/packages/semantic/src/generators/profiles/vietnamese.ts
+++ b/packages/semantic/src/generators/profiles/vietnamese.ts
@@ -118,7 +118,11 @@ export const vietnameseProfile: LanguageProfile = {
     settle: { primary: 'ổn định', normalized: 'settle' },
     // Control flow
     if: { primary: 'nếu', normalized: 'if' },
-    unless: { primary: 'trừ_khi', normalized: 'unless' },
+    // Spaced phrase (`trừ khi`) — what the i18n dict + transformer emit; the
+    // BaseTokenizer's multi-word matcher catches it longest-first so the trailing
+    // `khi` (=on/when) is not mistaken for a second event handler. The underscore
+    // form is kept as an alternative for any caller that pre-joins the phrase.
+    unless: { primary: 'trừ khi', alternatives: ['trừ_khi'], normalized: 'unless' },
     when: { primary: 'lúc', normalized: 'when' },
     where: { primary: 'ở_đâu', normalized: 'where' },
     else: { primary: 'không thì', alternatives: ['nếu không'], normalized: 'else' },

--- a/packages/semantic/test/lexicon-emit-mismatch.test.ts
+++ b/packages/semantic/test/lexicon-emit-mismatch.test.ts
@@ -108,7 +108,9 @@ const KNOWN_MISMATCHES = new Set([
   'qu:select:akllay',
   'qu:throw:wikchuy',
   'qu:transition:tikray',
-  'qu:unless:mana_sichus',
+  // qu:unless resolved (HANDOFF-lossy-tail unless-condition): dict realigned to the
+  // spaced `mana sichus` + quechua profile reads it as `unless` (was `mana_sichus`,
+  // which `_`-split to mana(=false)+sichus(=if)).
   'qu:until:hayk_akama',
   'qu:while:kay_kaq',
   'ru:catch:поймать',
@@ -151,7 +153,9 @@ const KNOWN_MISMATCHES = new Set([
   'vi:render:hiển thị',
   'vi:replaceUrl:thayThếUrl',
   'vi:select:chọn',
-  'vi:unless:trừ khi',
+  // vi:unless resolved (HANDOFF-lossy-tail unless-condition): vietnamese profile
+  // primary realigned `trừ_khi`→`trừ khi` so the spaced dict form reads as `unless`
+  // (the bare `khi` was previously mistaken for a second `on` handler).
   'zh:catch:捕获',
   'zh:pushUrl:推送网址',
   'zh:replaceUrl:替换网址',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -153,6 +153,36 @@ describe('Trailing event clause wraps a block body (unless-condition, ar+tl)', (
   });
 });
 
+describe('unless-condition guard parses (qu, vi, zh — unless keyword recognized)', () => {
+  // Three distinct keyword-recognition fixes that each restored `unless` to the
+  // `unless-condition` body parse (was a dropped `unless`, fid 0.667):
+  //  - vi: profile `unless` primary was `trừ_khi` (underscore) but the transformer
+  //    emits the spaced `trừ khi`; the bare `khi` (=on) was mistaken for a second
+  //    event handler. Profile primary → `trừ khi` (multi-word match).
+  //  - qu: profile had no `unless`; the dict's `mana_sichus` split to
+  //    `mana`(=false)+`sichus`(=if) and the clause parsed as `if`. Added
+  //    `unless: 'mana sichus'` (spaced, multi-word) + dict aligned to `mana sichus`.
+  //  - zh: the i18n transformer now keeps the unless condition marker-free
+  //    (`除非 I match .disabled 切换 把 .selected`, not `除非 把 I match …`); this
+  //    locks that the parser recovers the full body from the corrected form.
+  // See docs-internal/HANDOFF-lossy-tail.md (unless-condition arc).
+  const cases: Array<[string, string]> = [
+    ['vi', 'khi nhấp trừ khi I match .disabled chuyển đổi .selected'],
+    ['qu', 'I match .disabled tikray .selected ta ñitiy pi mana sichus'],
+    ['zh', '当 点击 时 除非 I match .disabled 切换 把 .selected'],
+  ];
+
+  for (const [lang, input] of cases) {
+    it(`[${lang}] recovers on + unless + toggle from the unless guard`, () => {
+      const node = parse(input, lang);
+      expect(node.action).toBe('on');
+      const body = JSON.stringify((node as { body?: unknown[] }).body ?? []);
+      expect(body).toContain('unless');
+      expect(body).toContain('toggle');
+    });
+  }
+});
+
 describe('Attribute selectors (@attr) in selector-expecting roles (form-disable)', () => {
   // `@disabled` tokenizes with kind `identifier` (load-bearing — bind's
   // `@property` relies on the identifier reading, expectedTypes

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-27T16:33:41.461Z",
-  "commit": "35d1cf8a",
+  "timestamp": "2026-06-27T18:05:19.403Z",
+  "commit": "ea271f4b",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9480,13 +9480,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7316532673675531,
-      "avgFidelity": 0.9937770562770564,
-      "avgPrecision": 0.942019452409063,
-      "avgRoleFidelity": 0.7786029848529846,
+      "avgFidelity": 0.9959415584415584,
+      "avgPrecision": 0.9441839545735651,
+      "avgRoleFidelity": 0.7802921740421739,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["append-content", "behavior-draggable", "unless-condition"],
+      "lossyPasses": ["append-content", "behavior-draggable"],
       "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
@@ -13902,19 +13902,14 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8044939187796312,
-      "avgFidelity": 0.9891774891774893,
-      "avgPrecision": 0.9719967532467534,
+      "avgConfidence": 0.803793032364459,
+      "avgFidelity": 0.9913419913419914,
+      "avgPrecision": 0.9741612554112554,
       "avgRoleFidelity": 0.8643593456093457,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": [
-        "input-mirror",
-        "morph-with-template",
-        "render-template-with-data",
-        "unless-condition"
-      ],
+      "lossyPasses": ["input-mirror", "morph-with-template", "render-template-with-data"],
       "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {
@@ -14181,10 +14176,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "unless-condition": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "two-way-binding": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -14413,6 +14404,10 @@
           "success": true,
           "confidence": 0.7142857142857143
         },
+        "unless-condition": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "copy-to-clipboard": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -14540,13 +14535,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9840032982890127,
-      "avgFidelity": 0.992965367965368,
+      "avgFidelity": 0.9951298701298701,
       "avgPrecision": 0.9983766233766234,
-      "avgRoleFidelity": 0.9308843183843183,
+      "avgRoleFidelity": 0.9325735075735074,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["tell-command", "tell-other-element", "unless-condition"],
+      "lossyPasses": ["tell-command", "tell-other-element"],
       "bundleSize": 445449,
       "patterns": {
         "toggle-class-basic": {


### PR DESCRIPTION
## Summary

Clears the `unless-condition` lossy cluster (qu/vi/zh) — the largest remaining lossy entry in the multilingual fidelity baseline. The pattern is `on click unless I match .disabled toggle .selected`; each language dropped the `unless` action (fid 0.667).

The handoff theorized this as "control-flow body-parse scoping" — **the trap**, as the doc warned. The en reference parses `unless I match .disabled` as a **flat sibling statement** (a bare `condition`, no nested body), so there is no body to scope. Grounding through `ml.parse` (the gate path) showed **three independent keyword/transform causes**:

| lang | cause | fix |
| --- | --- | --- |
| **vi** | profile `unless` primary `trừ_khi` (underscore) vs transformer's spaced `trừ khi`; bare `khi` (=on) mis-read as a 2nd event handler | profile primary → `trừ khi` (multi-word matcher) |
| **qu** | profile had **no `unless`**; dict `mana_sichus` `_`-split to `mana`(=false)+`sichus`(=if) → parsed as `if` | add `unless: 'mana sichus'` + i18n dict realign |
| **zh** | transform artifact: `parseEventHandler` swept the unless tail into one `patient` blob, so `把` landed ahead of the *condition* (`除非 把 I match …`) instead of on the toggle patient | widen Hebrew-only `tryTransformEventWithUnlessGuard` → `{he, zh}` |

## Verification

- **Gate**: `--regression` green (no regressions); baseline regenerated — **lossy 18 → 15**, degenerate **0**, avgFidelity **0.999**.
- **Guards** (both verified fail-without-fix per methodology):
  - semantic `multilingual-roadmap-fixes.test.ts` — vi/qu/zh recover `{on, toggle, unless}`
  - i18n `grammar.test.ts` — zh/he marker lands on toggle patient not condition; qu dict emits spaced `mana sichus`
- Pruned two now-stale `lexicon-emit-mismatch` allowlist entries (`qu:unless`, `vi:unless`).
- Full suites green: semantic 6185 passed, i18n 877 passed.

`patterns.db` intentionally not committed (CI repopulates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)