### PR TITLE
fix(multilingual): SOV-fronted patient → schema primaryRole (Arc 4 R1 +0.027)

### DIFF
--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -144,12 +144,88 @@ function stripQuotes(val: string): string {
 // Semantic Parser Implementation
 // =============================================================================
 
+/**
+ * R1 role-fidelity normalization (Arc 4 — SOV event-anchor role mistype).
+ *
+ * When an SOV/V2 reorder fronts a command's leading object, the fused-event and
+ * generic match paths bind it to the generic `patient` role. But many commands
+ * have NO `patient` role and a distinct `primaryRole` — `fetch`→source,
+ * `wait`→duration, `send`/`trigger`→event, `bind`/`tell`→destination. The fronted
+ * URL/duration/event then parses as `<cmd>.patient` instead of
+ * `<cmd>.<primaryRole>`: a pure role MISTYPE (the command and the value's TYPE are
+ * correct; only the role NAME is wrong) — invisible to R0 action-recall, but the
+ * dominant R1 (role-fidelity) drop across every SOV/reorder language
+ * (`fetch.source` alone was missing 13× per language).
+ *
+ * This relabels a spurious `patient` to the schema's `primaryRole`, gated so it can
+ * only ever CORRECT a mistype, never lose information:
+ *   - the schema defines `primaryRole` ≠ 'patient' and lists no `patient` role, so
+ *     any `patient` on this command is spurious by construction; and
+ *   - the `primaryRole` slot is empty, so a real value is never clobbered (e.g. a
+ *     `fetch` carrying both a `source` URL and a `body` patient keeps the patient).
+ * The value — and its type — is preserved, so `fetch.patient:literal` becomes
+ * `fetch.source:literal`, matching the en reference. Recurses into every body node
+ * and is idempotent (a second pass finds no spurious patient). Applied once on the
+ * final tree, outside the hot matching loop.
+ */
+const NORMALIZE_CHILD_FIELDS = [
+  'body',
+  'statements',
+  'thenBranch',
+  'elseBranch',
+  'eventHandlers',
+  'initBlock',
+] as const;
+
+function normalizeCommandRoles(node: SemanticNode): SemanticNode {
+  if (!node || typeof node !== 'object') return node;
+
+  if (node.action && node.roles instanceof Map) {
+    const schema = getSchema(node.action);
+    const primary = schema?.primaryRole;
+    if (
+      schema &&
+      primary &&
+      primary !== 'patient' &&
+      !schema.roles.some(r => r.role === 'patient') &&
+      node.roles.has('patient') &&
+      !node.roles.has(primary)
+    ) {
+      const roles = node.roles as Map<SemanticRole, SemanticValue>;
+      const value = roles.get('patient');
+      if (value !== undefined) {
+        roles.delete('patient');
+        roles.set(primary, value);
+      }
+    }
+  }
+
+  const rec = node as unknown as Record<string, unknown>;
+  for (const field of NORMALIZE_CHILD_FIELDS) {
+    const child = rec[field];
+    if (Array.isArray(child)) {
+      for (const c of child) normalizeCommandRoles(c as SemanticNode);
+    }
+  }
+  return node;
+}
+
 export class SemanticParserImpl implements ISemanticParser {
+  /**
+   * Parse input in the specified language to a semantic node, then apply the R1
+   * role-fidelity normalization (see {@link normalizeCommandRoles}) once on the
+   * assembled tree. Every public + recursive parse path funnels through here, so
+   * the normalization reaches body commands built by any sub-parser.
+   */
+  parse(input: string, language: string): SemanticNode {
+    return normalizeCommandRoles(this.parseInternal(input, language));
+  }
+
   /**
    * Parse input in the specified language to a semantic node.
    * Accumulates diagnostics from each fallback stage (Phase 3.4).
    */
-  parse(input: string, language: string): SemanticNode {
+  private parseInternal(input: string, language: string): SemanticNode {
     // Stage 0: structural / block layer. A `behavior … end` block is decomposed
     // into its handlers (each parsed by the single-statement path below) and
     // re-assembled — otherwise the leading keyword matches and the whole body is

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -8106,3 +8106,75 @@ describe('Optional call patient marker he/zh (form-submit-prevent lossy → fait
     expect(parse('调用 validateForm()', 'zh').action).toBe('call');
   });
 });
+
+describe('SOV primary-role normalization (Arc 4 — fronted patient → schema primaryRole; R1)', () => {
+  // When an SOV/V2 reorder fronts a command's leading object, the fused-event path
+  // binds it to the generic `patient` role. For commands with NO `patient` role and
+  // a distinct primaryRole (fetch→source, wait→duration, send/trigger→event), this
+  // is a pure R1 role MISTYPE — the command and the value's TYPE are right, only the
+  // role NAME is wrong (`fetch.source` was missing 13× per SOV language). The
+  // normalization relabels the spurious `patient` to the schema primaryRole, lifting
+  // avgRoleFidelity ~+0.04 across hi/bn/qu/ja/ko/tr with zero R0/precision regressions.
+  // See normalizeCommandRoles in semantic-parser.ts.
+
+  // First command node with the given action anywhere in the tree → its roles map.
+  function findRoles(node: any, action: string): Map<string, any> | undefined {
+    if (!node || typeof node !== 'object') return undefined;
+    if (node.action === action && node.roles instanceof Map) return node.roles;
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'eventHandlers', 'initBlock']) {
+      const child = node[f];
+      if (Array.isArray(child)) {
+        for (const c of child) {
+          const r = findRoles(c, action);
+          if (r) return r;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  // Corpus-shaped SOV translations: the fronted URL must land in `source`, never the
+  // spurious `patient` (fetch schema has no patient role).
+  const fetchCases: Array<[string, string]> = [
+    ['hi', '/api/data को क्लिक पर लाएं फिर यह को रखें #result में'],
+    ['ja', '/api/data を クリック で フェッチ それから それ を #result に 置く'],
+    ['ko', '/api/data 를 클릭 할 때 가져오기 그러면 그것 를 #result 에 넣다'],
+    ['qu', '/api/data ta ñitiy pi apamuy chayqa chay ta #result man churay'],
+  ];
+  for (const [lang, input] of fetchCases) {
+    it(`[${lang}] fronted fetch URL → fetch.source (not patient)`, () => {
+      const roles = findRoles(parse(input, lang), 'fetch');
+      expect(roles).toBeDefined();
+      expect(roles!.has('source')).toBe(true);
+      expect(roles!.has('patient')).toBe(false);
+    });
+  }
+
+  it('[hi] fronted wait duration → wait.duration (not patient)', () => {
+    const roles = findRoles(parse('2s को क्लिक पर प्रतीक्षा फिर मैं को हटाएं', 'hi'), 'wait');
+    expect(roles?.has('duration')).toBe(true);
+    expect(roles?.has('patient')).toBe(false);
+  });
+
+  it('[ja] fronted send payload → send.event (not patient)', () => {
+    const roles = findRoles(parse('"hello" を クリック で 送る ChatSocket に', 'ja'), 'send');
+    expect(roles?.has('event')).toBe(true);
+    expect(roles?.has('patient')).toBe(false);
+  });
+
+  // Control: a command that legitimately HAS a patient role (primaryRole === patient)
+  // keeps it — the normalization is gated to primaryRole !== patient, so toggle/add/etc
+  // are never touched.
+  it('[ja] toggle keeps its patient role (schema primaryRole IS patient — not remapped)', () => {
+    const roles = findRoles(parse('.active を クリック で トグル', 'ja'), 'toggle');
+    expect(roles?.has('patient')).toBe(true);
+  });
+
+  // Control: en SVO is unaffected (the standard pattern assigns source directly; the
+  // normalization is a no-op because there is no spurious patient).
+  it('[en] SVO fetch is unchanged (source, no patient)', () => {
+    const roles = findRoles(parse('on click fetch /api/data', 'en'), 'fetch');
+    expect(roles?.has('source')).toBe(true);
+    expect(roles?.has('patient')).toBe(false);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-27T21:59:18.763Z",
-  "commit": "12018416",
+  "timestamp": "2026-06-28T01:17:24.271Z",
+  "commit": "23b3dab8",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9,12 +9,12 @@
       "avgConfidence": 0.8371917985695063,
       "avgFidelity": 1,
       "avgPrecision": 0.978030303030303,
-      "avgRoleFidelity": 0.8783313533313536,
+      "avgRoleFidelity": 0.9219767844767845,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -641,12 +641,12 @@
       "avgConfidence": 0.8495030867211314,
       "avgFidelity": 1,
       "avgPrecision": 0.9231838695073992,
-      "avgRoleFidelity": 0.7842845592845592,
+      "avgRoleFidelity": 0.830568343068343,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.828035456606883,
       "avgFidelity": 1,
       "avgPrecision": 0.9951298701298701,
-      "avgRoleFidelity": 0.8609327046827049,
+      "avgRoleFidelity": 0.8818303880803882,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
       "avgPrecision": 0.983008658008658,
-      "avgRoleFidelity": 0.8436497623997625,
+      "avgRoleFidelity": 0.8692128254628255,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
       "avgPrecision": 0.9817099567099568,
-      "avgRoleFidelity": 0.8469718344718347,
+      "avgRoleFidelity": 0.8928695178695178,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3794,12 +3794,12 @@
       "avgConfidence": 0.8237889095031952,
       "avgFidelity": 1,
       "avgPrecision": 0.9835497835497835,
-      "avgRoleFidelity": 0.9068897881397883,
+      "avgRoleFidelity": 0.9095442282942283,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4426,12 +4426,12 @@
       "avgConfidence": 0.90909904631709,
       "avgFidelity": 1,
       "avgPrecision": 0.9165363046044861,
-      "avgRoleFidelity": 0.7570510758010759,
+      "avgRoleFidelity": 0.8008573821073822,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
       "avgPrecision": 0.9812770562770563,
-      "avgRoleFidelity": 0.8602681665181665,
+      "avgRoleFidelity": 0.8779483466983466,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.9728625541125538,
-      "avgRoleFidelity": 0.8406463468963471,
+      "avgRoleFidelity": 0.8605787793287796,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
       "avgPrecision": 0.9422938803620623,
-      "avgRoleFidelity": 0.7953987641487641,
+      "avgRoleFidelity": 0.8369528182028183,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6954,12 @@
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
       "avgPrecision": 0.9422938803620624,
-      "avgRoleFidelity": 0.8060486997986998,
+      "avgRoleFidelity": 0.847602753852754,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
       "avgPrecision": 0.9795454545454545,
-      "avgRoleFidelity": 0.8735453172953174,
+      "avgRoleFidelity": 0.8966952529452528,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
       "avgPrecision": 0.9912608225108225,
-      "avgRoleFidelity": 0.8438638501138503,
+      "avgRoleFidelity": 0.8621070933570935,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8850,12 @@
       "avgConfidence": 0.7995877138734262,
       "avgFidelity": 1,
       "avgPrecision": 0.9804112554112555,
-      "avgRoleFidelity": 0.8663492475992477,
+      "avgRoleFidelity": 0.885155553905554,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9482,12 @@
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
       "avgPrecision": 0.9474577640973745,
-      "avgRoleFidelity": 0.7847966785466785,
+      "avgRoleFidelity": 0.8263507326007323,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.8142650999793837,
       "avgFidelity": 1,
       "avgPrecision": 0.9886634199134199,
-      "avgRoleFidelity": 0.8436980249480251,
+      "avgRoleFidelity": 0.8647565835065837,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10746,12 +10746,12 @@
       "avgConfidence": 0.7962481962481944,
       "avgFidelity": 1,
       "avgPrecision": 0.9796536796536797,
-      "avgRoleFidelity": 0.872993391743392,
+      "avgRoleFidelity": 0.890673571923572,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.9737012987012986,
-      "avgRoleFidelity": 0.8291571791571792,
+      "avgRoleFidelity": 0.8523071148071149,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12010,12 +12010,12 @@
       "avgConfidence": 0.8216537651743292,
       "avgFidelity": 1,
       "avgPrecision": 0.9784632034632035,
-      "avgRoleFidelity": 0.8839056776556778,
+      "avgRoleFidelity": 0.9025511088011089,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12642,12 +12642,12 @@
       "avgConfidence": 0.8296585690806532,
       "avgFidelity": 1,
       "avgPrecision": 0.9444999717058541,
-      "avgRoleFidelity": 0.8066567408404142,
+      "avgRoleFidelity": 0.8484934755342919,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13273,12 +13273,12 @@
       "avgConfidence": 0.8135229849515544,
       "avgFidelity": 1,
       "avgPrecision": 0.9886634199134197,
-      "avgRoleFidelity": 0.8325493762993766,
+      "avgRoleFidelity": 0.8536079348579351,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13905,12 +13905,12 @@
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
       "avgPrecision": 0.9795725108225107,
-      "avgRoleFidelity": 0.8724674537174537,
+      "avgRoleFidelity": 0.8956173893673893,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14542,7 +14542,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 446559,
+      "bundleSize": 447087,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15165,7 +15165,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 446559,
+      "size": 447087,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

**Arc 4 — R1/SOV role-fidelity burn-down** (the highest-headroom remaining multilingual work per [MULTILINGUAL_NEXT_STEPS.md](docs-internal/MULTILINGUAL_NEXT_STEPS.md) Track 3 / [HANDOFF-lossy-tail.md](docs-internal/HANDOFF-lossy-tail.md) Arc 4).

Grounded empirically via the gate path (`ml.parse` over `patterns.db` translations, role-signature diff vs the en reference): the **dominant R1 drop in every SOV/reorder language** is a fronted object bound to the generic `patient` role for commands that have **no `patient` role**. `fetch` (primaryRole `source`), `wait` (`duration`), `send`/`trigger` (`event`), `bind`/`tell` (`destination`) — the URL/duration/event parsed as `<cmd>.patient` instead of `<cmd>.<primaryRole>`. A pure role **mistype** (command + value *type* correct; only the role *name* wrong) — invisible to R0 recall, but `fetch.source` alone was missing **13× per language**.

## Fix

A schema-driven post-parse normalization (`normalizeCommandRoles` in `semantic-parser.ts`) relabels a spurious `patient` to the schema `primaryRole`, gated so it can **only ever correct a mistype, never lose information**:
- the schema's `primaryRole ≠ patient` **and** the schema lists no `patient` role (so any `patient` is spurious by construction), and
- the `primaryRole` slot is empty (never clobber a real value — e.g. a `fetch` carrying both a `source` URL and a `body` patient keeps the patient).

The value **and its type** are preserved (`fetch.patient:literal` → `fetch.source:literal`). Applied once on the final tree — every parse path funnels through `SemanticParserImpl.parse` — recursive into all body nodes, idempotent, outside the hot matching loop. Because it only renames a role (never touches the action multiset), R0 recall/precision are structurally unaffected; en/SVO parses are no-ops.

## Result (`browser-priority`)

| signal | before | after |
|--------|--------|-------|
| **avgRoleFidelity (R1)** | 0.845 | **0.872** (+0.027) |
| avgFidelity (R0) | 1.000 | 1.000 |
| avgPrecision | 0.971 | 0.971 |
| avgExecutionFidelity (R2) | 1.000 | 1.000 |
| degenerate / lossy | 0 / 0 | 0 / 0 |

Per SOV/reorder language: hi 0.757→0.801 · bn 0.784→0.831 · qu 0.785→0.826 · ja 0.795→0.837 · ko 0.806→0.848 · tr 0.807→0.849 (~+0.04 each).

- `--regression` gate green; baseline regenerated (`--save-baseline`).
- 6216 semantic tests pass.
- Guard: `multilingual-roadmap-fixes.test.ts` → "SOV primary-role normalization" (fetch/wait/send fronted → primaryRole; toggle keeps its patient; en SVO unaffected) — **verified failing without the fix**.

Per repo convention, `patterns.db` is not committed (CI repopulates); only the fix + guard + regenerated baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)