### PR TITLE
fix(multilingual): vi two-word-verb repeat-times HEAD (repeat.quantity:literal R1; +0.0017 vi, zero regressions)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,27 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-29p (Arc B R1 — vi two-word-verb repeat-times HEAD fix; mean R1 0.9465 → 0.9466
+> (+0.0001), vi 0.9641 → 0.9657 (+0.0017), ZERO regressions.)** Grounding CORRECTED the handoff
+> theory (which blamed a mid-verb verb-finder landing): the vi tokenizer fuses the two-word verb
+> `lặp lại` into a SINGLE keyword token (`value="lặp lại"`, `normalized="repeat"`), but
+> `repeatTimesHead` (`repeat.ts`) SPLIT the verb on whitespace into two literal tokens
+> (`['lặp','lại']`) — which never match the one fused token. So `repeat-vi-times` failed to match
+> even STANDALONE (`lặp lại 3 lần` fell through to the generated positional repeat →
+> `loopType:literal=3`, no quantity), and a fortiori in-handler (the block-body HEAD re-parse found
+> no `-times` match to swap in). **Fix: match the verb as a SINGLE literal token (`{type:'literal',
+value: verb}`) instead of splitting on whitespace.** For the 16 single-word verb-first langs this
+> is byte-identical (one push either way); only vi changes. With it, `lặp lại 3 lần` matches
+> `repeat-vi-times` (quantity:literal=3 + loopType:literal="times"), and the in-handler HEAD re-parse
+> swaps it in — both matching en. **vi +0.0017 (the only changed lang); R0 1.000 / precision 0.9747
+> flat / R2 1.000 / parse-rate 3696/3696; ZERO drops on the other 16.** semantic 6376 green. Guard:
+> `multilingual-roadmap-fixes.test.ts` "Counted-loop HEAD patterns" gained 2 vi cases (standalone +
+> in-handler; both fail without the fix). **Remaining repeat residue:** the for-each two-sided
+> EN-phantom (`repeat for X in Y` — the EN reference itself mis-captures `in` as `event:literal`, so
+> it's two-sided and riskier — needs the EN reference fixed first), and the qu dict fix (`kutichiy`
+> ↔ `repeat`, see 2026-06-29o). The counted-loop (`times`) cluster is now closed across every
+> parsing lang except qu.
+>
 > **Update 2026-06-29o (Arc B R1 — SOV repeat-times fronted-count HEAD pattern; mean R1 0.9460 →
 > 0.9465 (+0.0005), hi/bn +0.0034 · ja/ko/tr +0.0017, ZERO regressions. Lifts the five SOV
 > laggards directly; qu excluded as a separate dict bug.)** SOV langs front the count ahead of a

--- a/packages/semantic/src/patterns/repeat.ts
+++ b/packages/semantic/src/patterns/repeat.ts
@@ -39,8 +39,13 @@ function repeatTimesHead(
   markerBefore?: string
 ): LanguagePattern {
   const tokens: LanguagePattern['template']['tokens'] = [];
-  // The verb may be multi-word (vi `lặp lại`); split into literal tokens.
-  for (const w of verb.split(/\s+/)) tokens.push({ type: 'literal', value: w });
+  // Match the verb as a SINGLE literal token. A multi-word surface verb (vi
+  // `lặp lại`) tokenizes as ONE fused keyword token — splitting it on whitespace
+  // would expect two tokens the tokenizer never produces, so the pattern would
+  // never match (vi's repeat-times fell through to the generated positional
+  // repeat, mis-binding the count to loopType). For single-word verbs this is
+  // identical to the previous per-word push.
+  tokens.push({ type: 'literal', value: verb });
   if (markerBefore) tokens.push({ type: 'literal', value: markerBefore });
   tokens.push({ type: 'role', role: 'quantity', expectedTypes: ['literal', 'expression'] });
   tokens.push({ type: 'literal', value: countWord });

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -8969,6 +8969,22 @@ describe('Counted-loop HEAD patterns: `{verb} {quantity} times` (repeat.quantity
     expect(roles).toContain('loopType:literal');
   });
 
+  // Two-word verb (vi `lặp lại`) tokenizes as ONE fused keyword token, so the HEAD
+  // pattern must match the verb as a single literal (not split on whitespace).
+  // Verified both standalone and in-handler (the latter via the block-body HEAD
+  // re-parse swapping in the `repeat-vi-times` match). Without the fix vi fell
+  // through to the generated positional repeat → loopType:literal=3, no quantity.
+  it('[vi] standalone two-word-verb repeat-times captures quantity:literal', () => {
+    const roles = repeatRoles(parse('lặp lại 3 lần', 'vi'));
+    expect(roles).toContain('quantity:literal');
+    expect(roles).toContain('loopType:literal');
+  });
+  it('[vi] in-handler two-word-verb repeat-times captures quantity:literal', () => {
+    const roles = repeatRoles(parse('khi nhấp lặp lại 3 lần rồi thêm "<p>Line</p>" vào tôi', 'vi'));
+    expect(roles).toContain('quantity:literal');
+    expect(roles).toContain('loopType:literal');
+  });
+
   // IN-EVENT-HANDLER (event-first langs): the repeat sits in the fused-event body
   // and `repeat` is a BLOCK_BODY_ACTION, so the fused-body re-parse is normally
   // skipped. The block-body guard now makes an exception for a HEAD-ONLY counted

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-30T02:41:38.727Z",
-  "commit": "e4fa697a",
+  "timestamp": "2026-06-30T03:00:33.108Z",
+  "commit": "c5885504",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -13906,7 +13906,7 @@
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
       "avgPrecision": 0.9811958874458874,
-      "avgRoleFidelity": 0.9640558908941262,
+      "avgRoleFidelity": 0.9657450800833155,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],


### PR DESCRIPTION
## Summary

The vi tokenizer fuses the two-word repeat verb `lặp lại` into a **single** keyword token (`value="lặp lại"`, `normalized="repeat"`), but `repeatTimesHead` **split** the verb on whitespace into two literal tokens (`['lặp','lại']`) — which never match the one fused token. So `repeat-vi-times` failed to match even **standalone** (`lặp lại 3 lần` fell through to the generated positional repeat → `loopType:literal=3`, no quantity), and a fortiori in-handler (the block-body HEAD re-parse found no `-times` match to swap in).

**Fix:** match the verb as a single literal token instead of splitting on whitespace. For the 16 single-word verb-first langs this is byte-identical (one push either way); only vi changes. With it, `lặp lại 3 lần` matches `repeat-vi-times` (`quantity:literal=3` + `loopType:literal="times"`), and the in-handler HEAD re-parse swaps it in — both matching the en reference.

This corrects the handoff theory (which blamed a mid-verb verb-finder landing) — grounding showed the verb is one fused token and the split was the bug.

## Impact (gate-verified, `browser-priority`)

| signal | before | after |
| --- | --- | --- |
| **mean R1** | 0.9465 | **0.9466** (+0.0001) |
| vi | 0.9641 | 0.9657 (+0.0017) |
| R0 recall / precision / R2 / parse-rate | 1.000 / 0.9747 / 1.000 / 3696/3696 | flat |

vi is the only changed lang; **zero per-language drops** (confirms behavior-equivalence for the 16 single-word verb-first langs).

## Tests

- Guard: `multilingual-roadmap-fixes.test.ts` "Counted-loop HEAD patterns" — 2 new vi cases (standalone + in-handler); **both verified failing without the fix**.
- Full semantic suite green (6376 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)