### PR TITLE
fix(multilingual): block-body-guard HEAD-only exception unlocks in-handler repeat-times (11 langs +0.0017; mean R1 0.9440→0.9448, zero regressions)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,29 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-29k (Arc B R1 — block-body-guard HEAD-only exception UNLOCKS in-handler
+> repeat-times for the event-first langs; mean R1 0.9440 → 0.9448 (+0.0008), 11 langs +0.0017,
+> ZERO regressions. The largest win of this continuation; delivers the unlock predicted in 2026-06-29j.)**
+> #530/#532's fused-body re-parse SKIPS block-body actions (`repeat`/`if`/`for`/`while`/`unless`)
+> because re-parsing `[verb..boundary]` would swallow their inline body (the #530 repeat-forever
+> regression). But the counted-loop HEAD (`repeat {n} times`) is HEAD-ONLY — it stops after the
+> count word — so for the event-first langs whose corpus `repeat-times` puts the loop in the FUSED
+> event body (`en clic repetir 3 times entonces …` → fused `repeat{loopType:literal=3}`, the number
+> mistyped as loopType, body dropped), the HEAD re-parse recovers `quantity:literal` +
+> `loopType:literal="times"` without a body. **Fix (`buildEventHandler`, semantic-parser.ts): allow
+> `repeat` to ENTER the re-parse block, and gate the swap on the re-parse matching a HEAD-ONLY
+> pattern (`patternId` matches `/^repeat-.*-times$/`).** The body-swallowing GENERATED repeat (which
+> matches `repetir forever alternar .pulse` → `quantity:literal="toggle"`, swallowing the toggle) is
+> NOT a `-times` pattern, so the repeat-forever hazard stays excluded — VERIFIED: es/de in-handler
+> repeat-forever keep `loopType="forever"` + the toggle body survives. **11 langs gain
+> (de/es/fr/id/it/pl/pt/ru/sw/th/uk +0.0017); R0 1.000 / precision flat / R2 1.000 / parse-rate
+> 3696/3696.** Guard: `multilingual-roadmap-fixes.test.ts` "Counted-loop HEAD patterns" gained 4
+> in-handler cases + a repeat-forever hazard guard (failing-without-fix verified). **Residual:** vi
+> (two-word verb `lặp lại`) — the verb-finder lands mid-verb so the HEAD doesn't match in-handler;
+> ms net-neutral. SOV repeat-times (fronted count) still needs its own HEAD structure. The
+> general block-body-HEAD-exception now also positions the SOV `repeat forever`/until-event capture
+> (same mechanism, a HEAD-only SOV loop pattern) as the next repeat-cluster slice.
+>
 > **Update 2026-06-29j (Arc B R1 — `{verb} {quantity} times` counted-loop HEAD patterns for
 > verb-first langs; mean R1 0.9435 → 0.9440 (+0.0004), ar/tl +0.0017, he/zh +0.0034, ZERO
 > regressions. + a sharp scoping finding on the event-first majority.)** Mirrors the en

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -982,7 +982,15 @@ export class SemanticParserImpl implements ISemanticParser {
       // standalone `fetch-ar` pattern then recovers the `كـ {responseType}` tail.
       // If the event token can't be located in the clause, the swap is skipped
       // (re-parsing with the event still inside is the #530 hazard).
-      if (!BLOCK_BODY_ACTIONS.has(actionName)) {
+      // Block-body actions (`repeat`/`if`/`for`/`while`/`unless`) are normally NOT
+      // re-parsed: their inline body sits in the SAME clause, so re-parsing
+      // [verb..boundary] would swallow it (#530's repeat-forever regression). The
+      // ONE exception is a counted-loop HEAD (`repeat {n} times`): it is HEAD-ONLY
+      // (stops after the count word), so re-parsing recovers `quantity:literal` +
+      // `loopType:literal="times"` (which the fused capture mistypes as the number
+      // under `loopType`) WITHOUT a body — gated below on the re-parse matching a
+      // `-times` HEAD pattern, which the body-swallowing generated repeat never is.
+      if (!BLOCK_BODY_ACTIONS.has(actionName) || actionName === 'repeat') {
         const isVerbFirst = match.pattern.id.includes('verb-first');
         const all = tokens.tokens;
         const pos = tokens.position();
@@ -1078,12 +1086,24 @@ export class SemanticParserImpl implements ISemanticParser {
                 const rv = (first as CommandSemanticNode).roles.get(mapRole(role));
                 return rv !== undefined && valType(rv) === valType(val);
               });
+            // For a block-body action (only `repeat` reaches here) the swap is
+            // additionally gated on the re-parse matching a HEAD-ONLY counted-loop
+            // pattern (`repeat-<lang>-times`): it stops after the count word so no
+            // body is swallowed. The body-swallowing generated repeat (matching
+            // `repetir forever alternar …` → quantity:literal="toggle") is NOT a
+            // `-times` pattern, so the #530 repeat-forever hazard stays excluded.
+            const reparsePid =
+              (first as { metadata?: { patternId?: string } } | undefined)?.metadata?.patternId ??
+              '';
+            const headOnlyOk =
+              !BLOCK_BODY_ACTIONS.has(actionName) || /^repeat-.*-times$/.test(reparsePid);
             if (
               reparsed.length === 1 &&
               first &&
               first.kind === 'command' &&
               first.action === actionName &&
               preservesFused &&
+              headOnlyOk &&
               (first as CommandSemanticNode).roles.size > Object.keys(roles).length
             ) {
               commandNode = first as CommandSemanticNode;

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -8962,12 +8962,48 @@ describe('Counted-loop HEAD patterns: `{verb} {quantity} times` (repeat.quantity
   }
 
   // The HEAD pattern is HEAD-only: a STANDALONE counted loop captures the count and
-  // leaves the body for the clause loop (es, the verb is the clause head). The
-  // in-EVENT-HANDLER es case still mis-captures (block-body fused-body re-parse is
-  // deferred — see MULTILINGUAL_NEXT_STEPS.md), so this asserts the standalone form.
+  // leaves the body for the clause loop (es, the verb is the clause head).
   it('[es] standalone repeat-times captures quantity:literal (HEAD-only)', () => {
     const roles = repeatRoles(parse('repetir 3 times agregar "<p>x</p>" a yo', 'es'));
     expect(roles).toContain('quantity:literal');
     expect(roles).toContain('loopType:literal');
+  });
+
+  // IN-EVENT-HANDLER (event-first langs): the repeat sits in the fused-event body
+  // and `repeat` is a BLOCK_BODY_ACTION, so the fused-body re-parse is normally
+  // skipped. The block-body guard now makes an exception for a HEAD-ONLY counted
+  // loop (re-parse matched a `repeat-<lang>-times` pattern), recovering quantity +
+  // loopType="times" without swallowing the body. Corpus repeat-times texts.
+  for (const [lang, src] of [
+    ['es', 'en clic repetir 3 times entonces agregar "<p>x</p>" a yo'],
+    ['de', 'bei klick wiederholen 3 times dann hinzufügen "<p>x</p>" zu ich'],
+    ['ru', 'при клик повторить 3 times затем добавить "<p>x</p>" в я'],
+    ['it', 'su clic ripetere 3 times allora aggiungere "<p>x</p>" in io'],
+  ] as [string, string][]) {
+    it(`[${lang}] in-handler repeat-times captures quantity:literal (block-body HEAD exception)`, () => {
+      const roles = repeatRoles(parse(src, lang));
+      expect(roles).toContain('quantity:literal');
+      expect(roles).toContain('loopType:literal');
+    });
+  }
+
+  // HAZARD GUARD: repeat-FOREVER in a handler must NOT trigger the block-body
+  // exception (its re-parse matches the body-swallowing generated pattern, not a
+  // `-times` HEAD) — loopType stays "forever" and the toggle body survives (#530).
+  it('[es] in-handler repeat-forever keeps loopType="forever" + body (not swallowed)', () => {
+    const node = parse('en cargar repetir forever alternar .pulse entonces esperar 1s fin', 'es');
+    const roles = repeatRoles(node);
+    expect(roles).toContain('loopType:literal');
+    expect(roles).not.toContain('quantity:literal'); // no swallowed body verb
+    const hasToggle = (n: unknown): boolean => {
+      if (!n || typeof n !== 'object') return false;
+      const r = n as Record<string, unknown>;
+      if (r.action === 'toggle') return true;
+      return ['body', 'statements', 'thenBranch', 'elseBranch'].some(f => {
+        const c = r[f];
+        return Array.isArray(c) ? c.some(hasToggle) : !!c && typeof c === 'object' && hasToggle(c);
+      });
+    };
+    expect(hasToggle(node)).toBe(true); // body survives
   });
 });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-29T19:35:26.135Z",
-  "commit": "0c5494db",
+  "timestamp": "2026-06-29T21:45:34.118Z",
+  "commit": "0a720302",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.828035456606883,
       "avgFidelity": 1,
       "avgPrecision": 0.9967532467532467,
-      "avgRoleFidelity": 0.95137750873045,
+      "avgRoleFidelity": 0.9530666979196393,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
       "avgPrecision": 0.9846320346320346,
-      "avgRoleFidelity": 0.9530470798853153,
+      "avgRoleFidelity": 0.9547362690745045,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
       "avgPrecision": 0.9833333333333334,
-      "avgRoleFidelity": 0.9480793495499377,
+      "avgRoleFidelity": 0.9497685387391268,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
       "avgPrecision": 0.9829004329004329,
-      "avgRoleFidelity": 0.9517392594598475,
+      "avgRoleFidelity": 0.9534284486490368,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.976650432900433,
-      "avgRoleFidelity": 0.9548457879340235,
+      "avgRoleFidelity": 0.9565349771232127,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
       "avgPrecision": 0.9928841991341991,
-      "avgRoleFidelity": 0.943697139285375,
+      "avgRoleFidelity": 0.9453863284745642,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8850,12 @@
       "avgConfidence": 0.7984333127190251,
       "avgFidelity": 1,
       "avgPrecision": 0.9820346320346321,
-      "avgRoleFidelity": 0.9519209537591891,
+      "avgRoleFidelity": 0.9536101429483782,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.8135642135642115,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367965,
-      "avgRoleFidelity": 0.9453700225759052,
+      "avgRoleFidelity": 0.9470592117650943,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10746,12 +10746,12 @@
       "avgConfidence": 0.7962481962481944,
       "avgFidelity": 1,
       "avgPrecision": 0.9852813852813852,
-      "avgRoleFidelity": 0.9527045104250984,
+      "avgRoleFidelity": 0.9543936996142877,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.9753246753246753,
-      "avgRoleFidelity": 0.9509800524506408,
+      "avgRoleFidelity": 0.95266924163983,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13274,12 +13274,12 @@
       "avgConfidence": 0.8139764996907833,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367963,
-      "avgRoleFidelity": 0.945370022575905,
+      "avgRoleFidelity": 0.9470592117650941,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459500,
+      "bundleSize": 459594,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 459500,
+      "size": 459594,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Delivers the unlock predicted in `MULTILINGUAL_NEXT_STEPS.md` 2026-06-29j. #530/#532's fused-body re-parse **skips block-body actions** (`repeat`/`if`/`for`/`while`/`unless`) because re-parsing `[verb..boundary]` would swallow their inline body (the #530 repeat-forever regression). But the counted-loop HEAD (`repeat {n} times`) is **HEAD-only** — it stops after the count word — so for the event-first langs whose corpus `repeat-times` puts the loop in the **fused event body** (`en clic repetir 3 times entonces …` → fused `repeat{loopType:literal=3}`, the number mistyped as loopType, body dropped), the HEAD re-parse recovers `quantity:literal` + `loopType:literal="times"` without a body.

**Fix** (`buildEventHandler`): allow `repeat` to **enter** the re-parse block, and gate the swap on the re-parse matching a HEAD-only pattern (`patternId` matches `/^repeat-.*-times$/`). The body-swallowing **generated** repeat (which matches `repetir forever alternar .pulse` → `quantity:literal="toggle"`, swallowing the toggle) is **not** a `-times` pattern, so the repeat-forever hazard stays excluded.

## Results (gate-verified, zero regression)

- **Mean R1 0.9440 → 0.9448 (+0.0008)** — `de/es/fr/id/it/pl/pt/ru/sw/th/uk +0.0017`, all others flat, **zero drops**.
- **Hazard verified:** es/de in-handler repeat-forever keep `loopType="forever"` and the toggle body survives.
- `--regression` gate: ✓ No regression, no within-tolerance warning. parse-rate 3696/3696 / R0 1.000 / precision flat / R2 1.000. Baseline regenerated.
- semantic suite 6354 green; typecheck clean. Guard: `multilingual-roadmap-fixes.test.ts` "Counted-loop HEAD patterns" gained 4 in-handler cases + a repeat-forever hazard guard (failing-without-fix verified).

## Residual (documented, 2026-06-29k)

vi (two-word verb `lặp lại`) — the verb-finder lands mid-verb so the HEAD doesn't match in-handler. SOV repeat-times (fronted count) needs its own HEAD structure. The block-body-HEAD exception now also positions the SOV `repeat forever`/until-event capture (same mechanism) as the next repeat-cluster slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)