### PR TITLE
fix(multilingual): positional put before/after captures manner in 11 languages (R1 +0.004–0.008)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,44 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-28e (positional put `before`/`after` — 11 of 14 langs fixed; R1
+> +0.004–0.008; VSO ar/tl/uk residual).** The last two wave-5 R2 divergences (`put-after`
+> /`put-before`, `put "<p>New</p>" before/after me`) are a multi-family arc. The unifying
+> root cause: the position word (`before`/`after` + translations) was not captured as the
+> put command's `manner` role (what the AST-mapper turns into the DOM-insert modifier) —
+> instead it was rendered into the destination (it/vi), mis-read as a `before`/`after`
+> COMMAND in SOV (ja/ko/hi/bn/tr/qu), or split as a then-clause (tr `sonra` / bn `পরে`
+> collided with `then`). A parallel **workflow** (5 family-design agents) produced the
+> per-language pattern specs; implemented centrally:
+>
+> - **SVO (it, vi, ru, pl, th)** — handcrafted/priority-tuned put-before/after capturing
+>   `manner` (it/vi added; ru/pl bumped; th added).
+> - **SOV (ja, ko, tr)** — new verb-final put generators (`{patient} <posWord> {dest} … {verb}`),
+>   priority 105 so the matcher wins before the SOV verb-anchoring fallback; **(hi, bn)** added
+>   to their existing put functions.
+> - **Tokenizer/collision fixes** — tr `sonra`→after (dropped the stale `sonra`→then EXTRA +
+>   moved `then` to `ardından` in the dict & then-set); bn `পরে` removed from the then-set; qu
+>   `ñawpaqpi`/`qhepapi` as single position-word tokens.
+> - **Renderer** — extended the existing `-at-end`/`-at-start` render-only penalty to
+>   `-before`/`-after` so the canonical into-form still wins RENDER selection (parse stays
+>   priority-ordered) — a latent parser-vs-renderer priority conflict the high-priority
+>   positional patterns exposed.
+>
+> Result: **11 of 14 langs** now parse `put before/after me` with `manner` captured;
+> **avgRoleFidelity +0.004–0.008** across bn/hi/it/ja/ko/pl/qu/ru/th/tr/vi + precision gains,
+> **zero regressions**, R2 still 1.000. Guard: `multilingual-roadmap-fixes.test.ts`
+> "Positional put `before`/`after`" (22 cases, verified failing without the fix).
+>
+> **Residual blocking the R2 entry: `ar`, `tl`, `uk` (VSO).** Their put is captured INLINE by
+> the generated fused VSO event pattern (`put-event-{ar,tl}-vso-verb-first-2role`,
+> `put-event-uk-vso-2role`) — the position word (قبل/بعد, bago/matapos, до/після) is a
+> destination-marker ALTERNATIVE, so it's consumed as the "into" marker and `manner` is lost
+> (inserts INTO me → `+p[2]` + `Δ#btn` instead of before/after). Unlike SVO/SOV there is no
+> body re-parse to reach a command-stage put-before pattern. Fixing it needs the VSO
+> event-handler GENERATOR (`event-handlers-vso.ts`) to capture `manner` when the destination
+> marker is a position word (or handcrafted high-priority VSO put-before/after `on` patterns).
+> Once ar/tl/uk match, `put-before`/`put-after` can join `EXECUTION_SUBSET` (40 → 42).
+>
 > **Update 2026-06-28d (R2 wave 7 — multiple-events fixed; subset 39 → 40).** The first
 > of the three genuinely-divergent wave-5 candidates is FIXED. `multiple-events`
 > (`on click or keypress[key=="Enter"] toggle .active`) diverged in 7 languages

--- a/packages/i18n/src/dictionaries/tr.ts
+++ b/packages/i18n/src/dictionaries/tr.ts
@@ -127,7 +127,7 @@ export const tr: Dictionary = {
     equals: 'eşittir',
     has: 'var',
     have: 'var',
-    then: 'sonra',
+    then: 'ardından',
     else: 'yoksa',
     otherwise: 'aksi_halde',
     end: 'son',

--- a/packages/i18n/src/parser/parser-integration.test.ts
+++ b/packages/i18n/src/parser/parser-integration.test.ts
@@ -384,7 +384,11 @@ describe('KeywordProvider Integration', () => {
       expect(trKeywords.resolve('ve')).toBe('and');
       expect(trKeywords.resolve('veya')).toBe('or');
       expect(trKeywords.resolve('değil')).toBe('not');
-      expect(trKeywords.resolve('sonra')).toBe('then'); // dictionary uses 'sonra'
+      // 'sonra' is the positional `after` (`put X sonra Y`); `then` uses 'ardından'
+      // (disambiguated so the put-after position word no longer collides with then —
+      // mirrors zh then:'那么' vs after:'之后'). See put-tr-after / the tr then-set.
+      expect(trKeywords.resolve('sonra')).toBe('after');
+      expect(trKeywords.resolve('ardından')).toBe('then');
       expect(trKeywords.resolve('yoksa')).toBe('else');
     });
 

--- a/packages/semantic/src/explicit/renderer.ts
+++ b/packages/semantic/src/explicit/renderer.ts
@@ -211,15 +211,18 @@ export class SemanticRendererImpl implements ISemanticRenderer {
         }
       }
 
