### PR TITLE
fix(multilingual): event-anchor guard rejects fronted positional/possessive/optional-chaining heads (R1 cluster C)

### DIFF
--- a/docs-internal/HANDOFF-r1-residual.md
+++ b/docs-internal/HANDOFF-r1-residual.md
@@ -1,5 +1,37 @@
 # Handoff — R1 residual triage (hi/qu/ko + corpus-wide clusters)
 
+> **STATUS UPDATE (2026-07-04, same day): slices B → A1 → C are LANDED** (#564,
+> #565, #566 — each with fail-without-fix guard tests, gate green, zero-regression
+> per-(lang,pattern) A/B, baseline regen). Aggregate: **every laggard language up,
+> none down** — hi +0.013, ko/qu +0.009, bn +0.008, ja/tr +0.003; corpus mean R1
+> 0.9535 → 0.9555. Execution learnings for the next session:
+>
+> - **Cluster B** landed as a `responseType` sibling of #563's trailing-role
+>   reclaim in `buildEventHandler`, gated on a RESPONSE_TYPE_WORDS loanword set +
+>   schema-invalid-destination relabel (the ko `json 로` case). The reclaim-
+>   mechanism family now covers quantity + responseType; further trailing-role
+>   candidates should reuse it.
+> - **Cluster A sub-cause 1** turned out to be UPSTREAM of the role-swap theory:
+>   `getPossessiveReference` never read `specialForms` (render-side), so ko
+>   `그것의.name` couldn't parse back and the whole set clause fell to the
+>   scrambling fallback. Fixed by inverting specialForms in the lookup + qu
+>   `chay: it` keyword + `paq`/`pa` connectors. The mapRoleForCommand swap-fix
+>   theory was NOT needed for these patterns — re-verify before applying it
+>   elsewhere. **A2 (still open):** expression-valued set patients
+>   (`"Hello, " + my value`, two-way-binding) still fail the generated pattern's
+>   {patient} role token — needs multi-token expression-run assembly in
+>   matchRoleToken (greedy-capture risk; A/B per marker).
+> - **Cluster C** landed in the matchRoleToken event-anchor guard (positional
+>   keywords + profile possessive heads + `?.`-fused tokens). Note: the fresh
+>   populate's hi first-in-parent translation leaks English `in closest` (the
+>   fully-localized form appears in sweep context) — didn't matter for the fix,
+>   but it's a transformer artifact worth knowing. **window-resize was
+>   reassigned to cluster E** (its hi translation is scrambled — modifier words
+>   reordered mid-sentence — not an anchor bug).
+> - **Clusters D and E remain**, each a dedicated arc (D: en-reference
+>   canonicalization + baseline churn; E: transformer parenthesized-expression
+>   opacity). Start the next session from the cluster D/E sections below.
+
 > **Written 2026-07-04**, immediately after the SOV literal-role-extraction arc
 > (#560/#561/#562 — see [HANDOFF-sov-literal-role-extraction.md](HANDOFF-sov-literal-role-extraction.md)).
 > This is the **fresh grounding** of what remains in R1 role fidelity now that the

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -369,12 +369,36 @@ export class PatternMatcher {
     // falls through to the command stage (or the per-command SOV event pattern
     // whose patient role legitimately captures it). See
     // docs-internal/HANDOFF-sov-event-anchor.md.
-    if (
-      patternToken.role === 'event' &&
-      this.currentPatternCommand === 'on' &&
-      !PatternMatcher.tokenLooksLikeEvent(token)
-    ) {
-      return patternToken.optional || false;
+    if (patternToken.role === 'event' && this.currentPatternCommand === 'on') {
+      if (!PatternMatcher.tokenLooksLikeEvent(token)) {
+        return patternToken.optional || false;
+      }
+      // R1 cluster C (the surviving tail of the #508 guard): a fronted
+      // POSITIONAL phrase or POSSESSIVE head is never an event either — the
+      // expression assemblers below would otherwise capture it wholesale into
+      // the event role (hi `पहला <input/> …` → event:expression via the
+      // positional matcher, focus-patient defaults to me; hi `मेरा @data-count
+      // को लोड पर डिफ़ॉल्ट …` → event:property-path via the possessive matcher,
+      // the default body gets garbage roles). Rejecting here lets the input
+      // fall through to the per-command pattern whose patient/destination
+      // legitimately captures the fronted phrase — the same fall-through
+      // contract as tokenLooksLikeEvent.
+      const evNorm = (token.normalized ?? token.value).toLowerCase();
+      if (PatternMatcher.POSITIONAL_OR_SCOPE_KEYWORDS.has(evNorm)) {
+        return patternToken.optional || false;
+      }
+      if (
+        this.currentProfile &&
+        (getPossessiveReference(this.currentProfile, token.value) ??
+          getPossessiveReference(this.currentProfile, evNorm)) !== undefined
+      ) {
+        return patternToken.optional || false;
+      }
+      // An optional-chaining head fused into one token (hi
+      // `मेरा?.dataset?.customValue`) is a property access, never an event.
+      if (token.value.includes('?.')) {
+        return patternToken.optional || false;
+      }
     }
 
     // A `duration` slot is never a positional/scope keyword. The temporal

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -9660,3 +9660,58 @@ describe('possessive render/parse symmetry (specialForms inversion + qu chay-paq
     expect(node.roles?.get('patient')?.type).not.toBe('property-path');
   });
 });
