### PR TITLE
fix(multilingual): en split-`'s` possessive capture (hi crosses 0.90; mean 0.9195→0.9218)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,29 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-28l (Arc B R1 — English split-`'s` possessive capture; hi CROSSES 0.90
+> (0.8899 → 0.9034), 7 langs +0.0068, mean 0.9195 → 0.9218, ZERO regressions).** Completing the
+> bind cluster surfaced ANOTHER **broken en reference**: `bind $color to #picker's value` parsed
+> the source as a bare `#picker` selector, **dropping `'s value`** — because the en tokenizer
+> splits the possessive clitic `'s` into two tokens (`'` + `s`) after a selector, which the
+> single-token `'s` check in `tryMatchSelectorPropertyExpression`/`tryMatchPossessiveSelectorExpression`
+> (pattern-matcher.ts) missed. ja/ko/qu/bn/tr/zh keep their possessive (の/의/…) whole and captured
+> the full property-path, so the en reference dropping it capped `bind-explicit-property` /
+> `bind-non-form-display` (en `bind.source:selector` vs SOV `property-path`). Two-line fix in the
+> possessive matcher: (1) recognize the split `'` + `s` pair as the English possessive; (2) accept
+> a `keyword` property after the English `'s` (vi's `value` → `giá trị` is a single KEYWORD token,
+> not an identifier — without this vi REGRESSED -0.0034 as the only lang still capturing a bare
+> selector; the keyword case lifted vi back to parity → zero net regression). **hi 0.8899 → 0.9034
+> (crosses 0.90 — the first SOV lang to clear it!), ja/ko/qu/bn/tr/zh +0.0068 each, mean +0.0024;
+> hi precision +0.0065; R0 1.000 / R2 1.000 / parse-rate 3696/3696 unchanged.** ALSO clears the
+> hi bind-explicit-property/non-form-display (the possessive source now matches the bind pattern →
+> the #522 bare-event command-peek succeeds → bind, not phantom-on). semantic 6289 green. Guard:
+> `multilingual-roadmap-fixes.test.ts` "English split `'s` possessive captures the property" (4
+> cases; failing-without-fix verified: 3 fail). **The bind cluster is now fully closed** (all 4
+> patterns faithful across SOV langs). Methodology note: the vi -0.0034 was UNDER the 0.02 gate
+> tolerance (gate would have passed) but was caught by a manual per-lang A/B diff — re-grounding
+> before shipping matters even when the gate is green.
+>
 > **Update 2026-06-28k (Arc B R1 — hi `bind` two-part fix; hi 0.8764 → 0.8899 (+0.0135),
 > the biggest single-LANGUAGE jump of the campaign, + hi precision +0.0075).** The doc's
 > "bind is fragile, defer" framing was RIGHT about the mechanism but the fix turned out

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -1547,6 +1547,16 @@ export class PatternMatcher {
     const profileMarker = this.currentProfile?.possessive?.marker?.replace(/^-/, '');
     const isEnglishPossessive =
       !!possessiveToken && possessiveToken.kind === 'punctuation' && possessiveToken.value === "'s";
+    // The en tokenizer splits the possessive clitic `'s` into two tokens (`'` + `s`)
+    // when it trails a selector — `#picker's value` → `#picker ' s value` — so the
+    // single-token check above misses it and the property (`value`/`textContent`) is
+    // dropped, capturing only the bare `#picker` selector. ja/ko/… keep their の/의
+    // possessive whole, so they captured the full property-path while en lost it (the
+    // bind-explicit-property / bind-non-form-display R1 cap). Detect the split pair.
+    const splitEnglishPossessive =
+      !!possessiveToken &&
+      possessiveToken.value === "'" &&
+      (tokens.peek(1)?.value ?? '').toLowerCase() === 's';
     // Non-English markers (の, 의, র, pa, …) arrive as `particle` tokens. Match
     // them against the active profile's possessive marker. Empty markers
     // (Turkish, suffix-fused) don't have a standalone token and aren't handled here.
@@ -1556,11 +1566,12 @@ export class PatternMatcher {
       profileMarker !== "'s" &&
       possessiveToken.value === profileMarker &&
       (possessiveToken.kind === 'particle' || possessiveToken.kind === 'punctuation');
-    if (!isEnglishPossessive && !isProfilePossessive) {
+    if (!isEnglishPossessive && !isProfilePossessive && !splitEnglishPossessive) {
       tokens.reset(mark);
       return null;
     }
-    tokens.advance(); // consume the possessive marker
+    tokens.advance(); // consume the possessive marker (`'s`, profile marker, or split `'`)
+    if (splitEnglishPossessive) tokens.advance(); // consume the trailing `s` of the split pair
 
     const propertyToken = tokens.peek();
     if (!propertyToken) {
@@ -1572,9 +1583,15 @@ export class PatternMatcher {
     // `#element's *opacity`). For profile markers, only an identifier is a
     // property — otherwise a target+patient construct like `#button の .active`
     // ("toggle .active on #button") would be mis-read as a property path.
+    // A `keyword` property is also valid for the English `'s` (whole or split):
+    // some property names translate to a profile KEYWORD rather than a bare
+    // identifier (vi `value` → `giá trị`, a single keyword token), so without this
+    // the English-possessive `#picker's giá trị` lost its property and fell back to a
+    // bare `#picker` selector — mismatching the en reference's property-path.
     const propertyOk =
       propertyToken.kind === 'identifier' ||
-      (isEnglishPossessive && propertyToken.kind === 'selector');
+      ((isEnglishPossessive || splitEnglishPossessive) &&
+        (propertyToken.kind === 'selector' || propertyToken.kind === 'keyword'));
     if (!propertyOk) {
       tokens.reset(mark);
       return null;

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1117,6 +1117,43 @@ describe('SOV bind: bare-event guard prefers a command over a phantom reference 
   });
 });
 
+describe('English split `\'s` possessive captures the property (bind-explicit-property R1)', () => {
+  // The en tokenizer splits the clitic `'s` into `'` + `s` after a selector
+  // (`#picker's value` → `#picker ' s value`), so the single-token `'s` check in
+  // tryMatchPossessiveSelectorExpression missed it and the property was DROPPED —
+  // capturing only the bare `#picker` selector. ja/ko/… keep their possessive (の/의)
+  // whole and captured the full property-path, so the en reference dropping it capped
+  // bind-explicit-property / bind-non-form-display across SOV langs at 0.50 (hi 0.00).
+  // The split pair is now recognized, AND a keyword property (vi `value` → `giá trị`,
+  // a single keyword token) is accepted. hi crosses 0.90; ja/ko/qu/bn/tr/zh +0.0068.
+  function source(node: unknown): { type?: string; property?: string } | undefined {
+    const n = node as { roles?: unknown };
+    const roles =
+      n.roles instanceof Map
+        ? n.roles
+        : new Map(Object.entries((n.roles as object) ?? {}));
+    return roles.get('source') as { type?: string; property?: string } | undefined;
+  }
+  it("[en] `#picker's value` is a property-path source, not a bare selector", () => {
+    const node = parse("bind $color to #picker's value", 'en') as { action?: string };
+    expect(node.action).toBe('bind');
+    const src = source(node);
+    expect(src?.type).toBe('property-path');
+    expect(src?.property).toBe('value');
+  });
+  it("[en] `#status's textContent` is a property-path source", () => {
+    expect(source(parse("bind $message to #status's textContent", 'en'))?.type).toBe(
+      'property-path'
+    );
+  });
+  it('[vi] a keyword property (giá trị) is captured as property-path (no en mismatch)', () => {
+    expect(source(parse("bind $color vào #picker's giá trị", 'vi'))?.type).toBe('property-path');
+  });
+  it('[en] a plain `#selector` source (no possessive) stays a selector', () => {
+    expect(source(parse('bind $greeting to #name-input', 'en'))?.type).toBe('selector');
+  });
+});
+
 describe('SOV verb-first event-body reorder — modifier-prefixed bodies (Track 5)', () => {
   // A leading command-modifier (async/once/debounced) used to displace the verb in
   // the i18n SOV reorder, surfacing it first (`取得 /api/data を クリック …`). The

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-29T01:06:58.583Z",
-  "commit": "3bb6abd1",
+  "timestamp": "2026-06-29T01:44:41.934Z",
+  "commit": "54e3d123",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -641,12 +641,12 @@
       "avgConfidence": 0.8495030867211314,
       "avgFidelity": 1,
       "avgPrecision": 0.929409218232748,
-      "avgRoleFidelity": 0.9119005762388115,
+      "avgRoleFidelity": 0.9186573329955682,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.90909904631709,
       "avgFidelity": 1,
-      "avgPrecision": 0.9300335216731319,
-      "avgRoleFidelity": 0.889887491725727,
+      "avgPrecision": 0.9365270281666384,
+      "avgRoleFidelity": 0.9034010052392405,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
       "avgPrecision": 0.9482462613144433,
-      "avgRoleFidelity": 0.9048940504822859,
+      "avgRoleFidelity": 0.9116508072390427,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6954,12 @@
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
       "avgPrecision": 0.9482462613144431,
-      "avgRoleFidelity": 0.9094548612930968,
+      "avgRoleFidelity": 0.9162116180498535,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9482,12 @@
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
       "avgPrecision": 0.9512456428852532,
-      "avgRoleFidelity": 0.8998423520482346,
+      "avgRoleFidelity": 0.9065991088049914,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12642,12 +12642,12 @@
       "avgConfidence": 0.827517929021688,
       "avgFidelity": 1,
       "avgPrecision": 0.9508127424523529,
-      "avgRoleFidelity": 0.9158785118343942,
+      "avgRoleFidelity": 0.922635268591151,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14538,12 +14538,12 @@
       "avgConfidence": 0.9840032982890127,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9518599158305037,
+      "avgRoleFidelity": 0.9586166725872605,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457150,
+      "bundleSize": 457261,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 457150,
+      "size": 457261,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## What

Completing the bind cluster surfaced another **broken en reference**: `bind $color to #picker's value` parsed the source as a bare `#picker` selector, **dropping `'s value`** — because the en tokenizer splits the possessive clitic `'s` into two tokens (`'` + `s`) after a selector, which the single-token `'s` check in the possessive matcher missed.

```
EN  bind $color to #picker's value   →  source: #picker  (selector)   ← dropped 's value!
ja  $color を #pickerの 値 に バインド  →  source: property-path        ← correct
```

ja/ko/qu/bn/tr/zh keep their possessive (の/의/…) whole and captured the full property-path, so the en reference dropping it capped `bind-explicit-property` / `bind-non-form-display` (en `bind.source:selector` vs SOV `property-path`).

## Fix

Two lines in `tryMatchPossessiveSelectorExpression` (`pattern-matcher.ts`):
1. Recognize the split `'` + `s` pair as the English possessive.
2. Accept a `keyword` property after the English `'s` (vi `value` → `giá trị` is a single **keyword** token, not an identifier — without this **vi regressed −0.0034** as the only language still capturing a bare selector; the keyword case lifts vi back to parity → **zero net regression**).

## Impact

- **hi 0.8899 → 0.9034 — crosses 0.90, the first SOV language to clear it!**
- ja/ko/qu/bn/tr/zh **+0.0068 each**; mean R1 0.9195 → 0.9218 (+0.0024); hi precision +0.0065.
- R0-recall 1.000 / R2 1.000 / parse-rate 3696/3696 unchanged; **zero regressions**.
- Also clears hi `bind-explicit-property`/`bind-non-form-display` — the possessive source now matches the bind pattern, so the #522 bare-event command-peek succeeds → `bind`, not phantom-`on`. **The bind cluster is now fully closed.**

## Tests

- Guard: `multilingual-roadmap-fixes.test.ts` → "English split `'s` possessive captures the property" (4 cases; **failing-without-fix verified**: 3 fail). Full semantic suite **6289** green.

## Methodology note

The vi −0.0034 was **under the 0.02 gate tolerance** (the gate would have passed) but was caught by a manual per-language A/B diff — re-grounding before shipping matters even when the gate is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)