### PR TITLE
fix(multilingual): mid-clause if fold — capture the full condition (if.condition en-reference noise)

### DIFF
--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -2095,6 +2095,43 @@ export class SemanticParserImpl implements ISemanticParser {
         continue;
       }
 
+      // Mid-clause `if` fold — the parseClause mirror of the fused-body walker's
+      // hook (see the matchBest-yields-flat-`if` fold in parseBody). A juxtaposed
+      // `<cmd> … if <condition> <cmd> …` clause (no `then` before the `if`, so the
+      // clause-boundary fold in parseBodyWithClauses never fires) otherwise
+      // pattern-matches the flat `if` head (`if-en-basic` = `if {condition}`),
+      // truncating the condition to its FIRST token (`if result is false` →
+      // condition:reference="result", the comparison silently dropped) and
+      // flattening the branch into sibling commands. This was en-REFERENCE noise:
+      // translations reach the folding walkers and capture the full condition as
+      // an expression, then mis-score against the truncated en signature
+      // (form-submit-prevent ×14). Rewind and fold the whole `if … end` block —
+      // same condition/branch split, full-expression condition. Junk between the
+      // match start and the if-keyword joins the skipped-run recovery (restored on
+      // a failed fold). tryParseConditionalBlock returns null without consuming
+      // when the head isn't a usable conditional, so a non-foldable flat `if`
+      // (e.g. no branch commands) is byte-identical to before.
+      if (commandMatch && (commandMatch.pattern.command as string) === 'if') {
+        const afterMatch = clauseStream.mark();
+        const skippedLenBefore = skipped.length;
+        clauseStream.reset(startMark);
+        while (!clauseStream.isAtEnd()) {
+          const h = clauseStream.peek();
+          if (!h || this.isIfKeyword((h.normalized ?? h.value).toLowerCase(), language)) break;
+          skipped.push(h);
+          clauseStream.advance();
+        }
+        const conditional = this.tryParseConditionalBlock(clauseStream, commandPatterns, language);
+        if (conditional) {
+          flushSkipped();
+          commands.push(conditional);
+          directHits++;
+          continue;
+        }
+        skipped.length = skippedLenBefore;
+        clauseStream.reset(afterMatch);
+      }
+
       if (commandMatch) {
         flushSkipped();
         const cmd = this.buildCommand(commandMatch, language);

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -2338,10 +2338,6 @@ describe('`is empty` predicate keywords (de/sw) — block-body Phase 1a', () => 
       'de',
       'bei unscharf wenn mein wert ist leer hinzufügen .error zu ich dann setzen "Required" zu nächste .error-message ende',
     ],
-    [
-      'sw',
-      'kwenye poteza_macho kama yangu thamani ni tupu ongeza .error kwa mimi kisha weka "Required" kwa ijayo .error-message mwisho',
-    ],
   ];
 
   for (const [lang, input] of cases) {
@@ -2349,6 +2345,42 @@ describe('`is empty` predicate keywords (de/sw) — block-body Phase 1a', () => 
       expect(actions(parse(input, lang as 'de')).has('empty')).toBe(true);
     });
   }
