### PR TITLE
fix(multilingual): SOV repeat-forever loop-keyword recovery (6 SOV langs +0.0011; mean R1 0.9448→0.9451, zero regressions)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,35 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-29l (Arc B R1 — SOV repeat-forever loop-keyword recovery; mean R1 0.9448 →
+> 0.9451 (+0.0003), all 6 SOV langs (bn/hi/ja/ko/qu/tr) +0.0011, ZERO regressions. Lifts the SOV
+> laggards directly.)** The verb-first SOV loop head `{repeat-verb} forever <body>` (ja `繰り返し
+forever .pulse を 切り替え`) has its `forever` DROPPED by the fused SOV event pattern, so the loop
+> defaults to `loopType:reference="me"` (the normalizeCommandRoles default-patient→primaryRole leak)
+> while en is `loopType:literal="forever"`. **Grounding showed the general #537 re-parse mechanism
+> does NOT fit here** — it fights two load-bearing guards: `preservesFused` (fused `reference` vs
+> re-parse `literal` loopType) and `reparsed.length===1` (forever juxtaposes its body, no `then`).
+> **So a CONTAINED fix instead** (`buildEventHandler`, at the fused-capture site): when the action
+> is `repeat` and the token immediately after the verb is a `forever` keyword (en `forever` / native
+> hi `हमेशा` / bn `চিরকাল`, all normalized to `forever` — recognized since #527), set
+> `loopType:literal="forever"` AND **drop the SOV default-patient leak** (`delete roles.patient` —
+> else, with loopType now occupied, it surfaces as a phantom `patient:reference=me` the en reference
+> lacks; verified the phantom appears without the delete). The body (toggle/wait) is still recovered
+> by the trailing-body path. **All 6 SOV langs match en's `repeat{loopType:literal="forever"}`
+> exactly; SVO (es) unchanged (different path).** R0 1.000 / precision flat / R2 1.000 / parse-rate
+> 3696/3696. Guard: `multilingual-roadmap-fixes.test.ts` "SOV repeat-forever loop-keyword recovery"
+> (6 cases asserting loopType + no-phantom-patient + body-survives; failing-without-fix verified).
+>
+> **DEFERRED — SOV `repeat until event` (the other half of this slice).** Grounded as a genuine
+> dedicated arc, NOT contained: (1) the until head `{verb} {event-kw} {event} {marker} {until}`
+> (ja `繰り返し イベント マウス解放 を まで`) currently breaks into PHANTOM `event` + `until` commands
+> (ja/ko/bn) or fails outright (tr/hi/qu), so it needs a SOV until-event HEAD pattern; (2) capturing
+> it via the fused-body re-parse fights the SAME `preservesFused` reference-vs-literal guard as
+> forever did (fused `loopType:reference=me` → re-parse `loopType:literal="until-event"`) — needs a
+> principled relaxation allowing a default `reference:me` loopType to be replaced; (3) the event
+> token itself is an underscore-split compound for tr/hi/qu/bn (`fare_bırak` / `माउस_ऊपर` /
+> `rat_huqariy` / mouseup) — the #535-class fuse fix, per-lang. A multi-part arc.
+>
 > **Update 2026-06-29k (Arc B R1 — block-body-guard HEAD-only exception UNLOCKS in-handler
 > repeat-times for the event-first langs; mean R1 0.9440 → 0.9448 (+0.0008), 11 langs +0.0017,
 > ZERO regressions. The largest win of this continuation; delivers the unlock predicted in 2026-06-29j.)**

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -939,6 +939,35 @@ export class SemanticParserImpl implements ISemanticParser {
         }
       }
 
