### PR TITLE
test(multilingual): R2 execution wave 5 — add remove-element (subset 32 → 33)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,32 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-28b (R1 default-fill → 0.908; R2 wave 5).** Two more fixes:
+>
+> - **R1 schema default-fill (#512).** After Arc 4, the dominant remaining R1 drop was
+>   DEFAULTED roles: the SVO pattern path materializes a schema role's `default` when
+>   absent (toggle/add destination → me, increment/decrement quantity → 1) so en carries
+>   it, but the SOV paths drop it (both default identically at runtime — a measurement
+>   false-positive). A `fillSchemaDefaults` MEASUREMENT pass (parse-validator, on en +
+>   every translation; NOT in `parse()`, which would pollute the renderer) lifts
+>   **avgRoleFidelity 0.872 → 0.908** (per-SOV ~+0.04). R0/precision/R2 unchanged.
+> - **R2 execution wave 5 (#513).** Added `remove-element` (`remove me`) — the only one
+>   of ten fixture-eligible candidates that matched the en effect in **all 23 languages**,
+>   so **avgExecutionFidelity stays 1.000** (subset 32 → 33). The other nine eligible
+>   candidates have real per-language EXECUTION gaps (parse-faithful but executes
+>   differently — exactly what R2 catches) and are the **grounded next-wave worklist**:
+>   `next-element` (1 lang: ms) · `toggle-aria-expanded` (2: id,ms) · `set-opacity` (4) ·
+>   `set-transform` (4) · `multiple-events` (6) · `accordion-toggle` (6) · `put-after` (14) ·
+>   `put-before` (14) · `caret-var-on-target` (23, all). Each must be FIXED (not just
+>   recorded) before it can join the subset without dropping R2 below 1.0 — the next
+>   correctness arc beyond structural fidelity.
+>
+> Current authoritative state: parse rate **3696/3696 (100%)**, degenerate **0**, lossy
+> **0**, avgFidelity **1.000**, avgPrecision **0.971**, **avgRoleFidelity 0.908**, R2
+> **1.000** (33-pattern curated subset). Remaining R1 headroom (hi 0.852 · ja 0.880 the
+> laggards) is per-command value-type mismatches (`set.destination:property-path`,
+> `repeat` loop roles, `halt.patient` literal-vs-reference) — harder/structural, lower ROI.
+
 > **Update 2026-06-28 (Arc 4 R1 landed + parse rate 100%).** Two follow-on fixes shipped:
 >
 > - **Arc 4 — SOV role-fidelity (#508).** A schema-driven primary-role normalization

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-28T02:37:46.043Z",
-  "commit": "827e79da",
+  "timestamp": "2026-06-28T02:47:33.771Z",
+  "commit": "2c806662",
   "languages": {
     "ar": {
       "parseSuccess": 154,

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
@@ -19,7 +19,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { ExecutionValidator, EXECUTION_SUBSET, loadExecutionSubset } from './execution-validator';
 
 describe('R2 execution subset (lock)', () => {
-  it('contains exactly the 32 curated patterns', () => {
+  it('contains exactly the 33 curated patterns', () => {
     // Changing this list recalibrates avgExecutionFidelity for every language.
     // If you expand the subset, regenerate the baseline (--save-baseline) in
     // the SAME PR and update this lock.
@@ -88,6 +88,12 @@ describe('R2 execution subset (lock)', () => {
         // PATTERN_TRIGGER dispatches a CustomEvent whose detail.message the
         // handler reads. set @role on the #sr-announce scope landed in S1.
         'announce-screen-reader',
+        // Session-12 expansion wave 5: `remove me` (bare self-removal). The only
+        // one of ten fixture-eligible candidates that matched the en effect in ALL
+        // 23 languages (so avgExecutionFidelity stays 1.0); the other nine have
+        // per-language execution gaps tracked as the next-wave worklist (see the
+        // wave-5 note in execution-validator.ts).
+        'remove-element',
       ].sort()
     );
   });

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.ts
@@ -125,6 +125,22 @@ export const EXECUTION_SUBSET: readonly string[] = [
   // with a `detail` payload. The en reference writes the announcement text into
   // #sr-announce and sets role=alert on it: two clean effect lines.
   'announce-screen-reader',
+  // Expansion wave 5 (session 12): `remove me` — the bare self-removal positional.
+  // Discovery probe (every non-subset, non-network/timer/behavior pattern executed
+  // against this fixture, then all 23 translations checked against the en effect
+  // signature) found ten patterns with a clean non-empty en effect, but only
+  // `remove-element` matched en in ALL 23 languages — so it's the only all-match
+  // addition that keeps avgExecutionFidelity at 1.0. No fixture/setup/trigger change
+  // (it removes #btn on the default click). The other nine eligible candidates are
+  // the grounded worklist for the next wave — each has real per-language EXECUTION
+  // gaps to fix BEFORE it can join (divergent-lang counts, session 12 probe):
+  //   next-element (1: ms) · toggle-aria-expanded (2: id,ms) ·
+  //   set-opacity (4) · set-transform (4) · multiple-events (6) · accordion-toggle (6) ·
+  //   put-after (14) · put-before (14) · caret-var-on-target (23, all).
+  // These execution divergences are invisible to R0/R1 (parse-faithful) — exactly the
+  // class R2 exists to catch — but each must be fixed (not just recorded) before adding,
+  // or it drops R2 below 1.0. Tracked in docs-internal/MULTILINGUAL_NEXT_STEPS.md.
+  'remove-element',
 ];
 
 /**


### PR DESCRIPTION
## Summary

**Tier 3 — expand the R2 execution subset.** A discovery probe ran every non-subset, non-network/timer/behavior pattern through the execution validator against the curated fixture, then checked all 23 translations against the en effect signature. Ten patterns produced a clean non-empty en effect, but only **`remove-element`** (`remove me`) matched en in **all 23 languages** — so it's the one all-match addition that keeps `avgExecutionFidelity` at **1.000** (subset 32 → 33). No fixture/setup/trigger change.

> Stacked on #512 (R1 default-fill); the regenerated baseline includes both. Merge #512 first, then retarget this to `main`.

## The grounded next-wave worklist

The other nine fixture-eligible candidates have **real per-language execution gaps** — parse-faithful (R0/R1 clean) but executes differently, exactly the class R2 exists to catch. Divergent-language counts from the session-12 probe:

| candidate | langs diverging |
|-----------|-----------------|
| next-element | 1 (ms) |
| toggle-aria-expanded | 2 (id, ms) |
| set-opacity / set-transform | 4 each |
| multiple-events / accordion-toggle | 6 each |
| put-after / put-before | 14 each |
| caret-var-on-target | 23 (all) |

Each must be **fixed** (not just recorded) before joining the subset, or it drops R2 below 1.0. This is the next correctness arc beyond structural fidelity — recorded in `MULTILINGUAL_NEXT_STEPS.md` and the wave-5 note in `execution-validator.ts`.

## Validation

- `--regression` gate green; baseline regenerated (R2 **1.000** over 33 patterns, **0** execution failures; R0/R1/precision unchanged).
- Subset-lock test updated (32 → 33); `execution-validator.test.ts` 10/10 pass.

`patterns.db` not committed (CI repopulates), per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)