### PR TITLE
fix(multilingual): fused event-handler body re-parses dropped secondary role clauses (fetch.responseType R1; +0.0032, 13 langs, zero regressions)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,40 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-29e (Arc B R1 — fused-body fix LANDED; mean R1 0.9390 → 0.9422 (+0.0032),
+> 13 langs +0.0059, ZERO regressions. The largest R1 win of the campaign since the URL fix.)**
+> Supersedes 2026-06-29d (which reverted a single-site attempt): the fix DOES live in the
+> action-fused re-parse (`buildEventHandler`), the earlier attempt just had the wrong VERB-finder.
+> es fetch uses `fetch-event-es-vso` (verb-MEDIAL: `<event> buscar /api/user`), so the verb is NOT
+> `all[pos-1]` (that's the already-consumed `source`); the original re-parse only checked pos-1, so
+> it never fired. **Fix: find the verb by scanning BACK from the consumed region for the token whose
+> normalized form is the captured action, reconstruct `[verb..clause-boundary]`, re-parse it through
+> the command patterns, and swap in the richer node** — capturing the dropped secondary clauses
+> (fetch's `as {responseType}` ×63, and more across the fetch family). Three guards make it
+> zero-regression (each found via the gate / a clean before-after diff):
+>
+> 1. **block-body actions** (`repeat`/`if`/`for`/`while`/`unless`) skipped — their inline body is in
+>    the same clause (`repeat forever toggle .pulse then …`), so re-parsing would SWALLOW the body
+>    command (regressed repeat-forever in 17 langs on the first gate run).
+> 2. **verb-FIRST fused patterns** (`…-vso-verb-first`, ar/ko/tr) skipped — the event head sits
+>    BETWEEN the verb and the tail, so `[verb..boundary]` would re-include it (a separate residue).
+> 3. **SUPERSET check** — swap only if every fused role reappears with the SAME value-type (mapping
+>    the fused generic `patient` → the command's primaryRole, since `normalizeCommandRoles` relabels
+>    later). This is the verb-FINAL SOV rail: qu `#score ta ñitiy pi yapachiy 10` has the patient
+>    FRONTED (not in `[verb..boundary]`), so re-parsing `yapachiy 10` fills a DEFAULT `patient:me`;
+>    the superset check rejects that swap (selector≠reference) and keeps the real `patient:selector`
+>    (caught a qu −0.0017 on the second gate run; this guard zeroed it).
+>
+> **Result: de/es/fr/it/ms/pl/pt/ru/sw/th/uk/vi +0.0059, id +0.0028; R0 1.000 / precision 0.9743→
+> 0.9744 (UP) / R2 1.000 / parse-rate unchanged.** semantic 6327 green. Guard:
+> `multilingual-roadmap-fixes.test.ts` "Fused event-handler body re-parses secondary role clauses"
+> (6 cases incl. the qu superset rail + the repeat block-body rail; failing-without-fix verified —
+> the 4 fetch cases fail). **Remaining fused-body residue (follow-ups):** verb-FIRST langs
+> (ar/ko/tr) still drop secondary clauses (guard #2 — needs the event excised from the clause);
+> `trigger.event` namespaced events and SOV `repeat` loop-keyword capture are still open (different
+> shapes). The general lesson HELD: aligning the BODY parse toward the standalone Stage-2 parse is
+> the right direction; the care is all in the three guards.
+>
 > **Update 2026-06-29d (Arc B R1 — fused-body fix ATTEMPTED (one bounded, gate-guarded cycle)
 > and REVERTED; NO PR. Sharper scope for the next session.)** Implemented the "re-parse the full
 > clause when it yields STRICTLY MORE roles than the fused capture" change at the action-fused

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -945,51 +945,113 @@ export class SemanticParserImpl implements ISemanticParser {
         confidence: match.confidence,
       });
 
-      // A handcrafted fused pattern (`su {event} {action}` / `เมื่อ {event}
-      // {action}`) captures only the body VERB — the body's arguments trail
-      // unconsumed and the command node above comes out with ZERO roles, while
-      // the en reference re-parses the same clause through the command patterns
-      // and captures everything (`set my.textContent to X` → destination +
-      // patient). When that happens, retry: re-parse [verb..clause boundary]
-      // with the command patterns and swap in the result — but only when it is
-      // a single command with the SAME action and at least one role, so a body
-      // whose standalone pattern is missing (blur/transition/breakpoint) keeps
-      // the zero-roled node instead of degenerating to nothing.
-      if (Object.keys(roles).length === 0) {
+      // A fused event pattern captures the wrapped command's VERB + (at most) its
+      // PRIMARY arg, leaving every SECONDARY role clause unconsumed: `su {event}
+      // {action}` keeps only the verb (ZERO roles, args trail); `{event} {verb}
+      // {source}` (fetch-event-<lang>-vso) keeps `source` but DROPS the `as
+      // {responseType}` / `via {method}` tail. The en reference re-parses the same
+      // clause through the command patterns and captures everything — so an
+      // event-handler BODY silently loses roles a STANDALONE parse of the identical
+      // clause keeps (the fused-body R1 residue: fetch.responseType ×63, …). Retry:
+      // re-parse [verb..clause boundary] and swap in the result whenever it is the
+      // SAME single command with STRICTLY MORE roles than the fused capture.
+      //
+      // The VERB is found by scanning BACK from the consumed region for the token
+      // whose normalized form is the captured action — verb-LAST patterns put it at
+      // pos-1, verb-MEDIAL ones (fetch: `… buscar /api/user`, source already
+      // consumed between the verb and pos) put it earlier. The original code only
+      // checked pos-1, so verb-medial fused captures never re-parsed. ">" (not
+      // "> 0") subsumes the zero-role case AND the partial-capture case while never
+      // REDUCING a node — a complete fused capture (re-parse ≤ fused) and a body
+      // whose standalone pattern is missing (0 roles, not more) are left untouched.
+      //
+      // EXCLUDES block-body actions (`repeat`/`if`/`for`/`while`/`unless`): their
+      // loop/conditional BODY sits in the SAME clause (no `then` before it —
+      // `repeat forever toggle .pulse then …`), so re-parsing [verb..boundary] would
+      // swallow the body command into the block node and DROP it (regressed
+      // repeat-forever in 17 langs). Their bodies are recovered by the dedicated
+      // block paths (parseBodyWithClauses fold / hasBlockBody trailing re-parse).
+      // Also skips VERB-FIRST fused patterns (`…-vso-verb-first`): there the event
+      // clause sits BETWEEN the verb and the tail, so [verb..boundary] would wrongly
+      // re-include the event head (a separate, smaller residue — left for later).
+      if (!BLOCK_BODY_ACTIONS.has(actionName) && !match.pattern.id.includes('verb-first')) {
         const all = tokens.tokens;
         const pos = tokens.position();
-        const verbToken = pos > 0 ? all[pos - 1] : undefined;
-        const verbNormalized = verbToken
-          ? ((verbToken as { normalized?: string }).normalized ?? verbToken.value)
-          : undefined;
-        // Every action-capturing pattern puts {action} last, so the verb is the
-        // previously consumed token; require it to map to the captured action.
-        if (verbToken && verbNormalized === actionName) {
-          const clauseTokens: LanguageToken[] = [verbToken];
-          let clauseEnd = pos;
-          while (clauseEnd < all.length) {
-            const t = all[clauseEnd];
-            const isBoundary =
-              t.kind === 'conjunction' ||
-              (t.kind === 'keyword' &&
-                (this.isThenKeyword(t.value, language) || this.isEndKeyword(t.value, language)));
-            if (isBoundary) break;
-            clauseTokens.push(t);
-            clauseEnd++;
+        const isClauseBoundary = (t: LanguageToken): boolean =>
+          t.kind === 'conjunction' ||
+          (t.kind === 'keyword' &&
+            (this.isThenKeyword(t.value, language) || this.isEndKeyword(t.value, language)));
+        let verbIdx = -1;
+        for (let k = pos - 1; k >= 0; k--) {
+          const t = all[k];
+          if (isClauseBoundary(t)) break; // don't cross into a previous clause
+          const tn = ((t as { normalized?: string }).normalized ?? t.value).toLowerCase();
+          if (tn === actionName) {
+            verbIdx = k;
+            break;
           }
-          // Only retry when the verb has trailing arguments to reclaim.
+        }
+        if (verbIdx >= 0) {
+          // Clause runs from the verb to the next boundary at/after the unconsumed
+          // tail (the verb..pos span is already consumed by the fused match; the
+          // tail pos..clauseEnd holds the dropped secondary clause).
+          let clauseEnd = pos;
+          while (clauseEnd < all.length && !isClauseBoundary(all[clauseEnd])) clauseEnd++;
+          const clauseTokens = all.slice(verbIdx, clauseEnd);
+          // Only retry when there are trailing args beyond the verb to reclaim.
           if (clauseTokens.length > 1) {
             const commandPatterns = getPatternsForLanguage(language)
               .filter(p => p.command !== 'on')
               .sort((a, b) => b.priority - a.priority);
             const reparsed = this.parseClause(clauseTokens, commandPatterns, language);
             const first = reparsed[0];
+            // Swap ONLY when the re-parse is a SUPERSET of the fused capture: every
+            // fused role must reappear with the SAME value-type. This is the safety
+            // rail for verb-FINAL SOV (qu `#score ta ñitiy pi yapachiy 10`): the real
+            // patient `#score` is FRONTED, ahead of the event, so it is NOT in the
+            // [verb..boundary] clause — re-parsing `yapachiy 10` fills a DEFAULT
+            // `patient:reference=me`, which would inflate the role count (2 > 1) and,
+            // without this guard, REPLACE the correctly-captured `patient:selector`.
+            // Requiring superset means the re-parse can only ADD roles (fetch's
+            // `responseType` atop a preserved `source`), never swap a real role for a
+            // defaulted one.
+            const valType = (v: unknown): string =>
+              v !== null &&
+              typeof v === 'object' &&
+              typeof (v as { type?: unknown }).type === 'string'
+                ? (v as { type: string }).type
+                : typeof v;
+            // The fused capture binds the wrapped command's PRIMARY arg under the
+            // generic `patient` role; `normalizeCommandRoles` relabels it to the
+            // command's primaryRole (fetch→source, trigger→event) LATER, on the final
+            // tree. The re-parse already uses the real role, so map fused `patient` →
+            // primaryRole here (only when the schema has no real `patient` role — the
+            // exact relabel condition) so the superset check lines them up. For commands
+            // that DO keep `patient` (increment, …) the mapping is a no-op, so a
+            // verb-final SOV default-`patient` re-parse still fails the type match.
+            const schema = getSchema(actionName as ActionType);
+            const primary = schema?.primaryRole;
+            const mapRole = (role: string): SemanticRole =>
+              (role === 'patient' &&
+              primary &&
+              primary !== 'patient' &&
+              !schema?.roles.some(r => r.role === 'patient')
+                ? primary
+                : role) as SemanticRole;
+            const preservesFused =
+              !!first &&
+              first.kind === 'command' &&
+              Object.entries(roles).every(([role, val]) => {
+                const rv = (first as CommandSemanticNode).roles.get(mapRole(role));
+                return rv !== undefined && valType(rv) === valType(val);
+              });
             if (
               reparsed.length === 1 &&
               first &&
               first.kind === 'command' &&
               first.action === actionName &&
-              (first as CommandSemanticNode).roles.size > 0
+              preservesFused &&
+              (first as CommandSemanticNode).roles.size > Object.keys(roles).length
             ) {
               commandNode = first as CommandSemanticNode;
               while (tokens.position() < clauseEnd) tokens.advance();

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -8792,3 +8792,74 @@ describe('repeat forever loop keyword recognized (repeat.loopType:literal R1)', 
     );
   });
 });
+
+describe('Fused event-handler body re-parses secondary role clauses (fetch.responseType R1)', () => {
+  // A fused event-handler pattern captures the wrapped command's VERB + PRIMARY arg
+  // and drops every SECONDARY role clause: `<event> fetch /api as json` keeps
+  // `source` but loses the `as {responseType}` tail — even though a STANDALONE parse
+  // of the same clause keeps it. buildEventHandler now re-parses [verb..clause
+  // boundary] (finding the verb by scanning BACK, so verb-MEDIAL fused captures like
+  // fetch-event-<lang>-vso are handled) and swaps in the richer node when it is the
+  // SAME command, a SUPERSET of the fused roles (never replacing a real role with a
+  // defaulted one), with strictly MORE roles. Guards: block-body actions
+  // (repeat/if/for/while) are skipped (their inline body must not be swallowed),
+  // verb-FIRST fused patterns are skipped (the event head sits inside the clause).
+  function commandSig(node: unknown, action: string): string[] | undefined {
+    if (!node || typeof node !== 'object') return undefined;
+    const rec = node as Record<string, unknown>;
+    if (rec.action === action && rec.roles instanceof Map) {
+      return [...rec.roles.entries()].map(([k, v]) => {
+        const t =
+          v !== null && typeof v === 'object' && typeof (v as { type?: unknown }).type === 'string'
+            ? (v as { type: string }).type
+            : typeof v;
+        return `${k}:${t}`;
+      });
+    }
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches', 'eventHandlers']) {
+      const c = rec[f];
+      if (Array.isArray(c)) {
+        for (const x of c) {
+          const r = commandSig(x, action);
+          if (r) return r;
+        }
+      } else if (c && typeof c === 'object') {
+        const r = commandSig(c, action);
+        if (r) return r;
+      }
+    }
+    return undefined;
+  }
+
+  // fetch in an event handler keeps its `as {responseType}` tail (the 63× residue),
+  // across SVO (es/it/pt/sw) and the native-`as`-word langs (de `als`, fr `comme`,
+  // ru `как`). Real corpus fetch-json texts (head: `on click fetch … as json then …`).
+  for (const [lang, src] of [
+    ['es', 'en clic buscar /api/user como json entonces establecer #x a su.name'],
+    ['de', 'bei klick abrufen /api/user als json dann festlegen #x zu sein.name'],
+    ['fr', 'sur clic récupérer /api/user comme json alors définir #x à son.name'],
+    ['ru', 'при клик загрузить /api/user как json затем установить #x в его.name'],
+  ] as [string, string][]) {
+    it(`[${lang}] fetch in event handler keeps responseType`, () => {
+      const sig = commandSig(parse(src, lang), 'fetch');
+      expect(sig).toBeTruthy();
+      expect(sig).toContain('responseType:expression');
+      expect(sig).toContain('source:literal');
+    });
+  }
+
+  // Superset guard: verb-FINAL SOV (qu) — the fronted patient `#score` is NOT in the
+  // [verb..boundary] clause, so the re-parse fills a DEFAULT patient; the superset
+  // check must REJECT that swap and keep the real `patient:selector`.
+  it('[qu] verb-final increment keeps the fronted patient:selector (no default-swap)', () => {
+    const sig = commandSig(parse('#score ta ñitiy pi yapachiy 10', 'qu'), 'increment');
+    expect(sig).toContain('patient:selector');
+  });
+
+  // Block-body guard: the loop body command must survive (not be swallowed into repeat).
+  it('[es] repeat-forever keeps its toggle body command (block body not swallowed)', () => {
+    const node = parse('en cargar repetir forever alternar .pulse entonces esperar 1s fin', 'es');
+    expect(commandSig(node, 'toggle')).toBeTruthy();
+    expect(commandSig(node, 'repeat')).toBeTruthy();
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-29T12:49:15.429Z",
-  "commit": "ce99d057",
+  "timestamp": "2026-06-29T15:00:59.548Z",
+  "commit": "66d5fce3",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.828035456606883,
       "avgFidelity": 1,
       "avgPrecision": 0.9967532467532467,
-      "avgRoleFidelity": 0.9432533131062545,
+      "avgRoleFidelity": 0.9491252564781979,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
       "avgPrecision": 0.9846320346320346,
-      "avgRoleFidelity": 0.9439576332958687,
+      "avgRoleFidelity": 0.9498295766678121,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
       "avgPrecision": 0.9833333333333334,
-      "avgRoleFidelity": 0.939955153925742,
+      "avgRoleFidelity": 0.9458270972976853,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
       "avgPrecision": 0.9829004329004329,
-      "avgRoleFidelity": 0.9489239441445321,
+      "avgRoleFidelity": 0.9517392594598475,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.976650432900433,
-      "avgRoleFidelity": 0.946721592309828,
+      "avgRoleFidelity": 0.9525935356817714,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
       "avgPrecision": 0.9811688311688311,
-      "avgRoleFidelity": 0.9547558871088286,
+      "avgRoleFidelity": 0.960627830480772,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
       "avgPrecision": 0.9928841991341991,
-      "avgRoleFidelity": 0.9355729436611793,
+      "avgRoleFidelity": 0.9414448870331227,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8850,12 @@
       "avgConfidence": 0.7995877138734262,
       "avgFidelity": 1,
       "avgPrecision": 0.9820346320346321,
-      "avgRoleFidelity": 0.9428315071697426,
+      "avgRoleFidelity": 0.9487034505416858,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.8142650999793837,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367965,
-      "avgRoleFidelity": 0.9385328282387109,
+      "avgRoleFidelity": 0.9444047716106543,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10745,13 +10745,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7962481962481944,
       "avgFidelity": 1,
-      "avgPrecision": 0.9812770562770563,
-      "avgRoleFidelity": 0.9468325670531552,
+      "avgPrecision": 0.9852813852813852,
+      "avgRoleFidelity": 0.9527045104250984,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.9753246753246753,
-      "avgRoleFidelity": 0.9451081090786976,
+      "avgRoleFidelity": 0.9509800524506408,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13274,12 +13274,12 @@
       "avgConfidence": 0.8146773861059555,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367963,
-      "avgRoleFidelity": 0.9385328282387106,
+      "avgRoleFidelity": 0.9444047716106543,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13906,12 +13906,12 @@
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
       "avgPrecision": 0.9811958874458874,
-      "avgRoleFidelity": 0.9572186965569319,
+      "avgRoleFidelity": 0.9630906399288753,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458135,
+      "bundleSize": 458555,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 458135,
+      "size": 458555,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

**The largest R1 win of the campaign since the URL fix: mean R1 0.9390 → 0.9422 (+0.0032), 13 languages +0.0059, zero regressions on all six gate signals.** Solves the fused-event-body root cause flagged in #528/#529.

## Root cause
A fused event-handler pattern (`<event> {verb} {source}`, e.g. `fetch-event-es-vso`) captures only the wrapped command's **verb + primary arg** and drops every **secondary role clause** — so `on click fetch /api as json` keeps `source` but loses `as {responseType}` *inside a handler*, even though a standalone parse of the same clause keeps it. This is the `fetch.responseType` ×63 residue (plus more across the fetch family).

`buildEventHandler` already re-parsed `[verb..clause-boundary]` when the fused capture had **zero** roles — but it assumed the verb is `all[pos-1]`. For **verb-medial** fused patterns the verb sits earlier (the primary arg is consumed between it and `pos`), so the re-parse never fired.

## Fix
Find the verb by **scanning back** for the captured action, reconstruct the clause, re-parse it through the command patterns, and swap in the richer node. Three guards keep it zero-regression — each found via the gate or a clean before/after diff:

1. **block-body actions** (`repeat`/`if`/`for`/`while`/`unless`) skipped — their inline body is in the same clause and would be swallowed (regressed `repeat-forever` in 17 langs on the first gate run).
2. **verb-first fused patterns** skipped — the event head sits inside the clause.
3. **superset check** — swap only if every fused role reappears with the same value-type (mapping the fused generic `patient` → the command's primaryRole). The verb-final SOV rail: qu `#score ta ñitiy pi yapachiy 10` fronts the patient *outside* `[verb..boundary]`, so the re-parse fills a default patient; the superset check rejects that swap and keeps the real `patient:selector` (caught a qu −0.0017 on the second gate run; this guard zeroed it).

## Results
- **+0.0059**: de, es, fr, it, ms, pl, pt, ru, sw, th, uk, vi · **+0.0028**: id
- R0-recall **1.000** / R0-precision **0.9743 → 0.9744** / R2 **1.000** / parse-rate **1.000** — all flat-or-up
- semantic suite **6327 green**
- Guard: "Fused event-handler body re-parses secondary role clauses" (6 cases incl. the qu superset rail + the repeat block-body rail; failing-without-fix verified — the 4 fetch cases fail)

## Follow-ups (documented)
verb-first langs (ar/ko/tr) still drop secondary clauses (guard #2 — needs the event excised from the clause); `trigger.event` namespaced events and SOV `repeat` loop-keyword capture remain open (different shapes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)