### PR TITLE
fix(multilingual): qu repeat-times HEAD completes the SOV set (repeat.quantity/loopType:literal R1; +0.0034 qu, zero regressions)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,33 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-29q (Arc B R1 — qu repeat-times HEAD (completes the SOV set); mean R1 0.9466 →
+> 0.9467 (+0.0001), qu 0.9108 → 0.9142 (+0.0034), ZERO regressions. Lifts the SINGLE biggest
+> laggard; the counted-loop (`times`) cluster is now closed across ALL parsing langs.)** #542
+> EXCLUDED qu from the SOV repeat-times HEAD on the belief its corpus repeat verb was `kutichiy`
+> (which normalizes to `return`). Grounding the leverage map exposed that as a STALE-DB artifact:
+> the committed `patterns.db` lagged the dicts (the i18n qu dict already maps `repeat: 'kutipay'`),
+> and a FRESH `populate` (what CI always does) emits `3 times ta ñitiy pi kutipay …` — `kutipay`
+> normalizes to `repeat` (confirmed: qu repeat-forever/until-event already parse via it). So qu only
+> needed the HEAD pattern. **Fix: add `['qu', 'times', 'ta']` to `SOV_REPEAT_TIMES` (`repeat.ts`).**
+> The patient-first SOV body clause `3 times ta kutipay` (marker `ta`) then matches `repeat-qu-times`
+> → quantity:literal=3 + loopType:literal="times", matching en; the `add` body survives. **qu +0.0034
+> (the only changed lang — confirming the committed baseline already reflected `kutipay` for the
+> rest, i.e. NOT a db-freshness artifact); R0 1.000 / precision 0.9747 flat / R2 1.000 / parse-rate
+> 3696/3696.** semantic 6377 green. Guard: `multilingual-roadmap-fixes.test.ts` "SOV repeat-times
+> fronted-count HEAD" gained a qu case (hardcoded `kutipay` corpus form; fails without the fix).
+> **Methodology note for the next session:** a raw read of the COMMITTED `patterns.db` can lag the
+> dicts — always `npm run populate` before grounding a per-language corpus claim, else you score a
+> stale translation (this is how #542 mis-excluded qu). **Remaining repeat residue:** only the
+> for-each two-sided EN-phantom (`repeat for X in Y` — the EN reference itself mis-captures `in` as
+> `event:literal`, two-sided and riskier). **Next leverage targets (grounded, all structural — the
+> easy R1 wins are exhausted at this depth):** `if.condition:expression` (124× — de V2 `wenn` + SOV
+> fail to FOLD the if/else block in the handler body, SOV also glues `else`/`end` onto selectors;
+> a conditional-folding arc); `toggle.destination:expression` (115× — accordion-toggle's positional
+> `on closest X` destination dropped in the body); `set` cluster (ko SOV destination↔patient
+> role-swap, ms drops the body, sw/qu translate set→put). `fetch.source:literal` (64×) is an
+> action-naming divergence (dicts map fetch→holen/ambil/取得), not a clean fix.
+>
 > **Update 2026-06-29p (Arc B R1 — vi two-word-verb repeat-times HEAD fix; mean R1 0.9465 → 0.9466
 > (+0.0001), vi 0.9641 → 0.9657 (+0.0017), ZERO regressions.)** Grounding CORRECTED the handoff
 > theory (which blamed a mid-verb verb-finder landing): the vi tokenizer fuses the two-word verb

--- a/packages/semantic/src/patterns/repeat.ts
+++ b/packages/semantic/src/patterns/repeat.ts
@@ -12,13 +12,14 @@
  * Two surface shapes:
  * - **Verb-FIRST** (SVO/VSO): the count phrase follows the verb, so the en-shaped
  *   HEAD pattern applies directly (`repetir 3 times`).
- * - **Verb-LAST** (SOV ja/ko/tr/hi/bn): the count is FRONTED ahead of a clause-final
+ * - **Verb-LAST** (SOV ja/ko/tr/hi/bn/qu): the count is FRONTED ahead of a clause-final
  *   verb (`3 times を 繰り返し` = `{quantity} {countWord} {objMarker} {verb}`). Inside
  *   an event handler the event is stripped first, so the body clause re-parse sees
  *   exactly this 4-token shape; without a dedicated HEAD the generated positional
- *   repeat mis-binds the count to `loopType:literal=3` and drops `quantity`. (qu is
- *   excluded: its corpus repeat verb `kutichiy` normalizes to `return`, not `repeat`
- *   — a dict mismatch with the profile's `kutipay`/`muyu`, a separate fix.)
+ *   repeat mis-binds the count to `loopType:literal=3` and drops `quantity`. (qu uses
+ *   `kutipay` for repeat (normalized `repeat`) in the FRESHLY-populated corpus — the
+ *   committed patterns.db can lag with the older `kutichiy`=`return`, but CI always
+ *   re-populates, so the qu HEAD fires there.)
  *
  * The count word is taken VERBATIM from the corpus: most languages leave the
  * English `times` untranslated (es `repetir 3 times`); a few translate it
@@ -120,6 +121,7 @@ const SOV_REPEAT_TIMES: Array<[string, string, string]> = [
   ['tr', 'times', 'i'],
   ['hi', 'times', 'को'],
   ['bn', 'বার', 'কে'],
+  ['qu', 'times', 'ta'],
 ];
 
 const BY_LANG = new Map<string, LanguagePattern[]>();

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -9061,14 +9061,18 @@ describe('SOV repeat-times fronted-count HEAD (`{quantity} {countWord} {marker} 
 
   // Corpus repeat-times translations (`on click repeat 3 times add "<p>Line</p>" to me`).
   // Before the fix: ja/ko/tr captured loopType:literal (the number) but NOT
-  // quantity:literal; hi/bn produced a roleless repeat node — so the quantity:literal
-  // assertion fails without the fix for all five.
+  // quantity:literal; hi/bn/qu produced a roleless or absent repeat node — so the
+  // quantity:literal assertion fails without the fix for all six. (qu uses the
+  // patient-first SOV order with the `ta` marker and the `kutipay` repeat verb —
+  // the FRESHLY-populated corpus form; the older committed db lagged with the
+  // `return` verb `kutichiy`, but CI re-populates so the qu HEAD fires.)
   for (const [lang, src] of [
     ['ja', '3 times を クリック で 繰り返し それから "<p>Line</p>" を 追加 私 に'],
     ['ko', '3 times 를 클릭 반복 그러면 "<p>Line</p>" 를 추가 나 에'],
     ['tr', '3 times i tıklama de tekrarla sonra "<p>Line</p>" i ekle ben e'],
     ['hi', '3 times को क्लिक पर दोहराएं फिर "<p>Line</p>" को जोड़ें मैं में'],
     ['bn', '3 বার কে ক্লিক এ পুনরাবৃত্তি তারপর "<p>Line</p>" কে যোগ আমি তে'],
+    ['qu', '3 times ta ñitiy pi kutipay chayqa "<p>Line</p>" ta noqa man yapay'],
   ] as [string, string][]) {
     it(`[${lang}] fronted-count repeat-times captures quantity:literal + loopType:literal`, () => {
       const roles = repeatRoles(parse(src, lang));

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-30T03:00:33.108Z",
-  "commit": "c5885504",
+  "timestamp": "2026-06-30T03:21:27.073Z",
+  "commit": "3e1b26ec",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9482,7 +9482,7 @@
       "avgConfidence": 0.7349000206143064,
       "avgFidelity": 1,
       "avgPrecision": 0.9512456428852532,
-      "avgRoleFidelity": 0.9107818629877455,
+      "avgRoleFidelity": 0.914160241366124,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],


### PR DESCRIPTION
## Summary

#542 excluded qu from the SOV repeat-times HEAD on the belief its corpus repeat verb was `kutichiy` (which normalizes to `return`). Grounding the leverage map exposed that as a **stale-DB artifact**: the committed `patterns.db` lagged the dicts (the i18n qu dict already maps `repeat: 'kutipay'`), and a **fresh** `populate` (what CI always does) emits `3 times ta ñitiy pi kutipay …` — `kutipay` normalizes to `repeat` (confirmed: qu repeat-forever/until-event already parse via it). So qu only needed the HEAD pattern.

**Fix:** add `['qu', 'times', 'ta']` to `SOV_REPEAT_TIMES`. The patient-first SOV body clause `3 times ta kutipay` (marker `ta`) then matches `repeat-qu-times` → `quantity:literal=3` + `loopType:literal="times"`, matching the en reference; the `add` body survives.

## Impact (gate-verified, `browser-priority`)

| signal | before | after |
| --- | --- | --- |
| **mean R1** | 0.9466 | **0.9467** (+0.0001) |
| qu | 0.9108 | 0.9142 (+0.0034) |
| R0 recall / precision / R2 / parse-rate | 1.000 / 0.9747 / 1.000 / 3696/3696 | flat |

qu was the **single biggest laggard**, and is the only changed lang (confirming the committed baseline already reflected `kutipay` for the rest — not a db-freshness artifact). The counted-loop (`times`) cluster is now **closed across all parsing langs**.

## Tests

- Guard: `multilingual-roadmap-fixes.test.ts` "SOV repeat-times fronted-count HEAD" — new qu case (hardcoded `kutipay` corpus form; **verified failing without the fix**).
- Full semantic suite green (6377 passed).

> **Methodology note:** a raw read of the committed `patterns.db` can lag the dicts — always `npm run populate` before grounding a per-language corpus claim (this is how #542 mis-excluded qu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)