### PR TITLE
fix(multilingual): URL tokenization in 14 tokenizers (mean R1 0.9259→0.9382, +0.0122 — largest of the campaign)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,28 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-28n (Arc B R1 — URL tokenization in 14 tokenizers; mean R1 0.9259 → 0.9382
+> (+0.0122), the LARGEST single-PR win of the campaign by ~3×, 14 langs +0.0137–0.0218, ZERO
+> regressions).** Re-grounding after #524 found the biggest remaining residue was
+> **`fetch.source:literal` (188×, 19 langs)** — and it was a one-line-per-tokenizer gap, not a
+> per-pattern problem. A fetch source URL (`/api/data`) tokenized as a bare `identifier` in 14
+> space-using langs → the role typed `expression`, mismatching the en reference's `literal`.
+> Root cause: those 14 tokenizers' `classifyToken` (`tokenizers/*.ts`) **lacked the
+> `startsWith('/')|'./'|'http' → 'url'` line** that en/fr/hi/ja/ko/zh/ar/bn/qu/tr already
+> carried (the working vs broken split matched the URL-line presence EXACTLY). Added the line to
+> de/he/id/it/ms/pl/pt/ru/es/sw/th/tl/uk/vi. Lifts `fetch.source` across fetch-basic/-json/
+> -with-method/event-debounce. **14 langs +0.0137–0.0218 (de/es/he/id/it/ms/pt/sw/th/tl/vi
+> +0.0218; pl/ru/uk +0.0137); R0 1.000 / R2 1.000 / parse-rate 3696/3696 / precision all
+> unchanged.** semantic 6314 green. Guard: `multilingual-roadmap-fixes.test.ts` "URL tokenization
+> across space-using langs" (15 cases; failing-without-fix verified: 14 fail). **Method lesson
+> (recurring this arc): the biggest R1 levers keep being shared mechanism gaps (a missing
+> tokenizer line, a broken en reference, a dict/profile misalignment) masquerading as 188 separate
+> drops — re-grounding the top aggregate drop to its single root cause each time has paid off far
+> better than per-pattern fixes.** Remaining big aggregate drops (next candidates): `repeat.event`
+> / `repeat.loopType` (the two-sided for-each/until-event SOV work, ~132+116×), `halt.patient:
+reference` (70×, form-submit-prevent + behaviors), `set.destination:property-path` (47×, the
+> trailing-`from` SOV role-swap), `send.destination:reference` (42×).
+>
 > **Update 2026-06-28m (Arc B R1 — cross-language event-keyword alignment sweep; mean R1
 > 0.9218 → 0.9259 (+0.0041), the biggest single-PR MEAN win of the campaign, 8 langs +, ZERO
 > regressions).** Grounding the new laggard (uk, after the bind cluster closed) found a

--- a/packages/semantic/src/tokenizers/german.ts
+++ b/packages/semantic/src/tokenizers/german.ts
@@ -158,6 +158,8 @@ export class GermanTokenizer extends BaseTokenizer {
       return 'selector';
     if (token.startsWith('"') || token.startsWith("'")) return 'literal';
     if (/^\d/.test(token)) return 'literal';
+    // URLs (`/api/data`, `./x`, `http…`) — else typed identifier→expression (fetch.source R1).
+    if (token.startsWith('/') || token.startsWith('./') || token.startsWith('http')) return 'url';
     return 'identifier';
   }
 

--- a/packages/semantic/src/tokenizers/he.ts
+++ b/packages/semantic/src/tokenizers/he.ts
@@ -170,6 +170,8 @@ export class HebrewTokenizer extends BaseTokenizer {
     if (token.startsWith('"') || token.startsWith("'")) return 'literal';
     if (/^\d/.test(token)) return 'literal';
     if (['==', '!=', '<=', '>=', '<', '>', '&&', '||', '!'].includes(token)) return 'operator';
+    // URLs (`/api/data`, `./x`, `http…`) — else typed identifier→expression (fetch.source R1).
+    if (token.startsWith('/') || token.startsWith('./') || token.startsWith('http')) return 'url';
 
     return 'identifier';
   }

