### PR TITLE
fix(multilingual): repeat-until-event recovery (event:literal + loopType:literal; mean R1 0.9451→0.9457, 12 langs, zero regressions)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,31 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-29m (Arc B R1 — repeat-until-event recovery; mean R1 0.9451 → 0.9457 (+0.0007),
+> 12 langs, ZERO regressions. Broader than the SOV-only scope predicted — it generalizes to
+> SVO/VSO.)** The fused event-handler captures the repeat verb but leaves the until-event clause
+> `{event-kw} {event} {obj-marker} {until-marker}` (ja `繰り返し イベント マウス解放 を まで`, de
+> `wiederholen bis ereignis mausoben`) unconsumed → the loop defaulted to `loopType:reference=me`
+> AND the span broke into PHANTOM `event`/`until` body commands. **Fix (`buildEventHandler`,
+> alongside the 2026-06-29l forever recovery, as an else-branch): when the token after the repeat
+> verb is the event-kw (`normalized==='event'`), capture the NEXT token as `event:literal`, set
+> `loopType:literal="until-event"` (matching the en reference), drop the SOV default-patient leak,
+> and CONSUME the span to the next clause boundary (then/end/EOF) so the phantoms can't form.** The
+> body (increment/wait, after the boundary) is still recovered by the trailing path. This is the
+> targeted-recovery approach again (NOT the #537 re-parse — same `preservesFused`/length guards
+> would block it). **Gains: bn/ja/ko +0.0019 (both roles), ar/de/fr/it/ms/pl/th/tl/vi +0.0010 —
+> the recovery fires for any lang whose repeat-until-event routes through the fused-action path,
+> not just SOV.** R0 1.000 / precision flat (the phantom `event`/`until` removal is also a latent
+> precision win) / R2 1.000 / parse-rate 3696/3696. Guard: `multilingual-roadmap-fixes.test.ts`
+> "repeat-until-event recovery" (5 cases incl. SVO de + VSO ar; failing-without-fix verified).
+> **DEFERRED — tr/hi/qu** (NOT in the gain set): they route their repeat-until-event through a
+> different (compound/traditional) parse path that doesn't reach the fused-action recovery, AND
+> their event token is the #535-class underscore-split compound (`fare_bırak` / `माउस_ऊपर` /
+> `rat_huqariy`; qu's until-marker `hayk_akama` is also split, and qu's mousedown `rat_ñitiy`
+> mis-captures as the `click` event). A separate slice: fuse those compounds (dict + tokenizer)
+> AND route their until-event through the recovery (or a SOV until-event HEAD pattern for the
+> traditional path).
+>
 > **Update 2026-06-29l (Arc B R1 — SOV repeat-forever loop-keyword recovery; mean R1 0.9448 →
 > 0.9451 (+0.0003), all 6 SOV langs (bn/hi/ja/ko/qu/tr) +0.0011, ZERO regressions. Lifts the SOV
 > laggards directly.)** The verb-first SOV loop head `{repeat-verb} forever <body>` (ja `繰り返し

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -951,12 +951,9 @@ export class SemanticParserImpl implements ISemanticParser {
       // recovered by the trailing-body path below.
       if (actionName === 'repeat') {
         const peeked = tokens.peek();
-        if (
-          peeked &&
-          peeked.kind === 'keyword' &&
-          ((peeked as { normalized?: string }).normalized ?? peeked.value).toLowerCase() ===
-            'forever'
-        ) {
+        const norm = (t: LanguageToken): string =>
+          ((t as { normalized?: string }).normalized ?? t.value).toLowerCase();
+        if (peeked && peeked.kind === 'keyword' && norm(peeked) === 'forever') {
           roles.loopType = { type: 'literal', value: 'forever' };
           // Drop the SOV default-patient leak (`reference:me`): repeat has no patient
           // role, so `normalizeCommandRoles` would normally relabel it to the
@@ -965,6 +962,35 @@ export class SemanticParserImpl implements ISemanticParser {
           // (a precision hit). en repeat-forever is `{loopType:literal="forever"}` only.
           delete roles.patient;
           tokens.advance();
+        } else if (peeked && peeked.kind === 'keyword' && norm(peeked) === 'event') {
+          // SOV repeat-UNTIL-event: `{repeat-verb} {event-kw} {event} {obj-marker}
+          // {until-marker} <body>` (ja `繰り返し イベント マウス解放 を まで …`). The
+          // fused SOV pattern leaves the event-kw..until span unconsumed, so the loop
+          // defaults to loopType:reference=me AND the span breaks into phantom
+          // `event`/`until` body commands. Recover: capture the event token after the
+          // event-kw as event:literal, set loopType:literal="until-event" (matching
+          // the en reference), drop the SOV default-patient leak, and CONSUME the span
+          // to the clause boundary (then/end/EOF) so the phantoms can't form. The body
+          // (increment/wait, after the boundary) is still recovered by the trailing path.
+          tokens.advance(); // consume the event-kw
+          const evTok = tokens.peek();
+          if (evTok) {
+            roles.event = { type: 'literal', value: norm(evTok) };
+            roles.loopType = { type: 'literal', value: 'until-event' };
+            delete roles.patient;
+            while (!tokens.isAtEnd()) {
+              const t = tokens.peek();
+              if (
+                !t ||
+                t.kind === 'conjunction' ||
+                (t.kind === 'keyword' &&
+                  (this.isThenKeyword(t.value, language) || this.isEndKeyword(t.value, language)))
+              ) {
+                break;
+              }
+              tokens.advance();
+            }
+          }
         }
       }
 

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -9064,3 +9064,60 @@ describe('SOV repeat-forever loop-keyword recovery (loopType:literal="forever")'
     });
   }
 });
