### PR TITLE
test(multilingual): R2 wave 6 — add 6 worklist patterns (subset 33 → 39, R2 stays 1.0)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,31 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-28c (R2 wave 6 — subset 33 → 39; the wave-5 worklist was stale).**
+> Re-grounding the wave-5 R2 worklist against a **freshly `populate`d** patterns.db (the
+> committed db snapshot lags the current dicts) found that **six of its nine** candidates
+> already match the en DOM effect in **all 23 priority languages** — their recorded
+> divergences were artifacts of the stale committed db (e.g. its ms `next-element` carried an
+> untranslated `to next`; a fresh populate emits `ke seterusnya`, which executes identically to
+> en). Those six joined `EXECUTION_SUBSET` with **no parser/dict fix** (R2 stays **1.000**,
+> subset 33 → 39): `next-element`, `toggle-aria-expanded`, `set-opacity`, `set-transform`,
+> `accordion-toggle`, `caret-var-on-target`. The wave-5 worklist counts (next-element 1,
+> toggle-aria-expanded 2, set-opacity 4, set-transform 4, accordion-toggle 6,
+> caret-var-on-target 23) are all corrected to **0** here. **Methodology lesson (again):** the
+> session-12 probe that built the worklist scored a STALE committed db — always `npm run
+populate` before grounding R2. The **three genuinely-divergent** candidates remain the
+> next-wave R2 worklist (re-grounded fresh-db divergent-lang counts):
+>
+> - **`multiple-events`** (7: ja, ko, it, hi, tr, bn, qu) — `on click or keypress[…]`: the `or`
+>   multi-event separator isn't recognized (it: "Unknown command: or"; ko: the `또는keypress…`
+>   run collapses into an invalid CSS selector; ja/hi/tr/bn/qu silently produce no effect).
+> - **`put-after`** / **`put-before`** (14 each) — positional `put "<p>New</p>" after/before me`:
+>   most langs error ("Unknown command: after", "put requires content and position", "put
+>   requires arguments"); the few that execute (ar/vi/tl/uk) insert at the wrong offset (an
+>   extra `Δ#btn` + `+p[2]` vs the en `+p[1]`).
+>
+> Each must be FIXED (not just recorded) before joining the subset, or it drops R2 below 1.0.
+>
 > **Update 2026-06-28b (R1 default-fill → 0.908; R2 wave 5).** Two more fixes:
 >
 > - **R1 schema default-fill (#512).** After Arc 4, the dominant remaining R1 drop was

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-28T02:47:33.771Z",
-  "commit": "2c806662",
+  "timestamp": "2026-06-28T11:43:34.209Z",
+  "commit": "9290bc14",
   "languages": {
     "ar": {
       "parseSuccess": 154,

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
@@ -19,7 +19,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { ExecutionValidator, EXECUTION_SUBSET, loadExecutionSubset } from './execution-validator';
 
 describe('R2 execution subset (lock)', () => {
-  it('contains exactly the 33 curated patterns', () => {
+  it('contains exactly the 39 curated patterns', () => {
     // Changing this list recalibrates avgExecutionFidelity for every language.
     // If you expand the subset, regenerate the baseline (--save-baseline) in
     // the SAME PR and update this lock.
@@ -88,12 +88,19 @@ describe('R2 execution subset (lock)', () => {
         // PATTERN_TRIGGER dispatches a CustomEvent whose detail.message the
         // handler reads. set @role on the #sr-announce scope landed in S1.
         'announce-screen-reader',
-        // Session-12 expansion wave 5: `remove me` (bare self-removal). The only
-        // one of ten fixture-eligible candidates that matched the en effect in ALL
-        // 23 languages (so avgExecutionFidelity stays 1.0); the other nine have
-        // per-language execution gaps tracked as the next-wave worklist (see the
-        // wave-5 note in execution-validator.ts).
+        // Session-12 expansion wave 5: `remove me` (bare self-removal).
         'remove-element',
+        // Session-13 expansion wave 6: six wave-5 "worklist" candidates that, when
+        // re-grounded against a freshly populated patterns.db, match the en effect in
+        // ALL 23 languages (the wave-5 divergence counts were measured against a stale
+        // committed db — see the wave-6 note in execution-validator.ts). multiple-events,
+        // put-after, put-before remain out (real cross-language execution divergences).
+        'next-element',
+        'toggle-aria-expanded',
+        'set-opacity',
+        'set-transform',
+        'accordion-toggle',
+        'caret-var-on-target',
       ].sort()
     );
   });
@@ -195,6 +202,70 @@ describe('R2 execution validator (lock)', () => {
     // No PATTERN_TRIGGER for toggle-class-basic → click dispatched → success
     // handler never runs → empty signature.
     expect(clickOnly.effects).toEqual([]);
+  });
+
+  it('wave-6 en references execute with their locked signatures', async () => {
+    // The six wave-6 additions. Each en reference must produce a non-empty,
+    // deterministic signature against the existing fixture (the foundation every
+    // language is scored against). next/closest positionals fall back to `me`
+    // when no match exists in the fixture; set *opacity/*transform write inline
+    // style; caret-var-on-target clears #btn text (undefined `^count`).
+    const cases: ReadonlyArray<[string, string, string[]]> = [
+      [
+        'next-element',
+        'on click add .highlight to next <li/>',
+        ['Δli[9] cls[active highlight items] attr[] style[] text[]'],
+      ],
+      [
+        'toggle-aria-expanded',
+        'on click toggle @aria-expanded on me toggle .open on next .panel',
+        ['Δ#btn cls[open] attr[aria-expanded=,id=btn] style[] text[Click]'],
+      ],
+      [
+        'set-opacity',
+        'on click set my *opacity to 0.5',
+        ['Δ#btn cls[] attr[id=btn] style[opacity: 0.5;] text[Click]'],
+      ],
+      [
+        'set-transform',
+        'on click set my *transform to "rotate(45deg)"',
+        ['Δ#btn cls[] attr[id=btn] style[transform: rotate(45deg);] text[Click]'],
+      ],
+      [
+        'accordion-toggle',
+        'on click toggle .open on closest .accordion-item toggle @aria-expanded',
+        ['Δ#btn cls[open] attr[aria-expanded=,id=btn] style[] text[Click]'],
+      ],
+      [
+        'caret-var-on-target',
+        'on click put ^count on #host into me',
+        ['Δ#btn cls[] attr[id=btn] style[] text[]'],
+      ],
+    ];
+    for (const [id, code, expected] of cases) {
+      const res = await validator.execute(id, code, 'en');
+      expect(res.error, `${id} errored: ${res.error}`).toBeUndefined();
+      expect(res.effects, `${id} signature`).toEqual(expected);
+    }
+  });
+
+  it('a localized translation reproduces the wave-6 en signature (ms next-element)', async () => {
+    // This is the wave-5 worklist's recorded ms "divergence": it only appeared
+    // because the committed db carried an UNTRANSLATED `to next` (a stale snapshot).
+    // A fresh populate localizes it (`ke seterusnya`), and it executes identically
+    // to en — the reason next-element joins the subset with no parser/dict fix.
+    const en = await validator.execute(
+      'next-element',
+      'on click add .highlight to next <li/>',
+      'en'
+    );
+    const ms = await validator.execute(
+      'next-element',
+      'apabila click tambah .highlight ke seterusnya <li/>',
+      'ms'
+    );
+    expect(ms.error, `ms errored: ${ms.error}`).toBeUndefined();
+    expect(ms.effects).toEqual(en.effects);
   });
 
   it('a parse failure comes back as an error, never a throw', async () => {

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.ts
@@ -128,19 +128,37 @@ export const EXECUTION_SUBSET: readonly string[] = [
   // Expansion wave 5 (session 12): `remove me` — the bare self-removal positional.
   // Discovery probe (every non-subset, non-network/timer/behavior pattern executed
   // against this fixture, then all 23 translations checked against the en effect
-  // signature) found ten patterns with a clean non-empty en effect, but only
-  // `remove-element` matched en in ALL 23 languages — so it's the only all-match
-  // addition that keeps avgExecutionFidelity at 1.0. No fixture/setup/trigger change
-  // (it removes #btn on the default click). The other nine eligible candidates are
-  // the grounded worklist for the next wave — each has real per-language EXECUTION
-  // gaps to fix BEFORE it can join (divergent-lang counts, session 12 probe):
-  //   next-element (1: ms) · toggle-aria-expanded (2: id,ms) ·
-  //   set-opacity (4) · set-transform (4) · multiple-events (6) · accordion-toggle (6) ·
-  //   put-after (14) · put-before (14) · caret-var-on-target (23, all).
-  // These execution divergences are invisible to R0/R1 (parse-faithful) — exactly the
-  // class R2 exists to catch — but each must be fixed (not just recorded) before adding,
-  // or it drops R2 below 1.0. Tracked in docs-internal/MULTILINGUAL_NEXT_STEPS.md.
+  // signature) found ten patterns with a clean non-empty en effect.
   'remove-element',
+  // Expansion wave 6 (session 13): the six wave-5 "worklist" candidates that, when
+  // RE-GROUNDED against a freshly `populate`d patterns.db, in fact match the en effect
+  // signature in ALL 23 languages — so each keeps avgExecutionFidelity at 1.0. The
+  // wave-5 worklist's per-language divergence counts were measured against a STALE
+  // committed patterns.db snapshot (the committed copy lags the current dicts — see
+  // patterns-reference/CLAUDE.md); e.g. its ms `next-element` carried untranslated
+  // `to`/`next` (`apabila click … to next <li/>`), but a fresh populate emits the
+  // localized `apabila click tambah .highlight ke seterusnya <li/>`, which executes
+  // identically to en. Re-grounded counts (fresh db, all 24 priority langs): these six
+  // diverge in 0/23; the wave-5 worklist said next-element 1, toggle-aria-expanded 2,
+  // set-opacity 4, set-transform 4, accordion-toggle 6, caret-var-on-target 23 — all
+  // stale. No fixture/setup/trigger change needed; each en reference produces a clean
+  // non-empty signature against the existing fixture (next/closest positionals fall
+  // back to `me` consistently across every language; set *opacity/*transform write
+  // inline style; caret-var-on-target clears #btn text — the undefined `^count` resolves
+  // the same way in every language). The THREE wave-5 candidates with REAL divergences
+  // remain the next-wave worklist (re-grounded fresh-db divergent-lang counts):
+  //   multiple-events (7: ja,ko,it,hi,tr,bn,qu — the `or` multi-event separator) ·
+  //   put-after (14) · put-before (14) — positional `put … after/before me`, which
+  //   errors ("Unknown command: after", "put requires content and position") or inserts
+  //   at the wrong offset in most languages. These are invisible to R0/R1 (parse-faithful)
+  //   — exactly the class R2 exists to catch — and each must be FIXED before joining, or
+  //   it drops R2 below 1.0. Tracked in docs-internal/MULTILINGUAL_NEXT_STEPS.md.
+  'next-element',
+  'toggle-aria-expanded',
+  'set-opacity',
+  'set-transform',
+  'accordion-toggle',
+  'caret-var-on-target',
 ];
 
 /**


### PR DESCRIPTION
## What

Expands the R2 execution-fidelity curated subset from **33 → 39** patterns. R2 (`avgExecutionFidelity`) stays **1.000** across all 24 priority languages, with zero execution failures.

## Why — the wave-5 worklist was stale

The wave-5 R2 worklist (`#513`) recorded nine candidates with per-language execution divergences. Re-grounding those nine against a **freshly `populate`d** patterns.db (the committed db snapshot lags the current dicts — CI repopulates fresh) shows that **six of nine already match the en DOM effect in all 23 priority languages** — their recorded divergences were artifacts of scoring the stale committed db.

Example: the worklist's ms `next-element` carried an **untranslated** `to next` (`apabila click … to next <li/>`), but a fresh populate emits the localized `apabila click tambah .highlight ke seterusnya <li/>`, which executes identically to en.

| pattern | wave-5 worklist said | re-grounded (fresh db) |
|---|---|---|
| next-element | 1 (ms) | **0** ✓ added |
| toggle-aria-expanded | 2 | **0** ✓ added |
| set-opacity | 4 | **0** ✓ added |
| set-transform | 4 | **0** ✓ added |
| accordion-toggle | 6 | **0** ✓ added |
| caret-var-on-target | 23 | **0** ✓ added |
| multiple-events | 6 | **7** ✗ real — deferred |
| put-after | 14 | **14** ✗ real — deferred |
| put-before | 14 | **14** ✗ real — deferred |

The six clean patterns join `EXECUTION_SUBSET` with **no parser/dict fix** — a fresh populate already makes them match. The three genuinely-divergent candidates remain the next-wave worklist:

- **`multiple-events`** (7: ja, ko, it, hi, tr, bn, qu) — the `or` multi-event separator isn't recognized.
- **`put-after`** / **`put-before`** (14 each) — positional `put "…" after/before me` errors in most langs / inserts at the wrong offset in the few that run.

## Changes

- **`execution-validator.ts`** — add the six ids as "wave 6"; correct the stale wave-5 worklist comment with re-grounded counts.
- **`execution-validator.test.ts`** — membership lock 33 → 39; add a wave-6 en-signature lock (the six en references execute with their locked DOM signatures) and a cross-language guard (ms `next-element` reproduces the en signature — the original recorded "divergence").
- **baseline** regenerated against a fresh populate: R2 1.000 all langs, zero execution failures; **R0 / R1 / precision / parse-rate unchanged** (verified: only execution fields differ).
- **`MULTILINGUAL_NEXT_STEPS.md`** — 2026-06-28c note.

## Verification

- `npx tsx src/multilingual/cli.ts --full --bundle browser-priority --regression` → **green** with the 39-pattern subset.
- `npx vitest run src/multilingual/` → 46 passed (incl. the new wave-6 locks).
- No semantic/i18n source touched (testing-framework + baseline + docs only).

**Methodology lesson (again):** always `npm run populate` before grounding R2 — the session-12 probe that built the worklist scored a stale committed db.

🤖 Generated with [Claude Code](https://claude.com/claude-code)