### PR TITLE
fix(multilingual): align mousedown/mouseup event keywords (es/pt/ja/ko; on.event R1; mean R1 0.9433→0.9434, +0.0002, zero regressions)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,25 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-29h (Arc B R1 — `mousedown`/`mouseup` event-keyword alignment (continues
+> 2026-06-29g); mean R1 0.9433 → 0.9434 (+0.0002), es/pt/ja/ko +0.0010 each, ZERO regressions.)**
+> The `repeat-until-event` pattern (`on mousedown repeat until event mouseup …`) has TWO events:
+> the handler event (`on mousedown`) and the loop until-event (`repeat until event mouseup`). The
+> i18n dict emits native forms the profiles/tokenizers never listed (es `ratónabajo`/`ratónarriba`,
+> pt `mouseBaixo`/`mouseCima`, ja `マウス押下`/`マウス解放`, ko `마우스다운`/`마우스업`), so the HANDLER
+> event typed as `expression` instead of en's `on.event:literal="mousedown"`. **Fix: register
+> `mousedown`/`mouseup` — es/pt via profile keyword, ja/ko via tokenizer EXTRAS (non-Latin, derive
+> events in the tokenizer not the profile).** This lifts `on.event:literal` for all four (+0.0010
+> each); precision flat, no new phantoms (ja's pre-existing `event.event` node from the
+> until-event is unchanged). **The loop until-event (`repeat.event:literal="mouseup"`) is STILL
+> dropped** — that's the separate repeat-cluster residue (the verb-final/SOV `repeat until event`
+> structure drops the event), not this fix. R0 1.000 / precision flat / R2 1.000 / parse-rate
+> 3696/3696 unchanged. Guard: `multilingual-roadmap-fixes.test.ts` "Event-keyword alignment" gained
+> 4 mousedown cases (all 4 fail without the fix). **Remaining `on.event` residue:** ru/uk
+> `mousedown`/`mouseup` SPLIT the underscore-compound (`мышь_вниз` → `мышь`+`_`+`вниз`) — a
+> single-token tokenizer fix (same class as #510 tr `boyut_değiştir`); and the bigger
+> `repeat.event`/`repeat.loopType` until-event capture is the repeat-cluster arc.
+>
 > **Update 2026-06-29g (Arc B R1 — `resize` event-keyword alignment (the 2026-06-28m audit
 > follow-up); mean R1 0.9427 → 0.9433 (+0.0006), de/es/fr/it/pl/pt +0.0023 each, ZERO
 > regressions.)** Re-grounding the post-#532 leverage map (NB: a raw-`parse()` map OVER-states any

--- a/packages/semantic/src/generators/profiles/portuguese.ts
+++ b/packages/semantic/src/generators/profiles/portuguese.ts
@@ -147,6 +147,10 @@ export const portugueseProfile: LanguageProfile = {
     submit: { primary: 'envio', alternatives: ['submeter'], normalized: 'submit' },
     input: { primary: 'entrada', alternatives: ['inserção'], normalized: 'input' },
     change: { primary: 'alteração', alternatives: ['mudança'], normalized: 'change' },
+    // mousedown/mouseup (repeat-until-event): dict emits mouseBaixo/mouseCima —
+    // register so both the on.event and the repeat until-event type as literal.
+    mousedown: { primary: 'mouseBaixo', normalized: 'mousedown' },
+    mouseup: { primary: 'mouseCima', normalized: 'mouseup' },
     // Event modifiers (for repeat until event)
     until: { primary: 'até', normalized: 'until' },
     event: { primary: 'evento', normalized: 'event' },

--- a/packages/semantic/src/generators/profiles/spanish.ts
+++ b/packages/semantic/src/generators/profiles/spanish.ts
@@ -117,6 +117,10 @@ export const spanishProfile: LanguageProfile = {
     keyup: { primary: 'tecla arriba', normalized: 'keyup' },
     mouseover: { primary: 'ratón encima', alternatives: ['raton encima'], normalized: 'mouseover' },
     mouseout: { primary: 'ratón fuera', alternatives: ['raton fuera'], normalized: 'mouseout' },
+    // mousedown/mouseup (repeat-until-event): dict emits ratónabajo/ratónarriba —
+    // register so both the on.event and the repeat until-event type as literal.
+    mousedown: { primary: 'ratónabajo', normalized: 'mousedown' },
+    mouseup: { primary: 'ratónarriba', normalized: 'mouseup' },
     // Navigation
     go: { primary: 'ir', alternatives: ['navegar'], normalized: 'go' },
     push: { primary: 'empujar', alternatives: ['push'], normalized: 'push' },

--- a/packages/semantic/src/tokenizers/japanese.ts
+++ b/packages/semantic/src/tokenizers/japanese.ts
@@ -99,6 +99,10 @@ const JAPANESE_EXTRAS: KeywordEntry[] = [
   { native: 'キーアップ', normalized: 'keyup' },
   { native: 'マウスオーバー', normalized: 'mouseover' },
   { native: 'マウスアウト', normalized: 'mouseout' },
+  // The i18n dict emits マウス押下/マウス解放 for mousedown/mouseup (repeat-until-event);
+  // recognize them so the event types as a literal, not a bare expression.
+  { native: 'マウス押下', normalized: 'mousedown' },
+  { native: 'マウス解放', normalized: 'mouseup' },
 
   // Conjunctions. `または` (or) must be listed so the keyword extractor's
   // longest-match keeps it whole — otherwise the profile's `and` primary `また`

--- a/packages/semantic/src/tokenizers/korean.ts
+++ b/packages/semantic/src/tokenizers/korean.ts
@@ -108,6 +108,10 @@ const KOREAN_EXTRAS: KeywordEntry[] = [
   { native: '키업', normalized: 'keyup' },
   { native: '마우스오버', normalized: 'mouseover' },
   { native: '마우스아웃', normalized: 'mouseout' },
+  // The i18n dict emits 마우스다운/마우스업 for mousedown/mouseup (repeat-until-event);
+  // recognize them so the event types as a literal, not a bare expression.
+  { native: '마우스다운', normalized: 'mousedown' },
+  { native: '마우스업', normalized: 'mouseup' },
 
   // References (additional forms not in profile)
   { native: '내', normalized: 'my' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1190,6 +1190,13 @@ describe('Event-keyword alignment: i18n-emitted event words recognized (on.event
     ['it', 'resize', 'su ridimensiona commutare .x'],
     ['pl', 'resize', 'gdy zmieńrozmiar przełącz .x'],
     ['pt', 'resize', 'em redimensionar alternar .x'],
+    // mousedown (repeat-until-event handler event): dict emits a native form the
+    // profiles/tokenizers didn't list → the handler event typed as expression.
+    // es/pt via profile keyword; ja/ko via tokenizer EXTRAS (non-Latin).
+    ['es', 'mousedown', 'en ratónabajo alternar .x'],
+    ['pt', 'mousedown', 'em mouseBaixo alternar .x'],
+    ['ja', 'mousedown', '.x を マウス押下 で 切り替え'],
+    ['ko', 'mousedown', '.x 를 마우스다운 할 때 토글'],
   ];
   for (const [lang, ev, text] of cases) {
     it(`[${lang}] ${ev} event (i18n-emitted word) types as literal`, () => {

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-29T18:01:17.734Z",
-  "commit": "b28492f3",
+  "timestamp": "2026-06-29T18:18:29.388Z",
+  "commit": "2c64b82a",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
       "avgPrecision": 0.9846320346320346,
-      "avgRoleFidelity": 0.9520818289200642,
+      "avgRoleFidelity": 0.9530470798853153,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
       "avgPrecision": 0.9482462613144433,
-      "avgRoleFidelity": 0.919252158590394,
+      "avgRoleFidelity": 0.9202174095556448,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6954,12 @@
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
       "avgPrecision": 0.9482462613144431,
-      "avgRoleFidelity": 0.9162116180498535,
+      "avgRoleFidelity": 0.9171768690151044,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8847,15 +8847,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7995877138734262,
+      "avgConfidence": 0.7984333127190251,
       "avgFidelity": 1,
       "avgPrecision": 0.9820346320346321,
-      "avgRoleFidelity": 0.9509557027939382,
+      "avgRoleFidelity": 0.9519209537591891,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8926,10 +8926,6 @@
           "confidence": 1
         },
         "closest-ancestor": {
-          "success": true,
-          "confidence": 1
-        },
-        "repeat-until-event": {
           "success": true,
           "confidence": 1
         },
@@ -9106,6 +9102,10 @@
           "confidence": 0.8222222222222222
         },
         "last-in-collection": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "repeat-until-event": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459028,
+      "bundleSize": 459500,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 459028,
+      "size": 459500,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Continues the 2026-06-28m event-keyword-alignment audit (after #533 `resize`). The `repeat-until-event` pattern (`on mousedown repeat until event mouseup …`) has two events; the **handler event** tokenized as `expression` because the i18n dict emits native forms the profiles/tokenizers never listed: es `ratónabajo`/`ratónarriba`, pt `mouseBaixo`/`mouseCima`, ja `マウス押下`/`マウス解放`, ko `마우스다운`/`마우스업`.

**Fix:** register `mousedown`/`mouseup` — es/pt via profile keyword, ja/ko via tokenizer EXTRAS (non-Latin). Lifts `on.event:literal` for all four; precision flat, no new phantoms.

## Results (gate-verified, zero regression)

- **Mean R1 0.9433 → 0.9434 (+0.0002)** — `es/pt/ja/ko +0.0010` each, all others flat, **zero drops**.
- `--regression` gate: ✓ No regression, no within-tolerance warning. parse-rate 3696/3696 / R0 1.000 / precision flat / R2 1.000. Baseline regenerated.
- semantic suite 6340 green; typecheck clean. Guard: `multilingual-roadmap-fixes.test.ts` "Event-keyword alignment" gained 4 mousedown cases (all 4 fail without the fix).

## Scope note

The loop until-event (`repeat.event:literal="mouseup"`) is **still dropped** — that's the separate repeat-cluster residue (verb-final/SOV `repeat until event` drops the event), not this fix.

## Follow-up (documented in MULTILINGUAL_NEXT_STEPS.md 2026-06-29h)

ru/uk split the underscore-compound (`мышь_вниз` → 3 tokens; single-token tokenizer fix, #510 class); the `repeat.event`/`repeat.loopType` until-event capture is the repeat-cluster arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)