+      // SOV repeat: recover a dropped `forever` loop keyword. The verb-first SOV
+      // loop head is `{repeat-verb} forever <body>` (ja `繰り返し forever .pulse を
+      // 切り替え`), but the fused SOV event pattern captures only the verb and
+      // leaves `forever` unconsumed — so the loop defaults to `loopType:reference=me`
+      // (the dropped-keyword residue) and the body parser later SKIPS the stray
+      // `forever`. The keyword sits immediately after the verb (at the current
+      // position); recognize it (en `forever` / native hi हमेशा / bn চিরকাল, all
+      // normalized to `forever`), set `loopType:literal="forever"` to match the en
+      // reference, and consume it so it can't leak. The body (toggle/wait) is still
+      // recovered by the trailing-body path below.
+      if (actionName === 'repeat') {
+        const peeked = tokens.peek();
+        if (
+          peeked &&
+          peeked.kind === 'keyword' &&
+          ((peeked as { normalized?: string }).normalized ?? peeked.value).toLowerCase() ===
+            'forever'
+        ) {
+          roles.loopType = { type: 'literal', value: 'forever' };
+          // Drop the SOV default-patient leak (`reference:me`): repeat has no patient
+          // role, so `normalizeCommandRoles` would normally relabel it to the
+          // primaryRole `loopType` — but with loopType now set it would instead
+          // surface as a phantom `patient:reference=me` that the en reference lacks
+          // (a precision hit). en repeat-forever is `{loopType:literal="forever"}` only.
+          delete roles.patient;
+          tokens.advance();
+        }
+      }
+
       let commandNode = createCommandNode(actionName as ActionType, roles, {
         sourceLanguage: language,
         patternId: match.pattern.id,

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -9007,3 +9007,60 @@ describe('Counted-loop HEAD patterns: `{verb} {quantity} times` (repeat.quantity
     expect(hasToggle(node)).toBe(true); // body survives
   });
 });
