### PR TITLE
fix(multilingual): sw as-marker is kuwa, not the if-homonym kama (R1 residue item 1)

### DIFF
--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -24,6 +24,18 @@ before trusting any number in this doc.
 
 ### 1. sw `kama` homonym — phantom `if` family (precision, sw-specific, smallest)
 
+> **STATUS: DONE (2026-07-05).** Dict-side fix, option 1 as suggested: the i18n
+> sw dict + grammar profile now emit `kuwa` ("to be/become" — the conversion
+> sense, cf. `badilisha kuwa`) for `as`/method, and the semantic `fetch-sw`
+> pattern reads `kuwa` as the responseType marker (hand-written `kama` still
+> tolerated in as-marker position via a new `asMarkerAlternatives` param on
+> `markerlessFetch`). A/B over all 8 kuwa-carrying sw translations: the 4
+> phantom-if patterns (computed-value, event-debounce, fetch-with-headers,
+> fetch-formdata) all reach precision 1.0, 4 unchanged, 0 regressed. sw
+> avgPrecision 0.9855 → 0.9942. The non-kama singletons surfaced by the same
+> probe (breakpoint-command `halt`, go-back `go`, behavior-sortable `empty`)
+> remain — item 3 territory.
+
 sw `kama` is both "as" and "if". The sw SEMANTIC parser reads a standalone
 `kama` as an `if` command, so any translation carrying `kama <word>` grows a
 phantom `if`. Probed spurious-action list for sw (multiset, vs en reference):

--- a/packages/i18n/src/dictionaries/sw.ts
+++ b/packages/i18n/src/dictionaries/sw.ts
@@ -80,7 +80,14 @@ export const sw: Dictionary = {
     at: 'katika',
     in: 'ndani',
     of: 'ya',
-    as: 'kama',
+    // `kuwa` ("to be/become" — the conversion sense, cf. `badilisha kuwa`), not
+    // `kama`: sw `kama` is the IF keyword (commands.if above and the semantic sw
+    // profile's if primary), so emitting it for `as` grew a phantom `if` command
+    // out of every transformed `as <Type>` tail (`kama JSON`, `kama Number`) when
+    // the semantic parser split event-body statements. Same dict↔profile homonym
+    // disambiguation as pl get/pobierz. The semantic fetch-sw pattern still
+    // tolerates hand-written `kama` in as-marker position.
+    as: 'kuwa',
     by: 'na',
     before: 'kabla',
     after: 'baada',

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -617,6 +617,28 @@ describe('GrammarTransformer', () => {
     });
   });
 
