### PR TITLE
fix(multilingual): drop redundant en `for.loopType:literal="for"` (for.loopType R1; +0.0006 mean R1, all 23 langs up, zero regressions)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,37 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-06-30d (Arc B R1 — en `for` reference: drop the redundant `loopType:literal="for"`.
+> LANDED. mean R1 0.9525 → 0.9531 (+0.0006); ALL 23 langs up (SVO +0.0007, SOV +0.0004), ZERO per-language
+> AND ZERO per-pattern regressions. The clean broken-EN-reference slice inside the `template-literal-list-build`
+> residue.)** Grounding the handoff's suggested "`set.destination` template-literal trailing-set-drop"
+> arc (fresh `populate`) split it into THREE distinct root causes — only one is a clean slice:
+>
+> 1. **`for.loopType:literal` missed by ALL 23 langs — LANDED (this slice).** The `for` schema
+>    (`command-schemas.ts` `forSchema`) has NO loopType role (unlike `repeat`, whose times/forever/until
+>    variants are meaningful). But the en handcrafted `for-en-basic` set an extraction default
+>    `loopType:literal="for"` — a role that merely DUPLICATES the action name and that no schema-generated
+>    translation reproduces. en was the R1 outlier. Dropped it from BOTH en for-pattern paths
+>    (`patterns/en.ts` `forEnglish` + `patterns/languages/en/control-flow.ts` `forEnglish`, kept in sync).
+>    R2-safe: `command-mappers.ts` `forMapper` reads only patient+source. Per-pattern A/B (3404 entries):
+>    **23 gains, 0 drops, all on `template-literal-list-build`** (the only `for`-pattern in the corpus).
+>    Guard: `multilingual-roadmap-fixes.test.ts` "en `for` reference: no redundant loopType role". semantic
+>    6397 green.
+> 2. **`set.destination:property-path` missed by ALL 23 — STRUCTURAL trailing-set DROP, NOT landed.** The
+>    handoff's "trailing-set-drop" is REAL but masked by action-dedup: en parses 3 sets (the trailing
+>    `set #list.innerHTML to $html` → property-path), but es/de capture only **2** — the trailing set
+>    AFTER the for-loop's `end then` is dropped (a block-continuation bug: the compound stops at the loop
+>    `end`). This is entangled with the for-loop body parse (the for `end` boundary). A real structural
+>    arc, NOT a slice.
+> 3. **SOV for-body roles (`for.patient:expression`, `for.source:reference`, `set.patient:reference`)
+>    missed by bn/hi/ja/ko/qu/tr — the repeat-for-each entanglement.** Under SOV reorder the for-loop body
+>    `set` degenerates (ja `set` destination undefined; ko captures the whole `$html+\`…\``as`patient:literal`). The hard for-loop arc.
+>
+> **Bottom line:** the `template-literal-list-build` residue's only clean lever was the redundant en
+> `for.loopType` (this slice). The trailing-set DROP (#2) and the SOV for-body (#3) are both structural —
+> they need the for-loop body/block-continuation arc, which is the same `repeat-for-each` arc flagged
+> below as the hardest remaining work. Don't re-attempt them as slices.
+>
 > **Update 2026-06-30c (Arc B R1 — `<ref>.<prop>` → property-path reclassification: LANDED, all four
 > coupled fronts. mean R1 0.9497 → 0.9525 (+0.0028); ALL 23 langs up or flat, ZERO per-language AND
 > ZERO per-pattern regressions. The 2026-06-30b arc — flagged below as "ATTEMPTED & REVERTED" because

--- a/packages/semantic/src/patterns/en.ts
+++ b/packages/semantic/src/patterns/en.ts
@@ -272,7 +272,14 @@ const forEnglish: LanguagePattern = {
   extraction: {
     patient: { position: 1 },
     source: { marker: 'in' },
-    loopType: { default: { type: 'literal', value: 'for' } },
+    // NOTE: no `loopType` default. The `for` schema has no loopType role (unlike
+    // `repeat`, whose variants times/forever/until/for are meaningful), so a
+    // `loopType:literal="for"` here merely DUPLICATES the action name — a
+    // redundant role NO schema-generated translation reproduces. Emitting it made
+    // en the R1 outlier: all 23 langs "missed" `for.loopType:literal` on every
+    // for-pattern (template-literal-list-build). The for AST mapper
+    // (command-mappers.ts forMapper) reads only patient+source, so dropping it is
+    // R2-safe. (Kept in sync with patterns/languages/en/control-flow.ts.)
   },
 };
 

--- a/packages/semantic/src/patterns/languages/en/control-flow.ts
+++ b/packages/semantic/src/patterns/languages/en/control-flow.ts
@@ -32,7 +32,10 @@ export const forEnglish: LanguagePattern = {
   extraction: {
     patient: { position: 1 },
     source: { marker: 'in' },
-    loopType: { default: { type: 'literal', value: 'for' } },
+    // NOTE: no `loopType` default — see the rationale in patterns/en.ts
+    // `forEnglish` (the `for` schema has no loopType role; a `loopType:literal="for"`
+    // here only duplicates the action name and is the R1 outlier no translation
+    // reproduces). R2-safe (forMapper reads only patient+source). Kept in sync.
   },
 };
 

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -9372,3 +9372,56 @@ describe('`<ref>.<prop>` → property-path reclassification (put/set patient R1)
     });
   }
 });
