### PR TITLE
fix(multilingual): R1 residue sweep 2 — send/tell/wait-for-event/halt

### DIFF
--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -1,5 +1,77 @@
 # Handoff — R1 residue after the five-cluster triage (fronted repeat-while · sw kama homonym · singletons)
 
+> **STATUS UPDATE (2026-07-05, follow-up session): the open residue from items
+> 1–3 is largely LANDED** as one "R1 residue sweep 2" PR (four increments, each
+> with fail-without-fix guard tests, per-(lang,pattern) A/B showing zero
+> regressions, six-signal gate green, baseline regenerated against a fresh
+> populate — corpus probe mean role-recall 0.9661 → 0.9771, all 23 languages
+> up, none down; parse 3696/3696, R2 1.0):
+>
+> 1. **send en-reference noise (65 lang-patterns).** Two en defects: the
+>    send schema's `[selector, reference]` destination rejected a
+>    bare-identifier target (`send "hello" to ChatSocket` → destination
+>    silently defaulted to `me`; socket-send ×23) — now admits `expression`
+>    (the add.destination precedent); and the event role's bare-call fold skip
+>    (an `on`-handler param-destructuring rule) truncated `send update(value:
+42) to #target` to `event:literal="update"` and dropped the destination
+>    (send-with-detail ×21) — the skip is now scoped to
+>    `currentPatternCommand === 'on'`. Both families cleared in all languages.
+> 2. **tell role alignment (21).** The generated marker extraction bound
+>    tell's element to the schema-unsanctioned `patient` and the dropped `to
+<command>` body's verb to `destination` as a schema-invalid literal.
+>    normalizeCommandRoles now relabels patient→destination over an
+>    absent-or-junk-literal destination (the #564 schema-invalid-destination
+>    precedent). NOTE: the `to show` BODY is still dropped in en AND all
+>    translations (equal lossiness) — a future tell-body arc.
+> 3. **wait for {event} — the diagnosed R2-touching arc (23 + 2).** Four
+>    pieces: a hand-crafted en `wait-en-for-event` head (also registered in
+>    buildEnglishPatterns — the per-command loaders are NOT auto-included
+>    there, a footgun worth remembering); a known-event duration→event relabel
+>    in normalizeCommandRoles gated on a new WAITABLE_EVENT_WORDS set (so
+>    `wait 2s` / `wait delay` are never touched); a trailing event-name
+>    reclaim in buildEventHandler (the #561/#563 sibling) for SOV verb-final
+>    renders, which also drops the sov-simple `patient:reference=me` extraction
+>    default leak and consumes a rendered for-postposition (bn `জন্য`, which
+>    otherwise anchors a phantom bare `for` — a parseBodyWithClauses filter
+>    catches stragglers, scoped to zero-role zero-body `for` ONLY: a bare
+>    `repeat` is a legitimate loop-recovery intermediate); and the waitMapper
+>    now emits the runtime's `modifiers.for`/`modifiers.from`, so event waits
+>    EXECUTE as event waits (R2-honest; the curated R2 subset contains no
+>    waits, so the ratchet is unaffected). tl needed a `wait-tl-from-first`
+>    mirror of `wait-ar-from-first` (its transformer fronts the from-phrase).
+>    A then-chain after `wait for X` in a handler body is no longer dropped.
+> 4. **halt leaked-article patient (74 → 6).** `detener the evento llamar …`:
+>    the leaked-article skip's §7y gate declined to fire when the ref-noun was
+>    followed by a command VERB, so every verb-first language captured
+>    `patient:expression="the"`. In SVO/VSO a ref-noun followed by a command
+>    verb IS a clause boundary (the verb opens the next juxtaposed command) —
+>    the skip now fires there via COMMAND_ACTION_KEYWORDS, SOV profiles
+>    exempt (tr's fronted patient has its verb later — the original §7y
+>    fragility, guard test rescoped to tr-only). form-submit-prevent cleared
+>    in all 17 non-SOV languages + the three behaviors ×17 each.
+>
+> **Remaining residue after this sweep** (probe-grounded, next session's menu):
+>
+> - **SOV halt.patient ×6** (form-submit-prevent bn/hi/ja/ko/qu/tr): the
+>   fronted `the <event-word>` sits ahead of OTHER commands' clauses
+>   (compound-level scrambling); tr additionally crosses call/halt roles.
+>   Needs fronted-role re-association machinery, not the article skip.
+> - **if.condition:reference ×14** (form-submit-prevent, es/it/de/pl/…): the
+>   en reference parses `if result is false` as `condition:reference="result"`
+>   and DROPS the comparison; translations capture the full expression and
+>   mismatch. en-noise, same discipline as this sweep: fix the en if-head to
+>   capture the full condition, then re-check.
+> - **set.destination:property-path ×46** (template-literal-list-build ×22 the
+>   bulk) + `set.patient` families — cluster A2 (expression-valued set
+>   patients, multi-token expression-run assembly in matchRoleToken).
+> - **behavior-sortable deep add.destination ×5** (nested handler sub-parse
+>   binding registry gap), `js.patient:expression` ×12,
+>   `render.style:expression` ×14, `send.event` fine now but `add.patient`
+>   form-disable-on-submit ×18, `toggle.patient:expression` accordion ×15.
+> - Spurious-action families (R0-precision): `transition` ×66 (biggest),
+>   `empty` ×28, `add` ×22, `go` ×21 (go-back every lang), `morph` ×18,
+>   `default` ×9 — none touched this sweep; each needs its own drill.
+
 > **Written 2026-07-05**, immediately after clusters D (#567) and E (#568) landed
 > the same session (B/A1/C landed 2026-07-04 as #564/#565/#566 — see
 > [HANDOFF-r1-residual.md](HANDOFF-r1-residual.md) for that triage and its

--- a/packages/semantic/src/ast-builder/command-mappers.ts
+++ b/packages/semantic/src/ast-builder/command-mappers.ts
@@ -310,6 +310,20 @@ const decrementMapper: CommandMapper = {
 const waitMapper: CommandMapper = {
   action: 'wait',
   toAST(node, _builder) {
+    // Event wait (`wait for transitionend [from document]`) — the runtime's
+    // WaitCommand reads the event from `modifiers.for` and the listen target
+    // from `modifiers.from`. The event role is set by the en
+    // `wait-en-for-event` head, the known-event duration→event relabel
+    // (normalizeCommandRoles), or the trailing event-name reclaim
+    // (buildEventHandler).
+    const event = convertRoleValue(node, 'event');
+    if (event) {
+      const modifiers: Record<string, ExpressionNode> = { for: event };
+      const source = convertRoleValue(node, 'source');
+      if (source) modifiers.from = source;
+      return createCommandNode('wait', [], modifiers, { isBlocking: true });
+    }
+
     const duration = convertRoleValue(node, 'duration');
 
     const args: ExpressionNode[] = duration ? [duration] : [];

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -1333,7 +1333,13 @@ export const sendSchema: CommandSchema = {
       role: 'destination',
       description: 'The target element (defaults to me)',
       required: false,
-      expectedTypes: ['selector', 'reference'],
+      // `expression` admits a bare-identifier target (`send "hello" to
+      // ChatSocket`): the identifier tokenizes as expression, so
+      // [selector, reference] rejected the marked `to ChatSocket` phrase and
+      // the destination silently defaulted to `me` — in the en reference AND
+      // most translations alike (socket-send ×23). Marker-guarded, same
+      // precedent as add.destination (#571).
+      expectedTypes: ['selector', 'reference', 'expression'],
       default: { type: 'reference', value: 'me' },
       svoPosition: 2,
       sovPosition: 1,

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -515,10 +515,16 @@ export class PatternMatcher {
     // into one expression value so the role captures it cleanly.
     //
     // Skipped in two cases:
-    //  - the `event` role: `on pointerdown(clientX, clientY)` destructures EVENT
-    //    PARAMS, not a call — the event name (`pointerdown`) must be captured
-    //    alone, with params handled by the event-handler builder (folding would
-    //    corrupt the event name to `pointerdown(clientX, clientY)`).
+    //  - the `on` HANDLER's `event` role: `on pointerdown(clientX, clientY)`
+    //    destructures EVENT PARAMS, not a call — the event name (`pointerdown`)
+    //    must be captured alone, with params handled by the event-handler
+    //    builder (folding would corrupt the event name to
+    //    `pointerdown(clientX, clientY)`). A COMMAND's event role (`send
+    //    update(value: 42) to #target`, trigger likewise) is the opposite: the
+    //    call shape IS the event-with-detail, and skipping the fold leaves a
+    //    dangling `( )` that breaks the following destination group — en
+    //    truncated the event to `literal="update"` AND dropped `to #target`
+    //    (send-with-detail ×21; translations captured both and were penalized).
     //  - DECLARATION commands (`behavior`/`def`/`install`): `Draggable(dragHandle)`
     //    is a declaration SIGNATURE, not a call. Folding it lets the single-command
     //    declaration pattern (e.g. SOV `{name} কে আচরণ`) consume the first line of a
@@ -527,7 +533,7 @@ export class PatternMatcher {
     //    dangling `(params)` makes that pattern fail, so the block falls through to
     //    the faithful path; the header's params are read separately by parseHeader.
     const skipBareCall =
-      patternToken.role === 'event' ||
+      (patternToken.role === 'event' && this.currentPatternCommand === 'on') ||
       PatternMatcher.DECLARATION_COMMANDS.has(this.currentPatternCommand ?? '');
     const bareCallValue = skipBareCall ? null : this.tryMatchBareCallExpression(tokens);
     if (bareCallValue) {
@@ -1978,10 +1984,24 @@ export class PatternMatcher {
       const afterRefNorm = afterRefNoun
         ? (afterRefNoun.normalized ?? afterRefNoun.value).toLowerCase()
         : '';
+      // In VERB-FIRST word orders (SVO/VSO/V2) a ref-noun followed by a
+      // COMMAND VERB is also a clause boundary: the verb begins the NEXT
+      // juxtaposed body command (`detener the evento llamar validateForm()…`
+      // — evento ends the halt clause, llamar opens the call). Without it the
+      // patient captured the bare article (`patient:expression="the"`, the
+      // halt.patient R1 residue across es/it/de/pl/zh + the behaviors ×17).
+      // Deliberately NOT applied to SOV profiles: there the fronted patient's
+      // own verb comes LATER in the clause, so a following verb is NOT a
+      // boundary (tr `the olay çağır …` — the §7y regression this branch's
+      // gate originally protected).
+      const verbBoundary =
+        this.currentProfile?.wordOrder !== 'SOV' &&
+        PatternMatcher.COMMAND_ACTION_KEYWORDS.has(afterRefNorm);
       const refNounFollowedByBoundary =
         !afterRefNoun ||
         afterRefNoun.kind === 'particle' ||
-        PatternMatcher.CLAUSE_BOUNDARY_KEYWORDS.has(afterRefNorm);
+        PatternMatcher.CLAUSE_BOUNDARY_KEYWORDS.has(afterRefNorm) ||
+        verbBoundary;
       if (
         nextToken &&
         nextToken.kind === 'keyword' &&

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -84,6 +84,87 @@ const POSITIONAL_VALUE_KEYWORDS = new Set([
   'closest',
 ]);
 
+/**
+ * Known WAITABLE event names — the gate for treating a `wait` argument as an
+ * event wait rather than a time wait. `wait for transitionend` (en head) and
+ * the marker-less translations (`esperar transitionend`) both put the event
+ * name where a duration would sit; a bare identifier is otherwise ambiguous
+ * with a time-variable wait (`wait delay`), so the relabel/reclaim fires ONLY
+ * on names in this set. Event names are untranslated loanwords in every corpus
+ * language (the RESPONSE_TYPE_WORDS precedent), so a value-set gate is
+ * language-invariant. Superset of the handler-side KNOWN_EVENTS plus the
+ * transition/animation/pointer/touch/drag families that waits actually target.
+ */
+const WAITABLE_EVENT_WORDS = new Set([
+  // handler-side KNOWN_EVENTS
+  'click',
+  'dblclick',
+  'input',
+  'change',
+  'submit',
+  'keydown',
+  'keyup',
+  'keypress',
+  'mouseover',
+  'mouseout',
+  'mousedown',
+  'mouseup',
+  'focus',
+  'blur',
+  'load',
+  'scroll',
+  'resize',
+  'contextmenu',
+  // transition / animation
+  'transitionend',
+  'transitionstart',
+  'transitionrun',
+  'transitioncancel',
+  'animationend',
+  'animationstart',
+  'animationiteration',
+  'animationcancel',
+  // pointer / touch / mouse movement
+  'pointerdown',
+  'pointerup',
+  'pointermove',
+  'pointerenter',
+  'pointerleave',
+  'pointercancel',
+  'pointerover',
+  'pointerout',
+  'touchstart',
+  'touchend',
+  'touchmove',
+  'touchcancel',
+  'mousemove',
+  'mouseenter',
+  'mouseleave',
+  'wheel',
+  // drag & drop
+  'dragstart',
+  'dragend',
+  'dragover',
+  'dragenter',
+  'dragleave',
+  'drop',
+  'drag',
+  // lifecycle / misc
+  'loadend',
+  'loadstart',
+  'error',
+  'abort',
+  'close',
+  'open',
+  'message',
+  'popstate',
+  'hashchange',
+  'storage',
+  'online',
+  'offline',
+  'visibilitychange',
+]);
+
 // =============================================================================
 // Parse Error with Diagnostics (Phase 3.4)
 // =============================================================================
@@ -191,6 +272,53 @@ function normalizeCommandRoles(node: SemanticNode, boundIdentifiers?: Set<string
       if (value !== undefined) {
         roles.delete('patient');
         roles.set(primary, value);
+      }
+    }
+
+    // tell: the generated marker extraction binds tell's element to the
+    // generic `patient` (tell has NO patient role) and the trailing verb of
+    // the dropped `to <command>` body to `destination` as a literal —
+    // schema-invalid, a tell destination is selector/reference (`decir #modal
+    // a mostrar` → patient:selector="#modal", destination:literal="show").
+    // Relabel patient→destination and drop the junk literal so translations
+    // align with the en reference (`tell #modal to show` →
+    // destination:selector="#modal"; the body verb is dropped in the en
+    // reference too — equal lossiness, no phantom). Cluster-B precedent: the
+    // schema-invalid-destination relabel (ko `json 로`).
+    if (node.action === 'tell') {
+      const roles = node.roles as Map<SemanticRole, SemanticValue>;
+      const pat = roles.get('patient');
+      const dest = roles.get('destination');
+      if (
+        pat &&
+        (pat.type === 'selector' || pat.type === 'reference') &&
+        (!dest || dest.type === 'literal')
+      ) {
+        roles.delete('patient');
+        roles.set('destination', pat);
+      }
+    }
+
+    // wait: a duration that IS a known waitable event name is an EVENT wait —
+    // `wait for transitionend` (en `wait-en-for-event` head) vs the
+    // marker-less translations (`esperar transitionend`), whose generated
+    // `wait {duration}` pattern binds the event name as
+    // duration:expression. Relabel duration→event:literal so both shapes
+    // align and the waitMapper emits the runtime's `modifiers.for` event
+    // wait. Gated on WAITABLE_EVENT_WORDS so a time-variable wait
+    // (`wait delay`, `wait 2s`) is never touched.
+    if (node.action === 'wait') {
+      const roles = node.roles as Map<SemanticRole, SemanticValue>;
+      if (!roles.has('event')) {
+        const dur = roles.get('duration') as
+          | { type: string; raw?: unknown; value?: unknown }
+          | undefined;
+        const word =
+          dur?.type === 'expression' ? dur.raw : dur?.type === 'literal' ? dur.value : undefined;
+        if (typeof word === 'string' && WAITABLE_EVENT_WORDS.has(word.toLowerCase())) {
+          roles.delete('duration');
+          roles.set('event', { type: 'literal', value: word, dataType: 'string' });
+        }
       }
     }
 
@@ -1383,6 +1511,65 @@ export class SemanticParserImpl implements ISemanticParser {
             }
           }
         }
+
+        // Trailing WAITABLE-EVENT reclaim — the `wait` sibling of the quantity /
+        // responseType reclaims above. The transformer renders `wait for
+        // transitionend` with the event name AFTER the verb in verb-final
+        // languages (ja `待つ transitionend`, hi `प्रतीक्षा transitionend`), but
+        // the fused event pattern ends at the verb, so the event name is left
+        // unconsumed and drops (the wait fills a junk schema-invalid
+        // duration:reference instead — wait-for-event ×23). Gated on the
+        // action being `wait`, an ABSENT event role, and the next unconsumed
+        // token being a KNOWN waitable event name (language-invariant
+        // loanwords — a then-keyword, `end`, selector, or bare number never
+        // matches). A schema-invalid duration (reference — the junk fill) is
+        // dropped in the rebuild; a real duration (literal/expression) is kept.
+        if (actionName === 'wait') {
+          const wNode = commandNode as CommandSemanticNode;
+          if (!wNode.roles.has('event')) {
+            const trailing = tokens.peek();
+            if (trailing && WAITABLE_EVENT_WORDS.has(trailing.value.toLowerCase())) {
+              const roles = Object.fromEntries(wNode.roles) as Record<string, SemanticValue>;
+              const dur = roles.duration as { type?: string } | undefined;
+              if (dur && dur.type !== 'literal' && dur.type !== 'expression') {
+                delete roles.duration;
+              }
+              // Drop the SOV default-patient leak (`patient:reference=me`, the
+              // sov-simple fused extraction default): wait has no patient
+              // role, and normalizeCommandRoles would otherwise relabel it
+              // into the empty primary `duration` slot — a junk
+              // duration:reference the en reference never has (the repeat
+              // default-patient precedent).
+              const pat = roles.patient as { type?: string; value?: unknown } | undefined;
+              if (pat && pat.type === 'reference' && pat.value === 'me') {
+                delete roles.patient;
+              }
+              roles.event = {
+                type: 'literal',
+                value: trailing.value,
+                dataType: 'string',
+              } as SemanticValue;
+              commandNode = createCommandNode(actionName as ActionType, roles, wNode.metadata);
+              tokens.advance();
+              // Consume a trailing rendered `for`-postposition (bn `transitionend
+              // জন্য` — the transformer renders the wait-for keyword AFTER the
+              // event in postpositional languages). Left in place it anchors a
+              // phantom bare `for` command in the remaining body tokens. জন্য
+              // tokenizes as a PARTICLE (no `normalized`), so also match the
+              // profile's for-keyword surface form.
+              const post = tokens.peek();
+              if (post) {
+                const postNorm = (post.normalized ?? '').toLowerCase();
+                const forKw = tryGetProfile(language)?.keywords?.for;
+                const isForWord =
+                  postNorm === 'for' ||
+                  post.value === forKw?.primary ||
+                  (forKw?.alternatives ?? []).includes(post.value);
+                if (isForWord) tokens.advance();
+              }
+            }
+          }
+        }
       }
 
       // Check if pattern has continuation marker (then-chains).
@@ -1668,6 +1855,28 @@ export class SemanticParserImpl implements ISemanticParser {
     }
 
     this.foldFrontedWhileIntoRepeat(clauses, language);
+
+    // Drop phantom BARE `for` clauses: a lone for-homonym token (bn `জন্য` is
+    // both the for-keyword and the benefactive postposition) parses as a `for`
+    // command node with ZERO roles and no body — never a real command, only a
+    // rendered marker orphaned from its phrase (`অপেক্ষা transitionend জন্য`:
+    // the trailing for-postposition survives the wait clause split and anchors
+    // an empty `for` — a precision phantom vs the en reference). Real for
+    // parses always carry a patient/source role or a body (loop kinds are
+    // built with them). Scoped to `for` ONLY: a bare zero-role `repeat` is a
+    // legitimate intermediate of the loop-body recovery paths (zh
+    // repeat-forever, qu repeat-while) and must survive.
+    for (let i = clauses.length - 1; i >= 0; i--) {
+      const c = clauses[i] as CommandSemanticNode & { body?: unknown[] };
+      if (
+        c.kind === 'command' &&
+        c.action === 'for' &&
+        (!(c.roles instanceof Map) || c.roles.size === 0) &&
+        (!Array.isArray(c.body) || c.body.length === 0)
+      ) {
+        clauses.splice(i, 1);
+      }
+    }
 
     // If we have multiple clauses, wrap in CompoundSemanticNode
     if (clauses.length > 1) {

--- a/packages/semantic/src/patterns/en.ts
+++ b/packages/semantic/src/patterns/en.ts
@@ -14,6 +14,7 @@ import { getTogglePatternsForLanguage } from './toggle';
 import { getPutPatternsForLanguage } from './put';
 import { getEventHandlerPatternsForLanguage } from './event-handler';
 import { getRepeatPatternsForLanguage } from './repeat';
+import { getWaitPatternsForLanguage } from './wait';
 
 // =============================================================================
 // Hand-crafted English-only patterns
@@ -385,6 +386,10 @@ export function buildEnglishPatterns(): LanguagePattern[] {
   // capturing the canonical loopType/patient/source head and stopping before
   // the loop body. The `until event` variants stay hand-crafted below.
   patterns.push(...getRepeatPatternsForLanguage('en'));
+  // Wait `for {event}` head (wait-for-event R1 arc): the generated
+  // `wait {duration}` captured the KEYWORD as the duration and dropped the
+  // event name + everything after it.
+  patterns.push(...getWaitPatternsForLanguage('en'));
 
   // 2. English-only hand-crafted patterns
   patterns.push(

--- a/packages/semantic/src/patterns/wait.ts
+++ b/packages/semantic/src/patterns/wait.ts
@@ -112,14 +112,89 @@ function getWaitPatternsAr(): LanguagePattern[] {
   ];
 }
 
+/**
+ * English `wait for {event}` head.
+ *
+ * The auto-generated `wait {duration}` pattern captured the KEYWORD as the
+ * duration (`wait for transitionend` → duration:literal="for") and dropped the
+ * event name — and everything after it, including a then-chain (`wait for X
+ * then remove me` lost the `remove`). This head captures the event by name;
+ * the waitMapper turns it into the runtime's `modifiers.for` event wait.
+ * Marker-less translations (`esperar transitionend`) reach the same shape via
+ * the known-event duration→event relabel in normalizeCommandRoles; SOV
+ * verb-final translations (ja `待つ transitionend`) via the trailing
+ * event-name reclaim in buildEventHandler.
+ */
+function getWaitPatternsEn(): LanguagePattern[] {
+  return [
+    {
+      id: 'wait-en-for-event',
+      language: 'en',
+      command: 'wait',
+      priority: 110,
+      template: {
+        format: 'wait for {event}',
+        tokens: [
+          { type: 'literal', value: 'wait' },
+          { type: 'literal', value: 'for' },
+          { type: 'role', role: 'event', expectedTypes: ['literal', 'expression'] },
+        ],
+      },
+      extraction: {
+        event: { position: 2 },
+      },
+    },
+  ];
+}
+
+/**
+ * Tagalog fronted-source wait — the tl mirror of `wait-ar-from-first`.
+ *
+ * The transformer fronts the from-phrase directly after the verb (`maghintay
+ * mula_sa dokumento pointermove(clientY) o pointerup(clientY)` for the
+ * behaviors' `wait for pointermove or pointerup from document` line), so the
+ * generated `maghintay {duration}` pattern can't anchor: the token after the
+ * verb is the source marker, not an event/duration. Captures the fronted
+ * source + the first following event word (the known-event duration→event
+ * relabel in normalizeCommandRoles then types it event:literal, matching the
+ * en reference); the `o <event>` tail stays harmless trailing tokens.
+ */
+function getWaitPatternsTl(): LanguagePattern[] {
+  return [
+    {
+      id: 'wait-tl-from-first',
+      language: 'tl',
+      command: 'wait',
+      priority: 105,
+      template: {
+        format: 'maghintay mula_sa {source} {duration}',
+        tokens: [
+          { type: 'literal', value: 'maghintay', alternatives: ['hintay'] },
+          { type: 'literal', value: 'mula_sa', alternatives: ['galing_sa'] },
+          { type: 'role', role: 'source', expectedTypes: ['expression', 'reference'] },
+          { type: 'role', role: 'duration', expectedTypes: ['expression', 'literal'] },
+        ],
+      },
+      extraction: {
+        source: { position: 2 },
+        duration: { position: 3 },
+      },
+    },
+  ];
+}
+
 export function getWaitPatternsForLanguage(language: string): LanguagePattern[] {
   switch (language) {
+    case 'en':
+      return getWaitPatternsEn();
     case 'zh':
       return getWaitPatternsZh();
     case 'he':
       return getWaitPatternsHe();
     case 'ar':
       return getWaitPatternsAr();
+    case 'tl':
+      return getWaitPatternsTl();
     default:
       return [];
   }

--- a/packages/semantic/test/ast-builder.test.ts
+++ b/packages/semantic/test/ast-builder.test.ts
@@ -238,6 +238,46 @@ describe('Command Mappers', () => {
       expect(result.args).toHaveLength(1);
       expect(result.isBlocking).toBe(true);
     });
+
+    it('should map an event wait to the runtime `for` modifier', () => {
+      // `wait for transitionend` — the runtime's WaitCommand reads the event
+      // from modifiers.for (and the listen target from modifiers.from).
+      const node: CommandSemanticNode = {
+        kind: 'command',
+        action: 'wait',
+        roles: new Map([
+          ['event', { type: 'literal', value: 'transitionend', dataType: 'string' }],
+        ]),
+      };
+
+      const mapper = getCommandMapper('wait');
+      const builder = new ASTBuilder();
+      const result = mapper!.toAST(node, builder);
+
+      expect(result.name).toBe('wait');
+      expect(result.args).toHaveLength(0);
+      expect(result.modifiers!['for']).toMatchObject({ type: 'literal', value: 'transitionend' });
+      expect(result.isBlocking).toBe(true);
+    });
+
+    it('should map an event wait with a source to for + from modifiers', () => {
+      const node: CommandSemanticNode = {
+        kind: 'command',
+        action: 'wait',
+        roles: new Map([
+          ['event', { type: 'literal', value: 'pointermove', dataType: 'string' }],
+          ['source', { type: 'expression', raw: 'document' }],
+        ]),
+      };
+
+      const mapper = getCommandMapper('wait');
+      const builder = new ASTBuilder();
+      const result = mapper!.toAST(node, builder);
+
+      expect(result.name).toBe('wait');
+      expect(result.modifiers!['for']).toMatchObject({ type: 'literal', value: 'pointermove' });
+      expect(result.modifiers!['from']).toBeDefined();
+    });
   });
 
   describe('log mapper', () => {

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -8728,25 +8728,37 @@ describe('`halt the event` skips the leaked article → patient:reference (halt.
     });
   }
 
-  // §7y guard: when a command VERB directly follows the ref noun (no clause
-  // boundary), the leaked article must NOT be skipped — skipping it breaks the
-  // fragile SOV/agglutinative body parse (tr form-submit-prevent: `the olay
-  // çağır …` = "the event call …"). The patient stays the article and the whole
-  // command sequence survives.
-  const formSubmitPrevent: Array<[string, string]> = [
-    ['tr', 'the olay çağır validateForm() i gönder de durdur eğer sonuç dir yanlış "Invalid form" i kaydet son'],
-    ['es', 'en enviar detener the evento llamar validateForm() si resultado es falso registrar "Invalid form" fin'],
-  ];
-  for (const [lang, code] of formSubmitPrevent) {
-    it(`[${lang}] §7y: verb after ref noun → article NOT skipped, body intact`, () => {
-      const node = parse(code, lang);
-      const halt = findHalt(node);
-      expect(halt, `no halt parsed for ${lang}`).toBeTruthy();
-      expect(patientType(halt)).not.toBe('reference');
-      // Body parse must survive (the §7y regression dropped commands).
-      expect(actions(node)).toEqual(['call', 'halt', 'if', 'log', 'on']);
-    });
-  }
+  // §7y guard, now SOV-scoped: when a command VERB directly follows the ref
+  // noun in an SOV language, the leaked article must NOT be skipped — skipping
+  // it breaks the fragile SOV/agglutinative body parse (tr form-submit-prevent:
+  // `the olay çağır …` = "the event call …"). The patient stays non-reference
+  // and the whole command sequence survives.
+  it('[tr] §7y: SOV — verb after ref noun → article NOT skipped, body intact', () => {
+    const node = parse(
+      'the olay çağır validateForm() i gönder de durdur eğer sonuç dir yanlış "Invalid form" i kaydet son',
+      'tr'
+    );
+    const halt = findHalt(node);
+    expect(halt, 'no halt parsed for tr').toBeTruthy();
+    expect(patientType(halt)).not.toBe('reference');
+    // Body parse must survive (the §7y regression dropped commands).
+    expect(actions(node)).toEqual(['call', 'halt', 'if', 'log', 'on']);
+  });
+
+  // SVO verb-boundary (R1 residue halt sweep): in a verb-first language the
+  // command verb after the ref noun IS a clause boundary (it opens the next
+  // juxtaposed body command), so the article is skipped, the patient is the
+  // event reference — and the body still survives intact.
+  it('[es] SVO — verb after ref noun IS a boundary: patient is the event reference, body intact', () => {
+    const node = parse(
+      'en enviar detener the evento llamar validateForm() si resultado es falso registrar "Invalid form" fin',
+      'es'
+    );
+    const halt = findHalt(node);
+    expect(halt, 'no halt parsed for es').toBeTruthy();
+    expect(patientType(halt)).toBe('reference');
+    expect(actions(node)).toEqual(['call', 'halt', 'if', 'log', 'on']);
+  });
 
   // Controls: a non-reference keyword after `the` keeps the article (no skip),
   // and a bare `halt` has no patient at all.
@@ -9839,5 +9851,208 @@ describe('en-reference noise sweep: for-body add.destination + trigger event typ
     const add = firstAction(node, 'add');
     const dest = roleOf(add, 'destination');
     expect(dest === undefined || (dest.type === 'reference' && dest.value === 'me')).toBe(true);
+  });
+});
+
+describe('en-reference noise: send destination dropped / event truncated (R1 residue, send family)', () => {
+  // Two EN-reference defects on the send command (socket-send ×23,
+  // send-with-detail ×21 — every language "missed" entries that were en noise):
+  //
+  // (a) `send "hello" to ChatSocket`: the bare-identifier target tokenizes as
+  //     expression, so the send schema's [selector, reference] destination
+  //     rejected the marked `to ChatSocket` phrase and silently defaulted to
+  //     `me`. The schema now admits `expression` (marker-guarded — the
+  //     add.destination precedent).
+  // (b) `send update(value: 42) to #target`: the event role skipped bare-call
+  //     folding (an `on`-handler rule, where `(clientX, clientY)` destructures
+  //     event params), so the event truncated to `literal="update"` and the
+  //     dangling `( )` broke the `to {destination}` group. The fold skip is now
+  //     scoped to the `on` handler's event role only.
+  function firstAction(node: unknown, action: string): Record<string, any> | null {
+    if (!node || typeof node !== 'object') return null;
+    const rec = node as Record<string, any>;
+    if (rec.action === action) return rec;
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'eventHandlers', 'initBlock']) {
+      const c = rec[f];
+      if (Array.isArray(c)) {
+        for (const child of c) {
+          const hit = firstAction(child, action);
+          if (hit) return hit;
+        }
+      }
+    }
+    return null;
+  }
+  const roleOf = (n: Record<string, any> | null, r: string) =>
+    n && n.roles instanceof Map ? n.roles.get(r) : undefined;
+
+  it('[en] send to a bare-identifier target captures the marked destination as expression', () => {
+    const node = parse('on click send "hello" to ChatSocket', 'en');
+    const send = firstAction(node, 'send');
+    expect(roleOf(send, 'event')).toMatchObject({ type: 'literal', value: 'hello' });
+    expect(roleOf(send, 'destination')).toMatchObject({ type: 'expression', raw: 'ChatSocket' });
+  });
+
+  it('[en] send with a call-shaped event keeps the whole call AND the destination', () => {
+    const node = parse('on click send update(value: 42) to #target', 'en');
+    const send = firstAction(node, 'send');
+    const ev = roleOf(send, 'event');
+    expect(ev?.type).toBe('expression');
+    expect(String(ev?.raw ?? '')).toContain('update');
+    expect(String(ev?.raw ?? '')).toContain('42');
+    expect(roleOf(send, 'destination')).toMatchObject({ type: 'selector', value: '#target' });
+  });
+
+  it('[ja] fused SOV send-with-detail matches the en reference role-for-role', () => {
+    const node = parse('update(value: 42) を クリック で 送る #target に', 'ja');
+    const send = firstAction(node, 'send');
+    expect(roleOf(send, 'event')?.type).toBe('expression');
+    expect(roleOf(send, 'destination')).toMatchObject({ type: 'selector', value: '#target' });
+  });
+
+  it('[en] on-handler event params are still destructured, not folded into the event name', () => {
+    // The bare-call fold must stay OFF for the `on` handler's event role.
+    const node = parse('on pointerdown(clientX, clientY) toggle .active', 'en');
+    const on = firstAction(node, 'on');
+    expect(roleOf(on, 'event')).toMatchObject({ value: 'pointerdown' });
+  });
+
+  it('[en] a plain send with a selector destination is unchanged', () => {
+    const node = parse('on click send update to #target', 'en');
+    const send = firstAction(node, 'send');
+    expect(roleOf(send, 'event')).toMatchObject({ type: 'literal', value: 'update' });
+    expect(roleOf(send, 'destination')).toMatchObject({ type: 'selector', value: '#target' });
+  });
+
+  describe('tell role alignment: patient→destination relabel over a junk literal destination', () => {
+    // `tell #modal to show`: the en reference parses destination:selector and
+    // drops the `to show` body. The generated marker extraction elsewhere bound
+    // the element to the schema-unsanctioned `patient` and the dropped body's
+    // verb to `destination` as a schema-invalid literal (`decir #modal a
+    // mostrar` → patient:selector, destination:literal="show") — a 21-language
+    // R1 miss. normalizeCommandRoles now relabels patient→destination when the
+    // patient is selector/reference-shaped and destination is absent or a junk
+    // literal.
+    const cases: Array<[string, string]> = [
+      ['es', 'en clic decir #modal a mostrar'],
+      ['ja', '#modal を クリック で 伝える 表示 に'],
+      ['qu', '#modal ta rikuchiy man ñitiy pi niy'],
+    ];
+    for (const [lang, input] of cases) {
+      it(`[${lang}] tell binds the element as destination:selector, no junk literal`, () => {
+        const node = parse(input, lang);
+        const tell = firstAction(node, 'tell');
+        expect(roleOf(tell, 'destination')).toMatchObject({ type: 'selector', value: '#modal' });
+        expect(roleOf(tell, 'patient')).toBeUndefined();
+      });
+    }
+
+    it('[en] tell with a selector destination is unchanged', () => {
+      const node = parse('on click tell #modal to show', 'en');
+      const tell = firstAction(node, 'tell');
+      expect(roleOf(tell, 'destination')).toMatchObject({ type: 'selector', value: '#modal' });
+    });
+  });
+
+  describe('wait for {event} (R1 residue: wait-for-event, the diagnosed R2-touching arc)', () => {
+    // en `wait for transitionend` captured the KEYWORD as the duration
+    // (duration:literal="for") and dropped the event name — and everything
+    // after it (`wait for X then remove me` lost the remove). Four pieces:
+    // the en `wait-en-for-event` head; the known-event duration→event relabel
+    // (marker-less translations `esperar transitionend`); the trailing
+    // event-name reclaim (SOV verb-final `待つ transitionend`); the waitMapper
+    // emitting the runtime's modifiers.for. Gated on WAITABLE_EVENT_WORDS so
+    // a time wait (`wait 2s`, `wait delay`) is never touched.
+    it('[en] wait for <event> captures the event, not the keyword', () => {
+      const node = parse('on click wait for transitionend', 'en');
+      const wait = firstAction(node, 'wait');
+      expect(roleOf(wait, 'event')).toMatchObject({ type: 'literal', value: 'transitionend' });
+      expect(roleOf(wait, 'duration')).toBeUndefined();
+    });
+
+    it('[en] a then-chain after the event wait is no longer dropped', () => {
+      const node = parse('on click wait for transitionend then remove me', 'en');
+      expect(firstAction(node, 'wait')).not.toBeNull();
+      expect(firstAction(node, 'remove')).not.toBeNull();
+    });
+
+    it('[en] time waits are unchanged (relabel gate)', () => {
+      const n1 = parse('wait 2s', 'en');
+      expect(roleOf(firstAction(n1, 'wait'), 'duration')).toMatchObject({ value: '2s' });
+      expect(roleOf(firstAction(n1, 'wait'), 'event')).toBeUndefined();
+      // A bare identifier that is NOT a known event name stays a duration
+      // (time-variable wait).
+      const n2 = parse('wait delay', 'en');
+      expect(roleOf(firstAction(n2, 'wait'), 'event')).toBeUndefined();
+    });
+
+    it('[es] a marker-less known-event wait relabels duration→event', () => {
+      const node = parse('en clic esperar transitionend', 'es');
+      const wait = firstAction(node, 'wait');
+      expect(roleOf(wait, 'event')).toMatchObject({ type: 'literal', value: 'transitionend' });
+      expect(roleOf(wait, 'duration')).toBeUndefined();
+    });
+
+    it('[ja] SOV trailing event name is reclaimed, junk default dropped', () => {
+      const node = parse('クリック で 待つ transitionend', 'ja');
+      const wait = firstAction(node, 'wait');
+      expect(roleOf(wait, 'event')).toMatchObject({ type: 'literal', value: 'transitionend' });
+      expect(roleOf(wait, 'duration')).toBeUndefined();
+    });
+
+    it('[bn] the trailing for-postposition does not anchor a phantom `for` command', () => {
+      const node = parse('ক্লিক এ অপেক্ষা transitionend জন্য', 'bn');
+      const wait = firstAction(node, 'wait');
+      expect(roleOf(wait, 'event')).toMatchObject({ type: 'literal', value: 'transitionend' });
+      expect(firstAction(node, 'for')).toBeNull();
+    });
+
+    it('[tl] the fronted-source behaviors wait line captures the event (wait-tl-from-first)', () => {
+      const node = parse('maghintay mula_sa dokumento pointermove o pointerup', 'tl');
+      const wait = firstAction(node, 'wait');
+      expect(roleOf(wait, 'event')).toMatchObject({ type: 'literal', value: 'pointermove' });
+    });
+  });
+
+  describe('leaked-article halt patient: verb-boundary extension (R1 residue, halt family)', () => {
+    // `halt the event` renders with the article leaked untranslated (`detener
+    // the evento llamar …`). The leaked-article skip declined to fire when the
+    // ref-noun was followed by a command VERB (the §7y tr gate), so the patient
+    // captured the bare article (`patient:expression="the"`) in every
+    // verb-first language — halt.patient missing ×74 (form-submit-prevent ×23
+    // + behaviors ×17 each). In SVO/VSO a ref-noun followed by a command verb
+    // IS a clause boundary (the verb opens the next juxtaposed body command),
+    // so the skip now fires there; SOV profiles are exempt (tr's fronted
+    // patient has its verb later in the clause — the original §7y fragility).
+    const svoCases: Array<[string, string]> = [
+      ['es', 'en enviar detener the evento llamar validateForm()'],
+      ['it', 'su invio fermare the evento chiamare validateForm()'],
+      ['zh', '当 提交 时 停止 把 the 事件 调用 validateForm()'],
+    ];
+    for (const [lang, input] of svoCases) {
+      it(`[${lang}] halt captures the leaked-article event reference`, () => {
+        const node = parse(input, lang);
+        const halt = firstAction(node, 'halt');
+        expect(roleOf(halt, 'patient')).toMatchObject({ type: 'reference', value: 'event' });
+      });
+    }
+
+    it('[en] halt the event is unchanged', () => {
+      const node = parse('on submit halt the event', 'en');
+      const halt = firstAction(node, 'halt');
+      expect(roleOf(halt, 'patient')).toMatchObject({ type: 'reference', value: 'event' });
+    });
+
+    it('[tr] the SOV exemption keeps the §7y parse shape (no NULL, halt present)', () => {
+      // tr is SOV: the verb-boundary must NOT fire there. This locks the parse
+      // returning a handler with a halt (the crossed roles are a known
+      // deferred residue, not this fix's concern).
+      const node = parse(
+        'the olay çağır validateForm() i gönder de durdur',
+        'tr'
+      );
+      expect(node).not.toBeNull();
+      expect(firstAction(node, 'halt')).not.toBeNull();
+    });
   });
 });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,20 +1,20 @@
 {
-  "timestamp": "2026-07-05T13:58:26.609Z",
-  "commit": "433c2af3",
+  "timestamp": "2026-07-05T15:43:30.672Z",
+  "commit": "1e50572f",
   "languages": {
     "ar": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8417754502119814,
+      "avgConfidence": 0.8399201626424081,
       "avgFidelity": 1,
       "avgPrecision": 0.9796536796536797,
-      "avgRoleFidelity": 0.9730129733806204,
+      "avgRoleFidelity": 0.9850788288288288,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -81,10 +81,6 @@
           "confidence": 1
         },
         "repeat-times": {
-          "success": true,
-          "confidence": 1
-        },
-        "halt-propagation": {
           "success": true,
           "confidence": 1
         },
@@ -456,6 +452,10 @@
           "success": true,
           "confidence": 0.7142857142857143
         },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "go-back": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8462563334743781,
       "avgFidelity": 1,
