### PR TITLE
fix(multilingual): multi-event `or` conjunction parses in all languages (R2 wave 7, subset 39 → 40)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,38 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-28d (R2 wave 7 — multiple-events fixed; subset 39 → 40).** The first
+> of the three genuinely-divergent wave-5 candidates is FIXED. `multiple-events`
+> (`on click or keypress[key=="Enter"] toggle .active`) diverged in 7 languages
+> (ja, ko, it, hi, tr, bn, qu): English handled the `or` multi-event conjunction in
+> `buildEventHandler` (`extractOrConjunctionEvents`), but the per-language pattern paths did
+> not — the SVO "full" patterns captured the translated `or` (`o`/`또는`/…) as a **phantom
+> body command** (it → runtime "Unknown command: or"), and the SOV Stage-3 fallback mangled
+> the clause (ko folded `또는keypress…할때` into an invalid CSS selector). Three root causes,
+> all semantic-side:
+>
+> - **Tokenizer (ja)** — `または` (or) mis-split into `また`(→**and**!) + `は` because the
+>   profile's `and` primary `また` is a 2-char prefix of the 3-char `または`. Added
+>   `または`→`or` to the ja tokenizer EXTRAS so longest-match keeps it whole.
+> - **OR_KEYWORDS (hi/bn)** — `या`/`অথবা` tokenize as bare identifiers; added their surface
+>   forms to `OR_KEYWORDS` so the pre-pass detects them (qu `utaq` was already present).
+> - **Parser (the unifier)** — a scoped **or-clause excision pre-pass** in `parseInternal`
+>   (mirrors the VSO from-first normalization): excise `<or-word> <known-event> [filter]`,
+>   re-parse the single-event handler every language already handles, then re-attach the
+>   second event as `additionalEvents`. **Gated on a KNOWN event after the or-word**, so it
+>   can NEVER fire on `or` inside an expression (`when $a or $b changes`, `($count or 0)`,
+>   `if a or b` — the post-`or` token there is a variable/number, not an event; all three
+>   verified untouched).
+>
+> Result: all 23 langs now match the en click effect; **R2 stays 1.000 (subset 39 → 40)**.
+> Bonus, ZERO regressions: removing the phantom `or` lifts **avgPrecision** +0.0022 (it, bn,
+> qu, tr) and the clean multi-event parse lifts **avgRoleFidelity** +0.0017 (bn, hi, ja, ko,
+> qu, tr). Guards: `multilingual-roadmap-fixes.test.ts` "Multi-event \`or\` conjunction"
+> (verified failing without the fix). **Two wave-5 divergences remain**: `put-after` /
+> `put-before` (positional `put … after/before me`, 14 langs each, multiple root causes —
+> `before`/`after` parsed as a command in SOV, position role lost in it/vi, wrong insert
+> offset in ar/tl/uk).
+>
 > **Update 2026-06-28c (R2 wave 6 — subset 33 → 39; the wave-5 worklist was stale).**
 > Re-grounding the wave-5 R2 worklist against a **freshly `populate`d** patterns.db (the
 > committed db snapshot lags the current dicts) found that **six of its nine** candidates

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -389,6 +389,70 @@ export class SemanticParserImpl implements ISemanticParser {
       }
     }
 
