### PR TITLE
fix(multilingual): hi put-into verb-final word-order rule (R1 hi 0.8646→0.8669)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,41 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-28h (Arc B R1 — hi `put-into` word-order rule; hi 0.8669, zero
+> regressions).** Grounding the worst laggard (hi) after the `halt` fix surfaced a contained
+> bug: the **hindiProfile was missing the `put-into` grammar rule** that every other SOV
+> profile (ja/ko/tr/bn) carries. Without it, `put X into Y` fell through to a verb-MID default
+> (`X को रखें Y में`) which the semantic parser mis-read (destination/patient swap/mistype —
+> the put.\* R1 residue). Added the rule (mirrors ja's, `roleOrder:
+['patient','destination','action']`) → hi emits the verb-final `X को Y में रखें` and parses
+> faithfully. **hi-only** (other SOV langs already had it; qu works via its default),
+> **hi 0.8646 → 0.8669 (+0.0023)**, R0/precision/R2 unchanged, i18n suite 882 + semantic 6277
+> green. Guard: `grammar.test.ts` "Hindi Transformation (SOV) — put-into verb-final"
+> (failing-without-fix verified).
+>
+> **Grounded-but-deferred next R1 arcs (re-ground before coding; all bigger/riskier):**
+>
+> - **`set` (~18 hi entries, ALL SOV langs) — biggest clean-reference cluster.** The i18n
+>   transformer defaults the first operand to `patient` and maps the `to`-marked operand to
+>   `destination` (right for `put`/`add`; **backwards for `set`**, whose semantics are
+>   destination-first), so SOV `set X to Y` swaps the destination/patient markers
+>   (`#x.innerText को सेट इसका.name में`), mis-parsed in ja/ko/hi. Fix = teach the transformer
+>   `set`'s leading arg is `destination` (`applyPrimaryRole` transformer.ts:1250 handles only
+>   literal primaries today and the comment explicitly punts on `set`→destination). High blast
+>   radius; guard precision/R0 hard.
+> - **`bind` (4 hi patterns, rf 0.00) — two-part, hi-only.** hindiProfile also lacks a
+>   `bind-to` rule (verb-mid); ADDING it fixes word order BUT the verb-final hi bind then still
+>   mis-parses — the fronted `$greeting` is anchored as a bare `on` event (`को#name-input`
+>   smushed into a literal destination): the **SOV event-anchor** path
+>   (HANDOFF-sov-event-anchor.md). ja/ko parse the identical token shape correctly. Needs the
+>   fragile event-anchor work; deferred.
+> - **`repeat` (~24 hi entries, ALL langs) — deepest.** The **en reference itself is garbage**:
+>   the schema positional pattern stuffs `repeat 3 times add …` into
+>   `loopType=3, quantity="times", event="add"` (body verb captured as `event`); the AST mapper
+>   reads `quantity`, so even execution is wrong. SOV side equally broken
+>   (`loopType:reference="me"`). Two-sided structural rewrite (handcrafted per-form patterns
+>   like the existing `until-event` ones, en + SOV) + re-baseline. Highest reward, highest risk.
+>
 > **Update 2026-06-28g (Arc B R1 — `halt the event` article skip; avgRoleFidelity
 > 0.9125 → 0.9142, all 23 langs +, zero regressions).** First convergent burn-down of
 > the R1 value-type residue. Grounding the `halt.patient` cluster (the most consistent

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -435,6 +435,31 @@ describe('GrammarTransformer', () => {
     });
   });
 