-      "avgPrecision": 0.9357467532467537,
-      "avgRoleFidelity": 0.951613264848559,
+      "avgPrecision": 0.937911255411256,
+      "avgRoleFidelity": 0.9611853369206311,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.828035456606883,
       "avgFidelity": 1,
       "avgPrecision": 0.9967532467532467,
-      "avgRoleFidelity": 0.9697954701631175,
+      "avgRoleFidelity": 0.9818613256113256,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
       "avgPrecision": 0.9859307359307358,
-      "avgRoleFidelity": 0.9746425441278382,
+      "avgRoleFidelity": 0.9867083995760464,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
       "avgPrecision": 0.9833333333333334,
-      "avgRoleFidelity": 0.9697954701631175,
+      "avgRoleFidelity": 0.9818613256113256,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3794,12 +3794,12 @@
       "avgConfidence": 0.8237889095031952,
       "avgFidelity": 1,
       "avgPrecision": 0.9864718614718616,
-      "avgRoleFidelity": 0.9808958562635034,
+      "avgRoleFidelity": 0.987331081081081,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4426,12 +4426,12 @@
       "avgConfidence": 0.8993587865768304,
       "avgFidelity": 1,
       "avgPrecision": 0.9412618766514869,
-      "avgRoleFidelity": 0.9389845647198588,
+      "avgRoleFidelity": 0.9485566367919308,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
       "avgPrecision": 0.9854978354978354,