+  describe('Swahili Transformation (as/if disambiguation)', () => {
+    const transformer = new GrammarTransformer('en', 'sw');
+
+    it('should emit kuwa for the as-marker, not the if-homonym kama', () => {
+      // Regression: sw `kama` is both "as/like" and the IF keyword. The dict +
+      // grammar profile emitted it for `as`, so every transformed `as <Type>`
+      // tail (`kama JSON`, `kama Number`) grew a phantom `if` command at
+      // semantic parse time (computed-value precision 0.500; event-debounce,
+      // fetch-with-headers, fetch-formdata 0.667–0.750). The dict/profile now
+      // emit `kuwa` ("to be/become" — the conversion sense, cf. badilisha kuwa).
+      const result = transformer.transform('on click fetch /api/data as json');
+      expect(result).toContain('kuwa');
+      expect(result).not.toMatch(/\bkama\b/);
+    });
+
+    it('should still emit kama for a real if', () => {
+      const result = transformer.transform('if true then log "Habari"');
+      expect(result).toMatch(/\bkama\b/);
+      expect(result).not.toContain('kuwa');
+    });
+  });
+
   describe('Duration / literal-primary marking (no spurious object particle)', () => {
     // A command whose primary argument is a literal/measure (e.g. `wait <duration>`)
     // must NOT have that argument marked as a fronted object: the generic argument

--- a/packages/i18n/src/grammar/profiles/index.ts
+++ b/packages/i18n/src/grammar/profiles/index.ts
@@ -727,7 +727,10 @@ export const swahiliProfile: LanguageProfile = {
     { form: 'kwa', role: 'destination', position: 'preposition', required: false },
     { form: 'kutoka', role: 'source', position: 'preposition', required: false },
     { form: 'na', role: 'style', position: 'preposition', required: false },
-    { form: 'kama', role: 'method', position: 'preposition', required: false }, // "as/like"
+    // `kuwa`, not `kama`: sw `kama` is the IF keyword — rendering the method
+    // role ("as X") with it grew a phantom `if` at semantic parse time. See the
+    // matching comment in dictionaries/sw.ts (modifiers.as).
+    { form: 'kuwa', role: 'method', position: 'preposition', required: false }, // "as/become"
   ],
 };
 

--- a/packages/semantic/src/patterns/fetch.ts
+++ b/packages/semantic/src/patterns/fetch.ts
@@ -196,7 +196,8 @@ function markerlessFetch(
   fromMarker: string,
   asMarker: string,
   verbAlternatives?: string[],
-  fromMarkerAlternatives?: string[]
+  fromMarkerAlternatives?: string[],
+  asMarkerAlternatives?: string[]
 ): LanguagePattern {
   return {
     id,
@@ -227,7 +228,11 @@ function markerlessFetch(
           type: 'group',
           optional: true,
           tokens: [
-            { type: 'literal', value: asMarker },
+            {
+              type: 'literal',
+              value: asMarker,
+              ...(asMarkerAlternatives ? { alternatives: asMarkerAlternatives } : {}),
+            },
             { type: 'role', role: 'responseType', expectedTypes: ['literal', 'expression'] },
           ],
         },
@@ -238,7 +243,10 @@ function markerlessFetch(
         marker: fromMarker,
         ...(fromMarkerAlternatives ? { markerAlternatives: fromMarkerAlternatives } : {}),
       },
-      responseType: { marker: asMarker },
+      responseType: {
+        marker: asMarker,
+        ...(asMarkerAlternatives ? { markerAlternatives: asMarkerAlternatives } : {}),
+      },
     },
   };
 }
@@ -323,7 +331,12 @@ export function getFetchPatternsForLanguage(language: string): LanguagePattern[]
       // dict emits `ambil`, profile primary is `muat` — accept both.
       return [markerlessFetch('fetch-id', 'id', 'muat', 'dari', 'sebagai', ['ambil'])];
     case 'sw':
-      return [markerlessFetch('fetch-sw', 'sw', 'leta', 'kutoka', 'kama')];
+      // `kuwa` is what the transformer now emits for `as` (sw `kama` is the IF
+      // keyword — the phantom-if homonym; see dictionaries/sw.ts). Hand-written
+      // `kama` stays tolerated in as-marker position.
+      return [
+        markerlessFetch('fetch-sw', 'sw', 'leta', 'kutoka', 'kuwa', undefined, undefined, ['kama']),
+      ];
     case 'he':
       // transformer inserts the `את` accusative particle (`הבא את /url`) where the
       // generated pattern expects `מ` (from); accept either. Verb alt `טען`.

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -9715,3 +9715,57 @@ describe('event-anchor guard: fronted positional/possessive/optional-chaining he
     expect(node.body?.some(c => c.action === 'toggle')).toBe(true);
   });
 });
