### PR TITLE
fix(multilingual): tr resize single-token keyword → parse rate 100% (3696/3696)

### DIFF
--- a/packages/i18n/src/dictionaries/tr.ts
+++ b/packages/i18n/src/dictionaries/tr.ts
@@ -105,7 +105,7 @@ export const tr: Dictionary = {
     reset: 'sıfırla',
     load: 'yükle',
     unload: 'yükle_kaldır',
-    resize: 'boyut_değiştir',
+    resize: 'boyutlandırma',
     scroll: 'kaydır',
     touchstart: 'dokunma_başla',
     touchend: 'dokunma_bitir',

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -2137,3 +2137,20 @@ describe('Chinese take translates to 拿取, not 获取 (zh take/get homonym)', 
     expect(zh('get #input.value')).not.toContain('拿取');
   });
 });
+
+describe('tr resize single-token event keyword (window-resize NULL → faithful)', () => {
+  // The dict previously emitted `boyut_değiştir` for the resize event; the tr
+  // semantic tokenizer splits on `_` → `boyut` + `değiştir`, and `değiştir`
+  // normalizes to `toggle` (homonym collision) — which destroyed the resize event
+  // and made `window-resize` the lone tr parse hard-fail. A non-underscore keyword
+  // (`boyutlandırma`) keeps the event token whole (mirrors the ru/uk install
+  // single-token route). Pairs with the semantic event-map entry.
+  const transformer = new GrammarTransformer('en', 'tr');
+
+  it('emits the single-token resize keyword (no underscore, no toggle homonym)', () => {
+    const result = transformer.transform('on resize from window call adjustLayout()');
+    expect(result).toContain('boyutlandırma');
+    expect(result).not.toContain('boyut_değiştir');
+    expect(result).not.toContain('değiştir'); // the toggle-homonym fragment is gone
+  });
+});

--- a/packages/semantic/src/patterns/event-handler.ts
+++ b/packages/semantic/src/patterns/event-handler.ts
@@ -112,7 +112,14 @@ export const eventNameTranslations: Record<string, Record<string, string>> = {
     bulanıklık: 'blur',
     yükleme: 'load',
     yükle: 'load',
-    boyut_değiştir: 'resize',
+    // resize: single-token `boyutlandırma` (and the verb stem `boyutlandır`). The
+    // former i18n emission `boyut_değiştir` split on `_` in the tr tokenizer →
+    // `boyut` + `değiştir`, and `değiştir` normalizes to `toggle` — a homonym
+    // collision that destroyed the resize event (window-resize was the lone tr
+    // parse hard-fail). A non-underscore keyword (mirrors the ru/uk install and
+    // the `kaydır`/`kaydırma` scroll precedent) keeps the event token whole.
+    boyutlandırma: 'resize',
+    boyutlandır: 'resize',
     kaydırma: 'scroll',
   },
   // Portuguese event names → English

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -8178,3 +8178,26 @@ describe('SOV primary-role normalization (Arc 4 — fronted patient → schema p
     expect(roles?.has('patient')).toBe(false);
   });
 });
+
+describe('tr resize single-token event keyword (window-resize NULL → faithful)', () => {
+  // `boyut_değiştir` split on `_` in the tr tokenizer → `boyut` + `değiştir`, and
+  // `değiştir` normalizes to `toggle` (homonym), destroying the resize event — the
+  // lone tr parse hard-fail. The non-underscore `boyutlandırma` (and the verb stem
+  // `boyutlandır`) keep the event token whole and resolve to the `resize` event.
+  // The window-resize corpus shape (en reference:
+  // `on resize from window debounced at 200ms call adjustLayout()`).
+  const corpus = 'debounced at 200ms adjustLayout() i boyutlandırma de çağır pencere den';
+
+  it('[tr] window-resize parses as a resize event handler (was the lone tr hard-fail)', () => {
+    const node: any = parse(corpus, 'tr');
+    expect(node.action).toBe('on');
+    expect(node.roles.get('event')?.value).toBe('resize');
+  });
+
+  it('[tr] resize keyword no longer mis-parses as the `toggle` homonym (call body, no toggle)', () => {
+    const node: any = parse(corpus, 'tr');
+    const actions = (node.body || []).map((b: any) => b.action);
+    expect(actions).toContain('call');
+    expect(actions).not.toContain('toggle');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-28T01:17:24.271Z",
-  "commit": "23b3dab8",
+  "timestamp": "2026-06-28T01:31:22.121Z",
+  "commit": "abed2b6d",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12636,18 +12636,18 @@
       }
     },
     "tr": {
-      "parseSuccess": 153,
-      "parseFailure": 1,
-      "parseRate": 0.9935064935064936,
-      "avgConfidence": 0.8296585690806532,
+      "parseSuccess": 154,
+      "parseFailure": 0,
+      "parseRate": 1,
+      "avgConfidence": 0.827517929021688,
       "avgFidelity": 1,
-      "avgPrecision": 0.9444999717058541,
-      "avgRoleFidelity": 0.8484934755342919,
+      "avgPrecision": 0.9448603614999719,
+      "avgRoleFidelity": 0.8495171682671683,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13170,7 +13170,8 @@
           "confidence": 0.5
         },
         "window-resize": {
-          "success": false
+          "success": true,
+          "confidence": 0.5
         },
         "set-color-variable": {
           "success": true,
@@ -13278,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13910,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14542,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447087,
+      "bundleSize": 447107,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15165,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 447087,
+      "size": 447107,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Clears the **lone remaining parse hard-fail** (`tr window-resize`), taking the priority corpus to **3696/3696 (100%)** — zero failing patterns across all 24 languages.

> **Stacked on #508** (Arc 4 R1 normalization). Base branch is `fix/multilingual-sov-primary-role-r1`; the regenerated baseline in this PR includes both changes. Merge #508 first, then retarget/rebase this to `main`.

## Root cause (grounded, not assumed)

The i18n tr dict emitted `boyut_değiştir` for the `resize` event. The tr semantic tokenizer splits on `_` → `boyut` + `değiştir`, and `değiştir` normalizes to **`toggle`** (homonym collision) — destroying the resize event so the handler parsed **NULL**.

Grounding via `ml.parse` on the actual gate translation **corrected the documented framing**: the handoff claimed the fronted untranslated `debounced at 200ms` modifier was "the separate, harder half" also needed. It isn't — the parser tolerates the fronted modifier; the underscore-split toggle homonym was the **sole** blocker. (Methodology lesson again: verify the theorized cause.)

## Fix (low-risk, single-token route)

Mirrors the documented ru/uk `install` single-token precedent and the working `kaydır`/`kaydırma` scroll pattern:
- **i18n tr dict**: `resize: 'boyut_değiştir'` → `'boyutlandırma'`
- **semantic event map**: `boyutlandırma`/`boyutlandır` → `resize` (replaces the dead underscore key)

`window-resize` tr now parses faithfully: `action=on, event=resize, body=call` — structurally identical to the en reference.

## Result

- Parse rate **3695/3696 → 3696/3696 (100%)**; tr `parseFailure` 1 → 0; **zero failing patterns** in all 24 priority languages.
- R0 recall 1.000, precision 0.971, avgRoleFidelity 0.872 (from #508), execution 1.000, degenerate 0, lossy 0 — all unchanged.
- `--regression` gate green; baseline regenerated; 6218 semantic + 880 i18n tests pass.
- Guards (verified failing without the fix): `grammar.test.ts` + `multilingual-roadmap-fixes.test.ts` → "tr resize single-token event keyword".

`patterns.db` not committed (CI repopulates), per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)