### PR TITLE
fix(multilingual): conjunction-split loop head — the owed `end` is block content, not the body terminator

### DIFF
--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1798,7 +1798,29 @@ export class SemanticParserImpl implements ISemanticParser {
           const clauseNodes = this.parseClause(currentClauseTokens, commandPatterns, language);
           clauses.push(...clauseNodes);
           currentClauseTokens.length = 0; // Clear for next clause
-          pendingBlockDepth = 0;
+          // Re-derive the "end debt" from what the clause actually PARSED to:
+          // each blockless loop-head command (for/repeat/while with no attached
+          // body) still owes its block-terminating `end`. The i18n transformer
+          // inserts a conjunction between a loop head and its body (`para item
+          // en $items ENTONCES establecer … fin` — en renders `for item in
+          // $items set … end`, no conjunction), so the head's `end` arrives in
+          // a LATER clause; the old unconditional reset made that `fin` read as
+          // the body terminator and every command after the loop was silently
+          // dropped (template-literal-list-build ×22 — the largest set-family
+          // R1 cluster, all 22 translations losing the final `set
+          // #list.innerHTML`). Deriving from the PARSE (not token-kind
+          // heuristics) is language-independent: pt `para` and sw `kwa`
+          // tokenize as destination PARTICLES (never keyword/for), and a
+          // spurious homonym token (bn `জন্য`, both `for` and a benefactive
+          // postposition) that parsed to no loop head contributes nothing —
+          // exactly the old reset.
+          pendingBlockDepth = clauseNodes.filter(n => {
+            const rec = n as { action?: string; body?: unknown[] };
+            return (
+              (rec.action === 'for' || rec.action === 'repeat' || rec.action === 'while') &&
+              (!Array.isArray(rec.body) || rec.body.length === 0)
+            );
+          }).length;
         }
         tokens.advance(); // Consume conjunction token
         continue;
