### PR TITLE
fix(core): increment/decrement read `by <amount>` from the semantic `by` modifier

### DIFF
--- a/packages/core/src/commands/helpers/__tests__/numeric-target-parser.test.ts
+++ b/packages/core/src/commands/helpers/__tests__/numeric-target-parser.test.ts
@@ -63,6 +63,36 @@ describe('numeric-target-parser', () => {
       expect(result.amount).toBe(5);
     });
 
+    it('should read "by <amount>" from a `by` modifier (semantic-parser path)', async () => {
+      // The semantic parser threads `by 10` through modifiers.by, not a
+      // positional arg. Without reading the modifier the amount silently
+      // defaulted to 1 (surfaced by the R2 execution sweep — every language
+      // incremented #score by 1 instead of 10).
+      const raw: NumericTargetRawInput = {
+        args: [{ type: 'selector', value: '#score' } as any],
+        modifiers: { by: { type: 'literal', value: 10 } as any },
+      };
+
+      const result = await parseNumericTargetInput(raw, mockEvaluator, mockContext, 'increment');
+
+      expect(result.target).toBe('#score');
+      expect(result.amount).toBe(10);
+    });
+
+    it('should evaluate a non-literal `by` modifier', async () => {
+      const evaluator = {
+        evaluate: async () => 7,
+      } as unknown as ExpressionEvaluator;
+      const raw: NumericTargetRawInput = {
+        args: [{ type: 'selector', value: '#score' } as any],
+        modifiers: { by: { type: 'variable', name: 'step' } as any },
+      };
+
+      const result = await parseNumericTargetInput(raw, evaluator, mockContext, 'increment');
+
+      expect(result.amount).toBe(7);
+    });
+
     it('should detect global scope from args', async () => {
       const raw: NumericTargetRawInput = {
         args: [

--- a/packages/core/src/commands/helpers/numeric-target-parser.ts
+++ b/packages/core/src/commands/helpers/numeric-target-parser.ts
@@ -133,6 +133,24 @@ export async function parseNumericTargetInput(
     }
   }
 
+  // The semantic parser carries `by <amount>` as a `by` MODIFIER, whereas the
+  // traditional parser threads it through a positional arg (handled by the loop
+  // above). Read the modifier too so `increment #x by 10` applies 10 — not the
+  // default 1 — regardless of which parser produced the node. (Uncaught until
+  // the R2 execution sweep: every language uniformly incremented by 1.)
+  const byModifier = raw.modifiers?.by;
+  if (byModifier) {
+    const byValue = (byModifier as { value?: unknown }).value;
+    if (getNodeType(byModifier) === 'literal' && typeof byValue === 'number') {
+      amount = byValue;
+    } else if (getNodeType(byModifier) !== 'literal') {
+      const evaluated = await evaluator.evaluate(byModifier, context);
+      if (typeof evaluated === 'number') {
+        amount = evaluated;
+      }
+    }
+  }
+
   return {
     target,
     amount,


### PR DESCRIPTION
## What

An **R2 execution finding**: `increment #x by 10` applied **+1, not +10**, whenever the AST came from the **semantic** parser (i.e. all multilingual input, and the semantic path for English).

## Why it hid from the ratchets

- **R0/R1 (parse-level) couldn't see it** — the AST carried the correct `modifiers.by` / `semanticRoles.quantity` value (`10`); only *execution* dropped it.
- **R2 couldn't see it either** — the bug is uniform across every language, and R2 scores translations against the **en reference**. It only surfaced when the en reference was executed and checked for *absolute* correctness during the R2 coverage sweep (`increment #score by 10` → `text[1]`).

## Root cause

`parseNumericTargetInput` extracted the amount by scanning positional `raw.args[1..]` — where the **traditional** parser puts `by 10`. The **semantic** parser instead threads it through `raw.modifiers.by`, which was never read, so `amount` silently defaulted to `1`.

## Fix

After the args loop, also read `raw.modifiers.by` (literal → use directly; otherwise evaluate). Additive — the traditional positional path is unchanged. Restores correct amounts for `increment`/`decrement … by N` on the semantic path for **en + 12 languages**.

> The remaining 11 languages are a **separate semantic-parser gap** (documented, not fixed here): their translations don't carry the amount into `modifiers.by` — a "by"-marker miss in es/de/fr/pt (`por`/`um`/…), and an SOV trailing-amount drop in ja/ko/hi/bn/tr/qu. That's why `increment-by-amount` is **not** added to the R2 subset yet.

## Validation

- Guards: `numeric-target-parser.test.ts` — literal `by` modifier + non-literal (evaluated) `by` modifier.
- All **1081** `data/` + `helpers/` command tests pass.
- R2-gate-safe: no curated-subset pattern uses `by N` (increment-counter/decrement-counter have no amount), so execution fidelity is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)