### PR TITLE
docs: slim root CLAUDE.md (1102 → 699 lines), refresh stale claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **HyperFixi** is a complete \_hyperscript ecosystem with server-side compilation, multi-language i18n (24 languages including SOV/VSO grammar transformation), semantic-first multilingual parsing, and comprehensive developer tooling. Engine packages are published under `@hyperfixi/*`, multilingual packages under `@lokascript/*`.
 
-- **8100+ tests** passing across all suites
+- **14,000+ tests** passing across all suites (core ~7000, semantic ~6500, i18n ~900, plus per-package suites)
 - **203 KB** browser bundle (gzipped, 39% reduction from original)
 - **\_hyperscript compatible** — tested via gallery examples, bundle compatibility matrix, and command/expression browser tests (Playwright)
 
@@ -120,7 +120,7 @@ npm run test:quick --prefix packages/core           # Build + test (<10 sec)
 npm run test:comprehensive --prefix packages/core   # Full browser suite
 
 # Unit tests
-npm test --prefix packages/core                     # Run vitest (5700+ tests)
+npm test --prefix packages/core                     # Run vitest (7000+ tests)
 npm test --prefix packages/core -- --run src/expressions/  # Test specific module
 
 # Build
@@ -141,7 +141,7 @@ cd packages/core && npx playwright test src/compatibility/
 
 ```bash
 # Tests
-npm test --prefix packages/i18n                     # Run vitest (90+ grammar tests)
+npm test --prefix packages/i18n                     # Run vitest (900+ tests)
 npx vitest run src/grammar/grammar.test.ts          # Grammar transformation tests
 
 # Build
@@ -155,7 +155,7 @@ npm run typecheck --prefix packages/i18n
 
 ```bash
 # Tests
-npm test --prefix packages/semantic                     # Run vitest (3100+ tests)
+npm test --prefix packages/semantic                     # Run vitest (6400+ tests)
 npm test --prefix packages/semantic -- --run            # Single run
 
 # Build
@@ -261,7 +261,7 @@ The four PR-only jobs already ran against the merged-as-PR code, so re-running t
 **Known Issues:**
 
 - Experimental behaviors (Draggable, Sortable, Resizable) still run imperative JS installers; migration to the compiled hyperscript `source` path is in progress. Curated (5) + optional (3) behaviors already run the source-compiled path and are fully tested (behaviors suite green).
-- SOV/VSO languages (Japanese, Korean, Turkish, Hindi) have lower round-trip **fidelity** than SVO languages — every non-behavior pattern parses in all 24 priority languages, but faithful command-for-command translation still lags on the hardest reorders. Tracked by the multilingual fidelity ratchet (not `continue-on-error`).
+- The SOV six (hi, qu, ko, tr, ja, bn) have lower **role fidelity** (R1 ~0.95 vs corpus ~0.98) than SVO languages — every pattern parses faithfully at the command level in all 24 priority languages, but role-level capture still lags on the hardest reorders. Tracked by the multilingual fidelity ratchet (not `continue-on-error`); remaining arcs in `docs-internal/MULTILINGUAL_NEXT_STEPS.md`.
 
 ### Multilingual parse rate ≠ fidelity
 
@@ -276,20 +276,20 @@ the fraction of the English reference parse's command actions present in each
 translation. By fidelity, passes fall into three bands, each tracked per-language in
 the committed baseline:
 
-- **degenerate** (fid < 0.5 — lost most of the structure): `degeneratePasses`. ~39.
+- **degenerate** (fid < 0.5 — lost most of the structure): `degeneratePasses`. **0.**
 - **lossy** (0.5 ≤ fid < 1.0 — parses, clears the floor, but silently drops ≥1
-  command): `lossyPasses`. **~113 — the larger correctness band.** See
-  `docs-internal/CORRECTNESS_RELIABILITY_PLAN.md`.
-- **faithful** (fid = 1.0). ~3534. Cross-language `avgFidelity` ≈ 0.98,
-  `avgPrecision` ≈ 0.96, `avgRoleFidelity` ≈ 0.83 (the laggard — SOV reorders).
+  command): `lossyPasses`. **0.** (Both bands were burned down across #492–#506;
+  history in `docs-internal/MULTILINGUAL_ROADMAP.md`.)
+- **faithful** (fid = 1.0). **3696 / 3696.** Cross-language `avgFidelity` = 1.000,
+  `avgPrecision` ≈ 0.976, `avgRoleFidelity` ≈ 0.977 (the SOV six sit ~0.95 —
+  the remaining headroom).
 
-> **Figures snapshot:** the band counts and averages above are illustrative as of
-> the **2026-06-15** baseline (commit `0af855c0`, `browser-priority` bundle, 3686 /
-> 3696 patterns passing). They drift as work lands — the **authoritative** numbers
-> always live in the committed baseline,
+> **Figures snapshot:** as of the **2026-07-05** baseline. They drift as work lands
+> — the **authoritative** numbers always live in the committed baseline,
 > `packages/testing-framework/baselines/multilingual-priority.json` (its `timestamp`
 > and `commit` fields stamp each regeneration). Treat the prose here as orientation,
-> not truth.
+> not truth. Current plan + per-arc history:
+> `docs-internal/MULTILINGUAL_NEXT_STEPS.md`.
 
 The `--regression` gate ratchets on **six** signals (each fails CI; each guarded so
 an un-regenerated baseline never retro-flags — a baseline lacking a signal's field
@@ -315,18 +315,12 @@ yields a 0 delta):
 After an _intentional_ fidelity change, regenerate the baseline (`--save-baseline`).
 **The baseline must be regenerated against a freshly `populate`d patterns.db** — a
 baseline generated against a stale/transitional DB will read as drifted.
-`populate` is **deterministic run-to-run** (verified 2026-06-28: two back-to-back
-populates produce byte-identical `pattern_translations`, and the gate parse/score is
-identical across separate processes; the one `readdir` in the load path —
-`db-stamp.ts` — is already `.sort()`ed). The ratchet tolerances (3 lossy / 3
-degenerate flips, avgFidelity 0.02) are therefore **conservative cross-machine
-headroom** (Mac-generated baseline vs CI Linux float/collation drift), not absorbers
-of local run-to-run jitter — so don't read a green gate as "within noise." (The
-earlier "minor residual jitter" caveat here was stale; the staleness it described was
-a stale _code-version_ DB snapshot, fixed by re-`populate`, not run jitter.) The
-degenerate and lossy bands are now both **0** (every priority-corpus pattern parses
-faithfully); the remaining fidelity headroom is R1 role-fidelity, tracked in
-`docs-internal/MULTILINGUAL_NEXT_STEPS.md`.
+`populate` is **deterministic run-to-run**, so the ratchet tolerances (3 lossy / 3
+degenerate flips, avgFidelity 0.02) are **conservative cross-machine headroom**
+(Mac-generated baseline vs CI Linux float/collation drift), not absorbers of local
+run-to-run jitter — don't read a green gate as "within noise." The remaining
+fidelity headroom is R1 role-fidelity (SOV six) and R0-precision spurious-action
+families, tracked in `docs-internal/MULTILINGUAL_NEXT_STEPS.md`.
 
 #### Running the multilingual `--regression` gate locally
 
