### PR TITLE
fix(multilingual): `{verb} {quantity} times` counted-loop HEAD patterns for verb-first langs (repeat.quantity:literal R1; mean R1 0.9435→0.9440, zero regressions)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,39 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-29j (Arc B R1 — `{verb} {quantity} times` counted-loop HEAD patterns for
+> verb-first langs; mean R1 0.9435 → 0.9440 (+0.0004), ar/tl +0.0017, he/zh +0.0034, ZERO
+> regressions. + a sharp scoping finding on the event-first majority.)** Mirrors the en
+> `repeat {quantity} times` HEAD pattern (#521) for verb-first languages: a new per-language
+> module (`packages/semantic/src/patterns/repeat.ts`, wired into `builders.ts`) emits
+> `{verb} [marker] {quantity} {countWord}` (priority 110 > the generated positional repeat's 100),
+> capturing `quantity:literal` + defaulting `loopType:literal="times"` and STOPPING after the count
+> word so the body parses separately. The count word is taken verbatim from the corpus (most langs
+> leave English `times`; th `ครั้ง`, vi `lần`, tl `beses`). Covers all verb-first langs
+> (es/de/fr/it/pt/ru/uk/pl/ar/he/id/ms/sw/th/vi/tl/zh).
+>
+> **GROUNDING FINDING (sharp, load-bearing for the next session): only the verb-first-INPUT langs
+> gain — ar/he/tl/zh.** The corpus `repeat-times` is always `on click repeat N times …`, i.e. the
+> repeat sits in the EVENT-HANDLER BODY. For ar/he/tl/zh the repeat verb is at/near the input head,
+> so it reaches the standalone command path and the HEAD pattern fires. For the event-first majority
+> (es/de/fr/it/pt/ru/uk/pl/id/ms/sw/th/vi) the repeat is captured by the fused/generated
+> event-handler body path, and **`repeat` is a BLOCK_BODY_ACTION whose fused-body re-parse is
+> deliberately SKIPPED** (#530/#532's block-body guard — re-parsing a block-body clause would
+> swallow its inline body). VERIFIED: es STANDALONE `repetir 3 times …` captures
+> `quantity:literal`+`loopType:literal` perfectly, but es IN-HANDLER `en clic repetir 3 times …`
+> still yields the phantom `loopType:literal=3`. So the event-first langs' HEAD patterns are correct
+>
+> - forward-looking but inert until the block-body unlock lands. **The unlock = a HEAD-only-aware
+>   refinement of the block-body guard: allow the fused-body re-parse for a block-body action when the
+>   re-parse is HEAD-only (consumes only up to the count/loop-keyword, leaving the body) — then the
+>   repeat HEAD pattern fires in-handler and ~13 more langs gain `repeat.quantity:literal` +
+>   `repeat.loopType:literal="times"`.** That is the next high-leverage repeat-cluster slice (also
+>   unblocks the SOV `repeat forever`/until-event drops). R0 1.000 / precision flat / R2 1.000 /
+>   parse-rate 3696/3696. Guard: `multilingual-roadmap-fixes.test.ts` "Counted-loop HEAD patterns"
+>   (5 cases incl. the es standalone-vs-in-handler distinction; failing-without-fix verified).
+>   **Also deferred:** SOV langs (ja/ko/tr/hi/bn/qu) front the count ahead of a clause-final verb —
+>   a different HEAD structure.
+>
 > **Update 2026-06-29i (Arc B R1 — ru/uk FUSED event keywords (the underscore-split follow-up to
 > 2026-06-29h); mean R1 0.9434 → 0.9435 (+0.0001), ru/uk +0.0010 each, ZERO regressions.)** The
 > ru/uk i18n dicts emitted UNDERSCORE compounds for several events (`мышь_вниз` mousedown,

--- a/packages/semantic/src/patterns/builders.ts
+++ b/packages/semantic/src/patterns/builders.ts
@@ -23,6 +23,7 @@ import { getIncrementPatternsForLanguage } from './increment';
 import { getDecrementPatternsForLanguage } from './decrement';
 import { getWaitPatternsForLanguage } from './wait';
 import { getFetchPatternsForLanguage } from './fetch';
+import { getRepeatPatternsForLanguage } from './repeat';
 import { getAppendPatternsForLanguage } from './append';
 import { getPrependPatternsForLanguage } from './prepend';
 import { getTriggerPatternsForLanguage } from './trigger';
@@ -70,6 +71,7 @@ const PATTERN_LOADERS: PatternLoader[] = [
   getDecrementPatternsForLanguage,
   getWaitPatternsForLanguage,
   getFetchPatternsForLanguage,
+  getRepeatPatternsForLanguage,
   getAppendPatternsForLanguage,
   getPrependPatternsForLanguage,
   getTriggerPatternsForLanguage,

--- a/packages/semantic/src/patterns/repeat.ts
+++ b/packages/semantic/src/patterns/repeat.ts
@@ -1,0 +1,85 @@
+/**
+ * Counted-loop HEAD patterns: `{verb} [marker] {quantity} {countWord}`.
+ *
+ * Mirrors the English `repeat {quantity} times` HEAD pattern (en.ts, #521): it
+ * captures the count as `quantity:literal` and defaults `loopType:literal="times"`,
+ * stopping after the count word so the loop BODY is parsed by the surrounding
+ * clause loop (not swallowed). Without it the generated positional `repeat` pattern
+ * grabs the NUMBER as `loopType` and drops `quantity` — the `repeat.quantity:literal`
+ * R1 residue.
+ *
+ * Verb-FIRST languages only (SVO/VSO): the count phrase follows the verb, so the
+ * en-shaped HEAD pattern applies directly. SOV languages (ja/ko/tr/hi/bn/qu) front
+ * the count ahead of a clause-final verb — a different structure, left for later.
+ *
+ * The count word is taken VERBATIM from the corpus: most languages leave the
+ * English `times` untranslated (es `repetir 3 times`); a few translate it
+ * (th `ครั้ง`, vi `lần`, tl `beses`).
+ */
+
+import type { LanguagePattern } from '../types';
+
+/**
+ * One verb-first counted-loop HEAD pattern.
+ * @param markerBefore optional token between the verb and the count (he accusative
+ *   `את`, zh object marker `把`).
+ */
+function repeatTimesHead(
+  language: string,
+  verb: string,
+  countWord: string,
+  markerBefore?: string
+): LanguagePattern {
+  const tokens: LanguagePattern['template']['tokens'] = [];
+  // The verb may be multi-word (vi `lặp lại`); split into literal tokens.
+  for (const w of verb.split(/\s+/)) tokens.push({ type: 'literal', value: w });
+  if (markerBefore) tokens.push({ type: 'literal', value: markerBefore });
+  tokens.push({ type: 'role', role: 'quantity', expectedTypes: ['literal', 'expression'] });
+  tokens.push({ type: 'literal', value: countWord });
+  return {
+    id: `repeat-${language}-times`,
+    language,
+    command: 'repeat',
+    priority: 110, // > the generated positional repeat (100)
+    template: {
+      format: `${verb}${markerBefore ? ' ' + markerBefore : ''} {quantity} ${countWord}`,
+      tokens,
+    },
+    extraction: {
+      loopType: { default: { type: 'literal', value: 'times' } },
+    },
+  };
+}
+
+// [lang, repeat-verb (corpus form), count-word, markerBefore?]
+const VERB_FIRST_REPEAT_TIMES: Array<[string, string, string, string?]> = [
+  ['es', 'repetir', 'times'],
+  ['de', 'wiederholen', 'times'],
+  ['fr', 'répéter', 'times'],
+  ['it', 'ripetere', 'times'],
+  ['pt', 'repetir', 'times'],
+  ['ru', 'повторить', 'times'],
+  ['uk', 'повторити', 'times'],
+  ['pl', 'powtórz', 'times'],
+  ['ar', 'كرر', 'times'],
+  ['he', 'חזור', 'times', 'את'],
+  ['id', 'ulangi', 'times'],
+  ['ms', 'ulang', 'times'],
+  ['sw', 'rudia', 'times'],
+  ['th', 'ทำซ้ำ', 'ครั้ง'],
+  ['vi', 'lặp lại', 'lần'],
+  ['tl', 'ulitin', 'beses'],
+  ['zh', '重复', 'times', '把'],
+];
+
+const BY_LANG = new Map<string, LanguagePattern[]>();
+for (const [lang, verb, countWord, marker] of VERB_FIRST_REPEAT_TIMES) {
+  BY_LANG.set(lang, [repeatTimesHead(lang, verb, countWord, marker)]);
+}
+
+/**
+ * Get counted-loop HEAD patterns for a specific language.
+ */
+export function getRepeatPatternsForLanguage(language: string): LanguagePattern[] {
+  return BY_LANG.get(language) ?? [];
+}

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -8912,3 +8912,62 @@ describe('Fused event-handler body re-parses secondary role clauses (fetch.respo
     expect(commandSig(node, 'repeat')).toBeTruthy();
   });
 });
+
+describe('Counted-loop HEAD patterns: `{verb} {quantity} times` (repeat.quantity:literal)', () => {
+  // Mirrors the en `repeat {quantity} times` HEAD pattern (#521) for verb-first
+  // languages. Captures quantity:literal + loopType:literal="times", stopping after
+  // the count word so the body is parsed separately. Without it the generated
+  // positional repeat grabs the NUMBER as loopType and drops quantity.
+  function repeatRoles(node: unknown): string[] | undefined {
+    if (!node || typeof node !== 'object') return undefined;
+    const rec = node as Record<string, unknown>;
+    if (rec.action === 'repeat' && rec.roles instanceof Map) {
+      return [...rec.roles.entries()].map(([k, v]) => {
+        const t =
+          v !== null && typeof v === 'object' && typeof (v as { type?: unknown }).type === 'string'
+            ? (v as { type: string }).type
+            : typeof v;
+        return `${k}:${t}`;
+      });
+    }
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      const c = rec[f];
+      if (Array.isArray(c)) {
+        for (const x of c) {
+          const r = repeatRoles(x);
+          if (r) return r;
+        }
+      } else if (c && typeof c === 'object') {
+        const r = repeatRoles(c);
+        if (r) return r;
+      }
+    }
+    return undefined;
+  }
+
+  // Verb-FIRST-input langs (the repeat reaches the standalone command path): the
+  // corpus repeat-times texts gain quantity:literal + loopType:literal="times".
+  for (const [lang, src] of [
+    ['ar', 'كرر 3 times عند نقر ثم أضف "<p>Line</p>" إلى أنا'],
+    ['he', 'ב לחיצה חזור את 3 times אז הוסף את "<p>Line</p>" על אני'],
+    ['tl', 'ulitin 3 beses kapag click pagkatapos idagdag "<p>Line</p>" sa ako'],
+    ['zh', '当 点击 时 重复 把 3 times 那么 添加 把 "<p>Line</p>" 到 我'],
+  ] as [string, string][]) {
+    it(`[${lang}] repeat-times captures quantity:literal + loopType:literal`, () => {
+      const roles = repeatRoles(parse(src, lang));
+      expect(roles).toBeTruthy();
+      expect(roles).toContain('quantity:literal');
+      expect(roles).toContain('loopType:literal');
+    });
+  }
+
+  // The HEAD pattern is HEAD-only: a STANDALONE counted loop captures the count and
+  // leaves the body for the clause loop (es, the verb is the clause head). The
+  // in-EVENT-HANDLER es case still mis-captures (block-body fused-body re-parse is
+  // deferred — see MULTILINGUAL_NEXT_STEPS.md), so this asserts the standalone form.
+  it('[es] standalone repeat-times captures quantity:literal (HEAD-only)', () => {
+    const roles = repeatRoles(parse('repetir 3 times agregar "<p>x</p>" a yo', 'es'));
+    expect(roles).toContain('quantity:literal');
+    expect(roles).toContain('loopType:literal');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,15 +1,15 @@
 {
-  "timestamp": "2026-06-29T19:20:51.923Z",
-  "commit": "c925c2f2",
+  "timestamp": "2026-06-29T19:35:26.135Z",
+  "commit": "0c5494db",
   "languages": {
     "ar": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8371917985695063,
+      "avgConfidence": 0.8387196824503315,
       "avgFidelity": 1,
       "avgPrecision": 0.9796536796536797,
-      "avgRoleFidelity": 0.9572494521023932,
+      "avgRoleFidelity": 0.9589386412915825,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
@@ -77,6 +77,10 @@
           "confidence": 1
         },
         "multiple-events": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-times": {
           "success": true,
           "confidence": 1
         },
@@ -435,10 +439,6 @@
         "take-class-from-siblings": {
           "success": true,
           "confidence": 0.7777777777777777
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.7647058823529411
         },
         "repeat-for-each": {
           "success": true,
@@ -3794,7 +3794,7 @@
       "avgConfidence": 0.8237889095031952,
       "avgFidelity": 1,
       "avgPrecision": 0.9851731601731601,
-      "avgRoleFidelity": 0.9558013572719452,
+      "avgRoleFidelity": 0.9591797356503236,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
@@ -12007,10 +12007,10 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8216537651743292,
+      "avgConfidence": 0.8231816490551542,
       "avgFidelity": 1,
       "avgPrecision": 0.9800865800865801,
-      "avgRoleFidelity": 0.9668215241744652,
+      "avgRoleFidelity": 0.9685107133636545,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
@@ -12066,6 +12066,10 @@
           "confidence": 1
         },
         "send-with-detail": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-times": {
           "success": true,
           "confidence": 1
         },
@@ -12380,10 +12384,6 @@
         "take-class-from-siblings": {
           "success": true,
           "confidence": 0.7777777777777777
-        },
-        "repeat-times": {
-          "success": true,
-          "confidence": 0.7647058823529411
         },
         "repeat-for-each": {
           "success": true,
@@ -14538,7 +14538,7 @@
       "avgConfidence": 0.9840032982890127,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9586166725872605,
+      "avgRoleFidelity": 0.9619950509656388,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],


### PR DESCRIPTION
## Summary

Mirrors the en `repeat {quantity} times` HEAD pattern (#521) for verb-first languages. A new per-language module (`packages/semantic/src/patterns/repeat.ts`, wired into `builders.ts`) emits `{verb} [marker] {quantity} {countWord}` (priority 110 > the generated positional repeat's 100), capturing `quantity:literal` + defaulting `loopType:literal="times"` and **stopping after the count word** so the loop body parses separately. Without it the generated pattern grabs the *number* as `loopType` and drops `quantity` (the `repeat.quantity:literal` residue). The count word is verbatim from the corpus (most langs leave English `times`; th `ครั้ง`, vi `lần`, tl `beses`).

## Results (gate-verified, zero regression)

- **Mean R1 0.9435 → 0.9440 (+0.0004)** — `ar/tl +0.0017`, `he/zh +0.0034`, all others flat, **zero drops**.
- `--regression` gate: ✓ No regression, no within-tolerance warning. parse-rate 3696/3696 / R0 1.000 / precision flat / R2 1.000. Baseline regenerated.
- semantic suite 6349 green; typecheck clean. Guard: `multilingual-roadmap-fixes.test.ts` "Counted-loop HEAD patterns" (5 cases; failing-without-fix verified).

## Grounding finding (documented for the next session — `MULTILINGUAL_NEXT_STEPS.md` 2026-06-29j)

Only the **verb-first-input** langs gain (ar/he/tl/zh). The corpus `repeat-times` is always `on click repeat N times …` — the repeat sits in the **event-handler body**. For the event-first majority (es/de/fr/it/pt/ru/uk/pl/id/ms/sw/th/vi) the repeat is captured by the fused-body path, and **`repeat` is a `BLOCK_BODY_ACTION` whose fused-body re-parse is deliberately skipped** (#530/#532's block-body guard). **Verified:** es *standalone* `repetir 3 times …` captures `quantity:literal` perfectly; es *in-handler* still yields phantom `loopType:literal=3`. So the event-first HEAD patterns are correct + forward-looking but inert until a **HEAD-only-aware refinement of the block-body guard** lands (the next repeat-cluster slice — would unlock ~13 more langs + the SOV `repeat forever`/until-event drops). SOV langs (which front the count) are a separate deferred HEAD structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)