### PR TITLE
fix(multilingual): verb-first fused event-handler body excises the event head (ar/tl R1; mean R1 0.9422→0.9427, +0.0005, zero regressions)

### DIFF
--- a/docs-internal/HANDOFF-r1-value-type-residue.md
+++ b/docs-internal/HANDOFF-r1-value-type-residue.md
@@ -13,11 +13,31 @@ You're continuing a long-running multilingual parse-fidelity effort in `~/projec
 ## Current state
 
 Authoritative source: `packages/testing-framework/baselines/multilingual-priority.json`
-(its `timestamp`/`commit` fields stamp each regen). **Mean R1 ≈ 0.9422** (24 langs × 154
+(its `timestamp`/`commit` fields stamp each regen). **Mean R1 ≈ 0.9427** (24 langs × 154
 patterns). R0-recall 1.000 · R0-precision ≈ 0.974 · R2 execution 1.000 · parse-rate 1.000.
-Last shipped: **#530** — the fused event-handler-body fix (the big one; see below).
+Last shipped: **the verb-first event-head excision** (ar/tl +0.0059 each; see the
+2026-06-29f entry in `MULTILINGUAL_NEXT_STEPS.md`), which extended **#530** (the fused
+event-handler-body fix; see below) to verb-FIRST VSO.
 