+
+describe('en `for` reference: no redundant loopType role (for.loopType R1)', () => {
+  // The `for` schema (command-schemas.ts forSchema) has NO loopType role — only
+  // patient + source. The en handcrafted `for-en-basic` pattern nonetheless set
+  // an extraction default `loopType:literal="for"`, a role that merely duplicates
+  // the action name and that NO schema-generated translation reproduces. That made
+  // en the R1 outlier: all 23 langs "missed" `for.loopType:literal` on the corpus
+  // for-pattern (template-literal-list-build). Dropping the default from both en
+  // for-pattern paths (patterns/en.ts + patterns/languages/en/control-flow.ts)
+  // aligns en TOWARD the translations. The for AST mapper (command-mappers.ts
+  // forMapper) reads only patient+source, so it's R2-safe.
+  function forRoles(node: unknown): Map<string, { type?: string }> | undefined {
+    if (!node || typeof node !== 'object') return undefined;
+    const r = node as Record<string, unknown>;
+    if (r.action === 'for' && r.roles instanceof Map)
+      return r.roles as Map<string, { type?: string }>;
+    for (const f of ['body', 'statements', 'commands', 'thenBranch', 'elseBranch', 'branches']) {
+      const c = r[f];
+      if (Array.isArray(c)) {
+        for (const x of c) {
+          const m = forRoles(x);
+          if (m) return m;
+        }
+      } else if (c && typeof c === 'object') {
+        const m = forRoles(c);
+        if (m) return m;
+      }
+    }
+    return undefined;
+  }
+
+  it('[en] `for item in $items` captures patient+source but NOT loopType', () => {
+    const roles = forRoles(parse('for item in $items', 'en'));
+    expect(roles).toBeTruthy();
+    expect(roles!.get('patient')).toBeTruthy();
+    expect(roles!.get('source')).toBeTruthy();
+    expect(roles!.has('loopType')).toBe(false); // the redundant role is gone
+  });
+
+  // The generated translations (schema-derived, no loopType) now MATCH the en
+  // reference's for role signature.
+  for (const [lang, src] of [
+    ['es', 'para item en $items'],
+    ['de', 'für item in $items'],
+    ['id', 'untuk item dalam $items'],
+  ] as [string, string][]) {
+    it(`[${lang}] for-loop has no loopType role (aligns with en)`, () => {
+      const roles = forRoles(parse(src, lang));
+      expect(roles).toBeTruthy();
+      expect(roles!.has('loopType')).toBe(false);
+    });
+  }
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-30T18:58:22.993Z",
-  "commit": "7eb3b61b",
+  "timestamp": "2026-06-30T20:02:42.292Z",
+  "commit": "ca90388e",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9,12 +9,12 @@
       "avgConfidence": 0.8387196824503315,
       "avgFidelity": 1,
       "avgPrecision": 0.9796536796536797,
-      "avgRoleFidelity": 0.965035809888751,
+      "avgRoleFidelity": 0.9656927167956579,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -641,12 +641,12 @@
       "avgConfidence": 0.8495030867211314,
       "avgFidelity": 1,
       "avgPrecision": 0.9315737203972502,
-      "avgRoleFidelity": 0.9302242570624923,
+      "avgRoleFidelity": 0.9307873201255555,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.828035456606883,
       "avgFidelity": 1,
       "avgPrecision": 0.9967532467532467,
-      "avgRoleFidelity": 0.960853055705997,
+      "avgRoleFidelity": 0.961509962612904,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
       "avgPrecision": 0.9846320346320346,
-      "avgRoleFidelity": 0.9615573758956112,
+      "avgRoleFidelity": 0.9622142828025181,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
       "avgPrecision": 0.9833333333333334,
-      "avgRoleFidelity": 0.9585201474907356,
+      "avgRoleFidelity": 0.9591770543976426,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3794,12 +3794,12 @@
       "avgConfidence": 0.8237889095031952,
       "avgFidelity": 1,
       "avgPrecision": 0.9851731601731601,
-      "avgRoleFidelity": 0.9660008424714303,
+      "avgRoleFidelity": 0.9666577493783371,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4426,12 +4426,12 @@
       "avgConfidence": 0.90909904631709,
       "avgFidelity": 1,
       "avgPrecision": 0.9365270281666384,
-      "avgRoleFidelity": 0.9149679293061647,
+      "avgRoleFidelity": 0.9153433046815399,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
       "avgPrecision": 0.9829004329004329,
-      "avgRoleFidelity": 0.9581581783787664,
+      "avgRoleFidelity": 0.9588150852856733,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.976650432900433,
-      "avgRoleFidelity": 0.9643213349095705,
+      "avgRoleFidelity": 0.9649782418164772,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
       "avgPrecision": 0.9504107634789454,
-      "avgRoleFidelity": 0.9317843336225691,
+      "avgRoleFidelity": 0.9321597089979444,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6954,12 @@
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
       "avgPrecision": 0.9504107634789454,
-      "avgRoleFidelity": 0.9253010646393,
+      "avgRoleFidelity": 0.9256764400146753,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
       "avgPrecision": 0.9811688311688311,
-      "avgRoleFidelity": 0.9663228111757526,
+      "avgRoleFidelity": 0.9669797180826596,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
       "avgPrecision": 0.9928841991341991,
-      "avgRoleFidelity": 0.953172686260922,
+      "avgRoleFidelity": 0.9538295931678289,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8850,12 @@
       "avgConfidence": 0.7984333127190251,
       "avgFidelity": 1,
       "avgPrecision": 0.9820346320346321,
-      "avgRoleFidelity": 0.9604312497694851,
+      "avgRoleFidelity": 0.961088156676392,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9482,12 @@
       "avgConfidence": 0.7349000206143064,
       "avgFidelity": 1,
       "avgPrecision": 0.9512456428852532,
-      "avgRoleFidelity": 0.9158494305553131,
+      "avgRoleFidelity": 0.9162248059306884,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.8135642135642115,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367965,
-      "avgRoleFidelity": 0.953880318586201,
+      "avgRoleFidelity": 0.9545372254931079,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10746,12 +10746,12 @@
       "avgConfidence": 0.7962481962481944,
       "avgFidelity": 1,
       "avgPrecision": 0.9852813852813852,
-      "avgRoleFidelity": 0.9612148064353945,
+      "avgRoleFidelity": 0.9618717133423015,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.9753246753246753,
-      "avgRoleFidelity": 0.9604555994261877,
+      "avgRoleFidelity": 0.9611125063330948,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12010,12 +12010,12 @@
       "avgConfidence": 0.8231816490551542,
       "avgFidelity": 1,
       "avgPrecision": 0.9800865800865801,
-      "avgRoleFidelity": 0.974607881960823,
+      "avgRoleFidelity": 0.9752647888677299,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12642,12 +12642,12 @@
       "avgConfidence": 0.8307646822684411,
       "avgFidelity": 1,
       "avgPrecision": 0.9508127424523529,
-      "avgRoleFidelity": 0.9325130034688861,
+      "avgRoleFidelity": 0.9328883788442613,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13274,12 +13274,12 @@
       "avgConfidence": 0.8139764996907833,
       "avgFidelity": 1,
       "avgPrecision": 0.9902867965367963,
-      "avgRoleFidelity": 0.953880318586201,
+      "avgRoleFidelity": 0.9545372254931079,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13906,12 +13906,12 @@
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
       "avgPrecision": 0.9811958874458874,
-      "avgRoleFidelity": 0.9691234584616939,
+      "avgRoleFidelity": 0.9697803653686008,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14538,12 +14538,12 @@
       "avgConfidence": 0.9840032982890127,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9688161577867457,
+      "avgRoleFidelity": 0.9694730646936526,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460799,
+      "bundleSize": 460751,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 460799,
+      "size": 460751,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## What

The `for` schema (`command-schemas.ts` `forSchema`) has **no `loopType` role** — only `patient` + `source`. Unlike `repeat` (whose `times`/`forever`/`until`/`for` variants are meaningful), the `for` command's loop type is fixed by the action name itself. But the en handcrafted `for-en-basic` set an extraction default `loopType:literal="for"` — a role that merely **duplicates the action name** and that no schema-generated translation reproduces. en was the R1 outlier: **all 23 langs "missed" `for.loopType:literal`** on the corpus for-pattern (`template-literal-list-build`).

Dropping the default from both en for-pattern paths (`patterns/en.ts` `forEnglish` + `patterns/languages/en/control-flow.ts` `forEnglish`, kept in sync) aligns en TOWARD the translations — the proven "fix the broken EN reference" pattern.

**R2-safe:** the for AST mapper (`command-mappers.ts` `forMapper`) reads only `patient` + `source`, never `loopType`.

## Results

- **mean R1 0.9525 → 0.9531 (+0.0006)**; all 23 langs up (SVO +0.0007, SOV +0.0004).
- R0 1.000 · precision 0.9747 flat · R2 1.000 · parse-rate 3696/3696.
- **Per-pattern A/B over 3404 entries: 23 gains, 0 drops** — all on `template-literal-list-build` (the only `for`-pattern in the corpus).
- Per-language baseline diff: every lang up, zero drops.

## Guard test

`multilingual-roadmap-fixes.test.ts` → "en `for` reference: no redundant loopType role" (4 cases — en captures patient+source but NOT loopType; es/de/id align — fails if the default is restored).

## Scope note

Grounding the handoff's suggested "`set.destination` trailing-set-drop" arc (fresh `populate`) split it into three root causes; **only the `for.loopType` one is a clean slice**. The other two are structural and **not** in this PR (documented in `MULTILINGUAL_NEXT_STEPS.md` §2026-06-30d):
- The trailing `set #list.innerHTML` IS dropped for all 23 langs (es/de capture 2 of 3 sets) — a block-continuation bug entangled with the for-loop body parse.
- SOV langs (bn/hi/ja/ko/qu/tr) additionally degenerate the loop-body `set` — the `repeat-for-each` arc.

semantic 6397 green · baseline regenerated · `patterns.db` not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)