+
+describe('event-anchor guard: fronted positional/possessive/optional-chaining heads (R1 cluster C, hi tail)', () => {
+  // The #508 guard rejects non-event-SHAPED single tokens for the event role,
+  // but the expression assemblers still captured a fronted POSITIONAL phrase
+  // (hi `पहला <input/> …` → event:expression) or POSSESSIVE head (hi `मेरा
+  // @data-count …` → event:property-path; fused optional-chaining `मेरा?.…`)
+  // wholesale into the event role — mis-anchoring the handler and garbling the
+  // body. The guard now also rejects positional keywords, profile possessive
+  // heads, and `?.`-fused tokens for the event role of `on` patterns, letting
+  // the input fall through to the per-command pattern.
+  it('[hi] first-in-parent: the fronted positional phrase is not the event', () => {
+    const node = parse('पहला <input/> in closest <form/> को क्लिक पर फोकस', 'hi') as {
+      kind: string;
+      roles?: Map<string, { type: string; value?: unknown }>;
+      body?: Array<{ action?: string; roles?: Map<string, { type: string }> }>;
+    };
+    expect(node.kind).toBe('event-handler');
+    expect(node.roles?.get('event')?.value).toBe('click');
+    const focus = node.body?.find(c => c.action === 'focus');
+    expect(focus).toBeTruthy();
+    expect(focus!.roles?.get('patient')?.type).toBe('expression');
+  });
+
+  it('[hi] default-value: the fronted possessive is not the event', () => {
+    const node = parse('मेरा @data-count को लोड पर डिफ़ॉल्ट "0" में', 'hi') as {
+      kind: string;
+      roles?: Map<string, { value?: unknown }>;
+    };
+    expect(node.kind).toBe('event-handler');
+    expect(node.roles?.get('event')?.value).toBe('load');
+  });
+
+  it('[hi] optional-chaining-possessive: the ?.-fused head is not the event, no phantom click command', () => {
+    const node = parse('मेरा?.dataset?.customValue को क्लिक पर लॉग', 'hi') as {
+      kind: string;
+      roles?: Map<string, { value?: unknown }>;
+      body?: Array<{ action?: string }>;
+    };
+    expect(node.kind).toBe('event-handler');
+    expect(node.roles?.get('event')?.value).toBe('click');
+    expect(node.body?.some(c => c.action === 'click')).toBe(false);
+    expect(node.body?.some(c => c.action === 'log')).toBe(true);
+  });
+
+  it('[hi] a plain selector-fronted handler still parses (guard is additive)', () => {
+    const node = parse('.active को क्लिक पर टॉगल', 'hi') as {
+      kind: string;
+      roles?: Map<string, { value?: unknown }>;
+      body?: Array<{ action?: string }>;
+    };
+    expect(node.kind).toBe('event-handler');
+    expect(node.roles?.get('event')?.value).toBe('click');
+    expect(node.body?.some(c => c.action === 'toggle')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-05T01:32:55.060Z",
-  "commit": "f871f231",
+  "timestamp": "2026-07-05T01:42:36.177Z",
+  "commit": "3227c8c3",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -638,15 +638,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8495030867211314,
+      "avgConfidence": 0.8462563334743781,
       "avgFidelity": 1,
       "avgPrecision": 0.9315737203972502,
-      "avgRoleFidelity": 0.9366592634974988,
+      "avgRoleFidelity": 0.9411637680020033,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -857,10 +857,6 @@
           "confidence": 1
         },
         "closest-ancestor": {
-          "success": true,
-          "confidence": 1
-        },
-        "first-in-parent": {
           "success": true,
           "confidence": 1
         },
@@ -1192,6 +1188,10 @@
           "success": true,
           "confidence": 0.5
         },
+        "first-in-parent": {
+          "success": true,
+          "confidence": 0.5
+        },
         "event-debounce": {
           "success": true,
           "confidence": 0.5
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4423,15 +4423,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.90909904631709,
+      "avgConfidence": 0.8993587865768304,
       "avgFidelity": 1,
-      "avgPrecision": 0.9365270281666384,
-      "avgRoleFidelity": 0.9183999327381681,
+      "avgPrecision": 0.9386915303311406,
+      "avgRoleFidelity": 0.928535067873303,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -4549,10 +4549,6 @@
           "success": true,
           "confidence": 1
         },
-        "default-value": {
-          "success": true,
-          "confidence": 1
-        },
         "install-behavior": {
           "success": true,
           "confidence": 1
@@ -4661,10 +4657,6 @@
           "success": true,
           "confidence": 1
         },
-        "first-in-parent": {
-          "success": true,
-          "confidence": 1
-        },
         "last-in-collection": {
           "success": true,
           "confidence": 1
@@ -4754,10 +4746,6 @@
           "confidence": 1
         },
         "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "optional-chaining-possessive": {
           "success": true,
           "confidence": 1
         },
@@ -5033,7 +5021,15 @@
           "success": true,
           "confidence": 0.5
         },
+        "default-value": {
+          "success": true,
+          "confidence": 0.5
+        },
         "set-color-variable": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "first-in-parent": {
           "success": true,
           "confidence": 0.5
         },
@@ -5042,6 +5038,10 @@
           "confidence": 0.5
         },
         "computed-value": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "optional-chaining-possessive": {
           "success": true,
           "confidence": 0.5
         },
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 461888,
+      "bundleSize": 462138,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 461888,
+      "size": 462138,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
Third slice of the R1-residual arc (docs-internal/HANDOFF-r1-residual.md, cluster C — the surviving tail of the old hi event-anchor cluster).

