### PR TITLE
fix(multilingual): VSO put before/after captures manner (ar/tl/uk) — put joins R2 (40→42, worklist closed)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,24 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-28f (R2 wave 8 — VSO ar/tl/uk fixed; put-before/after JOIN R2; the
+> wave-5 worklist is CLOSED). subset 40 → 42.** The last residual from 2026-06-28e — `ar`,
+> `tl`, `uk`, whose put is captured inline by the generated fused VSO event pattern (position
+> word consumed as a plain destination marker → manner dropped → content inserted INTO the
+> target) — is FIXED with handcrafted higher-priority (160) VSO put-before/after EVENT
+> patterns (`vsoPositionalPutPatterns` in `event-handler.ts`): ar/tl verb-first
+> (`{verb} {patient} <posWord> {dest} <evMarker> {event}`), uk event-first
+> (`<evMarker> {event} {verb} {patient} <posWord> {dest}`). They match the position word as
+> an explicit literal and record `manner`; the into-form stays on the generated pattern (its
+> `في`/`sa`/`в` marker); the `-before`/`-after` id triggers the renderer's positional penalty
+> so RENDER still prefers the into-form. **All 23 langs now match en for BOTH put-before and
+> put-after; both join `EXECUTION_SUBSET` (40 → 42); R2 stays 1.000.** ar/tl/uk avgRoleFidelity
+> +0.0027–0.0041, zero regressions; semantic suite 6262 pass; gate --regression green. Guard:
+> the "Positional put `before`/`after`" block now covers all 14 langs (28 cases) + a wave-8
+> execution lock (ar reproduces the en before/after offset). **The wave-5 R2 worklist (9
+> divergences) is now fully closed**: 6 were stale-DB artifacts (#514), `multiple-events`
+> (#515), put-before/after SVO+SOV (#516) + VSO (this). R2 subset 33 → 42.
+>
 > **Update 2026-06-28e (positional put `before`/`after` — 11 of 14 langs fixed; R1
 > +0.004–0.008; VSO ar/tl/uk residual).** The last two wave-5 R2 divergences (`put-after`
 > /`put-before`, `put "<p>New</p>" before/after me`) are a multi-family arc. The unifying

--- a/packages/semantic/src/patterns/event-handler.ts
+++ b/packages/semantic/src/patterns/event-handler.ts
@@ -7,7 +7,7 @@
  * Phase 3.2: Consolidated from 26 files into single file.
  */
 
-import type { LanguagePattern } from '../types';
+import type { LanguagePattern, PatternToken, ExtractionRules } from '../types';
 
 // =============================================================================
 // Shared Event Name Translations
@@ -1583,8 +1583,92 @@ function getEventHandlerPatternsTh(): LanguagePattern[] {
   ];
 }
 
+/**
+ * Handcrafted VSO put-before/after EVENT patterns (ar, tl, uk).
+ *
+ * The generated fused VSO 2-role put pattern (`put-event-<lang>-vso[-verb-first]-2role`)
+ * lists the position words (قبل/بعد, bago/matapos, до/після) as destination-marker
+ * ALTERNATIVES, so it captures the target but DROPS the position — `put X before Y`
+ * then inserts INTO Y (R2 divergence: the <p> lands inside #btn, not before it).
+ * Unlike SVO/SOV there is no body re-parse to reach a command-stage put-before
+ * pattern; the put is captured inline by the event pattern. These higher-priority
+ * (160 > the generated 155/148) variants match the position word as an EXPLICIT
+ * literal and record it as `manner`, which the put AST-mapper turns into the
+ * before/after DOM-insert modifier. The into-form keeps matching the generated
+ * pattern (its `في`/`sa`/`в` marker, not a position word). The `-before`/`-after`
+ * id suffix triggers the renderer's positional-variant penalty, so the canonical
+ * into-form still wins RENDER selection (parsing is priority-ordered, not here).
+ */
+function vsoPositionalPutPatterns(spec: {
+  lang: string;
+  verb: string;
+  verbAlts?: string[];
+  eventMarker: string;
+  eventMarkerAlts?: string[];
+  before: string;
+  after: string;
+  order: 'verb-first' | 'event-first';
+}): LanguagePattern[] {
+  const verbTok: PatternToken = spec.verbAlts
+    ? { type: 'literal', value: spec.verb, alternatives: spec.verbAlts }
+    : { type: 'literal', value: spec.verb };
+  const evTok: PatternToken = spec.eventMarkerAlts
+    ? { type: 'literal', value: spec.eventMarker, alternatives: spec.eventMarkerAlts }
+    : { type: 'literal', value: spec.eventMarker };
+
+  return (['before', 'after'] as const).map(manner => {
+    const posTok: PatternToken = {
+      type: 'literal',
+      value: manner === 'before' ? spec.before : spec.after,
+    };
+    const patientTok: PatternToken = { type: 'role', role: 'patient' };
+    const destTok: PatternToken = { type: 'role', role: 'destination' };
+    const eventTok: PatternToken = { type: 'role', role: 'event' };
+
+    const tokens: PatternToken[] =
+      spec.order === 'verb-first'
+        ? [verbTok, patientTok, posTok, destTok, evTok, eventTok]
+        : [evTok, eventTok, verbTok, patientTok, posTok, destTok];
+    const extraction: ExtractionRules =
+      spec.order === 'verb-first'
+        ? {
+            action: { value: 'put' },
+            patient: { position: 1 },
+            destination: { position: 3 },
+            event: { position: 5 },
+            manner: { default: { type: 'literal', value: manner } },
+          }
+        : {
+            action: { value: 'put' },
+            event: { position: 1 },
+            patient: { position: 3 },
+            destination: { position: 5 },
+            manner: { default: { type: 'literal', value: manner } },
+          };
+
+    return {
+      id: `put-event-${spec.lang}-vso-${manner}`,
+      language: spec.lang,
+      command: 'on',
+      priority: 160,
+      template: { format: `${spec.lang} put ${manner}`, tokens },
+      extraction,
+    } satisfies LanguagePattern;
+  });
+}
+
 function getEventHandlerPatternsTl(): LanguagePattern[] {
   return [
+    ...vsoPositionalPutPatterns({
+      lang: 'tl',
+      verb: 'ilagay',
+      verbAlts: ['maglagay'],
+      eventMarker: 'kapag',
+      eventMarkerAlts: ['sa'],
+      before: 'bago',
+      after: 'matapos',
+      order: 'verb-first',
+    }),
     // VSO with source: kapag [event] mula_sa [source] [body]
     {
       id: 'event-tl-kapag-source',
@@ -1632,6 +1716,16 @@ function getEventHandlerPatternsTl(): LanguagePattern[] {
 
 function getEventHandlerPatternsUk(): LanguagePattern[] {
   return [
+    ...vsoPositionalPutPatterns({
+      lang: 'uk',
+      verb: 'покласти',
+      verbAlts: ['поклади', 'помістити', 'помісти', 'вставити', 'встав'],
+      eventMarker: 'при',
+      eventMarkerAlts: ['коли'],
+      before: 'до',
+      after: 'після',
+      order: 'event-first',
+    }),
     {
       id: 'event-handler-uk-full',
       language: 'uk',
@@ -1951,6 +2045,16 @@ function getEventHandlerPatternsTr(): LanguagePattern[] {
 
 function getEventHandlerPatternsAr(): LanguagePattern[] {
   return [
+    ...vsoPositionalPutPatterns({
+      lang: 'ar',
+      verb: 'ضع',
+      verbAlts: ['اجعل'],
+      eventMarker: 'عند',
+      eventMarkerAlts: ['في', 'لدى', 'عندما', 'حين', 'حينما', 'لمّا', 'لما'],
+      before: 'قبل',
+      after: 'بعد',
+      order: 'verb-first',
+    }),
     {
       id: 'event-ar-when',
       language: 'ar',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -8378,6 +8378,11 @@ describe('Positional put `before`/`after` captures manner (put-before/put-after,
     ['ru', 'при клик положить "<p>New</p>" до я'],
     ['pl', 'gdy kliknięcie umieść "<p>New</p>" przed ja'],
     ['th', 'เมื่อ คลิก ใส่ "<p>New</p>" ก่อน ฉัน'],
+    // VSO (ar/tl verb-first, uk event-first): the handcrafted put-event-<lang>-vso-before
+    // pattern out-ranks the generated fused pattern (which drops manner).
+    ['ar', 'ضع "<p>New</p>" قبل أنا عند نقر'],
+    ['tl', 'ilagay "<p>New</p>" bago ako kapag click'],
+    ['uk', 'при клік покласти "<p>New</p>" до я'],
   ];
   const after: Array<[string, string]> = [
     ['ja', '"<p>New</p>" 後に 私 を クリック で 置く'],
@@ -8391,6 +8396,9 @@ describe('Positional put `before`/`after` captures manner (put-before/put-after,
     ['ru', 'при клик положить "<p>New</p>" после я'],
     ['pl', 'gdy kliknięcie umieść "<p>New</p>" po ja'],
     ['th', 'เมื่อ คลิก ใส่ "<p>New</p>" หลัง ฉัน'],
+    ['ar', 'ضع "<p>New</p>" بعد أنا عند نقر'],
+    ['tl', 'ilagay "<p>New</p>" matapos ako kapag click'],
+    ['uk', 'при клік покласти "<p>New</p>" після я'],
   ];
 
   for (const [lang, code] of before) {

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-28T14:02:11.528Z",
-  "commit": "378f8afd",
+  "timestamp": "2026-06-28T14:56:40.474Z",
+  "commit": "0a7166e9",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9,12 +9,12 @@
       "avgConfidence": 0.8371917985695063,
       "avgFidelity": 1,
       "avgPrecision": 0.978030303030303,
-      "avgRoleFidelity": 0.9435327154077153,
+      "avgRoleFidelity": 0.9462354181104179,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12010,12 +12010,12 @@
       "avgConfidence": 0.8216537651743292,
       "avgFidelity": 1,
       "avgPrecision": 0.9784632034632035,
-      "avgRoleFidelity": 0.9312793906543906,
+      "avgRoleFidelity": 0.9339820933570933,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13271,15 +13271,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8135229849515544,
+      "avgConfidence": 0.8146773861059555,
       "avgFidelity": 1,
       "avgPrecision": 0.9886634199134197,
-      "avgRoleFidelity": 0.895330907830908,
+      "avgRoleFidelity": 0.899384961884962,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13298,6 +13298,10 @@
           "confidence": 1
         },
         "put-before": {
+          "success": true,
+          "confidence": 1
+        },
+        "put-after": {
           "success": true,
           "confidence": 1
         },
@@ -13466,10 +13470,6 @@
           "confidence": 0.8222222222222222
         },
         "set-style": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "put-after": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 454103,
+      "bundleSize": 456012,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 454103,
+      "size": 456012,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
@@ -19,7 +19,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { ExecutionValidator, EXECUTION_SUBSET, loadExecutionSubset } from './execution-validator';
 
 describe('R2 execution subset (lock)', () => {
-  it('contains exactly the 40 curated patterns', () => {
+  it('contains exactly the 42 curated patterns', () => {
     // Changing this list recalibrates avgExecutionFidelity for every language.
     // If you expand the subset, regenerate the baseline (--save-baseline) in
     // the SAME PR and update this lock.
@@ -106,6 +106,11 @@ describe('R2 execution subset (lock)', () => {
         // now fixed by the semantic or-clause excision pre-pass + ja `または`→or
         // tokenizer fix + hi/bn OR_KEYWORDS. All 23 langs match the en click effect.
         'multiple-events',
+        // Session-14 expansion wave 8: put-before / put-after (`put X before/after me`),
+        // the last two wave-5 worklist divergences. Position word captured as `manner`
+        // across SVO/SOV (#516) + handcrafted VSO put-event patterns for ar/tl/uk.
+        'put-before',
+        'put-after',
       ].sort()
     );
   });
@@ -292,6 +297,26 @@ describe('R2 execution validator (lock)', () => {
     );
     expect(it.error, `it errored: ${it.error}`).toBeUndefined();
     expect(it.effects).toEqual(en.effects);
+  });
+
+  it('wave-8 put-before/after: en inserts the <p> at the right offset; a VSO translation matches', async () => {
+    // `put "<p>New</p>" before/after me` — the position word must land the content
+    // before/after #btn (not inside it). before → +p[1] (preceding #btn's parent
+    // diff), after → +p[2]. ar (VSO) used to drop the position (fused VSO event
+    // pattern consumed قبل/بعد as a plain destination marker → inserted INTO me);
+    // the handcrafted put-event-ar-vso-before/after now captures manner, so ar
+    // reproduces the en effect exactly.
+    for (const [id, enCode, arCode] of [
+      ['put-before', 'on click put "<p>New</p>" before me', 'ضع "<p>New</p>" قبل أنا عند نقر'],
+      ['put-after', 'on click put "<p>New</p>" after me', 'ضع "<p>New</p>" بعد أنا عند نقر'],
+    ] as const) {
+      const en = await validator.execute(id, enCode, 'en');
+      expect(en.error, `en ${id} errored: ${en.error}`).toBeUndefined();
+      expect(en.effects.join(), `en ${id} should insert a <p>`).toContain('text[New]');
+      const ar = await validator.execute(id, arCode, 'ar');
+      expect(ar.error, `ar ${id} errored: ${ar.error}`).toBeUndefined();
+      expect(ar.effects, `ar ${id} must reproduce en`).toEqual(en.effects);
+    }
   });
 
   it('a parse failure comes back as an error, never a throw', async () => {

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.ts
@@ -145,13 +145,7 @@ export const EXECUTION_SUBSET: readonly string[] = [
   // non-empty signature against the existing fixture (next/closest positionals fall
   // back to `me` consistently across every language; set *opacity/*transform write
   // inline style; caret-var-on-target clears #btn text — the undefined `^count` resolves
-  // the same way in every language). Two wave-5 candidates with REAL divergences
-  // remain the next-wave worklist (re-grounded fresh-db divergent-lang counts):
-  //   put-after (14) · put-before (14) — positional `put … after/before me`, which
-  //   errors ("Unknown command: after", "put requires content and position") or inserts
-  //   at the wrong offset in most languages. These are invisible to R0/R1 (parse-faithful)
-  //   — exactly the class R2 exists to catch — and each must be FIXED before joining, or
-  //   it drops R2 below 1.0. Tracked in docs-internal/MULTILINGUAL_NEXT_STEPS.md.
+  // the same way in every language).
   'next-element',
   'toggle-aria-expanded',
   'set-opacity',
@@ -164,8 +158,18 @@ export const EXECUTION_SUBSET: readonly string[] = [
   // tokenizer fix + hi/bn OR_KEYWORDS entries. It diverged in 7 languages
   // (ja,ko,it,hi,tr,bn,qu — the translated `or` became a phantom body command or
   // mangled into a selector); now all 23 match the en click effect (toggles .active
-  // on #btn). R2 stays 1.0. Only put-after/put-before remain from the wave-5 list.
+  // on #btn). R2 stays 1.0.
   'multiple-events',
+  // Expansion wave 8 (session 14): `put-before` / `put-after` — `put "<p>New</p>"
+  // before/after me`, the last two wave-5 worklist divergences (14 langs each), now
+  // FIXED. The position word (`before`/`after` + translations) is now captured as the
+  // put command's `manner` role (→ the DOM-insert modifier): per-language put-before/
+  // after patterns for SVO/SOV (#516) + handcrafted high-priority VSO put-event
+  // patterns for ar/tl/uk (the fused VSO event pattern consumed the position word as
+  // a plain destination marker and dropped manner). All 23 langs now insert the <p>
+  // before/after #btn (matching en); R2 stays 1.0.
+  'put-before',
+  'put-after',
 ];
 
 /**


### PR DESCRIPTION
## What

Completes positional put `before`/`after` and **closes the wave-5 R2 execution-divergence worklist**. The SVO/SOV languages were fixed in #516; this fixes the remaining VSO family (**ar, tl, uk**) and adds `put-before` + `put-after` to the R2 subset (**40 → 42**, R2 stays **1.000**).

## Why

For ar/tl/uk the put is captured **inline** by the generated fused VSO event pattern (`put-event-<lang>-vso[-verb-first]-2role`), which lists the position words (قبل/بعد, bago/matapos, до/після) as destination-marker **alternatives**. So it captured the target but **dropped the position** (`manner`) → the content inserted *into* the target (`+p[2]` + `Δ#btn`) instead of before/after it. Unlike SVO/SOV there's no body re-parse to reach a command-stage put-before pattern.

## Fix

Handcrafted higher-priority (160 > the generated 155/148) VSO put-before/after **event** patterns (`vsoPositionalPutPatterns` in `event-handler.ts`):
- **ar/tl** verb-first: `{verb} {patient} <posWord> {dest} <evMarker> {event}`
- **uk** event-first: `<evMarker> {event} {verb} {patient} <posWord> {dest}`

They match the position word as an **explicit literal** and record `manner` (→ the DOM-insert modifier). The into-form keeps matching the generated pattern (its `في`/`sa`/`в` marker, not a position word). The `-before`/`-after` id triggers the renderer's positional-variant penalty, so **render** still prefers the canonical into-form (consistent with `-at-end`/the #516 convention).

## Result

- **All 23 priority langs** now match en for **both** put-before and put-after; both join `EXECUTION_SUBSET` (**40 → 42**); **R2 = 1.000**.
- ar/tl/uk **avgRoleFidelity +0.0027–0.0041**; **zero regressions**.
- Semantic suite **6262 pass**; gate `--regression` **green** (baseline regenerated).

## Worklist closed 🎉

The wave-5 R2 worklist (9 divergences) is now fully resolved across the campaign — R2 subset **33 → 42**:
- 6 stale-DB artifacts → #514 (wave 6)
- `multiple-events` → #515 (wave 7)
- put-before/after SVO+SOV → #516
- put-before/after VSO (ar/tl/uk) → this (wave 8)

## Guards

- "Positional put `before`/`after`" now covers **all 14 langs (28 cases)**, verified failing without the fix.
- Wave-8 execution lock (`ar` reproduces the en before/after insert offset); subset membership lock **40 → 42**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)