+
+describe('repeat-until-event recovery (event:literal + loopType:literal="until-event")', () => {
+  // The fused event-handler captures the repeat verb but leaves the `until-event`
+  // clause (`{event-kw} {event} {obj-marker} {until-marker}`) unconsumed → the loop
+  // defaults to loopType:reference=me AND the span breaks into phantom `event`/`until`
+  // body commands. buildEventHandler now recovers it: capture the event after the
+  // event-kw as event:literal, set loopType:literal="until-event", drop the SOV
+  // default-patient leak, and consume the span (so the phantoms can't form). Matches
+  // the en reference `repeat{event:literal, loopType:literal="until-event"}`.
+  function repeatRolesUE(node: unknown): Map<string, { type?: string }> | undefined {
+    if (!node || typeof node !== 'object') return undefined;
+    const r = node as Record<string, unknown>;
+    if (r.action === 'repeat' && r.roles instanceof Map) return r.roles as Map<string, { type?: string }>;
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      const c = r[f];
+      if (Array.isArray(c)) {
+        for (const x of c) {
+          const m = repeatRolesUE(x);
+          if (m) return m;
+        }
+      } else if (c && typeof c === 'object') {
+        const m = repeatRolesUE(c);
+        if (m) return m;
+      }
+    }
+    return undefined;
+  }
+  function hasAct(n: unknown, act: string): boolean {
+    if (!n || typeof n !== 'object') return false;
+    const r = n as Record<string, unknown>;
+    if (r.action === act) return true;
+    return ['body', 'statements', 'thenBranch', 'elseBranch'].some(f => {
+      const c = r[f];
+      return Array.isArray(c)
+        ? c.some(x => hasAct(x, act))
+        : !!c && typeof c === 'object' && hasAct(c, act);
+    });
+  }
+  // Real corpus repeat-until-event texts (head: `on <ev> repeat until event <ev2> increment #counter wait 100ms end`).
+  for (const [lang, src] of [
+    ['ja', 'マウス押下 で 繰り返し イベント マウス解放 を まで それから #counter を 増加 それから 待つ 100ms 終わり'],
+    ['ko', '마우스다운 할 때 반복 이벤트 마우스업 를 까지 그러면 #counter 를 증가 그러면 대기 100ms 끝'],
+    ['bn', 'mousedown এ পুনরাবৃত্তি ঘটনা mouseup কে পর্যন্ত তারপর #counter কে বৃদ্ধি তারপর 100ms কে অপেক্ষা শেষ'],
+    ['de', 'bei mausunten wiederholen bis ereignis mausoben dann erhöhen #counter dann warten 100ms ende'],
+    ['ar', 'عند فأرة أسفل كرر حتى حدث فأرة أعلى ثم زِد #counter ثم انتظر 100ms النهاية'],
+  ] as [string, string][]) {
+    it(`[${lang}] repeat-until-event → event:literal + loopType:literal="until-event", no phantom event/until`, () => {
+      const node = parse(src, lang);
+      const roles = repeatRolesUE(node);
+      expect(roles).toBeTruthy();
+      expect(roles!.get('event')?.type).toBe('literal');
+      expect(roles!.get('loopType')).toMatchObject({ type: 'literal', value: 'until-event' });
+      expect(hasAct(node, 'until')).toBe(false); // phantom `until` command gone
+      expect(hasAct(node, 'increment')).toBe(true); // body survives
+    });
+  }
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-29T22:48:36.721Z",
-  "commit": "87035e2e",
+  "timestamp": "2026-06-29T23:51:11.573Z",
+  "commit": "3d117243",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9,12 +9,12 @@
       "avgConfidence": 0.8387196824503315,
       "avgFidelity": 1,
       "avgPrecision": 0.9796536796536797,
-      "avgRoleFidelity": 0.9589386412915825,
+      "avgRoleFidelity": 0.9599038922568334,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8495030867211314,
       "avgFidelity": 1,
-      "avgPrecision": 0.929409218232748,
-      "avgRoleFidelity": 0.9197834591216945,
+      "avgPrecision": 0.9315737203972502,
+      "avgRoleFidelity": 0.9217139610521964,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.828035456606883,
       "avgFidelity": 1,
       "avgPrecision": 0.9967532467532467,
-      "avgRoleFidelity": 0.9530666979196393,
+      "avgRoleFidelity": 0.9540319488848904,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
       "avgPrecision": 0.9833333333333334,
-      "avgRoleFidelity": 0.9497685387391268,
+      "avgRoleFidelity": 0.951699040669629,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.976650432900433,
-      "avgRoleFidelity": 0.9565349771232127,
+      "avgRoleFidelity": 0.9575002280884638,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6321,13 +6321,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
-      "avgPrecision": 0.9482462613144433,
-      "avgRoleFidelity": 0.921343535681771,
+      "avgPrecision": 0.9504107634789454,
+      "avgRoleFidelity": 0.9232740376122729,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6953,13 +6953,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
-      "avgPrecision": 0.9482462613144431,
-      "avgRoleFidelity": 0.9183029951412305,
+      "avgPrecision": 0.9504107634789454,
+      "avgRoleFidelity": 0.9202334970717324,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
       "avgPrecision": 0.9811688311688311,
-      "avgRoleFidelity": 0.960627830480772,
+      "avgRoleFidelity": 0.961593081446023,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
       "avgPrecision": 0.9928841991341991,
-      "avgRoleFidelity": 0.9453863284745642,
+      "avgRoleFidelity": 0.9463515794398152,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.9753246753246753,
-      "avgRoleFidelity": 0.95266924163983,
+      "avgRoleFidelity": 0.9536344926050809,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12010,12 +12010,12 @@
       "avgConfidence": 0.8231816490551542,
       "avgFidelity": 1,
       "avgPrecision": 0.9800865800865801,
-      "avgRoleFidelity": 0.9685107133636545,
+      "avgRoleFidelity": 0.9694759643289056,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13906,12 +13906,12 @@
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
       "avgPrecision": 0.9811958874458874,
-      "avgRoleFidelity": 0.9630906399288753,
+      "avgRoleFidelity": 0.9640558908941262,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 459775,
+      "bundleSize": 460132,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 459775,
+      "size": 460132,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

The fused event-handler captures the repeat verb but leaves the until-event clause `{event-kw} {event} {obj-marker} {until-marker}` (ja `繰り返し イベント マウス解放 を まで`, de `wiederholen bis ereignis mausoben`) unconsumed → the loop defaulted to `loopType:reference=me` **and** the span broke into **phantom `event`/`until` body commands**.

**Fix** (`buildEventHandler`, as an else-branch to the 2026-06-29l forever recovery): when the token after the repeat verb is the event-kw (`normalized==='event'`), capture the next token as `event:literal`, set `loopType:literal="until-event"` (matching the en reference), drop the SOV default-patient leak, and **consume the span to the next clause boundary** so the phantoms can't form. The body (increment/wait) is still recovered by the trailing path. This is the targeted-recovery approach again (NOT the #537 re-parse — the same `preservesFused` / `reparsed.length===1` guards would block it).

## Results (gate-verified, zero regression)

- **Mean R1 0.9451 → 0.9457 (+0.0007)** — broader than the SOV-only scope expected, since the recovery fires for any lang whose repeat-until-event routes through the fused-action path: **bn/ja/ko +0.0019** (both roles), **ar/de/fr/it/ms/pl/th/tl/vi +0.0010**. All others flat, **zero drops**.
- `--regression` gate: ✓ No regression. parse-rate 3696/3696 / R0 1.000 / precision flat (the phantom `event`/`until` removal is also a latent precision win) / R2 1.000. Baseline regenerated.
- semantic suite 6365 green; typecheck clean. Guard: `multilingual-roadmap-fixes.test.ts` "repeat-until-event recovery" (5 cases incl. SVO de + VSO ar; failing-without-fix verified).

## Deferred (documented, 2026-06-29m)

tr/hi/qu route their repeat-until-event through a different (compound/traditional) parse path that doesn't reach the fused-action recovery, and their event token is the #535-class underscore-split compound (`fare_bırak` / `माउस_ऊपर` / `rat_huqariy`). A separate slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)