### PR TITLE
fix(core): traverse flattened multi-segment property-access chains (event.detail.message)

### DIFF
--- a/packages/core/src/parser/runtime-ast-coverage.test.ts
+++ b/packages/core/src/parser/runtime-ast-coverage.test.ts
@@ -177,6 +177,23 @@ describe('AST evaluator coverage', () => {
       ctx.locals.set('nada', null);
       expect(await evaluateAST(paNode('nada', 'x') as any, ctx)).toBeUndefined();
     });
+
+    it('traverses a flattened multi-segment chain (event.detail.message)', async () => {
+      // The semantic builder emits `event.detail.message` as a single
+      // propertyAccess whose `property` is the dotted string "detail.message"
+      // (not nested nodes). Each segment must be walked. Regression: R2 found
+      // `put event.detail.message …` writing empty text (a two-deep access on
+      // the event object silently resolved to undefined).
+      const ctx = { ...createContext(), registry: FULL_REGISTRY } as any;
+      ctx.locals.set('evt', { detail: { message: 'hello' } });
+      expect(await evaluateAST(paNode('evt', 'detail.message') as any, ctx)).toBe('hello');
+    });
+
+    it('a broken link mid-chain returns undefined, not a throw', async () => {
+      const ctx = { ...createContext(), registry: FULL_REGISTRY } as any;
+      ctx.locals.set('evt', { detail: null });
+      expect(await evaluateAST(paNode('evt', 'detail.message') as any, ctx)).toBeUndefined();
+    });
   });
 
   // The semantic→AST builder emits the SURFACE form as the contextType

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -1455,8 +1455,20 @@ async function evaluatePropertyAccess(
   node: PropertyAccessNode,
   context: ExecutionContext
 ): Promise<any> {
-  const object = await evaluateAST(node.object, context);
-  return resolveNamedProperty(object, node.property, context);
+  let object = await evaluateAST(node.object, context);
+  // The semantic→AST builder FLATTENS a multi-segment chain
+  // (`event.detail.message`) into a single dotted `property` string
+  // ("detail.message") rather than nesting `propertyAccess` nodes — so a naive
+  // `object["detail.message"]` lookup misses. Traverse each dot segment. A
+  // single-segment property (the common case) splits to `[property]`, i.e. one
+  // hop — unchanged behavior. (The core parser emits nested `memberExpression`
+  // for dotted access, so only semantic-sourced nodes reach here; DOM/CSS
+  // property names never contain a literal dot, so splitting is safe.)
+  for (const segment of String(node.property).split('.')) {
+    if (object == null) return undefined;
+    object = await resolveNamedProperty(object, segment, context);
+  }
+  return object;
 }
 
 /**


### PR DESCRIPTION
## What

An **R2 execution finding**: `put event.detail.message into #x` wrote **empty text**. A two-deep property access on the event object silently resolved to `undefined` — `event.detail` worked, `event.detail.message` did not.

This made the curated `announce-screen-reader` R2 cell a **false pass**: en and all 23 translations uniformly produced empty text, so translation-vs-reference scoring (R0/R1/R2 all) couldn't see the break. It only surfaced when the en reference was executed and checked for *absolute* correctness during the R2 coverage sweep.

## Root cause

The semantic→AST builder **flattens** a multi-segment chain into a single `propertyAccess` node whose `property` is the dotted **string** `"detail.message"` (rather than nesting nodes — the core parser emits nested `memberExpression`). `evaluatePropertyAccess` then did a single lookup, `event["detail.message"]` → `undefined`.

## Fix

Split `node.property` on `.` and walk each segment through `resolveNamedProperty`. A single-segment property (the overwhelming common case) splits to a one-element array — **unchanged behavior**. Only semantic-sourced nodes reach this path, and DOM/CSS property names never contain a literal dot, so splitting is safe. A null mid-chain short-circuits to `undefined` (no throw), matching optional-chaining semantics.

## Validation

- `announce-screen-reader` now writes the real announcement text in **en + all 23 languages** — a **true** R2 pass. The pre-existing `execution-validator.test.ts` assertion (`text[Saved successfully]`) that this bug was silently failing now passes.
- Multilingual gate **green** (R2 stays 1.0, no regression).
- **2703** parser / expressions / runtime / core tests pass.
- Guards: `runtime-ast-coverage.test.ts` — flattened `event.detail.message` chain + a broken mid-chain link returning `undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)