--- a/packages/semantic/src/tokenizers/indonesian.ts
+++ b/packages/semantic/src/tokenizers/indonesian.ts
@@ -160,6 +160,8 @@ export class IndonesianTokenizer extends BaseTokenizer {
     if (token.startsWith('"') || token.startsWith("'")) return 'literal';
     if (/^\d/.test(token)) return 'literal';
     if (['==', '!=', '<=', '>=', '<', '>', '&&', '||', '!'].includes(token)) return 'operator';
+    // URLs (`/api/data`, `./x`, `http…`) — else typed identifier→expression (fetch.source R1).
+    if (token.startsWith('/') || token.startsWith('./') || token.startsWith('http')) return 'url';
 
     return 'identifier';
   }

--- a/packages/semantic/src/tokenizers/italian.ts
+++ b/packages/semantic/src/tokenizers/italian.ts
@@ -254,6 +254,8 @@ export class ItalianTokenizer extends BaseTokenizer {
     if (token.startsWith('"') || token.startsWith("'")) return 'literal';
     if (/^\d/.test(token)) return 'literal';
     if (['==', '!=', '<=', '>=', '<', '>', '&&', '||', '!'].includes(token)) return 'operator';
+    // URLs (`/api/data`, `./x`, `http…`) — else typed identifier→expression (fetch.source R1).
+    if (token.startsWith('/') || token.startsWith('./') || token.startsWith('http')) return 'url';
 
     return 'identifier';
   }

--- a/packages/semantic/src/tokenizers/ms.ts
+++ b/packages/semantic/src/tokenizers/ms.ts
@@ -103,6 +103,8 @@ export class MalayTokenizer extends BaseTokenizer {
     if (token.startsWith(':')) return 'identifier';
     if (token.startsWith('"') || token.startsWith("'")) return 'literal';
     if (/^-?\d/.test(token)) return 'literal';
+    // URLs (`/api/data`, `./x`, `http…`) — else typed identifier→expression (fetch.source R1).
+    if (token.startsWith('/') || token.startsWith('./') || token.startsWith('http')) return 'url';
     return 'identifier';
   }
 }

--- a/packages/semantic/src/tokenizers/polish.ts
+++ b/packages/semantic/src/tokenizers/polish.ts
@@ -199,6 +199,8 @@ export class PolishTokenizer extends BaseTokenizer {
     if (token.startsWith('"') || token.startsWith("'")) return 'literal';
     if (/^\d/.test(token)) return 'literal';
     if (['==', '!=', '<=', '>=', '<', '>', '&&', '||', '!'].includes(token)) return 'operator';
+    // URLs (`/api/data`, `./x`, `http…`) — else typed identifier→expression (fetch.source R1).
+    if (token.startsWith('/') || token.startsWith('./') || token.startsWith('http')) return 'url';
 
     return 'identifier';
   }

--- a/packages/semantic/src/tokenizers/portuguese.ts
+++ b/packages/semantic/src/tokenizers/portuguese.ts
@@ -170,6 +170,8 @@ export class PortugueseTokenizer extends BaseTokenizer {
       return 'selector';
     if (token.startsWith('"') || token.startsWith("'")) return 'literal';
     if (/^\d/.test(token)) return 'literal';
+    // URLs (`/api/data`, `./x`, `http…`) — else typed identifier→expression (fetch.source R1).
+    if (token.startsWith('/') || token.startsWith('./') || token.startsWith('http')) return 'url';
     return 'identifier';
   }
 }

