### PR TITLE
fix(multilingual): en element-swap reference (swap.* R1; +0.0029 mean, all 23 langs up, zero regressions)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,44 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-29r (Arc B R1 — en element-swap REFERENCE fix; mean R1 0.9467 → 0.9497 (+0.0029),
+> ALL 23 langs up, ZERO regressions. The biggest single R1 win since the URL fix (#525) — and a NEW
+> direction: fixing a broken EN REFERENCE where the translations were already correct.)** A
+> fresh-DB leverage-map re-run (the committed `patterns.db` lags the dicts, so the map MUST run
+> against a fresh `populate` — see 2026-06-29q) put `swap.destination:literal` + `swap.method:selector`
+> (~46 combined) near the top, all from the one `swap-content` pattern. Grounding flipped the usual
+> diagnosis: the EN reference is the BROKEN one. `swap #a with #b` is a method-less, `with`-marked
+> element swap, but `swap-en-handcrafted` (`swap {method} {destination}`, prio 110) greedily binds
+> `#a`→method and the bare word `with`→destination:literal, then DROPS `#b`. Every translation
+> (de/es/ja/ko/…) parses `{destination:selector, patient:selector}` CORRECTLY — so R1 (recall vs the
+> garbage en reference) scored them ~0 for swap. **Fix: a dedicated `swap-en-element` pattern
+> (`swap {destination} with {patient}`, priority 120 > 110) in BOTH en pattern paths (patterns/en.ts
+> `buildEnglishPatterns` — the registered/gate path — and patterns/languages/en/swap.ts — the
+> builders.ts path; kept in sync). The required `with` literal means it only fires on the element-swap
+> shape; `swap innerHTML #target` / `swap delete #item` (no `with`) still take the 110 method form.**
+> en now parses `swap {destination:selector="#a", patient:selector="#b"}`, matching the schema AND
+> every translation → R1 for swap-content jumps ~0 → 1.0 across the board. **ALL 23 langs gained
+> (+0.0034 most; +0.0017 for ar/bn/hi/qu/tl/tr whose swap-content was already partly degenerate); R0
+> 1.000 / precision 0.9747 flat / R2 1.000 (swap-content is NOT in the curated execution subset, so
+> no R2 risk) / parse-rate 3696/3696.** semantic 6382 green. Guard:
+> `multilingual-roadmap-fixes.test.ts` "en element-swap reference" (5 cases: the en parse — fails
+> without the fix — 3 translation-alignment, 1 method-form-unchanged control).
+>
+> **STRATEGIC NOTE — the remaining high-leverage R1 residues are BROKEN EN REFERENCES, not buggy
+> translations.** This INVERTS the campaign's default direction (align translations toward en).
+> Where en is the outlier and the translations already agree on the correct parse, fixing the EN
+> reference aligns it TOWARD them and lifts R1 broadly (the methodology's "if EN is the outlier
+> translations already agree against, great" case — the opposite of the abandoned trigger.event,
+> where en was right). The fresh-DB leverage map's top remaining clusters are this shape:
+> **`repeat-for-each`** (en mis-captures `in` as `event:literal`, never captures the loop variable or
+> collection; es/de capture `.items` as destination correctly — but it's TWO-sided: translations are
+> also imperfect (loopType:expression vs literal), so it's a real arc, fix en first); **`send-with-detail`**
+> (send.destination:reference 44× — ground next); **`set` cluster** (ko SOV destination↔patient
+> role-swap, ms drops the body, sw/qu translate set→put — fragmented). The structural `if.condition`
+> fold (de V2 `wenn` + SOV `else`/`end` selector-gluing) and `accordion-toggle` (positional `on
+closest X` destination) remain genuine arcs. **Next concrete slice candidate: `send-with-detail`
+> (one pattern, 44×) — ground it (fresh DB!) to see if it's an en-reference fix like swap.**
+>
 > **Update 2026-06-29q (Arc B R1 — qu repeat-times HEAD (completes the SOV set); mean R1 0.9466 →
 > 0.9467 (+0.0001), qu 0.9108 → 0.9142 (+0.0034), ZERO regressions. Lifts the SINGLE biggest
 > laggard; the counted-loop (`times`) cluster is now closed across ALL parsing langs.)** #542

--- a/packages/semantic/src/patterns/en.ts
+++ b/packages/semantic/src/patterns/en.ts
@@ -84,6 +84,35 @@ const swapSimpleEnglish: LanguagePattern = {
 };
 
 /**
+ * English element-swap: "swap {destination} with {patient}" (`swap #a with #b`).
+ *
+ * The method-less, `with`-marked shape the i18n transformer emits for an element
+ * swap. Without this, `swap-en-handcrafted` (`swap {method} {destination}`) greedily
+ * binds `#a`→method and the bare word `with`→destination, then DROPS `#b` — a broken
+ * en REFERENCE parse the translations (de/es/ja/ko all parse `{destination, patient}`
+ * correctly) are penalized against in R1. This captures `destination`+`patient` to
+ * match the schema (and the translations). Priority 120 > the method form's 110, and
+ * the required `with` literal means it only fires on the element-swap shape — the
+ * `swap innerHTML #target` / `swap delete #item` forms (no `with`) still take 110.
+ */
+const swapElementEnglish: LanguagePattern = {
+  id: 'swap-en-element',
+  language: 'en',
+  command: 'swap',
+  priority: 120,
+  template: {
+    format: 'swap {destination} with {patient}',
+    tokens: [
+      { type: 'literal', value: 'swap' },
+      { type: 'role', role: 'destination' },
+      { type: 'literal', value: 'with' },
+      { type: 'role', role: 'patient' },
+    ],
+  },
+  extraction: {},
+};
+
+/**
  * English: "repeat until event pointerup from document"
  */
 const repeatUntilEventFromEnglish: LanguagePattern = {
@@ -347,6 +376,7 @@ export function buildEnglishPatterns(): LanguagePattern[] {
   patterns.push(
     fetchWithResponseTypeEnglish,
     fetchSimpleEnglish,
+    swapElementEnglish,
     swapSimpleEnglish,
     repeatUntilEventFromEnglish,
     repeatUntilEventEnglish,

--- a/packages/semantic/src/patterns/languages/en/swap.ts
+++ b/packages/semantic/src/patterns/languages/en/swap.ts
@@ -33,6 +33,32 @@ export const swapSimpleEnglish: LanguagePattern = {
 };
 
 /**
+ * English element-swap: "swap {destination} with {patient}" (`swap #a with #b`).
+ *
+ * The method-less, `with`-marked element-swap shape. Without it the method form
+ * above greedily binds `#a`→method and the word `with`→destination and drops `#b`.
+ * Priority 120 > 110, and the required `with` literal means it only fires on this
+ * shape (the `swap innerHTML #target` form has no `with`). Mirrors `swapElementEnglish`
+ * in patterns/en.ts (the registered path); kept in sync so both builders agree.
+ */
+export const swapElementEnglish: LanguagePattern = {
+  id: 'swap-en-element',
+  language: 'en',
+  command: 'swap',
+  priority: 120,
+  template: {
+    format: 'swap {destination} with {patient}',
+    tokens: [
+      { type: 'literal', value: 'swap' },
+      { type: 'role', role: 'destination' },
+      { type: 'literal', value: 'with' },
+      { type: 'role', role: 'patient' },
+    ],
+  },
+  extraction: {},
+};
+
+/**
  * All English swap patterns.
  */
-export const swapPatternsEn: LanguagePattern[] = [swapSimpleEnglish];
+export const swapPatternsEn: LanguagePattern[] = [swapElementEnglish, swapSimpleEnglish];

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -9208,3 +9208,61 @@ describe('repeat-until-event recovery (event:literal + loopType:literal="until-e
     });
   }
 });
+
+describe('en element-swap reference: `swap {destination} with {patient}` (swap-content)', () => {
+  // The corpus element-swap `swap #a with #b` is method-less and `with`-marked. The
+  // method form `swap {method} {destination}` (swap-en-handcrafted) greedily bound
+  // #a→method and the bare word `with`→destination:literal, DROPPING #b — a broken en
+  // REFERENCE that the (correct) translations were penalized against in R1. A dedicated
+  // `swap-en-element` pattern (`swap {destination} with {patient}`, priority 120 > 110)
+  // captures destination+patient, matching the schema and the translations. The method
+  // forms (no `with`) still take the 110 pattern.
+  function swapRoles(node: unknown): Map<string, { type?: string }> | undefined {
+    if (!node || typeof node !== 'object') return undefined;
+    const r = node as Record<string, unknown>;
+    if (r.action === 'swap' && r.roles instanceof Map)
+      return r.roles as Map<string, { type?: string }>;
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      const c = r[f];
+      if (Array.isArray(c)) {
+        for (const x of c) {
+          const m = swapRoles(x);
+          if (m) return m;
+        }
+      } else if (c && typeof c === 'object') {
+        const m = swapRoles(c);
+        if (m) return m;
+      }
+    }
+    return undefined;
+  }
+
+  it('[en] `swap #a with #b` captures destination:selector + patient:selector (not method + #b dropped)', () => {
+    const roles = swapRoles(parse('on click swap #a with #b', 'en'));
+    expect(roles).toBeTruthy();
+    expect(roles!.get('destination')?.type).toBe('selector'); // #a, not the word "with"
+    expect(roles!.get('patient')?.type).toBe('selector'); // #b survives (was dropped)
+    expect(roles!.has('method')).toBe(false); // #a is no longer mis-bound as method
+  });
+
+  // Translations (correct all along) now MATCH the corrected en reference.
+  for (const [lang, src] of [
+    ['de', 'bei klick tauschen #a mit #b'],
+    ['es', 'en clic intercambiar #a con #b'],
+    ['ja', '#a を クリック で 交換 #b で'],
+  ] as [string, string][]) {
+    it(`[${lang}] swap-content has destination:selector + patient:selector (aligns with en)`, () => {
+      const roles = swapRoles(parse(src, lang));
+      expect(roles).toBeTruthy();
+      expect(roles!.get('destination')?.type).toBe('selector');
+      expect(roles!.get('patient')?.type).toBe('selector');
+    });
+  }
+
+  // The method form (no `with`) is UNCHANGED — still the 110 handcrafted pattern.
+  it('[en] `swap innerHTML #target` still parses as method + destination (unchanged)', () => {
+    const roles = swapRoles(parse('swap innerHTML #target', 'en'));
+    expect(roles!.get('method')?.type).toBe('literal');
+    expect(roles!.get('destination')?.type).toBe('selector');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-30T03:21:27.073Z",
-  "commit": "3e1b26ec",
+  "timestamp": "2026-06-30T03:39:50.978Z",
+  "commit": "0c1958cb",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9,12 +9,12 @@
       "avgConfidence": 0.8387196824503315,
       "avgFidelity": 1,
       "avgPrecision": 0.9796536796536797,
-      "avgRoleFidelity": 0.9599038922568334,
+      "avgRoleFidelity": 0.9615930814460225,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -641,12 +641,12 @@
       "avgConfidence": 0.8495030867211314,
       "avgFidelity": 1,
       "avgPrecision": 0.9315737203972502,
-      "avgRoleFidelity": 0.9250923394305748,
+      "avgRoleFidelity": 0.9267815286197639,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.828035456606883,
       "avgFidelity": 1,
       "avgPrecision": 0.9967532467532467,
-      "avgRoleFidelity": 0.9540319488848904,
+      "avgRoleFidelity": 0.9574103272632687,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
       "avgPrecision": 0.9846320346320346,
-      "avgRoleFidelity": 0.9547362690745045,
+      "avgRoleFidelity": 0.9581146474528829,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
       "avgPrecision": 0.9833333333333334,
-      "avgRoleFidelity": 0.951699040669629,
+      "avgRoleFidelity": 0.9550774190480074,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3794,12 +3794,12 @@
       "avgConfidence": 0.8237889095031952,
       "avgFidelity": 1,
       "avgPrecision": 0.9851731601731601,
-      "avgRoleFidelity": 0.9591797356503236,
+      "avgRoleFidelity": 0.962558114028702,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4426,12 +4426,12 @@
       "avgConfidence": 0.90909904631709,
       "avgFidelity": 1,
       "avgPrecision": 0.9365270281666384,
-      "avgRoleFidelity": 0.909836011674247,
+      "avgRoleFidelity": 0.9115252008634361,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
       "avgPrecision": 0.9829004329004329,
-      "avgRoleFidelity": 0.9534284486490368,
+      "avgRoleFidelity": 0.956806827027415,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.976650432900433,
-      "avgRoleFidelity": 0.9575002280884638,
+      "avgRoleFidelity": 0.960878606466842,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
       "avgPrecision": 0.9504107634789454,
-      "avgRoleFidelity": 0.924963226801462,
+      "avgRoleFidelity": 0.9283416051798404,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6954,12 @@
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
       "avgPrecision": 0.9504107634789454,
-      "avgRoleFidelity": 0.9219226862609216,
+      "avgRoleFidelity": 0.9253010646393,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
       "avgPrecision": 0.9811688311688311,
-      "avgRoleFidelity": 0.961593081446023,
+      "avgRoleFidelity": 0.9649714598244014,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
       "avgPrecision": 0.9928841991341991,
-      "avgRoleFidelity": 0.9463515794398152,
+      "avgRoleFidelity": 0.9497299578181935,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8850,12 @@
       "avgConfidence": 0.7984333127190251,
       "avgFidelity": 1,
       "avgPrecision": 0.9820346320346321,
-      "avgRoleFidelity": 0.9536101429483782,
+      "avgRoleFidelity": 0.9569885213267566,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9482,12 @@
       "avgConfidence": 0.7349000206143064,
       "avgFidelity": 1,
       "avgPrecision": 0.9512456428852532,
-      "avgRoleFidelity": 0.914160241366124,
+      "avgRoleFidelity": 0.9158494305553131,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.8135642135642115,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367965,
-      "avgRoleFidelity": 0.9470592117650943,
+      "avgRoleFidelity": 0.9504375901434727,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10746,12 +10746,12 @@
       "avgConfidence": 0.7962481962481944,
       "avgFidelity": 1,
       "avgPrecision": 0.9852813852813852,
-      "avgRoleFidelity": 0.9543936996142877,
+      "avgRoleFidelity": 0.9577720779926661,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.9753246753246753,
-      "avgRoleFidelity": 0.9536344926050809,
+      "avgRoleFidelity": 0.9570128709834593,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12010,12 +12010,12 @@
       "avgConfidence": 0.8231816490551542,
       "avgFidelity": 1,
       "avgPrecision": 0.9800865800865801,
-      "avgRoleFidelity": 0.9694759643289056,
+      "avgRoleFidelity": 0.9711651535180945,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12642,12 +12642,12 @@
       "avgConfidence": 0.8307646822684411,
       "avgFidelity": 1,
       "avgPrecision": 0.9508127424523529,
-      "avgRoleFidelity": 0.9273810858369682,
+      "avgRoleFidelity": 0.9290702750261575,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13274,12 +13274,12 @@
       "avgConfidence": 0.8139764996907833,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367963,
-      "avgRoleFidelity": 0.9470592117650941,
+      "avgRoleFidelity": 0.9504375901434725,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13906,12 +13906,12 @@
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
       "avgPrecision": 0.9811958874458874,
-      "avgRoleFidelity": 0.9657450800833155,
+      "avgRoleFidelity": 0.9691234584616939,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14538,12 +14538,12 @@
       "avgConfidence": 0.9840032982890127,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9619950509656388,
+      "avgRoleFidelity": 0.9653734293440172,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460263,
+      "bundleSize": 460533,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 460263,
+      "size": 460533,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

A **fresh-DB** leverage-map re-run put `swap.destination:literal` + `swap.method:selector` (~46 combined) near the top, all from the one `swap-content` pattern. Grounding flipped the usual diagnosis: **the EN reference is the broken one.** `swap #a with #b` is a method-less, `with`-marked element swap, but `swap-en-handcrafted` (`swap {method} {destination}`, prio 110) greedily binds `#a`→method and the bare word `with`→`destination:literal`, then **drops `#b`**. Every translation (de/es/ja/ko/…) parses `{destination:selector, patient:selector}` correctly — so R1 (recall vs the garbage en reference) scored them ~0 for swap.

**Fix:** a dedicated `swap-en-element` pattern (`swap {destination} with {patient}`, priority 120 > 110) in both en pattern paths (`patterns/en.ts` `buildEnglishPatterns` — the registered/gate path — and `patterns/languages/en/swap.ts`; kept in sync). The required `with` literal means it only fires on the element-swap shape; `swap innerHTML #target` / `swap delete #item` (no `with`) still take the 110 method form.

## Impact (gate-verified, `browser-priority`)

| signal | before | after |
| --- | --- | --- |
| **mean R1** | 0.9467 | **0.9497** (+0.0029) |
| all 23 langs | — | +0.0034 (most), +0.0017 (ar/bn/hi/qu/tl/tr) |
| R0 recall / precision / R2 / parse-rate | 1.000 / 0.9747 / 1.000 / 3696/3696 | flat |

en now parses `swap {destination:selector="#a", patient:selector="#b"}`, matching the schema and every translation → R1 for swap-content jumps ~0 → 1.0 across the board. **Zero per-language drops.** swap-content is **not** in the curated execution subset, so no R2 risk. Biggest single R1 win since the URL fix (#525).

## Strategic note

This validates a **new direction**: the remaining high-leverage R1 residues are **broken EN references** where translations are already correct — so fixing en aligns it *toward* them (the opposite of the abandoned trigger.event, where en was right). Next candidates of this shape: `send-with-detail`, `repeat-for-each` (two-sided).

## Tests

- Guard: `multilingual-roadmap-fixes.test.ts` "en element-swap reference" — 5 cases (the en parse **fails without the fix**; 3 translation-alignment; 1 method-form-unchanged control).
- Full semantic suite green (6382 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)