### PR TITLE
test(multilingual): R2 execution wave 9 — +3 coverage patterns (subset 42→45)

### DIFF
--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-06-30T20:02:42.292Z",
-  "commit": "ca90388e",
+  "timestamp": "2026-07-04T04:21:53.580Z",
+  "commit": "e034f9e7",
   "languages": {
     "ar": {
       "parseSuccess": 154,

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
@@ -19,7 +19,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { ExecutionValidator, EXECUTION_SUBSET, loadExecutionSubset } from './execution-validator';
 
 describe('R2 execution subset (lock)', () => {
-  it('contains exactly the 42 curated patterns', () => {
+  it('contains exactly the 45 curated patterns', () => {
     // Changing this list recalibrates avgExecutionFidelity for every language.
     // If you expand the subset, regenerate the baseline (--save-baseline) in
     // the SAME PR and update this lock.
@@ -111,6 +111,14 @@ describe('R2 execution subset (lock)', () => {
         // across SVO/SOV (#516) + handcrafted VSO put-event patterns for ar/tl/uk.
         'put-before',
         'put-after',
+        // Wave 9 (R2-coverage sweep): three patterns whose en reference runs with
+        // a clean deterministic signature and already match in all 23 languages —
+        // pure coverage, no parser/dict fix. See the wave-9 note in
+        // execution-validator.ts (the *opacity hide/show strategies are
+        // synchronous, not the excluded async transition family).
+        'chained-access-possessive-dot',
+        'hide-with-transition',
+        'show-with-transition',
       ].sort()
     );
   });
@@ -316,6 +324,36 @@ describe('R2 execution validator (lock)', () => {
       const ar = await validator.execute(id, arCode, 'ar');
       expect(ar.error, `ar ${id} errored: ${ar.error}`).toBeUndefined();
       expect(ar.effects, `ar ${id} must reproduce en`).toEqual(en.effects);
+    }
+  });
+
+  it('wave-9 en references execute with their locked signatures', async () => {
+    // The three wave-9 additions. Each en reference must produce a non-empty,
+    // deterministic signature against the existing fixture. The `*opacity`
+    // hide/show STRATEGIES are synchronous (no timer): hide writes display:none
+    // + a data-original-display marker on #btn; show adds the visibility class
+    // on #modal. chained-access-possessive-dot writes the parent (.card) display.
+    const cases: ReadonlyArray<[string, string, string[]]> = [
+      [
+        'chained-access-possessive-dot',
+        'on click set my.parentElement.style.display to "none"',
+        ['Δdiv[0] cls[card] attr[] style[display: none;] text[]'],
+      ],
+      [
+        'hide-with-transition',
+        'on click hide me with *opacity',
+        ['Δ#btn cls[] attr[data-original-display=,id=btn] style[display: none;] text[Click]'],
+      ],
+      [
+        'show-with-transition',
+        'on click show #modal with *opacity',
+        ['Δ#modal cls[show] attr[id=modal] style[] text[]'],
+      ],
+    ];
+    for (const [id, code, expected] of cases) {
+      const res = await validator.execute(id, code, 'en');
+      expect(res.error, `${id} errored: ${res.error}`).toBeUndefined();
+      expect(res.effects, `${id} signature`).toEqual(expected);
     }
   });
 

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.ts
@@ -170,6 +170,24 @@ export const EXECUTION_SUBSET: readonly string[] = [
   // before/after #btn (matching en); R2 stays 1.0.
   'put-before',
   'put-after',
+  // Expansion wave 9 (R2-coverage sweep): a fresh discovery probe (every
+  // non-subset, non-async pattern's en reference executed against the fixture,
+  // then all 23 translations checked against the en signature) surfaced three
+  // patterns whose en reference produces a clean, deterministic, non-empty
+  // effect AND that already match in ALL 23 languages — pure coverage, no
+  // parser/dict fix needed:
+  //  - chained-access-possessive-dot: `set my.parentElement.style.display to
+  //    "none"` — a synchronous chained-member write on the parent (.card).
+  //  - hide-with-transition / show-with-transition: `hide me with *opacity` /
+  //    `show #modal with *opacity`. Despite the names these are SYNCHRONOUS
+  //    hide/show STRATEGIES (the runtime writes display + a data-original-display
+  //    marker on hide, adds the visibility class on show) — no timer, no
+  //    animation frame, so the signature is deterministic (verified across two
+  //    back-to-back runs). Distinct from the async `transition … over Nms`
+  //    family the subset still excludes.
+  'chained-access-possessive-dot',
+  'hide-with-transition',
+  'show-with-transition',
 ];
 
 /**


### PR DESCRIPTION
## What

Expands the R2 execution-fidelity subset from **42 → 45** patterns. Now that R0 recall is saturated (every priority pattern parses faithfully, both fidelity bands 0), the un-mined question is whether those faithful parses actually *execute* correctly — and today only ~27% of the corpus is behaviorally verified. This is the first coverage sweep of that gap.

## How

A fresh R2 discovery probe executed every non-subset, non-async pattern's **en** reference against the jsdom fixture, then checked all 23 translations against the en effect signature. Three patterns already execute faithfully in **all 23 languages** — pure coverage, no parser/dict fix:

- **`chained-access-possessive-dot`** — `set my.parentElement.style.display to "none"` (synchronous chained-member write on the parent `.card`).
- **`hide-with-transition` / `show-with-transition`** — `hide me with *opacity` / `show #modal with *opacity`. Despite the names these are **synchronous** hide/show *strategies* (hide writes `display` + a `data-original-display` marker; show adds the visibility class) — no timer/animation frame, so the signature is deterministic (verified across two back-to-back runs). Distinct from the async `transition … over Nms` family the subset still excludes.

## Validation

- Baseline regenerated against a fresh `populate`: **only the commit stamp changed** — every per-language aggregate (R0 / R1 / precision / execution) is byte-identical, confirming the three additions pass everywhere and nothing else moved.
- `avgExecutionFidelity` stays **1.000**; gate green (`--regression` exit 0).
- Guards: `execution-validator.test.ts` subset lock (42→45) + a wave-9 signature lock (the three en effect signatures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)