### PR TITLE
fix(multilingual): fuse ru/uk underscore-split event keywords (mousedown/mouseup/resize; on.event R1; mean R1 0.9434→0.9435, zero regressions)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,24 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-29i (Arc B R1 — ru/uk FUSED event keywords (the underscore-split follow-up to
+> 2026-06-29h); mean R1 0.9434 → 0.9435 (+0.0001), ru/uk +0.0010 each, ZERO regressions.)** The
+> ru/uk i18n dicts emitted UNDERSCORE compounds for several events (`мышь_вниз` mousedown,
+> `изменение_размера` resize, …) which the semantic tokenizer SPLITS on `_` (→ `мышь`+`_`+`вниз`),
+> so the event typed as a bare expression — the on.event residue flagged in 2026-06-29h. **Fix
+> (the #510 tr-resize route, two-package): the i18n dict now emits the FUSED form (`мышьвниз` /
+> `изменениеразмера`; uk `мишавниз` / `змінарозміру`), registered in the ru/uk tokenizer EXTRAS.**
+> Covers the two underscore-event patterns in the priority corpus — `repeat-until-event`
+> (mousedown) and `window-resize` (resize) — so it completes BOTH the resize family (ru/uk were the
+> non-Latin gap from 2026-06-29g) and mousedown. R0 1.000 / precision flat / R2 1.000 / parse-rate
+> 3696/3696. Guards: `grammar.test.ts` "ru/uk fused … event keywords" (dict emits fused, no `_`) +
+> `multilingual-roadmap-fixes.test.ts` "Event-keyword alignment" gained 4 ru/uk cases. **Latent
+> (not in priority corpus, same fix when they get coverage):** the OTHER ru/uk underscore events
+> (dblclick/mouseenter/mouseleave/mousemove/keydown/keyup/keypress/touchstart) are still
+> underscore forms in the dict. **The `on.event` event-keyword-alignment seam is now essentially
+> exhausted** — the remaining `on.event` misses are singletons (hi default-value/load) or the
+> repeat until-event `repeat.event`/`repeat.loopType` capture (the repeat-cluster arc).
+>
 > **Update 2026-06-29h (Arc B R1 — `mousedown`/`mouseup` event-keyword alignment (continues
 > 2026-06-29g); mean R1 0.9433 → 0.9434 (+0.0002), es/pt/ja/ko +0.0010 each, ZERO regressions.)**
 > The `repeat-until-event` pattern (`on mousedown repeat until event mouseup …`) has TWO events:

