### PR TITLE
fix(i18n): parenthesized expressions are opaque units in grammar reorder (R1 cluster E)

### DIFF
--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -1,0 +1,120 @@
+# Handoff — R1 residue after the five-cluster triage (fronted repeat-while · sw kama homonym · singletons)
+
+> **Written 2026-07-05**, immediately after clusters D (#567) and E (#568) landed
+> the same session (B/A1/C landed 2026-07-04 as #564/#565/#566 — see
+> [HANDOFF-r1-residual.md](HANDOFF-r1-residual.md) for that triage and its
+> status blocks). All five clusters from that triage are now done. This doc is
+> the fresh grounding for what remains, from same-session probes against a
+> fresh populate.
+
+## Where things stand (2026-07-05 baseline, commit fb09542c)
+
+Corpus mean R1 **0.9654** (was 0.9535 at the start of 2026-07-04). Worst six:
+**qu 0.9347 · hi 0.9381 · ko 0.9428 · tr 0.9475 · ja 0.9479 · bn 0.9507**.
+Worst precision: **bn 0.9344 · hi 0.9400 · ja/ko 0.9517**. Parse 3696/3696,
+degenerate/lossy 0, R2 1.0 on the 47-pattern curated subset.
+
+**PR stack state:** #567 (cluster D, based on main) ← #568 (cluster E, based
+on #567). Both regenerate `multilingual-priority.json`; #568's copy supersedes
+#567's, so merge #567 first, retarget #568 to main, merge. **Start the next
+arc from merged main**, re-run the ordered build + populate, and re-probe
+before trusting any number in this doc.
+
+## The three remaining items (ranked by suggested order)
+
+### 1. sw `kama` homonym — phantom `if` family (precision, sw-specific, smallest)
+
+sw `kama` is both "as" and "if". The sw SEMANTIC parser reads a standalone
+`kama` as an `if` command, so any translation carrying `kama <word>` grows a
+phantom `if`. Probed spurious-action list for sw (multiset, vs en reference):
+
+- `computed-value` → `["if","if"]` (precision 0.500 — one per `kama Number`;
+  the second appeared when cluster E restored the dropped second operand — the
+  knowingly-accepted −0.0011 in #568)
+- `event-debounce`, `fetch-with-headers`, `fetch-formdata` → `["if"]` each
+- (same probe also surfaced non-kama singletons: `breakpoint-command` →
+  `["halt"]`, `go-back` → `["go"]`, `behavior-sortable` → `["empty"]`)
+
+Fix options, in precedent order:
+
+1. **Dict-side (pl get/pobierz precedent, cheapest):** make the i18n sw dict
+   emit a non-homonym "as" word so the transformer output stops colliding.
+   Check what natural sw uses — `kama` is the idiomatic "as/like", so verify an
+   alternative reads acceptably before swapping; if none does, go parser-side.
+2. **Parser-side:** make the sw `if` head require more than the bare keyword
+   (e.g. reject `kama` when it is immediately followed by a bare
+   identifier/number inside an expression run, or require a condition-shaped
+   continuation). Riskier — touches sw if-parsing for all patterns.
+
+Ratchet note: sw avgPrecision is 0.9842 — nowhere near the 0.02 per-language
+ratchet, so this is opportunistic quality, not a gate risk. But it is the
+single biggest identified phantom-action family with a known mechanism.
+
+### 2. SOV fronted repeat-while (hi/qu/ko + likely ja/bn/tr; parser-side arc)
+
+Cluster D canonicalized en repeat-while to `repeat{loopType:literal="while",
+condition:property-path}` and added verb-first while-heads (es/it/de/… now
+match in full). The SOV translations front the while-phrase BEFORE the event
+phrase:
+
+- hi `जब तक #counter.innerText < 10 को क्लिक पर दोहराएं …`
+- ko `동안 #counter.innerText < 10 를 클릭 할 때 반복 …`
+
+These parse as a SEPARATE `while{condition:property-path}` node followed by a
+bare `repeat{}` (ko's repeat carries `loopType:literal=10` — a value bug, but
+the TYPE matches so ko only misses `condition`). Current misses: **hi/qu
+condition+loopType (2 each) · ko condition (1)** — unchanged counts from
+before cluster D (neutral by design; D deliberately left this shape alone).
+
+Fix shape: this is FOLD machinery, not a head pattern — the fronted
+`while{condition}` node needs to merge into the adjacent `repeat` (set
+`loopType="while"`, move `condition`, drop the separate while node). Precedent:
+the trailing-`unless` guard recovery in `parseBodyWithClauses`
+(semantic-parser.ts) which re-associates a fronted condition with its body.
+Alternative: transformer-side (emit the while-phrase after the verb in SOV) —
+riskier, changes translations corpus-wide; probe first. Check ja/bn/tr/qu
+shapes before scoping (only hi/qu/ko were probed this session).
+
+Precision bonus: the merge removes the phantom standalone `while` action
+(currently spurious vs the en reference for these patterns).
+
+### 3. Singleton families (corpus-wide, opportunistic — batch or skip)
+
+Carried over from the 2026-07-04 triage (counts per language unless noted),
+plus new observations from the cluster D probes:
+
+- `send.destination:reference` ×2 (send-with-detail, socket-send — every lang)
+- `wait.duration:literal`, `tell.destination:selector`,
+  `trigger.event:literal` singletons (every lang)
+- `halt.patient:reference` ×4 (es/it/de only — ABSENT in the SOV trio; also
+  the behaviors' `halt the event` line, seen again in the D probes)
+- `js.patient:expression`; `render.style:expression` ×2 (trio)
+- **NEW (D probes):** `add.destination:reference` en NOISE on for-body
+  patterns — en `add .processed to item` parses `destination:reference=me`
+  (the `to item` binding-var destination is dropped and defaulted), while
+  it/qu produce the arguably-correct `destination:expression="item"` and get
+  penalized for it. Same shape as the old repeat-head noise: fix the EN
+  reference first (`to {identifier}` → destination:expression), then check
+  which langs already match. Affects repeat-for-each + stagger-animation
+  (it/qu missing lists).
+- **Still open from the original triage:** cluster A2 — expression-valued
+  `set` patients (`"Hello, " + my value`, two-way-binding) need multi-token
+  expression-run assembly in matchRoleToken (greedy-capture risk; A/B per
+  marker).
+
+Each is small; none is a coherent arc on its own. Suggested treatment: batch
+2–3 of the en-noise ones (add.destination, wait.duration, trigger.event) into
+one "en-reference noise sweep" PR with the same discipline (probe → en fix →
+per-lang check → gate → baseline regen).
+
+## Working discipline (unchanged — it has worked for five clusters)
+
+One increment per PR; fresh ordered build + populate before any probe (Node
+24 via nvm — better-sqlite3 is compiled for it; the shell may default to Node
+20); six-signal `--regression` gate + per-(lang,pattern) A/B per change;
+guard tests that FAIL without the fix (verify via stash round-trip, then
+REBUILD the stashed package — mtime staleness trips the gate); regenerate the
+baseline only on intentional change against a fresh populate; never commit
+patterns.db. Probe-writing notes: end `.mts` probes with `process.exit(0)`;
+standalone statement parses only try patterns at position 0 (no skip-ahead);
+value bugs are invisible to R0/R1 — check R2/execution probes for them.

--- a/docs-internal/HANDOFF-r1-residual.md
+++ b/docs-internal/HANDOFF-r1-residual.md
@@ -54,8 +54,30 @@
 >   (fronted while-phrase parses as a separate `while` node — hi/qu miss
 >   condition+loopType, ko condition; unchanged count vs before, needs the
 >   fronted-guard machinery, not a head).
-> - **Cluster E remains** — its own arc (transformer parenthesized-expression
->   opacity). Start the next session from the cluster E section below.
+> - **Cluster E is LANDED** (same session as D): standalone parenthesized
+>   groups are now fused into ONE token by the i18n transformer's tokenizer
+>   (previously only ATTACHED `(` was tracked), so the interior `of`/`as`
+>   keywords never reach the argument modifier map — the mangle (reorder
+>   inside parens, event phrase embedded mid-expression, whole `* (…)` second
+>   operand dropped in EVERY language) is gone. Interior keywords still
+>   translate word-by-word IN ORDER: role values are re-split on whitespace by
+>   translateMultiWordValue, and translateWord gained paren-stripping +
+>   fused-group recursion (`($count or 0)` → tl `($count o 0)` — the old
+>   operator-translation contract holds). computed-value now renders intact in
+>   all 24 languages. R0/R1 metrics were expected NOT to move (the corruption
+>   was value-level — the known R0/R1 blind spot); the win is correct
+>   display-facing text + future R2 eligibility. One knowingly-accepted
+>   residue: sw precision -0.0011 (well inside the 0.02 ratchet) because the
+>   restored second operand carries a second `kama` ("as"), and the sw
+>   SEMANTIC parser mis-reads standalone `kama` as `if` (a PRE-EXISTING
+>   homonym family — event-debounce/fetch-with-headers/fetch-formdata already
+>   show phantom sw `if`s; fix belongs parser-side or via a non-homonym sw
+>   "as" word, the pl get/pobierz precedent).
+> - **All five clusters from this triage are now landed.** Remaining known
+>   residue: SOV fronted repeat-while (hi/qu condition+loopType, ko condition
+>   — needs fronted-guard machinery), the sw `kama` homonym family above, the
+>   `add.destination` en noise on for-body patterns (it/qu), and the smaller
+>   singleton families listed at the bottom of this doc.
 
 > **Written 2026-07-04**, immediately after the SOV literal-role-extraction arc
 > (#560/#561/#562 — see [HANDOFF-sov-literal-role-extraction.md](HANDOFF-sov-literal-role-extraction.md)).

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -2169,10 +2169,10 @@ describe('Attached parenthesized arg list stays one token (tl behavior-resizable
   // reorder the two halves were SEPARATED (event role = `pointerdown(clientX,`, the
   // stray `clientY)` fronted) → `clientY) mula_sa ako kapag pointerdown(clientX,`,
   // an unparseable head that dropped the whole `on pointerdown … end` handler
-  // (tl behavior-resizable DEGENERATE → {behavior}; ar lossy). Fix: track an ATTACHED
-  // `(` (one that follows a token) as a depth scope, so the arg list stays atomic; a
-  // STANDALONE `(` opening an expression (`to ($count or 0)`) is left untracked so its
-  // internal operators still translate.
+  // (tl behavior-resizable DEGENERATE → {behavior}; ar lossy). Fix: track `(` as a
+  // depth scope so the group stays atomic. Since the cluster E fix, STANDALONE
+  // groups (`to ($count or 0)`) are atomic too — their interior keywords translate
+  // in place via translateMultiWordValue/translateWord's paren handling.
   it('[tl] event-handler head with destructured params keeps the event atomic', () => {
     const out = new GrammarTransformer('en', 'tl').transform(
       'on pointerdown(clientX, clientY) from me'
@@ -2190,12 +2190,63 @@ describe('Attached parenthesized arg list stays one token (tl behavior-resizable
     expect(out).toContain('pointerdown(clientX, clientY)');
   });
 
-  it('a standalone expression paren is still tokenized (operators translate)', () => {
-    // `($count or 0)` is NOT an attached call — its `or` must still split out and
-    // translate. Tagalog renders `or` → `o`.
+  it('a standalone expression paren still translates its interior operators', () => {
+    // `($count or 0)` is NOT an attached call — the group is now atomic (cluster E),
+    // but its `or` must still translate in place. Tagalog renders `or` → `o`.
     const out = new GrammarTransformer('en', 'tl').transform('set $x to ($count or 0)');
-    expect(out).toContain(' o '); // `or` translated, i.e. the paren was NOT made atomic
-    expect(out).not.toContain('($count or 0)');
+    expect(out).toContain('($count o 0)'); // atomic AND interior-translated
+  });
+});
+
+describe('Standalone parenthesized expressions are opaque units (R1 cluster E, computed-value)', () => {
+  // With standalone `(` untracked, `(the value of #price as Number)` tokenized
+  // LOOSE and its interior `of`/`as` keywords hit the argument modifier map: the
+  // parser split the expression across roles, so the transformer reordered INSIDE
+  // the parens, embedded the event phrase mid-expression (`(the valor de #price
+  // de .quantity como Number)`), and DROPPED the entire `* (my value as Number)`
+  // second operand — in every language, including the SVO controls. Fused groups
+  // keep the expression intact; interiors translate word-by-word in order.
+  const COMPUTED_VALUE =
+    'on input from .quantity set #total.innerText to (the value of #price as Number) * (my value as Number)';
+
+  const firstParenGroup = (s: string): string => {
+    const m = s.match(/\([^)]*\)/);
+    return m ? m[0] : '';
+  };
+
+  it.each(['es', 'de', 'ko', 'hi', 'ja', 'qu'])(
+    '[%s] keeps both operands and the * operator',
+    lang => {
+      const out = new GrammarTransformer('en', lang).transform(COMPUTED_VALUE);
+      // The second operand was dropped in every language before the fix.
+      expect(out).toContain(') * (');
+      // Exactly two paren groups survive, in source order.
+      expect(out.match(/\(/g)?.length).toBe(2);
+      expect(out.match(/\)/g)?.length).toBe(2);
+    }
+  );
+
+  it.each([
+    ['es', ['establecer', 'entrada']],
+    ['ko', ['설정', '입력']],
+    ['ja', ['設定', '入力']],
+  ] as Array<[string, string[]]>)(
+    '[%s] never embeds the verb or event phrase inside the parens',
+    (lang, forbidden) => {
+      const out = new GrammarTransformer('en', lang).transform(COMPUTED_VALUE);
+      const group = firstParenGroup(out);
+      expect(group).not.toBe('');
+      for (const word of forbidden) {
+        expect(group).not.toContain(word);
+      }
+      // The event source selector stays outside the expression too.
+      expect(group).not.toContain('.quantity');
+    }
+  );
+
+  it('[es] interior keywords translate in place, in order', () => {
+    const out = new GrammarTransformer('en', 'es').transform(COMPUTED_VALUE);
+    expect(out).toContain('(the valor de #price como Number) * (mi valor como Number)');
   });
 });
 

--- a/packages/i18n/src/grammar/transformer.ts
+++ b/packages/i18n/src/grammar/transformer.ts
@@ -959,16 +959,24 @@ function tokenize(input: string, profile: LanguageProfile): string[] {
       bracketDepth--;
     }
 
-    // Track an ATTACHED parenthesized argument list — a `(` that immediately
-    // follows a token (a call or event destructure: `pointerdown(clientX, clientY)`,
-    // `Resizable(a, b)`, `add(a, b)`) — so the comma-space inside doesn't split it
-    // into `pointerdown(clientX,` / `clientY)`. The event-handler-head reorder then
-    // separates the two halves (event role = `pointerdown(clientX,`, the stray
-    // `clientY)` fronted), mangling the head and dropping the whole handler. Only an
-    // attached `(` is tracked: a STANDALONE `(` opening an expression (`to ($count or
-    // 0)`, preceded by whitespace → `current` empty) is left untracked so its internal
-    // operators still tokenize and translate (`or` → the target conjunction).
-    if (char === '(' && (current.length > 0 || parenDepth > 0)) {
+    // Track EVERY parenthesized group as a depth scope so it stays ONE token:
+    //
+    // - An ATTACHED `(` (a call or event destructure: `pointerdown(clientX,
+    //   clientY)`, `Resizable(a, b)`) must not split at the comma-space — the
+    //   event-handler-head reorder would separate the halves and drop the
+    //   whole handler (tl behavior-resizable degenerate).
+    // - A STANDALONE `(` opening an expression (`to (the value of #price as
+    //   Number) * (my value as Number)`) must be OPAQUE to role segmentation:
+    //   left loose, its interior `of`/`as`/`from` keywords hit the argument
+    //   modifier map, so the parser split the expression across roles — the
+    //   R1 cluster E mangle (computed-value: the transformer reordered INSIDE
+    //   the parens, embedded the event phrase mid-expression, and dropped the
+    //   whole second operand in every language). Interior keywords still
+    //   translate IN PLACE: role values are re-split on whitespace by
+    //   translateMultiWordValue, and translateWord strips paren punctuation
+    //   before its dictionary lookup (`($count or 0)` → `($count o 0)` in tl —
+    //   the operator translates without the group being torn apart).
+    if (char === '(') {
       parenDepth++;
     } else if (char === ')' && parenDepth > 0) {
       parenDepth--;
@@ -1332,6 +1340,26 @@ function translateWord(word: string, sourceLocale: string, targetLocale: string)
   // Don't translate numbers
   if (/^\d+/.test(word)) {
     return word;
+  }
+
+  // A whole parenthesized group fused by the tokenizer (`(the value of #price
+  // as Number)`) reaching a single-token translate path: translate its
+  // interior word-by-word IN ORDER — never reordered, never re-segmented.
+  if (/\s/.test(word) && word.startsWith('(')) {
+    return word
+      .split(/\s+/)
+      .map(w => translateWord(w, sourceLocale, targetLocale))
+      .join(' ');
+  }
+
+  // A word carrying paren punctuation from a fused group after whitespace
+  // re-splitting (`(my` / `valor)` / `(($x`): strip the parens for the
+  // dictionary lookup and re-attach, so interior keywords still translate.
+  if (word.length > 1 && (word.startsWith('(') || word.endsWith(')'))) {
+    const m = word.match(/^(\(*)([^()]+)(\)*)$/);
+    if (m && (m[1] || m[3])) {
+      return m[1] + translateWord(m[2], sourceLocale, targetLocale) + m[3];
+    }
   }
 
   const sourceDict = sourceLocale === 'en' ? null : dictionaries[sourceLocale];

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-05T02:50:58.575Z",
-  "commit": "1697561d",
+  "timestamp": "2026-07-05T03:16:05.387Z",
+  "commit": "fb09542c",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -10745,7 +10745,7 @@
       "parseRate": 1,
       "avgConfidence": 0.7962481962481944,
       "avgFidelity": 1,
-      "avgPrecision": 0.9865800865800866,
+      "avgPrecision": 0.9854978354978355,
       "avgRoleFidelity": 0.9752652256328729,
       "avgExecutionFidelity": 1,
       "executionFailures": [],


### PR DESCRIPTION
## Summary

Lands **R1 cluster E** from `docs-internal/HANDOFF-r1-residual.md` — the i18n transformer mangling parenthesized/operator expressions.

> **Stacked on #567** (cluster D) — its baseline builds on that PR's regenerated baseline. Merge #567 first, then retarget/merge this one.

**The bug.** The tokenizer tracked only *attached* `(` (calls / event destructures); a *standalone* `(` opening an expression was left loose so its interior operators could translate. But loose interior tokens meant `of`/`as`/`from` inside `(the value of #price as Number)` hit the argument modifier map — the parser split the expression across roles, and the transformer then:
- reordered **inside** the parens (SOV verb + event phrase embedded mid-expression),
- **dropped the entire `* (my value as Number)` second operand — in every language, including the SVO controls**,
- leaked English mid-group.

**The fix** (`packages/i18n/src/grammar/transformer.ts`, ~30 lines):
- `tokenize()` tracks every `(` as a depth scope → a standalone group stays one token, opaque to role segmentation and reorder.
- Interior keywords still translate word-by-word **in order**: role values are re-split on whitespace by `translateMultiWordValue`, and `translateWord` now recurses into fused groups and strips paren punctuation before dictionary lookup. The old contract the loose behavior existed for still holds: tl `($count or 0)` → `($count o 0)`.

computed-value now renders structurally intact in all 24 languages, e.g.
- es: `… a (the valor de #price como Number) * (mi valor como Number) de .quantity`
- ko: `#total.innerText 를 (the 값 의 #price 로 Number) * (내 값 로 Number) 에 설정 …`

## Validation

- **Gate green**: parse 3696/3696, R2 1.0, all six ratchets clear; baseline regenerated against a fresh populate (patterns.db not committed)
- **R0/R1 flat by design** — the corruption was value-level, the documented R0/R1 blind spot; the win is correct display-facing translations + future R2 eligibility for these patterns
- **Known accepted residue**: sw avgPrecision −0.0011 (inside the 0.02 ratchet) — the restored second operand carries a second `kama` ("as"), which the sw *semantic* parser mis-reads as a phantom `if`; pre-existing homonym family (event-debounce / fetch-with-headers / fetch-formdata), parser-side follow-up noted in the handoff
- **Guard tests fail without the fix**: 10 new tests in `grammar.test.ts` (verified by stash round-trip: 10 failed pre-fix, 908/908 pass with it); template-literals / attached calls / two-way-binding confirmed unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)