### PR TITLE
fix(multilingual): en-reference noise sweep — for-body add.destination + trigger event typing (R1 residue item 3)

### DIFF
--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -108,6 +108,39 @@ Precision bonus: the merge removes the phantom standalone `while` action
 
 ### 3. Singleton families (corpus-wide, opportunistic — batch or skip)
 
+> **STATUS: PARTIAL (2026-07-05).** The suggested en-noise batch landed as one
+> PR, resolving two of the three families:
+>
+> - **add.destination (for-body)** — three-part fix: (1) the add schema's
+>   destination now admits `expression` (a loop binding var `item` tokenizes as
+>   expression, so `[selector, reference]` rejected the marked `to item` and
+>   defaulted to `me` in the EN reference and most translations alike); (2) a
+>   parse-scoped bound-identifier registry (repeat/for patients + set
+>   destinations) lets the strict trailing-destination reclaim admit `item に`
+>   in SOV; (3) a bound identifier captured as a bare literal (ja/ko typing)
+>   canonicalizes to expression in normalizeCommandRoles. repeat-for-each and
+>   stagger-animation now match en in ALL languages; only behavior-sortable's
+>   deep case remains for hi/bn/ja/ko/tr (its `set item` binding sits in a
+>   nested handler sub-parse).
+> - **trigger.event** — event NAMES canonicalize to `literal` on command nodes
+>   (normalizeCommandRoles): en typed `trigger init` literal only because
+>   `init` is an en keyword; untranslated names elsewhere typed expression, and
+>   colon-split `sortable:start` fragments hid truncation behind a vacuous
+>   expression:expression type match. Both the trigger-event 15-lang miss and
+>   the behaviors' family are gone.
+> - **wait.duration — NOT fixed, diagnosed:** en `wait for transitionend`
+>   parses as `wait{duration:literal="for"}` — the KEYWORD is captured as the
+>   duration and the event name is dropped (wait-en-generated). The honest fix
+>   needs a `wait for {event}` head + an event role on the wait schema + AST
+>   mapper support (the wait mapper reads only `duration`) + a duration→event
+>   value-shape relabel for the marker-less translations (`esperar
+transitionend`) — an R2-touching arc, out of scope for this sweep.
+>
+> Per-lang aggregate deltas from the honest-reference shift: 12 langs up
+> (qu +0.0029, it/pl +0.0022, zh/he +0.0017, …), 5 langs slightly down
+> (bn/hi −0.0010, ms/th/tl −0.0017 — vacuous matches of the old noise now
+> visible as real drops); corpus mean up. Gate green on all six signals.
+
 Carried over from the 2026-07-04 triage (counts per language unless noted),
 plus new observations from the cluster D probes:
 

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -326,7 +326,14 @@ export const addSchema: CommandSchema = {
       role: 'destination',
       description: 'The target element (defaults to me)',
       required: false,
-      expectedTypes: ['selector', 'reference'],
+      // `expression` admits a loop binding VARIABLE as the destination
+      // (`repeat for item in .items add .processed to item`): the bare
+      // identifier tokenizes as expression, so [selector, reference] rejected
+      // the marked `to item` phrase and the destination silently defaulted to
+      // `me` — in the en reference AND most translations alike (it/qu already
+      // captured it; everyone else vacuously "matched" the shared noise).
+      // Marker-guarded, so an unmarked trailing identifier is not affected.
+      expectedTypes: ['selector', 'reference', 'expression'],
       default: { type: 'reference', value: 'me' },
       svoPosition: 2,
       sovPosition: 1,

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -172,7 +172,7 @@ const NORMALIZE_CHILD_FIELDS = [
   'initBlock',
 ] as const;
 
-function normalizeCommandRoles(node: SemanticNode): SemanticNode {
+function normalizeCommandRoles(node: SemanticNode, boundIdentifiers?: Set<string>): SemanticNode {
   if (!node || typeof node !== 'object') return node;
 
   if (node.action && node.roles instanceof Map) {
@@ -193,13 +193,55 @@ function normalizeCommandRoles(node: SemanticNode): SemanticNode {
         roles.set(primary, value);
       }
     }
+
+    // Canonicalize a COMMAND's `event` role: an event NAME types as `literal`,
+    // not `expression`. The type an event name gets is tokenizer-incidental —
+    // en `trigger init` captured `event:literal` only because `init` happens to
+    // be an en KEYWORD (the init-block head), while every language whose
+    // tokenizer doesn't know the untranslated name captured `event:expression`
+    // (trigger-event R1 miss in 15 languages); namespaced `behavior:phase`
+    // names (`sortable:start`) split at the colon in several tokenizers, so the
+    // translation held a bare fragment while en kept the fused form. An event
+    // name is a name, not an evaluable — and the `on`-handler convention is
+    // `event:literal` everywhere. Command nodes only (`kind: 'command'`):
+    // handler nodes keep their own event typing, and a parenthesized/dotted/
+    // spaced raw stays `expression` (a real evaluable, e.g. `click(x)`).
+    if (node.kind === 'command' && node.action !== 'on') {
+      const roles = node.roles as Map<SemanticRole, SemanticValue>;
+      const ev = roles.get('event');
+      if (ev && ev.type === 'expression') {
+        const raw = (ev as { raw?: unknown }).raw;
+        if (typeof raw === 'string' && /^[A-Za-z_][A-Za-z0-9_-]*(:[A-Za-z0-9_-]+)?$/.test(raw)) {
+          roles.set('event', { type: 'literal', value: raw, dataType: 'string' });
+        }
+      }
+    }
+
+    // Canonicalize a destination holding a locally-BOUND identifier (a loop
+    // binding or set variable — see registerBoundIdentifiers) to `expression`:
+    // it is a variable read, and that is how the en reference types it (`add
+    // .processed to item` → destination:expression). Which type the marked
+    // capture got is tokenizer-incidental — ja/ko typed the untranslated `item`
+    // as a bare literal.
+    if (boundIdentifiers?.size) {
+      const roles = node.roles as Map<SemanticRole, SemanticValue>;
+      const dest = roles.get('destination');
+      if (
+        dest &&
+        dest.type === 'literal' &&
+        typeof dest.value === 'string' &&
+        boundIdentifiers.has(dest.value)
+      ) {
+        roles.set('destination', { type: 'expression', raw: dest.value } as SemanticValue);
+      }
+    }
   }
 
   const rec = node as unknown as Record<string, unknown>;
   for (const field of NORMALIZE_CHILD_FIELDS) {
     const child = rec[field];
     if (Array.isArray(child)) {
-      for (const c of child) normalizeCommandRoles(c as SemanticNode);
+      for (const c of child) normalizeCommandRoles(c as SemanticNode, boundIdentifiers);
     }
   }
   return node;
@@ -255,7 +297,46 @@ export class SemanticParserImpl implements ISemanticParser {
    * the normalization reaches body commands built by any sub-parser.
    */
   parse(input: string, language: string): SemanticNode {
-    return normalizeCommandRoles(this.parseInternal(input, language));
+    // Locally-bound identifiers are scoped to one top-level parse; recursive
+    // sub-parses (behavior handlers, block bodies) inherit the outer scope.
+    if (this.parseDepth === 0) this.boundIdentifiers.clear();
+    this.parseDepth++;
+    try {
+      return normalizeCommandRoles(this.parseInternal(input, language), this.boundIdentifiers);
+    } finally {
+      this.parseDepth--;
+    }
+  }
+
+  /** Re-entrancy depth of {@link parse} — see boundIdentifiers scoping. */
+  private parseDepth = 0;
+
+  /**
+   * Identifiers BOUND earlier in the current top-level parse: a loop binding
+   * variable (`repeat for item in .items` — repeat.patient) or a set variable
+   * (`set item to …` — set.destination). The strict trailing-`destination`
+   * reclaim (see {@link tryAttachTrailingRole}) rejects arbitrary bare
+   * identifiers by design, but an identifier the SAME input just bound is a
+   * legitimate destination (`add .processed to item` inside the loop body —
+   * the en reference captures it as destination:expression since the schema
+   * admits expression; without this the SOV trailing `item に` reclaim
+   * defaulted the destination to `me`).
+   */
+  private boundIdentifiers = new Set<string>();
+
+  /** Record identifiers a just-built command binds (repeat/for patient, set destination). */
+  private registerBoundIdentifiers(node: CommandSemanticNode): void {
+    const role =
+      node.action === 'repeat' || node.action === 'for'
+        ? 'patient'
+        : node.action === 'set'
+          ? 'destination'
+          : null;
+    if (!role) return;
+    const v = node.roles.get(role as SemanticRole) as { type?: string; raw?: unknown } | undefined;
+    if (v?.type === 'expression' && typeof v.raw === 'string' && /^[A-Za-z_]\w*$/.test(v.raw)) {
+      this.boundIdentifiers.add(v.raw);
+    }
   }
 
   /**
@@ -827,11 +908,13 @@ export class SemanticParserImpl implements ISemanticParser {
       roles[role] = value;
     }
 
-    return createCommandNode(match.pattern.command, roles, {
+    const node = createCommandNode(match.pattern.command, roles, {
       sourceLanguage: language,
       patternId: match.pattern.id,
       confidence: match.confidence,
     });
+    this.registerBoundIdentifiers(node);
+    return node;
   }
 
   /**
@@ -1014,6 +1097,7 @@ export class SemanticParserImpl implements ISemanticParser {
         patternId: match.pattern.id,
         confidence: match.confidence,
       });
+      this.registerBoundIdentifiers(commandNode);
 
       // A fused event pattern captures the wrapped command's VERB + (at most) its
       // PRIMARY arg, leaving every SECONDARY role clause unconsumed: `su {event}
@@ -1938,6 +2022,11 @@ export class SemanticParserImpl implements ISemanticParser {
         norm === 'window'
       )
         return true;
+      // A bare identifier the current parse BOUND (a loop binding variable or a
+      // set variable — see registerBoundIdentifiers) is a legitimate strict
+      // destination (`add .processed to item` in a for-body); arbitrary
+      // identifiers stay rejected per the over-capture rationale above.
+      if (this.boundIdentifiers.has(t.value)) return true;
       if (strict) return false;
       return t.kind === 'identifier' || (t.kind as string) === 'reference';
     };

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -9769,3 +9769,75 @@ describe('sw `as` marker is kuwa, not the if-homonym kama (phantom-if family)', 
     expect(node.body?.some(c => c.action === 'if')).toBe(true);
   });
 });
+
+describe('en-reference noise sweep: for-body add.destination + trigger event typing (R1 residue item 3)', () => {
+  // Two phantom cross-language mismatches rooted in the EN reference / in
+  // tokenizer-incidental typing (HANDOFF-r1-post-cluster-residue item 3):
+  //
+  // (a) `add .processed to item` in a for-body: `item` is a loop binding
+  //     variable; it tokenizes as expression, so the add schema's
+  //     [selector, reference] destination rejected the marked `to item` phrase
+  //     and destination silently defaulted to `me` — in the EN reference AND
+  //     most translations alike (it/qu captured it and were penalized for
+  //     being right). The schema now admits `expression`; a bound identifier
+  //     captured as a bare literal (ja/ko typing of the untranslated `item`)
+  //     is canonicalized to expression via the parse-scoped bound-identifier
+  //     registry.
+  // (b) `trigger init`: en typed the event literal only because `init` happens
+  //     to be an en KEYWORD; untranslated names elsewhere typed expression, and
+  //     colon-split namespaced names (`sortable:start`) held a bare fragment.
+  //     An event NAME now canonicalizes to `literal` on command nodes.
+  function firstAction(node: unknown, action: string): Record<string, any> | null {
+    if (!node || typeof node !== 'object') return null;
+    const rec = node as Record<string, any>;
+    if (rec.action === action) return rec;
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'eventHandlers', 'initBlock']) {
+      const c = rec[f];
+      if (Array.isArray(c)) {
+        for (const child of c) {
+          const hit = firstAction(child, action);
+          if (hit) return hit;
+        }
+      }
+    }
+    return null;
+  }
+  const roleOf = (n: Record<string, any> | null, r: string) =>
+    n && n.roles instanceof Map ? n.roles.get(r) : undefined;
+
+  it('[en] for-body add captures the binding-var destination as expression', () => {
+    const node = parse('on click repeat for item in .items add .processed to item', 'en');
+    const add = firstAction(node, 'add');
+    expect(roleOf(add, 'destination')).toMatchObject({ type: 'expression', raw: 'item' });
+  });
+
+  it('[ja] for-body add captures the binding-var destination as expression (not a bare literal, not defaulted me)', () => {
+    const node = parse(
+      'クリック で 繰り返し item の中 .items それから .processed を 追加 item に',
+      'ja'
+    );
+    const add = firstAction(node, 'add');
+    expect(roleOf(add, 'destination')).toMatchObject({ type: 'expression', raw: 'item' });
+  });
+
+  it('[es] trigger with an untranslated bare event name types it literal', () => {
+    const node = parse('disparar init', 'es');
+    const trigger = firstAction(node, 'trigger');
+    expect(roleOf(trigger, 'event')).toMatchObject({ type: 'literal', value: 'init' });
+  });
+
+  it('[en] trigger with a namespaced event name types it literal', () => {
+    const node = parse('trigger draggable:start', 'en');
+    const trigger = firstAction(node, 'trigger');
+    expect(roleOf(trigger, 'event')).toMatchObject({ type: 'literal', value: 'draggable:start' });
+  });
+
+  it('[en] an unmarked trailing identifier is NOT captured as add destination (marker-guarded)', () => {
+    // Without a `to` marker the identifier is not a destination phrase — the
+    // schema broadening must not let `add .x item` capture item.
+    const node = parse('add .processed', 'en');
+    const add = firstAction(node, 'add');
+    const dest = roleOf(add, 'destination');
+    expect(dest === undefined || (dest.type === 'reference' && dest.value === 'me')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-05T13:32:14.945Z",
-  "commit": "4efd5268",
+  "timestamp": "2026-07-05T13:58:26.609Z",
+  "commit": "433c2af3",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -641,12 +641,12 @@
       "avgConfidence": 0.8462563334743781,
       "avgFidelity": 1,
       "avgPrecision": 0.9357467532467537,
-      "avgRoleFidelity": 0.9526267783620725,
+      "avgRoleFidelity": 0.951613264848559,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3794,12 +3794,12 @@
       "avgConfidence": 0.8237889095031952,
       "avgFidelity": 1,
       "avgPrecision": 0.9864718614718616,
-      "avgRoleFidelity": 0.9792066670743143,
+      "avgRoleFidelity": 0.9808958562635034,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4426,12 +4426,12 @@
       "avgConfidence": 0.8993587865768304,
       "avgFidelity": 1,
       "avgPrecision": 0.9412618766514869,
-      "avgRoleFidelity": 0.9399980782333722,
+      "avgRoleFidelity": 0.9389845647198588,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
       "avgPrecision": 0.9854978354978354,
-      "avgRoleFidelity": 0.9712433466109937,
+      "avgRoleFidelity": 0.9722085975762448,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.9779491341991341,
-      "avgRoleFidelity": 0.9741083439612852,
+      "avgRoleFidelity": 0.97631564580094,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
       "avgPrecision": 0.952981109799292,
-      "avgRoleFidelity": 0.9488509437038849,
+      "avgRoleFidelity": 0.9495266193795605,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6954,12 @@
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
       "avgPrecision": 0.9529811097992917,
-      "avgRoleFidelity": 0.9437833761363174,
+      "avgRoleFidelity": 0.944459051811993,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
       "avgPrecision": 0.9811688311688311,
-      "avgRoleFidelity": 0.9752652256328727,
+      "avgRoleFidelity": 0.9735760364436835,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
       "avgPrecision": 0.9941829004329004,
-      "avgRoleFidelity": 0.9629596953126369,
+      "avgRoleFidelity": 0.9651669971522915,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9482,12 @@
       "avgConfidence": 0.7381467738610596,
       "avgFidelity": 1,
       "avgPrecision": 0.9525172879068982,
-      "avgRoleFidelity": 0.9366646502675916,
+      "avgRoleFidelity": 0.939547627782922,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.8135642135642115,
       "avgFidelity": 1,
       "avgPrecision": 0.9915854978354979,
-      "avgRoleFidelity": 0.9669654868184281,
+      "avgRoleFidelity": 0.9674835994688937,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.9753246753246753,
-      "avgRoleFidelity": 0.969398013883308,
+      "avgRoleFidelity": 0.9677088246941189,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12010,12 +12010,12 @@
       "avgConfidence": 0.8262374168168043,
       "avgFidelity": 1,
       "avgPrecision": 0.9800865800865801,
-      "avgRoleFidelity": 0.9825850454526924,
+      "avgRoleFidelity": 0.9808958562635032,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12642,12 +12642,12 @@
       "avgConfidence": 0.8340114355151945,
       "avgFidelity": 1,
       "avgPrecision": 0.9520843874739979,
-      "avgRoleFidelity": 0.9484534874240756,
+      "avgRoleFidelity": 0.9491291630997513,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13274,12 +13274,12 @@
       "avgConfidence": 0.8139764996907833,
       "avgFidelity": 1,
       "avgPrecision": 0.9915854978354978,
-      "avgRoleFidelity": 0.9669654868184281,
+      "avgRoleFidelity": 0.9674835994688937,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13906,12 +13906,12 @@
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
       "avgPrecision": 0.9811958874458874,
-      "avgRoleFidelity": 0.9780658729188142,
+      "avgRoleFidelity": 0.9785839855692797,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14538,12 +14538,12 @@
       "avgConfidence": 0.9840032982890127,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9800914804591274,
+      "avgRoleFidelity": 0.9817806696483166,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 472444,
+      "bundleSize": 473431,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 472444,
+      "size": 473431,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

**Stacked on #570** (baseline chain: merge #569 → #570 → this, retargeting each to main in turn).

Two phantom cross-language mismatches rooted in the EN reference / tokenizer-incidental typing (`docs-internal/HANDOFF-r1-post-cluster-residue.md`, item 3):

### add.destination (for-body)

`add .processed to item` — the loop binding var tokenizes as `expression`, so the add schema's `[selector, reference]` destination rejected the marked `to item` phrase and silently defaulted to `me` — in the EN reference AND most translations alike. it/qu captured it correctly and were **penalized for being right** (6-lang miss on repeat-for-each, stagger-animation, behavior-sortable). Three-part fix:

1. the add schema destination admits `expression` (marker-guarded — an unmarked trailing identifier still isn't captured)
2. a parse-scoped **bound-identifier registry** (repeat/for patients + set destinations) lets the strict trailing-destination reclaim admit the SOV trailing `item に` — without loosening the deliberate arbitrary-bare-identifier rejection
3. a bound identifier captured as a bare literal (ja/ko typing of the untranslated `item`) canonicalizes to `expression` in `normalizeCommandRoles`

**repeat-for-each and stagger-animation now match en in ALL languages.** Only behavior-sortable's deep case remains for hi/bn/ja/ko/tr (its `set item` binding sits in a nested handler sub-parse).

### trigger.event

en typed `trigger init` as `event:literal` only because `init` happens to be an en KEYWORD (the init-block head); untranslated names elsewhere typed `expression` (15-lang miss on trigger-event), and colon-split `sortable:start` fragments hid value truncation behind a vacuous expression:expression type match in the four behavior patterns. Event NAMES (bare or `behavior:phase`) on command nodes now canonicalize to `literal` in `normalizeCommandRoles`. **Both families are gone.**

### wait.duration — diagnosed, deferred

en `wait for transitionend` captures the KEYWORD as `duration:literal="for"` and drops the event name. The honest fix needs a `wait for {event}` head + a wait-schema event role + AST mapper support (the wait mapper reads only `duration`) — an R2-touching arc, documented in the handoff status block for the next session.

## Validation

- Guard tests FAIL without the fix (4 of 5; the marker-guard negative passes by design), verified via stash round-trip + rebuild
- Six-signal `--regression` gate green (exit 0), parse 3696/3696, R2 1.0
- Baseline A/B: 12 langs up (qu +0.0029, it/pl +0.0022), 5 slightly down (bn/hi −0.0010, ms/th/tl −0.0017 — vacuous matches of the old reference noise now visible as real drops, all far under the 0.02 ratchet); corpus mean up
- semantic 6463 passed, i18n 912 passed, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)