-      "avgRoleFidelity": 0.9722085975762448,
+      "avgRoleFidelity": 0.9842744530244529,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.9779491341991341,
-      "avgRoleFidelity": 0.97631564580094,
+      "avgRoleFidelity": 0.9883815012491481,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
       "avgPrecision": 0.952981109799292,
-      "avgRoleFidelity": 0.9495266193795605,
+      "avgRoleFidelity": 0.9590986914516327,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6954,12 @@
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
       "avgPrecision": 0.9529811097992917,
-      "avgRoleFidelity": 0.944459051811993,
+      "avgRoleFidelity": 0.954031123884065,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
       "avgPrecision": 0.9811688311688311,
-      "avgRoleFidelity": 0.9735760364436835,
+      "avgRoleFidelity": 0.9856418918918919,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
       "avgPrecision": 0.9941829004329004,
-      "avgRoleFidelity": 0.9651669971522915,
+      "avgRoleFidelity": 0.9772328526004996,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8850,12 @@
       "avgConfidence": 0.7984333127190251,
       "avgFidelity": 1,
       "avgPrecision": 0.9833333333333334,
-      "avgRoleFidelity": 0.9735164180017124,
+      "avgRoleFidelity": 0.9855822734499206,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9482,12 @@
       "avgConfidence": 0.7381467738610596,
       "avgFidelity": 1,
       "avgPrecision": 0.9525172879068982,