+
+  it('[sw] recovers the empty predicate inside the folded condition', () => {
+    // Originally locked as a flat `empty` ACTION sibling — the truncated-if-era
+    // shape. The mid-clause if fold (parseClause hook, if.condition en-noise
+    // sweep) now folds this into a conditional whose condition carries the
+    // NORMALIZED predicate (`… is empty`) — which still exercises the Phase 1a
+    // vocabulary (`ni`→is, `tupu`→empty): without it the predicate would not
+    // normalize. The corpus if-empty (`kwenye blur kama …`) folds identically
+    // in en/de/sw, so this is the faithful shape, not a regression.
+    const node = parse(
+      'kwenye poteza_macho kama yangu thamani ni tupu ongeza .error kwa mimi kisha weka "Required" kwa ijayo .error-message mwisho',
+      'sw'
+    );
+    function findIf(n: unknown): Record<string, any> | null {
+      if (!n || typeof n !== 'object') return null;
+      const rec = n as Record<string, any>;
+      if (rec.action === 'if') return rec;
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+        const c = rec[f];
+        if (Array.isArray(c)) {
+          for (const x of c) {
+            const hit = findIf(x);
+            if (hit) return hit;
+          }
+        }
+      }
+      return null;
+    }
+    const ifNode = findIf(node);
+    expect(ifNode).not.toBeNull();
+    const cond = ifNode!.roles instanceof Map ? ifNode!.roles.get('condition') : undefined;
+    expect(cond?.type).toBe('expression');
+    expect(String(cond?.raw ?? '')).toContain('empty');
+    // The predicate no longer leaks as a spurious flat `empty` action.
+    expect(actions(node).has('empty')).toBe(false);
+  });
 });
 
 describe('id toggle keyword alignment (unless-condition) — block-body Phase 1b', () => {
@@ -10053,6 +10085,55 @@ describe('en-reference noise: send destination dropped / event truncated (R1 res
       );
       expect(node).not.toBeNull();
       expect(firstAction(node, 'halt')).not.toBeNull();
+    });
+  });
+
+  describe('mid-clause if fold: full condition captured, branch nested (if.condition en-reference noise)', () => {
+    // `on submit halt the event call validateForm() if result is false log
+    // "Invalid form" end` — no `then` before the `if`, so the clause-boundary
+    // fold in parseBodyWithClauses never fires and the clause reaches
+    // parseClause with the `if` mid-clause. matchBest then pattern-matched the
+    // flat `if` head (`if-en-basic` = `if {condition}`), truncating the
+    // condition to its first token (condition:reference="result", the `is
+    // false` comparison silently dropped) and flattening `log` into a sibling.
+    // This was EN-REFERENCE noise: translations reach the folding body walkers,
+    // capture the full condition as an expression, and mis-scored against the
+    // truncated en signature (if.condition ×14, form-submit-prevent). The
+    // parseClause mirror of the fused-body fold hook now rewinds a flat-`if`
+    // match and folds the whole block (form-submit-prevent en+14; collateral:
+    // focus-trap ko/qu, behavior-removable js.patient bn/hi/ja/ko/qu/tr).
+    it('[en] mid-clause if captures the FULL comparison as an expression condition', () => {
+      const node = parse(
+        'on submit halt the event call validateForm() if result is false log "Invalid form" end',
+        'en'
+      );
+      const ifNode = firstAction(node, 'if');
+      const cond = roleOf(ifNode, 'condition');
+      expect(cond?.type).toBe('expression');
+      expect(String(cond?.raw ?? cond?.value)).toContain('is false');
+    });
+
+    it('[en] the branch command nests under thenBranch (not a flattened sibling)', () => {
+      const node = parse(
+        'on submit halt the event call validateForm() if result is false log "Invalid form" end',
+        'en'
+      );
+      const ifNode = firstAction(node, 'if');
+      expect(ifNode).not.toBeNull();
+      const thenBranch = (ifNode as Record<string, any>).thenBranch;
+      expect(Array.isArray(thenBranch)).toBe(true);
+      expect(thenBranch.some((c: Record<string, any>) => c.action === 'log')).toBe(true);
+      // halt and call remain siblings OUTSIDE the conditional
+      expect(firstAction(node, 'halt')).not.toBeNull();
+      expect(firstAction(node, 'call')).not.toBeNull();
+    });
+
+    it('[en] a clause-boundary if (existing fold path) is unchanged', () => {
+      const node = parse('on click if result is false log "bad" end', 'en');
+      const ifNode = firstAction(node, 'if');
+      const cond = roleOf(ifNode, 'condition');
+      expect(cond?.type).toBe('expression');
+      expect(String(cond?.raw ?? cond?.value)).toContain('is false');
     });
   });
 });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-05T15:43:30.672Z",
-  "commit": "1e50572f",
+  "timestamp": "2026-07-05T17:59:03.973Z",
+  "commit": "e91d39aa",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9,12 +9,12 @@
       "avgConfidence": 0.8399201626424081,
       "avgFidelity": 1,
       "avgPrecision": 0.9796536796536797,
-      "avgRoleFidelity": 0.9850788288288288,
+      "avgRoleFidelity": 0.9862049549549549,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -641,12 +641,12 @@
       "avgConfidence": 0.8462563334743781,
       "avgFidelity": 1,
       "avgPrecision": 0.937911255411256,
-      "avgRoleFidelity": 0.9611853369206311,
+      "avgRoleFidelity": 0.9618610125963069,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.828035456606883,
       "avgFidelity": 1,
       "avgPrecision": 0.9967532467532467,
-      "avgRoleFidelity": 0.9818613256113256,
+      "avgRoleFidelity": 0.9829874517374517,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
       "avgPrecision": 0.9859307359307358,
-      "avgRoleFidelity": 0.9867083995760464,
+      "avgRoleFidelity": 0.9878345257021727,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
       "avgPrecision": 0.9833333333333334,
-      "avgRoleFidelity": 0.9818613256113256,
+      "avgRoleFidelity": 0.9829874517374517,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4426,12 +4426,12 @@
       "avgConfidence": 0.8993587865768304,
       "avgFidelity": 1,
       "avgPrecision": 0.9412618766514869,
-      "avgRoleFidelity": 0.9485566367919308,
+      "avgRoleFidelity": 0.9492323124676065,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
       "avgPrecision": 0.9854978354978354,
-      "avgRoleFidelity": 0.9842744530244529,
+      "avgRoleFidelity": 0.9854005791505792,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.9779491341991341,
-      "avgRoleFidelity": 0.9883815012491481,
+      "avgRoleFidelity": 0.9895076273752744,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
       "avgPrecision": 0.952981109799292,
-      "avgRoleFidelity": 0.9590986914516327,
+      "avgRoleFidelity": 0.9597743671273083,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6954,12 @@
       "avgConfidence": 0.8170870900194204,
       "avgFidelity": 1,
       "avgPrecision": 0.9529811097992917,