+    // Multi-event `or` conjunction normalization. A handler head can list several
+    // events: `on click or keypress[key=="Enter"] toggle .active`. English handles
+    // this in buildEventHandler (extractOrConjunctionEvents runs right after the
+    // event is captured), but the per-language pattern paths do NOT: the SVO "full"
+    // patterns capture the translated `or` (`o`/`또는`/…) as a phantom body command
+    // (it → `or` command → runtime "Unknown command: or"), and the SOV Stage-3
+    // fallback mangles the clause (ko folds `또는keypress…할때` into an invalid CSS
+    // selector), so the handler never binds the first event and the body drops.
+    // Normalize uniformly: excise the `<or-word> <event>[ <[filter]>]` span and
+    // re-parse the remaining single-event handler — which every language already
+    // parses — then re-attach the extra event(s) as `additionalEvents`. The source
+    // event is preserved (moved to additionalEvents), so fidelity is intact, and en
+    // routes through here byte-identically to its old extractOrConjunctionEvents
+    // result. Gated on a KNOWN event after the or-word, so it can NEVER fire on `or`
+    // inside an expression (`when $a or $b changes`, `($count or 0)` — the post-`or`
+    // token there is a variable/number, not an event).
+    {
+      const arr = tokens.tokens as LanguageToken[];
+      for (let i = 1; i < arr.length - 1; i++) {
+        const t = arr[i];
+        const surface = t.value;
+        const norm = (t.normalized ?? t.value).toLowerCase();
+        const isOr =
+          norm === 'or' ||
+          SemanticParserImpl.OR_KEYWORDS.has(surface) ||
+          SemanticParserImpl.OR_KEYWORDS.has(norm);
+        if (!isOr) continue;
+        const evTok = arr[i + 1];
+        const evNorm = (evTok.normalized ?? evTok.value).toLowerCase();
+        if (!SemanticParserImpl.KNOWN_EVENTS.has(evNorm)) break;
+        // Optional trailing `[filter]` selector token (`keypress[key=="Enter"]`
+        // tokenizes as `keypress` + `[key=="Enter"]`).
+        let lastIdx = i + 1;
+        const filterTok = arr[i + 2];
+        if (filterTok && filterTok.kind === 'selector' && filterTok.value.startsWith('[')) {
+          lastIdx = i + 2;
+        }
+        const exciseStart = arr[i].position.start;
+        const exciseEnd = arr[lastIdx].position.end;
+        const reduced = (
+          parseInput.slice(0, exciseStart).trimEnd() +
+          ' ' +
+          parseInput.slice(exciseEnd).trimStart()
+        ).trim();
+        if (reduced && reduced !== parseInput) {
+          try {
+            const reparsed = this.parse(reduced, language);
+            if (reparsed && reparsed.kind === 'event-handler') {
+              (reparsed as { additionalEvents?: SemanticValue[] }).additionalEvents = [
+                { type: 'literal', value: evNorm },
+              ];
+              const result = modifiers
+                ? this.applyModifiers(reparsed as EventHandlerSemanticNode, modifiers)
+                : reparsed;
+              return withDiagnostics(result, diagnostics);
+            }
+          } catch {
+            // fall through to the normal stages unchanged
+          }
+        }
+        break; // only the first or-clause in the head
+      }
+    }
+
     // Stage 1: Try event handler patterns first (they wrap commands)
     const eventPatterns = sortedPatterns.filter(p => p.command === 'on');
     const eventMatch = patternMatcher.matchBest(tokens, eventPatterns);