-      "avgRoleFidelity": 0.939547627782922,
+      "avgRoleFidelity": 0.9491196998549942,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.8135642135642115,
       "avgFidelity": 1,
       "avgPrecision": 0.9915854978354979,
-      "avgRoleFidelity": 0.9674835994688937,
+      "avgRoleFidelity": 0.9795494549171019,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10746,12 +10746,12 @@
       "avgConfidence": 0.7962481962481944,
       "avgFidelity": 1,
       "avgPrecision": 0.9941558441558443,
-      "avgRoleFidelity": 0.9752652256328729,
+      "avgRoleFidelity": 0.987331081081081,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.9753246753246753,
-      "avgRoleFidelity": 0.9677088246941189,
+      "avgRoleFidelity": 0.9797746801423273,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12007,15 +12007,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8262374168168043,
+      "avgConfidence": 0.824382129247231,
       "avgFidelity": 1,
       "avgPrecision": 0.9800865800865801,
-      "avgRoleFidelity": 0.9808958562635032,
+      "avgRoleFidelity": 0.9929617117117115,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12070,10 +12070,6 @@
           "confidence": 1
         },
         "repeat-times": {
-          "success": true,
-          "confidence": 1
-        },
-        "halt-propagation": {
           "success": true,
           "confidence": 1
         },
