### PR TITLE
fix(multilingual): `halt the event` skips leaked article → patient:reference (R1 0.9125→0.9142)

### DIFF
--- a/docs-internal/HANDOFF-r1-value-type-residue.md
+++ b/docs-internal/HANDOFF-r1-value-type-residue.md
@@ -1,0 +1,162 @@
+# Handoff — HyperFixi multilingual: R1 value-type residue (the last open dimension)
+
+You're continuing a long-running multilingual parse/fidelity effort in the hyperfixi
+monorepo (`~/projects/hyperfixi`, branch `main`). **The R2 execution-divergence worklist is
+fully closed** (see "What just shipped"). The one remaining multilingual dimension with real
+headroom is **R1 role-fidelity** — specifically per-command value-TYPE mismatches in the hard
+SOV/reorder languages. This is **Arc B** from the previous handoff: harder/structural, lower
+ROI than the R2 work that's now done, but it's the only open band.
+
+> Read `docs-internal/MULTILINGUAL_NEXT_STEPS.md` first — the dated notes at the TOP
+> (2026-06-28f back through 2026-06-28b) are the current state. Then `packages/semantic/CLAUDE.md`
+> and the repo-root `CLAUDE.md` "Multilingual parse rate ≠ fidelity" section.
+
+## Current authoritative state (`browser-priority` gate)
+
+Source of truth: `packages/testing-framework/baselines/multilingual-priority.json`
+(its `timestamp`/`commit` fields stamp each regen). 24 langs × 154 patterns = 3696.
+
+| Signal                        | Value                  | Notes                                                        |
+| ----------------------------- | ---------------------- | ------------------------------------------------------------ |
+| parse rate                    | **3696 / 3696 (100%)** | zero hard fails                                              |
+| degenerate (fid < 0.5)        | **0**                  | band empty                                                   |
+| lossy (0.5 ≤ fid < 1.0)       | **0**                  | band empty                                                   |
+| avgFidelity (R0-recall)       | **1.000**              |                                                              |
+| avgPrecision (R0 trust floor) | **0.972**              | hi 0.921 is the outlier (next bn 0.928)                      |
+| avgRoleFidelity (R1)          | **0.9142**             | **the laggard / the work** (was 0.9125 pre-`halt the event`) |
+| avgExecutionFidelity (R2)     | **1.000**              | 42-pattern curated subset                                    |
+
+**R1 laggards (lowest first, post-`halt the event`):** hi 0.865 · ja 0.892 · ko 0.898 ·
+qu 0.899 · bn 0.900 · uk 0.901 · tr 0.902 · pl 0.907. All SOV/reorder-heavy. R1 measures
+`action.role:valueType` recall vs the en reference — a parse that keeps the verb but
+**drops or mistypes a role**.
+
+> **Shipped this arc (2026-06-28g): `halt the event` article skip.** The most consistent
+> R1 residue signature was `halt.patient: en=literal → SOV=reference`. Grounding showed the
+> **en reference was itself wrong** — `halt the event` captured the article `the` and dropped
+> the event (`patient:literal="the"`), so every faithful translation mismatched it. Fixed in
+> `skipNoiseWords` (pattern-matcher.ts): en now skips `the` before a valid reference word, and
+> the non-en skip was extended from "before a SOV particle" to "before a particle OR a clause
+> boundary (then/end/EOF) — never before a command verb" (preserving the §7y guard). Result:
+> en + all 23 langs agree on `halt.patient:reference`; **R1 0.9125 → 0.9142, all 23 langs +,
+> R0/precision unchanged.** Guard in `multilingual-roadmap-fixes.test.ts`. **Next R1 targets
+> (re-grounded below):** the `repeat` loop-role garbage and the VSO `halt the event`
+> verb-after residue.
+
+## What just shipped (the R2 worklist campaign — all merged to main)
+
+The wave-5 R2 execution-divergence worklist (9 items) is **fully closed**; R2 curated subset
+grew **33 → 42**, all at fidelity 1.000:
+
+- **#514 (wave 6)** — 6 of the 9 worklist items were **stale committed-DB artifacts**, not real
+  divergences: re-grounding against a freshly `populate`d DB showed they already matched en in
+  all 23 langs (subset 33 → 39). **Lesson: the committed `patterns.db` lags the dicts; always
+  `npm run populate` before grounding.**
+- **#515 (wave 7)** — `multiple-events` (`on click or keypress[...] toggle .active`): the `or`
+  multi-event separator wasn't recognized in 7 langs. Fixed via a scoped or-clause excision
+  pre-pass + ja `または`→or tokenizer fix + hi/bn OR_KEYWORDS (subset 39 → 40).
+- **#516** — positional put `before`/`after` for 11 SVO/SOV langs (the position word is now
+  captured as the put `manner` role); **R1 +0.004–0.008 across 11 langs**. Also fixed a
+  parser-vs-renderer priority conflict (renderer `-before`/`-after` penalty).
+- **#517 (wave 8)** — VSO put `before`/`after` (ar/tl/uk) via handcrafted high-priority VSO
+  put-event patterns; `put-before`/`put-after` joined R2 (subset 40 → 42). Worklist closed.
+
+## Your task: Arc B — R1 value-type residue burn-down
+
+**Why it's the work:** R1 (0.9125) is the only non-maxed signal. It drifted up incidentally
+(0.75 → 0.91 over many arcs) but has **never had a dedicated, convergent campaign**. The prior
+handoff characterized the residue (UNVERIFIED — re-ground it) as per-command value-TYPE
+mismatches, e.g.:
+
+- `set.destination:property-path` — `#x.prop` mistyped in SOV reorders.
+- `repeat` loop roles — `loopType` / `event` / `quantity` mistyped or dropped.
+- `halt.patient` — en "the event" parses as a `literal` vs SOV as a `reference`.
+  And **hi precision (0.921)** is the lowest — phantom-command sources in the hi profile (R0
+  precision, a different signal from R1; worth a parallel look since hi is the worst on both).
+
+**Suggested approach:**
+
+1. Triage hi / ja / ko first (the worst three). For each, dump the per-pattern
+   `action.role:valueType` signature diff vs the en reference and find the **recurring**
+   mistype/drop. The win is one or two systemic causes, not 50 one-offs.
+2. Expect the cause to be a marker→role mapping or a value-type classification in the
+   per-language profile/tokenizer — but **do not assume**: every theorized cause this project
+   has had was wrong until reproduced.
+3. This edits the hottest, most regression-sensitive SOV parser path. Guard R0/precision/
+   parse-rate carefully; a role-type change can shift other patterns.
+
+**Optional lower-priority follow-ups (not R1):**
+
+- **Render quality of positional put before/after-nodes.** #516/#517 made the _into-form_ win
+  RENDER selection (so the canonical round-trip is preserved), which means a before/after
+  _node_ currently renders back as the into-form (position lost on render — same accepted
+  tradeoff as `-at-end`). Parsing is 100% correct; only `semantic.render`/`translate` output of
+  a before/after node is lossy. Fix would need the renderer to select positional patterns when
+  the node carries `manner` (the role scoring in `explicit/renderer.ts` is priority + role
+  match; manner isn't a role token). Gate doesn't measure this (it uses the i18n transformer).
+- **hi avgPrecision 0.921** phantom-command sources (R0 precision).
+
+## METHODOLOGY (non-negotiable — every theorized cause this project has had was wrong)
+
+1. **GROUND before coding.** Reproduce via the gate path: `ml.parse(translation, lang)` over the
+   `patterns.db` translations, diff the role/`valueType` signature vs the en reference. Do NOT
+   theorize the root cause — reproduce it. The R1 metric is `collectRoleSignature` in
+   `packages/testing-framework/src/multilingual/fidelity.ts` (`action.role:valueType`, only on
+   non-structural-action nodes — the event-handler's own event role is NOT counted).
+2. **Throwaway probe** under `packages/patterns-reference/scripts/` (jsdom globals +
+   `import { MultilingualHyperscript } from '@hyperfixi/core/multilingual'`; inline
+   `collectActions`/`collectRoleSignature` from `testing-framework/.../fidelity.ts`). **DELETE it
+   after** (untracked probe files left in `src/` show up in the diff — keep the tree clean).
+3. **Re-ground the worklist.** The R2 campaign proved the committed DB lags the dicts — if you
+   inherit any "list of N divergent patterns," re-measure it against a fresh `populate` before
+   trusting it.
+
+## ENVIRONMENT + GATE WORKFLOW (gotchas that cost real time)
+
+- **Node 24:** `export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use 24`. `better-sqlite3`
+  works under it. **The shell does NOT persist between Bash calls — re-source nvm each time.**
+- **The gate REFUSES a stale dist or stale DB.** After editing a `src` package: rebuild it
+  (`npm run build --prefix packages/<pkg>`) — or the whole multilingual stack
+  (`npm run test:multilingual:build-deps`) — AND re-populate
+  (`npm run populate --prefix packages/patterns-reference`) before running the gate. A rebuild
+  bumps dist mtimes, which re-triggers the DB staleness check, so **rebuild THEN populate** (in
+  that order) or the gate refuses.
+- **Vitest semantic/i18n tests import from `../src`** (transpiled on the fly), so a guard can be
+  verified failing-without-fix by `git stash`-ing only the `src` files and re-running — no
+  rebuild needed. (The gate, by contrast, runs the built dist.)
+- **Gate run** (from `packages/testing-framework`):
+  `npx tsx src/multilingual/cli.ts --full --bundle browser-priority --regression`
+  After an intentional fidelity change: replace `--regression` with `--save-baseline`, commit
+  the new baseline. It refuses unless the stack is built + DB freshly populated.
+- **`patterns.db` is NOT committed** (CI repopulates). It's modified by `populate`; restore it
+  before committing: `git checkout -- packages/patterns-reference/data/patterns.db`. Commit
+  only the dicts/profiles/patterns + the regenerated baseline.
+- The R1 ratchet fires on a per-language **avgRoleFidelity drop > 0.02**; improvements are free.
+  Re-baseline to lock gains.
+
+## PR CONVENTIONS (also cost real time)
+
+- One defect/arc per PR, branch off `main`. **Guards required + verified failing-without-fix**
+  (semantic → `packages/semantic/test/multilingual-roadmap-fixes.test.ts`; i18n →
+  `packages/i18n/src/grammar/grammar.test.ts` or the relevant test).
+- **Run the FULL semantic suite before pushing** (`npm run test:check --prefix packages/semantic`)
+  — a role/parse change can break render/round-trip tests. (That's how a renderer regression was
+  caught in #516: a high-priority pattern shadowed the canonical render form.)
+- A **prettier pre-commit hook reformats staged files** — expect it; the change stays intact.
+- **Auto-merge is disabled; admin-merge denied.** Branch must be up-to-date with main:
+  `gh pr update-branch <n>` if behind, wait for CI, then
+  `gh pr merge <n> --squash --delete-branch`. CI ≈ 6 min build + ~3 min parallel jobs;
+  poll `gh pr checks <n>` (the `Multilingual Validation` job is the real R2/fidelity gate).
+- After merging, `git checkout main && git pull` before the next branch.
+
+## Optional: multi-agent workflow
+
+The R2 put arc used a `Workflow` (5 parallel per-family design agents) to produce per-language
+pattern specs, then implemented centrally with tight build-verify loops. Worktree agents have
+**no node_modules/dist** (can't build), so the pattern was: gather complete grounding data
+centrally → fan out **pure-reasoning design agents** (read-only, given the data) → implement +
+verify centrally. Useful for R1 if you triage many languages in parallel; the central
+build-verify loop is where the real correctness work happens (agents can't run the gate).
+
+Start by reading `MULTILINGUAL_NEXT_STEPS.md`, then ground hi's R1 residue end-to-end (dump the
+per-pattern `action.role:valueType` diff vs en) before touching code.

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,35 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-28g (Arc B R1 — `halt the event` article skip; avgRoleFidelity
+> 0.9125 → 0.9142, all 23 langs +, zero regressions).** First convergent burn-down of
+> the R1 value-type residue. Grounding the `halt.patient` cluster (the most consistent
+> cross-language signature: en `halt the event` → `patient:literal="the"`) showed the **en
+> reference itself was wrong** — it captured the article `the` and dropped the event, so every
+> faithful translation mismatched it. One defect, two facets in `skipNoiseWords`
+> (`pattern-matcher.ts`):
+>
+> - **en:** `event` tokenizes as a `keyword` (not selector/identifier), so the existing
+>   article-skip missed it. Added an en case: skip `the` before a valid reference word
+>   (`isValidReference`) → `patient:reference="event"`. (`the default`, a non-reference, stays
+>   `literal`; bare `halt` unchanged.)
+> - **SVO/VSO:** the transformer leaks an untranslated `the` before the translated event word
+>   (`the evento entonces …`); the pre-existing non-en skip only fired before a SOV **particle**,
+>   so these kept `patient:expression="the"`. Extended the non-en skip to also fire before a
+>   **clause boundary** (then/and/or/end/EOF) — but **never before a command verb**, preserving
+>   the §7y guard (tr form-submit-prevent's `the olay çağır …` keeps `the`; body parse intact).
+>
+> Result: en + all 23 priority langs now agree on `halt.patient:reference` for halt-propagation.
+> **avgRoleFidelity +0.0014–0.0029/lang** (SOV laggards hi/ja/ko/qu/bn/tr +0.0025–0.0029; every
+> SVO/VSO +0.0014–0.0015), **R0-recall 1.000 and R0-precision 0.972 both unchanged**, semantic
+> suite 6262 pass, gate `--regression` green. Guard: `multilingual-roadmap-fixes.test.ts`
+> "`halt the event` skips the leaked article" (15 cases incl. the §7y verb-after invariant +
+> `the default`/bare-`halt` controls; verified failing-without-fix: 8 fail). Remaining R1
+> residue (now hi 0.8646 the laggard): the **`repeat` loop-role garbage** (en reference itself
+> mis-parses `repeat N times`/`for X in Y` — body verb captured as `repeat.event`, biggest
+> cluster, two-sided en+SOV structural fix) and the **SVO `halt the event` → still `expression`
+> for VSO verb-after forms**. See HANDOFF-r1-value-type-residue.md.
+>
 > **Update 2026-06-28f (R2 wave 8 — VSO ar/tl/uk fixed; put-before/after JOIN R2; the
 > wave-5 worklist is CLOSED). subset 40 → 42.** The last residual from 2026-06-28e — `ar`,
 > `tl`, `uk`, whose put is captured inline by the generated fused VSO event pattern (position

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -723,6 +723,16 @@ export class PatternMatcher {
   );
 
   /**
+   * Normalized clause-boundary keywords — sequence/conjunction tokens that close
+   * one command and open the next. Tokenizers normalize every language's forms
+   * to these (es `entonces`→then, uk `тоді`→then). Used by skipNoiseWords to tell
+   * a `the <ref-noun>` patient phrase that ENDS a clause (`the evento entonces …`,
+   * safe to skip the leaked article) from one whose ref-noun is followed by a
+   * command verb (`the olay çağır …`, must NOT skip — the §7y regression).
+   */
+  private static readonly CLAUSE_BOUNDARY_KEYWORDS = new Set(['then', 'and', 'or', 'end', 'else']);
+
+  /**
    * Try to match a positional query expression:
    *   <positional> <selector> [<in/from-marker> <source-selector>]
    * e.g. "last <.message/> in #chat", "first <button/> in .modal", "آخر <.message/> في #chat".
@@ -1870,19 +1880,54 @@ export class PatternMatcher {
       // the handler). The reference noun (घटना→event) then fills the patient, so
       // `halt the event` continues.
       //
-      // Gated to `the <ref-noun> <particle-marker>` — a fronted patient phrase.
-      // This deliberately does NOT fire for `the <ref-noun> <verb>` (tr
-      // form-submit-prevent's `the olay çağır …` = "the event call …", where the
-      // ref noun is followed by the `call` verb, not a marker): skipping `the`
-      // there breaks tr's fragile body parse (the §7y regression). English keeps
-      // `the` (authored, not a leak) — byte identical, so the en reference parse
-      // is untouched. See STRUCTURAL_ARCS_ROADMAP.md (hi halt-propagation).
+      // Fires for a fronted/leaked-article reference-noun patient when the noun is
+      // followed by a clause boundary, NOT a command verb:
+      //   - a particle marker   (SOV `the घटना को …`  → reference="event")
+      //   - a sequence/conjunction keyword or end-of-stream (SVO `the evento
+      //     entonces …`, `the подія тоді …` → reference="event")
+      // It deliberately does NOT fire for `the <ref-noun> <verb>` (tr
+      // form-submit-prevent's `the olay çağır …` = "the event call …", ref noun
+      // followed by the `call` verb): skipping `the` there breaks tr's fragile
+      // body parse (the §7y regression). Before the boundary cases were added, the
+      // SVO/VSO translations kept the leaked `the` as the patient
+      // (`patient:expression="the"`), mismatching both the en reference and the SOV
+      // parse — part of the `halt.patient` R1 residue. See STRUCTURAL_ARCS_ROADMAP.md
+      // (hi halt-propagation).
+      const afterRefNoun = tokens.peek(1);
+      const afterRefNorm = afterRefNoun
+        ? (afterRefNoun.normalized ?? afterRefNoun.value).toLowerCase()
+        : '';
+      const refNounFollowedByBoundary =
+        !afterRefNoun ||
+        afterRefNoun.kind === 'particle' ||
+        PatternMatcher.CLAUSE_BOUNDARY_KEYWORDS.has(afterRefNorm);
       if (
         nextToken &&
         nextToken.kind === 'keyword' &&
         this.currentProfile?.code !== 'en' &&
         isValidReference(nextNorm) &&
-        tokens.peek(1)?.kind === 'particle'
+        refNounFollowedByBoundary
+      ) {
+        return;
+      }
+
+      // English authored `the` before a reference word ("halt the event"). The
+      // reference (`event`, `result`, `target`, …) tokenizes as a `keyword`, so
+      // the selector/identifier skip (case 1) and the positional skip (case 2)
+      // both miss it, and the role would otherwise capture only the article
+      // (`halt the event` → patient:literal="the", dropping the event). Skip it so
+      // the canonical reference fills the role (patient:reference="event"). This
+      // matches what the SOV branch above already produces for the leaked-article
+      // translations (`the घटना को` → reference="event"); before this, en was the
+      // odd reference (literal="the") that every faithful SOV parse mismatched —
+      // the dominant `halt.patient` R1 residue. en-only and gated to a valid
+      // reference: an English noun ("the color") is an identifier (case 1) and a
+      // non-reference keyword ("the default") is left untouched.
+      if (
+        nextToken &&
+        nextToken.kind === 'keyword' &&
+        this.currentProfile?.code === 'en' &&
+        isValidReference(nextNorm)
       ) {
         return;
       }

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -8418,3 +8418,103 @@ describe('Positional put `before`/`after` captures manner (put-before/put-after,
     });
   }
 });
+
+describe('`halt the event` skips the leaked article → patient:reference (halt.patient R1)', () => {
+  // `halt the event` parses with patient = the `event` REFERENCE, never the
+  // article. Two facets of one defect, both in skipNoiseWords (pattern-matcher):
+  //   - en: `event` tokenizes as a keyword (not selector/identifier), so the
+  //     existing article-skip missed it and the role captured `the` itself
+  //     (patient:literal="the", the event dropped). en was the odd reference that
+  //     every faithful translation mismatched.
+  //   - SVO/VSO: the i18n transformer leaves `the` untranslated before the
+  //     translated event word (`the evento entonces …`). The pre-existing
+  //     non-en skip only fired before a SOV particle, so these kept
+  //     patient:expression="the". Extending it to a clause boundary (then/end/
+  //     EOF) — but NOT a following command verb — skips the leaked article.
+  // Net: en + all 23 priority langs now agree on halt.patient:reference for
+  // halt-propagation (avgRoleFidelity +0.0014–0.0029/lang, zero regressions).
+  function findHalt(node: any): any {
+    if (!node || typeof node !== 'object') return undefined;
+    if (node.action === 'halt') return node;
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches', 'eventHandlers', 'initBlock']) {
+      const c = node[f];
+      if (Array.isArray(c)) for (const x of c) { const r = findHalt(x); if (r) return r; }
+      else if (c && typeof c === 'object') { const r = findHalt(c); if (r) return r; }
+    }
+    return undefined;
+  }
+  const patientType = (halt: any): string | undefined => {
+    const v = halt?.roles instanceof Map ? halt.roles.get('patient') : halt?.roles?.patient;
+    return v?.type;
+  };
+  function actions(node: any): string[] {
+    const acc = new Set<string>();
+    (function w(x: any) {
+      if (!x || typeof x !== 'object') return;
+      if (typeof x.action === 'string' && x.action !== 'compound') acc.add(x.action);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches', 'eventHandlers', 'initBlock']) {
+        const c = x[f];
+        if (Array.isArray(c)) c.forEach(w);
+        else if (c && typeof c === 'object') w(c);
+      }
+    })(node);
+    return [...acc].sort();
+  }
+
+  // halt-propagation corpus translations (en → lang): `... halt the event then
+  // toggle .active`. The ref noun is followed by a clause boundary (`then` / its
+  // translation), so the leaked article is skipped and patient is the event ref.
+  const haltEventCases: Array<[string, string]> = [
+    ['en', 'on click halt the event then toggle .active'],
+    ['es', 'en clic detener the evento entonces alternar .active'],
+    ['fr', 'sur clic stopper the événement alors basculer .active'],
+    ['de', 'bei klick anhalten the ereignis dann umschalten .active'],
+    ['ru', 'при клик остановить the событие затем переключить .active'],
+    ['uk', 'при клік зупинити the подія тоді перемкнути .active'],
+    ['pl', 'gdy kliknięcie zatrzymaj the zdarzenie wtedy przełącz .active'],
+    ['zh', '当 点击 时 停止 把 the 事件 那么 切换 把 .active'],
+    ['hi', 'the घटना को क्लिक पर रोकें फिर .active को टॉगल'],
+    ['ja', 'the イベント を クリック で 停止 それから .active を 切り替え'],
+    ['ko', 'the 이벤트 를 클릭 할 때 정지 그러면 .active 를 토글'],
+  ];
+  for (const [lang, code] of haltEventCases) {
+    it(`[${lang}] halt the event → patient:reference (article skipped)`, () => {
+      const halt = findHalt(parse(code, lang));
+      expect(halt, `no halt command parsed for ${lang}`).toBeTruthy();
+      expect(patientType(halt)).toBe('reference');
+    });
+  }
+
+  // §7y guard: when a command VERB directly follows the ref noun (no clause
+  // boundary), the leaked article must NOT be skipped — skipping it breaks the
+  // fragile SOV/agglutinative body parse (tr form-submit-prevent: `the olay
+  // çağır …` = "the event call …"). The patient stays the article and the whole
+  // command sequence survives.
+  const formSubmitPrevent: Array<[string, string]> = [
+    ['tr', 'the olay çağır validateForm() i gönder de durdur eğer sonuç dir yanlış "Invalid form" i kaydet son'],
+    ['es', 'en enviar detener the evento llamar validateForm() si resultado es falso registrar "Invalid form" fin'],
+  ];
+  for (const [lang, code] of formSubmitPrevent) {
+    it(`[${lang}] §7y: verb after ref noun → article NOT skipped, body intact`, () => {
+      const node = parse(code, lang);
+      const halt = findHalt(node);
+      expect(halt, `no halt parsed for ${lang}`).toBeTruthy();
+      expect(patientType(halt)).not.toBe('reference');
+      // Body parse must survive (the §7y regression dropped commands).
+      expect(actions(node)).toEqual(['call', 'halt', 'if', 'log', 'on']);
+    });
+  }
+
+  // Controls: a non-reference keyword after `the` keeps the article (no skip),
+  // and a bare `halt` has no patient at all.
+  it('[en] `halt the default` keeps the article (default is not a reference)', () => {
+    const halt = findHalt(parse('halt the default', 'en'));
+    expect(patientType(halt)).toBe('literal');
+  });
+  it('[en] bare `halt` has no patient role', () => {
+    const halt = findHalt(parse('on click halt', 'en'));
+    expect(halt).toBeTruthy();
+    const hasPatient = halt.roles instanceof Map ? halt.roles.has('patient') : !!halt.roles?.patient;
+    expect(hasPatient).toBe(false);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-28T14:56:40.474Z",
-  "commit": "0a7166e9",
+  "timestamp": "2026-06-28T19:11:45.530Z",
+  "commit": "2334ef9b",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9,12 +9,12 @@
       "avgConfidence": 0.8371917985695063,
       "avgFidelity": 1,
       "avgPrecision": 0.978030303030303,
-      "avgRoleFidelity": 0.9462354181104179,
+      "avgRoleFidelity": 0.9476612925142336,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -641,12 +641,12 @@
       "avgConfidence": 0.8495030867211314,
       "avgFidelity": 1,
       "avgPrecision": 0.9275128738364035,
-      "avgRoleFidelity": 0.8970419595419593,
+      "avgRoleFidelity": 0.8999100142482492,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.828035456606883,
       "avgFidelity": 1,
       "avgPrecision": 0.9951298701298701,
-      "avgRoleFidelity": 0.9162858256608256,
+      "avgRoleFidelity": 0.917711700064641,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
       "avgPrecision": 0.983008658008658,
-      "avgRoleFidelity": 0.9057355088605087,
+      "avgRoleFidelity": 0.9072110652993006,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
       "avgPrecision": 0.9817099567099568,
-      "avgRoleFidelity": 0.9235832673332675,
+      "avgRoleFidelity": 0.9250339827545709,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3794,12 +3794,12 @@
       "avgConfidence": 0.8237889095031952,
       "avgFidelity": 1,
       "avgPrecision": 0.9835497835497835,
-      "avgRoleFidelity": 0.9291468666468663,
+      "avgRoleFidelity": 0.9305975820681698,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4426,12 +4426,12 @@
       "avgConfidence": 0.90909904631709,
       "avgFidelity": 1,
       "avgPrecision": 0.9208653089334906,
-      "avgRoleFidelity": 0.8617298617298615,
+      "avgRoleFidelity": 0.8645979164361516,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
       "avgPrecision": 0.9812770562770563,
-      "avgRoleFidelity": 0.9104451291951289,
+      "avgRoleFidelity": 0.9118958446164325,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.9750270562770563,
-      "avgRoleFidelity": 0.908499467874468,
+      "avgRoleFidelity": 0.9099750243132599,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
       "avgPrecision": 0.9466228846910667,
-      "avgRoleFidelity": 0.8895764239514237,
+      "avgRoleFidelity": 0.8920718633953924,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6954,12 @@
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
       "avgPrecision": 0.9466228846910665,
-      "avgRoleFidelity": 0.8959108834108833,
+      "avgRoleFidelity": 0.898381481837364,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
       "avgPrecision": 0.9795454545454545,
-      "avgRoleFidelity": 0.9277883996633997,
+      "avgRoleFidelity": 0.9292142740672151,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
       "avgPrecision": 0.9912608225108225,
-      "avgRoleFidelity": 0.9051773958023959,
+      "avgRoleFidelity": 0.9066529522411878,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8850,12 @@
       "avgConfidence": 0.7995877138734262,
       "avgFidelity": 1,
       "avgPrecision": 0.9804112554112555,
-      "avgRoleFidelity": 0.9158143376893372,
+      "avgRoleFidelity": 0.9172898941281291,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9482,12 @@
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
       "avgPrecision": 0.9496222662618765,
-      "avgRoleFidelity": 0.8962456274956275,
+      "avgRoleFidelity": 0.8987162259221083,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.8142650999793837,
       "avgFidelity": 1,
       "avgPrecision": 0.9886634199134199,
-      "avgRoleFidelity": 0.908393970893971,
+      "avgRoleFidelity": 0.909894368350251,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10746,12 +10746,12 @@
       "avgConfidence": 0.7962481962481944,
       "avgFidelity": 1,
       "avgPrecision": 0.9796536796536797,
-      "avgRoleFidelity": 0.919840238590238,
+      "avgRoleFidelity": 0.9212909540115415,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.9737012987012986,
-      "avgRoleFidelity": 0.9181157806157806,
+      "avgRoleFidelity": 0.9195664960370843,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12010,12 +12010,12 @@
       "avgConfidence": 0.8216537651743292,
       "avgFidelity": 1,
       "avgPrecision": 0.9784632034632035,
-      "avgRoleFidelity": 0.9339820933570933,
+      "avgRoleFidelity": 0.9354079677609087,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12642,12 +12642,12 @@
       "avgConfidence": 0.827517929021688,
       "avgFidelity": 1,
       "avgPrecision": 0.9491893658289764,
-      "avgRoleFidelity": 0.8990720803220801,
+      "avgRoleFidelity": 0.9015923607835369,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13274,12 +13274,12 @@
       "avgConfidence": 0.8146773861059555,
       "avgFidelity": 1,
       "avgPrecision": 0.9886634199134197,
-      "avgRoleFidelity": 0.899384961884962,
+      "avgRoleFidelity": 0.9008853593412417,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13906,12 +13906,12 @@
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
       "avgPrecision": 0.9795725108225107,
-      "avgRoleFidelity": 0.9302015270765269,
+      "avgRoleFidelity": 0.9316770835153189,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14538,12 +14538,12 @@
       "avgConfidence": 0.9840032982890127,
       "avgFidelity": 1,
       "avgPrecision": 0.9983766233766234,
-      "avgRoleFidelity": 0.9481569481569476,
+      "avgRoleFidelity": 0.9496076635782513,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456012,
+      "bundleSize": 456249,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 456012,
+      "size": 456249,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

First convergent burn-down of the **R1 role-fidelity value-type residue** (Arc B). The most consistent cross-language R1 residue signature was `halt.patient: en=literal → SOV=reference`. Grounding it end-to-end (per-pattern `action.role:valueType` diff vs the en reference, over a freshly `populate`d `patterns.db`, replicating the gate's `ml.parse → fillSchemaDefaults → collectRoleSignature` path) showed the **English reference parse itself was wrong**: `halt the event` captured the article `the` as the patient and dropped the event (`patient:literal="the"`), so every faithful translation mismatched it.

## The fix (one defect, two facets — both in `skipNoiseWords`, `pattern-matcher.ts`)

- **en:** `event` tokenizes as a `keyword` (not a selector/identifier), so the pre-existing article-skip missed it. Added an en case: skip `the` before a valid reference word (`isValidReference`) → `patient:reference="event"`. Non-reference keywords (`the default`) stay `literal`; bare `halt` is unchanged.
- **SVO/VSO:** the i18n transformer leaks an untranslated `the` before the translated event word (`the evento entonces …`); the pre-existing non-en skip only fired before a SOV **particle**, so these kept `patient:expression="the"`. Extended it to also fire before a **clause boundary** (then/and/or/end/EOF) — but **never before a command verb**, which preserves the §7y guard (tr `form-submit-prevent`'s `the olay çağır …` keeps `the`, body parse intact).

## Result

en + all 23 priority languages now agree on `halt.patient:reference` for `halt-propagation`.

| Signal | Before | After |
| --- | --- | --- |
| avgRoleFidelity (R1) | 0.9125 | **0.9142** |
| avgFidelity (R0-recall) | 1.000 | 1.000 |
| avgPrecision (R0 trust floor) | 0.972 | 0.972 |
| avgExecutionFidelity (R2) | 1.000 | 1.000 |

Per-language: **all 23 langs improve, zero regress** (+0.0014–0.0029/lang; SOV laggards hi/ja/ko/qu/bn/tr +0.0025–0.0029). Baseline regenerated.

## Verification

- Guard: `multilingual-roadmap-fixes.test.ts` → "`halt the event` skips the leaked article" — 15 cases incl. the **§7y verb-after invariant** and the `the default` / bare-`halt` controls. **Verified failing-without-fix** (8 fail when the src change is stashed; the §7y + controls pass in both states, proving they're genuine invariants).
- Full semantic suite green (6277 passed).
- Multilingual gate `--regression` green (parse-rate / R0-recall / R0-precision / R1 / R2 ratchets).

## Notes

- `patterns.db` is intentionally **not** committed (CI repopulates); only dicts/code + the regenerated baseline are.
- Remaining R1 residue (now hi 0.865 the laggard) is documented for the next arc: the `repeat` loop-role garbage (the en reference mis-parses `repeat N times`/`for X in Y`) and the VSO `halt the event` verb-after residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)