@@ -1864,7 +1886,10 @@ export class SemanticParserImpl implements ISemanticParser {
       // Accumulate token for current clause. Count nested-block openers so the
       // depth-aware `end` check above knows when an `end` closes a nested block
       // rather than the body itself. (Openers reached at a clause boundary are
-      // consumed by the fold guards instead and never get here.)
+      // consumed by the fold guards instead and never get here. A loop opener
+      // that tokenizes as a PARTICLE — es/pt `para`, sw `kwa` — is invisible
+      // here, but the conjunction boundary re-derives the owed-`end` debt from
+      // the clause's PARSE, which covers it.)
       if (current.kind === 'keyword') {
         const cv = (current.normalized ?? current.value).toLowerCase();
         if (
@@ -2771,6 +2796,30 @@ export class SemanticParserImpl implements ISemanticParser {
       clauseHadMatch = false;
     };
 
+    // Loop-head "end debt": an `end` owed to an earlier flat loop HEAD
+    // (for/repeat/while pushed without a body) is block content, not the body
+    // terminator. The i18n transformer inserts a conjunction between a loop
+    // head and its body (`para item en $items ENTONCES establecer … fin` — en
+    // renders no conjunction there), so the head's `end` arrives clauses
+    // later; breaking on it silently dropped every command after the loop
+    // (template-literal-list-build ×22 — all translations losing the final
+    // `set #list.innerHTML`). parseBodyWithClauses carries the same debt
+    // across its conjunction boundary (pendingBlockDepth).
+    let endsConsumedAsContent = 0;
+    const outstandingLoopEndDebt = (): number => {
+      let heads = 0;
+      for (const n of commands) {
+        const rec = n as { action?: string; body?: unknown[] };
+        if (
+          (rec.action === 'for' || rec.action === 'repeat' || rec.action === 'while') &&
+          (!Array.isArray(rec.body) || rec.body.length === 0)
+        ) {
+          heads++;
+        }
+      }
+      return heads - endsConsumedAsContent;
+    };
+
     while (!tokens.isAtEnd()) {
       const current = tokens.peek();
 
@@ -2797,6 +2846,13 @@ export class SemanticParserImpl implements ISemanticParser {
         );
         if (!isPositionalEnd) {
           flushClause();
+          if (outstandingLoopEndDebt() > 0) {
+            // This `end` closes an earlier conjunction-split loop head — consume
+            // it as block content and keep walking the body.
+            endsConsumedAsContent++;
+            tokens.advance();
+            continue;
+          }
           tokens.advance();
           break;
         }

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -10243,4 +10243,93 @@ describe('en-reference noise: send destination dropped / event truncated (R1 res
       expect(roleOf2(inc, 'quantity')).toMatchObject({ type: 'literal', value: 10 });
     });
   });
+
+  describe('conjunction-split loop head: the owed `end` is block content, not the body terminator', () => {
+    // The i18n transformer inserts a conjunction between a loop head and its
+    // body (es `para item en $items ENTONCES establecer … fin`; en renders
+    // `for item in $items set … end`, no conjunction). Both body walkers
+    // treated the head's later `fin` as THE body terminator and silently
+    // dropped every command after the loop — template-literal-list-build lost
+    // its final `set #list.innerHTML to $html` in ALL 22 translations
+    // (set.destination:property-path ×46, the largest set-family R1 cluster).
+    // Now: parseBodyWithClauses carries the opener's depth across the
+    // conjunction boundary when the flushed clause really parsed to a loop
+    // head (a loop opener can tokenize as a PARTICLE — es `para` — so
+    // clause-initial particle openers count too), and
+    // parseBodyWithGrammarPatterns consumes an `end` owed to a pushed
+    // blockless loop head instead of breaking.
+    function allActions(n: unknown, acc: string[] = []): string[] {
+      if (!n || typeof n !== 'object') return acc;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string' && rec.action !== 'compound') acc.push(rec.action);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) allActions(x, acc);
+      }
+      return acc;
+    }
+
+    // pt `para` and sw `kwa` tokenize as destination PARTICLES (never
+    // keyword/for), so the debt must derive from the clause PARSE, not token
+    // kinds — these two lock the particle-opener languages alongside es.
+    const conjunctionSplitCases: Array<[string, string]> = [
+      [
+        'pt',
+        'em clique definir $html para "" então para item dentro $items então definir $html para $html + `<li>${item.name}</li>` fim então definir #list.innerHTML para $html',
+      ],
+      [
+        'sw',
+        'kwenye bonyeza seti $html kwa "" kisha kwa item ndani $items kisha seti $html kwa $html + `<li>${item.name}</li>` mwisho kisha seti #list.innerHTML kwa $html',
+      ],
+    ];
+    for (const [lang, input] of conjunctionSplitCases) {
+      it(`[${lang}] particle-opener loop keeps the final set after the loop end-word`, () => {
+        const node = parse(input, lang);
+        expect(allActions(node).filter(a => a === 'set').length).toBe(3);
+      });
+    }
+
+    it('[es] template-literal-list-build keeps the final set after the loop `fin`', () => {
+      const node = parse(
+        'en clic establecer $html a "" entonces para item en $items entonces establecer $html a $html + `<li>${item.name}</li>` fin entonces establecer #list.innerHTML a $html',
+        'es'
+      );
+      const sets = allActions(node).filter(a => a === 'set');
+      expect(sets.length).toBe(3);
+      // The reclaimed final set binds the property-path destination, like en.
+      function findLastSet(x: unknown): Record<string, any> | null {
+        let last: Record<string, any> | null = null;
+        (function walk(n: unknown) {
+          if (!n || typeof n !== 'object') return;
+          const rec = n as Record<string, any>;
+          if (rec.action === 'set') last = rec;
+          for (const f of ['body', 'statements']) {
+            const c = rec[f];
+            if (Array.isArray(c)) c.forEach(walk);
+          }
+        })(x);
+        return last;
+      }
+      const lastSet = findLastSet(node)!;
+      const dest = lastSet.roles instanceof Map ? lastSet.roles.get('destination') : undefined;
+      expect(dest?.type).toBe('property-path');
+    });
+
+    it('[en] the no-conjunction en form is unchanged (depth path, byte-identical)', () => {
+      const node = parse(
+        'on click set $html to "" then for item in $items set $html to $html + `<li>${item.name}</li>` end then set #list.innerHTML to $html',
+        'en'
+      );
+      const sets = allActions(node).filter(a => a === 'set');
+      expect(sets.length).toBe(3);
+    });
+
+    it('[es] a body with no loop head still terminates at `fin` (debt never negative)', () => {
+      // `fin` with no owed loop head must terminate the body exactly as before.
+      const node = parse('en clic alternar .active fin', 'es');
+      const actions = allActions(node);
+      expect(actions).toContain('toggle');
+      expect(actions.filter(a => a === 'for' || a === 'repeat')).toHaveLength(0);
+    });
+  });
 });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-05T18:29:26.295Z",
