### PR TITLE
fix(multilingual): cross-language event-keyword alignment (mean R1 0.9218→0.9259, 8 langs +, uk +0.0200)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,30 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-28m (Arc B R1 — cross-language event-keyword alignment sweep; mean R1
+> 0.9218 → 0.9259 (+0.0041), the biggest single-PR MEAN win of the campaign, 8 langs +, ZERO
+> regressions).** Grounding the new laggard (uk, after the bind cluster closed) found a
+> **systemic dict/profile misalignment**: the i18n dict emits one event word but the semantic
+> profile/tokenizer lists a different one, so the unrecognized word tokenized as a bare
+> `identifier` and the event role typed as `expression` instead of `literal` (the `on.event`
+> R1 residue). A sweep across the 6 common events found 10 misaligned (lang, event) pairs:
+> **submit** uk `надсилання`; **load** es `cargar` / fr `charger` / it `carica` / ru `загрузка`
+> / uk `завантаження` / ja `読み込み` (6 langs!); **change** fr `changer`; **input** pl `wejście`
+> / id `masukan`. Fix: register each i18n-emitted form as an event alternative in the semantic
+> profile (`generators/profiles/*.ts`) — or, for ja, the tokenizer EXTRAS
+> (`tokenizers/japanese.ts`, which derives events there, not from the profile). `load` is purely
+> an event (no command-collision risk); the verb forms (`cargar`/`charger`/`changer`) sit
+> alongside existing verb alternatives (`modifier`, `someter`), so no precision hit (verified:
+> precision flat in every lang). **uk +0.0200 (the laggard), es/fr/it/ru +0.0110, id/pl +0.0115,
+> ja +0.0076; R0 1.000 / R2 1.000 / parse-rate 3696/3696 unchanged.** semantic 6299 green. Guard:
+> `multilingual-roadmap-fixes.test.ts` "Event-keyword alignment" (10 cases, failing-without-fix
+> verified: all 10 fail). **Method lesson: a single language dominating the worst-pattern list
+> across UNRELATED patterns (uk in 6) signals a systemic per-language cause, not 6 one-offs —
+> grounding the common role-diff (`on.event:literal`→`expression`) found it in one pass.** A
+> broader audit of i18n-emitted-vs-profile event words across ALL 24 langs (beyond the 6 events
+> swept here) is a cheap follow-up — the same probe (`ev-sweep`) extends to keydown/keyup/focus/
+> mouseover/etc.
+>
 > **Update 2026-06-28l (Arc B R1 — English split-`'s` possessive capture; hi CROSSES 0.90
 > (0.8899 → 0.9034), 7 langs +0.0068, mean 0.9195 → 0.9218, ZERO regressions).** Completing the
 > bind cluster surfaced ANOTHER **broken en reference**: `bind $color to #picker's value` parsed

