### PR TITLE
fix(append): qu append keyword realign qhipaman_yapay→qatichiy (lossy→faithful)

### DIFF
--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -61,7 +61,7 @@ export const qu: Dictionary = {
     swap: "t'inkuy", // profile primary; 'rantin_tikray' splits, 'tikray' is toggle's word
     morph: 'tukunay', // auditor: dict emitted a word the profile reads differently
     settle: 'tiyakuy', // auditor: dict emitted a word the profile reads differently
-    append: 'qhipaman_yapay',
+    append: 'qatichiy', // profile's append primary (single token); `qhipaman_yapay` `_`-split to qhipaman+yapay(=add) at parse time
     exit: 'lluqsiy',
     install: 'tarpuy',
     breakpoint: 'sayachinay',

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -623,6 +623,19 @@ describe('vi render keyword (kết xuất, distinct from show)', () => {
   });
 });
 
+describe('qu append keyword (qatichiy, not the _-splitting qhipaman_yapay)', () => {
+  // `qhipaman_yapay` `_`-splits at parse time to `qhipaman`+`yapay`(=add); the dict
+  // now emits the profile's single-token append primary `qatichiy`.
+  // See docs-internal/HANDOFF-lossy-tail.md (singleton tail).
+  it('emits the single-token `qatichiy` for append', () => {
+    const result = new GrammarTransformer('en', 'qu').transform(
+      'on click append "<li>Item</li>" to #list'
+    );
+    expect(result).toContain('qatichiy');
+    expect(result).not.toContain('qhipaman_yapay');
+  });
+});
+
 // =============================================================================
 // Convenience Function Tests
 // =============================================================================

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -206,6 +206,20 @@ describe('vi render keyword alignment (kết xuất, not the show-colliding hi�
   }
 });
 
+describe('qu append keyword alignment (qatichiy, not the _-splitting qhipaman_yapay)', () => {
+  // The i18n qu dict emitted `append: 'qhipaman_yapay'`, which the qu tokenizer
+  // `_`-splits to `qhipaman`+`yapay`(=add) so `append-content` parsed as `add`
+  // (fid 0.5). Realigned the dict to the profile's single-token append primary
+  // `qatichiy`. See docs-internal/HANDOFF-lossy-tail.md (singleton tail).
+  it('parses qatichiy as append (not add) in an SOV event body', () => {
+    const node = parse('"<li>Item</li>" ta #list man ñitiy pi qatichiy', 'qu');
+    expect(node.action).toBe('on');
+    const dumped = JSON.stringify((node as { body?: unknown[] }).body ?? []);
+    expect(dumped).toContain('append');
+    expect(dumped).not.toContain('"add"');
+  });
+});
+
 describe('Attribute selectors (@attr) in selector-expecting roles (form-disable)', () => {
   // `@disabled` tokenizes with kind `identifier` (load-bearing — bind's
   // `@property` relies on the identifier reading, expectedTypes

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-27T18:26:43.876Z",
-  "commit": "b29fedca",
+  "timestamp": "2026-06-27T18:34:03.584Z",
+  "commit": "f0c181db",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9480,13 +9480,13 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7316532673675531,
-      "avgFidelity": 0.9959415584415584,
-      "avgPrecision": 0.9441839545735651,
-      "avgRoleFidelity": 0.7802921740421739,
+      "avgFidelity": 0.9991883116883117,
+      "avgPrecision": 0.9474307078203182,
+      "avgRoleFidelity": 0.7847966785466785,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["append-content", "behavior-draggable"],
+      "lossyPasses": ["behavior-draggable"],
       "bundleSize": 445449,
       "patterns": {
         "toggle-class-on-other": {


### PR DESCRIPTION
## Summary

Clears `append-content` (qu) — one of the remaining lossy entries.

The i18n qu dict emitted `append: 'qhipaman_yapay'`, which the qu tokenizer `_`-splits to `qhipaman`+`yapay`; `yapay` is the `add` primary, so `append-content` parsed as `add` (fid 0.5, `append` dropped). The semantic profile lists `qhipaman_yapay` as an append alternative, but the runtime `_`-split defeats it.

Fix: realign the dict to the profile's **single-token** append primary `qatichiy` (no underscore → no split). Same `_`-split keyword family as the qu `unless` (`mana_sichus`→`mana sichus`) fix in #501.

## Verification

- **Gate**: `--regression` green; baseline regenerated — **lossy 13 → 12**.
- **Guards** (i18n verified fail-without-fix):
  - i18n `grammar.test.ts` — append emits `qatichiy`, not `qhipaman_yapay`
  - semantic `multilingual-roadmap-fixes.test.ts` — qu `qatichiy` parses as append (not add)
- Full suites green (semantic 6187, i18n 879).

`patterns.db` not committed (CI repopulates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)