### PR TITLE
fix(multilingual): increment/decrement `by <amount>` marker for es/fr/pt/de (R2-found value bug)

### DIFF
--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -1023,7 +1023,12 @@ export const incrementSchema: CommandSchema = {
       default: { type: 'literal', value: 1, dataType: 'number' },
       svoPosition: 2,
       sovPosition: 2,
-      markerOverride: { en: 'by' }, // "increment :count by 5"
+      // "increment :count by 5". The by-marker langs render the amount with a
+      // preposition the quantity role must recognize, else it strands and the
+      // amount defaults to 1 (surfaced by the R2 sweep on increment-by-amount).
+      // Space-marked SVO langs (it/zh/…) render the amount BARE and capture it
+      // positionally, so they need no marker.
+      markerOverride: { en: 'by', es: 'por', pt: 'por', fr: 'par', de: 'um' },
     },
   ],
 };
@@ -1053,7 +1058,8 @@ export const decrementSchema: CommandSchema = {
       default: { type: 'literal', value: 1, dataType: 'number' },
       svoPosition: 2,
       sovPosition: 2,
-      markerOverride: { en: 'by' }, // "decrement :count by 5"
+      // "decrement :count by 5" — same by-marker recognition as increment.
+      markerOverride: { en: 'by', es: 'por', pt: 'por', fr: 'par', de: 'um' },
     },
   ],
 };

--- a/packages/semantic/src/patterns/increment.ts
+++ b/packages/semantic/src/patterns/increment.ts
@@ -73,7 +73,31 @@ function getIncrementPatternsBn(): LanguagePattern[] {
 }
 
 function getIncrementPatternsDe(): LanguagePattern[] {
+  const verbAlternatives = ['erhoehe', 'erhöhen', 'inkrementiere', 'inkrementieren', 'increment'];
   return [
+    // With quantity: erhöhe :counter um 5 — the by-marker langs need an explicit
+    // pattern because de uses the hand-crafted `increment-de-full` (the schema
+    // markerOverride reaches only the generated es/fr/pt patterns). `um` marks
+    // the amount; priority 105 > 100 so it wins when the amount is present.
+    {
+      id: 'increment-de-with-quantity',
+      language: 'de',
+      command: 'increment',
+      priority: 105,
+      template: {
+        format: 'erhöhe {patient} um {quantity}',
+        tokens: [
+          { type: 'literal', value: 'erhöhe', alternatives: verbAlternatives },
+          { type: 'role', role: 'patient', expectedTypes: ['selector', 'reference', 'expression'] },
+          { type: 'literal', value: 'um' },
+          { type: 'role', role: 'quantity' },
+        ],
+      },
+      extraction: {
+        patient: { position: 1 },
+        quantity: { marker: 'um', position: 3 },
+      },
+    },
     {
       id: 'increment-de-full',
       language: 'de',
@@ -82,11 +106,7 @@ function getIncrementPatternsDe(): LanguagePattern[] {
       template: {
         format: 'erhöhe {patient}',
         tokens: [
-          {
-            type: 'literal',
-            value: 'erhöhe',
-            alternatives: ['erhoehe', 'erhöhen', 'inkrementiere', 'inkrementieren', 'increment'],
-          },
+          { type: 'literal', value: 'erhöhe', alternatives: verbAlternatives },
           { type: 'role', role: 'patient', expectedTypes: ['selector', 'reference', 'expression'] },
         ],
       },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -9425,3 +9425,35 @@ describe('en `for` reference: no redundant loopType role (for.loopType R1)', () 
     });
   }
 });
+
+describe('increment/decrement by-marker quantity (es por, fr par, pt por, de um)', () => {
+  // The R2 execution sweep found `increment #x by N` applying +1, not +N, in the
+  // by-marker langs: they render the amount with a preposition the quantity role
+  // must recognize, else it strands and defaults to 1. es/pt `por`, fr `par`
+  // added to the increment/decrement schema quantity markerOverride; de uses the
+  // hand-crafted increment-de-with-quantity (`um`, since de takes the
+  // increment-de-full path the schema markerOverride can't reach). Space-marked
+  // SVO langs (it/zh) render the amount BARE and already capture it positionally.
+  // buildAST surfaces the captured amount as the `by` modifier.
+  const cases: Array<[string, string]> = [
+    ['incrementar #score por 10', 'es'],
+    ['incrémenter #score par 10', 'fr'],
+    ['incrementar #score por 10', 'pt'],
+    ['erhöhe #score um 10', 'de'],
+  ];
+  for (const [input, lang] of cases) {
+    it(`[${lang}] captures the by-amount (10) instead of defaulting to 1`, () => {
+      const node = parse(input, lang);
+      expect(node.action).toBe('increment');
+      const { ast } = buildAST(node) as { ast: { modifiers?: { by?: { value?: unknown } } } };
+      expect(ast.modifiers?.by?.value).toBe(10);
+    });
+  }
+
+  it('[de] the patient-only form (no amount) still parses without the quantity pattern', () => {
+    const node = parse('erhöhe #counter', 'de');
+    expect(node.action).toBe('increment');
+    const { ast } = buildAST(node) as { ast: { args?: Array<{ value?: unknown }> } };
+    expect(ast.args?.[0]?.value).toBe('#counter');
+  });
+});


### PR DESCRIPTION
## What

An **R2 execution finding**: `increment #x by 10` applied **+1, not +10**, in the by-marker languages (es/fr/pt/de). They render the amount with a preposition the quantity role never recognized, so the amount stranded and defaulted to 1.

## Why it hid from the gate

- **R1 is blind**: it scores `role:valueType` recall, not the value. es already had `quantity:literal` (with the wrong default `1`), so R1 was already 1.0 for that role.
- **R2 is blind**: `increment-by-amount` isn't in the curated execution subset (its SOV translations drop the amount — see note below), so translation-vs-en scoring never ran.

It only surfaces when the amount itself is checked — which the R2 coverage sweep did (`increment #score by 10` executed to `text[1]`).

## Fix (parse-layer)

- **es/pt `por`, fr `par`** → added to the increment + decrement schema `quantity` `markerOverride` (reaches the schema-generated patterns).
- **de** takes the hand-crafted `increment-de-full` path the schema override can't reach, so a new higher-priority `increment-de-with-quantity` pattern captures `erhöhe #x um N` (mirrors the existing `increment-bn-with-quantity`); the patient-only form still parses.

Space-marked SVO langs (it/zh/…) render the amount **bare** and already capture it positionally, so they need no marker.

## Validation

- es/fr/pt/de now capture the real amount (verified `by=10` via `buildAST`).
- Multilingual gate **green** (no regression); full semantic suite (**6397**) green.
- Guards: `multilingual-roadmap-fixes.test.ts` — the four marker langs capture the by-amount + de patient-only unaffected.

## Scope note

This is the **by-marker slice** of the `increment-by-amount` arc. The SOV langs (bn/hi/ja/ko/qu/tr — which drop the trailing bare amount) and th remain, so `increment-by-amount` does **not** yet join the R2 subset; that needs the SOV literal-role-extraction work (a shared structural blocker with `append-content`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)