### PR TITLE
fix(multilingual): transition family alignment — the spurious-transition ×66 precision drill

### DIFF
--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -50,7 +50,10 @@ export const qu: Dictionary = {
     throw: 'wikchuy',
     catch: 'hapsiy',
     measure: 'tupuy',
-    transition: 'tikray',
+    // pasay, not tikray: the semantic qu profile's toggle keyword is
+    // t'ikray/tikray, so a tikray render collided with toggle and the
+    // transition command never anchored (sw kama precedent, #569).
+    transition: 'pasay',
     increment: 'yapachiy',
     decrement: 'pisiyachiy',
     default: 'ñawpaq_kaq',

--- a/packages/i18n/src/dictionaries/th.ts
+++ b/packages/i18n/src/dictionaries/th.ts
@@ -38,7 +38,9 @@ export const thaiDictionary: Dictionary = {
     prepend: 'เพิ่มหน้า',
     focus: 'โฟกัส',
     blur: 'เบลอ',
-    transition: 'เปลี่ยน',
+    // เปลี่ยนผ่าน, not เปลี่ยน: the semantic th profile's `change` keyword is
+    // เปลี่ยน, so a เปลี่ยน render could never anchor a transition command.
+    transition: 'เปลี่ยนผ่าน',
     settle: 'คงที่',
     measure: 'วัด',
     async: 'อะซิงค์',

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -1594,7 +1594,19 @@ export const transitionSchema: CommandSchema = {
       role: 'patient',
       description: 'The property to transition (opacity, *background-color, etc.)',
       required: true,
-      expectedTypes: ['literal'], // Only literal - CSS properties are strings, not selectors
+      // A bare CSS property name (`transition opacity to 0`) tokenizes as an
+      // identifier → expression, so a literal-only patient rejected the idiomatic
+      // unquoted form in EVERY language: en (and 8 others) dropped the whole
+      // command, while the 14 languages whose body walkers recover it via
+      // verb-anchoring parsed it — and were then precision-penalized as
+      // "spurious transition" (×66, the largest R0-precision family) against the
+      // en reference that had silently dropped it. Admitting `expression` (the
+      // add/send.destination precedent, #571/#573) lets matchBest capture the
+      // property in all languages. `selector` is admitted for the style-property
+      // syntax ONLY: `*background-color` / `*max-height` tokenize as selector
+      // (transition-color, slide-toggle — en dropped both), and translations
+      // already capture patient:selector for them via the lax body walkers.
+      expectedTypes: ['literal', 'expression', 'selector'],
       svoPosition: 1,
       sovPosition: 2,
       // No marker before the CSS property name (SVO/VSO languages)
@@ -1604,25 +1616,48 @@ export const transitionSchema: CommandSchema = {
     {
       role: 'goal',
       description: 'The target value to transition to',
+      // Required, deliberately: goal-less transition (`transition *max-height
+      // over 300ms`, slide-toggle) IS valid hyperscript, but making goal
+      // optional wraps its marker group as skippable and the bare value then
+      // re-binds by particle metadata (`a 0` → destination:literal=0),
+      // clobbering goal+duration capture in every marker language — verified
+      // regression, do not repeat. The goal-less form stays a residue item.
       required: true,
       expectedTypes: ['literal', 'expression'],
       svoPosition: 2,
       sovPosition: 3,
-      // "to" preposition before goal value (same as set's patient marker)
+      // "to" preposition before goal value. These MUST match what the i18n
+      // transformer actually renders (the corpus ground truth) — de 'auf' and
+      // sw 'kwenye' were aspirational, never matched a rendered text, so the
+      // generated pattern could not fire and the whole command was dropped
+      // (the NO-TRANSITION half of the spurious-transition ×66 precision
+      // family). SOV languages (ja/ko/tr/bn/qu) reach transition via the fused
+      // grammar-transformed paths (this override is position-BEFORE, so it
+      // cannot capture their postposed `0 に` forms anyway); their entries are
+      // kept aligned to the rendered particles for the pattern renderer.
       markerOverride: {
         en: 'to',
         ar: 'إلى',
         tl: 'sa',
-        sw: 'kwenye',
+        sw: 'kwa',
         bn: 'তে',
         qu: 'man',
         es: 'a',
         pt: 'para',
         fr: 'à',
-        de: 'auf',
+        de: 'zu',
+        he: 'על',
+        it: 'in',
         ja: 'に',
-        ko: '으로',
+        ko: '에',
+        ms: 'ke',
+        pl: 'do',
+        ru: 'в',
+        th: 'ใน',
         tr: 'e',
+        uk: 'в',
+        vi: 'vào',
+        zh: '到',
         id: 'ke',
       },
     },

--- a/packages/semantic/src/generators/profiles/swahili.ts
+++ b/packages/semantic/src/generators/profiles/swahili.ts
@@ -81,7 +81,13 @@ export const swahiliProfile: LanguageProfile = {
     log: { primary: 'andika', alternatives: ['rekodi'], normalized: 'log' },
     show: { primary: 'onyesha', normalized: 'show' },
     hide: { primary: 'ficha', alternatives: ['mficho'], normalized: 'hide' },
-    transition: { primary: 'hamisha', alternatives: ['animisha'], normalized: 'transition' },
+    // 'mpito' is what the i18n transformer renders (dict `transition: 'mpito'`);
+    // without it the corpus transition clause never anchors (NO-TRANSITION sw).
+    transition: {
+      primary: 'hamisha',
+      alternatives: ['animisha', 'mpito'],
+      normalized: 'transition',
+    },
     on: { primary: 'unapo', alternatives: ['kwenye'], normalized: 'on' },
     trigger: { primary: 'chochea', normalized: 'trigger' },
     send: { primary: 'tuma', alternatives: ['peleka'], normalized: 'send' },

--- a/packages/semantic/src/generators/schema-validator.ts
+++ b/packages/semantic/src/generators/schema-validator.ts
@@ -202,17 +202,12 @@ function validateTransitionSchema(schema: CommandSchema, items: SchemaValidation
   const patientRole = schema.roles.find(r => r.role === 'patient');
   const goalRole = schema.roles.find(r => r.role === 'goal');
 
-  // Check that patient (property name) only accepts literals
-  if (patientRole && patientRole.expectedTypes.includes('selector')) {
-    items.push(
-      createSchemaValidationItem(
-        SchemaErrorCodes.TRANSITION_PATIENT_ACCEPTS_SELECTOR,
-        'warning',
-        {},
-        'patient'
-      )
-    );
-  }
+  // NOTE: patient accepting 'selector' is SANCTIONED, not flagged. The rule
+  // that warned here predated the style-property reality: `*background-color`
+  // / `*max-height` tokenize as selector tokens, and the corpus-idiomatic
+  // transition forms (transition-color, slide-toggle) need them — a
+  // literal-only patient made the generated pattern unmatchable and the whole
+  // command silently dropped (the spurious-transition ×66 precision family).
 
   // Check that transition has a goal role for the target value
   if (patientRole && !goalRole) {

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1462,6 +1462,39 @@ export class SemanticParserImpl implements ISemanticParser {
           }
         }
 
+        // Trailing DURATION reclaim — the `transition` sibling of the quantity
+        // reclaim above. The transformer renders `transition opacity to 0 over
+        // 500ms` with the duration AFTER the fused verb+goal, bare (ja `遷移 0
+        // に 500ms`, ko `전환 0 에 500ms` — the `over` marker never survives
+        // translation), so the time literal is left unconsumed and drops
+        // (transition.duration missing in the SOV six across every transition
+        // pattern). Gated to a schema-declared OPTIONAL `duration` role that is
+        // absent (today only `transition` — wait's duration is required and has
+        // its own paths) and to a TIME-shaped literal (`500ms`/`2s`/`2.5s`; a
+        // bare number is the quantity reclaim's domain and never matches here).
+        const dNode = commandNode as CommandSemanticNode;
+        const hasOptionalDuration = getSchema(actionName as ActionType)?.roles.some(
+          r => r.role === 'duration' && !r.required
+        );
+        if (hasOptionalDuration && !dNode.roles.has('duration')) {
+          const trailing = tokens.peek();
+          if (trailing && /^\d+(\.\d+)?(ms|s)$/i.test(trailing.value)) {
+            commandNode = createCommandNode(
+              actionName as ActionType,
+              {
+                ...(Object.fromEntries(dNode.roles) as Record<string, SemanticValue>),
+                duration: {
+                  type: 'literal',
+                  value: trailing.value,
+                  dataType: 'string',
+                },
+              },
+              dNode.metadata
+            );
+            tokens.advance();
+          }
+        }
+
         // Trailing RESPONSE-TYPE reclaim — the `responseType` sibling of the
         // quantity reclaim above (R1 handoff cluster B). The transformer
         // renders `fetch /api/user as json`'s tail AFTER the fused verb:

--- a/packages/semantic/src/tokenizers/extractors/chinese-particle.ts
+++ b/packages/semantic/src/tokenizers/extractors/chinese-particle.ts
@@ -90,25 +90,45 @@ const MULTI_CHAR_PARTICLES = new Map<string, ParticleMetadata>([
 export class ChineseParticleExtractor implements ContextAwareExtractor {
   readonly name = 'chinese-particle';
 
-  // Context available for future use (e.g., particle boundary detection)
   private _context?: TokenizerContext;
 
   setContext(context: TokenizerContext): void {
     this._context = context;
-    void this._context; // Satisfy noUnusedLocals
+  }
+
+  /**
+   * True when a profile KEYWORD strictly longer than `particleLen` starts at
+   * this position. This extractor runs BEFORE the keyword extractor, so
+   * without the check a particle char that is also a keyword's first char
+   * splits the keyword: `过渡` (transition, the profile primary) tokenized as
+   * `过` (aspect particle) + `渡` (stray identifier) and the command verb
+   * never anchored (zh NO-TRANSITION, spurious-transition precision family).
+   * Longest-match must win across extractors, not just within one.
+   */
+  private longerKeywordAt(input: string, position: number, particleLen: number): boolean {
+    const ctx = this._context;
+    if (!ctx) return false;
+    const maxLen = Math.min(10, input.length - position); // max zh keyword length
+    for (let len = maxLen; len > particleLen; len--) {
+      if (ctx.lookupKeyword(input.slice(position, position + len))) return true;
+    }
+    return false;
   }
 
   canExtract(input: string, position: number): boolean {
     const char = input[position];
 
     // Check single-character particles
-    if (SINGLE_CHAR_PARTICLES.has(char)) {
+    if (SINGLE_CHAR_PARTICLES.has(char) && !this.longerKeywordAt(input, position, 1)) {
       return true;
     }
 
     // Check multi-character particles (greedy longest-first)
     for (const [particle] of MULTI_CHAR_PARTICLES) {
-      if (input.startsWith(particle, position)) {
+      if (
+        input.startsWith(particle, position) &&
+        !this.longerKeywordAt(input, position, particle.length)
+      ) {
         return true;
       }
     }
@@ -119,7 +139,10 @@ export class ChineseParticleExtractor implements ContextAwareExtractor {
   extract(input: string, position: number): ExtractionResult | null {
     // Try multi-character particles first (longest match)
     for (const [particle, metadata] of MULTI_CHAR_PARTICLES) {
-      if (input.startsWith(particle, position)) {
+      if (
+        input.startsWith(particle, position) &&
+        !this.longerKeywordAt(input, position, particle.length)
+      ) {
         return {
           value: particle,
           length: particle.length,
@@ -135,7 +158,7 @@ export class ChineseParticleExtractor implements ContextAwareExtractor {
     // Try single-character particles
     const char = input[position];
     const metadata = SINGLE_CHAR_PARTICLES.get(char);
-    if (metadata) {
+    if (metadata && !this.longerKeywordAt(input, position, 1)) {
       return {
         value: char,
         length: 1,

--- a/packages/semantic/test/lexicon-emit-mismatch.test.ts
+++ b/packages/semantic/test/lexicon-emit-mismatch.test.ts
@@ -106,7 +106,8 @@ const KNOWN_MISMATCHES = new Set([
   'qu:replaceUrl:url_tikray',
   'qu:select:akllay',
   'qu:throw:wikchuy',
-  'qu:transition:tikray',
+  // qu:transition resolved (transition precision drill): dict realigned to the
+  // profile primary `pasay` (was `tikray`, which collided with toggle).
   // qu:unless resolved (HANDOFF-lossy-tail unless-condition): dict realigned to the
   // spaced `mana sichus` + quechua profile reads it as `unless` (was `mana_sichus`,
   // which `_`-split to mana(=false)+sichus(=if)).
@@ -126,10 +127,12 @@ const KNOWN_MISMATCHES = new Set([
   'sw:replaceUrl:badilishaUrl',
   'sw:return:rudi',
   'sw:select:chagua',
-  'sw:transition:mpito',
+  // sw:transition resolved (transition precision drill): `mpito` added as a
+  // profile alternative — the rendered verb now anchors.
   'th:clone:คัดลอก',
   'th:select:เลือก',
-  'th:transition:เปลี่ยน',
+  // th:transition resolved (transition precision drill): dict realigned to the
+  // profile primary `เปลี่ยนผ่าน` (was `เปลี่ยน`, the profile's `change` keyword).
   'tl:break:itigil',
   'tl:catch:hulihin',
   'tl:clone:kopyahin',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -10136,4 +10136,111 @@ describe('en-reference noise: send destination dropped / event truncated (R1 res
       expect(String(cond?.raw ?? cond?.value)).toContain('is false');
     });
   });
+
+  describe('transition family: schema/marker/keyword alignment (spurious-transition ×66 precision drill)', () => {
+    // The transition schema's literal-only patient rejected the idiomatic bare
+    // CSS property (`opacity` tokenizes identifier → expression; `*max-height`
+    // tokenizes selector), and the goal markerOverride table disagreed with
+    // what the i18n transformer actually renders in 11 languages — so the
+    // generated pattern never fired: en (and 8 other languages) silently
+    // DROPPED the whole command while the languages whose lax body walkers
+    // recovered it were precision-penalized as "spurious transition" (×66, the
+    // largest R0-precision family). Fixes locked here:
+    //  - patient admits expression + selector (style-property syntax);
+    //  - goal markers aligned to the rendered corpus (de zu, pl do, ru/uk в,
+    //    he על, th ใน, it in, ms ke, vi vào, zh 到, sw kwa);
+    //  - sw keyword alternative mpito (the rendered verb);
+    //  - zh particle extractor defers to longer profile keywords (过渡 was
+    //    split into 过 particle + 渡 identifier);
+    //  - trailing bare TIME literal reclaims into transition's absent optional
+    //    duration in verb-final renders (the #561 quantity-reclaim sibling).
+    function findTransition(n: unknown): Record<string, any> | null {
+      if (!n || typeof n !== 'object') return null;
+      const rec = n as Record<string, any>;
+      if (rec.action === 'transition') return rec;
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'eventHandlers', 'initBlock']) {
+        const c = rec[f];
+        if (Array.isArray(c)) {
+          for (const x of c) {
+            const hit = findTransition(x);
+            if (hit) return hit;
+          }
+        }
+      }
+      return null;
+    }
+    const roleOf2 = (n: Record<string, any> | null, r: string) =>
+      n && n.roles instanceof Map ? n.roles.get(r) : undefined;
+
+    it('[en] bare CSS property parses as the transition patient (expression)', () => {
+      const node = parse('transition opacity to 0 over 500ms', 'en');
+      const tr = findTransition(node);
+      expect(tr).not.toBeNull();
+      expect(roleOf2(tr, 'patient')).toMatchObject({ type: 'expression' });
+      expect(roleOf2(tr, 'goal')).toMatchObject({ type: 'literal' });
+      expect(roleOf2(tr, 'duration')).toMatchObject({ type: 'literal', value: '500ms' });
+    });
+
+    it('[en] style-property syntax parses as the transition patient (selector)', () => {
+      const node = parse('transition *background-color to "blue" over 500ms', 'en');
+      const tr = findTransition(node);
+      expect(tr).not.toBeNull();
+      expect(roleOf2(tr, 'patient')).toMatchObject({ type: 'selector' });
+    });
+
+    it('[de] corpus-shaped handler captures goal + duration (goal marker is zu, not auf)', () => {
+      const node = parse('bei klick übergang opacity zu 0 500ms dann entfernen ich', 'de');
+      const tr = findTransition(node);
+      expect(tr).not.toBeNull();
+      expect(roleOf2(tr, 'goal')).toMatchObject({ type: 'literal' });
+      expect(roleOf2(tr, 'duration')).toMatchObject({ type: 'literal', value: '500ms' });
+    });
+
+    it('[zh] 过渡 anchors the transition (particle extractor defers to the longer keyword)', () => {
+      // Without the longer-keyword guard the particle extractor split 过渡 into
+      // 过 (aspect particle) + 渡 (stray identifier) and the verb never anchored.
+      const node = parse('当 点击 时 过渡 把 opacity 到 0 500ms', 'zh');
+      const tr = findTransition(node);
+      expect(tr).not.toBeNull();
+      expect(roleOf2(tr, 'goal')).toMatchObject({ type: 'literal' });
+    });
+
+    it('[sw] the rendered verb mpito anchors the transition', () => {
+      const node = parse('kwenye bonyeza mpito opacity kwa 0 500ms', 'sw');
+      const tr = findTransition(node);
+      expect(tr).not.toBeNull();
+      expect(roleOf2(tr, 'goal')).toMatchObject({ type: 'literal' });
+    });
+
+    it('[ja] verb-final render reclaims the trailing bare duration', () => {
+      const node = parse('opacity を クリック で 遷移 0 に 500ms', 'ja');
+      const tr = findTransition(node);
+      expect(tr).not.toBeNull();
+      expect(roleOf2(tr, 'duration')).toMatchObject({ type: 'literal', value: '500ms' });
+    });
+
+    it('[en] a bare NUMBER is never reclaimed as duration (quantity domain untouched)', () => {
+      // The reclaim is gated to time-shaped literals; `increment #score 10`
+      // shapes stay the quantity reclaim's domain.
+      const node = parse('#score を クリック で 増加 10', 'ja');
+      function findAction2(n: unknown, a: string): Record<string, any> | null {
+        if (!n || typeof n !== 'object') return null;
+        const rec = n as Record<string, any>;
+        if (rec.action === a) return rec;
+        for (const f of ['body', 'statements']) {
+          const c = rec[f];
+          if (Array.isArray(c)) {
+            for (const x of c) {
+              const hit = findAction2(x, a);
+              if (hit) return hit;
+            }
+          }
+        }
+        return null;
+      }
+      const inc = findAction2(node, 'increment');
+      expect(inc).not.toBeNull();
+      expect(roleOf2(inc, 'quantity')).toMatchObject({ type: 'literal', value: 10 });
+    });
+  });
 });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-05T17:59:03.973Z",
-  "commit": "e91d39aa",
+  "timestamp": "2026-07-05T18:29:26.295Z",
+  "commit": "c6590360",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -8,13 +8,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8399201626424081,
       "avgFidelity": 1,
-      "avgPrecision": 0.9796536796536797,
+      "avgPrecision": 0.9904761904761905,
       "avgRoleFidelity": 0.9862049549549549,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8462563334743781,
       "avgFidelity": 1,
-      "avgPrecision": 0.937911255411256,
-      "avgRoleFidelity": 0.9618610125963069,
+      "avgPrecision": 0.9460281385281387,
+      "avgRoleFidelity": 0.9599305106658049,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2529,13 +2529,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
-      "avgPrecision": 0.9859307359307358,
+      "avgPrecision": 0.9967532467532467,
       "avgRoleFidelity": 0.9878345257021727,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3161,13 +3161,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
-      "avgPrecision": 0.9833333333333334,
+      "avgPrecision": 0.9941558441558441,
       "avgRoleFidelity": 0.9829874517374517,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3791,7 +3791,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8237889095031952,
+      "avgConfidence": 0.8284065141207998,
       "avgFidelity": 1,
       "avgPrecision": 0.9864718614718616,
       "avgRoleFidelity": 0.987331081081081,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -3809,7 +3809,23 @@
           "success": true,
           "confidence": 1
         },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 1
+        },
         "input-mirror": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
           "success": true,
           "confidence": 1
         },
@@ -3962,14 +3978,6 @@
           "confidence": 0.8222222222222222
         },
         "wait-then": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "transition-transform": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -4149,10 +4157,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "transition-color": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "next-element": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -4206,10 +4210,6 @@
           "confidence": 0.8222222222222222
         },
         "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "fade-out-remove": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8993587865768304,
       "avgFidelity": 1,
-      "avgPrecision": 0.9412618766514869,
-      "avgRoleFidelity": 0.9492323124676065,
+      "avgPrecision": 0.9526747062461347,
+      "avgRoleFidelity": 0.9433603690956631,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5057,13 +5057,13 @@
       "parseRate": 1,
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
-      "avgPrecision": 0.9854978354978354,
+      "avgPrecision": 0.9963203463203464,
       "avgRoleFidelity": 0.9854005791505792,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5689,13 +5689,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
-      "avgPrecision": 0.9779491341991341,
+      "avgPrecision": 0.988771645021645,
       "avgRoleFidelity": 0.9895076273752744,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6321,13 +6321,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
-      "avgPrecision": 0.952981109799292,
-      "avgRoleFidelity": 0.9597743671273083,
+      "avgPrecision": 0.9643939393939395,
+      "avgRoleFidelity": 0.9578438651968065,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6951,15 +6951,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8170870900194204,
+      "avgConfidence": 0.8300741030064334,
       "avgFidelity": 1,
-      "avgPrecision": 0.9529811097992917,
-      "avgRoleFidelity": 0.9563959887489298,
+      "avgPrecision": 0.9643939393939397,
+      "avgRoleFidelity": 0.9544654868184279,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7018,6 +7018,14 @@
           "confidence": 1
         },
         "wait-for-event": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
           "success": true,
           "confidence": 1
         },
@@ -7145,6 +7153,10 @@
           "success": true,
           "confidence": 1
         },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
         "next-element": {
           "success": true,
           "confidence": 1
@@ -7198,6 +7210,10 @@
           "confidence": 1
         },
         "if-empty": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
           "success": true,
           "confidence": 1
         },
@@ -7437,14 +7453,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 0.5
-        },
         "multiple-events": {
           "success": true,
           "confidence": 0.5
@@ -7477,10 +7485,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "transition-color": {
-          "success": true,
-          "confidence": 0.5
-        },
         "first-in-parent": {
           "success": true,
           "confidence": 0.5
@@ -7498,10 +7502,6 @@
           "confidence": 0.5
         },
         "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "fade-out-remove": {
           "success": true,
           "confidence": 0.5
         },
@@ -7585,13 +7585,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
-      "avgPrecision": 0.9811688311688311,
+      "avgPrecision": 0.9919913419913419,
       "avgRoleFidelity": 0.9867680180180182,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8215,7 +8215,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8025561739847434,
+      "avgConfidence": 0.807173778602348,
       "avgFidelity": 1,
       "avgPrecision": 0.9941829004329004,
       "avgRoleFidelity": 0.9783589787266259,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8246,6 +8246,14 @@
           "confidence": 1
         },
         "toggle-visibility": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
           "success": true,
           "confidence": 1
         },
@@ -8285,6 +8293,10 @@
           "success": true,
           "confidence": 1
         },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
         "next-element": {
           "success": true,
           "confidence": 1
@@ -8298,6 +8310,10 @@
           "confidence": 1
         },
         "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
           "success": true,
           "confidence": 1
         },
@@ -8413,14 +8429,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "multiple-events": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -8465,10 +8473,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "transition-color": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "last-in-collection": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -8482,10 +8486,6 @@
           "confidence": 0.8222222222222222
         },
         "event-throttle": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "fade-out-remove": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -8849,13 +8849,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7984333127190251,
       "avgFidelity": 1,
-      "avgPrecision": 0.9833333333333334,
+      "avgPrecision": 0.9941558441558441,
       "avgRoleFidelity": 0.9867083995760466,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9479,15 +9479,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7381467738610596,
+      "avgConfidence": 0.7251597608740467,
       "avgFidelity": 1,
-      "avgPrecision": 0.9525172879068982,
-      "avgRoleFidelity": 0.951484564719859,
+      "avgPrecision": 0.9639301175015461,
+      "avgRoleFidelity": 0.9349144231497175,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9530,14 +9530,6 @@
           "confidence": 1
         },
         "wait-for-event": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "transition-transform": {
           "success": true,
           "confidence": 1
         },
@@ -9629,10 +9621,6 @@
           "success": true,
           "confidence": 1
         },
-        "transition-color": {
-          "success": true,
-          "confidence": 1
-        },
         "next-element": {
           "success": true,
           "confidence": 1
@@ -9674,10 +9662,6 @@
           "confidence": 1
         },
         "if-empty": {
-          "success": true,
-          "confidence": 1
-        },
-        "fade-out-remove": {
           "success": true,
           "confidence": 1
         },
@@ -9873,6 +9857,14 @@
           "success": true,
           "confidence": 0.5
         },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 0.5
+        },
         "multiple-events": {
           "success": true,
           "confidence": 0.5
@@ -9961,6 +9953,10 @@
           "success": true,
           "confidence": 0.5
         },