-      "avgRoleFidelity": 0.954031123884065,
+      "avgRoleFidelity": 0.9563959887489298,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
       "avgPrecision": 0.9811688311688311,
-      "avgRoleFidelity": 0.9856418918918919,
+      "avgRoleFidelity": 0.9867680180180182,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8025561739847434,
       "avgFidelity": 1,
       "avgPrecision": 0.9941829004329004,
-      "avgRoleFidelity": 0.9772328526004996,
+      "avgRoleFidelity": 0.9783589787266259,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8850,12 @@
       "avgConfidence": 0.7984333127190251,
       "avgFidelity": 1,
       "avgPrecision": 0.9833333333333334,
-      "avgRoleFidelity": 0.9855822734499206,
+      "avgRoleFidelity": 0.9867083995760466,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9482,12 @@
       "avgConfidence": 0.7381467738610596,
       "avgFidelity": 1,
       "avgPrecision": 0.9525172879068982,
-      "avgRoleFidelity": 0.9491196998549942,
+      "avgRoleFidelity": 0.951484564719859,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.8135642135642115,
       "avgFidelity": 1,
       "avgPrecision": 0.9915854978354979,
-      "avgRoleFidelity": 0.9795494549171019,
+      "avgRoleFidelity": 0.9806755810432282,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10746,12 +10746,12 @@
       "avgConfidence": 0.7962481962481944,
       "avgFidelity": 1,
       "avgPrecision": 0.9941558441558443,
-      "avgRoleFidelity": 0.987331081081081,
+      "avgRoleFidelity": 0.9884572072072073,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.9753246753246753,
-      "avgRoleFidelity": 0.9797746801423273,
+      "avgRoleFidelity": 0.9809008062684536,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12642,12 +12642,12 @@
       "avgConfidence": 0.8340114355151945,
       "avgFidelity": 1,
       "avgPrecision": 0.9520843874739979,
-      "avgRoleFidelity": 0.9587012351718235,
+      "avgRoleFidelity": 0.9593769108474991,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13274,12 +13274,12 @@
       "avgConfidence": 0.8139764996907833,
       "avgFidelity": 1,
       "avgPrecision": 0.9915854978354978,
-      "avgRoleFidelity": 0.9795494549171019,
+      "avgRoleFidelity": 0.9806755810432282,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13906,12 +13906,12 @@
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
       "avgPrecision": 0.9811958874458874,
-      "avgRoleFidelity": 0.9906498410174881,
+      "avgRoleFidelity": 0.9917759671436144,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 477801,
+      "bundleSize": 478095,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 477801,
+      "size": 478095,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Continues the R1/precision burn-down (post-#573, probe mean R1 0.9771). This lands the `if.condition:reference ×14` en-reference-noise family from the "What's next" list in `docs-internal/HANDOFF-r1-post-cluster-residue.md`.

**Mechanism.** A juxtaposed `<cmd> … if <condition> <cmd> …` clause (no `then` before the `if`, e.g. form-submit-prevent's `… call validateForm() if result is false log "Invalid form" end`) never reaches the clause-boundary fold in `parseBodyWithClauses`, so `parseClause` pattern-matched the flat `if` head and truncated the condition to its first token (`condition:reference="result"` — the `is false` comparison silently dropped), flattening the branch into siblings. Translations reach the *folding* body walkers, capture the full condition as an expression, and were penalized for being right.

**Fix.** `parseClause` now mirrors the fused-body walker's existing fold hook: when matchBest yields a flat `if`, rewind and fold the whole `if … end` block via `tryParseConditionalBlock` (full-expression condition, nested branches). Junk between the match start and the if-keyword joins the skipped-run recovery; a non-foldable flat `if` is byte-identical to before.

## Numbers (per-(lang,pattern) A/B, corpus probe)

- Corpus probe mean R1: **0.9771 → 0.9781**; baseline `avgRoleFidelity` up in **all 23** non-en languages, none down.
- `if.condition ×14` (form-submit-prevent ar/de/es/fr/id/it/ms/pl/pt/ru/sw/th/uk/vi): **cleared**.
- Collateral wins: focus-trap ko/qu full-condition capture; behavior-removable bn/hi/ja/ko/qu/tr recover `js.patient:expression` (×12 → ×6).
- Spurious-action families: **byte-identical** (R0-precision untouched).
- Parse 3696/3696, degenerate/lossy 0, R2 1.0 — six-signal `--regression` gate green; baseline regenerated against a fresh populate in this PR (patterns.db itself not committed, per policy).

## Tests

- 2 mid-clause fold locks + 1 clause-boundary no-regression lock (new).
- The sw if-empty Phase-1a lock updated to the folded shape: the predicate now normalizes *inside* the condition (`"my thamani is empty"`), matching the en/de/sw corpus parses exactly — strictly more faithful than the old flat spurious-`empty` shape it locked.
- Stash round-trip verified: 3 of 4 fail without the parser fix.
- Full semantic suite: 6489 passed / 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)