@@ -12437,6 +12433,10 @@
           "success": true,
           "confidence": 0.7142857142857143
         },
+        "halt-propagation": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "go-back": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -12642,12 +12642,12 @@
       "avgConfidence": 0.8340114355151945,
       "avgFidelity": 1,
       "avgPrecision": 0.9520843874739979,
-      "avgRoleFidelity": 0.9491291630997513,
+      "avgRoleFidelity": 0.9587012351718235,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13274,12 +13274,12 @@
       "avgConfidence": 0.8139764996907833,
       "avgFidelity": 1,
       "avgPrecision": 0.9915854978354978,
-      "avgRoleFidelity": 0.9674835994688937,
+      "avgRoleFidelity": 0.9795494549171019,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13906,12 +13906,12 @@
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
       "avgPrecision": 0.9811958874458874,
-      "avgRoleFidelity": 0.9785839855692797,
+      "avgRoleFidelity": 0.9906498410174881,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14538,12 +14538,12 @@
       "avgConfidence": 0.9840032982890127,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9817806696483166,
+      "avgRoleFidelity": 0.9882158944658944,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 473431,
+      "bundleSize": 477801,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 473431,
+      "size": 477801,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
Four increments clearing the open residue from `docs-internal/HANDOFF-r1-post-cluster-residue.md` (the follow-on to #569/#571/#572). Corpus probe mean role-recall **0.9661 → 0.9771**; all 23 languages up, none down; zero new missing-role or spurious-action families in the per-(lang,pattern) A/B.

### 1. send en-reference noise (65 lang-patterns)
- The send schema's `[selector, reference]` destination rejected a bare-identifier target (`send "hello" to ChatSocket` → silently defaulted to `me`; socket-send ×23). Now admits `expression` (the add.destination precedent from #571).
- The event role's bare-call fold skip (an `on`-handler param-destructuring rule) truncated `send update(value: 42) to #target` to `event:literal="update"` and dropped the destination (send-with-detail ×21). The skip is now scoped to `currentPatternCommand === 'on'`.

### 2. tell role alignment (21)
The generated marker extraction bound tell's element to the schema-unsanctioned `patient` and the dropped `to <command>` body's verb to `destination` as a schema-invalid literal. `normalizeCommandRoles` now relabels patient→destination over an absent-or-junk-literal destination (the #564 schema-invalid-destination precedent). The `to show` body is still dropped in en and all translations alike (equal lossiness) — a future tell-body arc, noted in the handoff.

### 3. `wait for {event}` — the diagnosed R2-touching arc (23 + 2)
- en `wait-en-for-event` head (`wait for transitionend` no longer parses as `duration:literal="for"`); registered in `buildEnglishPatterns` — the per-command loaders are NOT auto-included there (footgun documented in the handoff).
- Known-event duration→event relabel gated on a new `WAITABLE_EVENT_WORDS` set — `wait 2s` / `wait delay` (time-variable waits) are never touched.
- Trailing event-name reclaim in `buildEventHandler` (the #561/#563 sibling) for SOV verb-final renders; drops the sov-simple `patient:reference=me` extraction-default leak and consumes bn's rendered `জন্য` for-postposition (which otherwise anchors a phantom bare `for`; a `parseBodyWithClauses` filter drops stragglers — scoped to zero-role zero-body `for` ONLY, since a bare `repeat` is a legitimate loop-recovery intermediate).
- `waitMapper` now emits the runtime's `modifiers.for`/`modifiers.from`, so event waits **execute** as event waits (R2-honest; the curated R2 subset contains no waits, so the ratchet is unaffected).
- tl gets `wait-tl-from-first` (the `wait-ar-from-first` mirror — its transformer fronts the from-phrase).
- Bonus: a then-chain after `wait for X` in a handler body is no longer dropped.

### 4. halt leaked-article patient (74 → 6)
`detener the evento llamar …`: the leaked-article skip's §7y gate declined to fire when the ref-noun was followed by a command VERB, so every verb-first language captured `patient:expression="the"`. In SVO/VSO a ref-noun followed by a command verb IS a clause boundary (the verb opens the next juxtaposed body command) — the skip now fires there via `COMMAND_ACTION_KEYWORDS`, with SOV profiles exempt (tr's fronted patient has its verb later in the clause — the original §7y fragility; guard test rescoped to tr-only). form-submit-prevent cleared in all 17 non-SOV languages + the three behaviors ×17 each. The SOV ×6 residue needs fronted-role re-association machinery — next session's menu in the handoff.

### Validation
- 15 new guard tests; fix-specific ones FAIL without the fix (verified via stash round-trip per increment).
- Six-signal `--regression` gate green against a fresh populate: parse 3696/3696, R2 1.0, degenerate/lossy 0.
- Baseline regenerated (`--save-baseline`, fresh populate): no per-language avgPrecision / avgRoleFidelity / avgFidelity decrease anywhere (checked programmatically over the diff).
- semantic 6486 passed, core 7012 passed, i18n 912 passed, typecheck clean. patterns.db not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)