### PR TITLE
fix(multilingual): reclaim fetch `as <type>` responseType after fused SOV event patterns (R1 cluster B)

### DIFF
--- a/docs-internal/HANDOFF-r1-residual.md
+++ b/docs-internal/HANDOFF-r1-residual.md
@@ -1,0 +1,190 @@
+# Handoff — R1 residual triage (hi/qu/ko + corpus-wide clusters)
+
+> **Written 2026-07-04**, immediately after the SOV literal-role-extraction arc
+> (#560/#561/#562 — see [HANDOFF-sov-literal-role-extraction.md](HANDOFF-sov-literal-role-extraction.md)).
+> This is the **fresh grounding** of what remains in R1 role fidelity now that the
+> 2026-06-17 Track-3 triage (hi 0.683-era, literal-fronted event mis-anchoring) is
+> largely harvested. Numbers below are from the **2026-07-04 baseline** (commit of
+> #562) and a same-day probe against a fresh populate.
+
+## Where R1 stands (2026-07-04 baseline)
+
+Worst six: **hi 0.915 · qu 0.916 · ko 0.926 · bn 0.934 · tr 0.936 · ja 0.937**
+(everything else ≥ 0.95; controls es 0.955-ish/it/de ~0.95–0.96). Parse rate 100%,
+degenerate/lossy 0, R2 1.0 on the 47-pattern subset. R1 is the only dimension
+with real headroom left.
+
+Patterns with ≥1 missing role entry (out of 148 en references with role
+signatures): **hi 41 · qu 40 · ko 38** vs controls **es 19 · it 19 · de 21**.
+So roughly HALF of the laggards' miss-mass is corpus-wide (shared with the
+controls) and half is SOV-trio-specific.
+
+## Method (reproduce in ~2 min per language set)
+
+Mirror the harness exactly — `MultilingualHyperscript.parse` →
+`fillSchemaDefaults` → `collectRoleSignature` (fidelity.ts), recall vs the en
+reference. Probe shape (place `.mts` inside `packages/testing-framework/`; end
+with `process.exit(0)` — jsdom/core keep handles open):
+
+```ts
+import { MultilingualHyperscript } from '@hyperfixi/core/multilingual';
+import { fillSchemaDefaults } from '@lokascript/semantic';
+import * as FID from './src/multilingual/fidelity.ts'; // CJS interop: (FID as any).default ?? FID
+import { getTranslationsByLanguage } from '@hyperfixi/patterns-reference';
+// for each lang: for each pattern with an en reference signature,
+//   missing = enSig.filter(e => !translationSig.has(e))
+// aggregate missing entries into clusters; print worst patterns.
+```
+
+Full ordered rebuild + fresh populate first (see the previous handoff's recipe —
+and remember `git checkout -- patterns.db` reverts to the stale committed copy;
+re-populate after).
+
+## The five clusters (ranked by leverage), each grounded by a parse drill
+
+### Cluster A — SOV `set` role-swap + property-path typing (SOV-trio-specific, the biggest trio delta)
+
+`set.destination:property-path` missing: **qu 6 · ko 5 · hi 4** (vs es 1 / it 2)
+— fetch-json, set-color-variable, two-way-binding, computed-value,
+template-literal-interpolation, template-literal-list-build; usually paired with
+a `set.patient:*` miss (the pair = per-pattern R1 0.50).
+
+Drill (`two-way-binding`, en `set #greeting.innerText to "Hello, " + my value`):
+
+- en: `set{destination:property-path, patient:literal}`
+- ko `#greeting.innerText 를 "Hello, " + 내 값 에 설정 …`:
+  `set{patient:selector="#greeting.innerText", destination:literal="\"Hello, \"+내값", source:…}`
+
+TWO independent defects visible in one parse:
+
+1. **Role swap.** The transformer emits set's TARGET with the object particle
+   (`를`/`को`/`ta`) and the VALUE with the dative (`에`/`में`/`man`). The SOV
+   marker extraction maps 를→patient, 에→destination positionally.
+   `mapRoleForCommand` (semantic-parser.ts) already documents the needed remap —
+   "for set and put: patient marker is the destination, dest marker is the
+   patient" — but only applies it when the first role is ALREADY TAKEN; in the
+   normal path patient is free, so the swap never fires. Fix shape: make the
+   remap schema-aware for `set`(/`put`?) rather than collision-triggered.
+   ⚠️ Overlaps the 2026-06-30e of-possessive arc cause (3) (ru/pl/uk destination
+   greedy-binding) — read that block first; one matcher-ordering fix may serve both.
+2. **Value-type misclassification.** en splits `#greeting.innerText` into a
+   `property-path`; the SOV path keeps it ONE selector token
+   (`selector="#greeting.innerText"`). Even with roles un-swapped, the TYPE
+   still mismatches (`selector` ≠ `property-path`). Fix lives in the SOV
+   tokenizers / `tokensToSemanticValue` (`#id.prop` → property-path split),
+   NOT in role mapping.
+
+### Cluster B — `fetch … as json` responseType under fused SOV patterns (trio + ja/tr/bn; the "×63 residue")
+
+`fetch.responseType:expression` missing ×3 in each of hi/qu/ko (fetch-json,
+fetch-error-handling, fetch-do-not-throw); absent from es/it/de (their `como/als
+json` marker patterns capture it). Same family as the code comment in
+semantic-parser.ts ("fetch.responseType ×63" fused-body residue).
+
+Drill (`fetch-json`, ko `… 가져오기 json 로 …`): the fused
+`fetch-event-ko-sov-patient-first` binds the `json 로` tail as
+**`destination:expression`** — right tokens, wrong role name (ko `로` maps to
+style/destination in roleMarkers; `responseType` has no marker entry). The #530
+re-parse can't fix it for the same reason as increment's quantity (fronted
+source is outside the [verb..boundary] slice → superset guard rejects).
+
+**Fix shape: the exact mechanism #561 proved** — extend the buildEventHandler
+trailing-role reclaim (or the marker→role mapping) so a trailing
+`{as-marker} {word}` / `{word} {style-marker}` pair fills an absent schema
+`responseType`. Smallest slice, proven pattern, and it also relabels the
+phantom `destination` (a precision win). Also fixes the trailing `set` clause's
+patient (`그것의.name` → property-path) if done at the marker-lookup level? NO —
+that's Cluster A's territory; keep the slices separate.
+
+### Cluster C — hi event-anchor mis-fire on fronted POSITIONAL/PROPERTY-PATH phrases (hi-specific tail)
+
+`on.event:literal` missing ×4 in hi only: default-value, window-resize,
+first-in-parent, optional-chaining-possessive. This is the surviving 10% of the
+old dominant cluster (was 22× at the 06-17 triage): the #508 event-anchor guard
+covers fronted bare literals, but NOT fronted **positional phrases** or
+**possessive property-paths**:
+
+- `first-in-parent` hi `पहला <input/> में निकटतम <form/> को क्लिक पर फोकस` →
+  `on{event:expression}` — the fronted `पहला <input/>` (a positional phrase)
+  is captured AS THE EVENT; focus.patient defaults to `me`.
+- `default-value` hi `मेरा @data-count को लोड पर डिफ़ॉल्ट "0" में` →
+  `on{event:property-path}` — the fronted `मेरा @data-count` possessive is the
+  event; the `default` body gets garbage roles (`destination:literal="कोलोड"`).
+
+Fix shape: extend the #508 guard's "this cannot be an event" test to positional
+keywords (`first`/`next`/`closest` normalized forms) and possessive/`@attr`
+property-path heads. Check tl/bn for the same shape before scoping to hi.
+
+### Cluster D — `repeat for X in Y` loop-head roles (CORPUS-WIDE, biggest total mass — and the EN REFERENCE IS NOISY)
+
+The `repeat.loopType:literal`, `repeat.event:literal`, `repeat.quantity:expression`,
+and `repeat.source:expression` entries are missing across **every probed language
+including es/it/de** (es 6/6/2/3, hi 6/5/2/3, …): repeat-for-each,
+stagger-animation, repeat-while, repeat-until-event,
+behavior-draggable/sortable/resizable.
+
+Drill (`repeat-for-each`, en `on click repeat for item in .items add .processed to item`):
+
+- **en itself parses the head wrong**: `repeat{loopType:literal="for",
+quantity:expression, event:literal="in"}` — `in` mis-captured as an _event_,
+  the binding var as _quantity_. Every translation then "misses" entries that
+  are en NOISE (they fail to reproduce a mis-parse). es binds
+  `{destination:selector=".items", loopType:expression}`; ko collapses to
+  `{loopType:reference=me}`.
+- The i18n transformer also DROPS the `for` binder keyword in transit (known —
+  see the bare-`repeat` recovery comment in parseClause).
+
+Fix shape (two stages, own arc): (1) canonicalize the EN head parse
+(`loopType:literal="for"`, `patient:identifier`, `source:selector|expression`;
+kill the `event="in"`/`quantity` noise) — this CHANGES the reference, so R1
+per-lang may transiently drop and the baseline must regen in the same PR;
+(2) align the per-language repeat patterns/transformer emission. Highest total
+R1 mass (moves all 24 langs), but baseline-churn-heavy — do it as a dedicated
+arc, not a tail-end increment. `for.loopType` precedent: #549.
+
+### Cluster E — i18n transformer MANGLES parenthesized/operator expressions (not a parser bug)
+
+Drill (`computed-value`, en
+`set #total.innerText to (the value of #price as Number) * (my value as Number)`):
+
+ko translation is `#total.innerText 를 (the 값 의 #price 에 설정 입력 할 때
+.quantity 에서 Number) 로` — the transformer **reordered INSIDE the
+parentheses**, embedded the event phrase (`입력 할 때`) mid-expression, dropped
+the whole `* (my value as Number)` second operand, and leaked English (`the`).
+hi/qu identical shape. No parser change can recover roles from a corrupt
+translation. Affected: computed-value, template-literal-\* (and any pattern with
+parenthesized arithmetic/concat). Fix is TRANSFORMER-side: treat parenthesized
+expressions as opaque units during grammar reorder
+(`packages/i18n/src/grammar/transformer.ts`). Separate arc; also an R0-precision
+and R2-eligibility blocker for those patterns.
+
+## Smaller residue seen in the probes (don't chase in this arc)
+
+`send.destination:reference` ×2 (send-with-detail, socket-send — every lang),
+`wait.duration:literal`, `tell.destination:selector`, `trigger.event:literal`
+singletons (every lang), `halt.patient:reference` ×4 (es/it/de only —
+interestingly ABSENT in the SOV trio), `js.patient:expression`,
+`render.style:expression` ×2 each (trio). Each is a singleton-family;
+opportunistic only.
+
+## Recommended sequencing
+
+1. **B first** — smallest, mechanism proven by #561 (trailing-role reclaim),
+   clears 3 patterns × ~6 langs plus a precision win.
+2. **A second** — biggest SOV-trio delta (the set role-swap + property-path
+   typing); read the 2026-06-30e of-possessive block first (shared machinery);
+   the two sub-causes are separable PRs (swap fix, then tokenizer typing).
+3. **C third** — hi tail (extend the #508 guard to positional/property-path heads).
+4. **D as its own arc** — corpus-wide repeat-head canonicalization (en reference
+   change + baseline regen in the same PR; highest mass, highest churn).
+5. **E as its own arc** — transformer parenthesized-expression opacity.
+
+## Working discipline (same as the last arc — it worked)
+
+One increment per PR; full six-signal `--regression` gate + per-(lang,pattern)
+A/B sweep per change (value-level bugs are invisible to R0/R1 — check R2/exec
+probes too); guard tests that FAIL without the fix; regenerate the baseline only
+on intentional fidelity change against a fresh populate; never commit
+patterns.db. Validation footguns from last session are recorded in the
+project memory (exit-code masking via `| tail`, stash-pop mtime staleness,
+stale committed patterns.db, hanging tsx probes → `process.exit`).

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -65,6 +65,13 @@ R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelit
 > The two "Remaining R2 gaps" bullets below marked ✔ RESOLVED. Still open from that list: the
 > `set`-target ×5 rejections (heterogeneous), `default-value`, and the harness's document-order
 > signature fragility.
+>
+> **Same-day follow-up: the R1 residual is freshly triaged** — see
+> [HANDOFF-r1-residual.md](HANDOFF-r1-residual.md) (five grounded clusters: SOV `set` role-swap +
+> property-path typing; fetch `as json` responseType under fused SOV; hi event-anchor on fronted
+> positional/property-path phrases; the CORPUS-WIDE `repeat for-each` head noise — the en reference
+> itself mis-parses; i18n transformer mangling of parenthesized expressions). It supersedes the
+> 2026-06-17 Track-3 triage, which is now largely harvested (hi 0.683 → 0.915).
 
 > **Update 2026-07-04 (R2 EXECUTION-COVERAGE SWEEP — the first systematic pass at "do the faithful
 > parses actually EXECUTE correctly?" Now that R0 recall is saturated (fid 1.0, both bands 0), R2 is

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1208,6 +1208,56 @@ export class SemanticParserImpl implements ISemanticParser {
             tokens.advance();
           }
         }
+
+        // Trailing RESPONSE-TYPE reclaim — the `responseType` sibling of the
+        // quantity reclaim above (R1 handoff cluster B). The transformer
+        // renders `fetch /api/user as json`'s tail AFTER the fused verb:
+        // bare (ja `フェッチ json`, bn `আনুন json`), word + as-postposition
+        // (tr `json olarak`, hi `json के रूप में`, qu `json hina` — the
+        // postposition stays unconsumed skip-noise exactly as before), or
+        // word + a particle the fused pattern's optional trailing DESTINATION
+        // group swallows (ko `json 로` — 로 is a destination alternative), so
+        // the responseType either drops or lands under `destination`, a role
+        // whose schema types (selector/reference) it VIOLATES. Two moves,
+        // both gated on the schema declaring an optional `responseType` that
+        // is absent AND on the word being a KNOWN response-type word
+        // (loanwords, language-invariant in the corpus):
+        //  (a) relabel a schema-invalid `destination` capture to responseType;
+        //  (b) capture a trailing bare response word and consume it.
+        const rNode = commandNode as CommandSemanticNode;
+        const rSchema = getSchema(actionName as ActionType);
+        const rSpec = rSchema?.roles.find(r => r.role === 'responseType' && !r.required);
+        if (rSpec && !rNode.roles.has('responseType')) {
+          const isResponseWord = (w: unknown): w is string =>
+            typeof w === 'string' && SemanticParserImpl.RESPONSE_TYPE_WORDS.has(w.toLowerCase());
+          const rebuildWithResponseType = (word: string, dropDestination: boolean): void => {
+            const roles = Object.fromEntries(rNode.roles) as Record<string, SemanticValue>;
+            if (dropDestination) delete roles.destination;
+            roles.responseType = { type: 'expression', raw: word } as SemanticValue;
+            commandNode = createCommandNode(actionName as ActionType, roles, rNode.metadata);
+          };
+          const dest = rNode.roles.get('destination') as
+            | { type: string; raw?: unknown; value?: unknown }
+            | undefined;
+          const destSpec = rSchema?.roles.find(r => r.role === 'destination');
+          const destWord = dest?.raw ?? dest?.value;
+          if (
+            dest &&
+            destSpec &&
+            !destSpec.expectedTypes.includes(
+              dest.type as (typeof destSpec.expectedTypes)[number]
+            ) &&
+            isResponseWord(destWord)
+          ) {
+            rebuildWithResponseType(destWord, true);
+          } else {
+            const trailing = tokens.peek();
+            if (trailing && isResponseWord(trailing.value)) {
+              rebuildWithResponseType(trailing.value, false);
+              tokens.advance();
+            }
+          }
+        }
       }
 
       // Check if pattern has continuation marker (then-chains).
@@ -2495,6 +2545,24 @@ export class SemanticParserImpl implements ISemanticParser {
    * SOV event marker particles per language (postpositions that mark the event role).
    * Korean has no event marker particle -- the event keyword stands alone.
    */
+  /**
+   * Known `fetch … as <type>` response-type words. Untranslated loanwords in
+   * every corpus language (the transformer localizes the `as` marker, never the
+   * word), so a value-set gate is language-invariant. Used by the trailing
+   * response-type reclaim in {@link buildEventHandler} — mirrors core's
+   * supported conversions (json/text/html/response + binary forms).
+   */
+  private static readonly RESPONSE_TYPE_WORDS = new Set([
+    'json',
+    'text',
+    'html',
+    'xml',
+    'blob',
+    'arraybuffer',
+    'formdata',
+    'response',
+  ]);
+
   private static readonly SOV_EVENT_MARKERS: Record<string, Set<string>> = {
     ja: new Set(['で']),
     ko: new Set(), // ko's marker is the two-token 할 때 phrase — see SOV_EVENT_MARKER_PHRASES

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -9561,3 +9561,59 @@ describe('SOV/th trailing bare quantity reclaim (increment-by-amount R2 blocker)
     expect(inc?.roles?.has('quantity')).toBe(false);
   });
 });