+
+describe('SOV repeat-forever loop-keyword recovery (loopType:literal="forever")', () => {
+  // The verb-first SOV loop head `{repeat-verb} forever <body>` (ja `繰り返し forever
+  // .pulse を 切り替え`) has its `forever` dropped by the fused SOV event pattern →
+  // loopType defaults to reference:me. buildEventHandler now recovers the trailing
+  // `forever` keyword (en `forever` / native hi हमेशा / bn চিরকাল) as
+  // loopType:literal="forever" and drops the SOV default-patient leak, matching the
+  // en reference `repeat{loopType:literal="forever"}` (no patient). Body survives.
+  function repeatNode(node: unknown): Record<string, unknown> | undefined {
+    if (!node || typeof node !== 'object') return undefined;
+    const r = node as Record<string, unknown>;
+    if (r.action === 'repeat' && r.roles instanceof Map) return r;
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      const c = r[f];
+      if (Array.isArray(c)) {
+        for (const x of c) {
+          const m = repeatNode(x);
+          if (m) return m;
+        }
+      } else if (c && typeof c === 'object') {
+        const m = repeatNode(c);
+        if (m) return m;
+      }
+    }
+    return undefined;
+  }
+  function hasAction(n: unknown, act: string): boolean {
+    if (!n || typeof n !== 'object') return false;
+    const r = n as Record<string, unknown>;
+    if (r.action === act) return true;
+    return ['body', 'statements', 'thenBranch', 'elseBranch'].some(f => {
+      const c = r[f];
+      return Array.isArray(c)
+        ? c.some(x => hasAction(x, act))
+        : !!c && typeof c === 'object' && hasAction(c, act);
+    });
+  }
+  // Real corpus repeat-forever texts (head: `on <event> repeat forever toggle .pulse wait 1s end`).
+  for (const [lang, src] of [
+    ['ja', '読み込み で 繰り返し forever .pulse を 切り替え それから 待つ 1s 終わり'],
+    ['ko', '로드 할 때 반복 forever .pulse 를 토글 그러면 대기 1s 끝'],
+    ['tr', 'yükle de tekrarla forever .pulse i değiştir ardından bekle 1s son'],
+    ['hi', 'लोड पर दोहराएं हमेशा .pulse को टॉगल फिर प्रतीक्षा 1s समाप्त'],
+    ['bn', 'লোড এ পুনরাবৃত্তি চিরকাল .pulse কে টগল তারপর 1s কে অপেক্ষা শেষ'],
+    ['qu', 'apakuy pi kutipay forever .pulse ta tikray chayqa suyay 1s tukuy'],
+  ] as [string, string][]) {
+    it(`[${lang}] repeat-forever → loopType:literal="forever", no phantom patient, body survives`, () => {
+      const node = parse(src, lang);
+      const rep = repeatNode(node);
+      expect(rep).toBeTruthy();
+      const roles = rep!.roles as Map<string, { type?: string; value?: unknown }>;
+      expect(roles.get('loopType')).toMatchObject({ type: 'literal', value: 'forever' });
+      expect(roles.has('patient')).toBe(false); // no SOV default-patient leak
+      expect(hasAction(node, 'toggle')).toBe(true); // body survives
+    });
+  }
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-29T21:45:34.118Z",
-  "commit": "0a720302",
+  "timestamp": "2026-06-29T22:48:36.721Z",
+  "commit": "87035e2e",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -641,12 +641,12 @@
       "avgConfidence": 0.8495030867211314,
       "avgFidelity": 1,
       "avgPrecision": 0.929409218232748,
-      "avgRoleFidelity": 0.9186573329955682,
+      "avgRoleFidelity": 0.9197834591216945,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4426,12 +4426,12 @@
       "avgConfidence": 0.90909904631709,
       "avgFidelity": 1,
       "avgPrecision": 0.9365270281666384,
-      "avgRoleFidelity": 0.9034010052392405,
+      "avgRoleFidelity": 0.9045271313653666,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
       "avgPrecision": 0.9482462613144433,
-      "avgRoleFidelity": 0.9202174095556448,
+      "avgRoleFidelity": 0.921343535681771,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6954,12 @@
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
       "avgPrecision": 0.9482462613144431,
-      "avgRoleFidelity": 0.9171768690151044,
+      "avgRoleFidelity": 0.9183029951412305,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9482,12 @@
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
       "avgPrecision": 0.9512456428852532,
-      "avgRoleFidelity": 0.9077252349311175,
+      "avgRoleFidelity": 0.9088513610572435,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12642,12 +12642,12 @@
       "avgConfidence": 0.827517929021688,
       "avgFidelity": 1,
       "avgPrecision": 0.9508127424523529,
-      "avgRoleFidelity": 0.922635268591151,
+      "avgRoleFidelity": 0.9237613947172771,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459594,
+      "bundleSize": 459775,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 459594,
+      "size": 459775,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

The verb-first SOV loop head `{repeat-verb} forever <body>` (ja `繰り返し forever .pulse を 切り替え`) has its `forever` **dropped** by the fused SOV event pattern, so the loop defaults to `loopType:reference="me"` (the `normalizeCommandRoles` default-patient→primaryRole leak) while en is `loopType:literal="forever"`.

**Grounding showed the general #537 re-parse mechanism does NOT fit** — it fights two load-bearing guards: `preservesFused` (fused `reference` vs re-parse `literal` loopType) and `reparsed.length===1` (forever juxtaposes its body, no `then`). So a **contained fix** instead (`buildEventHandler`, at the fused-capture site): when the action is `repeat` and the token immediately after the verb is a `forever` keyword (en `forever` / native hi `हमेशा` / bn `চিরকাল`, all normalized to `forever` since #527), set `loopType:literal="forever"` **and drop the SOV default-patient leak** (`delete roles.patient` — else, with loopType occupied, it surfaces as a phantom `patient:reference=me` the en reference lacks). The body (toggle/wait) is still recovered by the trailing-body path.

## Results (gate-verified, zero regression)

- **Mean R1 0.9448 → 0.9451 (+0.0003)** — all 6 SOV langs `bn/hi/ja/ko/qu/tr +0.0011` (lifts the SOV laggards directly), all others flat, **zero drops**.
- All 6 SOV langs now match en's `repeat{loopType:literal="forever"}` exactly; SVO (es) unchanged.
- `--regression` gate: ✓ No regression. parse-rate 3696/3696 / R0 1.000 / precision flat / R2 1.000. Baseline regenerated.
- semantic suite 6360 green; typecheck clean. Guard: `multilingual-roadmap-fixes.test.ts` "SOV repeat-forever loop-keyword recovery" (6 cases: loopType + no-phantom-patient + body-survives; failing-without-fix verified).

## Deferred (documented, 2026-06-29l)

SOV `repeat until event` is a multi-part arc — needs a SOV until-event HEAD pattern, a `preservesFused` relaxation for a default `reference:me` loopType, **and** the #535-class underscore-event fuse for tr/hi/qu/bn (`fare_bırak` / `माउस_ऊपर` / `rat_huqariy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)