--- a/packages/semantic/src/generators/profiles/french.ts
+++ b/packages/semantic/src/generators/profiles/french.ts
@@ -141,7 +141,11 @@ export const frenchProfile: LanguageProfile = {
     hover: { primary: 'survol', alternatives: ['survoler'], normalized: 'hover' },
     submit: { primary: 'soumission', alternatives: ['soumettre'], normalized: 'submit' },
     input: { primary: 'saisie', alternatives: ['entrée'], normalized: 'input' },
-    change: { primary: 'changement', alternatives: ['modifier'], normalized: 'change' },
+    // i18n dict emits the verb `changer` for `change` (profile primary is the noun
+    // `changement`); recognize it so `on change` events type as a literal.
+    change: { primary: 'changement', alternatives: ['modifier', 'changer'], normalized: 'change' },
+    // i18n dict emits `charger` for `load`; without it `on load` events type as expression.
+    load: { primary: 'charger', alternatives: ['chargement'], normalized: 'load' },
     // Event modifiers (for repeat until event)
     until: { primary: "jusqu'à", alternatives: ['jusque'], normalized: 'until' },
     event: { primary: 'événement', normalized: 'event' },

--- a/packages/semantic/src/generators/profiles/indonesian.ts
+++ b/packages/semantic/src/generators/profiles/indonesian.ts
@@ -147,7 +147,8 @@ export const indonesianProfile: LanguageProfile = {
     click: { primary: 'klik', alternatives: ['tekan'], normalized: 'click' },
     hover: { primary: 'hover', alternatives: ['arahkan'], normalized: 'hover' },
     submit: { primary: 'ajukan', normalized: 'submit' },
-    input: { primary: 'masuk', alternatives: ['input'], normalized: 'input' },
+    // i18n dict emits `masukan` for `input` (profile primary is `masuk`); recognize it.
+    input: { primary: 'masuk', alternatives: ['input', 'masukan'], normalized: 'input' },
     change: { primary: 'berubah', normalized: 'change' },
     // Event modifiers (for repeat until event)
     until: { primary: 'sampai', normalized: 'until' },

--- a/packages/semantic/src/generators/profiles/italian.ts
+++ b/packages/semantic/src/generators/profiles/italian.ts
@@ -158,6 +158,8 @@ export const italianProfile: LanguageProfile = {
     submit: { primary: 'invio', alternatives: ['sottomettere'], normalized: 'submit' },
     input: { primary: 'inserimento', alternatives: ['input'], normalized: 'input' },
     change: { primary: 'cambio', alternatives: ['cambiamento'], normalized: 'change' },
+    // i18n dict emits `carica` for `load`; without it `on load` events type as expression.
+    load: { primary: 'carica', alternatives: ['caricamento'], normalized: 'load' },
     // Event modifiers
     until: { primary: 'fino', normalized: 'until' },
     event: { primary: 'evento', normalized: 'event' },

--- a/packages/semantic/src/generators/profiles/polish.ts
+++ b/packages/semantic/src/generators/profiles/polish.ts
@@ -279,7 +279,8 @@ export const polishProfile: LanguageProfile = {
     click: { primary: 'kliknięciu', alternatives: ['klikniecie', 'klik'], normalized: 'click' },
     hover: { primary: 'najechaniu', alternatives: ['hover'], normalized: 'hover' },
     submit: { primary: 'wysłaniu', alternatives: ['wyslaniu', 'submit'], normalized: 'submit' },
-    input: { primary: 'wprowadzeniu', alternatives: ['input'], normalized: 'input' },
+    // i18n dict emits `wejście` for `input`; recognize it so `on input` types as literal.
+    input: { primary: 'wprowadzeniu', alternatives: ['input', 'wejście'], normalized: 'input' },
     change: { primary: 'zmianie', alternatives: ['zmiana'], normalized: 'change' },
     // Event modifiers
     until: { primary: 'aż', alternatives: ['az'], normalized: 'until' },

--- a/packages/semantic/src/generators/profiles/russian.ts
+++ b/packages/semantic/src/generators/profiles/russian.ts
@@ -183,6 +183,8 @@ export const russianProfile: LanguageProfile = {
     submit: { primary: 'отправке', alternatives: ['отправка'], normalized: 'submit' },
     input: { primary: 'вводе', alternatives: ['ввод'], normalized: 'input' },
     change: { primary: 'изменении', alternatives: ['изменение'], normalized: 'change' },
+    // i18n dict emits `загрузка` for `load`; without it `on load` events type as expression.
+    load: { primary: 'загрузка', alternatives: ['загрузке'], normalized: 'load' },
     // Navigation
     go: {
       primary: 'перейти',

--- a/packages/semantic/src/generators/profiles/spanish.ts
+++ b/packages/semantic/src/generators/profiles/spanish.ts
@@ -106,7 +106,9 @@ export const spanishProfile: LanguageProfile = {
     submit: { primary: 'envío', alternatives: ['envio', 'someter'], normalized: 'submit' },
     input: { primary: 'entrada', alternatives: ['introducir'], normalized: 'input' },
     change: { primary: 'cambio', alternatives: ['cambiar'], normalized: 'change' },
-    load: { primary: 'carga', normalized: 'load' },
+    // i18n dict emits the verb `cargar` for `load` (profile primary is the noun
+    // `carga`); recognize it so `on load` events type as a literal, not expression.
+    load: { primary: 'carga', alternatives: ['cargar'], normalized: 'load' },
     scroll: { primary: 'desplazar', alternatives: ['desplazamiento'], normalized: 'scroll' },
     keydown: { primary: 'tecla abajo', normalized: 'keydown' },
     keyup: { primary: 'tecla arriba', normalized: 'keyup' },

--- a/packages/semantic/src/generators/profiles/ukrainian.ts
+++ b/packages/semantic/src/generators/profiles/ukrainian.ts
@@ -185,9 +185,19 @@ export const ukrainianProfile: LanguageProfile = {
     // Common event names (for event handler patterns)
     click: { primary: 'кліку', alternatives: ['клік', 'натисканні'], normalized: 'click' },
     hover: { primary: 'наведенні', alternatives: ['наведення'], normalized: 'hover' },
-    submit: { primary: 'відправці', alternatives: ['відправка'], normalized: 'submit' },
+    // `надсилання` is the form the i18n dict emits for `submit` (the profile
+    // primary `відправці` is a different word); without it `on submit` events
+    // (fetch-with-method/-formdata, morph-form-update, form-submit-prevent) parse
+    // the event as a bare `expression`, not a `literal` (the on.event R1 residue).
+    submit: {
+      primary: 'відправці',
+      alternatives: ['відправка', 'надсилання'],
+      normalized: 'submit',
+    },
     input: { primary: 'введенні', alternatives: ['введення'], normalized: 'input' },
     change: { primary: 'зміні', alternatives: ['зміна'], normalized: 'change' },
+    // i18n dict emits `завантаження` for `load` (stagger-animation `on load`).
+    load: { primary: 'завантаження', normalized: 'load' },
     // Navigation
     go: {
       primary: 'перейти',

--- a/packages/semantic/src/tokenizers/japanese.ts
+++ b/packages/semantic/src/tokenizers/japanese.ts
@@ -91,6 +91,9 @@ const JAPANESE_EXTRAS: KeywordEntry[] = [
   { native: '送信', normalized: 'submit' },
   { native: '入力', normalized: 'input' },
   { native: 'ロード', normalized: 'load' },
+  // The i18n dict emits the native `読み込み` for `load` (not the loanword `ロード`);
+  // recognize it so `on load` events type as a literal, not a bare expression.
+  { native: '読み込み', normalized: 'load' },
   { native: 'スクロール', normalized: 'scroll' },
   { native: 'キーダウン', normalized: 'keydown' },
   { native: 'キーアップ', normalized: 'keyup' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1154,6 +1154,41 @@ describe('English split `\'s` possessive captures the property (bind-explicit-pr
   });
 });
 
+describe('Event-keyword alignment: i18n-emitted event words recognized (on.event:literal)', () => {
+  // The i18n dict emits event words the semantic profiles/tokenizer did not list, so
+  // the event role typed as a bare `expression` instead of `literal` — the on.event R1
+  // residue (uk especially, the laggard). submit uk `надсилання`; load es `cargar` /
+  // fr `charger` / it `carica` / ru `загрузка` / uk `завантаження` / ja `読み込み`;
+  // change fr `changer`; input pl `wejście` / id `masukan`. Each is now a recognized
+  // event alternative (load is purely an event → no command collision). uk +0.0200,
+  // es/fr/it/ru +0.0110, id/pl +0.0115, ja +0.0076; mean R1 +0.0041, zero regressions.
+  function eventType(text: string, lang: string): string | undefined {
+    const node = parse(text, lang) as { roles?: unknown };
+    const roles =
+      node.roles instanceof Map
+        ? node.roles
+        : new Map(Object.entries((node.roles as object) ?? {}));
+    return (roles.get('event') as { type?: string } | undefined)?.type;
+  }
+  const cases: Array<[string, string, string]> = [
+    ['uk', 'submit', 'при надсилання перемкнути .x'],
+    ['es', 'load', 'en cargar alternar .x'],
+    ['fr', 'load', 'sur charger basculer .x'],
+    ['it', 'load', 'su carica commutare .x'],
+    ['ru', 'load', 'при загрузка переключить .x'],
+    ['uk', 'load', 'при завантаження перемкнути .x'],
+    ['ja', 'load', '.x を 読み込み で 切り替え'],
+    ['fr', 'change', 'sur changer basculer .x'],
+    ['pl', 'input', 'gdy wejście przełącz .x'],
+    ['id', 'input', 'pada masukan alihkan .x'],
+  ];
+  for (const [lang, ev, text] of cases) {
+    it(`[${lang}] ${ev} event (i18n-emitted word) types as literal`, () => {
+      expect(eventType(text, lang)).toBe('literal');
+    });
+  }
+});
+
 describe('SOV verb-first event-body reorder — modifier-prefixed bodies (Track 5)', () => {
   // A leading command-modifier (async/once/debounced) used to displace the verb in
   // the i18n SOV reorder, surfacing it first (`取得 /api/data を クリック …`). The

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-29T01:44:41.934Z",
-  "commit": "54e3d123",
+  "timestamp": "2026-06-29T02:53:53.674Z",
+  "commit": "0a2fc38c",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
       "avgPrecision": 0.9846320346320346,
-      "avgRoleFidelity": 0.9100263806146158,
+      "avgRoleFidelity": 0.9210061103443454,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
       "avgPrecision": 0.9833333333333334,
-      "avgRoleFidelity": 0.9278492980698864,
+      "avgRoleFidelity": 0.9388290277996159,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
       "avgPrecision": 0.9829004329004329,
-      "avgRoleFidelity": 0.9144859347065225,
+      "avgRoleFidelity": 0.9259724211930089,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.976650432900433,
-      "avgRoleFidelity": 0.9127903396285751,
+      "avgRoleFidelity": 0.9237700693583047,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
       "avgPrecision": 0.9482462613144433,
-      "avgRoleFidelity": 0.9116508072390427,
+      "avgRoleFidelity": 0.919252158590394,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
       "avgPrecision": 0.9928841991341991,
-      "avgRoleFidelity": 0.9092430423312778,
+      "avgRoleFidelity": 0.9207295288177644,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.8142650999793837,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367965,
-      "avgRoleFidelity": 0.912709683665566,
+      "avgRoleFidelity": 0.923689413395296,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13274,12 +13274,12 @@
       "avgConfidence": 0.8146773861059555,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367963,
-      "avgRoleFidelity": 0.9037006746565571,
+      "avgRoleFidelity": 0.923689413395296,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457261,
+      "bundleSize": 457430,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 457261,
+      "size": 457430,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## What

Grounding the new laggard (**uk**, after the bind cluster closed in #522/#523) found a **systemic dict/profile misalignment**: the i18n dict emits one event word but the semantic profile/tokenizer lists a *different* one, so the unrecognized word tokenized as a bare `identifier` and the event role typed as `expression` instead of `literal` — the `on.event` R1 residue.

A sweep across the 6 common events found **10 misaligned (lang, event) pairs**:

| Event | Languages (i18n-emitted word) |
|---|---|
| submit | uk `надсилання` |
| **load** | es `cargar`, fr `charger`, it `carica`, ru `загрузка`, uk `завантаження`, ja `読み込み` |
| change | fr `changer` |
| input | pl `wejście`, id `masukan` |

## Fix

Register each i18n-emitted form as an event **alternative** in the semantic profile (`generators/profiles/*.ts`) — or, for ja, the tokenizer EXTRAS (`tokenizers/japanese.ts`, which derives events there, not from the profile). `load` is purely an event (no command-collision risk); the verb forms (`cargar`/`charger`/`changer`) sit alongside existing verb alternatives (`modifier`/`someter`), so no precision hit.

## Impact

- **uk +0.0200** (the laggard), es/fr/it/ru **+0.0110**, id/pl **+0.0115**, ja **+0.0076**.
- **Mean R1 0.9218 → 0.9259 (+0.0041)** — the biggest single-PR *mean* win of the campaign.
- R0-recall 1.000 / R2 1.000 / parse-rate 3696/3696 / precision all unchanged; **zero regressions**.

## Tests

- Guard: `multilingual-roadmap-fixes.test.ts` → "Event-keyword alignment" (10 cases; **failing-without-fix verified**: all 10 fail). Full semantic suite **6299** green.

## Method note

One language dominating the worst-pattern list across **unrelated** patterns (uk in 6) signaled a systemic per-language cause, not 6 one-offs — grounding the common role-diff (`on.event:literal`→`expression`) found it in one pass. A broader audit of i18n-vs-profile event words across all 24 langs / more events (keydown/keyup/mouseover/…) is a cheap follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)