+
+describe('SOV/marker-swallowed fetch responseType reclaim (R1 handoff cluster B)', () => {
+  // `fetch /api/user as json` renders its as-tail AFTER the fused verb: bare
+  // (ja/bn), word + as-postposition (tr olarak, hi के रूप में, qu hina — the
+  // postposition stays skip-noise), or word + a particle the fused pattern's
+  // optional trailing DESTINATION group swallows (ko `json 로` — 로 is a
+  // destination alternative, and `json` violates destination's selector/
+  // reference schema types). buildEventHandler now reclaims a known
+  // response-type word into the absent optional `responseType` role — either
+  // relabeling the schema-invalid destination (ko) or consuming the trailing
+  // bare word (the rest). Corpus forms from a fresh populate.
+  const cases: Array<[string, string]> = [
+    ['/api/user を クリック で フェッチ json それから #name.innerText を その.name に 設定', 'ja'],
+    ['/api/user 를 클릭 할 때 가져오기 json 로 그러면 #name.innerText 를 그것의.name 에 설정', 'ko'],
+    ['/api/user i tıklama de getir json olarak ardından #name.innerText i onun.name e ayarla', 'tr'],
+    ['/api/user কে ক্লিক এ আনুন json তারপর #name.innerText কে এর.name তে সেট', 'bn'],
+    ['/api/user को क्लिक पर लाएं json के रूप में फिर #name.innerText को इसका.name में सेट', 'hi'],
+    ['/api/user ta ñitiy pi apamuy json hina chayqa #name.innerText ta chaypaq.name man churanay', 'qu'],
+  ];
+  for (const [input, lang] of cases) {
+    it(`[${lang}] fetch-json captures responseType=json (and no phantom destination)`, () => {
+      const node = parse(input, lang) as {
+        kind: string;
+        body?: Array<{ action?: string; roles?: Map<string, { type: string; raw?: unknown }> }>;
+      };
+      expect(node.kind).toBe('event-handler');
+      const fetch = node.body?.find(c => c.action === 'fetch');
+      expect(fetch).toBeTruthy();
+      const rt = fetch!.roles?.get('responseType');
+      expect(rt?.type).toBe('expression');
+      expect(rt?.raw).toBe('json');
+      expect(fetch!.roles?.has('destination')).toBe(false);
+    });
+  }
+
+  it('[ko] a genuine selector destination is NOT relabeled', () => {
+    // `#output 로` is a schema-VALID destination (selector) — the reclaim must
+    // leave it alone and add no responseType.
+    const node = parse('/api/user 를 클릭 할 때 가져오기 #output 로', 'ko') as {
+      body?: Array<{ action?: string; roles?: Map<string, { type: string; value?: unknown }> }>;
+    };
+    const fetch = node.body?.find(c => c.action === 'fetch');
+    expect(fetch).toBeTruthy();
+    expect(fetch!.roles?.get('destination')?.type).toBe('selector');
+    expect(fetch!.roles?.has('responseType')).toBe(false);
+  });
+
+  it('[ja] a fetch with no as-tail gains no phantom responseType', () => {
+    const node = parse('/api/user を クリック で フェッチ', 'ja') as {
+      body?: Array<{ action?: string; roles?: Map<string, unknown> }>;
+    };
+    const fetch = node.body?.find(c => c.action === 'fetch');
+    expect(fetch).toBeTruthy();
+    expect(fetch!.roles?.has('responseType')).toBe(false);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-04T12:57:37.829Z",
-  "commit": "a026f7f4",
+  "timestamp": "2026-07-05T01:22:48.101Z",
+  "commit": "2ebb12b5",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -641,12 +641,12 @@
       "avgConfidence": 0.8495030867211314,
       "avgFidelity": 1,
       "avgPrecision": 0.9315737203972502,
-      "avgRoleFidelity": 0.9336026354408707,
+      "avgRoleFidelity": 0.9366592634974988,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4426,12 +4426,12 @@
       "avgConfidence": 0.90909904631709,
       "avgFidelity": 1,
       "avgPrecision": 0.9365270281666384,
-      "avgRoleFidelity": 0.9153433046815399,
+      "avgRoleFidelity": 0.9183999327381681,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
       "avgPrecision": 0.9504107634789454,
-      "avgRoleFidelity": 0.936664213502449,
+      "avgRoleFidelity": 0.939720841559077,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6954,12 @@
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
       "avgPrecision": 0.9504107634789454,
-      "avgRoleFidelity": 0.9256764400146753,
+      "avgRoleFidelity": 0.9287330680713034,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9482,12 @@
       "avgConfidence": 0.7349000206143064,
       "avgFidelity": 1,
       "avgPrecision": 0.9512456428852532,
-      "avgRoleFidelity": 0.9162248059306884,
+      "avgRoleFidelity": 0.9192814339873165,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12642,12 +12642,12 @@
       "avgConfidence": 0.8307646822684411,
       "avgFidelity": 1,
       "avgPrecision": 0.9508127424523529,
-      "avgRoleFidelity": 0.9362667572226397,
+      "avgRoleFidelity": 0.939323385279268,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461162,
+      "bundleSize": 461784,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 461162,
+      "size": 461784,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
First slice of the R1-residual arc — includes the fresh R1 triage handoff (docs-internal/HANDOFF-r1-residual.md, folded here per convention to avoid a doc-only CI run) and the Cluster B fix it recommends first.

**Bug:** `fetch … as json` renders its as-tail after the fused SOV verb — bare (ja/bn), with an as-postposition (tr `olarak`, hi `के रूप में`, qu `hina`), or swallowed by the fused pattern's optional trailing destination group (ko `json 로`, binding a schema-invalid `destination:expression`). The responseType dropped in 6 languages (th/es/it/de etc. already worked).

**Fix:** a `responseType` sibling of #563's trailing-quantity reclaim in `buildEventHandler`, gated on (1) the schema declaring an optional `responseType` that's absent, and (2) the word being a known response-type loanword (json/text/html/…, language-invariant in the corpus). Two moves: relabel the schema-invalid destination (ko), or capture the trailing bare word (rest).

**Validation:**
- Guard tests: 6 corpus forms fail without the fix; negative guards (genuine selector destination, no-tail fetch) hold both ways.
- Semantic suite 6423 passed; typecheck clean; six-signal `--regression` gate green (exit 0).
- Per-(lang,pattern) A/B sweep: **18 changes, all improvements, zero regressions** — fetch-json / fetch-error-handling / fetch-do-not-throw reach R1 1.0 in ja/tr/bn/hi, improve in ko/qu (their residual misses belong to cluster A, the next slice).
- Baseline regenerated against a fresh populate (patterns.db itself not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)