### PR TITLE
docs(multilingual): record Arc 4 + tr window-resize (parse rate 100%, R1 0.872) + patterns.db correction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,8 +343,14 @@ The gate exits non-zero on a parse-rate drop >2pts or >3 faithful→degenerate
 flips vs the committed baseline. After an _intentional_ fidelity change, re-run
 with `--save-baseline` (instead of `--regression`) to regenerate
 `packages/testing-framework/baselines/multilingual-priority.json`, and commit the
-new baseline. Per repo convention the regenerated `patterns.db` is **not**
-committed — CI re-populates it; only the dicts/profiles + baseline are tracked.
+new baseline. **Do not commit your locally-regenerated `patterns.db`** — commit
+only the dicts/profiles + baseline. (Note: a frozen copy of `patterns.db` _is_
+tracked — `.gitignore` has an explicit `!packages/patterns-reference/data/patterns.db`
+un-ignore, and CI is built around it via `db:init:force`/`populate`. But contributors
+don't commit regenerations, to avoid binary churn, so the tracked copy can lag the
+current dicts/profiles; CI always re-populates a fresh DB for the gate. If you `git
+checkout -- packages/patterns-reference/data/patterns.db` you revert to that possibly-stale
+committed copy — re-run `npm run populate` before any local gate/probe work.)
 
 **Other Workflows:**
 

--- a/docs-internal/HANDOFF-lossy-tail.md
+++ b/docs-internal/HANDOFF-lossy-tail.md
@@ -366,7 +366,22 @@ resizable.
 
 ---
 
-## Arc 4 — R1 / SOV role-fidelity burn-down (Track 3) [LARGER ARC]
+## Arc 4 — R1 / SOV role-fidelity burn-down (Track 3) [PARTLY DONE — #508]
+
+> **First increment DONE (2026-06-28, #508 — avgRoleFidelity 0.845 → 0.872).** Grounding (the
+> gate-faithful `ml.parse` role-signature diff) showed the dominant R1 drop was NOT the
+> "fronted literal mis-anchored as the event" theory below, but a **role MISTYPE**: an
+> SOV-fronted object bound to the generic `patient` role for commands that have NO `patient`
+> role and a distinct `primaryRole` (`fetch`→source — missing 13× per language, `wait`→duration,
+> `send`/`trigger`→event, `bind`/`tell`→destination). A schema-driven post-parse normalization
+> (`normalizeCommandRoles`) relabels the spurious `patient` to the schema `primaryRole`, gated so
+> it can only ever correct a mistype (en/SVO are no-ops). **Per-SOV-lang ~+0.04** (hi 0.757→0.801,
+> bn 0.784→0.831, qu 0.785→0.826, ja 0.795→0.837, ko 0.806→0.848, tr 0.807→0.849); R0/precision/
+> execution + degenerate/lossy all unchanged. The change was LOW-risk after all (a relabel on the
+> final tree, not a rewrite of the hot matching loop). **Remaining R1 headroom** is per-command
+> value-TYPE mismatches (e.g. `send.destination` selector-vs-reference, `repeat` loop roles,
+> `set.destination` property-path in SOV) — smaller, per-command, lower priority. The HIGH-risk
+> "SOV event-anchor" framing below was not needed for the dominant slice.
 
 avgRoleFidelity **0.845** is the laggard (hi 0.757 · bn 0.784 · qu 0.785 · ja 0.795 · ko 0.806 ·
 tr 0.807 — the SOV/reorder set). R1 measures `action.role:valueType` recall — a parse that keeps
@@ -385,9 +400,13 @@ it a dedicated arc with careful R0/precision/parse-rate guards — not a tail-en
 
 ## Deferred / out of scope
 
