### PR TITLE
fix(multilingual): SOV body-clause marker lookup — event markers must not clobber value roles (append-content R2 blocker)

### DIFF
--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1866,7 +1866,20 @@ export class SemanticParserImpl implements ISemanticParser {
     const lookup = new Map<string, string>();
     for (const [role, marker] of Object.entries(profile.roleMarkers)) {
       if (!marker) continue;
-      lookup.set(marker.primary, role);
+      // The `event` role reuses a value role's particle in most SOV profiles
+      // (ja event を = patient を, bn event তে = destination তে, tr event i =
+      // patient i, ko event 을 = patient 을). This lookup only feeds BODY-clause
+      // role extraction (parseSOVClauseByVerbAnchoring), where the event phrase
+      // has already been stripped — so letting `event` clobber a value role's
+      // marker mis-labels the fronted value as `event` and the role is dropped
+      // downstream (ja/tr append-content "append requires content", bn silent
+      // no-op; ko survived only because its corpus form uses the 를 ALTERNATIVE,
+      // which never clobbered). Event markers may only fill gaps (qu `pi` keeps
+      // its entry — no collision — preserving the not-a-verb shield).
+      const overwrite = role !== 'event';
+      if (overwrite || !lookup.has(marker.primary)) {
+        lookup.set(marker.primary, role);
+      }
       if (marker.alternatives) {
         for (const alt of marker.alternatives) {
           // Avoid overwriting more specific roles with generic ones

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -9457,3 +9457,37 @@ describe('increment/decrement by-marker quantity (es por, fr par, pt por, de um)
     expect(ast.args?.[0]?.value).toBe('#counter');
   });
 });
+
+describe('SOV body-clause marker lookup: event markers must not clobber value roles', () => {
+  // append-content (`append "<li>Item</li>" to #list`) reaches the Stage-3 SOV
+  // fallback (no generated pattern matches the patient-first corpus emission),
+  // where parseSOVClauseByVerbAnchoring binds roles via the profile's marker →
+  // role lookup. The `event` roleMarker reuses a value role's particle in most
+  // SOV profiles (ja を, tr i, bn তে, ko 을) and used to CLOBBER it, so the
+  // fronted content bound as a bogus `event` role and the append executed with
+  // no content (ja/tr runtime "append requires content", bn silent no-op). ko
+  // survived only because its corpus form uses the 를 ALTERNATIVE, which never
+  // clobbered. Event markers now only fill gaps in the body-clause lookup —
+  // the event phrase is already stripped before that lookup is consulted.
+  const cases: Array<[string, string, string]> = [
+    ['ja', '"<li>Item</li>" を クリック で 末尾追加 #list に', 'clobbered patient を'],
+    ['tr', '"<li>Item</li>" i tıklama de iliştir #list e', 'clobbered patient i'],
+    ['bn', '"<li>Item</li>" কে ক্লিক এ জুড়ুন #list তে', 'clobbered destination তে'],
+    ['ko', '"<li>Item</li>" 를 클릭 할 때 덧붙이다 #list 에', 'reference (already worked)'],
+  ];
+  for (const [lang, input, why] of cases) {
+    it(`[${lang}] append-content captures content + destination (${why})`, () => {
+      const node = parse(input, lang) as {
+        kind: string;
+        body?: Array<{ action?: string; roles?: Map<string, { type: string; value: unknown }> }>;
+      };
+      expect(node.kind).toBe('event-handler');
+      const append = node.body?.find(c => c.action === 'append');
+      expect(append).toBeTruthy();
+      expect(append!.roles?.get('patient')?.value).toBe('<li>Item</li>');
+      expect(append!.roles?.get('destination')?.value).toBe('#list');
+      // The bogus `event` role must be gone from the body command.
+      expect(append!.roles?.has('event')).toBe(false);
+    });
+  }
+});


### PR DESCRIPTION
The R2 execution sweep left `append-content` (`append "<li>Item</li>" to #list`)
out of the curated subset: the ja/tr translations failed at runtime with "append
requires content" and bn was a silent no-op, while ko worked — all four taking
the same Stage-3 SOV fallback path (no generated pattern matches the
patient-first corpus emission).

Root cause (the ko-works/ja-fails divergence the handoff flagged as the wedge):
`buildMarkerToRoleLookup` lets a later role's PRIMARY marker overwrite an
earlier role's entry, and every SOV profile declares an `event` roleMarker that
reuses a value role's particle — ja `を` (= patient), tr `i` (= patient), bn
`তে` (= destination), ko `을` (= patient). So in body-clause role extraction
(`parseSOVClauseByVerbAnchoring`) the fronted content bound to a bogus `event`
role and dropped downstream. ko survived only because its corpus form uses the
`를` ALTERNATIVE — and alternatives never clobber.

Fix (parse-layer, one site): the `event` role's markers now only FILL GAPS in
the body-clause marker→role lookup, never clobber a value role's marker. The
lookup's single caller runs strictly after the event phrase is stripped, so an
`event` binding there was never meaningful; qu's non-colliding `pi` keeps its
entry (preserving the marker-is-not-a-verb shield).

Validation:
- Guard tests (`multilingual-roadmap-fixes.test.ts`): ja/tr/bn append-content
  capture content + destination (fail without the fix), ko locked as reference.
- Full six-signal `--regression` gate: green.
- Per-(lang,pattern) A/B sweep (clean vs fix): see PR comment.
- Execution probe: append-content now matches the en jsdom effect signature in
  all 23 languages (was 20/23) — R2-subset join to follow as its own PR.

Part of the SOV literal-role-extraction arc
(docs-internal/HANDOFF-sov-literal-role-extraction.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
