### PR TITLE
fix(multilingual): possessive render/parse symmetry — invert specialForms in the matcher + qu chay-paq split (R1 cluster A1)

### DIFF
--- a/packages/semantic/src/generators/profiles/quechua.ts
+++ b/packages/semantic/src/generators/profiles/quechua.ts
@@ -52,7 +52,18 @@ export const quechuaProfile: LanguageProfile = {
       qampa: 'you',
       // "its/his/her" - paypa
       paypa: 'it',
+      // The corpus dot-notation possessive is chaypaq (its = chay + -paq
+      // genitive), which the agglutinative tokenizer SPLITS into `chay` (it) +
+      // `paq` particle — so the one-token keyword lookup sees only `chay`.
+      // Recognize the bare head here and skip the genitive particle via
+      // `connectors` below (the same mechanism as id `saya punya X`). Guarded
+      // against over-match by the matcher itself: it only fires when a
+      // property-shaped token follows (`.name`), so a marked `chay ta …`
+      // patient or the chayqa/chaymanta then-keywords never form a phantom
+      // possessive (single tokens / particle follows).
+      chay: 'it',
     },
+    connectors: ['paq', 'pa'],
   },
   roleMarkers: {
     patient: { primary: 'ta', position: 'after' },

--- a/packages/semantic/src/parser/utils/possessive-keywords.ts
+++ b/packages/semantic/src/parser/utils/possessive-keywords.ts
@@ -18,7 +18,23 @@ export function getPossessiveReference(
   profile: LanguageProfile,
   keyword: string
 ): string | undefined {
-  return profile.possessive?.keywords?.[keyword];
+  const direct = profile.possessive?.keywords?.[keyword];
+  if (direct) return direct;
+  // Render/parse symmetry: the i18n transformer renders possessives via
+  // `specialForms` (concept → surface, e.g. ko it → 그것의), but only `keywords`
+  // (surface → concept) was consulted here — so a surface form present ONLY in
+  // specialForms round-tripped out but never parsed back (ko `그것의.name`
+  // failed the whole generated set pattern and fell to the role-scrambling SOV
+  // fallback; R1 handoff cluster A). Invert specialForms as a fallback so
+  // whatever the renderer can emit, the matcher can read. `keywords` keeps
+  // precedence for languages that deliberately map a surface differently.
+  const special = profile.possessive?.specialForms;
+  if (special) {
+    for (const [concept, surface] of Object.entries(special)) {
+      if (surface === keyword) return concept;
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -9617,3 +9617,46 @@ describe('SOV/marker-swallowed fetch responseType reclaim (R1 handoff cluster B)
     expect(fetch!.roles?.has('responseType')).toBe(false);
   });
 });
+
+describe('possessive render/parse symmetry (specialForms inversion + qu chay-paq split) — R1 cluster A1', () => {
+  // The i18n transformer renders possessives via the profile's `specialForms`
+  // (concept → surface), but the matcher only consulted `keywords` (surface →
+  // concept) — so ko `그것의.name` (its.name, rendered from specialForms.it)
+  // never parsed back: the generated set pattern's {patient} failed and the
+  // whole clause fell to the role-scrambling SOV fallback. getPossessiveReference
+  // now inverts specialForms as a fallback. qu's `chaypaq.name` additionally
+  // TOKENIZES as chay + paq (agglutinative split), covered by a `chay: it`
+  // keyword + `paq`/`pa` possessive connectors. ja/hi (already-working) locked
+  // as references.
+  const cases: Array<[string, string]> = [
+    ['#name.innerText を その.name に 設定', 'ja'],
+    ['#name.innerText 를 그것의.name 에 설정', 'ko'],
+    ['#name.innerText ta chaypaq.name man churanay', 'qu'],
+    ['#name.innerText को इसका.name में सेट', 'hi'],
+  ];
+  for (const [input, lang] of cases) {
+    it(`[${lang}] set with its-possessive patient parses via the generated pattern (both roles property-path)`, () => {
+      const node = parse(input, lang) as {
+        action?: string;
+        roles?: Map<string, { type: string }>;
+        metadata?: { patternId?: string };
+      };
+      expect(node.action).toBe('set');
+      expect(node.metadata?.patternId).toBe(`set-${lang}-generated`);
+      expect(node.roles?.get('destination')?.type).toBe('property-path');
+      expect(node.roles?.get('patient')?.type).toBe('property-path');
+    });
+  }
+
+  it('[qu] a marked bare-chay patient does not form a phantom possessive', () => {
+    // `chay ta t'ikray` = "toggle it": chay is followed by the ta particle, not
+    // a property token — the possessive matcher must not fire and the patient
+    // stays a plain reference.
+    const node = parse("chay ta t'ikray", 'qu') as {
+      action?: string;
+      roles?: Map<string, { type: string }>;
+    };
+    expect(node.action).toBe('toggle');
+    expect(node.roles?.get('patient')?.type).not.toBe('property-path');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-05T01:22:48.101Z",
-  "commit": "2ebb12b5",
+  "timestamp": "2026-07-05T01:32:55.060Z",
+  "commit": "f871f231",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6954,12 @@
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
       "avgPrecision": 0.9504107634789454,
-      "avgRoleFidelity": 0.9287330680713034,
+      "avgRoleFidelity": 0.9346532739915094,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9482,12 @@
       "avgConfidence": 0.7349000206143064,
       "avgFidelity": 1,
       "avgPrecision": 0.9512456428852532,
-      "avgRoleFidelity": 0.9192814339873165,
+      "avgRoleFidelity": 0.9252016399075224,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461784,
+      "bundleSize": 461888,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 461784,
+      "size": 461888,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
Second slice of the R1-residual arc (docs-internal/HANDOFF-r1-residual.md, cluster A sub-cause 1) — the SOV `set` role-scramble's root cause turned out to be one asymmetry upstream of the role mapping.

**Bug:** the i18n transformer renders possessives via the profile's `specialForms` (concept → surface, ko `it → 그것의`), but `getPossessiveReference` only consulted `keywords` (surface → concept). A surface form present only in specialForms round-tripped out but never parsed back: ko `그것의.name` failed the generated `set` pattern's `{patient}` role token, so the whole clause fell to the role-scrambling SOV verb-anchoring fallback (patient/destination swapped, property-path typed as selector). ja escaped via its `keywords` entry (`その`); qu additionally tokenizes its its-form `chaypaq` into `chay` + `paq`, invisible to any one-token lookup.

**Fixes:**
- `getPossessiveReference` inverts `specialForms` as a fallback (keywords keep precedence) — whatever the renderer can emit, the matcher can read, for every language at once.
- qu: `chay: it` possessive keyword + `paq`/`pa` connectors (the id `saya punya X` mechanism); over-match guarded by the matcher's property-shape requirement + a negative guard test (`chay ta t'ikray` stays a plain patient).

**Validation:**
- Guard tests: ko/qu set-with-possessive clauses parse via `set-{lang}-generated` with both roles `property-path` — fail without the fix; ja/hi locked as references.
- Semantic suite 6428 passed; typecheck clean; six-signal `--regression` gate green (exit 0).
- Per-(lang,pattern) A/B sweep vs the #564 state: **8 changes, all improvements, zero regressions** — ko and qu reach R1 1.0 on fetch-json, fetch-error-handling, its-value-possessive-dot, and fetch-with-headers.
- Baseline regenerated against a fresh populate (patterns.db not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)