+
+describe('sw `as` marker is kuwa, not the if-homonym kama (phantom-if family)', () => {
+  // sw `kama` is both "as/like" (idiomatic) and the IF keyword — the semantic
+  // sw parser reads a standalone `kama` as an `if` head, so any transformed
+  // `as <Type>` tail (`kama JSON`, `kama Number`) mid-body grew a phantom `if`
+  // command (computed-value precision 0.500, event-debounce / fetch-with-headers
+  // / fetch-formdata 0.667–0.750). The i18n dict + grammar profile now emit
+  // `kuwa` ("to be/become" — the conversion sense) for `as`, and the fetch-sw
+  // pattern reads `kuwa` as the responseType marker while still tolerating
+  // hand-written `kama` in as-marker position. Same dict↔profile homonym
+  // disambiguation as pl get/pobierz.
+  it('[sw] fetch with kuwa responseType parses (transformer-emitted form)', () => {
+    const node = parse('leta /api/me kuwa JSON', 'sw') as {
+      action?: string;
+      roles?: Map<string, { type: string }>;
+    };
+    expect(node.action).toBe('fetch');
+    expect(node.roles?.get('source')?.type).toBe('literal');
+    expect(node.roles?.has('responseType')).toBe(true);
+  });
+
+  it('[sw] hand-written kama in as-marker position still captures responseType', () => {
+    const node = parse('leta /api/me kama JSON', 'sw') as {
+      action?: string;
+      roles?: Map<string, { type: string }>;
+    };
+    expect(node.action).toBe('fetch');
+    expect(node.roles?.has('responseType')).toBe(true);
+  });
+
+  it('[sw] corpus-shaped fetch-with-headers body grows no phantom if', () => {
+    // Transformer output for `on click fetch /api/me with headers:{…} as JSON
+    // then put its.name into me` — with `kuwa` the trailing as-phrase must not
+    // split into a phantom `if` statement.
+    const node = parse(
+      'kwenye bonyeza leta /api/me na headers:{Authorization:`Bearer ${$token}`} kuwa JSON kisha weka yake.name kwa mimi',
+      'sw'
+    ) as { kind: string; body?: Array<{ action?: string }> };
+    expect(node.kind).toBe('event-handler');
+    const actions = (node.body ?? []).map(c => c.action);
+    expect(actions).toContain('fetch');
+    expect(actions).toContain('put');
+    expect(actions).not.toContain('if');
+  });
+
+  it('[sw] kama still parses as a real conditional inside an event body', () => {
+    const node = parse('kwenye bonyeza kama mimi ana .loading rudi mwisho', 'sw') as {
+      kind: string;
+      body?: Array<{ action?: string }>;
+    };
+    expect(node.kind).toBe('event-handler');
+    expect(node.body?.some(c => c.action === 'if')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-05T03:16:05.387Z",
-  "commit": "fb09542c",
+  "timestamp": "2026-07-05T13:16:25.630Z",
+  "commit": "dec13c63",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -10745,7 +10745,7 @@
       "parseRate": 1,
       "avgConfidence": 0.7962481962481944,
       "avgFidelity": 1,
-      "avgPrecision": 0.9854978354978355,
+      "avgPrecision": 0.9941558441558443,
       "avgRoleFidelity": 0.9752652256328729,
       "avgExecutionFidelity": 1,
       "executionFailures": [],


### PR DESCRIPTION
## Summary

sw `kama` is both "as/like" (the idiomatic word) and the IF keyword. The semantic sw parser reads a standalone `kama` as an `if` head, so every transformed `as <Type>` tail (`kama JSON`, `kama Number`) mid-body grew a phantom `if` command:

- `computed-value` → precision 0.500 (two phantom `if`s, one per `kama Number`)
- `event-debounce`, `fetch-with-headers`, `fetch-formdata` → precision 0.667–0.750 (one phantom `if` each)

**Fix (dict-side — the pl `get`/`pobierz` precedent):**

- i18n sw dict `modifiers.as` + grammar profile `method` marker now emit `kuwa` ("to be/become" — the conversion sense, cf. `badilisha kuwa`) instead of `kama`
- semantic `fetch-sw` reads `kuwa` as the responseType marker; hand-written `kama` stays tolerated in as-marker position via a new `asMarkerAlternatives` param on `markerlessFetch`

## Validation

- Guard tests FAIL without the fix (verified via stash round-trip + rebuild): `grammar.test.ts` sw as/if disambiguation; `multilingual-roadmap-fixes.test.ts` sw kuwa block
- Per-(lang,pattern) A/B over all 8 kuwa-carrying sw translations vs a fresh populate: **4 improved to precision 1.0** (the whole phantom-if family), 4 unchanged, **0 regressed**
- sw avgPrecision 0.9855 → 0.9942
- semantic suite 6451 passed, i18n 910 passed, typecheck clean on both
- Six-signal `--regression` gate green (exit 0), parse 3696/3696, R2 1.0
- Baseline regenerated against a fresh populate (patterns.db itself not committed, per convention)

First item of `docs-internal/HANDOFF-r1-post-cluster-residue.md` (status block updated). The non-kama singletons the same probe surfaced (breakpoint-command `halt`, go-back `go`, behavior-sortable `empty`) are item-3 territory, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)