### PR TITLE
fix(multilingual): recognize `repeat forever` loop keyword (repeat.loopType R1; +0.0008, 17 langs, zero regressions)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,29 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-29b (Arc B R1 — `repeat forever` loop-keyword recognition; mean R1
+> 0.9382 → 0.9390 (+0.0008), 17 langs +0.0011, ZERO regressions).** The cleanest slice of the
+> `repeat.loopType:literal` residue (123×). The i18n dict never translated `forever`, so the
+> corpus leaves it the English word in most langs (`repetir forever`, `繰り返し forever`) and a
+> native word in a few (ru `всегда`, vi `mãi mãi`, tl `magpakailanman`, ms `selamanya`, th
+> `ตลอดไป`, bn `চিরকাল`, hi `हमेशा`). Unrecognized, the bare word typed `loopType:expression`
+> (SVO) / `loopType:reference=me` (SOV) instead of EN's `:literal`. Fix: add the **corpus word**
+> (English or native — taken verbatim from the corpus, so no guessing) as a `forever` keyword in
+> each profile (`generators/profiles/*.ts`), next to `while`/`until`. The generated repeat
+> pattern then types it `:literal`, matching EN — translations moving TOWARD the correct EN
+> reference (the opposite of the abandoned `trigger.event` direction; this is why it is a clean
+> win). **17 SVO/VSO langs gain (ar/de/es/fr/he/id/it/ms/pl/pt/qu/ru/sw/th/tl/uk/vi +0.0011); R0
+> 1.000 / precision 0.9743 / R2 1.000 / parse-rate unchanged.** semantic 6321 green. Guard:
+> `multilingual-roadmap-fixes.test.ts` "repeat forever loop keyword recognized" (7 cases,
+> failing-without-fix verified: 6 fail). **Excluded zh** (its generated repeat greedily grabs the
+> body verb after `forever` as a phantom `quantity:literal` → a within-tolerance lossy flip; needs
+> a HEAD-only `重复 forever` pattern — follow-up). **SOV langs ja/ko/tr/bn/hi recognize the keyword
+> but their fused/SOV repeat pattern still drops it** (`loopType:reference=me` unchanged — no gain,
+> no regression); capturing it is the SOV follow-up. **Next slices of the repeat residue:**
+> `repeat N times` needs a per-language HEAD-only `repeat {quantity} times` pattern (the generated
+> pattern grabs `N` as loopType, dropping `quantity:literal` — the `times` keyword alone doesn't
+> restructure it); the for-each `repeat for X in Y` is the two-sided EN-phantom + SOV problem.
+>
 > **Update 2026-06-29 (Arc B R1 — `trigger.event:literal` investigated and ABANDONED as
 > net-negative; NO PR. Negative result, documented so it is not re-attempted.)** Re-grounding
 > the leverage map on fresh main (post-#525, mean R1 0.9382) ranked the top remaining

--- a/packages/semantic/src/generators/profiles/arabic.ts
+++ b/packages/semantic/src/generators/profiles/arabic.ts
@@ -118,6 +118,9 @@ export const arabicProfile: LanguageProfile = {
     repeat: { primary: 'كرر', normalized: 'repeat' },
     for: { primary: 'لكل', normalized: 'for' },
     while: { primary: 'بينما', normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'forever', normalized: 'forever' },
     continue: { primary: 'واصل', normalized: 'continue' },
     halt: { primary: 'أوقف', normalized: 'halt' },
     throw: { primary: 'ارم', alternatives: ['ارمِ'], normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/bengali.ts
+++ b/packages/semantic/src/generators/profiles/bengali.ts
@@ -118,6 +118,9 @@ export const bengaliProfile: LanguageProfile = {
     repeat: { primary: 'পুনরাবৃত্তি', alternatives: ['বার বার'], normalized: 'repeat' },
     for: { primary: 'জন্য', alternatives: [], normalized: 'for' },
     while: { primary: 'যতক্ষণ', alternatives: [], normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'চিরকাল', normalized: 'forever', alternatives: ['forever'] },
     continue: { primary: 'চালিয়ে যান', alternatives: [], normalized: 'continue' },
     halt: { primary: 'থামুন', alternatives: ['থামাও'], normalized: 'halt' },
     throw: { primary: 'নিক্ষেপ', alternatives: ['ছুঁড়ে দিন'], normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/french.ts
+++ b/packages/semantic/src/generators/profiles/french.ts
@@ -111,6 +111,9 @@ export const frenchProfile: LanguageProfile = {
     repeat: { primary: 'répéter', normalized: 'repeat' },
     for: { primary: 'pour', normalized: 'for' },
     while: { primary: 'pendant', normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'forever', normalized: 'forever' },
     continue: { primary: 'continuer', normalized: 'continue' },
     halt: { primary: 'arrêter', alternatives: ['stopper'], normalized: 'halt' },
     throw: { primary: 'lancer', normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/german.ts
+++ b/packages/semantic/src/generators/profiles/german.ts
@@ -109,6 +109,9 @@ export const germanProfile: LanguageProfile = {
     repeat: { primary: 'wiederholen', normalized: 'repeat' },
     for: { primary: 'für', normalized: 'for' },
     while: { primary: 'solange', alternatives: ['während'], normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'forever', normalized: 'forever' },
     continue: { primary: 'fortfahren', alternatives: ['weiter'], normalized: 'continue' },
     halt: { primary: 'anhalten', alternatives: ['stoppen'], normalized: 'halt' },
     throw: { primary: 'werfen', normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/he.ts
+++ b/packages/semantic/src/generators/profiles/he.ts
@@ -114,6 +114,9 @@ export const hebrewProfile: LanguageProfile = {
     repeat: { primary: 'חזור', normalized: 'repeat' },
     for: { primary: 'עבור', alternatives: ['לכל'], normalized: 'for' },
     while: { primary: 'כל עוד', alternatives: ['בזמן'], normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'forever', normalized: 'forever' },
     continue: { primary: 'המשך', normalized: 'continue' },
     halt: { primary: 'עצור', alternatives: ['הפסק'], normalized: 'halt' },
     throw: { primary: 'זרוק', normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/hindi.ts
+++ b/packages/semantic/src/generators/profiles/hindi.ts
@@ -142,6 +142,9 @@ export const hindiProfile: LanguageProfile = {
     // SOV for-loop).
     for: { primary: 'के लिए', alternatives: ['हेतु'], normalized: 'for' },
     while: { primary: 'जब तक', alternatives: [], normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'हमेशा', normalized: 'forever', alternatives: ['forever'] },
     // `जब तक नहीं` ("as long as not" = unless), the SPACED form so it registers as
     // a multi-word keyword. It is a strict superset of while `जब तक`, but
     // multiWordKeywords are matched longest-first, so the full unless phrase wins

--- a/packages/semantic/src/generators/profiles/indonesian.ts
+++ b/packages/semantic/src/generators/profiles/indonesian.ts
@@ -118,6 +118,9 @@ export const indonesianProfile: LanguageProfile = {
     repeat: { primary: 'ulangi', normalized: 'repeat' },
     for: { primary: 'untuk', normalized: 'for' },
     while: { primary: 'selama', normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'forever', normalized: 'forever' },
     continue: { primary: 'lanjutkan', alternatives: ['terus'], normalized: 'continue' },
     halt: { primary: 'hentikan', alternatives: ['berhenti'], normalized: 'halt' },
     throw: { primary: 'lempar', normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/italian.ts
+++ b/packages/semantic/src/generators/profiles/italian.ts
@@ -125,6 +125,9 @@ export const italianProfile: LanguageProfile = {
     repeat: { primary: 'ripetere', normalized: 'repeat' },
     for: { primary: 'per', normalized: 'for' },
     while: { primary: 'mentre', normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'forever', normalized: 'forever' },
     continue: { primary: 'continuare', normalized: 'continue' },
     halt: { primary: 'fermare', normalized: 'halt' },
     throw: { primary: 'lanciare', normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/japanese.ts
+++ b/packages/semantic/src/generators/profiles/japanese.ts
@@ -138,6 +138,9 @@ export const japaneseProfile: LanguageProfile = {
     repeat: { primary: '繰り返し', alternatives: ['繰り返す', 'リピート'], normalized: 'repeat' },
     for: { primary: 'ために', alternatives: ['各'], normalized: 'for' },
     while: { primary: 'の間', alternatives: ['間'], normalized: 'while' },
+    // `repeat forever` loop keyword — left English in the corpus (`繰り返し forever`);
+    // recognize it so the loopType types as `:literal` like EN (see spanish.ts).
+    forever: { primary: 'forever', normalized: 'forever' },
     continue: { primary: '続ける', alternatives: ['継続'], normalized: 'continue' },
     halt: { primary: '停止', alternatives: ['止める', 'ハルト'], normalized: 'halt' },
     throw: { primary: '投げる', alternatives: ['スロー'], normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/korean.ts
+++ b/packages/semantic/src/generators/profiles/korean.ts
@@ -126,6 +126,9 @@ export const koreanProfile: LanguageProfile = {
     repeat: { primary: '반복', normalized: 'repeat' },
     for: { primary: '각각', normalized: 'for' }, // "each" — avoids collision with while 동안
     while: { primary: '동안', normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'forever', normalized: 'forever' },
     continue: { primary: '계속', normalized: 'continue' },
     halt: { primary: '정지', normalized: 'halt' },
     throw: { primary: '던지다', normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/ms.ts
+++ b/packages/semantic/src/generators/profiles/ms.ts
@@ -120,6 +120,9 @@ export const malayProfile: LanguageProfile = {
     repeat: { primary: 'ulang', normalized: 'repeat' },
     for: { primary: 'untuk', normalized: 'for' },
     while: { primary: 'selagi', alternatives: ['semasa'], normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'selamanya', normalized: 'forever', alternatives: ['forever'] },
     continue: { primary: 'teruskan', normalized: 'continue' },
     halt: { primary: 'henti', alternatives: ['berhenti'], normalized: 'halt' },
     throw: { primary: 'lempar', normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/polish.ts
+++ b/packages/semantic/src/generators/profiles/polish.ts
@@ -234,6 +234,9 @@ export const polishProfile: LanguageProfile = {
     },
     for: { primary: 'dla', alternatives: ['każdy', 'kazdy'], normalized: 'for' },
     while: { primary: 'dopóki', alternatives: ['dopoki', 'podczas'], normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'forever', normalized: 'forever' },
     continue: {
       primary: 'kontynuuj',
       alternatives: ['dalej'],

--- a/packages/semantic/src/generators/profiles/portuguese.ts
+++ b/packages/semantic/src/generators/profiles/portuguese.ts
@@ -110,6 +110,9 @@ export const portugueseProfile: LanguageProfile = {
     repeat: { primary: 'repetir', normalized: 'repeat' },
     for: { primary: 'para', normalized: 'for' },
     while: { primary: 'enquanto', normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'forever', normalized: 'forever' },
     continue: { primary: 'continuar', normalized: 'continue' },
     halt: { primary: 'parar', normalized: 'halt' },
     throw: { primary: 'lançar', normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/quechua.ts
+++ b/packages/semantic/src/generators/profiles/quechua.ts
@@ -119,6 +119,9 @@ export const quechuaProfile: LanguageProfile = {
     repeat: { primary: 'kutipay', alternatives: ['muyu'], normalized: 'repeat' },
     for: { primary: 'sapankaq', normalized: 'for' },
     while: { primary: 'kaykamaqa', normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'forever', normalized: 'forever' },
     continue: { primary: 'qatipay', normalized: 'continue' },
     halt: { primary: 'sayay', alternatives: [], normalized: 'halt' },
     throw: { primary: 'chanqay', normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/russian.ts
+++ b/packages/semantic/src/generators/profiles/russian.ts
@@ -244,6 +244,9 @@ export const russianProfile: LanguageProfile = {
     },
     for: { primary: 'для', alternatives: ['каждый'], normalized: 'for' },
     while: { primary: 'пока', normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'всегда', normalized: 'forever', alternatives: ['forever'] },
     continue: {
       primary: 'продолжить',
       alternatives: ['продолжи'],

--- a/packages/semantic/src/generators/profiles/spanish.ts
+++ b/packages/semantic/src/generators/profiles/spanish.ts
@@ -132,6 +132,14 @@ export const spanishProfile: LanguageProfile = {
     repeat: { primary: 'repetir', normalized: 'repeat' },
     for: { primary: 'para', normalized: 'for' },
     while: { primary: 'mientras', normalized: 'while' },
+    // `repeat forever` loop keyword. The i18n dict never translated `forever`, so the
+    // corpus leaves it English (`repetir forever`) — the bare word then typed
+    // `loopType:expression` (SVO) / `loopType:reference` (SOV) instead of EN's
+    // `:literal` (the repeat.loopType R1 residue). Recognizing the English form the
+    // corpus carries lets the generated repeat pattern type it as a literal, matching
+    // EN. (Native translation belongs to a separate i18n-dict pass; until then the
+    // corpus word IS the English one, so that is the primary here.)
+    forever: { primary: 'forever', normalized: 'forever' },
     continue: { primary: 'continuar', normalized: 'continue' },
     halt: { primary: 'detener', alternatives: ['parar'], normalized: 'halt' },
     throw: { primary: 'lanzar', alternatives: ['arrojar'], normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/swahili.ts
+++ b/packages/semantic/src/generators/profiles/swahili.ts
@@ -111,6 +111,9 @@ export const swahiliProfile: LanguageProfile = {
     repeat: { primary: 'rudia', normalized: 'repeat' },
     for: { primary: 'kwa', normalized: 'for' },
     while: { primary: 'kadri', normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'forever', normalized: 'forever' },
     continue: { primary: 'endelea', normalized: 'continue' },
     halt: { primary: 'simama', alternatives: ['acha'], normalized: 'halt' },
     throw: { primary: 'tupa', normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/thai.ts
+++ b/packages/semantic/src/generators/profiles/thai.ts
@@ -123,6 +123,9 @@ export const thaiProfile: LanguageProfile = {
     repeat: { primary: 'ทำซ้ำ', alternatives: [], normalized: 'repeat' },
     for: { primary: 'สำหรับ', alternatives: [], normalized: 'for' },
     while: { primary: 'ในขณะที่', alternatives: [], normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'ตลอดไป', normalized: 'forever', alternatives: ['forever'] },
     continue: { primary: 'ต่อไป', alternatives: [], normalized: 'continue' },
     halt: { primary: 'หยุด', alternatives: [], normalized: 'halt' },
     throw: { primary: 'โยน', alternatives: [], normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/tl.ts
+++ b/packages/semantic/src/generators/profiles/tl.ts
@@ -121,6 +121,9 @@ export const tagalogProfile: LanguageProfile = {
     repeat: { primary: 'ulitin', alternatives: ['paulit-ulit'], normalized: 'repeat' },
     for: { primary: 'para_sa', normalized: 'for' },
     while: { primary: 'habang', normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'magpakailanman', normalized: 'forever', alternatives: ['forever'] },
     continue: { primary: 'magpatuloy', normalized: 'continue' },
     halt: { primary: 'itigil', alternatives: ['huminto'], normalized: 'halt' },
     throw: { primary: 'ihagis', alternatives: ['itapon'], normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/turkish.ts
+++ b/packages/semantic/src/generators/profiles/turkish.ts
@@ -167,6 +167,9 @@ export const turkishProfile: LanguageProfile = {
     repeat: { primary: 'tekrarla', normalized: 'repeat' },
     for: { primary: 'için', normalized: 'for' },
     while: { primary: 'süresince', normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'forever', normalized: 'forever' },
     continue: { primary: 'devam', normalized: 'continue' },
     halt: { primary: 'durdur', normalized: 'halt' },
     throw: { primary: 'fırlat', normalized: 'throw' },

--- a/packages/semantic/src/generators/profiles/ukrainian.ts
+++ b/packages/semantic/src/generators/profiles/ukrainian.ts
@@ -257,6 +257,9 @@ export const ukrainianProfile: LanguageProfile = {
     },
     for: { primary: 'для', alternatives: ['кожний'], normalized: 'for' },
     while: { primary: 'поки', normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'завжди', normalized: 'forever', alternatives: ['forever'] },
     continue: {
       primary: 'продовжити',
       alternatives: ['продовжуй'],

--- a/packages/semantic/src/generators/profiles/vietnamese.ts
+++ b/packages/semantic/src/generators/profiles/vietnamese.ts
@@ -129,6 +129,9 @@ export const vietnameseProfile: LanguageProfile = {
     repeat: { primary: 'lặp lại', normalized: 'repeat' },
     for: { primary: 'với mỗi', normalized: 'for' },
     while: { primary: 'trong khi', normalized: 'while' },
+    // `repeat forever` loop keyword — corpus word recognized so loopType types
+    // as `:literal` like EN (the repeat.loopType R1 residue; see spanish.ts).
+    forever: { primary: 'mãi mãi', normalized: 'forever', alternatives: ['forever'] },
     continue: { primary: 'tiếp tục', normalized: 'continue' },
     halt: { primary: 'dừng', alternatives: ['dừng lại'], normalized: 'halt' },
     throw: { primary: 'ném', normalized: 'throw' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -8737,3 +8737,58 @@ describe('`halt the event` skips the leaked article → patient:reference (halt.
     expect(hasPatient).toBe(false);
   });
 });
+
+describe('repeat forever loop keyword recognized (repeat.loopType:literal R1)', () => {
+  // The i18n dict never translated `forever`, so the corpus leaves it as the English
+  // word in most langs (`repetir forever`) and a native word in a few (ru `всегда`,
+  // vi `mãi mãi`, tl `magpakailanman`, …). Unrecognized, it typed `loopType:expression`
+  // (SVO) instead of EN's `:literal` — the repeat.loopType R1 residue. Adding the
+  // corpus word as a `forever` keyword in each profile lets the generated repeat
+  // pattern type it as a literal, matching EN (17 SVO/VSO langs +0.0011, zero
+  // regression). SOV langs (ja/ko/tr/bn/hi) don't yet capture it (their fused/SOV
+  // repeat pattern drops the loop keyword — a separate follow-up), and zh is excluded
+  // (its generated repeat greedily grabs the body verb as a phantom `quantity`).
+  function repeatLoopType(node: unknown): string | undefined {
+    if (!node || typeof node !== 'object') return undefined;
+    const rec = node as Record<string, unknown>;
+    if (rec.action === 'repeat') {
+      const roles = rec.roles instanceof Map ? rec.roles : undefined;
+      const lt = roles?.get('loopType') as { type?: string } | undefined;
+      if (lt) return lt.type;
+    }
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches', 'eventHandlers']) {
+      const c = rec[f];
+      if (Array.isArray(c)) {
+        for (const x of c) {
+          const r = repeatLoopType(x);
+          if (r) return r;
+        }
+      } else if (c && typeof c === 'object') {
+        const r = repeatLoopType(c);
+        if (r) return r;
+      }
+    }
+    return undefined;
+  }
+
+  // Real corpus `repeat-forever` texts (head + body), spanning English-word and
+  // native-word forms, SVO and VSO, single- and multi-word keywords.
+  for (const [lang, src] of [
+    ['es', 'en cargar repetir forever alternar .pulse entonces esperar 1s fin'],
+    ['de', 'bei laden wiederholen forever umschalten .pulse dann warten 1s ende'],
+    ['ar', 'عند تحميل كرر forever بدل .pulse ثم انتظر 1s النهاية'],
+    ['ru', 'при загрузка повторить всегда переключить .pulse затем ждать 1s конец'],
+    ['tl', 'kapag load ulitin magpakailanman palitan .pulse pagkatapos maghintay 1s wakas'],
+    ['vi', 'khi tải lặp lại mãi mãi chuyển đổi .pulse rồi chờ 1s kết thúc'],
+  ] as [string, string][]) {
+    it(`[${lang}] repeat forever → loopType is a literal`, () => {
+      expect(repeatLoopType(parse(src, lang))).toBe('literal');
+    });
+  }
+
+  it('[en] repeat forever stays a literal (reference unchanged)', () => {
+    expect(repeatLoopType(parse('on load repeat forever toggle .pulse wait 1s end', 'en'))).toBe(
+      'literal'
+    );
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-29T03:28:46.394Z",
-  "commit": "53d43071",
+  "timestamp": "2026-06-29T12:49:15.429Z",
+  "commit": "ce99d057",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9,12 +9,12 @@
       "avgConfidence": 0.8371917985695063,
       "avgFidelity": 1,
       "avgPrecision": 0.9796536796536797,
-      "avgRoleFidelity": 0.9502513826043237,
+      "avgRoleFidelity": 0.9513775087304499,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.828035456606883,
       "avgFidelity": 1,
       "avgPrecision": 0.9967532467532467,
-      "avgRoleFidelity": 0.9421271869801284,
+      "avgRoleFidelity": 0.9432533131062545,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
       "avgPrecision": 0.9846320346320346,
-      "avgRoleFidelity": 0.9428315071697426,
+      "avgRoleFidelity": 0.9439576332958687,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
       "avgPrecision": 0.9833333333333334,
-      "avgRoleFidelity": 0.9388290277996159,
+      "avgRoleFidelity": 0.939955153925742,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3794,12 +3794,12 @@
       "avgConfidence": 0.8237889095031952,
       "avgFidelity": 1,
       "avgPrecision": 0.9851731601731601,
-      "avgRoleFidelity": 0.9546752311458191,
+      "avgRoleFidelity": 0.9558013572719452,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
       "avgPrecision": 0.9829004329004329,
-      "avgRoleFidelity": 0.947797818018406,
+      "avgRoleFidelity": 0.9489239441445321,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.976650432900433,
-      "avgRoleFidelity": 0.9455954661837017,
+      "avgRoleFidelity": 0.946721592309828,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
       "avgPrecision": 0.9811688311688311,
-      "avgRoleFidelity": 0.9536297609827026,
+      "avgRoleFidelity": 0.9547558871088286,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
       "avgPrecision": 0.9928841991341991,
-      "avgRoleFidelity": 0.9344468175350532,
+      "avgRoleFidelity": 0.9355729436611793,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8850,12 @@
       "avgConfidence": 0.7995877138734262,
       "avgFidelity": 1,
       "avgPrecision": 0.9820346320346321,
-      "avgRoleFidelity": 0.9417053810436163,
+      "avgRoleFidelity": 0.9428315071697426,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9482,12 @@
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
       "avgPrecision": 0.9512456428852532,
-      "avgRoleFidelity": 0.9065991088049914,
+      "avgRoleFidelity": 0.9077252349311175,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.8142650999793837,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367965,
-      "avgRoleFidelity": 0.9374067021125848,
+      "avgRoleFidelity": 0.9385328282387109,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10746,12 +10746,12 @@
       "avgConfidence": 0.7962481962481944,
       "avgFidelity": 1,
       "avgPrecision": 0.9812770562770563,
-      "avgRoleFidelity": 0.945706440927029,
+      "avgRoleFidelity": 0.9468325670531552,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.9753246753246753,
-      "avgRoleFidelity": 0.9439819829525715,
+      "avgRoleFidelity": 0.9451081090786976,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12010,12 +12010,12 @@
       "avgConfidence": 0.8216537651743292,
       "avgFidelity": 1,
       "avgPrecision": 0.9800865800865801,
-      "avgRoleFidelity": 0.9598234546763958,
+      "avgRoleFidelity": 0.9609495808025219,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13274,12 +13274,12 @@
       "avgConfidence": 0.8146773861059555,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367963,
-      "avgRoleFidelity": 0.9374067021125846,
+      "avgRoleFidelity": 0.9385328282387106,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13906,12 +13906,12 @@
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
       "avgPrecision": 0.9811958874458874,
-      "avgRoleFidelity": 0.9560925704308059,
+      "avgRoleFidelity": 0.9572186965569319,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 457694,
+      "bundleSize": 458135,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 457694,
+      "size": 458135,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

The cleanest slice of the `repeat.loopType:literal` R1 residue (123×). **Mean R1 0.9382 → 0.9390 (+0.0008), 17 languages +0.0011, zero regressions on all six gate signals.**

## Root cause
The i18n dict never translated `forever`, so the corpus leaves it the **English word** in most langs (`repetir forever`, `繰り返し forever`) and a **native word** in a few (ru `всегда`, vi `mãi mãi`, tl `magpakailanman`, ms `selamanya`, th `ตลอดไป`, bn `চিরকাল`, hi `हमेশা`). Unrecognized, the bare word typed `loopType:expression` (SVO) / `loopType:reference=me` (SOV) instead of en's `:literal` — `repeat-while` parses correctly because `while`/`until` *are* in the dict, but `forever` was never added.

## Fix
Add the **corpus word** (English or native, taken verbatim from the corpus — no guessing) as a `forever` keyword in each profile (`generators/profiles/*.ts`), next to `while`/`until`. The generated repeat pattern then types it `:literal`, matching en. This moves translations **toward** the correct en reference (the clean R1 direction).

## Results
- **17 SVO/VSO langs +0.0011**: ar, de, es, fr, he, id, it, ms, pl, pt, qu, ru, sw, th, tl, uk, vi
- R0-recall **1.000** / R0-precision **0.9743** / R2 execution **1.000** / parse-rate **1.000** — all unchanged
- semantic suite **6321 green**
- Guard: `multilingual-roadmap-fixes.test.ts` "repeat forever loop keyword recognized" (7 cases; failing-without-fix verified — 6 fail)

## Deliberately scoped out (follow-ups, documented in MULTILINGUAL_NEXT_STEPS.md)
- **zh excluded**: its generated repeat greedily grabs the body verb after `forever` as a phantom `quantity:literal` (a within-tolerance lossy flip) — needs a HEAD-only `重复 forever` pattern.
- **SOV langs ja/ko/tr/bn/hi**: recognize the keyword but their fused/SOV repeat pattern still drops it (`loopType:reference=me` unchanged — no gain, no regression).
- **`repeat N times`**: needs a per-language HEAD-only `repeat {quantity} times` pattern (the generated pattern grabs `N` as loopType; the `times` keyword alone doesn't restructure it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)