-- **`tr window-resize`** — the lone parse hard-fail (3695/3696). Compounded i18n underscore-split
-  (`boyut_değiştir` → `değiştir` collides with `toggle`) + an untranslated `debounced at 200ms`
-  modifier; a high-risk multi-part change to the hottest path for the single lowest-ROI pattern.
+- ~~**`tr window-resize`**~~ **DONE (2026-06-28, #510 — parse rate 3696/3696, 100%).** The
+  "compounded, high-risk multi-part change" framing was wrong (grounding via `ml.parse`): the
+  `boyut_değiştir` underscore-split → `değiştir`→`toggle` homonym was the **sole** blocker; the
+  untranslated `debounced at 200ms` modifier is tolerated by the parser, not a second blocker. A
+  single-token `boyutlandırma` (i18n dict + semantic event map; mirrors the ru/uk install route)
+  keeps the event token whole. LOW-risk, contained. Zero failing patterns now remain across all
+  24 priority languages.
 - **`populate` determinism (Track 5 hygiene).** CLAUDE.md flags "minor residual jitter" on a few
   boundary patterns that forces the ratchet tolerances (3 lossy / 3 degen flips, 0.02 avg). A
   deterministic populate lets the tolerances tighten toward 0 — fold in opportunistically.
@@ -425,13 +444,16 @@ for provenance:
    `input-mirror` (vi; registered `giá trị`=value), and `keydown-key-is-syntax` (hi; a `-`-compound
    `साफ़-करें` tokenization split — **NOT** the Arc-4 SOV anchor it was filed under).
 
-**Only two items remain — both separate dimensions, NOT lossy passes:**
+**Both remaining items are now DONE (2026-06-28):**
 
-- **Arc 4 (R1/SOV role-fidelity, avgRoleFidelity 0.845)** — the ONLY remaining fidelity dimension
-  and the highest-headroom multilingual work. Laggards hi 0.757 · bn 0.784 · qu 0.785. The
-  convergent SOV event-anchor arc; **HIGH risk** (hottest, most regression-sensitive parser path) —
-  and `--regression` won't flag R1 drift until someone drives it, so guard R0/precision/parse-rate
-  carefully in a dedicated session. (The qu/bn/hi-trigger residue lives here too — gate-invisible,
-  see the Arc 1 dead-end note.)
-- **`tr window-resize`** — the lone parse hard-fail (3695/3696), explicitly deferred as lowest-ROI
-  (see Deferred / out of scope above).
+- ~~**Arc 4 (R1/SOV role-fidelity)**~~ **First increment DONE (#508 — avgRoleFidelity
+  0.845 → 0.872).** The dominant slice (SOV-fronted `patient` → schema `primaryRole` mistype) is
+  fixed; see the Arc 4 DONE block. Residual R1 headroom is per-command value-type mismatches
+  (`send.destination`, `repeat` roles, SOV `set.destination` property-path) — smaller, lower
+  priority, NOT the convergent high-risk arc once theorized. (The qu/bn/hi-trigger residue remains
+  gate-invisible — see the Arc 1 dead-end note.)
+- ~~**`tr window-resize`**~~ **DONE (#510 — parse rate 3696/3696, 100%).** See Deferred / out of
+  scope above.
+
+**Net: the priority corpus is at 100% parse rate, both correctness bands empty, R1 0.872.** No
+open items remain in this handoff beyond the smaller per-command R1 type-mismatch follow-on.

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,28 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-28 (Arc 4 R1 landed + parse rate 100%).** Two follow-on fixes shipped:
+>
+> - **Arc 4 — SOV role-fidelity (#508).** A schema-driven primary-role normalization
+>   (`normalizeCommandRoles` in `semantic-parser.ts`) relabels an SOV-fronted spurious
+>   `patient` to the command's schema `primaryRole` for commands with no patient role
+>   (fetch→source, wait→duration, send/trigger→event). **avgRoleFidelity 0.845 → 0.872**;
+>   per-SOV-lang ~+0.04 (hi 0.757→0.801, bn 0.784→0.831, qu 0.785→0.826, ja/ko/tr similar).
+>   R0/precision/execution + degenerate/lossy all unchanged; gate green, guarded.
+> - **tr `window-resize` (#510).** The lone parse hard-fail, cleared: the i18n dict's
+>   `boyut_değiştir` split on `_` → `değiştir`→`toggle` homonym destroyed the resize event; a
+>   single-token `boyutlandırma` keeps it whole. **Parse rate 3695/3696 → 3696/3696 (100%)** —
+>   zero failing patterns across all 24 priority languages. (Grounding corrected the handoff:
+>   the fronted `debounced at 200ms` modifier was NOT a second blocker — the parser tolerates it.)
+>
+> Current authoritative state: parse rate **3696/3696 (100%)**, degenerate **0**, lossy **0**,
+> avgFidelity **1.000**, avgPrecision **0.971**, **avgRoleFidelity 0.872**, R2 **1.000**.
+> The 2026-06-21 table below is superseded. **R1/SOV role-fidelity is the only open headroom**
+> (laggards now hi 0.801 · qu 0.826 · bn 0.831): the dominant patient→primaryRole mistype is
+> fixed, and the remaining R1 drops are per-command value-TYPE mismatches (e.g.
+> `send.destination` selector-vs-reference, `repeat` loop roles, `set.destination` property-path
+> in SOV) — a smaller, lower-priority follow-on, not a single convergent defect. See Track 3.
+
 > **Update 2026-06-27 (lossy tail CLEARED — both correctness bands now empty).** The
 > degenerate band (→0, #492/#493) and the **lossy band (53 → 0, #495–#506)** are now BOTH
 > empty: **every one of the 3695/3696 parsing patterns is faithful** (fid = 1.0). The lossy

--- a/docs-internal/MULTILINGUAL_ROADMAP.md
+++ b/docs-internal/MULTILINGUAL_ROADMAP.md
@@ -47,6 +47,16 @@ _Earlier: after Track 5 **Tier 1 — if/else block-body in event handlers** (deg
 
 ## Current state
 
+> **Snapshot 2026-06-28 (post #508 + #510, `browser-priority`).** parse rate
+> **3696/3696 (100%)** — **zero hard fails, zero failing patterns across all 24 priority
+> languages** (`tr window-resize` cleared, #510) · degenerate **0** · lossy **0** · faithful
+> **3696** · avgFidelity **1.000** · avgPrecision **0.971** · **avgRoleFidelity 0.872** (was
+> 0.845; Arc 4 SOV primary-role normalization, #508) · avgExecutionFidelity **1.000**. R1/SOV
+> role-fidelity remains the only open headroom (laggards hi 0.801 · qu 0.826 · bn 0.831 — the
+> dominant patient→primaryRole mistype is fixed; the residue is per-command value-type
+> mismatches). See [MULTILINGUAL_NEXT_STEPS.md](MULTILINGUAL_NEXT_STEPS.md). Authoritative
+> numbers always live in the baseline JSON.
+
 > **Snapshot 2026-06-27 (baseline commit `12018416`, `browser-priority`).** parse rate
 > **3695/3696 (99.97%)**, 1 hard fail (`tr window-resize`) · degenerate **0** · **lossy 0** ·
 > faithful **3695** · avgFidelity **1.000** · avgPrecision **0.971** (hi 0.917 outlier) ·


### PR DESCRIPTION
## Summary

Follow-up docs refresh after **#508** (Arc 4 R1/SOV role-fidelity, 0.845→0.872) and **#510** (tr window-resize → 100% parse rate). Brings the planning/status docs to current authoritative state.

- **MULTILINGUAL_NEXT_STEPS.md** — dated 2026-06-28 note: Arc 4 landed (per-SOV-lang ~+0.04) + tr window-resize cleared (3696/3696, 100%); reframes the remaining R1 headroom as smaller per-command value-type mismatches.
- **MULTILINGUAL_ROADMAP.md** — 2026-06-28 Current-state snapshot (100% parse rate, R1 0.872).
- **HANDOFF-lossy-tail.md** — Arc 4 marked PARTLY DONE (#508) with the corrected grounding (it was a `patient→primaryRole` mistype, not the high-risk SOV event-anchor theory); tr window-resize marked DONE (#510).

## CLAUDE.md correction (the real "patterns.db" follow-up)

My earlier suggestion to gitignore `patterns.db` was based on misreading CLAUDE.md. Investigation showed `patterns.db` is **deliberately tracked** — `.gitignore` has an explicit `!packages/patterns-reference/data/patterns.db` un-ignore, and CI's `db:init:force` step is built around the committed copy. So gitignoring it would be wrong.

The actual defect was the CLAUDE.md wording ("patterns.db is not committed"), which contradicts that. Corrected it to: a frozen copy *is* tracked, contributors don't commit regenerations (binary churn) so the tracked copy can lag, and `git checkout -- patterns.db` reverts to that possibly-stale copy (re-populate before local gate work). No behavior change — doc accuracy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)