+        "transition-color": {
+          "success": true,
+          "confidence": 0.5
+        },
         "previous-element": {
           "success": true,
           "confidence": 0.5
@@ -9990,6 +9986,10 @@
           "confidence": 0.5
         },
         "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.5
+        },
+        "fade-out-remove": {
           "success": true,
           "confidence": 0.5
         },
@@ -10111,7 +10111,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8135642135642115,
+      "avgConfidence": 0.818181818181816,
       "avgFidelity": 1,
       "avgPrecision": 0.9915854978354979,
       "avgRoleFidelity": 0.9806755810432282,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10142,6 +10142,14 @@
           "confidence": 1
         },
         "toggle-visibility": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
           "success": true,
           "confidence": 1
         },
@@ -10173,6 +10181,10 @@
           "success": true,
           "confidence": 1
         },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
         "next-element": {
           "success": true,
           "confidence": 1
@@ -10186,6 +10198,10 @@
           "confidence": 1
         },
         "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
           "success": true,
           "confidence": 1
         },
@@ -10317,14 +10333,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "multiple-events": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -10369,10 +10377,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "transition-color": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "last-in-collection": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -10390,10 +10394,6 @@
           "confidence": 0.8222222222222222
         },
         "event-throttle": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "fade-out-remove": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -10743,7 +10743,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7962481962481944,