--- a/packages/semantic/src/tokenizers/russian.ts
+++ b/packages/semantic/src/tokenizers/russian.ts
@@ -175,6 +175,8 @@ export class RussianTokenizer extends BaseTokenizer {
       return 'selector';
     if (token.startsWith('"') || token.startsWith("'")) return 'literal';
     if (/^\d/.test(token)) return 'literal';
+    // URLs (`/api/data`, `./x`, `http…`) — else typed identifier→expression (fetch.source R1).
+    if (token.startsWith('/') || token.startsWith('./') || token.startsWith('http')) return 'url';
     return 'identifier';
   }
 }

--- a/packages/semantic/src/tokenizers/spanish.ts
+++ b/packages/semantic/src/tokenizers/spanish.ts
@@ -132,6 +132,10 @@ export class SpanishTokenizer extends BaseTokenizer {
     if (token.startsWith('"') || token.startsWith("'")) return 'literal';
     if (/^\d/.test(token)) return 'literal';
     if (['==', '!=', '<=', '>=', '<', '>', '&&', '||', '!'].includes(token)) return 'operator';
+    // URLs (`/api/data`, `./x`, `http…`) — fetch sources. Without this the URL falls
+    // through to `identifier` → typed `expression`, mismatching the en reference's
+    // `fetch.source:literal` (the on/fetch source R1 residue in 14 space-using langs).
+    if (token.startsWith('/') || token.startsWith('./') || token.startsWith('http')) return 'url';
 
     return 'identifier';
   }

--- a/packages/semantic/src/tokenizers/swahili.ts
+++ b/packages/semantic/src/tokenizers/swahili.ts
@@ -191,6 +191,8 @@ export class SwahiliTokenizer extends BaseTokenizer {
     if (token.startsWith('"') || token.startsWith("'")) return 'literal';
     if (/^\d/.test(token)) return 'literal';
     if (['==', '!=', '<=', '>=', '<', '>', '&&', '||', '!'].includes(token)) return 'operator';
+    // URLs (`/api/data`, `./x`, `http…`) — else typed identifier→expression (fetch.source R1).
+    if (token.startsWith('/') || token.startsWith('./') || token.startsWith('http')) return 'url';
 
     return 'identifier';
   }

--- a/packages/semantic/src/tokenizers/thai.ts
+++ b/packages/semantic/src/tokenizers/thai.ts
@@ -109,6 +109,8 @@ export class ThaiTokenizer extends BaseTokenizer {
     if (value.startsWith(':')) return 'identifier';
     if (value.startsWith('"') || value.startsWith("'")) return 'literal';
     if (/^-?\d/.test(value)) return 'literal';
+    // URLs (`/api/data`, `./x`, `http…`) — else typed identifier→expression (fetch.source R1).
+    if (value.startsWith('/') || value.startsWith('./') || value.startsWith('http')) return 'url';
     return 'identifier';
   }
 }

--- a/packages/semantic/src/tokenizers/tl.ts
+++ b/packages/semantic/src/tokenizers/tl.ts
@@ -103,6 +103,8 @@ export class TagalogTokenizer extends BaseTokenizer {
     if (token.startsWith(':')) return 'identifier';
     if (token.startsWith('"') || token.startsWith("'")) return 'literal';
     if (/^-?\d/.test(token)) return 'literal';
+    // URLs (`/api/data`, `./x`, `http…`) — else typed identifier→expression (fetch.source R1).
+    if (token.startsWith('/') || token.startsWith('./') || token.startsWith('http')) return 'url';
     return 'identifier';
   }
 }

--- a/packages/semantic/src/tokenizers/ukrainian.ts
+++ b/packages/semantic/src/tokenizers/ukrainian.ts
@@ -171,6 +171,8 @@ export class UkrainianTokenizer extends BaseTokenizer {
       return 'selector';
     if (token.startsWith('"') || token.startsWith("'")) return 'literal';
     if (/^\d/.test(token)) return 'literal';
+    // URLs (`/api/data`, `./x`, `http…`) — else typed identifier→expression (fetch.source R1).
+    if (token.startsWith('/') || token.startsWith('./') || token.startsWith('http')) return 'url';
     return 'identifier';
   }
 }

