### PR TITLE
test(multilingual): R2 execution wave 10 — append-content + increment-by-amount join the curated subset (45→47, R2 stays 1.0)

### DIFF
--- a/docs-internal/HANDOFF-sov-literal-role-extraction.md
+++ b/docs-internal/HANDOFF-sov-literal-role-extraction.md
@@ -1,5 +1,14 @@
 # Handoff — SOV literal-role extraction (the shared R2 blocker)
 
+> ✅ **ARC COMPLETE (2026-07-04, same-day): #560 (append event-marker clobber) · #561 (trailing
+> bare-quantity reclaim, SOV 6 + th) · #562 (R2 wave 10 — both join the subset, 45 → 47, R2 stays
+> 1.0 in all 23 langs).** See the 2026-07-04b update in
+> [MULTILINGUAL_NEXT_STEPS.md](MULTILINGUAL_NEXT_STEPS.md) for the landed root causes — notably: the
+> ko/ja divergence was the predicted wedge (event roleMarker PRIMARY clobbering value-role markers;
+> ko survived via the `를` alternative), the two-sided increment question resolved as option (c)
+> generic extraction, and th shared the fused-capture root cause (not a tokenizer issue). Kept for
+> the grounding-methodology record.
+
 > **Written 2026-07-04**, after the R2 execution-coverage sweep (PRs #554–#558).
 > Entry context: [MULTILINGUAL_NEXT_STEPS.md](MULTILINGUAL_NEXT_STEPS.md) top-of-file
 > update dated 2026-07-04 ("R2 EXECUTION-COVERAGE SWEEP"). Read that first for the

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -29,6 +29,43 @@ The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recal
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.**
 
+> **Update 2026-07-04b (SOV LITERAL-ROLE-EXTRACTION ARC: COMPLETE — both R2 blockers fixed +
+> joined; subset 45 → 47, R2 stays 1.0 in all 23 langs. #560 / #561 / #562.)** The arc planned in
+> [HANDOFF-sov-literal-role-extraction.md](HANDOFF-sov-literal-role-extraction.md) landed in three
+> stacked increments:
+>
+> 1. **`append-content` — body-clause marker lookup, event-clobber fix (#560).** The predicted
+>    ko-works/ja-fails wedge was real and crisp: `buildMarkerToRoleLookup` let a later role's PRIMARY
+>    marker overwrite an earlier role's entry, and every SOV profile's `event` roleMarker reuses a
+>    value role's particle (ja `を`=patient, tr `i`=patient, bn `তে`=destination, ko `을`=patient). In
+>    the Stage-3 SOV fallback the fronted content literal bound to a bogus `event` role and dropped at
+>    runtime; **ko survived only because its corpus form uses the `를` ALTERNATIVE** (alternatives
+>    never clobbered). Event markers now only fill gaps in that lookup (its single caller runs after
+>    the event phrase is stripped, so an event binding there was never meaningful; qu's non-colliding
+>    `pi` keeps its not-a-verb shield). A/B: 7 per-pattern deltas, ALL improvements (append-content
+>    ja/tr/bn R1 0.75→1.0 + collateral form-disable-on-submit, beep-debug-expression gains), zero
+>    drops. 23/23 langs now reproduce the en effect (was 20/23).
+> 2. **`increment-by-amount` — trailing bare-quantity reclaim (#561).** The handoff's two-sided
+>    question resolved as option (c), generic extraction: every fused event pattern ends at the verb
+>    (SOV `-sov-patient-first`) or the primary role (**th `-vso` — th shares this root cause; it was
+>    NOT a tokenizer issue**), stranding the transformer's post-verb bare amount; the #530 re-parse
+>    can't reclaim it because the fronted patient is outside the [verb..boundary] slice (superset
+>    guard, by design). `buildEventHandler` now reclaims a trailing bare NUMBER into the schema's
+>    absent optional `quantity` role — gated to non-block actions (⇒ increment/decrement), numeric
+>    tokens, and absent-quantity only (es/fr/pt/de #558 marker langs and positional it/zh capture it
+>    upstream). Parse-level A/B: ZERO changes — expected and re-confirming the #555/#558 lesson:
+>    `fillSchemaDefaults` injects `quantity:literal=1` into the role signature, so the value bug is
+>    invisible to R0/R1; only R2 sees it. 23/23 langs now apply +10 (was 16/23).
+> 3. **R2 wave 10 — both patterns join the curated subset (#562; 45 → 47, R2 stays 1.0, zero
+>    executionFailures in all 23 langs).** Fixture adds `<ul id="list">` + `<div id="score">0</div>`
+>    (appended LAST, indices preserved); membership + ja signature locks (ja locks the exact failure
+>    class each fix closed); baseline regenerated against a fresh populate — avgRoleFidelity ticks up
+>    from #560.
+>
+> The two "Remaining R2 gaps" bullets below marked ✔ RESOLVED. Still open from that list: the
+> `set`-target ×5 rejections (heterogeneous), `default-value`, and the harness's document-order
+> signature fragility.
+
 > **Update 2026-07-04 (R2 EXECUTION-COVERAGE SWEEP — the first systematic pass at "do the faithful
 > parses actually EXECUTE correctly?" Now that R0 recall is saturated (fid 1.0, both bands 0), R2 is
 > the un-mined dimension: only ~27% of the corpus was behaviorally verified. Three increments landed
@@ -67,13 +104,15 @@ R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelit
 >
 > **Remaining R2 gaps (grounded; each its own increment — NOT clean coverage adds):**
 >
-> - **`increment-by-amount` 11-lang semantic gap** (would let it join the subset). My #555 runtime fix
+> - ✔ **RESOLVED (2026-07-04b: #558 marker langs + #561 SOV/th reclaim; joined in #562)**
+>   **`increment-by-amount` 11-lang semantic gap** (would let it join the subset). My #555 runtime fix
 >   made en + 12 langs correct, but EXPOSED that 11 langs don't carry `by N` into `modifiers.by` at
 >   parse time — TWO causes: a **"by"-marker miss** in es (`por`)/de (`um`)/fr/pt (the amount is
 >   stranded → quantity defaults to 1; es even mis-captures `quantity:1`), and an **SOV trailing-amount
 >   drop** in ja/ko/hi/bn/tr/qu (the post-verb `10` isn't captured). A semantic command-schema / marker
 >   arc.
-> - **`append-content` SOV divergence.** `append "<li>…</li>" to #list` drops the fronted content
+> - ✔ **RESOLVED (2026-07-04b: #560 event-marker clobber fix; joined in #562)**
+>   **`append-content` SOV divergence.** `append "<li>…</li>" to #list` drops the fronted content
 >   patient in ja/tr (`append requires content` runtime error) and bn (silent no-op); ko/hi capture it
 >   and work. A per-language SOV content-role-capture fix.
 > - **`set`-target runtime rejections (×5).** `set command target must be a string or object literal`

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-04T04:21:53.580Z",
-  "commit": "e034f9e7",
+  "timestamp": "2026-07-04T12:57:37.829Z",
+  "commit": "a026f7f4",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -641,12 +641,12 @@
       "avgConfidence": 0.8495030867211314,
       "avgFidelity": 1,
       "avgPrecision": 0.9315737203972502,
-      "avgRoleFidelity": 0.9307873201255555,
+      "avgRoleFidelity": 0.9336026354408707,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
       "avgPrecision": 0.9504107634789454,
-      "avgRoleFidelity": 0.9321597089979444,
+      "avgRoleFidelity": 0.936664213502449,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12642,12 +12642,12 @@
       "avgConfidence": 0.8307646822684411,
       "avgFidelity": 1,
       "avgPrecision": 0.9508127424523529,
-      "avgRoleFidelity": 0.9328883788442613,
+      "avgRoleFidelity": 0.9362667572226397,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 460751,
+      "bundleSize": 461162,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 460751,
+      "size": 461162,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
@@ -19,7 +19,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { ExecutionValidator, EXECUTION_SUBSET, loadExecutionSubset } from './execution-validator';
 
 describe('R2 execution subset (lock)', () => {
-  it('contains exactly the 45 curated patterns', () => {
+  it('contains exactly the 47 curated patterns', () => {
     // Changing this list recalibrates avgExecutionFidelity for every language.
     // If you expand the subset, regenerate the baseline (--save-baseline) in
     // the SAME PR and update this lock.
@@ -119,6 +119,14 @@ describe('R2 execution subset (lock)', () => {
         'chained-access-possessive-dot',
         'hide-with-transition',
         'show-with-transition',
+        // Wave 10 (SOV literal-role-extraction arc, PRs #560/#561): the two R2
+        // blockers — the fronted append content literal (bogus `event` role in
+        // the body-clause marker lookup) and the trailing bare increment amount
+        // (unconsumed by every fused event pattern, defaulted to 1) — now
+        // captured in all 23 languages. See the wave-10 note in
+        // execution-validator.ts.
+        'append-content',
+        'increment-by-amount',
       ].sort()
     );
   });
@@ -354,6 +362,37 @@ describe('R2 execution validator (lock)', () => {
       const res = await validator.execute(id, code, 'en');
       expect(res.error, `${id} errored: ${res.error}`).toBeUndefined();
       expect(res.effects, `${id} signature`).toEqual(expected);
+    }
+  });
+
+  it('wave-10 en references execute with their locked signatures; SOV translations match', async () => {
+    // The two SOV literal-role-extraction blockers (PRs #560/#561). The en
+    // signatures anchor on the wave-10 fixture elements (appended last, so all
+    // pre-existing document-order indices are preserved). The ja translations
+    // lock the exact failure class each fix closed: append's fronted content
+    // literal (was a bogus `event` role → runtime "append requires content")
+    // and increment's trailing bare amount (was dropped → +1 instead of +10).
+    const cases: ReadonlyArray<[string, string, string, string]> = [
+      [
+        'append-content',
+        'on click append "<li>Item</li>" to #list',
+        '"<li>Item</li>" を クリック で 末尾追加 #list に',
+        'text[Item]',
+      ],
+      [
+        'increment-by-amount',
+        'on click increment #score by 10',
+        '#score を クリック で 増加 10',
+        'text[10]',
+      ],
+    ];
+    for (const [id, enCode, jaCode, marker] of cases) {
+      const en = await validator.execute(id, enCode, 'en');
+      expect(en.error, `en ${id} errored: ${en.error}`).toBeUndefined();
+      expect(en.effects.join(), `en ${id} signature must carry ${marker}`).toContain(marker);
+      const ja = await validator.execute(id, jaCode, 'ja');
+      expect(ja.error, `ja ${id} errored: ${ja.error}`).toBeUndefined();
+      expect(ja.effects, `ja ${id} must reproduce en`).toEqual(en.effects);
     }
   });
 

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.ts
@@ -188,6 +188,20 @@ export const EXECUTION_SUBSET: readonly string[] = [
   'chained-access-possessive-dot',
   'hide-with-transition',
   'show-with-transition',
+  // Expansion wave 10 (the SOV literal-role-extraction arc, PRs #560/#561):
+  // the two R2 blockers whose SOV translations silently dropped a bare literal
+  // role, now capturing it in all 23 languages:
+  //  - append-content: `append "<li>Item</li>" to #list` — the fronted content
+  //    literal bound to a bogus `event` role in the body-clause marker lookup
+  //    (ja/tr runtime "append requires content", bn silent no-op). Fixture adds
+  //    `<ul id="list">` (appended last, indices preserved).
+  //  - increment-by-amount: `increment #score by 10` — the trailing bare amount
+  //    was unconsumed by every fused event pattern and defaulted to 1 in the
+  //    SOV 6 + th (invisible to R0/R1: fillSchemaDefaults injects
+  //    quantity:literal=1 into the role signature — only R2 sees the value).
+  //    Fixture adds `<div id="score">0</div>` (appended last).
+  'append-content',
+  'increment-by-amount',
 ];
 
 /**
@@ -212,6 +226,8 @@ const FIXTURE_HTML = `<!DOCTYPE html><html><body>
   <div id="container"></div>
   <div class="dropdown-menu"></div>
   <div id="sr-announce"></div>
+  <ul id="list"></ul>
+  <div id="score">0</div>
 </body></html>`;
 
 /** Per-pattern fixture preconditions (applied identically for every language). */


### PR DESCRIPTION
Final slice of the SOV literal-role-extraction arc (docs-internal/HANDOFF-sov-literal-role-extraction.md), stacked on #560 and #561.

Both former R2 blockers now capture their literal role in all 23 languages, so they join the curated execution subset:

- **Fixture**: `<ul id="list">` + `<div id="score">0</div>` appended **last** (document-order indices preserved).
- **EXECUTION_SUBSET** 45 → 47, membership lock updated.
- **Wave-10 signature locks**: en signatures + ja translations reproduce en exactly — ja locks the exact failure class each fix closed (runtime "append requires content"; +1 instead of +10).
- **Baseline regenerated** against a freshly populated patterns.db (patterns.db itself not committed, per contributor convention): R2 stays **1.0 with zero executionFailures in all 23 languages** on the expanded subset; avgRoleFidelity ticks up from #560.
- Confirming `--regression` run green (exit 0) against the new baseline; full testing-framework suite 197 passed, typecheck clean.

Pre-join probes: append-content 23/23 (was 20/23), increment-by-amount 23/23 (was 16/23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)