### PR TITLE
fix(multilingual): hi `bind` two-part fix (hi R1 0.8764→0.8899 +0.0135, precision +0.0075)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,41 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-28k (Arc B R1 — hi `bind` two-part fix; hi 0.8764 → 0.8899 (+0.0135),
+> the biggest single-LANGUAGE jump of the campaign, + hi precision +0.0075).** The doc's
+> "bind is fragile, defer" framing was RIGHT about the mechanism but the fix turned out
+> tractable with a tight gate. Two coordinated fixes (mirrors the doc's "two-part" prediction):
+>
+> 1. **i18n — hindiProfile `bind-to` verb-final rule.** ja/ko/zh/tr/bn already carried a
+>    `bind-to` rule; **hi was the only SOV gap**, so the transformer emitted bind VERB-MEDIAL
+>    (`$greeting को bind #name-input में`), which the generated verb-final SOV bind pattern
+>    (`{destination} को {source} में bind`) never matched. The rule (roleOrder
+>    `['patient','destination','action']`, like put-into/set-to) emits verb-final
+>    `$greeting को #name-input में bind`.
+> 2. **semantic — bare-event guard: prefer a command over a phantom REFERENCE event.** Even
+>    verb-final, the fronted `$greeting` (a `$variable` **reference**) was grabbed by the
+>    `event-<lang>-bare` pattern as the event → a phantom `on` handler (the bind.\* rf=0.00).
+>    A reference can NEVER be an event name. Extended the existing bare-event guard
+>    (`semantic-parser.ts`, the same one that handles the unknown-event SOV case): when the
+>    bare capture is a `reference`, SOV extraction finds no real event, AND a command matches
+>    the full stream (rewind via `tokens.reset(eventStart)` since matchBest re-consumes the
+>    winner), prefer the command. Tightly gated — fires ONLY on a reference mis-anchor with a
+>    matching command, so real bare events (`.active को क्लिक पर टॉगल`, custom identifiers) are
+>    byte-identical (verified: 3 regression guards + gate).
+>
+> Result: **hi bind-auto-detect + bind-two-way 0.00 → 1.00** (the two with a simple `#selector`
+> source). **hi-only** in the gate (ja/ko/qu/bn/tr already parsed bind via their existing rules);
+> hi R1 +0.0135, **hi precision +0.0075** (the phantom-`on` command is gone), R0-recall 1.000 /
+> R2 1.000 / parse-rate 3696/3696 unchanged, **zero regressions** (no other lang moved). Mean R1
+> 0.9189 → 0.9195. semantic 6285 + i18n 893 green. Guards: `grammar.test.ts` "bind-to verb-final"
+>
+> - `multilingual-roadmap-fixes.test.ts` "SOV bind: bare-event guard prefers a command" (both
+>   failing-without-fix verified). **Remaining bind residue (deferred, NOT hi-specific):**
+>   `bind-explicit-property` / `bind-non-form-display` have a **possessive source** (`#picker's
+value`, `#status's textContent`) that caps EVERY SOV lang at 0.50 (ja/ko/qu/bn/tr drop
+>   `bind.source`; hi can't match the English-`'s` possessive at all → stays 0.00). That's a
+>   possessive-source value-typing fix, cross-language, separate arc.
+>
 > **Update 2026-06-28j (Arc B R1 — en `repeat N times` / `repeat forever` HEAD-only
 > patterns; R1 0.9164 → 0.9189, the biggest single R1 win yet, ALL 23 langs +).** The single
 > largest R1 residue (`repeat.event:literal` 42× + `repeat.loopType:literal` 39×, all SOV langs)

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -509,6 +509,27 @@ describe('GrammarTransformer', () => {
     }
   });
 
+  describe('Hindi Transformation (SOV) — bind-to verb-final (bind.* R1 residue)', () => {
+    // The hindiProfile lacked a `bind` word-order rule (ja/ko/zh/tr/bn had one), so hi
+    // emitted bind VERB-MEDIAL (`$greeting को bind #name-input में`), which the generated
+    // verb-final SOV bind pattern never matched → the bare-event fallback mis-anchored
+    // the fronted `$greeting` as a phantom `on` event (the rf=0.00 bind residue). The
+    // `bind-to` rule emits verb-final `$greeting को #name-input में bind`, like ja's
+    // `$greeting を #name-input に バインド`.
+    it('[hi] bind $var to #el → verb-final (bind verb after the element)', () => {
+      const t = new GrammarTransformer('en', 'hi');
+      const result = t.transform('bind $greeting to #name-input');
+      const verbIdx = result.indexOf('bind');
+      const elIdx = result.indexOf('#name-input');
+      expect(verbIdx).toBeGreaterThan(-1);
+      expect(elIdx).toBeGreaterThan(-1);
+      // verb-final: the bind verb follows the element (was verb-MEDIAL before the rule).
+      expect(verbIdx).toBeGreaterThan(elIdx);
+      // markerOverride alignment: the element carries the destination locative में.
+      expect(result).toContain('में');
+    });
+  });
+
   describe('Arabic Transformation (VSO)', () => {
     const transformer = new GrammarTransformer('en', 'ar');
 

--- a/packages/i18n/src/grammar/profiles/index.ts
+++ b/packages/i18n/src/grammar/profiles/index.ts
@@ -1018,6 +1018,25 @@ export const hindiProfile: LanguageProfile = {
         insertMarkers: true,
       },
     },
+    {
+      name: 'bind-to',
+      description: 'Transform bind $var to #el to Hindi verb-final order',
+      priority: 90,
+      match: {
+        commands: ['bind', 'बाइंड', 'बांधें'],
+        requiredRoles: ['action', 'patient', 'destination'],
+      },
+      transform: {
+        // $greeting को #name-input में bind — verb-final, matching the generated SOV
+        // bind pattern (`{destination} को {source} में bind`). The default reorder
+        // emitted verb-MEDIAL (`$greeting को bind #name-input में`), which the
+        // verb-final pattern never matched → the bare-event fallback mis-anchored
+        // the fronted `$greeting` as a phantom `on` event (the rf=0.00 bind residue).
+        // ja/ko/zh/tr/bn already carry this rule; hi was the only SOV gap.
+        roleOrder: ['patient', 'destination', 'action'],
+        insertMarkers: true,
+      },
+    },
   ],
 };
 

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -455,6 +455,9 @@ export class SemanticParserImpl implements ISemanticParser {
 
     // Stage 1: Try event handler patterns first (they wrap commands)
     const eventPatterns = sortedPatterns.filter(p => p.command === 'on');
+    // matchBest re-consumes the winning match, leaving the stream past the event;
+    // the bare-event guard below needs to rewind here to peek/re-run from the start.
+    const eventStart = tokens.mark();
     const eventMatch = patternMatcher.matchBest(tokens, eventPatterns);
 
     if (eventMatch) {
@@ -477,8 +480,11 @@ export class SemanticParserImpl implements ISemanticParser {
       // trailing-`unless` guard then fires). Additive: gated to a non-event bare
       // capture and only taken when trySOVEventExtraction actually succeeds, so a
       // genuine bare event (`क्लिक`) or a lang without SOV markers is byte-identical.
+      let preferCommandStage = false;
       if (/^event-[a-z]+-bare$/.test(eventMatch.pattern.id)) {
-        const ev = eventMatch.captured.get('event') as { raw?: string; value?: string } | undefined;
+        const ev = eventMatch.captured.get('event') as
+          | { type?: string; raw?: string; value?: string }
+          | undefined;
         const evVal = (ev?.raw ?? ev?.value ?? '').toString().toLowerCase();
         const langEvents = eventNameTranslations[language];
         const evIsKnownEvent =
@@ -499,12 +505,44 @@ export class SemanticParserImpl implements ISemanticParser {
               : sov;
             return withDiagnostics(guarded, diagnostics);
           }
+          // No real event to recover, but the bare-event pattern still anchored on a
+          // `reference` lead — a `$variable`, which can NEVER be an event name (events
+          // are bare identifiers like click/keyup). This is a bare COMMAND whose
+          // fronted operand the bare-event pattern grabbed: the SOV `bind`
+          // (`$greeting को #name-input में bind` → mis-anchors `$greeting` as the
+          // event). Prefer a full command parse when one exists; if no command
+          // matches, keep the existing event-handler build (no parse-rate change).
+          if (ev?.type === 'reference') {
+            tokens.reset(eventStart); // rewind past the consumed bare event
+            const commandPatterns = sortedPatterns.filter(p => p.command !== 'on');
+            const cmdPeek = patternMatcher.matchBest(tokens, commandPatterns);
+            tokens.reset(eventStart); // restore for Stage 2 (prefer) or event re-run (below)
+            if (cmdPeek && (cmdPeek.pattern.command as string) !== 'on') {
+              preferCommandStage = true;
+              diagnostics.push(
+                parseDiagnostic(
+                  `bare-event mis-anchor on reference "${evVal}" rejected; command ${cmdPeek.pattern.command} preferred`,
+                  'info',
+                  'stage-bare-event-guard'
+                )
+              );
+            } else {
+              // No command matched — keep the existing event-handler build. Re-run the
+              // event match to restore the post-event stream position buildEventHandler
+              // expects (matchBest is deterministic, so this re-consumes the same event).
+              patternMatcher.matchBest(tokens, eventPatterns);
+            }
+          }
         }
       }
 
-      const handler = this.buildEventHandler(eventMatch, tokens, language);
-      const result = modifiers ? this.applyModifiers(handler, modifiers) : handler;
-      return withDiagnostics(result, diagnostics);
+      if (!preferCommandStage) {
+        const handler = this.buildEventHandler(eventMatch, tokens, language);
+        const result = modifiers ? this.applyModifiers(handler, modifiers) : handler;
+        return withDiagnostics(result, diagnostics);
+      }
+      // else: fall through to Stage 1.5 / Stage 2 (command), the stream rewound to
+      // eventStart, where the real command (e.g. SOV bind) matches over the full stream.
     }
     diagnostics.push(
       parseDiagnostic(

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1079,6 +1079,44 @@ describe('en repeat HEAD-only patterns: counted / forever loops keep their body 
   });
 });
 