--- a/packages/semantic/src/tokenizers/vietnamese.ts
+++ b/packages/semantic/src/tokenizers/vietnamese.ts
@@ -150,6 +150,8 @@ export class VietnameseTokenizer extends BaseTokenizer {
     if (token.startsWith('"') || token.startsWith("'")) return 'literal';
     if (/^\d/.test(token)) return 'literal';
     if (['==', '!=', '<=', '>=', '<', '>', '&&', '||', '!'].includes(token)) return 'operator';
+    // URLs (`/api/data`, `./x`, `http…`) — else typed identifier→expression (fetch.source R1).
+    if (token.startsWith('/') || token.startsWith('./') || token.startsWith('http')) return 'url';
 
     return 'identifier';
   }

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1189,6 +1189,31 @@ describe('Event-keyword alignment: i18n-emitted event words recognized (on.event
   }
 });
 
+describe('URL tokenization across space-using langs (fetch.source:literal)', () => {
+  // 14 tokenizers' classifyToken lacked the `/`-prefixed URL check (en/fr/hi/ja/… had
+  // it), so a fetch source like `/api/data` fell through to `identifier` and the role
+  // typed as `expression` — mismatching the en reference's `fetch.source:literal`, the
+  // single biggest R1 residue (188× across fetch-basic/-json/-with-method/event-debounce
+  // in 14 space-using langs). Added `startsWith('/')|'./'|'http'` → 'url' to each. Mean
+  // R1 +0.0122 (the campaign's biggest single-PR win); 14 langs +0.0137–0.0218.
+  function firstKind(lang: string, text: string): string | undefined {
+    const raw = getTokenizer(lang).tokenize(text) as unknown;
+    const toks = (Array.isArray(raw) ? raw : (raw as { tokens: unknown[] }).tokens) as Array<{
+      kind: string;
+    }>;
+    return toks[0]?.kind;
+  }
+  const langs = ['es', 'de', 'pt', 'it', 'ru', 'uk', 'pl', 'vi', 'id', 'ms', 'sw', 'th', 'tl', 'he'];
+  for (const lang of langs) {
+    it(`[${lang}] /api/data tokenizes as a url (not a bare identifier)`, () => {
+      expect(firstKind(lang, '/api/data')).toBe('url');
+    });
+  }
+  it('[en] control: /api/data is still a url', () => {
+    expect(firstKind('en', '/api/data')).toBe('url');
+  });
+});
+
 describe('SOV verb-first event-body reorder — modifier-prefixed bodies (Track 5)', () => {
   // A leading command-modifier (async/once/debounced) used to displace the verb in
   // the i18n SOV reorder, surfacing it first (`取得 /api/data を クリック …`). The

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-29T02:53:53.674Z",
-  "commit": "0a2fc38c",
+  "timestamp": "2026-06-29T03:28:46.394Z",
+  "commit": "53d43071",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.828035456606883,
       "avgFidelity": 1,
       "avgPrecision": 0.9967532467532467,
-      "avgRoleFidelity": 0.9203017901547312,
+      "avgRoleFidelity": 0.9421271869801284,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
       "avgPrecision": 0.9846320346320346,
-      "avgRoleFidelity": 0.9210061103443454,
+      "avgRoleFidelity": 0.9428315071697426,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3794,12 +3794,12 @@
       "avgConfidence": 0.8237889095031952,
       "avgFidelity": 1,
       "avgPrecision": 0.9851731601731601,
-      "avgRoleFidelity": 0.9328498343204222,
+      "avgRoleFidelity": 0.9546752311458191,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
       "avgPrecision": 0.9829004329004329,
-      "avgRoleFidelity": 0.9259724211930089,
+      "avgRoleFidelity": 0.947797818018406,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.976650432900433,
-      "avgRoleFidelity": 0.9237700693583047,
+      "avgRoleFidelity": 0.9455954661837017,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
       "avgPrecision": 0.9811688311688311,
-      "avgRoleFidelity": 0.9318043641573055,
+      "avgRoleFidelity": 0.9536297609827026,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
       "avgPrecision": 0.9928841991341991,
-      "avgRoleFidelity": 0.9207295288177644,
+      "avgRoleFidelity": 0.9344468175350532,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8850,12 @@
       "avgConfidence": 0.7995877138734262,
       "avgFidelity": 1,
       "avgPrecision": 0.9820346320346321,
-      "avgRoleFidelity": 0.9198799842182191,
+      "avgRoleFidelity": 0.9417053810436163,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.8142650999793837,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367965,
-      "avgRoleFidelity": 0.923689413395296,
+      "avgRoleFidelity": 0.9374067021125848,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10746,12 +10746,12 @@
       "avgConfidence": 0.7962481962481944,
       "avgFidelity": 1,
       "avgPrecision": 0.9812770562770563,
-      "avgRoleFidelity": 0.9238810441016317,
+      "avgRoleFidelity": 0.945706440927029,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.9753246753246753,
-      "avgRoleFidelity": 0.9221565861271745,
+      "avgRoleFidelity": 0.9439819829525715,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12010,12 +12010,12 @@
       "avgConfidence": 0.8216537651743292,
       "avgFidelity": 1,
       "avgPrecision": 0.9800865800865801,
-      "avgRoleFidelity": 0.937998057850999,
+      "avgRoleFidelity": 0.9598234546763958,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13274,12 +13274,12 @@
       "avgConfidence": 0.8146773861059555,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367963,
-      "avgRoleFidelity": 0.923689413395296,
+      "avgRoleFidelity": 0.9374067021125846,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13906,12 +13906,12 @@
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
       "avgPrecision": 0.9811958874458874,
-      "avgRoleFidelity": 0.9342671736054089,
+      "avgRoleFidelity": 0.9560925704308059,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457430,
+      "bundleSize": 457694,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 457430,
+      "size": 457694,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## What

Re-grounding after #524 found the biggest remaining R1 residue was **`fetch.source:literal` (188×, 19 langs)** — and it was a **one-line-per-tokenizer gap**, not a per-pattern problem.

A fetch source URL (`/api/data`) tokenized as a bare `identifier` in 14 space-using languages, so the role typed as `expression`, mismatching the en reference's `literal`:

```
en/fr/hi/…  /api/data  →  kind: url   →  fetch.source:literal   ✓
es/de/it/…  /api/data  →  kind: identifier  →  fetch.source:expression  ✗
```

**Root cause:** those 14 tokenizers' `classifyToken` (`tokenizers/*.ts`) lacked the `startsWith('/') | './' | 'http' → 'url'` line that en/fr/hi/ja/ko/zh/ar/bn/qu/tr already carried — the working-vs-broken split matched the URL-line presence **exactly**.

## Fix

Added the one line to **de/he/id/it/ms/pl/pt/ru/es/sw/th/tl/uk/vi**. Lifts `fetch.source` across fetch-basic / fetch-json / fetch-with-method / event-debounce.

## Impact

- **Mean R1 0.9259 → 0.9382 (+0.0122)** — the largest single-PR win of the campaign, ~3× the prior best.
- 14 languages **+0.0137–0.0218** each (de/es/he/id/it/ms/pt/sw/th/tl/vi +0.0218; pl/ru/uk +0.0137).
- R0-recall 1.000 / R2 1.000 / parse-rate 3696/3696 / precision all unchanged; **zero regressions**.

## Tests

- Guard: `multilingual-roadmap-fixes.test.ts` → "URL tokenization across space-using langs" (15 cases; **failing-without-fix verified**: 14 fail, en control passes). Full semantic suite **6314** green.

## Method note

The biggest R1 levers keep being **shared mechanism gaps** (a missing tokenizer line, a broken en reference, a dict/profile misalignment) masquerading as ~188 separate drops — re-grounding the top aggregate drop to its single root cause has beaten per-pattern fixes every time this arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)