+      "avgConfidence": 0.800865800865799,
       "avgFidelity": 1,
       "avgPrecision": 0.9941558441558443,
       "avgRoleFidelity": 0.9884572072072073,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10774,6 +10774,14 @@
           "confidence": 1
         },
         "toggle-visibility": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
           "success": true,
           "confidence": 1
         },
@@ -10805,6 +10813,10 @@
           "success": true,
           "confidence": 1
         },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
         "next-element": {
           "success": true,
           "confidence": 1
@@ -10814,6 +10826,10 @@
           "confidence": 1
         },
         "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
           "success": true,
           "confidence": 1
         },
@@ -10937,14 +10953,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "multiple-events": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -10993,10 +11001,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "transition-color": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "last-in-collection": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -11018,10 +11022,6 @@
           "confidence": 0.8222222222222222
         },
         "event-throttle": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "fade-out-remove": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -11377,13 +11377,13 @@
       "parseRate": 1,
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
-      "avgPrecision": 0.9753246753246753,
+      "avgPrecision": 0.986147186147186,
       "avgRoleFidelity": 0.9809008062684536,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12009,13 +12009,13 @@
       "parseRate": 1,
       "avgConfidence": 0.824382129247231,
       "avgFidelity": 1,
-      "avgPrecision": 0.9800865800865801,
+      "avgPrecision": 0.9909090909090909,
       "avgRoleFidelity": 0.9929617117117115,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12641,13 +12641,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8340114355151945,
       "avgFidelity": 1,
