### PR TITLE
fix(multilingual): align resize event keyword across de/es/fr/it/pl/pt (on.event R1; mean R1 0.9427→0.9433, +0.0006, zero regressions)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,26 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-29g (Arc B R1 — `resize` event-keyword alignment (the 2026-06-28m audit
+> follow-up); mean R1 0.9427 → 0.9433 (+0.0006), de/es/fr/it/pl/pt +0.0023 each, ZERO
+> regressions.)** Re-grounding the post-#532 leverage map (NB: a raw-`parse()` map OVER-states any
+> role with a schema DEFAULT — increment.quantity / wait.duration / repeat.quantity show phantom
+> misses the gate's `fillSchemaDefaults` pass cancels; the genuinely-real non-behavior residues are
+> halt.patient §7y, set.destination role-swap, send.destination call-split, ko/tr fetch) surfaced
+> `on.event:literal` (24×). The dominant clean slice is the **`resize` event** in `window-resize`:
+> the i18n dict emits a native verb (de `größeändern`, es/pt `redimensionar`, fr `redimensionner`,
+> it `ridimensiona`, pl `zmieńrozmiar`) that the profiles never listed as the `resize` event, so
+> it tokenized as a bare `identifier` → `event:expression` instead of en's `event:literal="resize"`.
+> Exactly the 2026-06-28m mechanism. **Fix: add a `resize` event keyword to the 6 space-using Latin
+> profiles** (`generators/profiles/{german,spanish,french,italian,polish,portuguese}.ts`). `resize`
+> has no command homonym, so precision is flat (verified per-lang). **de/es/fr/it/pl/pt +0.0023;
+> R0 1.000 / precision flat / R2 1.000 / parse-rate 3696/3696 unchanged.** Guard:
+> `multilingual-roadmap-fixes.test.ts` "Event-keyword alignment" gained 6 resize cases
+> (failing-without-fix verified: all 6 fail). **Remaining `on.event` residue (follow-up):** zh/ja/ko
+> `resize` (`调整大小`/`マウス…`) need tokenizer EXTRAS (non-Latin, derive events in the tokenizer not
+> the profile); `mousedown`/`mouseup` (repeat-until-event) align for es/pt/ja/ko but ru/uk SPLIT the
+> underscore-compound (`мышь_вниз` → 3 tokens — a single-token tokenizer fix, same class as #510 tr).
+>
 > **Update 2026-06-29f (Arc B R1 — verb-FIRST event-head excision extends #530 to ar/tl; mean
 > R1 0.9422 → 0.9427 (+0.0005), ar +0.0059 · tl +0.0059, ZERO regressions. ko/tr GROUNDED as a
 > deeper, separate fix and DEFERRED.)** #530's fused-body re-parse skipped verb-FIRST fused

--- a/packages/semantic/src/generators/profiles/french.ts
+++ b/packages/semantic/src/generators/profiles/french.ts
@@ -141,6 +141,9 @@ export const frenchProfile: LanguageProfile = {
     after: { primary: 'après', normalized: 'after' },
     // Common event names (for event handler patterns)
     click: { primary: 'clic', alternatives: ['clique'], normalized: 'click' },
+    // `resize` event (window-resize): dict emits redimensionner; register it so the
+    // event types as literal="resize" (matching en) instead of expression.
+    resize: { primary: 'redimensionner', normalized: 'resize' },
     hover: { primary: 'survol', alternatives: ['survoler'], normalized: 'hover' },
     submit: { primary: 'soumission', alternatives: ['soumettre'], normalized: 'submit' },
     input: { primary: 'saisie', alternatives: ['entrée'], normalized: 'input' },

--- a/packages/semantic/src/generators/profiles/german.ts
+++ b/packages/semantic/src/generators/profiles/german.ts
@@ -146,6 +146,10 @@ export const germanProfile: LanguageProfile = {
     submit: { primary: 'Absenden', alternatives: ['Senden'], normalized: 'submit' },
     input: { primary: 'Eingabe', normalized: 'input' },
     change: { primary: 'Änderung', alternatives: ['Ändern'], normalized: 'change' },
+    // `resize` event (window-resize): the i18n dict emits größeändern; without it
+    // the word tokenized as an identifier → event:expression (the on.event R1
+    // residue). Registering it as the resize event yields event:literal="resize".
+    resize: { primary: 'größeändern', normalized: 'resize' },
     // Event modifiers (for repeat until event)
     until: { primary: 'bis', normalized: 'until' },
     event: { primary: 'Ereignis', alternatives: ['Event'], normalized: 'event' },

--- a/packages/semantic/src/generators/profiles/italian.ts
+++ b/packages/semantic/src/generators/profiles/italian.ts
@@ -157,6 +157,9 @@ export const italianProfile: LanguageProfile = {
     after: { primary: 'dopo', normalized: 'after' },
     // Common event names (for event handler patterns)
     click: { primary: 'clic', alternatives: ['clicca'], normalized: 'click' },
+    // `resize` event (window-resize): dict emits ridimensiona; register it so the
+    // event types as literal="resize" (matching en) instead of expression.
+    resize: { primary: 'ridimensiona', normalized: 'resize' },
     hover: { primary: 'passaggio', alternatives: ['sorvolo'], normalized: 'hover' },
     submit: { primary: 'invio', alternatives: ['sottomettere'], normalized: 'submit' },
     input: { primary: 'inserimento', alternatives: ['input'], normalized: 'input' },

--- a/packages/semantic/src/generators/profiles/polish.ts
+++ b/packages/semantic/src/generators/profiles/polish.ts
@@ -280,6 +280,9 @@ export const polishProfile: LanguageProfile = {
     after: { primary: 'po', normalized: 'after' },
     // Common event names (for event handler patterns)
     click: { primary: 'kliknięciu', alternatives: ['klikniecie', 'klik'], normalized: 'click' },
+    // `resize` event (window-resize): dict emits zmieńrozmiar; register it so the
+    // event types as literal="resize" (matching en) instead of expression.
+    resize: { primary: 'zmieńrozmiar', normalized: 'resize' },
     hover: { primary: 'najechaniu', alternatives: ['hover'], normalized: 'hover' },
     submit: { primary: 'wysłaniu', alternatives: ['wyslaniu', 'submit'], normalized: 'submit' },
     // i18n dict emits `wejście` for `input`; recognize it so `on input` types as literal.

--- a/packages/semantic/src/generators/profiles/portuguese.ts
+++ b/packages/semantic/src/generators/profiles/portuguese.ts
@@ -140,6 +140,9 @@ export const portugueseProfile: LanguageProfile = {
     after: { primary: 'depois', normalized: 'after' },
     // Common event names (for event handler patterns)
     click: { primary: 'clique', alternatives: ['clicar'], normalized: 'click' },
+    // `resize` event (window-resize): dict emits redimensionar; register it so the
+    // event types as literal="resize" (matching en) instead of expression.
+    resize: { primary: 'redimensionar', normalized: 'resize' },
     hover: { primary: 'sobrevoar', alternatives: ['passar'], normalized: 'hover' },
     submit: { primary: 'envio', alternatives: ['submeter'], normalized: 'submit' },
     input: { primary: 'entrada', alternatives: ['inserção'], normalized: 'input' },

--- a/packages/semantic/src/generators/profiles/spanish.ts
+++ b/packages/semantic/src/generators/profiles/spanish.ts
@@ -102,6 +102,9 @@ export const spanishProfile: LanguageProfile = {
     },
     // Common event names (for event handler patterns)
     click: { primary: 'clic', alternatives: ['hacer clic', 'click'], normalized: 'click' },
+    // `resize` event (window-resize): dict emits redimensionar; register it so the
+    // event types as literal="resize" (matching en) instead of expression.
+    resize: { primary: 'redimensionar', normalized: 'resize' },
     hover: { primary: 'sobrevolar', alternatives: ['pasar por encima'], normalized: 'hover' },
     submit: { primary: 'envío', alternatives: ['envio', 'someter'], normalized: 'submit' },
     input: { primary: 'entrada', alternatives: ['introducir'], normalized: 'input' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1181,6 +1181,15 @@ describe('Event-keyword alignment: i18n-emitted event words recognized (on.event
     ['fr', 'change', 'sur changer basculer .x'],
     ['pl', 'input', 'gdy wejście przełącz .x'],
     ['id', 'input', 'pada masukan alihkan .x'],
+    // resize (window-resize): dict emits a native verb the profiles didn't list as
+    // an event → it typed as expression. Registered as the resize event in the 6
+    // space-using Latin profiles (de/es/fr/it/pl/pt). resize has no command homonym.
+    ['de', 'resize', 'bei größeändern umschalten .x'],
+    ['es', 'resize', 'en redimensionar alternar .x'],
+    ['fr', 'resize', 'sur redimensionner basculer .x'],
+    ['it', 'resize', 'su ridimensiona commutare .x'],
+    ['pl', 'resize', 'gdy zmieńrozmiar przełącz .x'],
+    ['pt', 'resize', 'em redimensionar alternar .x'],
   ];
   for (const [lang, ev, text] of cases) {
     it(`[${lang}] ${ev} event (i18n-emitted word) types as literal`, () => {

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-29T17:38:56.447Z",
-  "commit": "f8ef4b51",
+  "timestamp": "2026-06-29T18:01:17.734Z",
+  "commit": "b28492f3",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.828035456606883,
       "avgFidelity": 1,
       "avgPrecision": 0.9967532467532467,
-      "avgRoleFidelity": 0.9491252564781979,
+      "avgRoleFidelity": 0.95137750873045,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
       "avgPrecision": 0.9846320346320346,
-      "avgRoleFidelity": 0.9498295766678121,
+      "avgRoleFidelity": 0.9520818289200642,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
       "avgPrecision": 0.9833333333333334,
-      "avgRoleFidelity": 0.9458270972976853,
+      "avgRoleFidelity": 0.9480793495499377,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.976650432900433,
-      "avgRoleFidelity": 0.9525935356817714,
+      "avgRoleFidelity": 0.9548457879340235,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
       "avgPrecision": 0.9928841991341991,
-      "avgRoleFidelity": 0.9414448870331227,
+      "avgRoleFidelity": 0.943697139285375,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8850,12 @@
       "avgConfidence": 0.7995877138734262,
       "avgFidelity": 1,
       "avgPrecision": 0.9820346320346321,
-      "avgRoleFidelity": 0.9487034505416858,
+      "avgRoleFidelity": 0.9509557027939382,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 458808,
+      "bundleSize": 459028,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 458808,
+      "size": 459028,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

The 2026-06-28m event-keyword-alignment audit follow-up. In `window-resize` the i18n dict emits a native resize verb (de `größeändern`, es/pt `redimensionar`, fr `redimensionner`, it `ridimensiona`, pl `zmieńrozmiar`) that the semantic profiles never listed as the `resize` event, so it tokenized as a bare `identifier` → `on.event:expression` instead of en's `on.event:literal="resize"`.

**Fix:** register `resize` as an event keyword in the 6 space-using Latin profiles (`generators/profiles/{german,spanish,french,italian,polish,portuguese}.ts`). `resize` has no command homonym, so precision is flat.

## Results (gate-verified, zero regression)

- **Mean R1 0.9427 → 0.9433 (+0.0006)** — `de/es/fr/it/pl/pt +0.0023` each, all other langs flat, **zero per-language drops**.
- `--regression` gate: ✓ No regression, no within-tolerance warning. parse-rate 3696/3696 / R0 1.000 / precision flat / R2 1.000. Baseline regenerated.
- semantic suite 6336 green; typecheck clean. Guard: `multilingual-roadmap-fixes.test.ts` "Event-keyword alignment" gained 6 resize cases (all 6 fail without the fix; verified by stash).

## Remaining `on.event` residue (follow-up)

Documented in `MULTILINGUAL_NEXT_STEPS.md` 2026-06-29g: zh/ja/ko `resize` need tokenizer EXTRAS (non-Latin, derive events in the tokenizer not the profile); `mousedown`/`mouseup` (repeat-until-event) align for es/pt/ja/ko but ru/uk split the underscore-compound (`мышь_вниз` → 3 tokens; single-token tokenizer fix, same class as #510 tr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)