### PR TITLE
fix(multilingual): complete tr/hi/qu repeat-until-event via fusing split mouse events (hi/qu/tr +0.0019; mean R1 0.9457→0.9460, zero regressions)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,27 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-29n (Arc B R1 — tr/hi/qu repeat-until-event completed via a single event fuse;
+> mean R1 0.9457 → 0.9460 (+0.0003), hi/qu/tr +0.0019, ZERO regressions. Completes the
+> repeat-until-event slice (the deferred half of 2026-06-29m).)** Grounding the 2026-06-29m
+> deferral found the two problems were ONE root cause: the underscore-split mouse events
+> (tr `fare_bas`/`fare_bırak`, hi `माउस_नीचे`/`माउस_ऊपर`, qu `rat_ñitiy`/`rat_huqariy`). The split
+> handler event (`fare_bas`→"bas") broke the fused event-handler match, ROUTING the whole handler
+> onto the compound/traditional body path — where the until-event recovery (2026-06-29m, in the
+> fused-action path) never runs, so the repeat node came out EMPTY. **Fix: just fuse the events
+> (the #535 route — dict emits `farebas`/`farebırak`/`माउसनीचे`/… + register the fused forms in the
+> tr/hi/qu tokenizer EXTRAS).** That single change cascaded: the clean handler event re-routes the
+> handler onto the fused-action path → the 2026-06-29m recovery fires → all three now match en's
+> `repeat{event:literal="mouseup", loopType:literal="until-event"}` AND get the correct handler
+> event (`mousedown`, fixing qu's prior `ñitiy`→click mis-capture). No buildEventHandler change
+> needed. **hi/qu/tr +0.0019; R0 1.000 / precision flat / R2 1.000 / parse-rate 3696/3696.** Guards:
+> `multilingual-roadmap-fixes.test.ts` "repeat-until-event recovery" gained tr/hi/qu cases +
+> `grammar.test.ts` "tr/hi/qu fused … mouse events". With this, **repeat-until-event is faithful
+> across all parsing langs**, and the repeat-cluster is largely burned down (times/forever/
+> until-event all done). Remaining repeat residue: SOV repeat-times (fronted count), vi two-word
+> verb, the for-each two-sided EN-phantom. (Latent: tr/hi/qu's OTHER underscore events —
+> keydown/keyup/mouseenter/etc. — same fuse when a corpus pattern needs them.)
+>
 > **Update 2026-06-29m (Arc B R1 — repeat-until-event recovery; mean R1 0.9451 → 0.9457 (+0.0007),
 > 12 langs, ZERO regressions. Broader than the SOV-only scope predicted — it generalizes to
 > SVO/VSO.)** The fused event-handler captures the repeat verb but leaves the until-event clause

--- a/packages/i18n/src/dictionaries/hi.ts
+++ b/packages/i18n/src/dictionaries/hi.ts
@@ -93,8 +93,10 @@ export const hindiDictionary: Dictionary = {
   events: {
     click: 'क्लिक',
     dblclick: 'डबल_क्लिक',
-    mousedown: 'माउस_नीचे',
-    mouseup: 'माउस_ऊपर',
+    // Fused (no `_`): the semantic tokenizer splits on `_`, breaking event
+    // recognition (mousedown → "नीचे"). Mirrors the #535 ru/uk fuse.
+    mousedown: 'माउसनीचे',
+    mouseup: 'माउसऊपर',
     mouseenter: 'माउस_प्रवेश',
     mouseleave: 'माउस_बाहर',
     mouseover: 'माउस_ओवर',

--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -96,8 +96,10 @@ export const qu: Dictionary = {
   events: {
     click: 'ñitiy',
     dblclick: 'iskay_ñitiy',
-    mousedown: 'rat_ñitiy',
-    mouseup: 'rat_huqariy',
+    // Fused (no `_`): the semantic tokenizer splits on `_` — and `rat_ñitiy` then
+    // mis-captured as the `click` event (ñitiy→click). Mirrors the #535 ru/uk fuse.
+    mousedown: 'ratñitiy',
+    mouseup: 'rathuqariy',
     mouseenter: 'rat_yaykuy',
     mouseleave: 'rat_lluqsiy',
     mouseover: 'rat_hawapi',

--- a/packages/i18n/src/dictionaries/tr.ts
+++ b/packages/i18n/src/dictionaries/tr.ts
@@ -87,8 +87,11 @@ export const tr: Dictionary = {
   events: {
     click: 'tıklama',
     dblclick: 'çift_tıklama',
-    mousedown: 'fare_bas',
-    mouseup: 'fare_bırak',
+    // Fused (no `_`): the semantic tokenizer splits on `_`, breaking event
+    // recognition (mousedown → "bas" / mouseup mis-captured). Mirrors the #535
+    // ru/uk fuse + #510 resize fix.
+    mousedown: 'farebas',
+    mouseup: 'farebırak',
     mouseenter: 'fare_gir',
     mouseleave: 'fare_çık',
     mouseover: 'fare_üstü',

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -2271,3 +2271,28 @@ describe('ru/uk fused (no-underscore) event keywords (mousedown/mouseup/resize)'
     expect(tr.transform('on mousedown toggle .x')).not.toContain('миша_вниз');
   });
 });
+
+describe('tr/hi/qu fused (no-underscore) mouse events (mousedown/mouseup)', () => {
+  // The tokenizer splits on `_`, so the old underscore forms broke event
+  // recognition (tr `fare_bas`→"bas", qu `rat_ñitiy`→click homonym). The dict now
+  // emits the fused form, recognized in the tr/hi/qu tokenizer EXTRAS — which also
+  // routes repeat-until-event onto the fused-action recovery path. Mirrors #535.
+  it('[tr] emits fused mousedown/mouseup (no underscore)', () => {
+    const t = new GrammarTransformer('en', 'tr');
+    expect(t.transform('on mousedown toggle .x')).toContain('farebas');
+    expect(t.transform('on mouseup toggle .x')).toContain('farebırak');
+    expect(t.transform('on mousedown toggle .x')).not.toContain('fare_bas');
+  });
+  it('[hi] emits fused mousedown/mouseup (no underscore)', () => {
+    const t = new GrammarTransformer('en', 'hi');
+    expect(t.transform('on mousedown toggle .x')).toContain('माउसनीचे');
+    expect(t.transform('on mouseup toggle .x')).toContain('माउसऊपर');
+    expect(t.transform('on mousedown toggle .x')).not.toContain('माउस_नीचे');
+  });
+  it('[qu] emits fused mousedown/mouseup (no underscore, no click homonym)', () => {
+    const t = new GrammarTransformer('en', 'qu');
+    expect(t.transform('on mousedown toggle .x')).toContain('ratñitiy');
+    expect(t.transform('on mouseup toggle .x')).toContain('rathuqariy');
+    expect(t.transform('on mousedown toggle .x')).not.toContain('rat_ñitiy');
+  });
+});

--- a/packages/semantic/src/tokenizers/hindi.ts
+++ b/packages/semantic/src/tokenizers/hindi.ts
@@ -46,6 +46,11 @@ const SINGLE_POSTPOSITIONS = new Set(['को', 'में', 'पर', 'से',
  * Extras provide: values, positional, events, modifiers
  */
 const HINDI_EXTRAS: KeywordEntry[] = [
+  // Fused mousedown/mouseup (dict emits these WITHOUT `_` since the tokenizer
+  // splits on it — see hi.ts events note). repeat-until-event / handler events.
+  { native: 'माउसनीचे', normalized: 'mousedown' },
+  { native: 'माउसऊपर', normalized: 'mouseup' },
+
   // Values
   { native: 'सच', normalized: 'true' },
   { native: 'सत्य', normalized: 'true' },

--- a/packages/semantic/src/tokenizers/quechua.ts
+++ b/packages/semantic/src/tokenizers/quechua.ts
@@ -161,6 +161,10 @@ const QUECHUA_EXTRAS: KeywordEntry[] = [
   { native: 'llave hawa', normalized: 'keyup' },
   { native: 'mausiri yayku', normalized: 'mouseover' },
   { native: 'mausiri lluqsi', normalized: 'mouseout' },
+  // Fused mousedown/mouseup (dict emits these WITHOUT `_` since the tokenizer
+  // splits on it; `rat_ñitiy` also mis-captured as click — see qu.ts events note).
+  { native: 'ratñitiy', normalized: 'mousedown' },
+  { native: 'rathuqariy', normalized: 'mouseup' },
   { native: 'qhaway', normalized: 'focus' },
   { native: 'mana qhaway', normalized: 'blur' },
   { native: 'kargay', normalized: 'load' },

--- a/packages/semantic/src/tokenizers/turkish.ts
+++ b/packages/semantic/src/tokenizers/turkish.ts
@@ -129,6 +129,11 @@ const TURKISH_EXTRAS: KeywordEntry[] = [
   { native: 'fare uzerinde', normalized: 'mouseover' },
   { native: 'fare dışında', normalized: 'mouseout' },
   { native: 'fare disinda', normalized: 'mouseout' },
+  // Fused mousedown/mouseup (dict emits these WITHOUT `_` since the tokenizer
+  // splits on it — see tr.ts events note). repeat-until-event / handler events.
+  { native: 'farebas', normalized: 'mousedown' },
+  { native: 'farebırak', normalized: 'mouseup' },
+  { native: 'farebirak', normalized: 'mouseup' },
   { native: 'kaydır', normalized: 'scroll' },
   { native: 'kaydir', normalized: 'scroll' },
   { native: 'tuş_bas', normalized: 'keydown' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -9109,6 +9109,11 @@ describe('repeat-until-event recovery (event:literal + loopType:literal="until-e
     ['bn', 'mousedown এ পুনরাবৃত্তি ঘটনা mouseup কে পর্যন্ত তারপর #counter কে বৃদ্ধি তারপর 100ms কে অপেক্ষা শেষ'],
     ['de', 'bei mausunten wiederholen bis ereignis mausoben dann erhöhen #counter dann warten 100ms ende'],
     ['ar', 'عند فأرة أسفل كرر حتى حدث فأرة أعلى ثم زِد #counter ثم انتظر 100ms النهاية'],
+    // tr/hi/qu: FUSED mouse events (dict no longer emits the `_`-split compound),
+    // which also routes the handler onto the fused-action path so the recovery fires.
+    ['tr', 'farebas de tekrarla olay farebırak i kadar ardından #counter i artır ardından bekle 100ms son'],
+    ['hi', 'माउसनीचे पर दोहराएं घटना माउसऊपर को तक फिर #counter को बढ़ाएं फिर प्रतीक्षा 100ms समाप्त'],
+    ['qu', 'ratñitiy pi kutipay ruway rathuqariy ta hayk_akama chayqa #counter ta yapachiy chayqa suyay 100ms tukuy'],
   ] as [string, string][]) {
     it(`[${lang}] repeat-until-event → event:literal + loopType:literal="until-event", no phantom event/until`, () => {
       const node = parse(src, lang);

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-29T23:51:11.573Z",
-  "commit": "3d117243",
+  "timestamp": "2026-06-30T00:32:30.963Z",
+  "commit": "ce222c63",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4426,12 +4426,12 @@
       "avgConfidence": 0.90909904631709,
       "avgFidelity": 1,
       "avgPrecision": 0.9365270281666384,
-      "avgRoleFidelity": 0.9045271313653666,
+      "avgRoleFidelity": 0.9064576332958686,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9479,15 +9479,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7316532673675531,
+      "avgConfidence": 0.7349000206143064,
       "avgFidelity": 1,
       "avgPrecision": 0.9512456428852532,
-      "avgRoleFidelity": 0.9088513610572435,
+      "avgRoleFidelity": 0.9107818629877455,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9638,6 +9638,10 @@
           "confidence": 1
         },
         "closest-ancestor": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-until-event": {
           "success": true,
           "confidence": 1
         },
@@ -9965,10 +9969,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.5
-        },
         "repeat-while": {
           "success": true,
           "confidence": 0.5
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12639,15 +12639,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.827517929021688,
+      "avgConfidence": 0.8307646822684411,
       "avgFidelity": 1,
       "avgPrecision": 0.9508127424523529,
-      "avgRoleFidelity": 0.9237613947172771,
+      "avgRoleFidelity": 0.9256918966477791,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12854,6 +12854,10 @@
           "confidence": 1
         },
         "last-in-collection": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-until-event": {
           "success": true,
           "confidence": 1
         },
@@ -13181,10 +13185,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "repeat-until-event": {
-          "success": true,
-          "confidence": 0.5
-        },
         "repeat-while": {
           "success": true,
           "confidence": 0.5
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460132,
+      "bundleSize": 460263,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 460132,
+      "size": 460263,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Completes the repeat-until-event slice (the deferred half of #539). Grounding found the two problems were **one root cause**: the underscore-split mouse events (tr `fare_bas`/`fare_bırak`, hi `माउस_नीचे`/`माउस_ऊपर`, qu `rat_ñitiy`/`rat_huqariy`). The split handler event (`fare_bas`→"bas") broke the fused event-handler match, **routing the whole handler onto the compound/traditional body path** — where the #539 until-event recovery (in the fused-action path) never runs, so the repeat node came out empty.

**Fix:** just fuse the events (the #535 route — dict emits `farebas`/`farebırak`/`माउसनीचे`/… + register the fused forms in the tr/hi/qu tokenizer EXTRAS). That single change **cascaded**: the clean handler event re-routes the handler onto the fused-action path → the #539 recovery fires → all three now match en's `repeat{event:literal="mouseup", loopType:literal="until-event"}` **and** get the correct handler event (`mousedown`, fixing qu's prior `ñitiy`→click mis-capture). No `buildEventHandler` change needed.

## Results (gate-verified, zero regression)

- **Mean R1 0.9457 → 0.9460 (+0.0003)** — hi/qu/tr +0.0019, all others flat, **zero drops**.
- `--regression` gate: ✓ No regression. parse-rate 3696/3696 / R0 1.000 / precision flat / R2 1.000. Baseline regenerated.
- semantic suite 6368 + i18n green; typechecks clean. Guards: `multilingual-roadmap-fixes.test.ts` "repeat-until-event recovery" gained tr/hi/qu cases + `grammar.test.ts` "tr/hi/qu fused … mouse events".

With this, **repeat-until-event is faithful across all parsing langs**.

## Remaining repeat residue (documented, 2026-06-29n)

SOV repeat-times (fronted count), vi two-word verb, the for-each two-sided EN-phantom. Latent: tr/hi/qu's other underscore events (keydown/keyup/mouseenter/…) — same fuse when a corpus pattern needs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)