+  describe('Hindi Transformation (SOV) — put-into verb-final', () => {
+    const transformer = new GrammarTransformer('en', 'hi');
+
+    // The hindiProfile was missing the `put-into` word-order rule that every
+    // other SOV profile (ja/ko/tr/bn) carries, so `put X into Y` fell through to a
+    // verb-MID default (`X को रखें Y में`). The semantic parser then mis-read the
+    // verb-mid form — destination/patient swapped/mistyped — the put.* R1 residue
+    // (hi only; other SOV langs already had the rule). With the rule, hi emits the
+    // verb-final form `X को Y में रखें` like ja's `X を Y に 置く`.
+    it('places the put verb after its destination (verb-final), not mid-clause', () => {
+      const result = transformer.transform('put "<p>x</p>" into #out');
+      const putIdx = result.indexOf('रखें');
+      const destIdx = result.indexOf('#out');
+      expect(putIdx).toBeGreaterThan(-1);
+      expect(destIdx).toBeGreaterThan(-1);
+      // verb-final: the put verb follows its destination.
+      expect(putIdx).toBeGreaterThan(destIdx);
+    });
+
+    it('keeps the destination marker in (में) on the put target', () => {
+      const result = transformer.transform('put "hi" into #out');
+      expect(result).toContain('#out में');
+    });
+  });
+
   describe('Arabic Transformation (VSO)', () => {
     const transformer = new GrammarTransformer('en', 'ar');
 

--- a/packages/i18n/src/grammar/profiles/index.ts
+++ b/packages/i18n/src/grammar/profiles/index.ts
@@ -904,6 +904,20 @@ export const hindiProfile: LanguageProfile = {
         insertMarkers: true,
       },
     },
+    {
+      name: 'put-into',
+      description: 'Transform put X into Y to Hindi verb-final order',
+      priority: 90,
+      match: {
+        commands: ['put', 'रखें'],
+        requiredRoles: ['action', 'patient', 'destination'],
+      },
+      transform: {
+        // "hi" को #out में रखें
+        roleOrder: ['patient', 'destination', 'action'],
+        insertMarkers: true,
+      },
+    },
   ],
 };
 

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-28T19:11:45.530Z",
-  "commit": "2334ef9b",
+  "timestamp": "2026-06-28T21:06:13.662Z",
+  "commit": "e7040a10",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -4426,7 +4426,7 @@
       "avgConfidence": 0.90909904631709,
       "avgFidelity": 1,
       "avgPrecision": 0.9208653089334906,
-      "avgRoleFidelity": 0.8645979164361516,
+      "avgRoleFidelity": 0.8668501686884038,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],


### PR DESCRIPTION
## Summary

Continues the **R1 role-fidelity** burn-down (Arc B) by fixing the worst laggard, **hi**. After the `halt the event` fix (#518), grounding hi's residue surfaced a contained grammar bug: the **hindiProfile was missing the `put-into` word-order rule** that every other SOV profile (ja/ko/tr/bn) carries.

Without it, `put X into Y` fell through to a **verb-MID** default (`"hi" को रखें #out में`), and the semantic parser mis-read the verb-mid form — the put `destination`/`patient` came out swapped/mistyped (the `put.*` R1 residue). With the rule (mirroring ja's, `roleOrder: ['patient','destination','action']`), hi emits the **verb-final** `"hi" को #out में रखें`, like ja's `"hi" を #out に 置く`, and parses faithfully.

## Why hi-only

The other SOV langs already carry the rule; qu reaches verb-final via its default. Only hi lacked it and had the put residue.

## Result

| Signal | Before | After |
| --- | --- | --- |
| hi avgRoleFidelity (R1) | 0.8646 | **0.8669** (+0.0023) |
| R1 mean | 0.9142 | 0.9143 |
| R0-recall / R0-precision / R2 | 1.000 / 0.972 / 1.000 | unchanged |

Only hi changed; all other languages and signals are byte-identical. Baseline regenerated.

## Verification

- Guard: `grammar.test.ts` → "Hindi Transformation (SOV) — put-into verb-final" asserts the put verb follows its destination (verb-final) and the `में` marker is preserved. **Verified failing-without-fix.**
- i18n suite green (882) · semantic suite green (6277) · multilingual gate `--regression` green.
- `patterns.db` not committed (CI repopulates); only the profile + guard + regenerated baseline.

## Next R1 arcs (grounded, deferred — documented in MULTILINGUAL_NEXT_STEPS.md)

- **`set`** (~18 hi entries, all SOV) — the transformer maps the `to`-marked operand to `destination`, which is backwards for `set` (destination-first semantics) → marker swap. Bigger, high blast radius.
- **`bind`** (4 hi patterns) — needs a `bind-to` rule *and* the fragile SOV event-anchor fix.
- **`repeat`** (~24, all langs) — the en reference itself mis-parses loop forms; two-sided structural rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)