### PR TITLE
fix(multilingual): fold SOV fronted repeat-while head into the repeat node (R1 residue item 2)

### DIFF
--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -64,6 +64,22 @@ single biggest identified phantom-action family with a known mechanism.
 
 ### 2. SOV fronted repeat-while (hi/qu/ko + likely ja/bn/tr; parser-side arc)
 
+> **STATUS: DONE (2026-07-05).** All SIX suspects were affected (probe confirmed
+> ja/bn split like hi; tr/qu never formed a `while` node at all). Two-part fix:
+> (a) `foldFrontedWhileIntoRepeat` in semantic-parser.ts — at the end of
+> `parseBodyWithClauses`, a flat `while{condition}` clause immediately followed
+> by a flat condition-less `repeat` merges into one
+> `repeat{loopType:"while", condition}` (junk numeric loopType from the
+> comparison tail, ko/ja/tr `loopType:10`, is overwritten; loop nodes with
+> bodies never enter the fold). (b) dict↔profile while-keyword alignment for
+> the two languages whose fronted head never parsed: qu `kay_kaq`→`kaykamaqa`,
+> tr `iken`→`süresince` (`iken` is the tr WHEN primary) — two
+> `KNOWN_MISMATCHES` entries pruned. After the fix all six languages match the
+> en reference role-for-role on repeat-while; fold blast radius corpus-wide is
+> exactly {hi,bn,ja,ko,tr,qu}×repeat-while, and the qu/tr dict words appear in
+> no other pattern. avgRoleFidelity +0.001–0.002 and avgPrecision +0.0013
+> across the six; zero metric decreased anywhere.
+
 Cluster D canonicalized en repeat-while to `repeat{loopType:literal="while",
 condition:property-path}` and added verb-first while-heads (es/it/de/… now
 match in full). The SOV translations front the while-phrase BEFORE the event

--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -28,7 +28,12 @@ export const qu: Dictionary = {
     unless: 'mana sichus', // spaced phrase ("if not"); `_` form split to `mana`+`sichus`(=if) at parse time
     repeat: 'kutipay',
     for: 'sapankaq', // profile's for word — rayku doubles as `by`
-    while: 'kay_kaq',
+    // `kaykamaqa` (the semantic qu profile's while primary), not `kay_kaq`: the
+    // `_` form is unknown to the profile (and `_` words split at parse time, cf.
+    // qhipaman_yapay), so the fronted repeat-while head never formed a `while`
+    // node — the condition dropped wholesale. Same dict↔profile alignment as
+    // vi render / de abrufen.
+    while: 'kaykamaqa',
     until: 'hayk_akama',
     continue: 'purichiy',
     break: 'p_akiy',

--- a/packages/i18n/src/dictionaries/tr.ts
+++ b/packages/i18n/src/dictionaries/tr.ts
@@ -22,7 +22,11 @@ export const tr: Dictionary = {
     unless: 'değilse',
     repeat: 'tekrarla',
     for: 'için',
-    while: 'iken',
+    // `süresince` (the semantic tr profile's while primary), not `iken`: `iken`
+    // is the profile's WHEN primary (logical.when below also emits it), so a
+    // fronted repeat-while head tokenized as `when` and the condition dropped
+    // wholesale. Same dict↔profile homonym disambiguation as pl get/pobierz.
+    while: 'süresince',
     until: 'kadar',
     continue: 'devam',
     break: 'dur',

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -639,6 +639,27 @@ describe('GrammarTransformer', () => {
     });
   });
 
