### PR TITLE
fix(tell): zh BA-marked tell target (markerOverride zh:把) (lossy→faithful)

### DIFF
--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -1965,11 +1965,12 @@ export const tellSchema: CommandSchema = {
       expectedTypes: ['selector', 'reference'],
       svoPosition: 1,
       sovPosition: 1,
-      // "tell #element ..." (no preposition in en). Hebrew: the transformer marks
-      // tell's object with the accusative את (`אמור את #element`), so the generated
-      // he pattern must expect it — without this the `את` token breaks the match and
-      // `tell` is dropped (tell-command / tell-other-element lossy).
-      markerOverride: { en: '', he: 'את' },
+      // "tell #element ..." (no preposition in en). Object-marking targets mark
+      // tell's object with their accusative/BA particle — Hebrew את (`אמור את
+      // #element`), Chinese 把 (`告诉 把 #modal`) — so the generated pattern must
+      // expect it; without it the marker token breaks the match and `tell` is
+      // dropped (tell-command / tell-other-element lossy in he and zh).
+      markerOverride: { en: '', he: 'את', zh: '把' },
     },
   ],
 };

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -220,6 +220,27 @@ describe('qu append keyword alignment (qatichiy, not the _-splitting qhipaman_ya
   });
 });
 
+describe('zh tell BA-marked target (告诉 把 #el — tellSchema markerOverride zh:把)', () => {
+  // tell's target is unmarked in en, but object-marking targets front it with their
+  // accusative/BA particle: he את (handled), zh 把 (`告诉 把 #modal`). The generated
+  // zh tell pattern didn't expect 把, so the token broke the match and `tell`
+  // dropped (tell-command, tell-other-element — fid 0.5/0.75). Added `zh: '把'` to
+  // tellSchema's destination markerOverride. See docs-internal/HANDOFF-lossy-tail.md.
+  const cases: Array<[string, string[]]> = [
+    ['当 点击 时 告诉 把 #modal 到 显示', ['tell']],
+    ['当 点击 时 告诉 把 #panel 那么 添加 把 .open 那么 等待 把 200ms 那么 添加 把 .visible', ['tell', 'add', 'wait']],
+  ];
+
+  for (const [input, expected] of cases) {
+    it(`recovers tell from "${input.slice(0, 20)}…"`, () => {
+      const node = parse(input, 'zh');
+      expect(node.action).toBe('on');
+      const dumped = JSON.stringify((node as { body?: unknown[] }).body ?? []);
+      for (const e of expected) expect(dumped).toContain(e);
+    });
+  }
+});
+
 describe('Attribute selectors (@attr) in selector-expecting roles (form-disable)', () => {
   // `@disabled` tokenizes with kind `identifier` (load-bearing — bind's
   // `@property` relies on the identifier reading, expectedTypes

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-27T18:34:03.584Z",
-  "commit": "f0c181db",
+  "timestamp": "2026-06-27T18:44:02.026Z",
+  "commit": "d623ba3a",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["keydown-key-is-syntax"],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["if-empty", "input-validation"],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["last-in-collection"],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["behavior-draggable"],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["repeat-until-event"],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13278,7 +13278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13910,7 +13910,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": ["input-mirror"],
-      "bundleSize": 445449,
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14535,14 +14535,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.9840032982890127,
-      "avgFidelity": 0.9951298701298701,
+      "avgFidelity": 1,
       "avgPrecision": 0.9983766233766234,
-      "avgRoleFidelity": 0.9325735075735074,
+      "avgRoleFidelity": 0.9373032373032373,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["tell-command", "tell-other-element"],
-      "bundleSize": 445449,
+      "lossyPasses": [],
+      "bundleSize": 445461,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15165,7 +15165,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 445449,
+      "size": 445461,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Clears the zh `tell` cluster (`tell-command`, `tell-other-element`) — zh is now fully clear of the lossy band.

`tell <el>`'s target is unmarked in en, but object-marking targets front it with their accusative/BA particle. Hebrew (already handled) emits `אמור את #el`; Chinese emits `告诉 把 #modal`. The generated zh tell pattern didn't expect `把`, so the token broke the match and `tell` dropped — `tell-command` (fid 0.5), `tell-other-element` (fid 0.75).

Fix: add `zh: '把'` to `tellSchema`'s destination `markerOverride` (mirroring the existing `he: 'את'`). Scoped to tell's destination role — only the generated zh tell pattern changes.

## Verification

- **Gate**: `--regression` green; baseline regenerated — **lossy 12 → 10** (zh now clear).
- **Guard** (verified fail-without-fix): semantic `multilingual-roadmap-fixes.test.ts` — zh `告诉 把 #el` recovers `tell` (both single-command and then-chain bodies).
- Full semantic suite green (6190).

`patterns.db` not committed (CI repopulates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)