### PR TITLE
fix(multilingual): clear the lossy tail (lossy 10 → 0)

### DIFF
--- a/docs-internal/HANDOFF-lossy-tail.md
+++ b/docs-internal/HANDOFF-lossy-tail.md
@@ -15,6 +15,47 @@
 
 The committed baseline is authoritative (`timestamp`/`commit` stamp each regen).
 
+> **Update 2026-06-27 (lossy tail CLEARED — lossy 10 → 0; the band is empty).** All ten
+> remaining lossy passes were fixed this session. The "hard residue / hottest-path body-parse"
+> framing held in only ONE case (ko if-folding); the rest were the same _localized-alignment_
+> family the doc kept declaring "exhausted" — the methodology lesson (theorized cause is wrong
+> until `ml.parse` corrects it) held on every single one. Fixes, each grounded + guarded
+> (`multilingual-roadmap-fixes.test.ts`, fail-without-fix verified):
+>
+> - **ar `measure`** (behavior-draggable, behavior-resizable): the dict emits the undiacritized
+>   imperative `قس`, the profile only knew `قياس`/`قِس`. Added `قس` to the profile measure
+>   alternatives (pruned the now-stale `ar:measure:قس` lexicon-emit-mismatch entry). NOT the
+>   loop-body fold the doc theorized.
+> - **qu `repeat`** (behavior-draggable): NOT a missing `tryParseLoopBlock`. A verb-final `wait`
+>   (`suyay`) greedily anchored its match AT the clause-final loop keyword `kutipay`, swallowing
+>   it — so matchBest _succeeded_ and the bare-`repeat` recovery (gated on matchBest failing)
+>   never fired. `parseClause` now rejects a non-`repeat` match anchored at the repeat keyword.
+> - **ar/sw `on`** (repeat-until-event): NOT loop-body — the multi-token event name dropped the
+>   whole handler. ar spaces events (`فأرة أسفل`=mousedown) and the leading `ف` was stripped as a
+>   `then` proclitic; the ar `tokenizeWithExtractors` override now runs `tryMultiWordKeyword`
+>   first. sw underscore-joins events (`panya_shuka`); the sw keyword reader now joins a `_` run
+>   when it resolves to a registered keyword.
+> - **hi `clear`** (keydown-key-is-syntax): `साफ़-करें` (a `-करें` compound) split on the hyphen.
+>   The hi keyword reader now joins a `-` run when it resolves to a registered keyword. (The Arc-4
+>   "SOV event-anchor mis-anchor" theory was wrong — it was a hyphen tokenization split.)
+> - **ms `scroll`** (last-in-collection): the dict keeps `scroll` English; the profile only knew
+>   `tatal`/`skrol`. Added `scroll` to the profile alternatives (cf. `push`).
+> - **vi `put`** (input-mirror): the possessive patient `của tôi giá trị` (my value) broke the
+>   match because `giá trị` (value) wasn't a registered token (only `đặt giá trị`=set was).
+>   Registered `giá trị`=value; longest-first keeps `đặt giá trị`=set.
+> - **ko `add`** (if-empty, input-validation): the ONE genuine hottest-path fix. The SOV transform
+>   splits the verb-final `is empty` predicate so the then-branch verb (`추가`=add) lands DIRECTLY
+>   after the copula `이다`(is); the conditional fold's copula guard swallowed it. ja/bn escaped
+>   only because their copula isn't lexed as a single `is` token. The condition-split now fires
+>   after a copula when a real SOV command-verb keyword opens there (gated to SOV + verb-lookup
+>   hit, so SVO `X is empty <cmd>` is byte-identical — verified on en).
+>
+> Gate: `--regression` green (3695/3696, R2 1.0), baseline regenerated (lossy 0, degenerate 0,
+> avgFidelity 1.0000, avgPrecision 0.9709, avgRoleFidelity 0.8447). Full semantic suite green
+> (6205). **What's left is no longer a lossy band** — only the R1/SOV role-fidelity burn-down
+> (Arc 4, avgRoleFidelity 0.845, hi 0.757 the laggard) and the deferred `tr window-resize`
+> hard-fail (3695/3696). Both are separate dimensions, not lossy passes.
+
 > **Update 2026-06-27 (session wrap — lossy 32 → 18; the clean alignments are harvested).**
 > Five fixes landed this session, all of the _localized-alignment_ kind (a marker, keyword,
 > tokenizer rule, or homonym):