-      "avgPrecision": 0.9520843874739979,
-      "avgRoleFidelity": 0.9593769108474991,
+      "avgPrecision": 0.9634972170686459,
+      "avgRoleFidelity": 0.9574464089169973,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13271,7 +13271,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8139764996907833,
+      "avgConfidence": 0.818594104308388,
       "avgFidelity": 1,
       "avgPrecision": 0.9915854978354978,
       "avgRoleFidelity": 0.9806755810432282,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13313,6 +13313,14 @@
           "success": true,
           "confidence": 1
         },
+        "transition-opacity": {
+          "success": true,
+          "confidence": 1
+        },
+        "transition-transform": {
+          "success": true,
+          "confidence": 1
+        },
         "send-event": {
           "success": true,
           "confidence": 1
@@ -13341,6 +13349,10 @@
           "success": true,
           "confidence": 1
         },
+        "transition-color": {
+          "success": true,
+          "confidence": 1
+        },
         "next-element": {
           "success": true,
           "confidence": 1
@@ -13350,6 +13362,10 @@
           "confidence": 1
         },
         "fetch-loading-state": {
+          "success": true,
+          "confidence": 1
+        },
+        "fade-out-remove": {
           "success": true,
           "confidence": 1
         },
@@ -13473,14 +13489,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "transition-opacity": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "transition-transform": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "multiple-events": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -13533,10 +13541,6 @@
           "success": true,
           "confidence": 0.8222222222222222
         },