-  "commit": "c6590360",
+  "timestamp": "2026-07-05T18:54:30.682Z",
+  "commit": "7e9db8ab",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9,12 +9,12 @@
       "avgConfidence": 0.8399201626424081,
       "avgFidelity": 1,
       "avgPrecision": 0.9904761904761905,
-      "avgRoleFidelity": 0.9862049549549549,
+      "avgRoleFidelity": 0.9870495495495494,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8462563334743781,
       "avgFidelity": 1,
-      "avgPrecision": 0.9460281385281387,
+      "avgPrecision": 0.9465476190476191,
       "avgRoleFidelity": 0.9599305106658049,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.828035456606883,
       "avgFidelity": 1,
       "avgPrecision": 0.9967532467532467,
-      "avgRoleFidelity": 0.9829874517374517,
+      "avgRoleFidelity": 0.9838320463320464,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
       "avgPrecision": 0.9967532467532467,
-      "avgRoleFidelity": 0.9878345257021727,
+      "avgRoleFidelity": 0.9886791202967673,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
       "avgPrecision": 0.9941558441558441,
-      "avgRoleFidelity": 0.9829874517374517,
+      "avgRoleFidelity": 0.9838320463320464,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3794,12 +3794,12 @@
       "avgConfidence": 0.8284065141207998,
       "avgFidelity": 1,
       "avgPrecision": 0.9864718614718616,
-      "avgRoleFidelity": 0.987331081081081,
+      "avgRoleFidelity": 0.9881756756756757,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4426,12 +4426,12 @@
       "avgConfidence": 0.8993587865768304,
       "avgFidelity": 1,
       "avgPrecision": 0.9526747062461347,
-      "avgRoleFidelity": 0.9433603690956631,
+      "avgRoleFidelity": 0.9450495582848523,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
       "avgPrecision": 0.9963203463203464,
-      "avgRoleFidelity": 0.9854005791505792,
+      "avgRoleFidelity": 0.9862451737451738,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.988771645021645,
-      "avgRoleFidelity": 0.9895076273752744,
+      "avgRoleFidelity": 0.990352221969869,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8351246080569386,
       "avgFidelity": 1,
       "avgPrecision": 0.9643939393939395,
-      "avgRoleFidelity": 0.9578438651968065,
+      "avgRoleFidelity": 0.9595330543859957,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6954,12 @@
       "avgConfidence": 0.8300741030064334,
       "avgFidelity": 1,
       "avgPrecision": 0.9643939393939397,
-      "avgRoleFidelity": 0.9544654868184279,
+      "avgRoleFidelity": 0.9561546760076172,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
       "avgPrecision": 0.9919913419913419,
-      "avgRoleFidelity": 0.9867680180180182,
+      "avgRoleFidelity": 0.9876126126126128,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.807173778602348,
       "avgFidelity": 1,
       "avgPrecision": 0.9941829004329004,
-      "avgRoleFidelity": 0.9783589787266259,
+      "avgRoleFidelity": 0.9792035733212205,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8850,12 @@
       "avgConfidence": 0.7984333127190251,
       "avgFidelity": 1,
       "avgPrecision": 0.9941558441558441,
-      "avgRoleFidelity": 0.9867083995760466,
+      "avgRoleFidelity": 0.9875529941706412,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9482,12 @@
       "avgConfidence": 0.7251597608740467,
       "avgFidelity": 1,
       "avgPrecision": 0.9639301175015461,
