### PR TITLE
fix(render): vi render keyword realign hiển thị→kết xuất (lossy→faithful)

### DIFF
--- a/packages/i18n/src/dictionaries/vi.ts
+++ b/packages/i18n/src/dictionaries/vi.ts
@@ -48,7 +48,7 @@ export const vi: Dictionary = {
     beep: 'beep',
     js: 'js',
     async: 'bất đồng bộ',
-    render: 'hiển thị',
+    render: 'kết xuất', // distinct from `show` (was `hiển thị`, which collides with show: the semantic profile reads `hiển thị` as show, `kết xuất` as render)
     swap: 'hoán đổi',
     morph: 'biến đổi',
     settle: 'ổn định',

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -609,6 +609,20 @@ describe('Inline `unless` guard in an event handler (no object marker on conditi
   });
 });
 
+describe('vi render keyword (kết xuất, distinct from show)', () => {
+  // `render`/`show` both mapped to `hiển thị`, which the semantic profile reads as
+  // `show` — so vi `render …` parsed as `show`. Dict realigned render → `kết xuất`
+  // (the profile's render primary); `show` keeps `hiển thị`.
+  // See docs-internal/HANDOFF-lossy-tail.md (render cluster).
+  it('emits `kết xuất` for render, leaving show as `hiển thị`', () => {
+    const t = new GrammarTransformer('en', 'vi');
+    const rendered = t.transform('on click render #x with y: $data then put it into #out');
+    expect(rendered).toContain('kết xuất');
+    expect(rendered).not.toMatch(/hiển thị #x/);
+    expect(t.transform('on click show #x')).toContain('hiển thị');
+  });
+});
+
 // =============================================================================
 // Convenience Function Tests
 // =============================================================================

--- a/packages/semantic/test/lexicon-emit-mismatch.test.ts
+++ b/packages/semantic/test/lexicon-emit-mismatch.test.ts
@@ -150,7 +150,9 @@ const KNOWN_MISMATCHES = new Set([
   'vi:clone:sao chép',
   'vi:prepend:thêm đầu',
   'vi:pushUrl:pushUrl',
-  'vi:render:hiển thị',
+  // vi:render resolved (HANDOFF-lossy-tail render cluster): dict realigned
+  // `hiển thị`→`kết xuất` (the profile's render primary); `hiển thị` collided with
+  // `show`, so render-template/morph-template parsed render as `show`.
   'vi:replaceUrl:thayThếUrl',
   'vi:select:chọn',
   // vi:unless resolved (HANDOFF-lossy-tail unless-condition): vietnamese profile

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -183,6 +183,29 @@ describe('unless-condition guard parses (qu, vi, zh — unless keyword recognize
   }
 });
 
+describe('vi render keyword alignment (kết xuất, not the show-colliding hiển thị)', () => {
+  // The i18n vi dict emitted `render: 'hiển thị'`, but `hiển thị` is also vi `show`
+  // and the semantic profile reads it as `show` (render primary is `kết xuất`). So
+  // `render #x with …` parsed as `show` and the `render` action dropped
+  // (render-template-with-data, morph-with-template — fid 0.5/0.667). Dict realigned
+  // to `kết xuất`. See docs-internal/HANDOFF-lossy-tail.md (render cluster).
+  const cases: Array<[string, string]> = [
+    ['kết xuất #user-list với users: $data rồi đặt nó vào #container', 'put'],
+    ['kết xuất #row với row: $data rồi biến đổi #target vào nó', undefined as unknown as string],
+  ];
+
+  for (const [body, alsoExpect] of cases) {
+    it(`parses kết xuất as render: "${body.slice(0, 28)}…"`, () => {
+      const node = parse(`khi nhấp ${body}`, 'vi');
+      expect(node.action).toBe('on');
+      const dumped = JSON.stringify((node as { body?: unknown[] }).body ?? []);
+      expect(dumped).toContain('render');
+      expect(dumped).not.toContain('"show"');
+      if (alsoExpect) expect(dumped).toContain(alsoExpect);
+    });
+  }
+});
+
 describe('Attribute selectors (@attr) in selector-expecting roles (form-disable)', () => {
   // `@disabled` tokenizes with kind `identifier` (load-bearing — bind's
   // `@property` relies on the identifier reading, expectedTypes

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-27T18:05:19.403Z",
-  "commit": "ea271f4b",
+  "timestamp": "2026-06-27T18:26:43.876Z",
+  "commit": "b29fedca",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -13903,13 +13903,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.803793032364459,
-      "avgFidelity": 0.9913419913419914,
-      "avgPrecision": 0.9741612554112554,
-      "avgRoleFidelity": 0.8643593456093457,
+      "avgFidelity": 0.9967532467532467,
+      "avgPrecision": 0.9795725108225107,
+      "avgRoleFidelity": 0.8679629492129495,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["input-mirror", "morph-with-template", "render-template-with-data"],
+      "lossyPasses": ["input-mirror"],
       "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {


### PR DESCRIPTION
## Summary

Clears the vi `render` cluster (`render-template-with-data`, `morph-with-template`) — 2 of the remaining lossy entries.

The i18n vi dict mapped **both** `show` and `render` to `hiển thị`, but the semantic vi profile reads `hiển thị` as `show` (render primary is `kết xuất`). So vi `render #x with …` parsed as `show` and the `render` action dropped (fid 0.667 / 0.5).

Fix: realign the dict `render` → `kết xuất` (the profile's render primary). `show` keeps `hiển thị`, so no collision. Same keyword-realign family as the prior zh `获取`→`抓取` / qu·sw `set` fixes.

## Verification

- **Gate**: `--regression` green; baseline regenerated — **lossy 15 → 13** (both render patterns cleared).
- **Guards** (verified fail-without-fix):
  - i18n `grammar.test.ts` — render emits `kết xuất`, show keeps `hiển thị`
  - semantic `multilingual-roadmap-fixes.test.ts` — vi `kết xuất` parses as render (not show)
  - pruned the now-stale `vi:render:hiển thị` `lexicon-emit-mismatch` allowlist entry
- Full suites green: semantic 6187 passed, i18n 878 passed.

`patterns.db` intentionally not committed (CI repopulates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)