@@ -577,174 +571,45 @@ registerCustomKeywords('my-lang', {
 
 ## Debugging Tools
 
-### Compilation Metadata
-
-Every compilation returns metadata about which parser was used and any warnings:
+Quick reference — full detail in [packages/core/docs/API.md](packages/core/docs/API.md).
 
 ```javascript
-const result = hyperfixi.compile('toggle .active');
-console.log(result.metadata);
-// {
-//   parserUsed: 'semantic',
-//   semanticConfidence: 0.98,
-//   semanticLanguage: 'en',
-//   warnings: []
-// }
-```
+// Which parser handled a compile, and with what confidence:
+hyperfixi.compile('toggle .active').metadata;
+// { parserUsed: 'semantic', semanticConfidence: 0.98, semanticLanguage: 'en', warnings: [] }
 
-This helps identify:
+// Debug logging (persists via localStorage, works in production builds):
+hyperfixi.debugControl.enable(); // or: localStorage.setItem('hyperfixi:debug', '*') + reload
+// Log prefixes: ATTR:/SCRIPT:/SCAN: (attribute-processor) · PARSE: · CMD: · EXPR:
 
-- Which parser processed the code (semantic vs traditional)
-- Confidence score if semantic parser was used
-- Any warnings about ambiguous type conversions or potential issues
-
-### Enable Debug Logging
-
-In browser console:
-
-```javascript
-hyperfixi.debugControl.enable(); // Enable detailed logging
-hyperfixi.debugControl.disable(); // Disable logging
-hyperfixi.debugControl.isEnabled(); // Check status
-hyperfixi.debugControl.status(); // Get detailed status
-```
-
-Or set localStorage directly:
-
-```javascript
-localStorage.setItem('hyperfixi:debug', '*');
-// Then reload page
-```
-
-Debug logging persists across page reloads via localStorage and works in production builds.
-
-**Debug Log Categories:**
-
-| Prefix    | Module              | Description                      |
-| --------- | ------------------- | -------------------------------- |
-| `ATTR:`   | attribute-processor | DOM scanning, element processing |
-| `SCRIPT:` | attribute-processor | Script tag compilation           |
-| `SCAN:`   | attribute-processor | Document scanning                |
-| `PARSE:`  | parser              | Tokenization, AST building       |
-| `CMD:`    | commands            | Command execution                |
-| `EXPR:`   | expressions         | Expression evaluation            |
-
-### Debug Events
-
-Listen to semantic parse events to understand parser decisions:
-
-```javascript
-window.addEventListener('hyperfixi:semantic-parse', e => {
-  console.log('Semantic parse:', e.detail);
-  // {
-  //   input: 'toggle .active',
-  //   language: 'en',
-  //   confidence: 0.95,
-  //   semanticSuccess: true,
-  //   command: 'toggle',
-  //   roles: { patient: '.active' }
-  // }
-});
-```
-
-### Debug Statistics
-
-Get parsing statistics:
-
-```javascript
-const stats = hyperfixi.semanticDebug.getStats();
-console.log(stats);
-// {
-//   totalParses: 42,
-//   semanticSuccesses: 38,
-//   semanticFallbacks: 4,
-//   traditionalParses: 0,
-//   averageConfidence: 0.91
-// }
+// Per-parse decisions and running stats:
+window.addEventListener('hyperfixi:semantic-parse', e => console.log(e.detail));
+hyperfixi.semanticDebug.getStats(); // { totalParses, semanticSuccesses, semanticFallbacks, averageConfidence }
 ```
 
 ### API v2 (Recommended)
 
-The new API provides cleaner methods with structured results:
-
 ```javascript
 import { hyperscript } from 'hyperfixi';
 
-// Compile (sync) - returns CompileResult with ok/errors/meta
-const result = hyperscript.compileSync('toggle .active');
-if (result.ok) {
-  console.log('Parser:', result.meta.parser); // 'semantic' or 'traditional'
-}
-
-// Compile + execute in one call
-await hyperscript.eval('add .clicked to me', element);
-
-// Async compilation (for language loading)
-const asyncResult = await hyperscript.compileAsync(code, { language: 'ja' });
-
-// Validation
-const validation = await hyperscript.validate('toggle .active');
-if (!validation.valid) {
-  console.error(validation.errors);
-}
-
-// Context with parent inheritance
-const parent = hyperscript.createContext();
-const child = hyperscript.createContext(element, parent);
+const result = hyperscript.compileSync('toggle .active'); // CompileResult { ok, errors, meta }
+await hyperscript.eval('add .clicked to me', element); // compile + execute
+await hyperscript.compileAsync(code, { language: 'ja' }); // async (language loading)
+await hyperscript.validate('toggle .active'); // { valid, errors }
 ```
 
-**Options:**
-
-- `language?: string` - Language code (e.g., 'en', 'ja', 'es')
-- `confidenceThreshold?: number` - Min confidence for semantic parsing (0-1)
-- `traditional?: boolean` - Force traditional parser
-
-See [packages/core/docs/API.md](packages/core/docs/API.md) for complete documentation.
-
-> **Note:** Legacy methods (`compile()`, `run()`, `evaluate()`) still work but show deprecation warnings. Migrate to `compileSync()`, `eval()`, `validate()` for new code.
+Options: `language?`, `confidenceThreshold?` (0–1), `traditional?` (force traditional parser).
+Legacy methods (`compile()`, `run()`, `evaluate()`) still work but log deprecation warnings.
 
 ## Type Safety: Environment-Specific Conditional Types
 
-HyperFixi uses TypeScript conditional types for zero-cost type safety across browser and server environments:
-
-**Browser code** (full DOM type safety):
-
-```typescript
-import type { BrowserEventPayload } from '@hyperfixi/core/registry/browser';
-
-const payload: BrowserEventPayload = {
-  type: 'click',
-  target: element, // ✅ Must be Element
-  nativeEvent: event, // ✅ Must be Event
-};
-```
-
-**Server code** (prevents DOM API misuse):
-
-```typescript
-import type { ServerEventPayload } from '@lokascript/server-integration';
-
-const payload: ServerEventPayload = {
-  type: 'request',
-  data: { request, response },
-  target: null, // ✅ Generic object
-  // nativeEvent        // ❌ TypeScript error - not available in Node.js
-};
-```
-
-**Universal code** (works in both):
-
-```typescript
-import type { UniversalEventPayload } from '@hyperfixi/core/registry/universal';
-
-function handle(payload: UniversalEventPayload) {
-  if (payload.target instanceof Element) {
-    payload.target.classList.add('active'); // ✅ Type-safe
-  }
-}
-```
-
-See [TYPE_SAFETY_DESIGN.md](docs-internal/analysis/TYPE_SAFETY_DESIGN.md) for implementation details.
+Zero-cost conditional types keep browser and server code honest: browser code uses
+`BrowserEventPayload` (`@hyperfixi/core/registry/browser` — target must be Element,
+nativeEvent must be Event); server code uses `ServerEventPayload`
+(`@lokascript/server-integration` — no `nativeEvent`, using it is a type error);
+code for both uses `UniversalEventPayload` (`@hyperfixi/core/registry/universal`)
+and narrows with `instanceof`. See
+[TYPE_SAFETY_DESIGN.md](docs-internal/analysis/TYPE_SAFETY_DESIGN.md).
 
 ## Important Files
 
@@ -801,302 +666,34 @@ hyperfixi({
 
 ## Browser Bundles
 
-### Choosing your bundle
+Full reference — decision tree, htmx-compat layer (`hx-live`, `sse-connect`/`sse-swap`,
+`ws-connect`/`ws-send`, localized attribute names), lifecycle events, custom bundle
+generator, and semantic regional bundles — lives in
+[docs/BROWSER_BUNDLES.md](docs/BROWSER_BUNDLES.md).
 
-Decision tree for the most common cases:
+Quick selection (sizes gzipped):
 
-1. **Using `@hyperfixi/vite-plugin`?** Don't pick a bundle by hand — the plugin scans your project and emits the right one (minimal handcrafted when possible, falls back to `hx-v4` when it spots htmx v4 features). See [vite plugin README](packages/vite-plugin/README.md).
-2. **Need `hx-live`, `bind`, `when`, SSE, or WebSocket?** Use `hyperfixi-hx-v4.js` (~257 KB gz). Single script tag, everything auto-installed. The size cost buys correctness — the slim runtime can't satisfy these features (its `set` doesn't fire `notifyGlobalWrite`, the slim parser doesn't know reactive features, and SSE/WS modules aren't wired).
-3. **Need only htmx v1/v2 attributes (`hx-get`/`hx-post`/etc.)?** Use `hyperfixi-hx.js` (~13 KB gz). Includes htmx-compat + the slim hybrid runtime for `_=` attributes. No reactivity, no streaming.
-4. **Pure hyperscript (`_=` attributes), ~85% feature coverage, smallest realistic size?** Use `hyperfixi-hybrid-complete.js` (~7.3 KB gz). Full AST parser, expressions, event modifiers, block commands (`if`, `for`, `repeat`, `while`, `fetch`).
-5. **Tiny static page (toggle / show / hide / put / set)?** Use `hyperfixi-lite.js` (~1.9 KB gz). Regex parser, 8 commands. Drops to `hyperfixi-lite-plus.js` (~2.6 KB gz) if you need a few more commands + i18n aliases.
-6. **Authoring in multiple languages (Japanese, Korean, Arabic, etc.) or need the full semantic parser at runtime?** Use `hyperfixi.js` (full bundle, ~203 KB gz) or `hyperfixi-multilingual.js` (~64 KB, parser-free i18n via the semantic bundle loaded separately).
+| Bundle                         | Size     | Use case                                                                                   |
+| ------------------------------ | -------- | ------------------------------------------------------------------------------------------ |
+| via `@hyperfixi/vite-plugin`   | minimal  | **Default for Vite projects** — scans usage, emits the right bundle                        |
+| `hyperfixi-lite.js`            | 1.9 KB   | Tiny static page (8 commands, regex parser)                                                |
+| `hyperfixi-hybrid-complete.js` | 7.3 KB   | Pure hyperscript, ~85% coverage (AST parser, blocks, modifiers)                            |
+| `hyperfixi-hx.js`              | 9.7 KB   | + htmx v1/v2 attributes (`hx-get` etc.); no reactivity/streaming                           |
+| `hyperfixi-hx-v4.js`           | ~257 KB  | `hx-live`, `bind`, `when`, SSE, WebSocket — full runtime + reactivity                      |
+| `hyperfixi.js`                 | 203.5 KB | Full bundle with parser (`window.hyperfixi`)                                               |
+| `hyperfixi-multilingual.js`    | 64.3 KB  | Multilingual, parser-free (pair with a semantic bundle)                                    |
+| semantic bundles               | 16–90 KB | `LokaScriptSemantic*` globals; regional subsets (en/es/western/east-asian/priority/all-24) |
 
-Rule of thumb: start as small as you can; upgrade when you hit a missing feature. The vite plugin removes this decision entirely for projects that use it.
+Rule of thumb: start as small as you can; upgrade when you hit a missing feature.
+The vite plugin removes this decision entirely.
 
-### Core Bundles
-
-| Bundle                                               | Global                  | Size (gzip) | Use Case                             |
-| ---------------------------------------------------- | ----------------------- | ----------- | ------------------------------------ |
-| `packages/core/dist/hyperfixi.js`                    | `window.hyperfixi`      | 203.5 KB    | Full bundle with parser              |
-| `packages/behaviors/dist/resolver.browser.global.js` | `HyperFixiBehaviors`    | 3.8 KB      | Lazy behavior resolver (8 behaviors) |
-| `packages/core/dist/hyperfixi-multilingual.js`       | `window.hyperfixi`      | 64.3 KB     | Multilingual (no parser)             |
-| `packages/i18n/dist/lokascript-i18n.min.js`          | `window.LokaScriptI18n` | 35.0 KB     | Grammar transformation               |
-
-> **Note**: As of v2.0.0, the primary bundles are `hyperfixi-*.js`. Backward-compatible aliases (`lokascript-*.js`) are provided but will be removed in v3.0.0. See [MIGRATION.md](MIGRATION.md).
-
-### Lite Bundles (Size-Optimized)
-
-For projects prioritizing bundle size over features:
-
-| Bundle                         | Size (gzip) | Commands  | Features                                                      |
-| ------------------------------ | ----------- | --------- | ------------------------------------------------------------- |
-| `hyperfixi-lite.js`            | 1.9 KB      | 8         | Regex parser, basic commands                                  |
-| `hyperfixi-lite-plus.js`       | 2.6 KB      | 14        | Regex parser, more commands, i18n aliases                     |
-| `hyperfixi-hybrid-complete.js` | 7.3 KB      | 21+blocks | Full AST parser, expressions, event modifiers                 |
-| `hyperfixi-hx.js`              | 9.7 KB      | 21+blocks | hybrid-complete + htmx/fixi attribute support                 |
-| `hyperfixi-hx-v4.js`           | ~257 KB     | 40+blocks | Full runtime + htmx-compat + reactivity (hx-live, bind, when) |
-
-**Hybrid Complete** (~85% hyperscript coverage) is recommended - it supports:
-
-- Full expression parser with operator precedence
-- Block commands: `repeat N times`, `for each`, `if/else/else if`, `unless`, `fetch`, `while`, `async`
-- Event modifiers: `.once`, `.prevent`, `.stop`, `.debounce(N)`, `.throttle(N)`
-- Positional expressions: `first`, `last`, `next`, `previous`, `closest`, `parent`
-- Function calls and method chaining: `str.toUpperCase()`, `arr.join('-')`
-- HTML selectors: `<button.class#id/>`
-- i18n keyword aliases
+Multilingual usage (execute/translate in any of 24 languages):
 
 ```html
-<!-- Example: Hybrid Complete with expressions and blocks -->
-<button
-  _="on click
-  set :total to #price's textContent then
-  set :tax to :total * 0.1 then
-  put :total + :tax into #grand-total"
->
-  Calculate Total
-</button>
-
-<button
-  _="on click.debounce(300)
-  if me has .loading
-    return
-  end then
-  add .loading then
-  fetch /api/data as json then
-  for each item in result
-    append item.name to #results
-  end then
-  remove .loading"
->
-  Load Data
-</button>
-```
-
-**Hybrid-HX** adds htmx and fixi attribute compatibility for declarative AJAX:
-
-```html
-<!-- htmx-style attributes (hybrid-hx bundle) -->
-<button hx-get="/api/users" hx-target="#users-list" hx-swap="innerHTML">Load Users</button>
-
-<!-- fixi-style attributes (also supported) -->
-<button fx-action="/api/users" fx-target="#users-list" fx-swap="innerHTML">Load Users</button>
-
-<!-- hx-on:* for inline hyperscript -->
-<button hx-on:click="toggle .active on me">Toggle</button>
-```
-
-Fixi features include request dropping (anti-double-submit), `fx-ignore` attribute, and a rich event lifecycle (`fx:init`, `fx:config`, `fx:before`, `fx:after`, `fx:error`, `fx:finally`, `fx:swapped`).
-
-### `hx-live` reactive expressions (htmx v4)
-
-When `@hyperfixi/reactivity` is installed, the htmx-compat layer recognizes the htmx v4 `hx-live` attribute and translates it to a `live ... end` block. The body is hyperscript syntax (not JavaScript like upstream htmx v4) — it gets fine-grained dependency tracking and inherits hyperscript's multilingual support:
-
-```html
-<div hx-live="put $count into me"></div>
-```
-
-The expression re-runs only when its tracked dependencies actually change (not on every DOM mutation, which is the upstream htmx v4 approach). If reactivity isn't installed, the element is skipped with a clear console error pointing to the install command.
-
-**Easiest path: use the `hyperfixi-hx-v4.js` bundle.** It ships the full runtime + `@hyperfixi/reactivity` auto-installed + the htmx-compat layer in a single script tag. Larger than `hyperfixi-hx.js` (~257 KB vs 13 KB gzipped) but no manual plugin wiring required. For size-tuned production builds, use `@hyperfixi/vite-plugin` instead.
-
-```html
-<script src="hyperfixi-hx-v4.js"></script>
-<div hx-live="put $count into me"></div>
-<button _="on click set $count to ($count or 0) + 1">+1</button>
-```
-
-See the working demos in [`examples/hx-v4/`](examples/hx-v4/).
-
-### `sse-connect` / `sse-swap` (htmx v4)
-
-The htmx-compat processor recognizes `sse-connect="<url>"` to open a long-lived `EventSource` against the URL, and `sse-swap="<event-name>[, <event-name>...]"` to route named events through the existing `hx-target` / `hx-swap` machinery.
-
-```html
-<!-- Stream incoming `tick` events into #notifications -->
-<div sse-connect="/events" sse-swap="tick" hx-target="#notifications" hx-swap="beforeend"></div>
-
-<!-- One connection, multiple named events -->
-<div
-  sse-connect="/feed"
-  sse-swap="post, like, comment"
-  hx-target="#timeline"
-  hx-swap="afterbegin"
-></div>
-```
-
-The connection auto-reconnects on transient errors with exponential backoff (1s → 2s → 4s …, capped at 30s, 5 retries before giving up). On element removal from the DOM, the connection is closed automatically via MutationObserver — no leaks. Custom lifecycle events fire on the element: `htmx:sseOpen`, `htmx:sseMessage`, `htmx:sseError`, `htmx:sseClose`.
-
-The `hyperfixi-hx-v4.js` bundle bundles this support; the slim `hyperfixi-hx.js` doesn't ship the SSE module (size budget).
-
-### `ws-connect` / `ws-send` (htmx v4)
-
-WebSocket support follows the same shape as SSE but is bidirectional. `ws-connect="<url>"` on an element opens a per-element WebSocket; `ws-send` on a descendant form or button forwards a JSON-serialized payload over the socket on submit/click.
-
-```html
-<div ws-connect="wss://example/api">
-  <form ws-send>
-    <input name="msg" />
-    <button type="submit">Send</button>
-  </form>
-</div>
-```
-
-Incoming messages are routed two ways:
-
-- **JSON envelope** `{ target, swap?, data }` → applies through the existing `hx-target`/`hx-swap` machinery, letting the server drive surgical updates without the client knowing the layout up front.
-- **Anything else** → dispatched as `htmx:wsMessage` with the raw text; consumers can subscribe and route however they like.
-
-Reconnect on unclean close uses the same bounded exponential backoff as SSE (1s → 2s → 4s … capped at 30s, 5 retries). Outbound sends queue while the socket is connecting and flush on `htmx:wsOpen`. Lifecycle events: `htmx:wsOpen`, `htmx:wsMessage`, `htmx:wsError`, `htmx:wsClose`.
-
-> **When to use SSE vs WS:** prefer SSE for server-push streams (notifications, telemetry, live feeds) — it's HTTP-native, plays nice with proxies and HTTP/2, and the browser handles reconnect. Reach for WebSockets when you genuinely need a low-latency bidirectional channel (chat, collaborative editing, control planes). SSE is the documented default for that reason.
-
-The `hyperfixi-hx-v4.js` bundle bundles this support; the slim `hyperfixi-hx.js` doesn't.
-
-### Localized htmx attribute names (Phase 8)
-
-The htmx-compat layer in `hyperfixi-hx-v4.js` recognizes localized attribute names per-element based on the nearest `lang=` ancestor. Spanish authors can write `hx-obtener` / `hx-objetivo` / `sse-conectar`; Japanese authors `hx-取得` / `hx-ターゲット`; Arabic `hx-احصل` / `hx-هدف`. The orchestrator translates them to canonical English (`hx-get` / `hx-target` / `sse-connect`) before they hit the existing processor paths.
-
-```html
-<script src="hyperfixi-hx-v4.js"></script>
-<!-- Opt in to languages by loading their vocab modules. -->
-<script src="packages/core/vocab/htmx/es.js"></script>
-<script src="packages/core/vocab/htmx/ja.js"></script>
-
-<section lang="es">
-  <button hx-obtener="/api/usuarios" hx-objetivo="#out">Cargar</button>
-</section>
-<section lang="ja">
-  <button hx-取得="/api/ユーザー" hx-ターゲット="#out">読み込む</button>
-</section>
-```
-
-**Resolution order** for `langOf(element)`:
-
-1. `data-hyperfixi-lang` on the element itself
-2. `data-hyperfixi-lang` on any ancestor
-3. `lang=` on any ancestor (HTML standard)
-4. `'en'` fallback
-
-Regional variants collapse to base codes (`es-MX` → `es`). Elements outside any lang scope use English literals — same behavior as before Phase 8. Missing-vocab langs log a one-time console warning per language and fall back to English.
-
-**Bundled vocab modules** (`packages/core/vocab/htmx/`) cover 8 priority languages — en, es, fr, ja, zh, ar, ko, de. Each is a self-registering `<script>` tag (loka-js convention). To add another language: edit the keyword translations in `packages/semantic/src/generators/profiles/{lang}.ts` and run `npm run generate:htmx-vocab --prefix packages/core`.
-
-**The `hx-` / `sse-` / `ws-` prefixes are preserved across languages** — only the suffix is localized. Spanish writes `hx-obtener`, not `xx-obtener`. The brand prefix doubles as a discovery anchor.
-
-**Out of scope** for this arc: localizing the `_=` hyperscript attribute itself. The vocab orchestrator translates htmx-compat attribute names only.
-
-See the live demos in [`examples/hx-v4-i18n/`](examples/hx-v4-i18n/).
-
-### htmx Lifecycle Events
-
-The htmx compatibility layer dispatches CustomEvents at key points in the request lifecycle:
-
-| Event                | When                                                | Cancelable | Detail                     |
-| -------------------- | --------------------------------------------------- | ---------- | -------------------------- |
-| `htmx:configuring`   | After attributes collected, before translation      | Yes        | `{ config, element }`      |
-| `htmx:beforeRequest` | Before hyperscript execution                        | Yes        | `{ element, url, method }` |
-| `htmx:afterSettle`   | After successful execution                          | No         | `{ element, target }`      |
-| `htmx:error`         | On execution failure                                | No         | `{ element, error }`       |
-| `htmx:sseOpen`       | SSE connection opens                                | No         | `{ url }`                  |
-| `htmx:sseMessage`    | SSE message received (any event)                    | No         | `{ url, event?, data }`    |
-| `htmx:sseError`      | SSE error / connection lost                         | No         | `{ url, error or event }`  |
-| `htmx:sseClose`      | SSE connection closed (manual or after retry limit) | No         | `{ url }`                  |
-| `htmx:wsOpen`        | WS connection opens                                 | No         | `{ url }`                  |
-| `htmx:wsMessage`     | WS message received (raw or envelope)               | No         | `{ url, envelope?, data }` |
-| `htmx:wsError`       | WS error                                            | No         | `{ url, error or event }`  |
-| `htmx:wsClose`       | WS connection closed                                | No         | `{ url, code, reason }`    |
-
-**Example usage:**
-
-```javascript
-// Intercept and modify config before processing
-document.addEventListener('htmx:configuring', e => {
-  e.detail.config.headers = { 'X-Custom': 'value' };
-});
-
-// Cancel request based on condition
-document.addEventListener('htmx:beforeRequest', e => {
-  if (someCondition) {
-    e.preventDefault(); // Cancels execution
-  }
-});
-
-// React to successful completion
-document.addEventListener('htmx:afterSettle', e => {
-  console.log('Request completed for:', e.detail.url);
-});
-
-// Handle errors
-document.addEventListener('htmx:error', e => {
-  showErrorNotification(e.detail.error.message);
-});
-```
-
-### Custom Bundle Generator
-
-Generate minimal bundles with only the commands you need:
-
-```bash
-cd packages/core
-
-# Generate from config file
-npm run generate:bundle -- --config bundle-configs/textshelf.config.json
-
-# Generate from command line with blocks and positional expressions
-npm run generate:bundle -- --commands toggle,add,set --blocks if,repeat --positional --output src/my-bundle.ts
-```
-
-See [bundle-configs/README.md](packages/core/bundle-configs/README.md) for full documentation.
-
-### Semantic Bundles (Regional Options)
-
-| Bundle                                    | Global                        | Size (gzip) | Languages          |
-| ----------------------------------------- | ----------------------------- | ----------- | ------------------ |
-| `browser.global.js`                       | `LokaScriptSemantic`          | 90 KB       | All 24             |
-| `browser-priority.priority.global.js`     | `LokaScriptSemanticPriority`  | 48 KB       | 11 priority        |
-| `browser-western.western.global.js`       | `LokaScriptSemanticWestern`   | 30 KB       | en, es, pt, fr, de |
-| `browser-east-asian.east-asian.global.js` | `LokaScriptSemanticEastAsian` | 24 KB       | ja, zh, ko         |
-| `browser-es-en.es-en.global.js`           | `LokaScriptSemanticEsEn`      | 25 KB       | en, es             |
-| `browser-en.en.global.js`                 | `LokaScriptSemanticEn`        | 20 KB       | en only            |
-| `browser-es.es.global.js`                 | `LokaScriptSemanticEs`        | 16 KB       | es only            |
-
-Choose the smallest bundle that covers your target languages. See `packages/semantic/README.md` for details.
-
-### Multilingual Bundle (Recommended for i18n)
-
-For developers writing hyperscript in their native language:
-
-```html
-<!-- Load both bundles -->
 <script src="lokascript-semantic.browser.global.js"></script>
 <script src="hyperfixi-multilingual.js"></script>
 <script>
-  // Execute in any of 24 supported languages
-  await hyperfixi.execute('토글 .active', 'ko');      // Korean
-  await hyperfixi.execute('トグル .active', 'ja');    // Japanese
-  await hyperfixi.execute('alternar .active', 'es');  // Spanish
-
-  // Translate between languages
+  await hyperfixi.execute('토글 .active', 'ko');
   const korean = await hyperfixi.translate('toggle .active', 'en', 'ko');
-</script>
-```
-
-**Total size:** ~511 KB (250 KB + 261 KB) vs 924 KB with full bundle
-
-### Full Bundle Usage
-
-```html
-<script src="hyperfixi.js"></script>
-<script src="lokascript-i18n.min.js"></script>
-<script src="lokascript-semantic.browser.global.js"></script>
-<script>
-  // Grammar transformation (i18n)
-  const result = LokaScriptI18n.translate('on click toggle .active', 'en', 'ja');
-
-  // Semantic parsing (24 languages)
-  const parsed = LokaScriptSemantic.parse('トグル .active', 'ja');
-  const translations = LokaScriptSemantic.getAllTranslations('toggle .active', 'en');
 </script>
 ```

--- a/docs/BROWSER_BUNDLES.md
+++ b/docs/BROWSER_BUNDLES.md
@@ -1,0 +1,306 @@
+# Browser Bundles — full reference
+
+> Relocated from the root CLAUDE.md (which keeps only the decision tree and
+> summary table). This is the complete reference for bundle selection, the
+> htmx-compat layer (hx-live / SSE / WebSocket / localized attributes), the
+> lifecycle events, and the custom bundle generator.
+
+## Choosing your bundle
+
+Decision tree for the most common cases:
+
+1. **Using `@hyperfixi/vite-plugin`?** Don't pick a bundle by hand — the plugin scans your project and emits the right one (minimal handcrafted when possible, falls back to `hx-v4` when it spots htmx v4 features). See [vite plugin README](../packages/vite-plugin/README.md).
+2. **Need `hx-live`, `bind`, `when`, SSE, or WebSocket?** Use `hyperfixi-hx-v4.js` (~257 KB gz). Single script tag, everything auto-installed. The size cost buys correctness — the slim runtime can't satisfy these features (its `set` doesn't fire `notifyGlobalWrite`, the slim parser doesn't know reactive features, and SSE/WS modules aren't wired).
+3. **Need only htmx v1/v2 attributes (`hx-get`/`hx-post`/etc.)?** Use `hyperfixi-hx.js` (~13 KB gz). Includes htmx-compat + the slim hybrid runtime for `_=` attributes. No reactivity, no streaming.
+4. **Pure hyperscript (`_=` attributes), ~85% feature coverage, smallest realistic size?** Use `hyperfixi-hybrid-complete.js` (~7.3 KB gz). Full AST parser, expressions, event modifiers, block commands (`if`, `for`, `repeat`, `while`, `fetch`).
+5. **Tiny static page (toggle / show / hide / put / set)?** Use `hyperfixi-lite.js` (~1.9 KB gz). Regex parser, 8 commands. Drops to `hyperfixi-lite-plus.js` (~2.6 KB gz) if you need a few more commands + i18n aliases.
+6. **Authoring in multiple languages (Japanese, Korean, Arabic, etc.) or need the full semantic parser at runtime?** Use `hyperfixi.js` (full bundle, ~203 KB gz) or `hyperfixi-multilingual.js` (~64 KB, parser-free i18n via the semantic bundle loaded separately).
+
+Rule of thumb: start as small as you can; upgrade when you hit a missing feature. The vite plugin removes this decision entirely for projects that use it.
+
+## Core Bundles
+
+| Bundle                                               | Global                  | Size (gzip) | Use Case                             |
+| ---------------------------------------------------- | ----------------------- | ----------- | ------------------------------------ |
+| `packages/core/dist/hyperfixi.js`                    | `window.hyperfixi`      | 203.5 KB    | Full bundle with parser              |
+| `packages/behaviors/dist/resolver.browser.global.js` | `HyperFixiBehaviors`    | 3.8 KB      | Lazy behavior resolver (8 behaviors) |
+| `packages/core/dist/hyperfixi-multilingual.js`       | `window.hyperfixi`      | 64.3 KB     | Multilingual (no parser)             |
+| `packages/i18n/dist/lokascript-i18n.min.js`          | `window.LokaScriptI18n` | 35.0 KB     | Grammar transformation               |
+
+> **Note**: As of v2.0.0, the primary bundles are `hyperfixi-*.js`. Backward-compatible aliases (`lokascript-*.js`) are provided but will be removed in v3.0.0. See [MIGRATION.md](../MIGRATION.md).
+
+## Lite Bundles (Size-Optimized)
+
+For projects prioritizing bundle size over features:
+
+| Bundle                         | Size (gzip) | Commands  | Features                                                      |
+| ------------------------------ | ----------- | --------- | ------------------------------------------------------------- |
+| `hyperfixi-lite.js`            | 1.9 KB      | 8         | Regex parser, basic commands                                  |
+| `hyperfixi-lite-plus.js`       | 2.6 KB      | 14        | Regex parser, more commands, i18n aliases                     |
+| `hyperfixi-hybrid-complete.js` | 7.3 KB      | 21+blocks | Full AST parser, expressions, event modifiers                 |
+| `hyperfixi-hx.js`              | 9.7 KB      | 21+blocks | hybrid-complete + htmx/fixi attribute support                 |
+| `hyperfixi-hx-v4.js`           | ~257 KB     | 40+blocks | Full runtime + htmx-compat + reactivity (hx-live, bind, when) |
+
+**Hybrid Complete** (~85% hyperscript coverage) is recommended - it supports:
+
+- Full expression parser with operator precedence
+- Block commands: `repeat N times`, `for each`, `if/else/else if`, `unless`, `fetch`, `while`, `async`
+- Event modifiers: `.once`, `.prevent`, `.stop`, `.debounce(N)`, `.throttle(N)`
+- Positional expressions: `first`, `last`, `next`, `previous`, `closest`, `parent`
+- Function calls and method chaining: `str.toUpperCase()`, `arr.join('-')`
+- HTML selectors: `<button.class#id/>`
+- i18n keyword aliases
+
+```html
+<!-- Example: Hybrid Complete with expressions and blocks -->
+<button
+  _="on click
+  set :total to #price's textContent then
+  set :tax to :total * 0.1 then
+  put :total + :tax into #grand-total"
+>
+  Calculate Total
+</button>
+
+<button
+  _="on click.debounce(300)
+  if me has .loading
+    return
+  end then
+  add .loading then
+  fetch /api/data as json then
+  for each item in result
+    append item.name to #results
+  end then
+  remove .loading"
+>
+  Load Data
+</button>
+```
+
+**Hybrid-HX** adds htmx and fixi attribute compatibility for declarative AJAX:
+
+```html
+<!-- htmx-style attributes (hybrid-hx bundle) -->
+<button hx-get="/api/users" hx-target="#users-list" hx-swap="innerHTML">Load Users</button>
+
+<!-- fixi-style attributes (also supported) -->
+<button fx-action="/api/users" fx-target="#users-list" fx-swap="innerHTML">Load Users</button>
+
+<!-- hx-on:* for inline hyperscript -->
+<button hx-on:click="toggle .active on me">Toggle</button>
+```
+
+Fixi features include request dropping (anti-double-submit), `fx-ignore` attribute, and a rich event lifecycle (`fx:init`, `fx:config`, `fx:before`, `fx:after`, `fx:error`, `fx:finally`, `fx:swapped`).
+
+## `hx-live` reactive expressions (htmx v4)
+
+When `@hyperfixi/reactivity` is installed, the htmx-compat layer recognizes the htmx v4 `hx-live` attribute and translates it to a `live ... end` block. The body is hyperscript syntax (not JavaScript like upstream htmx v4) — it gets fine-grained dependency tracking and inherits hyperscript's multilingual support:
+
+```html
+<div hx-live="put $count into me"></div>
+```
+
+The expression re-runs only when its tracked dependencies actually change (not on every DOM mutation, which is the upstream htmx v4 approach). If reactivity isn't installed, the element is skipped with a clear console error pointing to the install command.
+
+**Easiest path: use the `hyperfixi-hx-v4.js` bundle.** It ships the full runtime + `@hyperfixi/reactivity` auto-installed + the htmx-compat layer in a single script tag. Larger than `hyperfixi-hx.js` (~257 KB vs 13 KB gzipped) but no manual plugin wiring required. For size-tuned production builds, use `@hyperfixi/vite-plugin` instead.
+
+```html
+<script src="hyperfixi-hx-v4.js"></script>
+<div hx-live="put $count into me"></div>
+<button _="on click set $count to ($count or 0) + 1">+1</button>
+```
+
+See the working demos in [`examples/hx-v4/`](../examples/hx-v4/).
+
+## `sse-connect` / `sse-swap` (htmx v4)
+
+The htmx-compat processor recognizes `sse-connect="<url>"` to open a long-lived `EventSource` against the URL, and `sse-swap="<event-name>[, <event-name>...]"` to route named events through the existing `hx-target` / `hx-swap` machinery.
+
+```html
+<!-- Stream incoming `tick` events into #notifications -->
+<div sse-connect="/events" sse-swap="tick" hx-target="#notifications" hx-swap="beforeend"></div>
+
+<!-- One connection, multiple named events -->
+<div
+  sse-connect="/feed"
+  sse-swap="post, like, comment"
+  hx-target="#timeline"
+  hx-swap="afterbegin"
+></div>
+```
+
+The connection auto-reconnects on transient errors with exponential backoff (1s → 2s → 4s …, capped at 30s, 5 retries before giving up). On element removal from the DOM, the connection is closed automatically via MutationObserver — no leaks. Custom lifecycle events fire on the element: `htmx:sseOpen`, `htmx:sseMessage`, `htmx:sseError`, `htmx:sseClose`.
+
+The `hyperfixi-hx-v4.js` bundle bundles this support; the slim `hyperfixi-hx.js` doesn't ship the SSE module (size budget).
+
+## `ws-connect` / `ws-send` (htmx v4)
+
+WebSocket support follows the same shape as SSE but is bidirectional. `ws-connect="<url>"` on an element opens a per-element WebSocket; `ws-send` on a descendant form or button forwards a JSON-serialized payload over the socket on submit/click.
+
+```html
+<div ws-connect="wss://example/api">
+  <form ws-send>
+    <input name="msg" />
+    <button type="submit">Send</button>
+  </form>
+</div>
+```
+
+Incoming messages are routed two ways:
+
+- **JSON envelope** `{ target, swap?, data }` → applies through the existing `hx-target`/`hx-swap` machinery, letting the server drive surgical updates without the client knowing the layout up front.
+- **Anything else** → dispatched as `htmx:wsMessage` with the raw text; consumers can subscribe and route however they like.
+
+Reconnect on unclean close uses the same bounded exponential backoff as SSE (1s → 2s → 4s … capped at 30s, 5 retries). Outbound sends queue while the socket is connecting and flush on `htmx:wsOpen`. Lifecycle events: `htmx:wsOpen`, `htmx:wsMessage`, `htmx:wsError`, `htmx:wsClose`.
+
+> **When to use SSE vs WS:** prefer SSE for server-push streams (notifications, telemetry, live feeds) — it's HTTP-native, plays nice with proxies and HTTP/2, and the browser handles reconnect. Reach for WebSockets when you genuinely need a low-latency bidirectional channel (chat, collaborative editing, control planes). SSE is the documented default for that reason.
+
+The `hyperfixi-hx-v4.js` bundle bundles this support; the slim `hyperfixi-hx.js` doesn't.
+
+## Localized htmx attribute names (Phase 8)
+
+The htmx-compat layer in `hyperfixi-hx-v4.js` recognizes localized attribute names per-element based on the nearest `lang=` ancestor. Spanish authors can write `hx-obtener` / `hx-objetivo` / `sse-conectar`; Japanese authors `hx-取得` / `hx-ターゲット`; Arabic `hx-احصل` / `hx-هدف`. The orchestrator translates them to canonical English (`hx-get` / `hx-target` / `sse-connect`) before they hit the existing processor paths.
+
+```html
+<script src="hyperfixi-hx-v4.js"></script>
+<!-- Opt in to languages by loading their vocab modules. -->
+<script src="packages/core/vocab/htmx/es.js"></script>
+<script src="packages/core/vocab/htmx/ja.js"></script>
+
+<section lang="es">
+  <button hx-obtener="/api/usuarios" hx-objetivo="#out">Cargar</button>
+</section>
+<section lang="ja">
+  <button hx-取得="/api/ユーザー" hx-ターゲット="#out">読み込む</button>
+</section>
+```
+
+**Resolution order** for `langOf(element)`:
+
+1. `data-hyperfixi-lang` on the element itself
+2. `data-hyperfixi-lang` on any ancestor
+3. `lang=` on any ancestor (HTML standard)
+4. `'en'` fallback
+
+Regional variants collapse to base codes (`es-MX` → `es`). Elements outside any lang scope use English literals — same behavior as before Phase 8. Missing-vocab langs log a one-time console warning per language and fall back to English.
+
+**Bundled vocab modules** (`packages/core/vocab/htmx/`) cover 8 priority languages — en, es, fr, ja, zh, ar, ko, de. Each is a self-registering `<script>` tag (loka-js convention). To add another language: edit the keyword translations in `packages/semantic/src/generators/profiles/{lang}.ts` and run `npm run generate:htmx-vocab --prefix packages/core`.
+
+**The `hx-` / `sse-` / `ws-` prefixes are preserved across languages** — only the suffix is localized. Spanish writes `hx-obtener`, not `xx-obtener`. The brand prefix doubles as a discovery anchor.
+
+**Out of scope** for this arc: localizing the `_=` hyperscript attribute itself. The vocab orchestrator translates htmx-compat attribute names only.
+
+See the live demos in [`examples/hx-v4-i18n/`](../examples/hx-v4-i18n/).
+
+## htmx Lifecycle Events
+
+The htmx compatibility layer dispatches CustomEvents at key points in the request lifecycle:
+
+| Event                | When                                                | Cancelable | Detail                     |
+| -------------------- | --------------------------------------------------- | ---------- | -------------------------- |
+| `htmx:configuring`   | After attributes collected, before translation      | Yes        | `{ config, element }`      |
+| `htmx:beforeRequest` | Before hyperscript execution                        | Yes        | `{ element, url, method }` |
+| `htmx:afterSettle`   | After successful execution                          | No         | `{ element, target }`      |
+| `htmx:error`         | On execution failure                                | No         | `{ element, error }`       |
+| `htmx:sseOpen`       | SSE connection opens                                | No         | `{ url }`                  |
+| `htmx:sseMessage`    | SSE message received (any event)                    | No         | `{ url, event?, data }`    |
+| `htmx:sseError`      | SSE error / connection lost                         | No         | `{ url, error or event }`  |
+| `htmx:sseClose`      | SSE connection closed (manual or after retry limit) | No         | `{ url }`                  |
+| `htmx:wsOpen`        | WS connection opens                                 | No         | `{ url }`                  |
+| `htmx:wsMessage`     | WS message received (raw or envelope)               | No         | `{ url, envelope?, data }` |
+| `htmx:wsError`       | WS error                                            | No         | `{ url, error or event }`  |
+| `htmx:wsClose`       | WS connection closed                                | No         | `{ url, code, reason }`    |
+
+**Example usage:**
+
+```javascript
+// Intercept and modify config before processing
+document.addEventListener('htmx:configuring', e => {
+  e.detail.config.headers = { 'X-Custom': 'value' };
+});
+
+// Cancel request based on condition
+document.addEventListener('htmx:beforeRequest', e => {
+  if (someCondition) {
+    e.preventDefault(); // Cancels execution
+  }
+});
+
+// React to successful completion
+document.addEventListener('htmx:afterSettle', e => {
+  console.log('Request completed for:', e.detail.url);
+});
+
+// Handle errors
+document.addEventListener('htmx:error', e => {
+  showErrorNotification(e.detail.error.message);
+});
+```
+
+## Custom Bundle Generator
+
+Generate minimal bundles with only the commands you need:
+
+```bash
+cd packages/core
+
+# Generate from config file
+npm run generate:bundle -- --config bundle-configs/textshelf.config.json
+
+# Generate from command line with blocks and positional expressions
+npm run generate:bundle -- --commands toggle,add,set --blocks if,repeat --positional --output src/my-bundle.ts
+```
+
+See [bundle-configs/README.md](../packages/core/bundle-configs/README.md) for full documentation.
+
+## Semantic Bundles (Regional Options)
+
+| Bundle                                    | Global                        | Size (gzip) | Languages          |
+| ----------------------------------------- | ----------------------------- | ----------- | ------------------ |
+| `browser.global.js`                       | `LokaScriptSemantic`          | 90 KB       | All 24             |
+| `browser-priority.priority.global.js`     | `LokaScriptSemanticPriority`  | 48 KB       | 11 priority        |
+| `browser-western.western.global.js`       | `LokaScriptSemanticWestern`   | 30 KB       | en, es, pt, fr, de |
+| `browser-east-asian.east-asian.global.js` | `LokaScriptSemanticEastAsian` | 24 KB       | ja, zh, ko         |
+| `browser-es-en.es-en.global.js`           | `LokaScriptSemanticEsEn`      | 25 KB       | en, es             |
+| `browser-en.en.global.js`                 | `LokaScriptSemanticEn`        | 20 KB       | en only            |
+| `browser-es.es.global.js`                 | `LokaScriptSemanticEs`        | 16 KB       | es only            |
+
+Choose the smallest bundle that covers your target languages. See `packages/semantic/README.md` for details.
+
+## Multilingual Bundle (Recommended for i18n)
+
+For developers writing hyperscript in their native language:
+
+```html
+<!-- Load both bundles -->
+<script src="lokascript-semantic.browser.global.js"></script>
+<script src="hyperfixi-multilingual.js"></script>
+<script>
+  // Execute in any of 24 supported languages
+  await hyperfixi.execute('토글 .active', 'ko');      // Korean
+  await hyperfixi.execute('トグル .active', 'ja');    // Japanese
+  await hyperfixi.execute('alternar .active', 'es');  // Spanish
+
+  // Translate between languages
+  const korean = await hyperfixi.translate('toggle .active', 'en', 'ko');
+</script>
+```
+
+**Total size:** ~511 KB (250 KB + 261 KB) vs 924 KB with full bundle
+
+## Full Bundle Usage
+
+```html
+<script src="hyperfixi.js"></script>
+<script src="lokascript-i18n.min.js"></script>
+<script src="lokascript-semantic.browser.global.js"></script>
+<script>
+  // Grammar transformation (i18n)
+  const result = LokaScriptI18n.translate('on click toggle .active', 'en', 'ja');
+
+  // Semantic parsing (24 languages)
+  const parsed = LokaScriptSemantic.parse('トグル .active', 'ja');
+  const translations = LokaScriptSemantic.getAllTranslations('toggle .active', 'en');
+</script>
+```

--- a/packages/semantic/CLAUDE.md
+++ b/packages/semantic/CLAUDE.md
@@ -4,15 +4,15 @@ This file provides guidance for working with the `@lokascript/semantic` package.
 
 ## Package Overview
 
-**Semantic-first multilingual parsing** for Hyperscript. This package parses hyperscript commands directly from 13 languages without requiring English translation first.
+**Semantic-first multilingual parsing** for Hyperscript. This package parses hyperscript commands directly from 24 languages without requiring English translation first.
 
-**1240+ tests** | **13 languages** | **45 command schemas**
+**6400+ tests** | **24 languages** | **45+ command schemas**
 
 ## Architecture
 
 ```
 src/
-├── tokenizers/           # Language-specific tokenizers (13 languages)
+├── tokenizers/           # Language-specific tokenizers (24 languages)
 │   ├── english.ts        # SVO word order
 │   ├── japanese.ts       # SOV word order
 │   ├── arabic.ts         # VSO word order, RTL
@@ -36,7 +36,7 @@ src/
 │
 ├── generators/           # Pattern generation from schemas
 │   ├── command-schemas.ts      # 45 command definitions
-│   ├── language-profiles.ts    # Keywords for 13 languages
+│   ├── language-profiles.ts    # Keywords per language
 │   └── pattern-generator.ts    # Generate patterns from schemas
 │
 ├── parser/               # Semantic parser
@@ -67,7 +67,7 @@ src/
 ## Essential Commands
 
 ```bash
-# Run tests (1240+ tests)
+# Run tests (6400+ tests)
 npm test --prefix packages/semantic
 npm test --prefix packages/semantic -- --run  # Single run (no watch)
 
@@ -238,7 +238,7 @@ Available templates:
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `src/types.ts`                                | ActionType union (45 actions), SemanticNode types (command, event-handler, conditional, compound, loop) |
 | `src/generators/command-schemas.ts`           | Schema definitions for all commands                                                                     |
-| `src/generators/language-profiles.ts`         | Keyword translations (13 languages)                                                                     |
+| `src/generators/language-profiles.ts`         | Keyword translations (per language)                                                                     |
 | `src/generators/profiles/marker-templates.ts` | Shared role markers, verb configs, possessive templates                                                 |
 | `src/patterns/builders.ts`                    | Pattern registry and `buildPatternsForLanguage()`                                                       |
 | `src/parser/semantic-parser.ts`               | Main parsing logic                                                                                      |


### PR DESCRIPTION
The root CLAUDE.md is loaded into every agent session's context; it had grown to 1102 lines, ~40% of it user-facing product documentation rather than agent guidance, and several claims had drifted stale.

**Relocated, not deleted** — the 300-line Browser Bundles deep-dive (`hx-live`, `sse-connect`/`sse-swap`, `ws-connect`/`ws-send`, localized htmx attribute names, lifecycle-event tables, custom bundle generator, semantic regional bundles) was documented nowhere else in the repo, so it moves verbatim to **`docs/BROWSER_BUNDLES.md`**. CLAUDE.md keeps a compact selection table + pointer. All relative links in the relocated doc verified.

**Compressed** — Debugging Tools 128 → ~35 lines (packages/core/docs/API.md carries the detail) and Type Safety 43 → ~10 lines (TYPE_SAFETY_DESIGN.md carries the detail).

**Refreshed stale claims:**
- Test counts: 8100+ → 14,000+ overall; core 5700+ → 7000+; semantic 3100+ → 6400+; i18n 90+ → 900+; `packages/semantic/CLAUDE.md` 1240+ → 6400+ and "13 languages" → 24 (six mentions)
- Fidelity snapshot: the 2026-06-15 band counts (~39 degenerate / ~113 lossy / R1 ≈ 0.83) → the 2026-07-05 baseline (0 / 0 / R1 ≈ 0.977), pointing at MULTILINGUAL_NEXT_STEPS.md
- Known Issues: the SOV note now states the actual remaining gap (role fidelity ~0.95 on the SOV six)

**Kept intact** — everything operationally load-bearing for agents: cold-start/build-order footguns, the esbuild-hang workaround, stale-dist auto-rebuild notes, the six-signal gate recipe, patterns.db discipline, and the add-command / add-language checklists.

Net: CLAUDE.md 1102 → 699 lines; every cut line either relocated or replaced by a pointer to where it already lived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)