### PR TITLE
fix(multilingual): reclaim trailing bare literal quantity after fused event patterns (increment-by-amount R2 blocker, SOV 6 + th)

### DIFF
--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1168,6 +1168,48 @@ export class SemanticParserImpl implements ISemanticParser {
         }
       }
 
+      // Trailing BARE-literal quantity reclaim. The i18n transformer renders
+      // `increment #score by 10` with the amount AFTER the verb, bare (ja
+      // `#score を クリック で 増加 10`, th `เมื่อ คลิก เพิ่มค่า #score 10`), but every
+      // fused event pattern ends at the verb (SOV) or the primary role (th
+      // VSO), so the amount is left unconsumed and silently drops — quantity
+      // defaults to 1 (the R2 blocker on increment-by-amount in the SOV 6 +
+      // th). The re-parse swap above cannot reclaim it in SOV: the fronted
+      // patient sits OUTSIDE the [verb..boundary] slice, so the superset guard
+      // rejects the re-parse (by design — the qu safety rail). Reclaim the
+      // amount directly: when the schema declares an optional `quantity` role
+      // the fused capture missed and the very next unconsumed token is a bare
+      // number, capture it and consume the token. Precision-safe: gated to
+      // non-block actions (only increment/decrement carry an optional
+      // quantity outside `repeat`, whose counted-loop head has its own path
+      // above), to a NUMERIC next token (a then-keyword, `end`, selector, or
+      // duration like `200ms` never matches), and to an ABSENT quantity (the
+      // marker langs es/fr/pt/de and positional it/zh capture it upstream).
+      if (!BLOCK_BODY_ACTIONS.has(actionName)) {
+        const qNode = commandNode as CommandSemanticNode;
+        const hasOptionalQuantity = getSchema(actionName as ActionType)?.roles.some(
+          r => r.role === 'quantity' && !r.required
+        );
+        if (hasOptionalQuantity && !qNode.roles.has('quantity')) {
+          const trailing = tokens.peek();
+          if (trailing && /^-?\d+(\.\d+)?$/.test(trailing.value)) {
+            commandNode = createCommandNode(
+              actionName as ActionType,
+              {
+                ...(Object.fromEntries(qNode.roles) as Record<string, SemanticValue>),
+                quantity: {
+                  type: 'literal',
+                  value: parseFloat(trailing.value),
+                  dataType: 'number',
+                },
+              },
+              qNode.metadata
+            );
+            tokens.advance();
+          }
+        }
+      }
+
       // Check if pattern has continuation marker (then-chains).
       const continuesValue = match.captured.get('continues');
       const hasContinuesMarker =

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -9491,3 +9491,73 @@ describe('SOV body-clause marker lookup: event markers must not clobber value ro
     });
   }
 });
+
+describe('SOV/th trailing bare quantity reclaim (increment-by-amount R2 blocker)', () => {
+  // The i18n transformer renders `increment #score by 10` with the amount AFTER
+  // the verb, bare (no marker), in the SOV languages and th — but every fused
+  // event pattern ends at the verb (SOV) or the primary role (th VSO), so the
+  // amount was left unconsumed and silently dropped: quantity defaulted to 1.
+  // The fused-capture re-parse can't reclaim it in SOV (the fronted patient is
+  // outside the [verb..boundary] slice, so the superset guard rejects the
+  // re-parse — the qu safety rail). buildEventHandler now reclaims a trailing
+  // bare NUMBER into the schema's absent optional `quantity` role. Marker langs
+  // (es/fr/pt/de, #558) and positional SVO langs (it/zh) capture it upstream
+  // and never reach the reclaim. Corpus forms from a fresh populate.
+  const cases: Array<[string, string]> = [
+    ['#score を クリック で 増加 10', 'ja'],
+    ['#score 를 클릭 할 때 증가 10', 'ko'],
+    ['#score i tıklama de artır 10', 'tr'],
+    ['#score কে ক্লিক এ বৃদ্ধি 10', 'bn'],
+    ['#score को क्लिक पर बढ़ाएं 10', 'hi'],
+    ['#score ta ñitiy pi yapachiy 10', 'qu'],
+    ['เมื่อ คลิก เพิ่มค่า #score 10', 'th'],
+  ];
+  for (const [input, lang] of cases) {
+    it(`[${lang}] captures the trailing bare amount (10) instead of defaulting to 1`, () => {
+      const node = parse(input, lang) as {
+        kind: string;
+        body?: Array<{ action?: string; roles?: Map<string, { value?: unknown }> }>;
+      };
+      expect(node.kind).toBe('event-handler');
+      const inc = node.body?.find(c => c.action === 'increment');
+      expect(inc).toBeTruthy();
+      expect(inc!.roles?.get('patient')?.value).toBe('#score');
+      expect(inc!.roles?.get('quantity')?.value).toBe(10);
+    });
+  }
+
+  it('[ja] the amount-less form still parses without a phantom quantity', () => {
+    const node = parse('#score を クリック で 増加', 'ja') as {
+      body?: Array<{ action?: string; roles?: Map<string, unknown> }>;
+    };
+    const inc = node.body?.find(c => c.action === 'increment');
+    expect(inc).toBeTruthy();
+    expect(inc!.roles?.has('quantity')).toBe(false);
+  });
+
+  it('[ja] a trailing then-chain command is not swallowed as a quantity', () => {
+    // `increment #score then wait 200ms` shape: the token after the verb is a
+    // then-keyword, not a number — the reclaim must not fire and the chain must
+    // survive as a second body command.
+    const node = parse('#score を クリック で 増加 それから 200ms 待つ', 'ja') as {
+      body?: Array<{
+        action?: string;
+        statements?: Array<{ action?: string }>;
+        roles?: Map<string, unknown>;
+      }>;
+    };
+    const actions: string[] = [];
+    for (const stmt of node.body ?? []) {
+      if (stmt.action) actions.push(stmt.action);
+      for (const s of stmt.statements ?? []) if (s.action) actions.push(s.action);
+    }
+    expect(actions).toContain('increment');
+    expect(actions).toContain('wait');
+    const inc = (node.body ?? [])
+      .flatMap(s => [s, ...(s.statements ?? [])])
+      .find(c => (c as { action?: string }).action === 'increment') as
+      | { roles?: Map<string, unknown> }
+      | undefined;
+    expect(inc?.roles?.has('quantity')).toBe(false);
+  });
+});


### PR DESCRIPTION
Reopened replacement for #561 (auto-closed when its base branch was deleted on #560's merge — GitHub closed instead of retargeting). Same branch, same single commit; diff vs main is the increment change only now that #560 is merged. Validation details + A/B analysis: see #561.

Summary: `increment #score by 10` applied +1 in ja/ko/tr/bn/hi/qu **and th** — the fused event patterns end at the verb (SOV) or primary role (th VSO), stranding the transformer's post-verb bare amount, and the #530 re-parse can't reclaim it (fronted patient fails the superset guard, by design). `buildEventHandler` now reclaims a trailing bare NUMBER into the schema's absent optional `quantity` role (non-block actions ⇒ increment/decrement only; numeric token only; absent-quantity only). Guard tests: 7 corpus forms fail without the fix; execution probe 16/23 → **23/23** matching the en jsdom signature.

Part of docs-internal/HANDOFF-sov-literal-role-extraction.md (arc: #560 → this → #562).

🤖 Generated with [Claude Code](https://claude.com/claude-code)