--- a/packages/semantic/src/generators/profiles/arabic.ts
+++ b/packages/semantic/src/generators/profiles/arabic.ts
@@ -139,7 +139,11 @@ export const arabicProfile: LanguageProfile = {
     init: { primary: 'تهيئة', alternatives: ['بدء'], normalized: 'init' },
     behavior: { primary: 'سلوك', normalized: 'behavior' },
     install: { primary: 'تثبيت', alternatives: ['ثبّت'], normalized: 'install' },
-    measure: { primary: 'قياس', alternatives: ['قِس'], normalized: 'measure' },
+    // `قِس` is the imperative with the kasra diacritic; the i18n dict (and real
+    // Arabic prose) emits it undiacritized as `قس`, so list both — otherwise the
+    // generated `قس width`/`قس x` (behavior-draggable/resizable) parse to null and
+    // the whole `measure` command drops from the event-handler body (lossy).
+    measure: { primary: 'قياس', alternatives: ['قِس', 'قس'], normalized: 'measure' },
     beep: { primary: 'صفّر', normalized: 'beep' },
     break: { primary: 'توقف', normalized: 'break' },
     copy: { primary: 'انسخ', normalized: 'copy' },

--- a/packages/semantic/src/generators/profiles/ms.ts
+++ b/packages/semantic/src/generators/profiles/ms.ts
@@ -99,7 +99,11 @@ export const malayProfile: LanguageProfile = {
     breakpoint: { primary: 'titik-henti', normalized: 'breakpoint' },
     // Navigation
     go: { primary: 'pergi', alternatives: ['pindah'], normalized: 'go' },
-    scroll: { primary: 'tatal', alternatives: ['skrol'], normalized: 'scroll' },
+    // The i18n ms dict keeps the `scroll` command in English (`scroll: 'scroll'`),
+    // but the profile only knew `tatal`/`skrol`, so the generated scroll pattern
+    // never matched the emitted `scroll ke …` and the command dropped
+    // (last-in-collection ms, fid 0.5). List the English form too (cf. `push`).
+    scroll: { primary: 'tatal', alternatives: ['skrol', 'scroll'], normalized: 'scroll' },
     push: { primary: 'tolak', alternatives: ['push'], normalized: 'push' },
     replace: { primary: 'ganti_url', alternatives: ['gantikan_url'], normalized: 'replace' },
     process: { primary: 'proses', normalized: 'process' },

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1197,7 +1197,41 @@ export class SemanticParserImpl implements ISemanticParser {
 
     while (!clauseStream.isAtEnd()) {
       // Try to match as a command
+      const startTok = clauseStream.peek();
+      const startIsRepeatKw = !!startTok && startTok.normalized?.toLowerCase() === 'repeat';
+      const startMark = clauseStream.mark();
       const commandMatch = patternMatcher.matchBest(clauseStream, commandPatterns);
+
+      // A verb-final command (qu `… suyay` = wait, verb-LAST) can greedily span
+      // backward across the clause-final `repeat` loop keyword, anchoring its
+      // match AT that keyword and consuming it as part of the argument run — so
+      // matchBest *succeeds* (as `wait`/`set`/…), the swallowed `repeat` keyword
+      // disappears, and the bare-`repeat` recovery below (gated on matchBest
+      // failing) never fires (behavior-draggable qu: `… kutipay suyay …` matched
+      // `wait` from `kutipay`, dropping the loop — was lossy 0.875). When a
+      // NON-repeat command anchors AT the repeat keyword, reject the swallow:
+      // rewind, emit the bare repeat, and consume only that keyword so the
+      // verb-final command re-matches cleanly on the next iteration. A genuine
+      // `repeat` variant (`repeat N times`/`repeat for …`) keeps its full match.
+      if (
+        startIsRepeatKw &&
+        commandMatch &&
+        (commandMatch.pattern.command as string) !== 'repeat'
+      ) {
+        clauseStream.reset(startMark);
+        flushSkipped();
+        commands.push(
+          createCommandNode(
+            'repeat' as ActionType,
+            {},
+            { sourceLanguage: language, confidence: 0.6 }
+          )
+        );
+        directHits++;
+        clauseStream.advance(); // consume only the repeat keyword
+        continue;
+      }
+
       if (commandMatch) {
         flushSkipped();
         const cmd = this.buildCommand(commandMatch, language);
@@ -2858,9 +2892,24 @@ export class SemanticParserImpl implements ISemanticParser {
         // A condition operator (`match`/`contains`/`exists`/…) is part of the
         // expression, never a then-branch command head — don't truncate at it
         // even if a verb-last SOV command pattern spuriously matches the span.
+        //
+        // Copula guard: normally don't truncate right AFTER a copula (`is`/`be`/…),
+        // because the next token is the predicate (`X is empty …` → don't split at
+        // `empty`). But the SOV transform can split a verb-final `is empty` predicate
+        // so a then-branch command VERB lands DIRECTLY after the copula
+        // (ko `… 내 값 이다 추가 .error 를 … 비어있는 …` = my value IS add .error … empty):
+        // the guard then swallows `add` into the condition and drops it
+        // (if-empty/input-validation ko, fid 0.75). ja/bn escape only because their
+        // copula isn't lexed as a single `is` token, so the split already fires there.
+        // Allow the split after a copula when a real SOV command-VERB keyword opens
+        // here — gated to SOV (verb lookup present) and an actual verb-lookup hit, so
+        // SVO `X is empty <cmd>` (a predicate, not a verb, after the copula) is
+        // byte-identical to before.
+        const curIsSovCommandVerb =
+          sovVerbLookup !== null && sovVerbLookup.has(t.value.toLowerCase());
         if (
           !SemanticParserImpl.CONDITION_OPERATORS.has(cur) &&
-          !SemanticParserImpl.CONDITION_COPULAS.has(prev) &&
+          (!SemanticParserImpl.CONDITION_COPULAS.has(prev) || curIsSovCommandVerb) &&
           (this.tokensBeginCommand(blockTokens.slice(i), commandPatterns, language) ||
             this.sovCommandStartsAt(blockTokens.slice(i), sovVerbLookup))
         ) {

--- a/packages/semantic/src/tokenizers/arabic.ts
+++ b/packages/semantic/src/tokenizers/arabic.ts
@@ -132,6 +132,21 @@ const ARABIC_EXTRAS: KeywordEntry[] = [
   { native: 'مغادرة الفأرة', normalized: 'mouseout' },
   { native: 'تحميل', normalized: 'load' },
   { native: 'تمرير', normalized: 'scroll' },
+  // Multi-word mouse/key event names AS THE i18n DICT EMITS THEM (dictionaries/ar.ts
+  // `events`). The tokenizer previously knew only the singular/colloquial forms above
+  // (`ضغط`/`تمرير الفأرة`), so the dict's `فأرة أسفل`/`فأرة أعلى` tokenized as two bare
+  // identifiers, the `عند <event>` handler never anchored, and the whole handler dropped
+  // (repeat-until-event ar: `on` lost, fid 0.75). The BaseTokenizer multi-word matcher
+  // catches these longest-first. See docs-internal/HANDOFF-lossy-tail.md (repeat-until-event).
+  { native: 'فأرة أسفل', normalized: 'mousedown' },
+  { native: 'فأرة أعلى', normalized: 'mouseup' },
+  { native: 'فأرة دخول', normalized: 'mouseenter' },
+  { native: 'فأرة خروج', normalized: 'mouseleave' },
+  { native: 'فأرة فوق', normalized: 'mouseover' },
+  { native: 'فأرة خارج', normalized: 'mouseout' },
+  { native: 'فأرة تحرك', normalized: 'mousemove' },
+  { native: 'مفتاح أسفل', normalized: 'keydown' },
+  { native: 'مفتاح أعلى', normalized: 'keyup' },
 
   // References (feminine "it" not in profile)
   { native: 'هي', normalized: 'it' },
@@ -203,6 +218,22 @@ export class ArabicTokenizer extends BaseTokenizer {
         pos++;
       }
       if (pos >= input.length) break;
+
+      // Match a space-containing profile keyword (multi-word event/command phrase)
+      // BEFORE the per-extractor pass. This override otherwise skips the base
+      // tokenizer's tryMultiWordKeyword step, so the dict's multi-word event names
+      // (`فأرة أسفل`=mousedown, `فأرة أعلى`=mouseup) were split — and worse, their
+      // leading `ف` was stripped as a `then` proclitic — so the `عند <event>`
+      // handler never anchored and the whole handler dropped (repeat-until-event
+      // ar: `on` lost, fid 0.75). Longest-first + word-boundary-gated, marker
+      // concepts excluded (base-tokenizer multiWordKeywords filter), so this can
+      // only fuse a genuine multi-word keyword that was previously mis-split.
+      const multiWord = this.tryMultiWordKeyword(input, pos);
+      if (multiWord) {
+        tokens.push(multiWord);
+        pos = multiWord.position.end;
+        continue;
+      }
 
       // Try registered extractors in order
       let extracted = false;

--- a/packages/semantic/src/tokenizers/extractors/hindi-keyword.ts
+++ b/packages/semantic/src/tokenizers/extractors/hindi-keyword.ts
@@ -60,6 +60,31 @@ export class HindiKeywordExtractor implements ContextAwareExtractor {
       pos++;
     }
 
+    // Hyphen-joined keyword recovery. Several hi profile/dict keywords are
+    // `<verb>-करें` compounds (`साफ़-करें`=clear, `बंद-करें`=close, `खाली-करें`=empty,
+    // `चिह्नित-करें`=select). The reader stops at `-`, so `साफ़-करें` split into three
+    // tokens, the command verb never matched, and the action dropped
+    // (keydown-key-is-syntax hi: `clear` lost, fid 0.5). When a `-` joins two
+    // Devanagari runs, read the joined form and adopt it ONLY if it resolves to a
+    // REGISTERED keyword — so hyphenated identifiers/selectors stay split as before.
+    // See docs-internal/HANDOFF-lossy-tail.md (Arc 4 / keydown-key-is-syntax).
+    if (
+      this.context &&
+      input[pos] === '-' &&
+      pos + 1 < input.length &&
+      isDevanagari(input[pos + 1])
+    ) {
+      let extPos = pos;
+      let ext = word;
+      while (extPos < input.length && (input[extPos] === '-' || isDevanagari(input[extPos]))) {
+        ext += input[extPos++];
+      }
+      if (this.context.lookupKeyword(ext)) {
+        word = ext;
+        pos = extPos;
+      }
+    }
+
     if (!word) return null;
 
     // Look up keyword entry

--- a/packages/semantic/src/tokenizers/extractors/swahili-keyword.ts
+++ b/packages/semantic/src/tokenizers/extractors/swahili-keyword.ts
@@ -79,6 +79,28 @@ export class SwahiliKeywordExtractor implements ContextAwareExtractor {
       word += input[pos++];
     }
 
+    // Underscore-joined keyword recovery. The i18n sw dict joins multi-word event
+    // names with `_` (`panya_shuka`=mousedown, `panya_juu`=mouseup); the reader stops
+    // at `_`, so `kwenye panya_shuka` split and the handler dropped (repeat-until-event
+    // sw, fid 0.75). When `_` follows, read the full `_`-joined run and adopt it ONLY
+    // if it resolves to a REGISTERED keyword — so arbitrary snake_case identifiers and
+    // unregistered dict forms (the blur `poteza_macho`) stay split exactly as before.
+    // See docs-internal/HANDOFF-lossy-tail.md (repeat-until-event).
+    if (this.context && pos < input.length && input[pos] === '_') {
+      let extPos = pos;
+      let ext = word;
+      while (
+        extPos < input.length &&
+        (input[extPos] === '_' || isSwahiliIdentifierChar(input[extPos]))
+      ) {
+        ext += input[extPos++];
+      }
+      if (this.context.lookupKeyword(ext.toLowerCase())) {
+        word = ext;
+        pos = extPos;
+      }
+    }
+
     if (!word) return null;
 
     const lower = word.toLowerCase();

--- a/packages/semantic/src/tokenizers/swahili.ts
+++ b/packages/semantic/src/tokenizers/swahili.ts
@@ -97,6 +97,20 @@ const SWAHILI_EXTRAS: KeywordEntry[] = [
   { native: 'bonyeza kitufe', normalized: 'keydown' },
   { native: 'sogeza juu', normalized: 'mouseover' },
   { native: 'sogeza nje', normalized: 'mouseout' },
+  // Underscore-joined mouse/key event names AS THE i18n DICT EMITS THEM
+  // (dictionaries/sw.ts `events`). The tokenizer's identifier reader now keeps `_`
+  // inside a word (swahili-keyword.ts), so these resolve as one keyword token —
+  // otherwise `kwenye panya_shuka` split and the handler dropped (repeat-until-event
+  // sw, fid 0.75). `panya_juu` is the dict's shared mouseup/mouseover form; map it to
+  // mouseup (the corpus use). See docs-internal/HANDOFF-lossy-tail.md.
+  { native: 'panya_shuka', normalized: 'mousedown' },
+  { native: 'panya_juu', normalized: 'mouseup' },
+  { native: 'panya_ingia', normalized: 'mouseenter' },
+  { native: 'panya_toka', normalized: 'mouseleave' },
+  { native: 'panya_nje', normalized: 'mouseout' },
+  { native: 'panya_sogea', normalized: 'mousemove' },
+  { native: 'kitufe_shuka', normalized: 'keydown' },
+  { native: 'kitufe_juu', normalized: 'keyup' },
   { native: 'fifia', normalized: 'blur' },
   { native: 'pakia', normalized: 'load' },
   { native: 'sukuma', normalized: 'scroll' },

--- a/packages/semantic/src/tokenizers/vietnamese.ts
+++ b/packages/semantic/src/tokenizers/vietnamese.ts
@@ -89,6 +89,7 @@ const VIETNAMESE_EXTRAS: KeywordEntry[] = [
   { native: 'nhân bản', normalized: 'clone' },
   { native: 'tạo ra', normalized: 'make' },
   { native: 'đặt giá trị', normalized: 'set' },
+  { native: 'giá trị', normalized: 'value' },
   { native: 'ghi nhật ký', normalized: 'log' },
   { native: 'chuyển tới', normalized: 'go' },
   { native: 'ngược lại', normalized: 'else' },

--- a/packages/semantic/test/lexicon-emit-mismatch.test.ts
+++ b/packages/semantic/test/lexicon-emit-mismatch.test.ts
@@ -41,7 +41,6 @@ const LANGS = ['ar','bn','de','es','fr','he','hi','id','it','ja','ko','ms','pl',
 
 const KNOWN_MISMATCHES = new Set([
   'ar:catch:التقط',
-  'ar:measure:قس',
   'ar:pushUrl:ادفع رابط',
   'ar:replaceUrl:استبدل رابط',
   'ar:select:اختر',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -241,6 +241,261 @@ describe('zh tell BA-marked target (告诉 把 #el — tellSchema markerOverride
   }
 });
 
+describe('ko if-empty: command verb directly after copula in a split SOV predicate', () => {
+  // The SOV transform splits a verb-final `is empty` predicate so a then-branch
+  // command verb lands DIRECTLY after the copula (ko `… 내 값 이다 추가 .error 를 … 비어있는`
+  // = my value IS add .error … empty). The conditional fold's copula guard swallowed
+  // `추가`(add) into the condition and dropped it (if-empty/input-validation ko, fid
+  // 0.75 — ja/bn escaped only because their copula isn't lexed as a single `is`). The
+  // split now fires after a copula when a real SOV command-verb keyword opens here.
+  // See docs-internal/HANDOFF-lossy-tail.md (control-flow if-folding).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches', 'eventHandlers'])
+      {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('[ko] if-empty recovers the add buried after the copula', () => {
+    const a = actions(
+      parse(
+        '블러 할 때 만약 내 값 이다 추가 .error 를 비어있는 나 에 그러면 "Required" 를 다음 .error-message 에 넣다 끝',
+        'ko'
+      )
+    );
+    expect(a.has('if')).toBe(true);
+    expect(a.has('add')).toBe(true); // was swallowed into the condition
+    expect(a.has('put')).toBe(true);
+  });
+
+  it('[ko] input-validation recovers add (if/else body)', () => {
+    const a = actions(
+      parse('블러 할 때 만약 내 값 이다 추가 .error 를 비어있는 나 에 아니면 .error 를 제거 나 에서 끝', 'ko')
+    );
+    expect(a.has('if')).toBe(true);
+    expect(a.has('add')).toBe(true);
+    expect(a.has('remove')).toBe(true);
+  });
+
+  it('[en] a normal `is empty` predicate is unaffected (no phantom empty command)', () => {
+    const a = actions(
+      parse(
+        'on blur if my value is empty add .error to me put "Required" into next .error-message end',
+        'en'
+      )
+    );
+    expect(a.has('add')).toBe(true);
+    expect(a.has('put')).toBe(true);
+    expect(a.has('empty')).toBe(false); // copula guard still protects SVO predicate
+  });
+});
+
+describe('hi hyphen-compound keyword (साफ़-करें = clear) tokenizes as one keyword', () => {
+  // Several hi profile/dict command keywords are `<verb>-करें` compounds joined by a
+  // hyphen (`साफ़-करें`=clear). The keyword reader stopped at `-`, splitting it into
+  // three tokens; the command verb never matched and the action dropped
+  // (keydown-key-is-syntax hi: `clear` lost, fid 0.5). The reader now joins a `-`
+  // run when it resolves to a registered keyword. See docs-internal/HANDOFF-lossy-tail.md.
+  it('parses साफ़-करें as clear (keydown-key-is-syntax)', () => {
+    const node = parse("मैं को keyup[key is 'Escape'] पर साफ़-करें", 'hi') as Record<string, unknown>;
+    expect(node.action).toBe('on');
+    const dumped = JSON.stringify((node as { body?: unknown[] }).body ?? []);
+    expect(dumped).toContain('clear');
+  });
+
+  it('a hyphenated selector (.error-message) is NOT fused into a keyword', () => {
+    // The join is gated to Devanagari runs that resolve to a REGISTERED keyword, so
+    // a `.error-message` CSS selector (handled by the selector extractor) stays one
+    // selector token rather than being mangled by hyphen handling.
+    const tk = getTokenizer('hi');
+    const raw = tk.tokenize('रखें .error-message में') as unknown;
+    const toks = (Array.isArray(raw) ? raw : (raw as { tokens: unknown[] }).tokens) as Array<{
+      value: string;
+      kind: string;
+    }>;
+    expect(toks.some(t => t.value === '.error-message' && t.kind === 'selector')).toBe(true);
+  });
+});
+
+describe('ms scroll keyword alignment (English `scroll` form the dict emits)', () => {
+  // The i18n ms dict keeps the scroll command in English (`scroll: 'scroll'`), but
+  // the semantic ms profile only knew `tatal`/`skrol`, so the generated scroll
+  // pattern never matched the emitted `scroll ke …` and the command dropped
+  // (last-in-collection ms, fid 0.5). Added `scroll` to the profile alternatives.
+  it('parses the English scroll form (last-in-collection)', () => {
+    const node = parse('apabila click scroll ke terakhir <.message/> dalam #chat', 'ms') as Record<
+      string,
+      unknown
+    >;
+    expect(node.action).toBe('on');
+    expect(JSON.stringify((node as { body?: unknown[] }).body ?? [])).toContain('scroll');
+  });
+});
+
+describe('vi value reference (giá trị) tokenizes as one token for possessive patient', () => {
+  // `value` is `giá trị` (two words) in vi; only `đặt giá trị`(=set) was registered,
+  // so a standalone `giá trị` split into two identifiers and the possessive patient
+  // `của tôi giá trị`(=my value) broke the `put` match, dropping it (input-mirror vi,
+  // fid 0.5). Registered `giá trị`=value; longest-first keeps `đặt giá trị`=set intact.
+  it('parses put my value (input-mirror)', () => {
+    const node = parse('khi nhập đặt của tôi giá trị vào #preview', 'vi') as Record<string, unknown>;
+    expect(node.action).toBe('on');
+    expect(JSON.stringify((node as { body?: unknown[] }).body ?? [])).toContain('put');
+  });
+
+  it('the longer đặt giá trị still tokenizes as set (not over-shadowed)', () => {
+    const tk = getTokenizer('vi');
+    const raw = tk.tokenize('đặt giá trị của #x thành 5') as unknown;
+    const toks = (Array.isArray(raw) ? raw : (raw as { tokens: unknown[] }).tokens) as Array<{
+      value: string;
+      normalized?: string;
+    }>;
+    expect(toks[0]?.value).toBe('đặt giá trị');
+    expect(toks[0]?.normalized).toBe('set');
+  });
+});
+
+describe('Multi-token event names anchor the event handler (ar multi-word, sw underscore)', () => {
+  // The i18n dicts emit DOM mouse/key event names as MULTI-token forms: ar spaces
+  // them (`فأرة أسفل`=mousedown) and sw underscore-joins them (`panya_shuka`). Neither
+  // tokenized as one event token — worse, ar stripped the leading `ف` as a `then`
+  // proclitic — so the `عند`/`kwenye <event>` handler never anchored and the WHOLE
+  // handler dropped (repeat-until-event ar+sw: `on` lost, fid 0.75). Fixes: the ar
+  // tokenizeWithExtractors override now runs tryMultiWordKeyword first; the sw
+  // identifier reader keeps `_` inside a word. See docs-internal/HANDOFF-lossy-tail.md.
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches', 'eventHandlers'])
+      {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('[ar] on mousedown (فأرة أسفل) anchors the handler', () => {
+    const a = actions(parse('عند فأرة أسفل ثم زِد #counter', 'ar'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('increment')).toBe(true);
+  });
+
+  it('[ar] repeat-until-event recovers the on handler (was dropped)', () => {
+    const a = actions(
+      parse('عند فأرة أسفل كرر حتى حدث فأرة أعلى ثم زِد #counter ثم انتظر 100ms النهاية', 'ar')
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+    expect(a.has('increment')).toBe(true);
+  });
+
+  it('[sw] on mousedown (panya_shuka) anchors the handler', () => {
+    const a = actions(parse('kwenye panya_shuka kisha ongezeko #counter', 'sw'));
+    expect(a.has('on')).toBe(true);
+    expect(a.has('increment')).toBe(true);
+  });
+
+  it('[sw] repeat-until-event recovers the on handler (was dropped)', () => {
+    const a = actions(
+      parse(
+        'kwenye panya_shuka rudia hadi tukio panya_juu kisha ongezeko #counter kisha ngoja 100ms mwisho',
+        'sw'
+      )
+    );
+    expect(a.has('on')).toBe(true);
+    expect(a.has('repeat')).toBe(true);
+    expect(a.has('increment')).toBe(true);
+  });
+});
+
+describe('qu repeat loop-keyword swallow guard (verb-final wait eats the loop kw)', () => {
+  // An SOV verb-final loop head renders `repeat until event <ev> from <src>` with
+  // the loop keyword (qu kutipay) clause-FINAL, immediately followed by the loop
+  // body's first command whose verb is ALSO verb-final (qu `suyay` = wait). The
+  // `wait` pattern greedily anchored AT `kutipay` and consumed it as part of its
+  // argument run, so matchBest succeeded as `wait` and the `repeat` loop keyword
+  // was swallowed — the loop node never formed (behavior-draggable qu, fid 0.875).
+  // parseClause now rejects a NON-repeat match anchored at the repeat keyword and
+  // emits the bare repeat instead. See docs-internal/HANDOFF-lossy-tail.md (Arc 2).
+  function actions(node: unknown, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.add(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches', 'eventHandlers'])
+      {
+      const c = rec[f];
+      if (Array.isArray(c)) c.forEach(x => actions(x, acc));
+      else if (c && typeof c === 'object') actions(c, acc);
+    }
+    return acc;
+  }
+
+  it('recovers repeat when a verb-final wait follows the clause-final loop keyword', () => {
+    const a = actions(
+      parse(
+        'Foo(h) ta behavior\n' +
+          '    h manta pointerdown(clientX, clientY) pi\n' +
+          '        x ta tupuy\n' +
+          '        hayk_akama ruway pointerup ta qillqa manta kutipay\n' +
+          '            suyay pointermove(clientX, clientY) utaq qillqa manta pointerup(clientX, clientY)\n' +
+          '            .x ta yapay\n' +
+          '        tukuy\n' +
+          '    tukuy\n' +
+          'tukuy',
+        'qu'
+      )
+    );
+    expect(a.has('repeat')).toBe(true); // was swallowed by the verb-final wait
+    expect(a.has('wait')).toBe(true);
+    expect(a.has('add')).toBe(true);
+    expect(a.has('measure')).toBe(true);
+  });
+
+  it('a genuine counted `repeat N times` keeps its variant match (not over-triggered)', () => {
+    // The swallow-guard fires only when matchBest anchors a NON-repeat command at
+    // the repeat keyword. A real `repeat N times` match (command === 'repeat') must
+    // be left untouched — confirm it still yields the repeat action and was matched
+    // by the generated repeat pattern, not rewritten to a bare guard-emitted node.
+    const node = parse('repeat 3 times toggle .x end', 'en') as Record<string, unknown>;
+    expect(node.action).toBe('repeat');
+    const meta = node.metadata as { patternId?: string } | undefined;
+    expect(meta?.patternId).toContain('repeat-en');
+  });
+});
+
+describe('ar measure keyword alignment (undiacritized قس)', () => {
+  // The semantic ar profile listed measure as قياس/قِس (the kasra-diacritized
+  // imperative), but the i18n dict + real Arabic prose emit it undiacritized as
+  // قس. So `قس width`/`قس x` parsed to null and the whole `measure` command
+  // dropped from the event-handler body (behavior-draggable, behavior-resizable
+  // — fid 0.875/0.889). Added قس to the profile measure alternatives.
+  // See docs-internal/HANDOFF-lossy-tail.md (Arc 2 — ar measure).
+  for (const clause of ['قس width', 'قس x', 'قس height']) {
+    it(`parses "${clause}" as measure`, () => {
+      const node = parse(clause, 'ar');
+      expect(node?.action).toBe('measure');
+    });
+  }
+
+  it('recovers measure inside an ar behavior event body', () => {
+    const node = parse(
+      'من أنا عند pointerdown\n        قس width\n        اضبط startWidth إلى هو',
+      'ar'
+    );
+    expect(node.action).toBe('on');
+    const dumped = JSON.stringify((node as { body?: unknown[] }).body ?? []);
+    expect(dumped).toContain('measure');
+  });
+});
+
 describe('Attribute selectors (@attr) in selector-expecting roles (form-disable)', () => {
   // `@disabled` tokenizes with kind `identifier` (load-bearing — bind's
   // `@property` relies on the identifier reading, expectedTypes

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,20 +1,20 @@
 {
-  "timestamp": "2026-06-27T18:44:02.026Z",
-  "commit": "d623ba3a",
+  "timestamp": "2026-06-27T21:59:18.763Z",
+  "commit": "12018416",
   "languages": {
     "ar": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8368310482087561,
-      "avgFidelity": 0.9968434343434344,
+      "avgConfidence": 0.8371917985695063,
+      "avgFidelity": 1,
       "avgPrecision": 0.978030303030303,
-      "avgRoleFidelity": 0.8763266013266016,
+      "avgRoleFidelity": 0.8783313533313536,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["behavior-draggable", "behavior-resizable", "repeat-until-event"],
-      "bundleSize": 445461,
+      "lossyPasses": [],
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -540,6 +540,10 @@
           "success": true,
           "confidence": 0.5555555555555556
         },
+        "repeat-until-event": {
+          "success": true,
+          "confidence": 0.5555555555555556
+        },
         "repeat-forever": {
           "success": true,
           "confidence": 0.5555555555555556
@@ -596,10 +600,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.5
-        },
         "event-once": {
           "success": true,
           "confidence": 0.5
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4424,14 +4424,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.90909904631709,
-      "avgFidelity": 0.9967532467532467,
+      "avgFidelity": 1,
       "avgPrecision": 0.9165363046044861,
-      "avgRoleFidelity": 0.7502943190443191,
+      "avgRoleFidelity": 0.7570510758010759,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["keydown-key-is-syntax"],
-      "bundleSize": 445461,
+      "lossyPasses": [],
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6952,14 +6952,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.8170870900194204,
-      "avgFidelity": 0.9967532467532467,
+      "avgFidelity": 1,
       "avgPrecision": 0.9422938803620624,
-      "avgRoleFidelity": 0.8015441952941952,
+      "avgRoleFidelity": 0.8060486997986998,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["if-empty", "input-validation"],
-      "bundleSize": 445461,
+      "lossyPasses": [],
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7583,15 +7583,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8395794681508945,
-      "avgFidelity": 0.9967532467532467,
+      "avgConfidence": 0.8377241805813213,
+      "avgFidelity": 1,
       "avgPrecision": 0.9795454545454545,
       "avgRoleFidelity": 0.8735453172953174,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["last-in-collection"],
-      "bundleSize": 445461,
+      "lossyPasses": [],
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7718,10 +7718,6 @@
           "confidence": 1
         },
         "closest-ancestor": {
-          "success": true,
-          "confidence": 1
-        },
-        "last-in-collection": {
           "success": true,
           "confidence": 1
         },
@@ -8069,6 +8065,10 @@
           "success": true,
           "confidence": 0.7142857142857143
         },
+        "last-in-collection": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "event-key-combo": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9480,14 +9480,14 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 0.7316532673675531,
-      "avgFidelity": 0.9991883116883117,
-      "avgPrecision": 0.9474307078203182,
+      "avgFidelity": 1,
+      "avgPrecision": 0.9474577640973745,
       "avgRoleFidelity": 0.7847966785466785,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["behavior-draggable"],
-      "bundleSize": 445461,
+      "lossyPasses": [],
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10743,15 +10743,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7941558441558423,
-      "avgFidelity": 0.9983766233766234,
+      "avgConfidence": 0.7962481962481944,
+      "avgFidelity": 1,
       "avgPrecision": 0.9796536796536797,
-      "avgRoleFidelity": 0.8718672656172657,
+      "avgRoleFidelity": 0.872993391743392,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["repeat-until-event"],
-      "bundleSize": 445461,
+      "lossyPasses": [],
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10998,6 +10998,10 @@
           "confidence": 0.8222222222222222
         },
         "last-in-collection": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "repeat-until-event": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -11349,10 +11353,6 @@
           "success": true,
           "confidence": 0.5555555555555556
         },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.5
-        },
         "behavior-removable": {
           "success": true,
           "confidence": 0.5
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13278,7 +13278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13902,15 +13902,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.803793032364459,
-      "avgFidelity": 0.9967532467532467,
+      "avgConfidence": 0.8049474335188601,
+      "avgFidelity": 1,
       "avgPrecision": 0.9795725108225107,
-      "avgRoleFidelity": 0.8679629492129495,
+      "avgRoleFidelity": 0.8724674537174537,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
-      "lossyPasses": ["input-mirror"],
-      "bundleSize": 445461,
+      "lossyPasses": [],
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13961,6 +13961,10 @@
           "confidence": 1
         },
         "dropdown-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "input-mirror": {
           "success": true,
           "confidence": 1
         },
@@ -14133,10 +14137,6 @@
           "confidence": 0.8222222222222222
         },
         "tabs-aria": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "input-mirror": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -14542,7 +14542,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 445461,
+      "bundleSize": 446559,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15165,7 +15165,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 445461,
+      "size": 446559,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
Clears all 10 remaining lossy passes in the browser-priority baseline — the lossy band is now **empty**. Each was grounded via gate-faithful `ml.parse` repro first; all but one (ko) were the same localized-alignment family the handoff kept declaring "exhausted" (the theorized body-parse cause was wrong every time).

## Fixes (each with a fail-without-fix guard in `multilingual-roadmap-fixes.test.ts`)

**Keyword/profile alignments**
- **ar `measure`** (behavior-draggable, behavior-resizable): dict emits undiacritized `قس`; added to profile alternatives. Pruned stale `ar:measure:قس` from the lexicon-emit-mismatch allowlist.
- **ms `scroll`** (last-in-collection): dict keeps English `scroll`; added to profile alternatives (cf. `push`).
- **vi `put`** (input-mirror): registered `giá trị`=value so the possessive patient `của tôi giá trị` (my value) matches; longest-first keeps `đặt giá trị`=set.

**Multi-token event/keyword tokenization**
- **ar repeat-until-event**: run `tryMultiWordKeyword` in the ar `tokenizeWithExtractors` override so spaced event names (`فأرة أسفل`=mousedown) match before the `ف` `then`-proclitic strip.
- **sw repeat-until-event**: the sw keyword reader joins a `_`-run when it resolves to a registered keyword (`panya_shuka`=mousedown); arbitrary snake_case stays split.
- **hi keydown-key-is-syntax**: the hi keyword reader joins a `-`-run when it resolves to a registered keyword (`साफ़-करें`=clear); selectors/identifiers stay split.

**Parser (`semantic-parser.ts`)**
- **qu `repeat`** (behavior-draggable): `parseClause` rejects a non-`repeat` matchBest hit anchored at the clause-final loop keyword (a verb-final `wait` was swallowing `kutipay`).
- **ko `add`** (if-empty, input-validation): the conditional fold's copula guard swallowed a then-branch verb that the SOV-split `is empty` predicate left directly after the copula `이다`. The split now fires after a copula when a real SOV command-verb keyword opens there — gated to SOV + verb-lookup hit, so SVO `X is empty <cmd>` is byte-identical (verified on en).

## Verification
- `--regression` gate: **✓ no regression**, parse rate 3695/3696, R2 execution 1.0
- Baseline regenerated: **lossy 10→0**, degenerate 0, avgFidelity 0.999→**1.0000**, avgPrecision 0.970→0.9709, avgRoleFidelity 0.843→**0.8447** (hi 0.750→0.757)
- Full semantic suite: **6208 passed**, 10 skipped, 0 failed

Per repo convention the regenerated `patterns.db` is not committed (CI repopulates); only the dicts/profiles/tokenizers + baseline are tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)