### PR TITLE
fix(multilingual): `<ref>.<prop>` → property-path (put/set.patient R1; +0.0028 mean R1, all 23 langs up/flat, zero regressions)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,54 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-30c (Arc B R1 — `<ref>.<prop>` → property-path reclassification: LANDED, all four
+> coupled fronts. mean R1 0.9497 → 0.9525 (+0.0028); ALL 23 langs up or flat, ZERO per-language AND
+> ZERO per-pattern regressions. The 2026-06-30b arc — flagged below as "ATTEMPTED & REVERTED" because
+> the EN-only slice regressed 5 langs — converges once the three coupled fronts land WITH it. R0
+> 1.000 / precision 0.9747 flat / R2 1.000 / parse-rate 3696/3696.)** The 2026-06-30b spike's gating
+> question — "can condition-position `event.X` stay expression while patient/destination flip to
+> property-path?" — RESOLVED **yes**. The 06-30b note ruled it out by `expectedTypes` (both `put.patient`
+> and `if.condition` omit `property-path`), but missed that it scopes cleanly by **role NAME**: the SOV
+> window-keydown condition DOES route through `matchRoleToken` with `patternToken.role === 'condition'`
+> (confirmed empirically — `tryMatchPropertyAccessExpression` has exactly one caller), so an
+> `allowPropertyPath = patternToken.role !== 'condition'` flag at that call site keeps the condition an
+> `expression` while every other role flips. EN's own `if event.X` is captured as a raw span (never
+> routed through the matcher), so the en reference stays `expression` and the SOV condition now matches it.
+>
+> **The four coupled fronts (all required for zero regression; each independently verified):**
+>
+> 1. **F1 — EN `it.X`/`result.X` → property-path** (`pattern-matcher.ts`
+>    `tryMatchPropertyAccessExpression`, both the fused-dot and operator-dot return points): when the
+>    dotted base `isValidReference`, emit `createPropertyPath(createReference(base), props)` instead of
+>    `{type:expression}`. **GAIN: de/es/ja + 15 others (18 langs) on `put.patient`/`set.patient`** —
+>    they already render the possessive as property-path; en was the outlier. (+0.0034/lang on the 3
+>    fetch patterns.)
+> 2. **F2 — guard the fused-dot path against trailing method-calls.** The fused path consumed
+>    `.`-selector props and returned BEFORE checking for a trailing `(`, so `target.closest("li")` →
+>    property-path. Added `fusedIsMethodCall = peek().value.startsWith('(')` → stays expression.
+>    **Protects behavior-sortable** (OFF-LIMITS) `set item to the target.closest("li")` from
+>    regressing. (Verified load-bearing: without the guard that clause flips to property-path.)
+> 3. **F3 — id/ms possessive keywords.** The i18n dict renders the reference `it` as id `miliknya` / ms
+>    bare `nya` (not in the profiles' `possessive.keywords` — id had only `nya`/`dia`, ms had `-nya`
+>    suffix / `dia`/`ia`). Without them id/ms `miliknya.error`/`nya.error` stayed `expression` and
+>    NEWLY mismatched the flipped en reference — the exact −0.0038 regression the 06-30b EN-only slice
+>    hit. Added `miliknya:'it'` (id) and bare `nya:'it'` (ms). The possessive matcher (`tryMatchPossessiveExpression`,
+>    runs BEFORE the property-access matcher) then assembles the property-path. **id/ms +0.0014.**
+> 4. **F4 — condition role exclusion** (the gating question above). ja/ko/qu `window-keydown` condition
+>    stays `expression`. **No regression** (06-30b's −0.0017 ko/qu eliminated).
+>
+> **Grounding rigor (per the methodology — a green gate's 0.02 tolerance hides per-pattern drops):**
+> ran a full per-(lang,pattern) R1 A/B (clean HEAD vs all-fronts, 3404 entries): **56 gains, 0 drops**
+> (fetch-json/-error-handling/-with-headers × 18 langs each, +2 on `its-value-possessive-dot`). Plus a
+> per-language baseline diff (every lang up or flat). Guard: `multilingual-roadmap-fixes.test.ts`
+> "`<ref>.<prop>` → property-path reclassification" (11 cases, one per front + alignment; each fails
+> if its front is reverted). semantic 6393 green.
+>
+> **Residue unchanged by this arc:** ko/qu render `put.patient` as `:selector` (`그것의.error`,
+> `chaypaq.error`), NOT property-path — they neither gained nor lost (already mismatched both before
+> and after). A separate, smaller residue (the SOV/qu possessive-dot → selector typing); not pursued
+> here. The 06-30b leverage map below otherwise still stands.
+>
 > **Update 2026-06-30b (Arc B R1 — `<ref>.<prop>` → property-path reclassification: ATTEMPTED &
 > REVERTED. A genuine high-value EN-outlier opportunity (+0.0016 mean R1, 18 langs +0.0030) that does
 > NOT converge to zero-regression in one slice — it's a multi-front ARC. Plus a FRESH-DB leverage map

--- a/packages/semantic/src/generators/profiles/indonesian.ts
+++ b/packages/semantic/src/generators/profiles/indonesian.ts
@@ -56,6 +56,12 @@ export const indonesianProfile: LanguageProfile = {
       // "its/his/her"
       nya: 'it', // third person clitic (suffix form: -nya)
       dia: 'it', // third person pronoun
+      // The id dict renders the reference `it` (possessive `it.X`) as the
+      // standalone possessive pronoun `miliknya` ("belonging to it") — e.g.
+      // `it.error` → `miliknya.error` (fetch-error-handling/-with-headers/-json
+      // rows). Recognize it so the possessive matcher assembles the
+      // property-path, matching the en reference's `it.error:property-path`.
+      miliknya: 'it', // "its" (milik + -nya, standalone possessive)
     },
     // `saya punya *background` = "I have *background" = "my *background". The
     // i18n dict's `my` is the two-word `saya punya`; `punya` ("have/own") is a

--- a/packages/semantic/src/generators/profiles/ms.ts
+++ b/packages/semantic/src/generators/profiles/ms.ts
@@ -46,6 +46,13 @@ export const malayProfile: LanguageProfile = {
       anda: 'you', // your (formal)
       dia: 'it', // his/her/its
       ia: 'it', // its
+      // The ms dict renders the reference `it` (possessive `it.X`) as a
+      // STANDALONE `nya` token — e.g. `it.error` → `nya.error`
+      // (fetch-error-handling/-with-headers/-json rows). The suffix `-nya` key
+      // below is a distinct lexeme (exact-match lookup), so it doesn't cover the
+      // bare form. Recognize it so the possessive matcher assembles the
+      // property-path, matching the en reference's `it.error:property-path`.
+      nya: 'it', // "its" (standalone clitic, dot-notation possessor)
       // Suffix forms (attached to nouns)
       '-ku': 'me', // my (suffix)
       '-mu': 'you', // your (suffix)

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -533,7 +533,16 @@ export class PatternMatcher {
     }
 
     // Check for property access expression (e.g., 'userData.name', 'it.data')
-    const propertyAccessValue = this.tryMatchPropertyAccessExpression(tokens);
+    // The condition position keeps the raw-span expression form: the en
+    // reference's `if event.ctrlKey` is captured as a raw span (never routed
+    // through this matcher), so flipping `<ref>.<prop>` to property-path here
+    // would mismatch en for the SOV langs that DO route the condition through
+    // the matcher (ja/ko/qu window-keydown). Scope the property-path emission
+    // out of the condition role. (Role-NAME scoping, not expectedTypes —
+    // `put.patient` and `if.condition` both omit property-path, relying on the
+    // isTypeCompatible rule, so a type-list scope can't separate them.)
+    const allowPropertyPath = patternToken.role !== 'condition';
+    const propertyAccessValue = this.tryMatchPropertyAccessExpression(tokens, allowPropertyPath);
     if (propertyAccessValue) {
       if (patternToken.expectedTypes && patternToken.expectedTypes.length > 0) {
         if (
@@ -1393,7 +1402,10 @@ export class PatternMatcher {
    * Pattern: (identifier | keyword) + '.' + identifier [+ '.' + identifier ...]
    * Returns an expression value if matched, or null if not.
    */
-  private tryMatchPropertyAccessExpression(tokens: TokenStream): SemanticValue | null {
+  private tryMatchPropertyAccessExpression(
+    tokens: TokenStream,
+    allowPropertyPath = true
+  ): SemanticValue | null {
     const token = tokens.peek();
     if (!token) return null;
 
@@ -1421,16 +1433,35 @@ export class PatternMatcher {
       /^\.[a-zA-Z_]/.test(fusedFirst.value)
     ) {
       let fusedChain = token.value;
+      const fusedProps: string[] = [];
       let fusedDepth = 0;
       while (fusedDepth < PatternMatcher.MAX_PROPERTY_DEPTH) {
         const prop = tokens.peek();
         if (prop && prop.kind === 'selector' && /^\.[a-zA-Z_]/.test(prop.value)) {
           fusedChain += `.${prop.value.slice(1)}`;
+          fusedProps.push(prop.value.slice(1));
           tokens.advance();
           fusedDepth++;
         } else {
           break;
         }
+      }
+      // A fused `<ref>.<prop>` access where the base is a real reference
+      // (`it.error`, `result.name`, `event.ctrlKey`) is semantically a property
+      // access — emit property-path so it aligns with the translations that
+      // already render the possessive as property-path (the put/set.patient R1
+      // arc). Guard against a trailing method call (`target.closest("li")`): the
+      // fused path consumes the `.`-selector props but a following `(` means it's
+      // a method call, which must stay an expression (behavior-sortable).
+      const fusedTrailing = tokens.peek();
+      const fusedIsMethodCall = !!fusedTrailing && fusedTrailing.value.startsWith('(');
+      if (
+        allowPropertyPath &&
+        !fusedIsMethodCall &&
+        fusedProps.length > 0 &&
+        isValidReference(baseLower)
+      ) {
+        return createPropertyPath(createReference(baseLower), fusedProps.join('.'));
       }
       return { type: 'expression', raw: fusedChain } as SemanticValue;
     }
@@ -1516,6 +1547,15 @@ export class PatternMatcher {
       } as SemanticValue;
     }
 
+    // Un-fused `<ref> . <prop>` where the base is a real reference →
+    // property-path (mirrors the fused-dot path above). Plain identifiers
+    // (`userData.name`) keep the expression form. The method-call shape is
+    // already handled above (the `(` branch returns an expression before here).
+    const opBaseLower = token.value.toLowerCase();
+    if (allowPropertyPath && isValidReference(opBaseLower)) {
+      const opProps = chain.split('.').slice(1).join('.');
+      return createPropertyPath(createReference(opBaseLower), opProps);
+    }
     // Create expression value: userData.name
     return {
       type: 'expression',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -9266,3 +9266,109 @@ describe('en element-swap reference: `swap {destination} with {patient}` (swap-c
     expect(roles!.get('destination')?.type).toBe('selector');
   });
 });
+
+describe('`<ref>.<prop>` → property-path reclassification (put/set patient R1)', () => {
+  // A dotted member access off a real reference (`it.error`, `result.name`) is
+  // semantically a property access. The en reference previously typed it as a
+  // bare `expression`, but ~18 translations render the possessive as
+  // property-path (de `sein.error`, es `su.error`, ja `その.error`), so R1
+  // (recall vs the en role signature) penalized them for `put.patient`. Emitting
+  // property-path for reference-based dotted access in
+  // `tryMatchPropertyAccessExpression` aligns en TOWARD the translations.
+  // Four coupled fronts (all required for zero per-language regression):
+  //   F1 — en `it.X` → property-path (the core flip)
+  //   F2 — guard the fused-dot path against trailing method-calls
+  //        (`target.closest("li")` is a call, NOT a property — stays expression)
+  //   F3 — id/ms possessive: the dict renders `it` as id `miliknya` / ms `nya`,
+  //        not in the profiles' possessive.keywords → without them id/ms stay
+  //        `expression` and newly MISMATCH the flipped en reference
+  //   F4 — keep the condition role as `expression` (the en `if event.X`
+  //        condition is captured as a raw span, never routed through the value
+  //        matcher; SOV window-keydown DOES route it through the matcher, so
+  //        scope property-path emission out of the `condition` role).
+  function rolesOf(node: unknown, action: string): Map<string, { type?: string }> | undefined {
+    if (!node || typeof node !== 'object') return undefined;
+    const r = node as Record<string, unknown>;
+    if (r.action === action && r.roles instanceof Map)
+      return r.roles as Map<string, { type?: string }>;
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = r[f];
+      if (Array.isArray(c)) {
+        for (const x of c) {
+          const m = rolesOf(x, action);
+          if (m) return m;
+        }
+      } else if (c && typeof c === 'object') {
+        const m = rolesOf(c, action);
+        if (m) return m;
+      }
+    }
+    return undefined;
+  }
+
+  // F1: en `it.X` patient → property-path (was `expression`).
+  it('[en] `put it.error into #error` → put.patient:property-path', () => {
+    const roles = rolesOf(parse('on click put it.error into #error', 'en'), 'put');
+    expect(roles?.get('patient')?.type).toBe('property-path');
+  });
+  it('[en] `set #name.innerText to it.name` → set.patient:property-path', () => {
+    const roles = rolesOf(parse('on click set #name.innerText to it.name', 'en'), 'set');
+    expect(roles?.get('patient')?.type).toBe('property-path');
+  });
+
+  // F2: a fused `<ref>.<method>(...)` is a method CALL, not a property — it must
+  // stay `expression` (else behavior-sortable's `set item to the
+  // target.closest("li")` regresses; the fused path returned before checking for
+  // a trailing `(`). behavior-sortable is OFF-LIMITS to edit; this guards the
+  // PARSER fix that protects it.
+  it('[en] `set item to the target.closest("li")` keeps patient:expression (method-call guard)', () => {
+    const roles = rolesOf(parse('set item to the target.closest("li")', 'en'), 'set');
+    expect(roles?.get('patient')?.type).toBe('expression');
+    expect(roles?.get('patient')?.type).not.toBe('property-path');
+  });
+
+  // F3: id/ms render the reference `it` as the standalone possessor `miliknya` /
+  // `nya`; with those in possessive.keywords the possessive matcher assembles the
+  // property-path, matching the flipped en reference (without them they stay
+  // `expression` and newly mismatch en → the regression the previous attempt hit).
+  it('[id] `taruh miliknya.error ke #error` → put.patient:property-path', () => {
+    const roles = rolesOf(parse('pada klik taruh miliknya.error ke #error', 'id'), 'put');
+    expect(roles?.get('patient')?.type).toBe('property-path');
+  });
+  it('[ms] `letak nya.error ke #error` → put.patient:property-path', () => {
+    const roles = rolesOf(parse('apabila click letak nya.error ke #error', 'ms'), 'put');
+    expect(roles?.get('patient')?.type).toBe('property-path');
+  });
+
+  // F4: the SOV window-keydown condition `event.ctrlKey` DOES route through the
+  // value matcher (unlike en, where it's a raw span) — but the en reference types
+  // it `expression`, so the condition role must NOT flip to property-path or
+  // ja/ko/qu regress. Scoped out by role name (`condition`).
+  for (const [lang, src] of [
+    [
+      'ja',
+      'keydown[key=="s"] で ウィンドウ から もし event.ctrlKey 呼び出し saveDocument() を 停止 終わり',
+    ],
+    ['ko', 'keydown[key=="s"] 할 때 창 에서 만약 event.ctrlKey 호출 saveDocument() 를 정지 끝'],
+    ['qu', 'k_iri manta keydown[key=="s"] pi sichus event.ctrlKey qayay saveDocument() ta sayay tukuy'],
+  ] as [string, string][]) {
+    it(`[${lang}] window-keydown condition stays if.condition:expression (not property-path)`, () => {
+      const roles = rolesOf(parse(src, lang), 'if');
+      expect(roles?.get('condition')?.type).toBe('expression');
+      expect(roles?.get('condition')?.type).not.toBe('property-path');
+    });
+  }
+
+  // Translation-alignment: the ~18 langs that already render property-path now
+  // MATCH the corrected en reference (the R1 gain).
+  for (const [lang, src] of [
+    ['de', 'bei klick setzen sein.name zu ich'],
+    ['es', 'en clic poner su.name a yo'],
+    ['ja', 'その.name を 私 に 置く'],
+  ] as [string, string][]) {
+    it(`[${lang}] possessive .name patient is property-path (aligns with en)`, () => {
+      const roles = rolesOf(parse(src, lang), 'put');
+      expect(roles?.get('patient')?.type).toBe('property-path');
+    });
+  }
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-30T03:39:50.978Z",
-  "commit": "0c1958cb",
+  "timestamp": "2026-06-30T18:58:22.993Z",
+  "commit": "7eb3b61b",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9,12 +9,12 @@
       "avgConfidence": 0.8387196824503315,
       "avgFidelity": 1,
       "avgPrecision": 0.9796536796536797,
-      "avgRoleFidelity": 0.9615930814460225,
+      "avgRoleFidelity": 0.965035809888751,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -641,12 +641,12 @@
       "avgConfidence": 0.8495030867211314,
       "avgFidelity": 1,
       "avgPrecision": 0.9315737203972502,
-      "avgRoleFidelity": 0.9267815286197639,
+      "avgRoleFidelity": 0.9302242570624923,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.828035456606883,
       "avgFidelity": 1,
       "avgPrecision": 0.9967532467532467,
-      "avgRoleFidelity": 0.9574103272632687,
+      "avgRoleFidelity": 0.960853055705997,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
       "avgPrecision": 0.9846320346320346,
-      "avgRoleFidelity": 0.9581146474528829,
+      "avgRoleFidelity": 0.9615573758956112,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
       "avgPrecision": 0.9833333333333334,
-      "avgRoleFidelity": 0.9550774190480074,
+      "avgRoleFidelity": 0.9585201474907356,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3794,12 +3794,12 @@
       "avgConfidence": 0.8237889095031952,
       "avgFidelity": 1,
       "avgPrecision": 0.9851731601731601,
-      "avgRoleFidelity": 0.962558114028702,
+      "avgRoleFidelity": 0.9660008424714303,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4426,12 +4426,12 @@
       "avgConfidence": 0.90909904631709,
       "avgFidelity": 1,
       "avgPrecision": 0.9365270281666384,
-      "avgRoleFidelity": 0.9115252008634361,
+      "avgRoleFidelity": 0.9149679293061647,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
       "avgPrecision": 0.9829004329004329,
-      "avgRoleFidelity": 0.956806827027415,
+      "avgRoleFidelity": 0.9581581783787664,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.976650432900433,
-      "avgRoleFidelity": 0.960878606466842,
+      "avgRoleFidelity": 0.9643213349095705,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
       "avgPrecision": 0.9504107634789454,
-      "avgRoleFidelity": 0.9283416051798404,
+      "avgRoleFidelity": 0.9317843336225691,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
       "avgPrecision": 0.9811688311688311,
-      "avgRoleFidelity": 0.9649714598244014,
+      "avgRoleFidelity": 0.9663228111757526,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
       "avgPrecision": 0.9928841991341991,
-      "avgRoleFidelity": 0.9497299578181935,
+      "avgRoleFidelity": 0.953172686260922,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8850,12 @@
       "avgConfidence": 0.7984333127190251,
       "avgFidelity": 1,
       "avgPrecision": 0.9820346320346321,
-      "avgRoleFidelity": 0.9569885213267566,
+      "avgRoleFidelity": 0.9604312497694851,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.8135642135642115,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367965,
-      "avgRoleFidelity": 0.9504375901434727,
+      "avgRoleFidelity": 0.953880318586201,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10746,12 +10746,12 @@
       "avgConfidence": 0.7962481962481944,
       "avgFidelity": 1,
       "avgPrecision": 0.9852813852813852,
-      "avgRoleFidelity": 0.9577720779926661,
+      "avgRoleFidelity": 0.9612148064353945,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.9753246753246753,
-      "avgRoleFidelity": 0.9570128709834593,
+      "avgRoleFidelity": 0.9604555994261877,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12010,12 +12010,12 @@
       "avgConfidence": 0.8231816490551542,
       "avgFidelity": 1,
       "avgPrecision": 0.9800865800865801,
-      "avgRoleFidelity": 0.9711651535180945,
+      "avgRoleFidelity": 0.974607881960823,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12642,12 +12642,12 @@
       "avgConfidence": 0.8307646822684411,
       "avgFidelity": 1,
       "avgPrecision": 0.9508127424523529,
-      "avgRoleFidelity": 0.9290702750261575,
+      "avgRoleFidelity": 0.9325130034688861,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13274,12 +13274,12 @@
       "avgConfidence": 0.8139764996907833,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367963,
-      "avgRoleFidelity": 0.9504375901434725,
+      "avgRoleFidelity": 0.953880318586201,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14538,12 +14538,12 @@
       "avgConfidence": 0.9840032982890127,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9653734293440172,
+      "avgRoleFidelity": 0.9688161577867457,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460533,
+      "bundleSize": 460799,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 460533,
+      "size": 460799,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## What

Reclassify a dotted member access off a real reference (`it.error`, `result.name`) from a bare `expression` to a **property-path** — the semantically correct type, and the one ~18 translations already use (`de sein.error`, `es su.error`, `ja その.error`). The en reference was the outlier; R1 (recall vs the en role signature) penalized those translations on `put.patient`/`set.patient`. This aligns en TOWARD them.

This lands the `<ref>.<prop>` arc that the [2026-06-30b note](../blob/main/docs-internal/MULTILINGUAL_NEXT_STEPS.md) flagged as "ATTEMPTED & REVERTED" — the EN-only slice regressed 5 langs, but it converges to **zero regression** once the three coupled fronts land with it.

## The four coupled fronts (each independently verified, each guarded by a test)

| # | Front | Effect |
|---|-------|--------|
| **F1** | en `it.X`/`result.X` → property-path (fused-dot + operator-dot return points in `tryMatchPropertyAccessExpression`) | **GAIN**: de/es/ja + 15 others on put/set.patient |
| **F2** | guard the fused-dot path against a trailing method-call (`target.closest("li")` is a call, not a property — stays expression) | protects OFF-LIMITS `behavior-sortable` from regressing |
| **F3** | id/ms possessive: the i18n dict renders `it` as id `miliknya` / ms bare `nya` (absent from the profiles' `possessive.keywords`) — added them so the possessive matcher assembles the property-path | id/ms **+0.0014** (eliminates the −0.0038 the EN-only slice hit) |
| **F4** | keep the `condition` role an `expression` — scope property-path emission out by role NAME (`allowPropertyPath = role !== 'condition'`) | ja/ko/qu window-keydown condition no regression |

**F4 resolves the 06-30b gating question.** That note ruled out scoping by `expectedTypes` (both `put.patient` and `if.condition` omit property-path, relying on `isTypeCompatible`). But scoping by the **role name** works: the SOV window-keydown condition routes through `matchRoleToken` with `role === 'condition'` (confirmed — `tryMatchPropertyAccessExpression` has exactly one caller), while en's own `if event.X` is a raw span that never reaches the matcher, so en stays `expression` and the SOV condition now matches it.

## Results

- **mean R1 0.9497 → 0.9525 (+0.0028)**; all 23 langs up or flat.
- **R0 1.000 · precision 0.9747 (flat) · R2 1.000 · parse-rate 3696/3696.**

## Grounding (per methodology — a green gate's 0.02 tolerance hides per-pattern drops)

- **Full per-(lang,pattern) R1 A/B** over 3404 entries (clean HEAD vs all-fronts): **56 gains, 0 drops** (fetch-json / -error-handling / -with-headers × 18 langs each, +2 on `its-value-possessive-dot`).
- **Per-language baseline diff**: every lang up or flat, zero drops.
- Baseline regenerated against a fresh `populate`. semantic suite **6393 green**. typecheck clean.

**Residue unchanged:** ko/qu render put.patient as `:selector` (`그것의.error`, `chaypaq.error`), not property-path — neither gained nor lost (mismatched before and after). A separate, smaller residue.

## Guard test

`multilingual-roadmap-fixes.test.ts` → "`<ref>.<prop>` → property-path reclassification" (11 cases, one per front + alignment; each fails if its front is reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)