-## The next target: extend #530 to verb-first / SOV langs (ar, ko, tr)
+## The next target: extend the fused-body fix to SOV langs (ko, tr) — ar/tl DONE
+
+**ar/tl (verb-first VSO) are SHIPPED.** The 2026-06-29f fix excises the event head
+(`{on-marker} {event}`) from the verb-first clause before re-parsing, so `fetch-ar` /
+`fetch-tl` (markerlessFetch, `كـ`/`bilang` as-marker) recover `responseType`. ko/tr did NOT
+gain and remain open — and grounding **corrected** the original theory below:
+
+**ko/tr need a DEEPER, two-part fix (not just a re-assembly).** A standalone probe proved the
+event-excised re-assembly recovers nothing: ko `/api/user 를 가져오기 json 로` / tr
+`getir /api/user json olarak` parse to `source:literal` ONLY — the SOV standalone fetch pattern
+(`sovFetch`, `packages/semantic/src/patterns/fetch.ts` ~L256) **deliberately omits** responseType.
+So ko/tr need: (1) extend `sovFetch` with an optional trailing `{responseType} {asMarker}` clause
+(ko `로`, tr `olarak`, hi `के रूप में`) — this is the prerequisite and carries its own
+standalone-parse regression risk; AND (2) SOV non-contiguous clause re-assembly in `buildEventHandler`
+(the fronted source sits BEFORE the event, outside `[verb..boundary]`). The superset guard keeps
+ko/tr regression-free today. Expected upside is small (~+0.0003 mean, ko/tr × fetch family) — weigh
+it against the standalone-parse risk before committing.
+
+## (Original framing — superseded by the grounding above; kept for the trail) verb-first / SOV (ar, ko, tr)
 
 **Background — what #530 did.** A fused event-handler pattern (`<event> {verb} {source}`,
 e.g. `fetch-event-es-vso`) captures only the wrapped command's verb + PRIMARY arg and drops

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,41 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-29f (Arc B R1 — verb-FIRST event-head excision extends #530 to ar/tl; mean
+> R1 0.9422 → 0.9427 (+0.0005), ar +0.0059 · tl +0.0059, ZERO regressions. ko/tr GROUNDED as a
+> deeper, separate fix and DEFERRED.)** #530's fused-body re-parse skipped verb-FIRST fused
+> patterns (`…-vso-verb-first`) outright (its guard #2): there the event head sits BETWEEN the
+> verb and the trailing secondary clause, so the `[verb..clause-boundary]` slice RE-INCLUDES it
+> and the standalone re-parse drops everything after the event. ar `fetch-event-ar-vso-verb-first`
+> is exactly this: `احضر /api/user عند نقر كـjson` (`fetch /api/user on click as-json`) keeps
+> `source` but drops `as {responseType}`. **Fix (in `buildEventHandler`, semantic-parser.ts):
+> stop skipping verb-first; instead EXCISE the event head from the clause before re-parsing —
+> the event TOKEN (located by `token.normalized === captured-event`, e.g. نقر→"click") plus an
+> immediately-preceding `on`-marker keyword (`عند`, `kind==='keyword' && normalized==='on'`).** The
+> standalone `fetch-ar` (markerlessFetch, `كـ` as-marker) then recovers `responseType:expression`.
+> Excision is a NO-OP for every non-verb-first order (the event isn't inside `[verb..boundary]`),
+> so the proven #530 path is byte-identical; and if the event token can't be located the swap is
+> skipped (re-parsing with the event still inside is the #530 hazard). The block-body skip and the
+> superset + strictly-more-roles guards are unchanged (qu's fronted-patient rail still holds).
+> **tl (Tagalog, also verb-first VSO via `fetch-event-tl-vso-verb-first` + `fetch-tl`) gained
+> identically — a bonus the handoff didn't predict.** R0 1.000 / precision flat / R2 1.000 /
+> parse-rate unchanged; semantic suite green. Guard: `multilingual-roadmap-fixes.test.ts`
+> "Fused event-handler body re-parses secondary role clauses" gained 2 ar responseType cases +
+> 1 ar no-tail control (the 2 responseType cases fail without the fix; verified by stash).
+>
+> **ko/tr deferred — grounding corrected the handoff.** The handoff theorized ko/tr just need
+> the clause "re-assembled from non-contiguous parts (fronted patient + verb + tail, minus the
+> front event)". A standalone probe of the event-excised re-assembly disproved it: ko
+> `/api/user 를 가져오기 json 로` and tr `getir /api/user json olarak` STILL parse to `source:literal`
+> only — no responseType. Cause: the SOV standalone fetch pattern (`sovFetch`, `patterns/fetch.ts`
+> ~L256) **deliberately OMITS responseType** ("its SOV surface marker varies per language: ja none,
+> ko 로, tr olarak, hi के रूप में"). So ko/tr need TWO coordinated changes, not just a re-parse: (1)
+> extend `sovFetch` with an optional trailing `{responseType} {asMarker}` clause per language, AND
+> (2) SOV non-contiguous re-assembly in the fused body (the fronted source is BEFORE the event,
+> outside `[verb..boundary]`). The superset guard keeps them regression-free today (the
+> `[verb..boundary]`-only re-parse drops the fronted source → fails the superset check → no swap).
+> A dedicated follow-up; (1) is the prerequisite and carries its own standalone-parse regression risk.
+>
 > **Update 2026-06-29e (Arc B R1 — fused-body fix LANDED; mean R1 0.9390 → 0.9422 (+0.0032),
 > 13 langs +0.0059, ZERO regressions. The largest R1 win of the campaign since the URL fix.)**
 > Supersedes 2026-06-29d (which reverted a single-site attempt): the fix DOES live in the

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -971,10 +971,19 @@ export class SemanticParserImpl implements ISemanticParser {
       // swallow the body command into the block node and DROP it (regressed
       // repeat-forever in 17 langs). Their bodies are recovered by the dedicated
       // block paths (parseBodyWithClauses fold / hasBlockBody trailing re-parse).
-      // Also skips VERB-FIRST fused patterns (`…-vso-verb-first`): there the event
-      // clause sits BETWEEN the verb and the tail, so [verb..boundary] would wrongly
-      // re-include the event head (a separate, smaller residue — left for later).
-      if (!BLOCK_BODY_ACTIONS.has(actionName) && !match.pattern.id.includes('verb-first')) {
+      //
+      // VERB-FIRST fused patterns (`…-vso-verb-first`, ar) put the event head
+      // BETWEEN the verb and the tail (`احضر /api/user عند نقر كـjson` =
+      // `fetch /api/user on click as-json`), so the [verb..boundary] slice
+      // RE-INCLUDES `عند نقر` and the standalone re-parse drops everything after it.
+      // #530 therefore skipped them. Instead we EXCISE the event head (the event
+      // token — located by its captured normalized value — plus an immediately
+      // preceding `on`-marker keyword) from the clause before re-parsing; the
+      // standalone `fetch-ar` pattern then recovers the `كـ {responseType}` tail.
+      // If the event token can't be located in the clause, the swap is skipped
+      // (re-parsing with the event still inside is the #530 hazard).
+      if (!BLOCK_BODY_ACTIONS.has(actionName)) {
+        const isVerbFirst = match.pattern.id.includes('verb-first');
         const all = tokens.tokens;
         const pos = tokens.position();
         const isClauseBoundary = (t: LanguageToken): boolean =>
@@ -998,12 +1007,36 @@ export class SemanticParserImpl implements ISemanticParser {
           let clauseEnd = pos;
           while (clauseEnd < all.length && !isClauseBoundary(all[clauseEnd])) clauseEnd++;
           const clauseTokens = all.slice(verbIdx, clauseEnd);
+          // For verb-first fused patterns the event head sits inside the clause;
+          // excise it (event token + a preceding `on`-marker keyword) so the
+          // re-parse sees only the standalone command. For every other order the
+          // event is OUTSIDE [verb..boundary], so reparseTokens === clauseTokens
+          // (a no-op — the proven #530 path is byte-identical).
+          let reparseTokens: LanguageToken[] | null = clauseTokens;
+          if (isVerbFirst) {
+            const eventNorm = String((eventValue as { value?: unknown }).value ?? '').toLowerCase();
+            const evIdx = clauseTokens.findIndex(
+              t =>
+                ((t as { normalized?: string }).normalized ?? t.value).toLowerCase() === eventNorm
+            );
+            if (evIdx < 0) {
+              // Event token not in the clause → re-parsing would re-include it.
+              reparseTokens = null;
+            } else {
+              const prev = clauseTokens[evIdx - 1];
+              const from =
+                prev && prev.kind === 'keyword' && prev.normalized?.toLowerCase() === 'on'
+                  ? evIdx - 1
+                  : evIdx;
+              reparseTokens = [...clauseTokens.slice(0, from), ...clauseTokens.slice(evIdx + 1)];
+            }
+          }
           // Only retry when there are trailing args beyond the verb to reclaim.
-          if (clauseTokens.length > 1) {
+          if (reparseTokens && reparseTokens.length > 1) {
             const commandPatterns = getPatternsForLanguage(language)
               .filter(p => p.command !== 'on')
               .sort((a, b) => b.priority - a.priority);
-            const reparsed = this.parseClause(clauseTokens, commandPatterns, language);
+            const reparsed = this.parseClause(reparseTokens, commandPatterns, language);
             const first = reparsed[0];
             // Swap ONLY when the re-parse is a SUPERSET of the fused capture: every
             // fused role must reappear with the SAME value-type. This is the safety

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -8848,6 +8848,31 @@ describe('Fused event-handler body re-parses secondary role clauses (fetch.respo
     });
   }
 
+  // VERB-FIRST excision (ar): `fetch-event-ar-vso-verb-first` puts the event head
+  // `عند نقر` (on click) BETWEEN the verb and the `كـ {responseType}` tail, so the
+  // [verb..boundary] slice re-includes it. #530 skipped verb-first patterns; now we
+  // EXCISE the event token + its preceding `on`-marker keyword before re-parsing, so
+  // the standalone `fetch-ar` pattern recovers responseType. Corpus fetch-json /
+  // fetch-error-handling texts (head: verb-first `fetch /api on click as-json …`).
+  for (const src of [
+    'احضر /api/user عند نقر كـjson ثم اضبط #name.innerText إلى له.name',
+    'احضر /api/data عند نقر كـjson ثم إذا له.error ضع له.error إلى #error وإلا ضع له.data إلى #result النهاية',
+  ]) {
+    it(`[ar] verb-first fetch keeps responseType (event head excised): "${src.slice(0, 28)}…"`, () => {
+      const sig = commandSig(parse(src, 'ar'), 'fetch');
+      expect(sig).toBeTruthy();
+      expect(sig).toContain('responseType:expression');
+      expect(sig).toContain('source:literal');
+    });
+  }
+
+  // Verb-first excision must NOT fire when there is no secondary tail to reclaim:
+  // bare `fetch /api on click` keeps a single `source` role, never a phantom.
+  it('[ar] verb-first fetch without a tail keeps exactly source:literal', () => {
+    const sig = commandSig(parse('احضر /api/data عند نقر ثم ضع هو إلى #result', 'ar'), 'fetch');
+    expect(sig).toEqual(['source:literal']);
+  });
+
   // Superset guard: verb-FINAL SOV (qu) — the fronted patient `#score` is NOT in the
   // [verb..boundary] clause, so the re-parse fills a DEFAULT patient; the superset
   // check must REJECT that swap and keep the real `patient:selector`.

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-29T15:00:59.548Z",
-  "commit": "66d5fce3",
+  "timestamp": "2026-06-29T17:38:56.447Z",
+  "commit": "f8ef4b51",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9,12 +9,12 @@
       "avgConfidence": 0.8371917985695063,
       "avgFidelity": 1,
       "avgPrecision": 0.9796536796536797,
-      "avgRoleFidelity": 0.9513775087304499,
+      "avgRoleFidelity": 0.9572494521023932,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12010,12 +12010,12 @@
       "avgConfidence": 0.8216537651743292,
       "avgFidelity": 1,
       "avgPrecision": 0.9800865800865801,
-      "avgRoleFidelity": 0.9609495808025219,
+      "avgRoleFidelity": 0.9668215241744652,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458555,
+      "bundleSize": 458808,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 458555,
+      "size": 458808,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Extends the #530 fused event-handler-body fix to **verb-FIRST VSO** languages. #530's re-parse skipped verb-first patterns (guard #2): there the event head sits *between* the verb and the trailing secondary clause, so the `[verb..clause-boundary]` slice re-includes it and the standalone re-parse drops everything after the event. ar `fetch-event-ar-vso-verb-first` is exactly this — `احضر /api/user عند نقر كـjson` (`fetch /api/user on click as-json`) kept `source` but dropped `as {responseType}`.

**Fix** (`buildEventHandler`, `semantic-parser.ts`): stop skipping verb-first; instead **excise the event head** from the clause before re-parsing — the event token (located by `token.normalized === captured-event`, e.g. نقر→"click") plus an immediately preceding `on`-marker keyword (عند, `kind==='keyword' && normalized==='on'`). The standalone `fetch-ar` (markerlessFetch, `كـ` as-marker) then recovers `responseType:expression`.

- Excision is a **no-op for every non-verb-first order** (the event isn't inside `[verb..boundary]`) → the proven #530 path is byte-identical.
- If the event token can't be located, the swap is skipped (re-parsing with the event still inside is the #530 hazard).
- The block-body skip and the superset + strictly-more-roles guards are unchanged (qu's fronted-patient rail still holds).
- **tl** (Tagalog, also verb-first VSO) gained identically — a bonus the handoff didn't predict.

## Results (gate-verified, zero regression)

- **Mean R1 0.9422 → 0.9427 (+0.0005)** — `ar +0.0059`, `tl +0.0059`, **all other 21 langs flat, zero per-language drops**.
- `--regression` gate: ✓ No regression, no within-tolerance warning. parse-rate 1.000 / R0-recall 1.000 / precision flat / R2 1.000. Baseline regenerated.
- Full semantic suite green. Guard: `multilingual-roadmap-fixes.test.ts` gained 2 ar responseType cases + 1 ar no-tail control (the 2 responseType cases fail without the fix; verified by stash).

## ko/tr deferred (grounding corrected the handoff)

A standalone probe disproved the handoff's "just re-assemble the clause" theory: the event-excised re-assembly still recovers nothing — ko `/api/user 를 가져오기 json 로` / tr `getir /api/user json olarak` parse to `source`-only because the SOV standalone fetch pattern (`sovFetch`, `patterns/fetch.ts`) **deliberately omits** responseType. ko/tr need a separate two-part fix (extend `sovFetch` with a trailing `{responseType} {asMarker}` clause + SOV non-contiguous re-assembly). Documented in `MULTILINGUAL_NEXT_STEPS.md` 2026-06-29f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)