+  describe('qu/tr while keyword alignment (fronted repeat-while head)', () => {
+    // Regression: the qu dict emitted `kay_kaq` (unknown to the semantic qu
+    // profile, whose while primary is `kaykamaqa`), and the tr dict emitted
+    // `iken` (the tr profile's WHEN primary) — so the fronted repeat-while head
+    // never formed a `while` node at parse time and the condition dropped
+    // wholesale. Align both dicts to the profile while primary.
+    const source = 'on click repeat while #counter.innerText < 10 increment #counter end';
+
+    it('qu: repeat-while emits the profile while word kaykamaqa, not kay_kaq', () => {
+      const result = new GrammarTransformer('en', 'qu').transform(source);
+      expect(result).toContain('kaykamaqa');
+      expect(result).not.toContain('kay_kaq');
+    });
+
+    it('tr: repeat-while emits süresince, not the when-homonym iken', () => {
+      const result = new GrammarTransformer('en', 'tr').transform(source);
+      expect(result).toContain('süresince');
+      expect(result).not.toMatch(/\biken\b/);
+    });
+  });
+
   describe('Duration / literal-primary marking (no spurious object particle)', () => {
     // A command whose primary argument is a literal/measure (e.g. `wait <duration>`)
     // must NOT have that argument marked as a fronted object: the generic argument

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1583,12 +1583,64 @@ export class SemanticParserImpl implements ISemanticParser {
       clauses.push(...clauseNodes);
     }
 
+    this.foldFrontedWhileIntoRepeat(clauses, language);
+
     // If we have multiple clauses, wrap in CompoundSemanticNode
     if (clauses.length > 1) {
       return [createCompoundNode(clauses, 'then', { sourceLanguage: language })];
     }
 
     return clauses;
+  }
+
+  /**
+   * Merge a fronted `while {condition}` clause into the adjacent `repeat` head.
+   *
+   * The SOV reorder fronts a repeat-while's while-phrase BEFORE the event phrase
+   * (hi `जब तक #counter.innerText < 10 को क्लिक पर दोहराएं …`, ko `동안 … 반복 …`),
+   * so the body splits into a standalone `while{condition}` node followed by a
+   * bare `repeat` — while the en reference (cluster D, #567) canonicalizes the
+   * same head as ONE `repeat{loopType:"while", condition}` node. The split costs
+   * both recall (repeat.condition/loopType missing) and precision (the standalone
+   * `while` is spurious vs the en reference). Re-associate them, mirroring the
+   * trailing-`unless` guard recovery in parseClause.
+   *
+   * Conservative: fires only when a flat `while` COMMAND node carrying a
+   * condition is immediately followed by a flat `repeat` command that has no
+   * condition of its own and no attached body. A ko/ja/tr `repeat` that grabbed a
+   * junk numeric loopType from the fronted condition's comparison tail
+   * (`loopType:10` from `< 10 를`) is overwritten — the fronted while-phrase IS
+   * the loop head, so `loopType` is `"while"` by construction. Loop nodes with
+   * bodies (`kind: 'loop'`) and conditionals never enter the fold.
+   */
+  private foldFrontedWhileIntoRepeat(clauses: SemanticNode[], language: string): void {
+    for (let i = 0; i + 1 < clauses.length; i++) {
+      const whileNode = clauses[i] as CommandSemanticNode & { body?: unknown };
+      const repeatNode = clauses[i + 1] as CommandSemanticNode & { body?: unknown };
+      if (whileNode.kind !== 'command' || whileNode.action !== 'while') continue;
+      if (repeatNode.kind !== 'command' || repeatNode.action !== 'repeat') continue;
+      const condition = whileNode.roles.get('condition');
+      if (!condition) continue;
+      if (repeatNode.roles.has('condition')) continue;
+      if (Array.isArray(whileNode.body) || Array.isArray(repeatNode.body)) continue;
+
+      const roles = new Map(repeatNode.roles);
+      roles.set('condition', condition);
+      roles.set('loopType', { type: 'literal', value: 'while', dataType: 'string' });
+      clauses.splice(i, 2, {
+        ...repeatNode,
+        roles,
+        metadata: {
+          ...repeatNode.metadata,
+          sourceLanguage: language,
+          patternId: `repeat-${language}-fronted-while-fold`,
+          confidence: Math.max(
+            repeatNode.metadata?.confidence ?? 0,
+            whileNode.metadata?.confidence ?? 0
+          ),
+        },
+      });
+    }
   }
 
   /**

--- a/packages/semantic/test/lexicon-emit-mismatch.test.ts
+++ b/packages/semantic/test/lexicon-emit-mismatch.test.ts
@@ -111,7 +111,8 @@ const KNOWN_MISMATCHES = new Set([
   // spaced `mana sichus` + quechua profile reads it as `unless` (was `mana_sichus`,
   // which `_`-split to mana(=false)+sichus(=if)).
   'qu:until:hayk_akama',
-  'qu:while:kay_kaq',
+  // qu:while resolved (HANDOFF-r1-post-cluster-residue item 2): dict realigned to
+  // the profile primary `kaykamaqa` (was `kay_kaq`, unknown to the profile).
   'ru:catch:поймать',
   'ru:pushUrl:добавить_url',
   'ru:replaceUrl:заменить_url',
@@ -138,7 +139,8 @@ const KNOWN_MISMATCHES = new Set([
   'tr:pushUrl:urlEkle',
   'tr:replaceUrl:urlDeğiştir',
   'tr:select:seç',
-  'tr:while:iken',
+  // tr:while resolved (HANDOFF-r1-post-cluster-residue item 2): dict realigned to
+  // the profile primary `süresince` (was `iken`, the tr WHEN primary).
   'uk:catch:зловити',
   'uk:pushUrl:додати_url',
   'uk:replaceUrl:замінити_url',

--- a/packages/semantic/test/repeat-loop-heads.test.ts
+++ b/packages/semantic/test/repeat-loop-heads.test.ts
@@ -178,3 +178,48 @@ describe('existing repeat variants are not over-triggered', () => {
     expect(role(node, 'quantity')).toBeDefined();
   });
 });
+
+describe('SOV fronted repeat-while fold (R1 post-cluster residue item 2)', () => {
+  // The SOV reorder fronts a repeat-while's while-phrase BEFORE the event
+  // phrase, so the body used to split into a standalone `while{condition}`
+  // node followed by a bare `repeat` (ko/ja/tr additionally grabbed a junk
+  // numeric loopType from the condition's comparison tail) — while the en
+  // reference (cluster D) canonicalizes the same head as ONE
+  // `repeat{loopType:"while", condition}` node. `foldFrontedWhileIntoRepeat`
+  // (semantic-parser.ts) re-associates them. qu/tr additionally needed a
+  // dict↔profile while-keyword alignment (qu kay_kaq→kaykamaqa, tr
+  // iken→süresince; iken is the tr WHEN primary) before the while node could
+  // form at all. Corpus-shaped inputs (repeat-while, en:
+  // `on click repeat while #counter.innerText < 10 increment #counter wait 200ms end`).
+  const cases: Array<[string, string]> = [
+    ['hi', 'जब तक #counter.innerText < 10 को क्लिक पर दोहराएं फिर #counter को बढ़ाएं फिर प्रतीक्षा 200ms समाप्त'],
+    ['ko', '동안 #counter.innerText < 10 를 클릭 할 때 반복 그러면 #counter 를 증가 그러면 대기 200ms 끝'],
+    ['ja', 'の間 #counter.innerText < 10 を クリック で 繰り返し それから #counter を 増加 それから 待つ 200ms 終わり'],
+    ['bn', 'যতক্ষণ #counter.innerText < 10 কে ক্লিক এ পুনরাবৃত্তি তারপর #counter কে বৃদ্ধি তারপর 200ms শেষ কে অপেক্ষা'],
+    ['tr', 'süresince #counter.innerText < 10 i tıklama de tekrarla ardından #counter i artır ardından bekle 200ms son'],
+    ['qu', 'kaykamaqa #counter.innerText < 10 ta ñitiy pi kutipay chayqa #counter ta yapachiy chayqa suyay 200ms tukuy'],
+  ];
+
+  for (const [lang, input] of cases) {
+    it(`[${lang}] fronted while-phrase folds into the repeat head (condition + loopType:"while", no standalone while)`, () => {
+      const node = parse(input, lang) as AnyNode;
+      const repeat = findRepeat(node);
+      expect(repeat).toBeTruthy();
+      expect(role(repeat!, 'loopType')).toMatchObject({ type: 'literal', value: 'while' });
+      expect(role(repeat!, 'condition')).toMatchObject({ type: 'property-path' });
+      // The spurious standalone `while` sibling is gone; the body survives.
+      const actions = collectActions(node);
+      expect(actions.has('while')).toBe(false);
+      expect(actions.has('increment')).toBe(true);
+      expect(actions.has('wait')).toBe(true);
+    });
+  }
+
+  it('[ko] a fronted while before a non-repeat command is left unfolded (no fabricated repeat)', () => {
+    // The fold requires an ADJACENT repeat head — a while-phrase followed by an
+    // ordinary command must not conjure a repeat or steal the condition.
+    const node = parse('동안 #counter.innerText < 10 를 클릭 할 때 #counter 를 증가', 'ko') as AnyNode;
+    expect(findRepeat(node)).toBeNull();
+    expect(collectActions(node).has('increment')).toBe(true);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-05T13:16:25.630Z",
-  "commit": "dec13c63",
+  "timestamp": "2026-07-05T13:32:14.945Z",
+  "commit": "4efd5268",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8462563334743781,
       "avgFidelity": 1,
-      "avgPrecision": 0.9344480519480524,
-      "avgRoleFidelity": 0.9506962764315706,
+      "avgPrecision": 0.9357467532467537,
+      "avgRoleFidelity": 0.9526267783620725,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8993587865768304,
       "avgFidelity": 1,
-      "avgPrecision": 0.9399631753527856,
-      "avgRoleFidelity": 0.9380675763028703,
+      "avgPrecision": 0.9412618766514869,
+      "avgRoleFidelity": 0.9399980782333722,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6321,13 +6321,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
-      "avgPrecision": 0.9516824085005904,
-      "avgRoleFidelity": 0.9478856927386338,
+      "avgPrecision": 0.952981109799292,
+      "avgRoleFidelity": 0.9488509437038849,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6953,13 +6953,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
-      "avgPrecision": 0.9516824085005905,
-      "avgRoleFidelity": 0.9428181251710662,
+      "avgPrecision": 0.9529811097992917,
+      "avgRoleFidelity": 0.9437833761363174,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9479,15 +9479,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7349000206143064,
+      "avgConfidence": 0.7381467738610596,
       "avgFidelity": 1,
       "avgPrecision": 0.9525172879068982,
-      "avgRoleFidelity": 0.9347341483370897,
+      "avgRoleFidelity": 0.9366646502675916,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9646,6 +9646,10 @@
           "confidence": 1
         },
         "repeat-forever": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-while": {
           "success": true,
           "confidence": 1
         },
@@ -9969,10 +9973,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.5
-        },
         "event-debounce": {
           "success": true,
           "confidence": 0.5
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12639,15 +12639,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8307646822684411,
+      "avgConfidence": 0.8340114355151945,
       "avgFidelity": 1,
       "avgPrecision": 0.9520843874739979,
-      "avgRoleFidelity": 0.9474882364588247,
+      "avgRoleFidelity": 0.9484534874240756,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12862,6 +12862,10 @@
           "confidence": 1
         },
         "repeat-forever": {
+          "success": true,
+          "confidence": 1
+        },
+        "repeat-while": {
           "success": true,
           "confidence": 1
         },
@@ -13185,10 +13189,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "repeat-while": {
-          "success": true,
-          "confidence": 0.5
-        },
         "event-debounce": {
           "success": true,
           "confidence": 0.5
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 471816,
+      "bundleSize": 472444,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 471816,
+      "size": 472444,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
Supersedes #570 (auto-closed when its stacked base branch was deleted on the #569 merge; rebased onto main, content identical). Full description and validation in #570.

**TL;DR:** The SOV reorder fronts a repeat-while's while-phrase before the event phrase, splitting the parse into a standalone `while{condition}` + bare `repeat` (hi/bn/ja/ko), or dropping the condition entirely where the dict emitted a word the profile doesn't read as while (qu `kay_kaq`→`kaykamaqa`, tr `iken`→`süresince`). Fix: `foldFrontedWhileIntoRepeat` in `parseBodyWithClauses` + the two dict↔profile while-keyword alignments (two `KNOWN_MISMATCHES` entries pruned). All six languages now match the en reference role-for-role on repeat-while; corpus-wide fold blast radius is exactly those six × repeat-while; no metric decreased anywhere. Guard tests fail without the fix; six-signal gate green; baseline regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)