### PR TITLE
fix(multilingual): repeat loop-HEAD canonicalization — for-in/while/until heads for en + 23 langs (R1 cluster D)

### DIFF
--- a/docs-internal/HANDOFF-r1-residual.md
+++ b/docs-internal/HANDOFF-r1-residual.md
@@ -28,9 +28,34 @@
 >   but it's a transformer artifact worth knowing. **window-resize was
 >   reassigned to cluster E** (its hi translation is scrambled — modifier words
 >   reordered mid-sentence — not an anchor bug).
-> - **Clusters D and E remain**, each a dedicated arc (D: en-reference
->   canonicalization + baseline churn; E: transformer parenthesized-expression
->   opacity). Start the next session from the cluster D/E sections below.
+> - **Cluster D is LANDED** (same day, later session): repeat loop-HEAD
+>   canonicalization — `for-in` / `while-head` / `until-head` patterns for en +
+>   all 23 translations (packages/semantic/src/patterns/repeat.ts), plus two
+>   parser enablers (head-only re-parse allowlist extended to the new ids; the
+>   repeat default-patient leak `reference:me` dropped so the superset guard
+>   can't block the swap, with schema-unsanctioned fused junk roles exempted).
+>   en reference now emits `repeat{loopType, patient, source}` for for-loops
+>   (killed the `event="in"`/`quantity` noise), `{loopType, condition}` for
+>   while, and translations reproduce the until-event-from head (behaviors ×3).
+>   A/B: **every language up, none down** — mean R1 0.9555 → 0.9654 (+0.0099,
+>   biggest single-arc move; es/pt/ru/uk/id +0.012, sw +0.013, he +0.0125);
+>   precision up-or-flat everywhere; parse 3696/3696; R2 1.0; gate green;
+>   baseline regenerated against a fresh populate. Execution learnings:
+>   the transformer's repeat-head emission is VERB-FIRST in every language
+>   (even the SOV six) in handler context, but UNTIL-FIRST in statement context
+>   (the behaviors' repeat line) — two surface shapes per SOV language; the
+>   `in`-word normalization is wildly inconsistent across profiles (es
+>   `en`→destination, pt `dentro`→into, fr `en`→identifier), so the heads are
+>   surface-keyed tables like the `-times` heads, NOT normalized-keyword
+>   patterns; standalone statement parses only try patterns at position 0 (no
+>   skip-ahead), which is why qu needs the `hayk _ a` junk-prefix variant AND a
+>   mid-clause variant (a preceding greedy verb-first trigger eats `hayk` in
+>   the sortable body). Remaining repeat-family residue: SOV repeat-while
+>   (fronted while-phrase parses as a separate `while` node — hi/qu miss
+>   condition+loopType, ko condition; unchanged count vs before, needs the
+>   fronted-guard machinery, not a head).
+> - **Cluster E remains** — its own arc (transformer parenthesized-expression
+>   opacity). Start the next session from the cluster E section below.
 
 > **Written 2026-07-04**, immediately after the SOV literal-role-extraction arc
 > (#560/#561/#562 — see [HANDOFF-sov-literal-role-extraction.md](HANDOFF-sov-literal-role-extraction.md)).

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -992,6 +992,21 @@ export class SemanticParserImpl implements ISemanticParser {
             }
           }
         }
+        // Drop the SOV default-patient leak for ANY remaining repeat variant
+        // (the forever/until branches above already delete it on their paths).
+        // The fused SOV event pattern defaults `patient:reference=me`, but
+        // repeat has no patient role — left in place it (a) surfaces as a
+        // phantom `loopType:reference=me` via normalizeCommandRoles (a
+        // precision hit the en reference never has), and (b) blocks the
+        // fused re-parse swap below for the `for-in` HEAD: the superset guard
+        // maps fused `patient`→`loopType` and the re-parse's
+        // `loopType:literal="for"` can't type-match `reference`. Gated on the
+        // exact default value so a REAL fused capture (`-times`' fronted
+        // count under `patient`) is never touched.
+        const leak = roles.patient as { type?: string; value?: unknown } | undefined;
+        if (leak && leak.type === 'reference' && leak.value === 'me') {
+          delete roles.patient;
+        }
       }
 
       let commandNode = createCommandNode(actionName as ActionType, roles, {
@@ -1134,10 +1149,31 @@ export class SemanticParserImpl implements ISemanticParser {
               !schema?.roles.some(r => r.role === 'patient')
                 ? primary
                 : role) as SemanticRole;
+            // A fused role is IGNORABLE (exempt from the superset requirement)
+            // for a block-body action when the schema says it cannot be real:
+            // the mapped role isn't declared at all (es `repeat-event-es-vso`
+            // binds `.items` under `destination` — repeat has no destination
+            // role), or its captured TYPE violates the role's expectedTypes
+            // (`loopType:expression="item"` — loopType is literal-only). Such
+            // junk would otherwise block the head-only re-parse swap below
+            // (the fused mis-capture can never "reappear" in the canonical
+            // parse). Scoped to block-body actions (only `repeat` reaches
+            // here); real captures — the `-times` fronted count (patient→
+            // loopType, literal ✓ literal) and every non-block command — keep
+            // full superset protection, including the qu verb-final safety rail.
+            const isIgnorableFusedRole = (role: string, val: unknown): boolean => {
+              if (!BLOCK_BODY_ACTIONS.has(actionName) || !schema) return false;
+              const spec = schema.roles.find(r => r.role === mapRole(role));
+              if (!spec) return true;
+              return (
+                spec.expectedTypes.length > 0 && !spec.expectedTypes.includes(valType(val) as never)
+              );
+            };
             const preservesFused =
               !!first &&
               first.kind === 'command' &&
               Object.entries(roles).every(([role, val]) => {
+                if (isIgnorableFusedRole(role, val)) return true;
                 const rv = (first as CommandSemanticNode).roles.get(mapRole(role));
                 return rv !== undefined && valType(rv) === valType(val);
               });
@@ -1151,7 +1187,12 @@ export class SemanticParserImpl implements ISemanticParser {
               (first as { metadata?: { patternId?: string } } | undefined)?.metadata?.patternId ??
               '';
             const headOnlyOk =
-              !BLOCK_BODY_ACTIONS.has(actionName) || /^repeat-.*-times$/.test(reparsePid);
+              !BLOCK_BODY_ACTIONS.has(actionName) ||
+              // All four repeat HEAD families are HEAD-ONLY by construction
+              // (they stop before the loop body — see patterns/repeat.ts), so
+              // the swap can never swallow a body command. The body-swallowing
+              // generated repeat matches none of these ids.
+              /^repeat-.*-(times|for-in|while-head|until-head)$/.test(reparsePid);
             if (
               reparsed.length === 1 &&
               first &&

--- a/packages/semantic/src/patterns/en.ts
+++ b/packages/semantic/src/patterns/en.ts
@@ -13,6 +13,7 @@ import { generatePatternsForLanguage } from '../generators/pattern-generator';
 import { getTogglePatternsForLanguage } from './toggle';
 import { getPutPatternsForLanguage } from './put';
 import { getEventHandlerPatternsForLanguage } from './event-handler';
+import { getRepeatPatternsForLanguage } from './repeat';
 
 // =============================================================================
 // Hand-crafted English-only patterns
@@ -378,6 +379,12 @@ export function buildEnglishPatterns(): LanguagePattern[] {
   patterns.push(...getTogglePatternsForLanguage('en'));
   patterns.push(...getPutPatternsForLanguage('en'));
   patterns.push(...getEventHandlerPatternsForLanguage('en'));
+  // Repeat loop-HEAD patterns (`for-in` / `while` — R1 cluster D): kill the
+  // generated repeat's en-reference noise (`repeat for item in .items` →
+  // quantity:expression="item" + event:literal="in", `.items` dropped) by
+  // capturing the canonical loopType/patient/source head and stopping before
+  // the loop body. The `until event` variants stay hand-crafted below.
+  patterns.push(...getRepeatPatternsForLanguage('en'));
 
   // 2. English-only hand-crafted patterns
   patterns.push(

--- a/packages/semantic/src/patterns/repeat.ts
+++ b/packages/semantic/src/patterns/repeat.ts
@@ -124,16 +124,389 @@ const SOV_REPEAT_TIMES: Array<[string, string, string]> = [
   ['qu', 'times', 'ta'],
 ];
 
-const BY_LANG = new Map<string, LanguagePattern[]>();
-for (const [lang, verb, countWord, marker] of VERB_FIRST_REPEAT_TIMES) {
-  BY_LANG.set(lang, [repeatTimesHead(lang, verb, countWord, marker)]);
+// =============================================================================
+// R1 cluster D — `repeat for X in Y` / `repeat while C` / `repeat until event E
+// [from S]` loop-HEAD patterns (docs-internal/HANDOFF-r1-residual.md).
+//
+// Before these heads, only the en `-times`/`forever`/`until event` variants had
+// HEAD-ONLY patterns; every other repeat head fell to the GENERATED positional
+// repeat, which binds junk (`repeat for item in .items` → `loopType="for",
+// quantity:expression="item", event:literal="in"`, `.items` dropped — the en
+// reference NOISE every translation then "missed"), or to the bare-`repeat`
+// clause-loop recovery (roles lost entirely). Each head below captures the
+// canonical roles and STOPS before the loop body, so the surrounding clause
+// loop parses the body as sibling commands (the same contract as the `-times`
+// heads; ids must stay under the /^repeat-.*-(times|for-in|while-head|
+// until-head)$/ head-only allowlist in semantic-parser's fused re-parse gate).
+//
+// Surface forms are taken VERBATIM from the freshly-populated corpus (the i18n
+// transformer's emission is deterministic — see the probe tables in the
+// handoff). Literal tokens also match by NORMALIZED form, so `repeat`/`until`/
+// `event` literals cover every language whose tokenizer normalizes its verb.
+// =============================================================================
+
+/**
+ * For-binding loop HEAD: `{repeat-verb} [for-word(s)] {patient} {in-word(s)}
+ * {source}` — canonical roles `loopType:literal="for"` + `patient` (the binding
+ * variable) + `source` (the collection). The transformer usually DROPS the
+ * `for` binder in transit (`repetir item en .items`) but keeps it in the
+ * `with index` variant (`repetir para item en .item con index`), so the
+ * for-group is optional. Any trailing `with index` tail is left unconsumed —
+ * it is marker-led, so the clause loop's skipped-run recovery discards it.
+ */
+function repeatForInHead(
+  language: string,
+  spec: { forWords?: string[]; inWords: string[] }
+): LanguagePattern {
+  const tokens: LanguagePattern['template']['tokens'] = [
+    { type: 'literal', value: 'repeat' }, // matches the verb's normalized form
+  ];
+  if (spec.forWords && spec.forWords.length > 0) {
+    tokens.push({
+      type: 'group',
+      optional: true,
+      tokens: spec.forWords.map(w => ({ type: 'literal' as const, value: w })),
+    });
+  }
+  tokens.push({ type: 'role', role: 'patient', expectedTypes: ['expression', 'reference'] });
+  for (const w of spec.inWords) tokens.push({ type: 'literal', value: w });
+  tokens.push({
+    type: 'role',
+    role: 'source',
+    expectedTypes: ['selector', 'expression', 'reference'],
+  });
+  return {
+    id: `repeat-${language}-for-in`,
+    language,
+    command: 'repeat',
+    priority: 110, // > the generated positional repeat (100)
+    template: {
+      format: `repeat [${(spec.forWords ?? []).join(' ')}] {patient} ${spec.inWords.join(' ')} {source}`,
+      tokens,
+    },
+    extraction: {
+      loopType: { default: { type: 'literal', value: 'for' } },
+    },
+  };
 }
-for (const [lang, countWord, marker] of SOV_REPEAT_TIMES) {
-  BY_LANG.set(lang, [repeatTimesHeadSOV(lang, countWord, marker)]);
+
+// in-word/for-word surfaces per language (corpus forms; several langs tokenize
+// the in-word as TWO tokens — ja `の 中`, ko `안 에`, qu `uku pi`).
+const FOR_IN_HEADS: Array<[string, { forWords?: string[]; inWords: string[] }]> = [
+  ['en', { forWords: ['for'], inWords: ['in'] }],
+  ['es', { forWords: ['para'], inWords: ['en'] }],
+  ['pt', { forWords: ['para'], inWords: ['dentro'] }],
+  ['fr', { forWords: ['pour'], inWords: ['en'] }],
+  ['it', { forWords: ['per'], inWords: ['in'] }],
+  ['de', { forWords: ['für'], inWords: ['in'] }],
+  ['ru', { forWords: ['для'], inWords: ['в'] }],
+  ['uk', { forWords: ['для'], inWords: ['у'] }],
+  ['pl', { forWords: ['dla'], inWords: ['w'] }],
+  ['ar', { forWords: ['لكل'], inWords: ['في'] }],
+  // he keeps English `in` untranslated; stagger inserts `עבור את` before the var.
+  ['he', { forWords: ['עבור', 'את'], inWords: ['in'] }],
+  ['hi', { inWords: ['में'] }],
+  ['bn', { inWords: ['এ'] }],
+  ['ja', { inWords: ['の', '中'] }],
+  ['ko', { inWords: ['안', '에'] }],
+  ['zh', { forWords: ['为', '把'], inWords: ['在'] }],
+  ['tr', { inWords: ['içinde'] }],
+  ['id', { forWords: ['untuk'], inWords: ['dalam'] }],
+  ['ms', { forWords: ['untuk'], inWords: ['dalam'] }],
+  ['sw', { forWords: ['kwa'], inWords: ['ndani'] }],
+  ['th', { forWords: ['สำหรับ'], inWords: ['ใน'] }],
+  ['vi', { forWords: ['với mỗi'], inWords: ['trong'] }],
+  ['tl', { forWords: ['para_sa'], inWords: ['sa_loob'] }],
+  ['qu', { inWords: ['uku', 'pi'] }],
+];
+
+/**
+ * Conditional loop HEAD: `{repeat-verb} [pre] {while-word} {condition}` —
+ * canonical roles `loopType:literal="while"` + `condition` (the guard
+ * expression; typed `property-path` for the corpus's `#id.prop < N` shape —
+ * the trailing comparator tokens are junk-led and discarded by the clause
+ * loop, same as the en reference). Verb-first languages only: the SOV six
+ * front the while-phrase BEFORE the event (`जब तक <cond> को क्लिक पर दोहराएं`),
+ * which parses as a separate `while` node — out of scope for this head.
+ */
+function repeatWhileHead(
+  language: string,
+  spec: { pre?: string[]; whileWord: string }
+): LanguagePattern {
+  const tokens: LanguagePattern['template']['tokens'] = [{ type: 'literal', value: 'repeat' }];
+  for (const w of spec.pre ?? []) tokens.push({ type: 'literal', value: w });
+  tokens.push({ type: 'literal', value: spec.whileWord });
+  tokens.push({
+    type: 'role',
+    role: 'condition',
+    expectedTypes: ['property-path', 'expression'],
+  });
+  return {
+    id: `repeat-${language}-while-head`,
+    language,
+    command: 'repeat',
+    priority: 110,
+    template: {
+      format: `repeat ${(spec.pre ?? []).join(' ')} ${spec.whileWord} {condition}`,
+      tokens,
+    },
+    extraction: {
+      loopType: { default: { type: 'literal', value: 'while' } },
+    },
+  };
+}
+
+const WHILE_HEADS: Array<[string, { pre?: string[]; whileWord: string }]> = [
+  ['en', { whileWord: 'while' }],
+  ['es', { whileWord: 'mientras' }],
+  ['pt', { whileWord: 'enquanto' }],
+  ['fr', { whileWord: 'tantque' }],
+  ['it', { whileWord: 'mentre' }],
+  ['de', { whileWord: 'während' }],
+  ['ru', { whileWord: 'пока' }],
+  ['uk', { whileWord: 'поки' }],
+  ['pl', { whileWord: 'dopóki' }],
+  ['ar', { whileWord: 'بينما' }],
+  ['he', { pre: ['את'], whileWord: 'כל עוד' }], // fused two-word token
+  ['zh', { pre: ['把'], whileWord: '当' }],
+  ['id', { whileWord: 'selama' }],
+  ['ms', { whileWord: 'selagi' }],
+  ['sw', { whileWord: 'wakati' }],
+  ['th', { whileWord: 'ในขณะที่' }],
+  ['vi', { whileWord: 'trong khi' }], // fused two-word token
+  ['tl', { whileWord: 'habang' }],
+];
+
+/**
+ * Event-terminated loop HEAD, verb-first: `{repeat-verb} [pre] {until-word}
+ * [pre-event] {event-word} {event} [{from-word} {source}]` — the translation of
+ * en's hand-crafted `repeat until event {event} [from {source}]` (which is
+ * registered for en only, so every other language previously fell to the
+ * generated repeat or the bare-`repeat` recovery and dropped event+source —
+ * the behaviors-×3 `repeat.event`/`repeat.source` residue).
+ */
+function repeatUntilHeadVerbFirst(
+  language: string,
+  spec: {
+    pre?: string[];
+    untilWord: string;
+    preEvent?: string;
+    eventWord: string;
+    fromWord: string;
+  }
+): LanguagePattern {
+  const tokens: LanguagePattern['template']['tokens'] = [{ type: 'literal', value: 'repeat' }];
+  for (const w of spec.pre ?? []) tokens.push({ type: 'literal', value: w });
+  tokens.push({ type: 'literal', value: spec.untilWord });
+  if (spec.preEvent) tokens.push({ type: 'literal', value: spec.preEvent });
+  tokens.push({ type: 'literal', value: spec.eventWord });
+  tokens.push({ type: 'role', role: 'event', expectedTypes: ['literal', 'expression'] });
+  tokens.push({
+    type: 'group',
+    optional: true,
+    tokens: [
+      { type: 'literal', value: spec.fromWord },
+      { type: 'role', role: 'source', expectedTypes: ['selector', 'reference', 'expression'] },
+    ],
+  });
+  return {
+    id: `repeat-${language}-until-head`,
+    language,
+    command: 'repeat',
+    priority: 110,
+    template: {
+      format: `repeat ${spec.untilWord} ${spec.eventWord} {event} [${spec.fromWord} {source}]`,
+      tokens,
+    },
+    extraction: {
+      loopType: { default: { type: 'literal', value: 'until-event' } },
+    },
+  };
+}
+
+const VERB_FIRST_UNTIL_HEADS: Array<
+  [
+    string,
+    { pre?: string[]; untilWord: string; preEvent?: string; eventWord: string; fromWord: string },
+  ]
+> = [
+  ['es', { untilWord: 'hasta', eventWord: 'evento', fromWord: 'de' }],
+  ['pt', { untilWord: 'até', eventWord: 'evento', fromWord: 'de' }],
+  ['fr', { untilWord: 'jusquà', eventWord: 'événement', fromWord: 'de' }],
+  ['it', { untilWord: 'fino', eventWord: 'evento', fromWord: 'da' }],
+  ['de', { untilWord: 'bis', eventWord: 'ereignis', fromWord: 'von' }],
+  ['ru', { untilWord: 'до', eventWord: 'событие', fromWord: 'из' }],
+  ['uk', { untilWord: 'до', eventWord: 'подія', fromWord: 'з' }],
+  ['pl', { untilWord: 'aż', eventWord: 'zdarzenie', fromWord: 'z' }],
+  ['ar', { untilWord: 'حتى', eventWord: 'حدث', fromWord: 'من' }],
+  ['he', { untilWord: 'עד', preEvent: 'את', eventWord: 'אירוע', fromWord: 'מ' }],
+  ['id', { untilWord: 'sampai', eventWord: 'peristiwa', fromWord: 'dari' }],
+  ['ms', { untilWord: 'sehingga', eventWord: 'peristiwa', fromWord: 'dari' }],
+  ['sw', { untilWord: 'hadi', eventWord: 'tukio', fromWord: 'kutoka' }],
+  ['th', { untilWord: 'จนถึง', eventWord: 'เหตุการณ์', fromWord: 'จาก' }],
+  ['vi', { untilWord: 'cho đến khi', eventWord: 'sự kiện', fromWord: 'từ' }],
+  ['tl', { untilWord: 'hanggang', eventWord: 'pangyayari', fromWord: 'mula_sa' }],
+  ['zh', { pre: ['把'], untilWord: '直到', eventWord: '事件', fromWord: '从' }],
+];
+
+/**
+ * Event-terminated loop HEAD, SOV statement order: `{until-word} {event-word}
+ * {event} {obj-marker} {repeat-verb} [{source} {from-marker}]`. This is the
+ * transformer's STATEMENT-context emission (the behaviors' repeat line:
+ * ko `까지 이벤트 pointerup 를 반복 문서 에서`); the HANDLER-context emission
+ * (`반복 이벤트 X 를 까지`) is covered by the fused-capture recovery in
+ * buildEventHandler. The trailing `{source} {from-marker}` pair is part of the
+ * head (postpositional), captured in-pattern so its TYPE matches the en
+ * reference's `source:expression`.
+ */
+function repeatUntilHeadSOV(
+  language: string,
+  spec: { untilWord: string; eventWord: string; objMarker: string; fromWord: string }
+): LanguagePattern {
+  return {
+    id: `repeat-${language}-until-head`,
+    language,
+    command: 'repeat',
+    priority: 110,
+    template: {
+      format: `${spec.untilWord} ${spec.eventWord} {event} ${spec.objMarker} repeat [{source} ${spec.fromWord}]`,
+      tokens: [
+        { type: 'literal', value: spec.untilWord },
+        { type: 'literal', value: spec.eventWord },
+        { type: 'role', role: 'event', expectedTypes: ['literal', 'expression'] },
+        { type: 'literal', value: spec.objMarker },
+        { type: 'literal', value: 'repeat' },
+        {
+          type: 'group',
+          optional: true,
+          tokens: [
+            {
+              type: 'role',
+              role: 'source',
+              expectedTypes: ['selector', 'reference', 'expression'],
+            },
+            { type: 'literal', value: spec.fromWord },
+          ],
+        },
+      ],
+    },
+    extraction: {
+      loopType: { default: { type: 'literal', value: 'until-event' } },
+    },
+  };
 }
 
 /**
- * Get counted-loop HEAD patterns for a specific language.
+ * Mid-clause twin of {@link repeatUntilHeadQu}: anchors at `kama`(→until)
+ * WITHOUT the `hayk _ a` junk prefix. Inside a multi-command clause (the
+ * sortable behavior body) the PRECEDING command's verb-first pattern greedily
+ * consumes `hayk` as its trailing role, so the clause loop reaches the repeat
+ * head at `_ a kama …` and skips to `kama` — where the prefixed variant can no
+ * longer match. Both variants are HEAD-ONLY (id ends in `-until-head` for the
+ * re-parse allowlist).
+ */
+const repeatUntilHeadQuMidClause: LanguagePattern = {
+  id: 'repeat-qu-midclause-until-head',
+  language: 'qu',
+  command: 'repeat',
+  priority: 109, // below the prefixed variant so position-0 parses prefer it
+  template: {
+    format: 'until event {event} ta {source} manta repeat',
+    tokens: [
+      { type: 'literal', value: 'until' },
+      { type: 'literal', value: 'event' },
+      { type: 'role', role: 'event', expectedTypes: ['literal', 'expression'] },
+      { type: 'literal', value: 'ta' },
+      { type: 'role', role: 'source', expectedTypes: ['selector', 'reference', 'expression'] },
+      { type: 'literal', value: 'manta' },
+      { type: 'literal', value: 'repeat' },
+    ],
+  },
+  extraction: {
+    loopType: { default: { type: 'literal', value: 'until-event' } },
+  },
+};
+
+const SOV_UNTIL_HEADS: Array<
+  [string, { untilWord: string; eventWord: string; objMarker: string; fromWord: string }]
+> = [
+  ['hi', { untilWord: 'तक', eventWord: 'घटना', objMarker: 'को', fromWord: 'से' }],
+  ['bn', { untilWord: 'পর্যন্ত', eventWord: 'ঘটনা', objMarker: 'কে', fromWord: 'থেকে' }],
+  ['ja', { untilWord: 'まで', eventWord: 'イベント', objMarker: 'を', fromWord: 'から' }],
+  ['ko', { untilWord: '까지', eventWord: '이벤트', objMarker: '를', fromWord: '에서' }],
+  ['tr', { untilWord: 'kadar', eventWord: 'olay', objMarker: 'i', fromWord: 'den' }],
+];
+
+/**
+ * qu event-terminated loop HEAD: `hayk_akama ruway {event} ta {source} manta
+ * kutipay` — until + event-kw fronted, source phrase BEFORE the clause-final
+ * verb (unlike the other SOV five, where source trails the verb). The
+ * `hayk_akama` until-compound tokenizes as `hayk _ a kama`(→until); the junk
+ * prefix is matched IN-PATTERN because a standalone statement parse only
+ * tries patterns at position 0 (it has no skip-ahead — the behaviors' repeat
+ * line is exactly this statement). The trailing literals are NORMALIZED forms
+ * (kama→until, ruway→event, kutipay→repeat), so the head survives dictionary
+ * respellings of the verbs.
+ */
+const repeatUntilHeadQu: LanguagePattern = {
+  id: 'repeat-qu-until-head',
+  language: 'qu',
+  command: 'repeat',
+  priority: 110,
+  template: {
+    format: 'hayk _ a until event {event} ta {source} manta repeat',
+    tokens: [
+      { type: 'literal', value: 'hayk' },
+      { type: 'literal', value: '_' },
+      { type: 'literal', value: 'a' },
+      { type: 'literal', value: 'until' },
+      { type: 'literal', value: 'event' },
+      { type: 'role', role: 'event', expectedTypes: ['literal', 'expression'] },
+      { type: 'literal', value: 'ta' },
+      { type: 'role', role: 'source', expectedTypes: ['selector', 'reference', 'expression'] },
+      { type: 'literal', value: 'manta' },
+      { type: 'literal', value: 'repeat' },
+    ],
+  },
+  extraction: {
+    loopType: { default: { type: 'literal', value: 'until-event' } },
+  },
+};
+
+const BY_LANG = new Map<string, LanguagePattern[]>();
+const addPattern = (lang: string, p: LanguagePattern) => {
+  const list = BY_LANG.get(lang);
+  if (list) list.push(p);
+  else BY_LANG.set(lang, [p]);
+};
+for (const [lang, verb, countWord, marker] of VERB_FIRST_REPEAT_TIMES) {
+  addPattern(lang, repeatTimesHead(lang, verb, countWord, marker));
+}
+for (const [lang, countWord, marker] of SOV_REPEAT_TIMES) {
+  addPattern(lang, repeatTimesHeadSOV(lang, countWord, marker));
+}
+for (const [lang, spec] of FOR_IN_HEADS) {
+  addPattern(lang, repeatForInHead(lang, spec));
+}
+for (const [lang, spec] of WHILE_HEADS) {
+  addPattern(lang, repeatWhileHead(lang, spec));
+}
+for (const [lang, spec] of VERB_FIRST_UNTIL_HEADS) {
+  addPattern(lang, repeatUntilHeadVerbFirst(lang, spec));
+}
+for (const [lang, spec] of SOV_UNTIL_HEADS) {
+  addPattern(lang, repeatUntilHeadSOV(lang, spec));
+}
+addPattern('qu', repeatUntilHeadQu);
+addPattern('qu', repeatUntilHeadQuMidClause);
+
+/**
+ * Get repeat loop-HEAD patterns for a specific language (counted `-times`
+ * heads + the cluster-D `for-in` / `while` / `until-event` heads).
+ * Note: `en` rows here are ALSO pushed by patterns/en.ts buildEnglishPatterns
+ * (the registered-patterns path); builders.ts picks them up via
+ * PATTERN_LOADERS. The en `until event` variants stay in en.ts (hand-crafted
+ * originals).
  */
 export function getRepeatPatternsForLanguage(language: string): LanguagePattern[] {
   return BY_LANG.get(language) ?? [];

--- a/packages/semantic/test/repeat-loop-heads.test.ts
+++ b/packages/semantic/test/repeat-loop-heads.test.ts
@@ -1,0 +1,180 @@
+/**
+ * R1 cluster D — repeat loop-HEAD canonicalization guards
+ * (docs-internal/HANDOFF-r1-residual.md, cluster D).
+ *
+ * Before the `for-in` / `while-head` / `until-head` patterns
+ * (patterns/repeat.ts), every non-`times`/`forever`/`until event` repeat head
+ * fell to the GENERATED positional repeat or the bare-`repeat` recovery:
+ *
+ * - en `repeat for item in .items` parsed as `loopType:literal="for",
+ *   quantity:expression="item", event:literal="in"` with `.items` DROPPED —
+ *   reference NOISE all 23 translations then "missed" (R1).
+ * - es `repetir item en .items` bound `.items` to `destination` and the
+ *   binding var to `loopType`; the SOV trio collapsed to a bare `repeat`.
+ * - The behaviors' `repeat until event pointerup from document` line lost
+ *   event + source + loopType in EVERY non-en language.
+ *
+ * Each test here fails without the head patterns (plus the parser's extended
+ * head-only re-parse allowlist and the repeat default-patient-leak drop).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse } from '../src';
+
+type AnyNode = Record<string, any>;
+
+/** Depth-first search for the first `repeat` command node in the tree. */
+function findRepeat(node: unknown): AnyNode | null {
+  if (!node || typeof node !== 'object') return null;
+  const rec = node as AnyNode;
+  if (rec.action === 'repeat') return rec;
+  for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'eventHandlers', 'initBlock']) {
+    const c = rec[f];
+    if (Array.isArray(c)) {
+      for (const child of c) {
+        const hit = findRepeat(child);
+        if (hit) return hit;
+      }
+    } else if (c && typeof c === 'object') {
+      const hit = findRepeat(c);
+      if (hit) return hit;
+    }
+  }
+  return null;
+}
+
+function collectActions(node: unknown, acc = new Set<string>()): Set<string> {
+  if (!node || typeof node !== 'object') return acc;
+  const rec = node as AnyNode;
+  if (typeof rec.action === 'string') acc.add(rec.action);
+  for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'eventHandlers', 'initBlock']) {
+    const c = rec[f];
+    if (Array.isArray(c)) c.forEach(x => collectActions(x, acc));
+    else if (c && typeof c === 'object') collectActions(c, acc);
+  }
+  return acc;
+}
+
+const role = (n: AnyNode, r: string) => (n.roles instanceof Map ? n.roles.get(r) : n.roles?.[r]);
+
+describe('en repeat-for head canonicalization (repeat-for-each / stagger-animation)', () => {
+  it('standalone `repeat for item in .items` yields loopType/patient/source, no event/quantity noise', () => {
+    const node = parse('repeat for item in .items', 'en') as AnyNode;
+    expect(node.action).toBe('repeat');
+    expect(role(node, 'loopType')).toMatchObject({ type: 'literal', value: 'for' });
+    expect(role(node, 'patient')).toMatchObject({ type: 'expression' });
+    expect(role(node, 'source')).toMatchObject({ type: 'selector', value: '.items' });
+    // The generated-pattern noise the reference used to carry:
+    expect(role(node, 'event')).toBeUndefined();
+    expect(role(node, 'quantity')).toBeUndefined();
+  });
+
+  it('in-handler head stops before the body (add survives as sibling)', () => {
+    const node = parse('on click repeat for item in .items add .processed to item', 'en');
+    const rep = findRepeat(node);
+    expect(rep).not.toBeNull();
+    expect(role(rep!, 'source')).toMatchObject({ type: 'selector', value: '.items' });
+    expect(role(rep!, 'event')).toBeUndefined();
+    expect(collectActions(node).has('add')).toBe(true);
+  });
+
+  it('`with index` variant (stagger-animation) matches the same head', () => {
+    const node = parse(
+      'on load repeat for item in .item with index add .visible to item wait 100ms end',
+      'en'
+    );
+    const rep = findRepeat(node);
+    expect(rep).not.toBeNull();
+    expect(role(rep!, 'loopType')).toMatchObject({ type: 'literal', value: 'for' });
+    expect(role(rep!, 'source')).toMatchObject({ type: 'selector', value: '.item' });
+    const actions = collectActions(node);
+    expect(actions.has('add')).toBe(true);
+    expect(actions.has('wait')).toBe(true);
+  });
+});
+
+describe('en repeat-while head canonicalization (repeat-while)', () => {
+  it('captures loopType="while" + condition, no quantity noise', () => {
+    const node = parse('repeat while #counter.innerText < 10', 'en') as AnyNode;
+    expect(node.action).toBe('repeat');
+    expect(role(node, 'loopType')).toMatchObject({ type: 'literal', value: 'while' });
+    expect(role(node, 'condition')).toBeDefined();
+    expect(role(node, 'quantity')).toBeUndefined();
+  });
+});
+
+describe('translation repeat-for heads (corpus transformer emission)', () => {
+  // [lang, corpus-shaped input (repeat-for-each translation), expected source value]
+  const cases: Array<[string, string]> = [
+    ['es', 'en clic repetir item en .items entonces agregar .processed a item'],
+    ['de', 'bei klick wiederholen item in .items dann hinzufügen .processed zu item'],
+    ['ko', '클릭 할 때 반복 item 안에 .items 그러면 .processed 를 추가 item 에'],
+    ['ja', 'クリック で 繰り返し item の中 .items それから .processed を 追加 item に'],
+    ['hi', 'क्लिक पर दोहराएं item में .items फिर .processed को जोड़ें item में'],
+  ];
+
+  for (const [lang, input] of cases) {
+    it(`[${lang}] captures loopType/patient/source and keeps the add body`, () => {
+      const node = parse(input, lang);
+      const rep = findRepeat(node);
+      expect(rep, `no repeat node in ${lang} parse`).not.toBeNull();
+      expect(role(rep!, 'loopType')).toMatchObject({ type: 'literal', value: 'for' });
+      expect(role(rep!, 'patient')).toMatchObject({ type: 'expression' });
+      expect(role(rep!, 'source')).toMatchObject({ type: 'selector', value: '.items' });
+      expect(collectActions(node).has('add')).toBe(true);
+    });
+  }
+});
+
+describe('translation repeat-until-event heads (behaviors repeat line, statement context)', () => {
+  it('[es] verb-first `repetir hasta evento pointerup de documento`', () => {
+    const node = parse('repetir hasta evento pointerup de documento', 'es') as AnyNode;
+    expect(node.action).toBe('repeat');
+    expect(role(node, 'loopType')).toMatchObject({ type: 'literal', value: 'until-event' });
+    expect(role(node, 'event')).toMatchObject({ type: 'literal' });
+    expect(role(node, 'source')).toBeDefined();
+  });
+
+  it('[ko] SOV `까지 이벤트 pointerup 를 반복 문서 에서`', () => {
+    const node = parse('까지 이벤트 pointerup 를 반복 문서 에서', 'ko');
+    const rep = findRepeat(node);
+    expect(rep).not.toBeNull();
+    expect(role(rep!, 'loopType')).toMatchObject({ type: 'literal', value: 'until-event' });
+    expect(role(rep!, 'event')).toMatchObject({ type: 'literal' });
+    expect(role(rep!, 'source')).toBeDefined();
+  });
+
+  it('[qu] verb-final `hayk_akama ruway pointerup ta qillqa manta kutipay`', () => {
+    const node = parse('hayk_akama ruway pointerup ta qillqa manta kutipay', 'qu');
+    const rep = findRepeat(node);
+    expect(rep).not.toBeNull();
+    expect(role(rep!, 'loopType')).toMatchObject({ type: 'literal', value: 'until-event' });
+    expect(role(rep!, 'event')).toMatchObject({ type: 'literal' });
+    expect(role(rep!, 'source')).toBeDefined();
+  });
+});
+
+describe('translation repeat-while heads', () => {
+  it('[es] `repetir mientras <cond>` captures loopType + condition', () => {
+    const node = parse('repetir mientras #counter.innerText < 10', 'es') as AnyNode;
+    expect(node.action).toBe('repeat');
+    expect(role(node, 'loopType')).toMatchObject({ type: 'literal', value: 'while' });
+    expect(role(node, 'condition')).toBeDefined();
+  });
+});
+
+describe('existing repeat variants are not over-triggered', () => {
+  it('en `repeat until event mouseup` keeps the hand-crafted until-event parse', () => {
+    const node = parse('repeat until event mouseup', 'en') as AnyNode;
+    expect(node.action).toBe('repeat');
+    expect(role(node, 'loopType')).toMatchObject({ type: 'literal', value: 'until-event' });
+    expect(role(node, 'event')).toMatchObject({ type: 'literal', value: 'mouseup' });
+  });
+
+  it('en `repeat 3 times` keeps the counted-loop head', () => {
+    const node = parse('repeat 3 times toggle .x end', 'en') as AnyNode;
+    expect(node.action).toBe('repeat');
+    expect(role(node, 'loopType')).toMatchObject({ type: 'literal', value: 'times' });
+    expect(role(node, 'quantity')).toBeDefined();
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,20 +1,20 @@
 {
-  "timestamp": "2026-07-05T01:42:36.177Z",
-  "commit": "3227c8c3",
+  "timestamp": "2026-07-05T02:50:58.575Z",
+  "commit": "1697561d",
   "languages": {
     "ar": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8387196824503315,
+      "avgConfidence": 0.8417754502119814,
       "avgFidelity": 1,
       "avgPrecision": 0.9796536796536797,
-      "avgRoleFidelity": 0.9656927167956579,
+      "avgRoleFidelity": 0.9730129733806204,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -153,6 +153,10 @@
           "confidence": 1
         },
         "last-in-collection": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-while": {
           "success": true,
           "confidence": 1
         },
@@ -588,10 +592,6 @@
           "success": true,
           "confidence": 0.5555555555555556
         },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.5294117647058824
-        },
         "async-block": {
           "success": true,
           "confidence": 0.5
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8462563334743781,
       "avgFidelity": 1,
-      "avgPrecision": 0.9315737203972502,
-      "avgRoleFidelity": 0.9411637680020033,
+      "avgPrecision": 0.9344480519480524,
+      "avgRoleFidelity": 0.9506962764315706,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.828035456606883,
       "avgFidelity": 1,
       "avgPrecision": 0.9967532467532467,
-      "avgRoleFidelity": 0.961509962612904,
+      "avgRoleFidelity": 0.9697954701631175,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2529,13 +2529,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
-      "avgPrecision": 0.9846320346320346,
-      "avgRoleFidelity": 0.9622142828025181,
+      "avgPrecision": 0.9859307359307358,
+      "avgRoleFidelity": 0.9746425441278382,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
       "avgPrecision": 0.9833333333333334,
-      "avgRoleFidelity": 0.9591770543976426,
+      "avgRoleFidelity": 0.9697954701631175,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3793,13 +3793,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8237889095031952,
       "avgFidelity": 1,
-      "avgPrecision": 0.9851731601731601,
-      "avgRoleFidelity": 0.9666577493783371,
+      "avgPrecision": 0.9864718614718616,
+      "avgRoleFidelity": 0.9792066670743143,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8993587865768304,
       "avgFidelity": 1,
-      "avgPrecision": 0.9386915303311406,
-      "avgRoleFidelity": 0.928535067873303,
+      "avgPrecision": 0.9399631753527856,
+      "avgRoleFidelity": 0.9380675763028703,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5057,13 +5057,13 @@
       "parseRate": 1,
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
-      "avgPrecision": 0.9829004329004329,
-      "avgRoleFidelity": 0.9588150852856733,
+      "avgPrecision": 0.9854978354978354,
+      "avgRoleFidelity": 0.9712433466109937,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5689,13 +5689,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
-      "avgPrecision": 0.976650432900433,
-      "avgRoleFidelity": 0.9649782418164772,
+      "avgPrecision": 0.9779491341991341,
+      "avgRoleFidelity": 0.9741083439612852,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6321,13 +6321,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
-      "avgPrecision": 0.9504107634789454,
-      "avgRoleFidelity": 0.939720841559077,
+      "avgPrecision": 0.9516824085005904,
+      "avgRoleFidelity": 0.9478856927386338,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6953,13 +6953,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
-      "avgPrecision": 0.9504107634789454,
-      "avgRoleFidelity": 0.9346532739915094,
+      "avgPrecision": 0.9516824085005905,
+      "avgRoleFidelity": 0.9428181251710662,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
       "avgPrecision": 0.9811688311688311,
-      "avgRoleFidelity": 0.9669797180826596,
+      "avgRoleFidelity": 0.9752652256328727,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8217,13 +8217,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
-      "avgPrecision": 0.9928841991341991,
-      "avgRoleFidelity": 0.9538295931678289,
+      "avgPrecision": 0.9941829004329004,
+      "avgRoleFidelity": 0.9629596953126369,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8849,13 +8849,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7984333127190251,
       "avgFidelity": 1,
-      "avgPrecision": 0.9820346320346321,
-      "avgRoleFidelity": 0.961088156676392,
+      "avgPrecision": 0.9833333333333334,
+      "avgRoleFidelity": 0.9735164180017124,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9481,13 +9481,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7349000206143064,
       "avgFidelity": 1,
-      "avgPrecision": 0.9512456428852532,
-      "avgRoleFidelity": 0.9252016399075224,
+      "avgPrecision": 0.9525172879068982,
+      "avgRoleFidelity": 0.9347341483370897,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10113,13 +10113,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8135642135642115,
       "avgFidelity": 1,
-      "avgPrecision": 0.9902867965367965,
-      "avgRoleFidelity": 0.9545372254931079,
+      "avgPrecision": 0.9915854978354979,
+      "avgRoleFidelity": 0.9669654868184281,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10745,13 +10745,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7962481962481944,
       "avgFidelity": 1,
-      "avgPrecision": 0.9852813852813852,
-      "avgRoleFidelity": 0.9618717133423015,
+      "avgPrecision": 0.9865800865800866,
+      "avgRoleFidelity": 0.9752652256328729,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.9753246753246753,
-      "avgRoleFidelity": 0.9611125063330948,
+      "avgRoleFidelity": 0.969398013883308,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12007,15 +12007,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8231816490551542,
+      "avgConfidence": 0.8262374168168043,
       "avgFidelity": 1,
       "avgPrecision": 0.9800865800865801,
-      "avgRoleFidelity": 0.9752647888677299,
+      "avgRoleFidelity": 0.9825850454526924,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12142,6 +12142,10 @@
           "confidence": 1
         },
         "last-in-collection": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-while": {
           "success": true,
           "confidence": 1
         },
@@ -12605,10 +12609,6 @@
           "success": true,
           "confidence": 0.5555555555555556
         },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.5294117647058824
-        },
         "async-block": {
           "success": true,
           "confidence": 0.5
@@ -12641,13 +12641,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8307646822684411,
       "avgFidelity": 1,
-      "avgPrecision": 0.9508127424523529,
-      "avgRoleFidelity": 0.939323385279268,
+      "avgPrecision": 0.9520843874739979,
+      "avgRoleFidelity": 0.9474882364588247,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13273,13 +13273,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8139764996907833,
       "avgFidelity": 1,
-      "avgPrecision": 0.9902867965367963,
-      "avgRoleFidelity": 0.9545372254931079,
+      "avgPrecision": 0.9915854978354978,
+      "avgRoleFidelity": 0.9669654868184281,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13906,12 +13906,12 @@
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
       "avgPrecision": 0.9811958874458874,
-      "avgRoleFidelity": 0.9697803653686008,
+      "avgRoleFidelity": 0.9780658729188142,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14538,12 +14538,12 @@
       "avgConfidence": 0.9840032982890127,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9694730646936526,
+      "avgRoleFidelity": 0.9800914804591274,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 462138,
+      "bundleSize": 471816,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 462138,
+      "size": 471816,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Lands **R1 cluster D** from `docs-internal/HANDOFF-r1-residual.md` — the corpus-wide `repeat` loop-head role mass (repeat-for-each, stagger-animation, repeat-while, repeat-until-event, behavior-draggable/sortable/resizable).

**Stage 1 — en reference canonicalization.** `repeat for item in .items` previously parsed through the generated positional pattern as `loopType="for" + quantity:expression="item" + event:literal="in"` with `.items` dropped — reference noise all 23 translations then "missed". New HEAD-only patterns give the canonical parse: `repeat{loopType:literal="for", patient:expression, source:selector}` for for-loops and `repeat{loopType:literal="while", condition}` for while-loops (quantity/event noise killed).

**Stage 2 — per-language alignment.** Surface-keyed head tables in `packages/semantic/src/patterns/repeat.ts` (same approach as the proven `-times` heads, #521/#561) for all 23 translations:
- **for-in heads** — the transformer emits the repeat-for head verb-first in *every* language (even the SOV six), with wildly inconsistent in-word normalization (es `en`→destination, pt `dentro`→into, fr `en`→identifier), hence surface tables, not normalized keywords.
- **while heads** (verb-first languages; the SOV fronted-while shape parses as a separate `while` node — unchanged miss count, future arc).
- **until-event heads** with optional `from {source}` group — verb-first + SOV statement-order variants (the behaviors' repeat line is UNTIL-first in statement context vs verb-first in handler context), plus two qu variants (position-0 `hayk _ a` junk-prefix + a mid-clause twin).

**Parser enablers** (`semantic-parser.ts`):
- fused re-parse head-only allowlist extended: `/^repeat-.*-(times|for-in|while-head|until-head)$/`
- the SOV default-patient leak (`patient:reference=me`) is dropped for every repeat variant (previously only forever/until branches), so the superset guard can't block the head swap
- fused junk roles the repeat schema doesn't sanction (es/de vso event patterns bind `destination:selector` + `loopType:expression`) are exempt from superset protection — scoped to block-body actions; the qu verb-final safety rail and `-times` count mapping keep full protection

## Validation

- **A/B vs committed baseline: every language up, none down** — mean R1 **0.9555 → 0.9654 (+0.0099)**; biggest movers sw +0.0134, he/es/pt/ru/uk/id +0.012; laggards hi/qu/bn/ko all +0.008–0.0095
- Parse **3696/3696**, R2 execution **1.0** (no repeat patterns in the curated subset), precision up-or-flat everywhere, R0 avgFidelity 1.0 in all languages
- Six-signal `--regression` gate **green** against a fresh populate; baseline regenerated in this PR (`multilingual-priority.json`); patterns.db **not** committed
- Guard tests fail without the fix: `packages/semantic/test/repeat-loop-heads.test.ts` (15 tests — en canonicalization incl. noise-kill assertions, translation for-in/until/while heads, non-over-trigger checks)
- Suites: semantic 6447 ✓, core 7012 ✓, i18n 898 ✓, testing-framework 197 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)