+describe('SOV bind: bare-event guard prefers a command over a phantom reference event', () => {
+  // The verb-final SOV bind (`$greeting को #name-input में bind`) LEADS with a `$variable`
+  // reference, which the `event-<lang>-bare` pattern grabbed as the event → a phantom `on`
+  // handler (the bind.* rf=0.00 residue). A `$variable` reference can NEVER be an event name
+  // (events are bare identifiers like click/keyup). When the bare-event mis-anchored on a
+  // reference, SOV extraction found no real event, AND a command matches the full stream, the
+  // parser now rewinds and prefers the command. hi bind-auto-detect/two-way 0.00 → 1.00; hi
+  // R1 +0.0135, precision +0.0075, zero regressions. Pairs with the hindiProfile `bind-to`
+  // verb-final i18n rule. See docs-internal/MULTILINGUAL_NEXT_STEPS.md.
+  it('[hi] verb-final bind parses as bind, not a phantom on-handler', () => {
+    const node = parse('$greeting को #name-input में bind', 'hi') as Record<string, unknown>;
+    expect(node.action).toBe('bind');
+    const roles = node.roles as Map<string, { value?: unknown }>;
+    expect(roles.get('destination')?.value).toBe('$greeting');
+    expect(roles.get('source')?.value).toBe('#name-input');
+  });
+
+  it('[hi] translated bind verb (बांधें) also parses as bind', () => {
+    expect((parse('$greeting को #name-input में बांधें', 'hi') as { action?: string }).action).toBe(
+      'bind'
+    );
+  });
+
+  // Regression guards — the fix must NOT over-reach beyond the reference mis-anchor:
+  it('[hi] a real bare-event handler still anchors the event (no over-reach)', () => {
+    // `.active को क्लिक पर टॉगल` = "on click toggle .active" — a genuine event handler.
+    expect((parse('.active को क्लिक पर टॉगल', 'hi') as { action?: string }).action).toBe('on');
+  });
+  it('[hi] event-led handler with a known event is untouched', () => {
+    expect((parse('click पर टॉगल .active', 'hi') as { action?: string }).action).toBe('on');
+  });
+  it('[en] plain SVO bind is unaffected', () => {
+    expect((parse('bind $greeting to #name-input', 'en') as { action?: string }).action).toBe(
+      'bind'
+    );
+  });
+});
+
 describe('SOV verb-first event-body reorder — modifier-prefixed bodies (Track 5)', () => {
   // A leading command-modifier (async/once/debounced) used to displace the verb in
   // the i18n SOV reorder, surfacing it first (`取得 /api/data を クリック …`). The

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-28T23:09:55.128Z",
-  "commit": "94b3da22",
+  "timestamp": "2026-06-29T01:06:58.583Z",
+  "commit": "3bb6abd1",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.90909904631709,
       "avgFidelity": 1,
-      "avgPrecision": 0.9224577640973743,
-      "avgRoleFidelity": 0.8763739782122134,
+      "avgPrecision": 0.9300335216731319,
+      "avgRoleFidelity": 0.889887491725727,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 456819,
+      "bundleSize": 457150,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 456819,
+      "size": 457150,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## What

The worst R1 laggard (**hi**) had `bind-auto-detect` + `bind-two-way` stuck at **rf=0.00**. Two coordinated fixes (the roadmap's "two-part" prediction was correct):

### 1. i18n — hindiProfile `bind-to` verb-final rule
ja/ko/zh/tr/bn already carried a `bind-to` rule; **hi was the only SOV gap**, so the transformer emitted bind **verb-medial** (`$greeting को bind #name-input में`), which the generated verb-final SOV bind pattern (`{destination} को {source} में bind`) never matched. The rule (roleOrder `['patient','destination','action']`, like put-into/set-to) emits verb-final `$greeting को #name-input में bind`.

### 2. semantic — bare-event guard prefers a command over a phantom *reference* event
Even verb-final, the fronted `$greeting` (a `$variable` **reference**) was grabbed by the `event-<lang>-bare` pattern as the event → a phantom `on` handler. A `reference` can never be an event name. The existing bare-event guard (the one that already handles the unknown-event SOV case) is extended: when the bare capture is a `reference`, SOV extraction finds no real event, **and** a command matches the full stream (rewinding via `tokens.reset(eventStart)`, since `matchBest` re-consumes the winner), prefer the command.

**Tightly gated** — fires only on a reference mis-anchor *with a matching command*, so real bare events (`.active को क्लिक पर टॉगल`, custom-identifier events) are byte-identical.

## Impact

- **hi bind-auto-detect + bind-two-way 0.00 → 1.00** (the two with a simple `#selector` source).
- **hi R1 0.8764 → 0.8899 (+0.0135)** — the biggest single-language jump of the campaign.
- **hi precision +0.0075** (the phantom-`on` command is gone).
- **hi-only** in the gate (ja/ko/qu/bn/tr already parsed bind); R0-recall 1.000 / R2 1.000 / parse-rate 3696/3696 unchanged; **zero regressions** (no other language moved). Mean R1 0.9189 → 0.9195.

## Tests

- Guards (both **failing-without-fix verified**): `grammar.test.ts` → "bind-to verb-final"; `multilingual-roadmap-fixes.test.ts` → "SOV bind: bare-event guard prefers a command" (incl. 3 over-reach regression guards).
- Full suites green: **semantic 6285**, **i18n 893**. Baseline regenerated.

## Deferred

`bind-explicit-property` / `bind-non-form-display` have a **possessive source** (`#picker's value`, `#status's textContent`) that caps *every* SOV language at 0.50 — a separate cross-language possessive-source value-typing arc (documented in `MULTILINGUAL_NEXT_STEPS.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)