**Bug:** the #508 guard rejects non-event-shaped single tokens for the event role, but the expression assemblers still captured a fronted **positional phrase** (hi/bn `पहला <input/> …` → `event:expression`, focus-patient defaulting to `me`) or **possessive head** (hi `मेरा @data-count …` → `event:property-path`; the `?.`-fused `मेरा?.dataset?.customValue` likewise) wholesale into the event role — mis-anchoring the handler and garbling the body (a phantom `click` command in optional-chaining-possessive).

**Fix:** the `matchRoleToken` event-anchor guard additionally rejects, for `on` patterns' event role: positional/scope keywords (by normalized form), profile possessive heads (`getPossessiveReference` — language-agnostic), and `?.`-fused tokens. Same fall-through contract as `tokenLooksLikeEvent`: the input drops to the per-command pattern that legitimately captures the fronted phrase.

**Validation:**
- Guard tests: hi default-value + optional-chaining-possessive fail without the fix; first-in-parent + a plain selector-fronted handler locked as behavior.
- Semantic suite 6432 passed; typecheck clean; six-signal `--regression` gate green (exit 0).
- Per-(lang,pattern) A/B sweep vs the #565 state: **4 changes, all improvements, zero regressions** — first-in-parent R1 0.33→1.0 in **hi and bn**, default-value 0.5→1.0, optional-chaining-possessive precision 0.67→**1.0** (phantom `click` gone) + R1 0.33→0.67.
- window-resize (the 4th pattern from the triage) is a translation scramble, not an anchor bug — stays with cluster E.
- Baseline regenerated against a fresh populate (patterns.db not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)