-        "transition-color": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
         "last-in-collection": {
           "success": true,
           "confidence": 0.8222222222222222
@@ -13554,10 +13558,6 @@
           "confidence": 0.8222222222222222
         },
         "event-throttle": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "fade-out-remove": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -13905,13 +13905,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
-      "avgPrecision": 0.9811958874458874,
+      "avgPrecision": 0.9920183982683983,
       "avgRoleFidelity": 0.9917759671436144,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478095,
+      "bundleSize": 478781,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 478095,
+      "size": 478781,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Second increment of this session's R1/precision burn-down (follows #576). Drills the **largest R0-precision family** — spurious `transition` ×66 — which had never been probed. The mechanism turned out inverted: the 14 "spurious" languages were parsing the command correctly; **the en reference (and 8 other languages) silently dropped it** because the transition schema couldn't match the corpus-idiomatic forms.

## Mechanisms and fixes (one family, five aligned fixes)

1. **Schema patient admits `expression` + `selector`** — the bare CSS property (`opacity` → identifier/expression) and style-property syntax (`*background-color` → selector) were rejected by the literal-only patient in *every* language; only the lax body walkers recovered it. The `SCHEMA_TRANSITION_PATIENT_ACCEPTS_SELECTOR` validator rule encoding the obsolete premise is retired.
2. **Goal markers aligned to the rendered corpus** — de `zu` (was `auf`), sw `kwa` (was `kwenye`), + new he/it/ms/pl/ru/th/uk/vi/zh/ko entries. The override table disagreed with what the i18n transformer actually renders, so the generated pattern could never fire.
3. **sw keyword** — `mpito` (the rendered verb) added as a profile alternative.
4. **zh tokenizer** — the particle extractor now defers to longer profile keywords: `过渡` was split into `过` (aspect particle) + `渡` (stray identifier), so the verb never anchored. Longest-match now wins across extractors.
5. **th/qu dict realignment** (the #569 sw-`kama` precedent) — th `เปลี่ยน` collided with the profile's `change` keyword, qu `tikray` with `toggle`; dicts now render the profile primaries `เปลี่ยนผ่าน` / `pasay`. Lexicon-mismatch allowlist pruned.
6. **SOV trailing duration reclaim** (the #561 quantity-reclaim sibling) — verb-final renders strand the bare time literal (ja `遷移 0 に 500ms`); a TIME-shaped trailing literal now reclaims into transition's absent optional `duration` (bare numbers stay the quantity reclaim's domain — locked by test).

## Numbers

- **Spurious `transition` ×66 → ×6** (slide-toggle only — the goal-less `transition *max-height over 300ms` form; making goal optional verifiably clobbers goal+duration capture in every marker language, so it stays a residue item). Phantom qu `toggle` ×6 and th `change` ×4 also cleared.
- **avgPrecision mean 0.9764 → 0.9840**, every language up.
- 17 languages at full en role parity on the transition patterns; **zero-lossy verified action-level in all 24 languages** (incl. behavior-removable, slide-toggle).
- avgRoleFidelity mean 0.9781 → 0.9768: the en reference now carries real `transition.*` entries the SOV six don't fully match yet (duration hi/qu; behavior-removable roles bn/hi/ja/ko/qu/tr) — tracked residue, not a parse regression (those parses are unchanged or better).
- Parse 3696/3696, degenerate/lossy 0, R2 1.0. Six-signal `--regression` gate green; baseline regenerated against a fresh populate (patterns.db not committed, per policy).

## Tests

- 7 new locks; **6 fail without the fixes** (stash round-trip verified; the 7th is the quantity-domain no-regression lock, passes both ways by design).
- Suites: semantic 6496 passed / 10 skipped, i18n 912 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)