-      "avgRoleFidelity": 0.9349144231497175,
+      "avgRoleFidelity": 0.9366036123389068,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.818181818181816,
       "avgFidelity": 1,
       "avgPrecision": 0.9915854978354979,
-      "avgRoleFidelity": 0.9806755810432282,
+      "avgRoleFidelity": 0.9815201756378227,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10746,12 +10746,12 @@
       "avgConfidence": 0.800865800865799,
       "avgFidelity": 1,
       "avgPrecision": 0.9941558441558443,
-      "avgRoleFidelity": 0.9884572072072073,
+      "avgRoleFidelity": 0.9893018018018019,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.986147186147186,
-      "avgRoleFidelity": 0.9809008062684536,
+      "avgRoleFidelity": 0.9817454008630481,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12010,12 +12010,12 @@
       "avgConfidence": 0.824382129247231,
       "avgFidelity": 1,
       "avgPrecision": 0.9909090909090909,
-      "avgRoleFidelity": 0.9929617117117115,
+      "avgRoleFidelity": 0.9938063063063062,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12642,12 +12642,12 @@
       "avgConfidence": 0.8340114355151945,
       "avgFidelity": 1,
       "avgPrecision": 0.9634972170686459,
-      "avgRoleFidelity": 0.9574464089169973,
+      "avgRoleFidelity": 0.9591355981061864,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13274,12 +13274,12 @@
       "avgConfidence": 0.818594104308388,
       "avgFidelity": 1,
       "avgPrecision": 0.9915854978354978,
-      "avgRoleFidelity": 0.9806755810432282,
+      "avgRoleFidelity": 0.9815201756378227,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13906,12 +13906,12 @@
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
       "avgPrecision": 0.9920183982683983,
-      "avgRoleFidelity": 0.9917759671436144,
+      "avgRoleFidelity": 0.992620561738209,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14538,12 +14538,12 @@
       "avgConfidence": 0.9840032982890127,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9882158944658944,
+      "avgRoleFidelity": 0.989060489060489,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 478781,
+      "bundleSize": 479120,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 478781,
+      "size": 479120,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Third increment of this session's burn-down (follows #576, #577). Drills the largest remaining set-family R1 cluster: `set.destination:property-path` ×46, with template-literal-list-build ×22 as the bulk — **all 22 translations** were losing the final `set #list.innerHTML to $html`.

**Mechanism.** The i18n transformer inserts a conjunction between a loop head and its body (es `para item en $items ENTONCES establecer … fin`; en renders `for item in $items set … end` with no conjunction). Both body walkers treated the head's later `fin` as *the body terminator* and silently dropped every command after the loop.

**Fix (mirrored in both walkers, parse-derived).** The "end debt" derives from what the clause actually **parsed to** — not token-kind heuristics, which are language-dependent: a loop opener can tokenize as a destination *particle* (es/pt `para`, sw `kwa` never tokenize as keyword/for), while a for-homonym particle that parses to no loop head (bn `জন্য`, benefactive) contributes nothing.

- `parseBodyWithClauses`: the conjunction boundary re-derives `pendingBlockDepth` as the count of blockless loop-head commands (for/repeat/while with no attached body) in the flushed clause, instead of unconditionally resetting.
- `parseBodyWithGrammarPatterns`: an `end` owed to an already-pushed blockless loop head is consumed as block content instead of breaking the walk.

## Numbers

- Baseline avgRoleFidelity **0.9768 → 0.9778**, **zero languages down**, precision flat at 0.984.
- `set.destination:property-path` ×46 → ×24: template-literal-list-build cleared in **all 22 languages**; `set.patient:reference` ×5 also cleared.
- Parse 3696/3696, lossy/degenerate/executionFailures 0, six-signal gate green; baseline regenerated against a fresh populate (patterns.db not committed).

## Tests

- es/pt/sw full-handler locks (**fail without the fix**, stash-verified on es), en no-conjunction depth-path lock, no-loop-head `fin` termination lock.
- Suites: semantic 6501 passed / 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)