@@ -3205,6 +3269,8 @@ export class SemanticParserImpl implements ISemanticParser {
     'או', // HE
     'หรือ', // TH
     'o', // IT
+    'या', // HI (tokenizes as a bare identifier; matched here by surface form)
+    'অথবা', // BN (idem)
   ]);
 
   /**

--- a/packages/semantic/src/tokenizers/japanese.ts
+++ b/packages/semantic/src/tokenizers/japanese.ts
@@ -97,6 +97,14 @@ const JAPANESE_EXTRAS: KeywordEntry[] = [
   { native: 'マウスオーバー', normalized: 'mouseover' },
   { native: 'マウスアウト', normalized: 'mouseout' },
 
+  // Conjunctions. `または` (or) must be listed so the keyword extractor's
+  // longest-match keeps it whole — otherwise the profile's `and` primary `また`
+  // (a 2-char prefix of the 3-char `または`) wins and the trailing `は` falls to
+  // the topic-particle extractor (`また`→and + `は`), destroying the multi-event
+  // `or` conjunction (`on click または keypress …`). `と`/`そして`/`また` already
+  // cover `and` via the profile; only `or` is missing.
+  { native: 'または', normalized: 'or' },
+
   // References (alternative forms not in profile)
   { native: '私', normalized: 'me' }, // Alternative to 自分 (jibun)
 

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -8271,3 +8271,73 @@ describe('Schema default-role fill (Tier 2b — SOV drops defaulted roles; R1)',
     expect(r?.has('quantity')).toBe(false);
   });
 });
+
+describe('Multi-event `or` conjunction in handler heads (multiple-events, R2)', () => {
+  // `on click or keypress[key=="Enter"] toggle .active` lists two events. en
+  // handled it (extractOrConjunctionEvents); the per-language pattern paths did
+  // not — the SVO "full" patterns captured the translated `or` (`o`/`또는`/…) as a
+  // phantom body command (it → "Unknown command: or" at runtime) and the SOV
+  // Stage-3 fallback mangled the clause (ko folded `또는keypress…할때` into an
+  // invalid CSS selector). A scoped pre-pass now excises `<or-word> <event>[filter]`
+  // and re-parses the single-event handler every language already handles, then
+  // re-attaches the extra event. See execution-validator.ts wave 7.
+  function bodyActions(node: any, acc = new Set<string>()): Set<string> {
+    if (!node || typeof node !== 'object') return acc;
+    if (typeof node.action === 'string' && node.action !== 'compound') acc.add(node.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = node[f];
+      if (Array.isArray(c)) c.forEach((x: any) => bodyActions(x, acc));
+      else if (c && typeof c === 'object') bodyActions(c, acc);
+    }
+    return acc;
+  }
+
+  // Corpus-shaped multiple-events translations (en → lang). Each must parse to a
+  // single-event toggle handler — toggle present, NO phantom `or` command.
+  const cases: Array<[string, string]> = [
+    ['en', 'on click or keypress[key=="Enter"] toggle .active'],
+    ['it', 'su clic o keypress[key=="Enter"] commutare .active'],
+    ['ja', '.active を クリック または keypress[key=="Enter"] で 切り替え'],
+    ['ko', '.active 를 클릭 또는 keypress[key=="Enter"] 할 때 토글'],
+    ['hi', '.active को क्लिक या keypress[key=="Enter"] पर टॉगल'],
+    ['tr', '.active i tıklama veya keypress[key=="Enter"] de değiştir'],
+    ['bn', '.active কে ক্লিক অথবা keypress[key=="Enter"] এ টগল'],
+    ['qu', '.active ta ñitiy utaq keypress[key=="Enter"] pi tikray'],
+  ];
+
+  for (const [lang, input] of cases) {
+    it(`[${lang}] parses to a single-event toggle handler (no phantom 'or' command)`, () => {
+      const node = parse(input, lang);
+      expect(node.action).toBe('on');
+      const actions = bodyActions(node);
+      expect(actions.has('toggle')).toBe(true);
+      expect(actions.has('or')).toBe(false);
+      // The second event is preserved (moved to additionalEvents), not dropped.
+      const extra = (node as any).additionalEvents?.map((e: any) => e.value) ?? [];
+      expect(extra).toContain('keypress');
+    });
+  }
+
+  it('[ja] `または` tokenizes as a single `or` keyword, not `また`(and) + `は`', () => {
+    const tk = getTokenizer('ja')!;
+    const toks = (tk.tokenize('または keypress') as any).tokens.map((t: any) => t.normalized ?? t.value);
+    expect(toks).toContain('or');
+    expect(toks).not.toContain('and');
+  });
+
+  // Control: `or` inside an EXPRESSION must NEVER be excised (the post-`or` token
+  // is a variable/number, not an event), so no phantom additionalEvents appear.
+  it('[en] `or` in a condition is untouched (if I match .a or I match .b)', () => {
+    const node = parse('on click if I match .a or I match .b then toggle .x end', 'en');
+    expect(node.action).toBe('on');
+    expect((node as any).additionalEvents ?? []).toHaveLength(0);
+    expect(bodyActions(node).has('if')).toBe(true);
+  });
+
+  it('[en] `or` in a value default is untouched (set $count to ($count or 0) + 1)', () => {
+    const node = parse('on click set $count to ($count or 0) + 1', 'en');
+    expect(node.action).toBe('on');
+    expect((node as any).additionalEvents ?? []).toHaveLength(0);
+    expect(bodyActions(node).has('set')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-28T11:43:34.209Z",
-  "commit": "9290bc14",
+  "timestamp": "2026-06-28T12:36:23.053Z",
+  "commit": "993b10d1",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8495030867211314,
       "avgFidelity": 1,
-      "avgPrecision": 0.9231838695073992,
-      "avgRoleFidelity": 0.887244662244662,
+      "avgPrecision": 0.9253483716719012,
+      "avgRoleFidelity": 0.8889338514338513,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4426,12 +4426,12 @@
       "avgConfidence": 0.90909904631709,
       "avgFidelity": 1,
       "avgPrecision": 0.9165363046044861,
-      "avgRoleFidelity": 0.8519325644325644,
+      "avgRoleFidelity": 0.8536217536217535,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5689,13 +5689,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
-      "avgPrecision": 0.9728625541125538,
+      "avgPrecision": 0.9750270562770563,
       "avgRoleFidelity": 0.9030940624690625,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
       "avgPrecision": 0.9422938803620623,
-      "avgRoleFidelity": 0.8797791266541266,
+      "avgRoleFidelity": 0.8814683158433159,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6954,12 @@
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
       "avgPrecision": 0.9422938803620624,
-      "avgRoleFidelity": 0.886113586113586,
+      "avgRoleFidelity": 0.8878027753027753,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9481,13 +9481,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
-      "avgPrecision": 0.9474577640973745,
-      "avgRoleFidelity": 0.8877996815496816,
+      "avgPrecision": 0.9496222662618765,
+      "avgRoleFidelity": 0.8894888707388707,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12641,13 +12641,13 @@
       "parseRate": 1,
       "avgConfidence": 0.827517929021688,
       "avgFidelity": 1,
-      "avgPrecision": 0.9448603614999719,
-      "avgRoleFidelity": 0.8892747830247829,
+      "avgPrecision": 0.9470248636644741,
+      "avgRoleFidelity": 0.890963972213972,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447107,
+      "bundleSize": 447841,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 447107,
+      "size": 447841,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
@@ -19,7 +19,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { ExecutionValidator, EXECUTION_SUBSET, loadExecutionSubset } from './execution-validator';
 
 describe('R2 execution subset (lock)', () => {
-  it('contains exactly the 39 curated patterns', () => {
+  it('contains exactly the 40 curated patterns', () => {
     // Changing this list recalibrates avgExecutionFidelity for every language.
     // If you expand the subset, regenerate the baseline (--save-baseline) in
     // the SAME PR and update this lock.
@@ -101,6 +101,11 @@ describe('R2 execution subset (lock)', () => {
         'set-transform',
         'accordion-toggle',
         'caret-var-on-target',
+        // Session-13 expansion wave 7: multiple-events (`on click or
+        // keypress[...] toggle .active`), the third wave-5 worklist divergence,
+        // now fixed by the semantic or-clause excision pre-pass + ja `または`→or
+        // tokenizer fix + hi/bn OR_KEYWORDS. All 23 langs match the en click effect.
+        'multiple-events',
       ].sort()
     );
   });
@@ -266,6 +271,27 @@ describe('R2 execution validator (lock)', () => {
     );
     expect(ms.error, `ms errored: ${ms.error}`).toBeUndefined();
     expect(ms.effects).toEqual(en.effects);
+  });
+
+  it('wave-7 multiple-events: en + a translation toggle .active on click', async () => {
+    // `on click or keypress[...] toggle .active` — the multi-event handler. R2
+    // dispatches click only, so both events bind but only the click effect is
+    // measured: .active toggled onto #btn. A translation whose `or`-clause used to
+    // become a phantom command (it `o`) or mangle (ko) now reproduces it exactly.
+    const en = await validator.execute(
+      'multiple-events',
+      'on click or keypress[key=="Enter"] toggle .active',
+      'en'
+    );
+    expect(en.error).toBeUndefined();
+    expect(en.effects).toEqual(['Δ#btn cls[active] attr[id=btn] style[] text[Click]']);
+    const it = await validator.execute(
+      'multiple-events',
+      'su clic o keypress[key=="Enter"] commutare .active',
+      'it'
+    );
+    expect(it.error, `it errored: ${it.error}`).toBeUndefined();
+    expect(it.effects).toEqual(en.effects);
   });
 
   it('a parse failure comes back as an error, never a throw', async () => {

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.ts
@@ -145,9 +145,8 @@ export const EXECUTION_SUBSET: readonly string[] = [
   // non-empty signature against the existing fixture (next/closest positionals fall
   // back to `me` consistently across every language; set *opacity/*transform write
   // inline style; caret-var-on-target clears #btn text — the undefined `^count` resolves
-  // the same way in every language). The THREE wave-5 candidates with REAL divergences
+  // the same way in every language). Two wave-5 candidates with REAL divergences
   // remain the next-wave worklist (re-grounded fresh-db divergent-lang counts):
-  //   multiple-events (7: ja,ko,it,hi,tr,bn,qu — the `or` multi-event separator) ·
   //   put-after (14) · put-before (14) — positional `put … after/before me`, which
   //   errors ("Unknown command: after", "put requires content and position") or inserts
   //   at the wrong offset in most languages. These are invisible to R0/R1 (parse-faithful)
@@ -159,6 +158,14 @@ export const EXECUTION_SUBSET: readonly string[] = [
   'set-transform',
   'accordion-toggle',
   'caret-var-on-target',
+  // Expansion wave 7 (session 13): `multiple-events` — `on click or
+  // keypress[key=="Enter"] toggle .active`. The third wave-5 worklist divergence,
+  // now FIXED (semantic): a scoped or-clause excision pre-pass + the ja `または`→or
+  // tokenizer fix + hi/bn OR_KEYWORDS entries. It diverged in 7 languages
+  // (ja,ko,it,hi,tr,bn,qu — the translated `or` became a phantom body command or
+  // mangled into a selector); now all 23 match the en click effect (toggles .active
+  // on #btn). R2 stays 1.0. Only put-after/put-before remain from the wave-5 list.
+  'multiple-events',
 ];
 
 /**


### PR DESCRIPTION
## What

Fixes the multi-event `or` conjunction (`on click or keypress[key=="Enter"] toggle .active`) so it parses and executes consistently across all 24 languages, and adds `multiple-events` to the R2 execution-fidelity subset (**39 → 40**, R2 stays **1.000**).

## Why

`multiple-events` was the first of the three genuinely-divergent wave-5 R2 candidates. It was **parse-faithful by R0/R1 but executed differently** from the en reference in **7 languages** (ja, ko, it, hi, tr, bn, qu) — exactly the class R2 exists to catch. English handled the `or` conjunction in `buildEventHandler` (`extractOrConjunctionEvents`), but the per-language pattern paths did not:

- **it** (SVO "full" pattern): captured the translated `o`(→or) as a **phantom body command** → runtime `Unknown command: or`.
- **ko** (SOV Stage-3 fallback): folded `또는keypress…할때` into an **invalid CSS selector**.
- **ja/hi/tr/bn/qu**: the translated `or` wasn't recognized / the clause mangled → handler never bound `click`, empty effect.

## Root causes (3, all semantic-side)

1. **Tokenizer (ja)** — `または` (or) mis-split into `また`(→**and**!) + `は`, because the profile's `and` primary `また` is a 2-char prefix of the 3-char `または`. Added `または`→`or` to the ja tokenizer EXTRAS so longest-match keeps it whole.
2. **OR_KEYWORDS (hi/bn)** — `या`/`অথবা` tokenize as bare identifiers; added their surface forms so the pre-pass detects them (qu `utaq` was already present).
3. **Parser (the unifier)** — a scoped **or-clause excision pre-pass** in `parseInternal` (mirrors the existing VSO from-first normalization): excise `<or-word> <known-event> [filter]`, re-parse the single-event handler every language already parses, then re-attach the second event as `additionalEvents`.

### Safety

The pre-pass is **gated on a KNOWN event after the or-word**, so it can NEVER fire on `or` inside an expression. All three corpus `or`-expression sites verified untouched:
- `when $firstName or $lastName changes …` (reactive)
- `on click set $count to ($count or 0) + 1` (value default)
- `on click if I match .a or I match .b then …` (condition)

## Result

- All 23 langs match the en click effect (`toggle .active` on `#btn`); `multiple-events` joins `EXECUTION_SUBSET` (39 → 40); **R2 stays 1.000**.
- **Zero regressions**, with bonus correctness from the cleaner parse:
  - `avgPrecision` **+0.0022** (it, bn, qu, tr) — phantom `or` command removed
  - `avgRoleFidelity` **+0.0017** (bn, hi, ja, ko, qu, tr) — clean multi-event parse

## Verification

- `multilingual-roadmap-fixes.test.ts` "Multi-event \`or\` conjunction" guard — **verified failing without the fix** (9 fail → pass; the 2 always-passing are the expression controls).
- Full semantic suite **6234 pass** (10 skipped).
- Gate `--regression` **green**; baseline regenerated against a fresh populate (only execution + the precision/role improvements above differ).
- Wave-7 execution lock added to `execution-validator.test.ts` (membership 39 → 40 + en/it click-effect parity).

**Remaining wave-5 divergences** (next PRs): `put-after` / `put-before` (positional `put … after/before me`, 14 langs each, multiple root causes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)