-      // Positional variants (`put X at end of Y`, `at start of`) are handcrafted
-      // for PARSING that specific surface form; they carry the position as baked-in
-      // literals, not a role, so role scoring can't distinguish them from the
-      // canonical `put X into Y`. Some carry a higher parse priority (e.g.
-      // `put-bn-at-end` at 110) and would otherwise win render selection, emitting
-      // the verbose positional form for every plain put. Penalize them for
-      // rendering only — parsing is priority-ordered in the matcher, not here, so
-      // positional INPUT still matches its pattern via the literals.
-      if (/-at-end|-at-start/i.test(pattern.id)) {
+      // Positional variants (`put X at end of Y`, `at start of`, `before`/`after`)
+      // are handcrafted for PARSING that specific surface form; they carry the
+      // position as baked-in literals, not a role, so role scoring can't distinguish
+      // them from the canonical `put X into Y`. Several carry a higher parse priority
+      // (e.g. `put-bn-at-end` at 110, the SOV `put-{ja,ko,hi,bn,tr,qu}-before/after`
+      // at 105/106 — needed so the matcher prefers them over the into-form / the SOV
+      // verb-anchoring fallback when the position word IS present) and would
+      // otherwise win render selection, emitting the verbose positional form (or a
+      // literal `before`/`after`) for every plain put. Penalize them for rendering
+      // only — parsing is priority-ordered in the matcher, not here, so positional
+      // INPUT still matches its pattern via the literals.
+      if (/-at-end|-at-start|-before$|-after$/i.test(pattern.id)) {
         score -= 30;
       }
 

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -2765,13 +2765,21 @@ export class SemanticParserImpl implements ISemanticParser {
       // `after` (`放置 把 X 之后 Y`, put-after) and emits 那么 for then — keeping
       // it here split the put clause at 之后 and dropped the put.
       zh: new Set(['然后', '接着', '那么']),
-      tr: new Set(['sonra', 'ardından', 'daha sonra']),
+      // 'sonra' is deliberately ABSENT (mirrors zh dropping 之后): the tr
+      // transformer emits it as positional `after` (`{patient} sonra {dest} … koy`,
+      // put-after); keeping it here split the put clause at sonra and dropped the
+      // put. then-chains use ardından (the i18n dict's then emission).
+      tr: new Set(['ardından', 'daha sonra', 'ardindan']),
       pt: new Set(['então', 'depois', 'logo']),
       fr: new Set(['puis', 'ensuite', 'alors']),
       de: new Set(['dann', 'danach', 'anschließend']),
       id: new Set(['lalu', 'kemudian', 'setelah itu']),
       tl: new Set(['pagkatapos', 'tapos']),
-      bn: new Set(['তারপর', 'পরে']),
+      // 'পরে' is deliberately ABSENT (mirrors tr dropping 'sonra' / zh dropping
+      // 之后): the bn transformer emits it as positional `after` (`{patient} পরে
+      // {dest} … রাখুন`, put-after); keeping it here split the put clause at পরে and
+      // dropped the put. then-chains use তারপর (the bn dict's then emission).
+      bn: new Set(['তারপর']),
       qu: new Set(['chaymantataq', 'hinaspa', 'chaymanta', 'chayqa']),
       sw: new Set(['kisha', 'halafu', 'baadaye']),
     };

--- a/packages/semantic/src/patterns/put.ts
+++ b/packages/semantic/src/patterns/put.ts
@@ -11,6 +11,54 @@ import type { LanguagePattern } from '../types';
 
 function getPutPatternsBn(): LanguagePattern[] {
   return [
+    // SOV verb-final positional put: `{patient} <posWord> {destination} কে রাখুন`
+    // (put X before/after me). আগে→before / পরে→after; position word → `manner`,
+    // target (আমি→me) → `destination`, কে the pre-verb object marker. priority 105
+    // out-ranks put-bn-full(100); requires the position word so it never shadows
+    // the into-put. Without these the verb-final body fell to the SOV
+    // verb-anchorer (phantom `before` command) / a roleless put.
+    {
+      id: 'put-bn-before',
+      language: 'bn',
+      command: 'put',
+      priority: 105,
+      template: {
+        format: '{patient} before {destination} কে রাখুন',
+        tokens: [
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: 'before' },
+          { type: 'role', role: 'destination' },
+          { type: 'literal', value: 'কে' },
+          { type: 'literal', value: 'রাখুন', alternatives: ['রাখ'] },
+        ],
+      },
+      extraction: {
+        patient: { position: 0 },
+        destination: { marker: 'before' },
+        manner: { default: { type: 'literal', value: 'before' } },
+      },
+    },
+    {
+      id: 'put-bn-after',
+      language: 'bn',
+      command: 'put',
+      priority: 105,
+      template: {
+        format: '{patient} after {destination} কে রাখুন',
+        tokens: [
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: 'after' },
+          { type: 'role', role: 'destination' },
+          { type: 'literal', value: 'কে' },
+          { type: 'literal', value: 'রাখুন', alternatives: ['রাখ'] },
+        ],
+      },
+      extraction: {
+        patient: { position: 0 },
+        destination: { marker: 'after' },
+        manner: { default: { type: 'literal', value: 'after' } },
+      },
+    },
     // Full pattern: 'hello' কে #output এ রাখুন
     {
       id: 'put-bn-full',
@@ -234,6 +282,56 @@ function getPutPatternsEs(): LanguagePattern[] {
 
 function getPutPatternsHi(): LanguagePattern[] {
   return [
+    // SOV verb-final positional put: `{patient} <posWord> {destination} को रखें`
+    // (put X before/after me). से पहले→before / के बाद→after normalize to
+    // before/after, so one literal (the normalized form) covers both surface
+    // variants. The position word is captured as `manner`; the target (मैं→me) as
+    // `destination`. priority 106 out-ranks put-hi-verb-medial(105); specific
+    // enough (requires the position word) never to shadow the into-puts. Without
+    // these the verb-final body found no put pattern and the SOV verb-anchoring
+    // fallback turned `before`/`after` into a phantom command.
+    {
+      id: 'put-hi-before',
+      language: 'hi',
+      command: 'put',
+      priority: 106,
+      template: {
+        format: '{patient} before {destination} को रखें',
+        tokens: [
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: 'before' },
+          { type: 'role', role: 'destination' },
+          { type: 'literal', value: 'को' },
+          { type: 'literal', value: 'रखें', alternatives: ['रख', 'डालें', 'डाल'] },
+        ],
+      },
+      extraction: {
+        patient: { position: 0 },
+        destination: { marker: 'before' },
+        manner: { default: { type: 'literal', value: 'before' } },
+      },
+    },
+    {
+      id: 'put-hi-after',
+      language: 'hi',
+      command: 'put',
+      priority: 106,
+      template: {
+        format: '{patient} after {destination} को रखें',
+        tokens: [
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: 'after' },
+          { type: 'role', role: 'destination' },
+          { type: 'literal', value: 'को' },
+          { type: 'literal', value: 'रखें', alternatives: ['रख', 'डालें', 'डाल'] },
+        ],
+      },
+      extraction: {
+        patient: { position: 0 },
+        destination: { marker: 'after' },
+        manner: { default: { type: 'literal', value: 'after' } },
+      },
+    },
     // Verb-MEDIAL pattern: यह को रखें #container में (`{patient} को रखें
     // {destination} में`). The hi transformer emits put VERB-MEDIAL in a fused
     // event body's then-clause (`… बनाएं फिर यह को रखें #container में` —
@@ -434,6 +532,49 @@ function getPutPatternsIt(): LanguagePattern[] {
       },
     },
     {
+      // before/after must out-rank put-it-full (100): that pattern's destination
+      // group is optional, so it greedily matches `mettere {patient}` alone and
+      // would otherwise shadow the position clause (`prima io` dropped).
+      id: 'put-it-before',
+      language: 'it',
+      command: 'put',
+      priority: 105,
+      template: {
+        format: 'mettere {patient} prima {target}',
+        tokens: [
+          { type: 'literal', value: 'mettere', alternatives: ['metti', 'inserire', 'put'] },
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: 'prima' },
+          { type: 'role', role: 'destination' },
+        ],
+      },
+      extraction: {
+        patient: { position: 1 },
+        destination: { marker: 'prima' },
+        manner: { default: { type: 'literal', value: 'before' } },
+      },
+    },
+    {
+      id: 'put-it-after',
+      language: 'it',
+      command: 'put',
+      priority: 105,
+      template: {
+        format: 'mettere {patient} dopo {target}',
+        tokens: [
+          { type: 'literal', value: 'mettere', alternatives: ['metti', 'inserire', 'put'] },
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: 'dopo' },
+          { type: 'role', role: 'destination' },
+        ],
+      },
+      extraction: {
+        patient: { position: 1 },
+        destination: { marker: 'dopo' },
+        manner: { default: { type: 'literal', value: 'after' } },
+      },
+    },
+    {
       id: 'put-it-simple',
       language: 'it',
       command: 'put',
@@ -483,7 +624,9 @@ function getPutPatternsPl(): LanguagePattern[] {
       id: 'put-pl-before',
       language: 'pl',
       command: 'put',
-      priority: 95,
+      // 105 (not 95) so the position clause out-ranks put-pl-full (100), which
+      // would otherwise capture `umieść {patient}` alone and drop `przed {target}`.
+      priority: 105,
       template: {
         format: 'umieść {patient} przed {destination}',
         tokens: [
@@ -503,7 +646,7 @@ function getPutPatternsPl(): LanguagePattern[] {
       id: 'put-pl-after',
       language: 'pl',
       command: 'put',
-      priority: 95,
+      priority: 105,
       template: {
         format: 'umieść {patient} po {destination}',
         tokens: [
@@ -557,7 +700,8 @@ function getPutPatternsRu(): LanguagePattern[] {
       id: 'put-ru-before',
       language: 'ru',
       command: 'put',
-      priority: 95,
+      // 105 (not 95) so the position clause out-ranks put-ru-full (100).
+      priority: 105,
       template: {
         format: 'положить {patient} перед {destination}',
         tokens: [
@@ -577,7 +721,7 @@ function getPutPatternsRu(): LanguagePattern[] {
       id: 'put-ru-after',
       language: 'ru',
       command: 'put',
-      priority: 95,
+      priority: 105,
       template: {
         format: 'положить {patient} после {destination}',
         tokens: [
@@ -616,6 +760,51 @@ function getPutPatternsTh(): LanguagePattern[] {
       extraction: {
         patient: { position: 1 },
         destination: { marker: 'ใน', position: 3 },
+      },
+    },
+    // SVO positional put: `ใส่ {patient} ก่อน/หลัง {destination}` (put X before/after
+    // me). ก่อน→before / หลัง→after captured as `manner`; target as `destination`.
+    // priority 105 out-ranks put-th-full(100) so the position clause wins the
+    // event-handler retry's matchBest (th fuses the event, then re-parses the body
+    // clause). Without these th dropped all roles → "put requires arguments".
+    {
+      id: 'put-th-before',
+      language: 'th',
+      command: 'put',
+      priority: 105,
+      template: {
+        format: 'ใส่ {patient} ก่อน {destination}',
+        tokens: [
+          { type: 'literal', value: 'ใส่', alternatives: ['วาง'] },
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: 'ก่อน' },
+          { type: 'role', role: 'destination' },
+        ],
+      },
+      extraction: {
+        patient: { position: 1 },
+        destination: { marker: 'ก่อน' },
+        manner: { default: { type: 'literal', value: 'before' } },
+      },
+    },
+    {
+      id: 'put-th-after',
+      language: 'th',
+      command: 'put',
+      priority: 105,
+      template: {
+        format: 'ใส่ {patient} หลัง {destination}',
+        tokens: [
+          { type: 'literal', value: 'ใส่', alternatives: ['วาง'] },
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: 'หลัง' },
+          { type: 'role', role: 'destination' },
+        ],
+      },
+      extraction: {
+        patient: { position: 1 },
+        destination: { marker: 'หลัง' },
+        manner: { default: { type: 'literal', value: 'after' } },
       },
     },
   ];
@@ -720,26 +909,31 @@ function getPutPatternsVi(): LanguagePattern[] {
       id: 'put-vi-before',
       language: 'vi',
       command: 'put',
-      priority: 95,
+      priority: 105,
       template: {
         format: 'đặt {patient} trước {target}',
         tokens: [
           { type: 'literal', value: 'đặt', alternatives: ['để', 'đưa'] },
           { type: 'role', role: 'patient' },
           { type: 'literal', value: 'trước', alternatives: ['trước khi'] },
-          { type: 'role', role: 'manner' },
+          { type: 'role', role: 'destination' },
         ],
       },
+      // The target is the destination (the node to insert relative to); the
+      // position word itself is the `manner` (before/after) the AST mapper turns
+      // into the DOM-insert modifier. The previous pattern captured the target as
+      // `manner` and never recorded the position → wrong insert offset.
       extraction: {
         patient: { position: 1 },
-        manner: { marker: 'trước', markerAlternatives: ['trước khi'] },
+        destination: { marker: 'trước', markerAlternatives: ['trước khi'] },
+        manner: { default: { type: 'literal', value: 'before' } },
       },
     },
     {
       id: 'put-vi-after',
       language: 'vi',
       command: 'put',
-      priority: 95,
+      priority: 105,
       template: {
         format: 'đặt {patient} sau {target}',
         tokens: [
@@ -752,6 +946,7 @@ function getPutPatternsVi(): LanguagePattern[] {
       extraction: {
         patient: { position: 1 },
         destination: { marker: 'sau', markerAlternatives: ['sau khi'] },
+        manner: { default: { type: 'literal', value: 'after' } },
       },
     },
   ];
@@ -759,6 +954,36 @@ function getPutPatternsVi(): LanguagePattern[] {
 
 function getPutPatternsQu(): LanguagePattern[] {
   return [
+    // SOV verb-final positional put: `{patient} <posWord> {destination} ta churay`
+    // (put X before/after me). ñawpaqpi→before / qhepapi→after (single keyword
+    // tokens after the quechua tokenizer fix); position word → `manner`, target
+    // (noqa→me) → `destination` marked by accusative `ta`. priority 105 out-ranks
+    // put-qu-patient-first(96) and makes matchBest win before the SOV
+    // verb-anchoring fallback. `alternatives:[manner]` accepts the normalized form.
+    ...(['before', 'after'] as const).map(manner => {
+      const posWord = manner === 'before' ? 'ñawpaqpi' : 'qhepapi';
+      return {
+        id: `put-qu-${manner}`,
+        language: 'qu',
+        command: 'put',
+        priority: 105,
+        template: {
+          format: `{patient} ${posWord} {destination} ta churay`,
+          tokens: [
+            { type: 'role', role: 'patient' },
+            { type: 'literal', value: posWord, alternatives: [manner] },
+            { type: 'role', role: 'destination' },
+            { type: 'group', optional: true, tokens: [{ type: 'literal', value: 'ta' }] },
+            { type: 'literal', value: 'churay', alternatives: ['tiyachiy'] },
+          ],
+        },
+        extraction: {
+          patient: { position: 0 },
+          destination: { position: 2 },
+          manner: { default: { type: 'literal', value: manner } },
+        },
+      } satisfies LanguagePattern;
+    }),
     // Patient-first SOV with destination: chay ta kurku man churay — the i18n
     // transformer emits PATIENT-first for qu (`chay ta noqa man churay`,
     // async-block / fetch-with-headers / if-exists then-tails); there were no
@@ -1107,6 +1332,102 @@ function buildAtEndPutPatterns(language: string): LanguagePattern[] {
   ];
 }
 
+// Verb-FINAL SOV positional put (`{patient} <posWord> {destination} <objMarker> <verb>`).
+// buildPositionalPutPatterns is verb-FIRST only, so ja/ko/tr need handcrafted SOV
+// patterns. The position word (前に/전에/önce → before, 後に/후에/sonra → after) is
+// captured as `manner` (the put AST-mapper turns it into the DOM-insert modifier);
+// the target (me) is the destination. Priority 105 makes matchBest succeed so the
+// SOV verb-anchoring fallback — which would mis-read the position word as a bogus
+// `before`/`after` COMMAND — is never reached. Mirrors put-en/it/vi-before/after.
+function getPutPatternsJa(): LanguagePattern[] {
+  return (['before', 'after'] as const).map(manner => {
+    const posWord = manner === 'before' ? '前に' : '後に';
+    const posAlt = manner === 'before' ? '前' : '後';
+    return {
+      id: `put-ja-${manner}`,
+      language: 'ja',
+      command: 'put',
+      priority: 105,
+      template: {
+        format: `{patient} ${posWord} {destination} を 置く`,
+        tokens: [
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: posWord, alternatives: [posAlt] },
+          { type: 'role', role: 'destination' },
+          { type: 'literal', value: 'を' },
+          { type: 'literal', value: '置く', alternatives: ['入れる'] },
+        ],
+      },
+      extraction: {
+        patient: { position: 0 },
+        destination: { position: 2 },
+        manner: { default: { type: 'literal', value: manner } },
+      },
+    } satisfies LanguagePattern;
+  });
+}
+
+function getPutPatternsKo(): LanguagePattern[] {
+  return (['before', 'after'] as const).map(manner => {
+    const posWord = manner === 'before' ? '전에' : '후에';
+    return {
+      id: `put-ko-${manner}`,
+      language: 'ko',
+      command: 'put',
+      priority: 105,
+      template: {
+        format: `{patient} ${posWord} {destination} 를 넣다`,
+        tokens: [
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: posWord },
+          { type: 'role', role: 'destination' },
+          { type: 'literal', value: '를', alternatives: ['을'] },
+          { type: 'literal', value: '넣다', alternatives: ['넣기', '놓기'] },
+        ],
+      },
+      extraction: {
+        patient: { position: 0 },
+        destination: { position: 2 },
+        manner: { default: { type: 'literal', value: manner } },
+      },
+    } satisfies LanguagePattern;
+  });
+}
+
+function getPutPatternsTr(): LanguagePattern[] {
+  // önce → before, sonra → after (after the turkish tokenizer drops the stale
+  // `sonra`→then EXTRA). The accusative `i` (+vowel-harmony alts) on the target
+  // is optional.
+  const mk = (manner: 'before' | 'after', posWord: string): LanguagePattern => ({
+    id: `put-tr-${manner}`,
+    language: 'tr',
+    command: 'put',
+    priority: 105,
+    template: {
+      format: `{patient} ${posWord} {destination} i koy`,
+      tokens: [
+        { type: 'role', role: 'patient' },
+        { type: 'literal', value: posWord },
+        { type: 'role', role: 'destination' },
+        {
+          type: 'group',
+          optional: true,
+          tokens: [
+            { type: 'literal', value: 'i', alternatives: ['ı', 'u', 'ü', 'yi', 'yı', 'yu', 'yü'] },
+          ],
+        },
+        { type: 'literal', value: 'koy', alternatives: ['koymak'] },
+      ],
+    },
+    extraction: {
+      patient: { position: 0 },
+      destination: { position: 2 },
+      manner: { default: { type: 'literal', value: manner } },
+    },
+  });
+  return [mk('before', 'önce'), mk('after', 'sonra')];
+}
+
 function buildPositionalPutPatterns(language: string): LanguagePattern[] {
   const spec = PUT_POSITIONAL.find(s => s.lang === language);
   if (!spec) return [];
@@ -1169,6 +1490,12 @@ export function getPutPatternsForLanguage(language: string): LanguagePattern[] {
       return [...getPutPatternsId(), ...positional, ...atEnd];
     case 'it':
       return [...getPutPatternsIt(), ...atEnd];
+    case 'ja':
+      return [...getPutPatternsJa(), ...atEnd];
+    case 'ko':
+      return [...getPutPatternsKo(), ...atEnd];
+    case 'tr':
+      return [...getPutPatternsTr(), ...atEnd];
     case 'pl':
       return [...getPutPatternsPl(), ...atEnd];
     case 'ru':

--- a/packages/semantic/src/tokenizers/quechua.ts
+++ b/packages/semantic/src/tokenizers/quechua.ts
@@ -119,6 +119,15 @@ const QUECHUA_EXTRAS: KeywordEntry[] = [
   { native: 'mana riqsisqa', normalized: 'undefined' },
 
   // Positional
+  // Put-position words (`put X before/after Y`): the i18n dict emits the locative
+  // -pi forms ñawpaqpi (before) / qhepapi (after). They must be exact single-token
+  // entries ABOVE the bare ñawpaq/qhipa (longest-first), else the greedy loop binds
+  // the prefix (ñawpaq→first) and strands `pi` — which the SOV parser then mis-reads
+  // as the event marker, and the position word is lost from the put.
+  { native: 'ñawpaqpi', normalized: 'before' },
+  { native: 'nawpaqpi', normalized: 'before' },
+  { native: 'qhepapi', normalized: 'after' },
+  { native: 'qhipapi', normalized: 'after' },
   { native: 'ñawpaq', normalized: 'first' },
   { native: 'nawpaq', normalized: 'first' },
   { native: 'qhipa', normalized: 'last' },

--- a/packages/semantic/src/tokenizers/turkish.ts
+++ b/packages/semantic/src/tokenizers/turkish.ts
@@ -141,9 +141,6 @@ const TURKISH_EXTRAS: KeywordEntry[] = [
   { native: 'milisaniye', normalized: 'ms' },
   { native: 'dakika', normalized: 'm' },
   { native: 'saat', normalized: 'h' },
-
-  // Then disambiguation (sonra for clause chaining)
-  { native: 'sonra', normalized: 'then' },
 ];
 
 // =============================================================================

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -8341,3 +8341,72 @@ describe('Multi-event `or` conjunction in handler heads (multiple-events, R2)', 
     expect(bodyActions(node).has('set')).toBe(true);
   });
 });
+
+describe('Positional put `before`/`after` captures manner (put-before/put-after, R2 worklist)', () => {
+  // `put X before/after me` must parse with roles { patient, destination:me,
+  // manner:'before'/'after' } so the put AST-mapper inserts the content relative to
+  // the target (English's DOM effect). Each language's position word was previously
+  // dropped (rendered into the destination, mis-read as a `before`/`after` COMMAND
+  // in SOV, or split as a then-clause for tr `sonra` / bn `পরে`), losing the
+  // position. Corpus translations (en → lang) of `on click put "<p>New</p>"
+  // before/after me`. ar/tl/uk (VSO) are NOT here — the fused VSO event pattern
+  // still drops manner (tracked separately).
+  function findPut(node: any): any {
+    if (!node || typeof node !== 'object') return undefined;
+    if (node.action === 'put') return node;
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = node[f];
+      if (Array.isArray(c)) for (const x of c) { const r = findPut(x); if (r) return r; }
+      else if (c && typeof c === 'object') { const r = findPut(c); if (r) return r; }
+    }
+    return undefined;
+  }
+  const role = (put: any, r: string) => {
+    const v = put?.roles instanceof Map ? put.roles.get(r) : put?.roles?.[r];
+    return v?.value ?? v;
+  };
+
+  const before: Array<[string, string]> = [
+    ['ja', '"<p>New</p>" 前に 私 を クリック で 置く'],
+    ['ko', '"<p>New</p>" 전에 나 를 클릭 할 때 넣다'],
+    ['hi', '"<p>New</p>" से पहले मैं को क्लिक पर रखें'],
+    ['bn', '"<p>New</p>" আগে আমি কে ক্লিক এ রাখুন'],
+    ['tr', '"<p>New</p>" önce ben i tıklama de koy'],
+    ['qu', '"<p>New</p>" ñawpaqpi noqa ta ñitiy pi churay'],
+    ['it', 'su clic mettere "<p>New</p>" prima io'],
+    ['vi', 'khi nhấp đặt "<p>New</p>" trước tôi'],
+    ['ru', 'при клик положить "<p>New</p>" до я'],
+    ['pl', 'gdy kliknięcie umieść "<p>New</p>" przed ja'],
+    ['th', 'เมื่อ คลิก ใส่ "<p>New</p>" ก่อน ฉัน'],
+  ];
+  const after: Array<[string, string]> = [
+    ['ja', '"<p>New</p>" 後に 私 を クリック で 置く'],
+    ['ko', '"<p>New</p>" 후에 나 를 클릭 할 때 넣다'],
+    ['hi', '"<p>New</p>" के बाद मैं को क्लिक पर रखें'],
+    ['bn', '"<p>New</p>" পরে আমি কে ক্লিক এ রাখুন'],
+    ['tr', '"<p>New</p>" sonra ben i tıklama de koy'],
+    ['qu', '"<p>New</p>" qhepapi noqa ta ñitiy pi churay'],
+    ['it', 'su clic mettere "<p>New</p>" dopo io'],
+    ['vi', 'khi nhấp đặt "<p>New</p>" sau tôi'],
+    ['ru', 'при клик положить "<p>New</p>" после я'],
+    ['pl', 'gdy kliknięcie umieść "<p>New</p>" po ja'],
+    ['th', 'เมื่อ คลิก ใส่ "<p>New</p>" หลัง ฉัน'],
+  ];
+
+  for (const [lang, code] of before) {
+    it(`[${lang}] put-before captures manner=before + destination`, () => {
+      const put = findPut(parse(code, lang));
+      expect(put, `no put command parsed for ${lang}`).toBeTruthy();
+      expect(role(put, 'manner')).toBe('before');
+      expect(role(put, 'destination')).toBeTruthy();
+    });
+  }
+  for (const [lang, code] of after) {
+    it(`[${lang}] put-after captures manner=after + destination`, () => {
+      const put = findPut(parse(code, lang));
+      expect(put, `no put command parsed for ${lang}`).toBeTruthy();
+      expect(role(put, 'manner')).toBe('after');
+      expect(role(put, 'destination')).toBeTruthy();
+    });
+  }
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-28T12:36:23.053Z",
-  "commit": "993b10d1",
+  "timestamp": "2026-06-28T14:02:11.528Z",
+  "commit": "378f8afd",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8495030867211314,
       "avgFidelity": 1,
-      "avgPrecision": 0.9253483716719012,
-      "avgRoleFidelity": 0.8889338514338513,
+      "avgPrecision": 0.9275128738364035,
+      "avgRoleFidelity": 0.8970419595419593,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.90909904631709,
       "avgFidelity": 1,
-      "avgPrecision": 0.9165363046044861,
-      "avgRoleFidelity": 0.8536217536217535,
+      "avgPrecision": 0.9208653089334906,
+      "avgRoleFidelity": 0.8617298617298615,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.9750270562770563,
-      "avgRoleFidelity": 0.9030940624690625,
+      "avgRoleFidelity": 0.908499467874468,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6321,13 +6321,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
-      "avgPrecision": 0.9422938803620623,
-      "avgRoleFidelity": 0.8814683158433159,
+      "avgPrecision": 0.9466228846910667,
+      "avgRoleFidelity": 0.8895764239514237,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6953,13 +6953,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
-      "avgPrecision": 0.9422938803620624,
-      "avgRoleFidelity": 0.8878027753027753,
+      "avgPrecision": 0.9466228846910665,
+      "avgRoleFidelity": 0.8959108834108833,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
       "avgPrecision": 0.9912608225108225,
-      "avgRoleFidelity": 0.8997719903969905,
+      "avgRoleFidelity": 0.9051773958023959,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9482,12 @@
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
       "avgPrecision": 0.9496222662618765,
-      "avgRoleFidelity": 0.8894888707388707,
+      "avgRoleFidelity": 0.8962456274956275,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.8142650999793837,
       "avgFidelity": 1,
       "avgPrecision": 0.9886634199134199,
-      "avgRoleFidelity": 0.9029885654885657,
+      "avgRoleFidelity": 0.908393970893971,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.9737012987012986,
-      "avgRoleFidelity": 0.9100076725076723,
+      "avgRoleFidelity": 0.9181157806157806,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12641,13 +12641,13 @@
       "parseRate": 1,
       "avgConfidence": 0.827517929021688,
       "avgFidelity": 1,
-      "avgPrecision": 0.9470248636644741,
-      "avgRoleFidelity": 0.890963972213972,
+      "avgPrecision": 0.9491893658289764,
+      "avgRoleFidelity": 0.8990720803220801,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13906,12 +13906,12 @@
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
       "avgPrecision": 0.9795725108225107,
-      "avgRoleFidelity": 0.9261474730224729,
+      "avgRoleFidelity": 0.9302015270765269,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 447841,
+      "bundleSize": 454103,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 447841,
+      "size": 454103,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## What

`put "<p>New</p>" before/after me` diverged at runtime from English in 14 languages — parse-faithful by the old R0/R1, but the **position word was dropped**, so the content inserted *into* the target instead of before/after it (the exact class R2 exists to catch). This fixes **11 of the 14** languages; R1 (the documented laggard) rises **+0.004–0.008** across them, zero regressions.

## Root cause

The position word (`before`/`after` and its translations) was not captured as the put command's `manner` role (what the AST-mapper turns into the DOM-insert modifier). It was instead rendered into the destination (it/vi), mis-read as a `before`/`after` **command** in SOV (ja/ko/hi/bn/tr/qu), or split as a then-clause (tr `sonra` / bn `পরে` collided with `then`).

## Fixes (per family; specs from a parallel design workflow, implemented + verified centrally)

- **SVO (it, vi, ru, pl, th)** — handcrafted/priority-tuned put-before/after capturing `manner` (it/vi added, ru/pl bumped 95→105, th added).
- **SOV (ja, ko, tr)** — new verb-final put generators (`{patient} <posWord> {dest} … {verb}`) at priority 105 so the matcher wins before the SOV verb-anchoring fallback; **hi, bn** added to their existing put functions.
- **Collision/tokenizer fixes** — tr `sonra`→after (dropped the stale `sonra`→then EXTRA; moved `then` to `ardından` in dict + then-set); bn `পরে` removed from the then-set (dict already uses তারপর); qu `ñawpaqpi`/`qhepapi` as single position-word tokens.
- **Renderer** — extended the existing `-at-end`/`-at-start` render-only penalty to `-before`/`-after` so the canonical into-form still wins **render** selection while parsing stays priority-ordered (a latent parser-vs-renderer priority conflict the high-priority positional patterns exposed — caught by the bn render round-trip test).

## Result

- **11/14 langs** parse `put before/after me` with `manner` captured; **avgRoleFidelity +0.004–0.008** across bn/hi/it/ja/ko/pl/qu/ru/th/tr/vi + precision gains; **zero regressions**; **R2 still 1.000** (baseline regenerated).
- Full semantic suite **6234 pass**, i18n **880 pass**, gate `--regression` **green**.

## Not yet in R2 (deliberate)

`put-before`/`put-after` stay **out** of `EXECUTION_SUBSET` because the **VSO family (ar, tl, uk)** still diverges: their put is captured inline by the generated fused VSO event pattern (the position word is a destination-marker *alternative*, so `manner` is lost; there's no body re-parse to reach a command-stage pattern). Completing it needs the VSO event-handler **generator** to capture `manner` from position-word markers; then put-before/after can join R2 (40 → 42). Tracked in `docs-internal/MULTILINGUAL_NEXT_STEPS.md` (2026-06-28e).

## Guards

- `multilingual-roadmap-fixes.test.ts` "Positional put `before`/`after`" — 22 cases (11 langs × 2), **verified failing without the fix**.
- `parser-integration.test.ts` updated for the tr mapping (`sonra`→after, `ardından`→then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)