--- a/packages/i18n/src/dictionaries/ru.ts
+++ b/packages/i18n/src/dictionaries/ru.ts
@@ -96,8 +96,11 @@ export const russianDictionary: Dictionary = {
   events: {
     click: 'клик',
     dblclick: 'двойной_клик',
-    mousedown: 'мышь_вниз',
-    mouseup: 'мышь_вверх',
+    // Fused (no `_`): the semantic tokenizer splits on `_`, so an underscore form
+    // breaks event recognition (mousedown → bare expression). Mirrors the #510 tr
+    // resize fix (boyut_değiştir → boyutlandırma) and the enyakın superlative.
+    mousedown: 'мышьвниз',
+    mouseup: 'мышьвверх',
     mouseenter: 'мышь_вход',
     mouseleave: 'мышь_выход',
     mouseover: 'наведение',
@@ -114,7 +117,7 @@ export const russianDictionary: Dictionary = {
     reset: 'сброс',
     load: 'загрузка',
     unload: 'выгрузка',
-    resize: 'изменение_размера',
+    resize: 'изменениеразмера', // fused (no `_`) — see mousedown note above
     scroll: 'прокрутка',
     touchstart: 'касание_начало',
     touchend: 'касание_конец',

--- a/packages/i18n/src/dictionaries/uk.ts
+++ b/packages/i18n/src/dictionaries/uk.ts
@@ -96,8 +96,10 @@ export const ukrainianDictionary: Dictionary = {
   events: {
     click: 'клік',
     dblclick: 'подвійний_клік',
-    mousedown: 'миша_вниз',
-    mouseup: 'миша_вгору',
+    // Fused (no `_`): the semantic tokenizer splits on `_`, so an underscore form
+    // breaks event recognition. Mirrors the #510 tr resize fix + enyakın.
+    mousedown: 'мишавниз',
+    mouseup: 'мишавгору',
     mouseenter: 'миша_вхід',
     mouseleave: 'миша_вихід',
     mouseover: 'наведення',
@@ -114,7 +116,7 @@ export const ukrainianDictionary: Dictionary = {
     reset: 'скидання',
     load: 'завантаження',
     unload: 'вивантаження',
-    resize: 'зміна_розміру',
+    resize: 'змінарозміру', // fused (no `_`) — see mousedown note above
     scroll: 'прокрутка',
     touchstart: 'дотик_початок',
     touchend: 'дотик_кінець',

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -2249,3 +2249,25 @@ describe('tr resize single-token event keyword (window-resize NULL → faithful)
     expect(result).not.toContain('değiştir'); // the toggle-homonym fragment is gone
   });
 });
+
+describe('ru/uk fused (no-underscore) event keywords (mousedown/mouseup/resize)', () => {
+  // The semantic tokenizer splits on `_`, so the old underscore forms
+  // (мышь_вниз / изменение_размера) broke event recognition → the event typed as
+  // a bare expression. The dict now emits the FUSED form (мышьвниз / изменениеразмера),
+  // registered in the ru/uk tokenizer EXTRAS. Mirrors the #510 tr resize route.
+  it('[ru] emits fused mousedown/mouseup/resize (no underscore)', () => {
+    const tr = new GrammarTransformer('en', 'ru');
+    expect(tr.transform('on mousedown toggle .x')).toContain('мышьвниз');
+    expect(tr.transform('on mouseup toggle .x')).toContain('мышьвверх');
+    expect(tr.transform('on resize call f()')).toContain('изменениеразмера');
+    expect(tr.transform('on mousedown toggle .x')).not.toContain('мышь_вниз');
+  });
+
+  it('[uk] emits fused mousedown/mouseup/resize (no underscore)', () => {
+    const tr = new GrammarTransformer('en', 'uk');
+    expect(tr.transform('on mousedown toggle .x')).toContain('мишавниз');
+    expect(tr.transform('on mouseup toggle .x')).toContain('мишавгору');
+    expect(tr.transform('on resize call f()')).toContain('змінарозміру');
+    expect(tr.transform('on mousedown toggle .x')).not.toContain('миша_вниз');
+  });
+});

--- a/packages/semantic/src/tokenizers/russian.ts
+++ b/packages/semantic/src/tokenizers/russian.ts
@@ -82,6 +82,13 @@ const PREPOSITIONS = new Set([
  * are now in the profile.
  */
 const RUSSIAN_EXTRAS: KeywordEntry[] = [
+  // Fused event names (the i18n dict emits these WITHOUT `_`, since the tokenizer
+  // splits on `_` — see ru.ts events note). Recognize them so the event types as
+  // a literal, not a bare expression (window-resize, repeat-until-event).
+  { native: 'мышьвниз', normalized: 'mousedown' },
+  { native: 'мышьвверх', normalized: 'mouseup' },
+  { native: 'изменениеразмера', normalized: 'resize' },
+
   // Values/Literals (not in profile - generic across all languages)
   { native: 'истина', normalized: 'true' },
   { native: 'правда', normalized: 'true' },

--- a/packages/semantic/src/tokenizers/ukrainian.ts
+++ b/packages/semantic/src/tokenizers/ukrainian.ts
@@ -78,6 +78,13 @@ const PREPOSITIONS = new Set([
  * are now in the profile.
  */
 const UKRAINIAN_EXTRAS: KeywordEntry[] = [
+  // Fused event names (the i18n dict emits these WITHOUT `_`, since the tokenizer
+  // splits on `_` — see uk.ts events note). Recognize them so the event types as
+  // a literal, not a bare expression (window-resize, repeat-until-event).
+  { native: 'мишавниз', normalized: 'mousedown' },
+  { native: 'мишавгору', normalized: 'mouseup' },
+  { native: 'змінарозміру', normalized: 'resize' },
+
   // Values/Literals (not in profile - generic across all languages)
   { native: 'істина', normalized: 'true' },
   { native: 'правда', normalized: 'true' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1197,6 +1197,14 @@ describe('Event-keyword alignment: i18n-emitted event words recognized (on.event
     ['pt', 'mousedown', 'em mouseBaixo alternar .x'],
     ['ja', 'mousedown', '.x を マウス押下 で 切り替え'],
     ['ko', 'mousedown', '.x 를 마우스다운 할 때 토글'],
+    // ru/uk FUSED event forms: the i18n dict emits underscore compounds
+    // (мышь_вниз) that the tokenizer splits, breaking event recognition; the dict
+    // now emits the fused form (мышьвниз) which is registered in the tokenizer
+    // EXTRAS. Covers mousedown (repeat-until-event) and resize (window-resize).
+    ['ru', 'mousedown', 'при мышьвниз переключить .x'],
+    ['ru', 'resize', 'при изменениеразмера переключить .x'],
+    ['uk', 'mousedown', 'при мишавниз перемкнути .x'],
+    ['uk', 'resize', 'при змінарозміру перемкнути .x'],
   ];
   for (const [lang, ev, text] of cases) {
     it(`[${lang}] ${ev} event (i18n-emitted word) types as literal`, () => {

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-29T18:18:29.388Z",
-  "commit": "2c64b82a",
+  "timestamp": "2026-06-29T19:20:51.923Z",
+  "commit": "c925c2f2",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -10111,10 +10111,10 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8142650999793837,
+      "avgConfidence": 0.8135642135642115,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367965,
-      "avgRoleFidelity": 0.9444047716106543,
+      "avgRoleFidelity": 0.9453700225759052,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
@@ -10354,10 +10354,6 @@
           "confidence": 0.8222222222222222
         },
         "input-clear": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "window-resize": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -10618,6 +10614,10 @@
           "confidence": 0.7142857142857143
         },
         "window-scroll": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-resize": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -13271,10 +13271,10 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8146773861059555,
+      "avgConfidence": 0.8139764996907833,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367963,
-      "avgRoleFidelity": 0.9444047716106543,
+      "avgRoleFidelity": 0.945370022575905,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
@@ -13518,10 +13518,6 @@
           "confidence": 0.8222222222222222
         },
         "window-scroll": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "window-resize": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -13770,6 +13766,10 @@
           "confidence": 0.7142857142857143
         },
         "form-submit-prevent": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "window-resize": {
           "success": true,
           "confidence": 0.7142857142857143
         },


### PR DESCRIPTION
## Summary

Completes the `on.event` event-keyword-alignment audit (after #533 resize / #534 mousedown). The ru/uk i18n dicts emitted **underscore compounds** (`мышь_вниз` mousedown, `изменение_размера` resize, …) which the semantic tokenizer **splits on `_`** (→ `мышь`+`_`+`вниз`), so the event typed as a bare `expression`.

**Fix (the #510 tr-resize route, two-package):** the i18n dict now emits the **fused** form (ru `мышьвниз`/`изменениеразмера`, uk `мишавниз`/`змінарозміру`), registered in the ru/uk tokenizer EXTRAS. Covers the two underscore-event patterns in the priority corpus — `repeat-until-event` (mousedown) and `window-resize` (resize) — so it completes **both** the resize family (ru/uk were the non-Latin gap from #533) and mousedown.

## Results (gate-verified, zero regression)

- **Mean R1 0.9434 → 0.9435 (+0.0001)** — `ru/uk +0.0010` each, all others flat, **zero drops**.
- `--regression` gate: ✓ No regression, no within-tolerance warning. parse-rate 3696/3696 / R0 1.000 / precision flat / R2 1.000. Baseline regenerated.
- semantic suite 6344 + i18n 895 green; typecheck clean. Guards: `grammar.test.ts` "ru/uk fused … event keywords" (dict emits fused, no `_`) + `multilingual-roadmap-fixes.test.ts` "Event-keyword alignment" gained 4 ru/uk cases.

## Scope / follow-up

The other ru/uk underscore events (dblclick/mouseenter/mouseleave/mousemove/keydown/keyup/keypress/touchstart) are not in the priority corpus — same fix when they get coverage (documented in `MULTILINGUAL_NEXT_STEPS.md` 2026-06-29i). With this, the `on.event` event-keyword seam is essentially exhausted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)