### PR TITLE
fix(multilingual): set of-possessive coverage + A2 operator-run assembly (set family R1 drill)

### DIFF
--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -446,6 +446,28 @@ export class PatternMatcher {
       return true;
     }
 
+    // Multi-token OPERATOR-RUN expression (cluster A2): `"Hello, " + my value`,
+    // `(the value of #price as Number) * (my value as Number)`. The tokenizers
+    // split these into value/operator/value token runs, so a single-token role
+    // capture takes only the first operand and the pattern then dies on the
+    // operator — the en reference silently dropped the `+ my value` tail
+    // (patient:literal="Hello, ") and every SOV set fell through to the
+    // role-swapping verb-anchoring fallback. Assembling the whole run into one
+    // expression value lets the surrounding pattern match at position 0. Strictly
+    // pairwise (value OP value (OP value)*): it fires only when a binary operator
+    // DIRECTLY follows the first operand, so every non-arithmetic capture is
+    // untouched. Skipped for the event role (an event name is never an operand).
+    if (
+      patternToken.role !== 'event' &&
+      (!patternToken.expectedTypes || patternToken.expectedTypes.includes('expression'))
+    ) {
+      const runValue = this.tryMatchOperatorRunExpression(tokens);
+      if (runValue) {
+        captured.set(patternToken.role, runValue);
+        return true;
+      }
+    }
+
     // Check for an "of"-possessive expression (e.g. "*--primary-color of #theme",
     // AR "*--primary-color من #theme", TL "*--primary-color ng #theme"). Gated to
     // roles that opt into property-path (currently `set`'s destination), so the
@@ -913,6 +935,25 @@ export class PatternMatcher {
     sw: new Set(['ya']),
     vi: new Set(['của']),
     zh: new Set(['的']),
+    // The i18n transformer keeps the en of-form order (property first) in every
+    // language and only swaps the connector word, so the genitive particles /
+    // of-prepositions below are safe to read property-first here. Several of
+    // them normalize to OTHER senses (it `di`→tell, pl `z`/uk `з`→style,
+    // qu `pa`/tr `nin`→destination), which is why the normalized-form check in
+    // isOfPossessiveMarker can't catch them. ru `из` needs no entry (normalizes
+    // to `source`, already accepted). Without these, `set the *--primary-color
+    // of #theme to …` captured a bare selector as the destination and dropped
+    // the owner (SVO) or skipped ahead past the property entirely (SOV).
+    it: new Set(['di']),
+    pl: new Set(['z']),
+    uk: new Set(['з']),
+    th: new Set(['ของ']),
+    ja: new Set(['の']),
+    ko: new Set(['의']),
+    bn: new Set(['র']),
+    hi: new Set(['का']),
+    qu: new Set(['pa']),
+    tr: new Set(['nin']),
   };
 
   /**
@@ -932,6 +973,102 @@ export class PatternMatcher {
       ? PatternMatcher.OF_POSSESSIVE_MARKERS[this.currentProfile.code]
       : undefined;
     return !!langMarkers && langMarkers.has(value);
+  }
+
+  /**
+   * Binary operators that can join operands in an operator-run expression.
+   * `*` tokenizes as a SELECTOR (the style-prefix char) but is only read as an
+   * operator here when it sits BETWEEN two operands, so a bare `*opacity`
+   * style selector (one fused token) is never affected.
+   */
+  private static readonly RUN_OPERATORS = new Set(['+', '-', '*', '/']);
+
+  /**
+   * Try to match a multi-token operator-run expression:
+   *   <operand> <op> <operand> (<op> <operand>)*
+   * where an operand is a parenthesized group (balanced `(`…`)` tokens), a
+   * possessive pair (`my value`, `私の 値`), or a single value token.
+   * Returns null — leaving the stream untouched — unless an operator DIRECTLY
+   * follows the first operand, so ordinary single-token captures never change.
+   */
+  private tryMatchOperatorRunExpression(tokens: TokenStream): SemanticValue | null {
+    const mark = tokens.mark();
+    const startIdx = tokens.position();
+
+    if (!this.tryConsumeRunOperand(tokens)) {
+      tokens.reset(mark);
+      return null;
+    }
+
+    let operands = 1;
+    for (;;) {
+      const op = tokens.peek();
+      if (!op || !PatternMatcher.RUN_OPERATORS.has(op.value)) break;
+      const beforeOp = tokens.mark();
+      tokens.advance();
+      if (!this.tryConsumeRunOperand(tokens)) {
+        // Dangling operator — leave it (and whatever follows) unconsumed.
+        tokens.reset(beforeOp);
+        break;
+      }
+      operands++;
+    }
+
+    if (operands < 2) {
+      tokens.reset(mark);
+      return null;
+    }
+
+    const raw = tokens.tokens
+      .slice(startIdx, tokens.position())
+      .map(t => t.value)
+      .join(' ');
+    return { type: 'expression', raw, value: raw } as SemanticValue;
+  }
+
+  /**
+   * Consume one operand of an operator run. Returns false (stream untouched)
+   * if the upcoming tokens do not form an operand.
+   */
+  private tryConsumeRunOperand(tokens: TokenStream): boolean {
+    const token = tokens.peek();
+    if (!token) return false;
+
+    // Parenthesized group: `(` … matching `)` (parens tokenize as standalone
+    // identifier tokens; role markers INSIDE the parens — hi `के_रूप_में`'s में —
+    // are opaque to the balance count, which is the point).
+    if (token.value === '(') {
+      const mark = tokens.mark();
+      let depth = 0;
+      while (!tokens.isAtEnd()) {
+        const t = tokens.advance();
+        if (t.value === '(') depth++;
+        else if (t.value === ')') {
+          depth--;
+          if (depth === 0) return true;
+        }
+      }
+      tokens.reset(mark); // unbalanced
+      return false;
+    }
+
+    // Possessive pair (`my value`, `私の 値`, `mi valor`).
+    if (this.tryMatchPossessiveExpression(tokens)) return true;
+
+    // Single value token. Particles/conjunctions/punctuation are never
+    // operands (they belong to the surrounding pattern).
+    if (
+      (token.kind === 'literal' ||
+        token.kind === 'identifier' ||
+        token.kind === 'selector' ||
+        token.kind === 'keyword') &&
+      !PatternMatcher.RUN_OPERATORS.has(token.value) &&
+      token.value !== ')'
+    ) {
+      tokens.advance();
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -898,6 +898,34 @@ export class SemanticParserImpl implements ISemanticParser {
           return withDiagnostics(result, diagnostics);
         }
       }
+      // SOV trailing-event guard: a fused SOV render is `<body> <event> <marker>`
+      // (ja `… に 設定 クリック で`). When the plain command pattern can now match
+      // the body AT POSITION 0 (e.g. the of-possessive destination made
+      // set-ja-generated whole), it wins Stage 2 with the trailing event phrase
+      // left unconsumed — and the handler wrapper silently drops (the event
+      // extraction stages never run after a Stage-2 return). If the match left a
+      // trailing remainder in an SOV language, prefer the event extraction; it
+      // fires only on a real event whose body parses (null otherwise), so it can
+      // only add the wrapper back, never break a genuine bare command.
+      if (
+        commandMatch.consumedTokens < tokens.tokens.length &&
+        tryGetProfile(language)?.wordOrder === 'SOV'
+      ) {
+        const sovTrailing = this.trySOVEventExtraction(parseInput, language, sortedPatterns);
+        if (sovTrailing) {
+          diagnostics.push(
+            parseDiagnostic(
+              `SOV event extraction preferred over partial ${commandMatch.pattern.command} command (trailing remainder)`,
+              'info',
+              'stage-sov-trailing'
+            )
+          );
+          const result = modifiers
+            ? this.applyModifiers(sovTrailing as EventHandlerSemanticNode, modifiers)
+            : sovTrailing;
+          return withDiagnostics(result, diagnostics);
+        }
+      }
       diagnostics.push(
         parseDiagnostic(
           `command pattern matched: ${commandMatch.pattern.id} (confidence: ${commandMatch.confidence.toFixed(2)})`,

--- a/packages/semantic/src/patterns/set.ts
+++ b/packages/semantic/src/patterns/set.ts
@@ -458,7 +458,13 @@ function getSetPatternsIt(): LanguagePattern[] {
         format: 'impostare {destination} a {patient}',
         tokens: [
           { type: 'literal', value: 'impostare', alternatives: ['imposta', 'set', 'definire'] },
-          { type: 'role', role: 'destination' },
+          {
+            type: 'role',
+            role: 'destination',
+            // property-path opts the of-possessive matcher in (mirrors set-es-full;
+            // `impostare the *--primary-color di #theme in …` truncated without it)
+            expectedTypes: ['property-path', 'selector', 'reference', 'expression'],
+          },
           {
             type: 'group',
             optional: true,
@@ -505,7 +511,12 @@ function getSetPatternsPl(): LanguagePattern[] {
         format: 'ustaw {destination} na {patient}',
         tokens: [
           { type: 'literal', value: 'ustaw', alternatives: ['określ', 'okresl', 'przypisz'] },
-          { type: 'role', role: 'destination' },
+          {
+            type: 'role',
+            role: 'destination',
+            // property-path opts the of-possessive matcher in (mirrors set-es-full)
+            expectedTypes: ['property-path', 'selector', 'reference', 'expression'],
+          },
           {
             type: 'group',
             optional: true,
@@ -627,7 +638,12 @@ function getSetPatternsRu(): LanguagePattern[] {
         format: 'установить {destination} в {patient}',
         tokens: [
           { type: 'literal', value: 'установить', alternatives: ['установи', 'задать', 'задай'] },
-          { type: 'role', role: 'destination' },
+          {
+            type: 'role',
+            role: 'destination',
+            // property-path opts the of-possessive matcher in (mirrors set-es-full)
+            expectedTypes: ['property-path', 'selector', 'reference', 'expression'],
+          },
           {
             type: 'group',
             optional: true,
@@ -714,7 +730,12 @@ function getSetPatternsTh(): LanguagePattern[] {
         format: 'ตั้ง {destination} ใน {patient}',
         tokens: [
           { type: 'literal', value: 'ตั้ง', alternatives: ['กำหนด', 'ตั้งค่า'] },
-          { type: 'role', role: 'destination' },
+          {
+            type: 'role',
+            role: 'destination',
+            // property-path opts the of-possessive matcher in (mirrors set-es-full)
+            expectedTypes: ['property-path', 'selector', 'reference', 'expression'],
+          },
           {
             type: 'group',
             optional: true,
@@ -744,7 +765,12 @@ function getSetPatternsUk(): LanguagePattern[] {
         format: 'встановити {destination} в {patient}',
         tokens: [
           { type: 'literal', value: 'встановити', alternatives: ['встанови', 'задати', 'задай'] },
-          { type: 'role', role: 'destination' },
+          {
+            type: 'role',
+            role: 'destination',
+            // property-path opts the of-possessive matcher in (mirrors set-es-full)
+            expectedTypes: ['property-path', 'selector', 'reference', 'expression'],
+          },
           {
             type: 'group',
             optional: true,

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -10333,3 +10333,134 @@ describe('en-reference noise: send destination dropped / event truncated (R1 res
     });
   });
 });
+
+describe('set of-possessive destination + operator-run patient (the set/A2 drill)', () => {
+  // set-color-variable: `set the *--primary-color of #theme to "#ff6600"`.
+  // The of-connector the i18n transformer emits per language was unknown to
+  // isOfPossessiveMarker in 10 languages (it `di` normalizes to `tell`,
+  // pl `z`/uk `з` to `style`, th `ของ`/ja `の`/ko `의`/bn `র`/hi `का` carry no
+  // usable normalization, qu `pa`/tr `nin` normalize to `destination`), and the
+  // hand-crafted it/pl/ru/th/uk set patterns' destination tokens never opted
+  // into property-path — so the destination truncated to a bare selector (SVO)
+  // or the whole property half was skipped (SOV).
+  function findAction(n: unknown, action: string): Record<string, any> | null {
+    if (!n || typeof n !== 'object') return null;
+    const rec = n as Record<string, any>;
+    if (rec.action === action) return rec;
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      const c = rec[f];
+      if (Array.isArray(c)) {
+        for (const x of c) {
+          const hit = findAction(x, action);
+          if (hit) return hit;
+        }
+      } else if (c && typeof c === 'object') {
+        const hit = findAction(c, action);
+        if (hit) return hit;
+      }
+    }
+    return null;
+  }
+  function roleOf(cmd: Record<string, any> | null, role: string): any {
+    if (!cmd) return undefined;
+    return cmd.roles instanceof Map ? cmd.roles.get(role) : undefined;
+  }
+
+  // Corpus-shaped renders (i18n transformer output for set-color-variable).
+  const ofPossessiveCases: Array<[string, string]> = [
+    ['it', 'su clic impostare the *--primary-color di #theme in "#ff6600"'],
+    ['pl', 'gdy kliknięcie ustaw the *--primary-color z #theme do "#ff6600"'],
+    ['ru', 'при клик установить the *--primary-color из #theme в "#ff6600"'],
+    ['th', 'เมื่อ คลิก ตั้ง the *--primary-color ของ #theme ใน "#ff6600"'],
+    ['uk', 'при клік встановити the *--primary-color з #theme в "#ff6600"'],
+    ['ja', 'the *--primary-color の #theme を "#ff6600" に 設定 クリック で'],
+    ['ko', 'the *--primary-color 의 #theme 를 "#ff6600" 에 설정 클릭 할 때'],
+    ['hi', 'the *--primary-color का #theme को "#ff6600" में सेट क्लिक पर'],
+    ['bn', 'the *--primary-color র #theme কে "#ff6600" তে সেট ক্লিক এ'],
+    ['tr', 'the *--primary-color nin #theme i "#ff6600" e ayarla tıklama de'],
+    ['qu', 'the *--primary-color pa #theme ta "#ff6600" man ñitiy pi churanay'],
+  ];
+  for (const [lang, input] of ofPossessiveCases) {
+    it(`[${lang}] set-color-variable destination is the full of-possessive property-path`, () => {
+      const node = parse(input, lang);
+      // The handler wrapper must survive (SOV trailing-event guard: the now-
+      // whole set pattern must not swallow the trailing event phrase).
+      expect((node as Record<string, any>).action).toBe('on');
+      const set = findAction(node, 'set');
+      expect(set).not.toBeNull();
+      expect(roleOf(set, 'destination')?.type).toBe('property-path');
+      expect(roleOf(set, 'patient')?.type).toBe('literal');
+    });
+  }
+
+  it('[en] set-color-variable reference shape is unchanged', () => {
+    const node = parse('on click set the *--primary-color of #theme to "#ff6600"', 'en');
+    const set = findAction(node, 'set');
+    expect(roleOf(set, 'destination')?.type).toBe('property-path');
+    expect(roleOf(set, 'patient')?.type).toBe('literal');
+  });
+
+  // two-way-binding: `set #greeting.innerText to "Hello, " + my value`.
+  // The tokenizers split the concatenation into value/operator/value runs; a
+  // single-token capture took only `"Hello, "` — the en reference silently
+  // dropped the `+ my value` tail, and the SOV six fell through to the
+  // role-swapping verb-anchoring fallback (patient↔destination inverted).
+  it('[en] operator-run patient captures the FULL concatenation as expression', () => {
+    const node = parse(
+      'on input from #firstName set #greeting.innerText to "Hello, " + my value',
+      'en'
+    );
+    const set = findAction(node, 'set');
+    expect(roleOf(set, 'destination')?.type).toBe('property-path');
+    const patient = roleOf(set, 'patient');
+    expect(patient?.type).toBe('expression');
+    expect(String(patient?.raw ?? patient?.value)).toContain('+');
+  });
+
+  const operatorRunCases: Array<[string, string]> = [
+    ['ja', '#greeting.innerText を "Hello, " + 私の 値 に 設定 入力 で #firstName から'],
+    ['ko', '#greeting.innerText 를 "Hello, " + 내 값 에 설정 입력 할 때 #firstName 에서'],
+    ['tr', '#greeting.innerText i "Hello, " + benim değer e ayarla giriş de #firstName den'],
+    ['hi', '#greeting.innerText को "Hello, " + मेरा मान में सेट इनपुट पर #firstName से'],
+    ['bn', '#greeting.innerText কে "Hello, " + আমার মান তে সেট ইনপুট এ #firstName থেকে'],
+  ];
+  for (const [lang, input] of operatorRunCases) {
+    it(`[${lang}] two-way-binding matches the generated set pattern (no role swap)`, () => {
+      const node = parse(input, lang);
+      expect((node as Record<string, any>).action).toBe('on');
+      const set = findAction(node, 'set');
+      expect(set).not.toBeNull();
+      // destination is the selector+property lvalue, patient the expression run
+      expect(roleOf(set, 'destination')?.type).toBe('property-path');
+      expect(roleOf(set, 'patient')?.type).toBe('expression');
+    });
+  }
+
+  it('[ja] computed-value parenthesized operator-run patient assembles', () => {
+    const node = parse(
+      '#total.innerText を (the 値 の #price として Number) * (私の 値 として Number) に 設定 入力 で .quantity から',
+      'ja'
+    );
+    const set = findAction(node, 'set');
+    expect(roleOf(set, 'destination')?.type).toBe('property-path');
+    expect(roleOf(set, 'patient')?.type).toBe('expression');
+  });
+
+  // Blast-radius locks: non-arithmetic captures must be untouched.
+  it('[en] a plain literal patient does not assemble (set x to 5)', () => {
+    const set = findAction(parse('set x to 5', 'en'), 'set');
+    expect(roleOf(set, 'patient')?.type).toBe('literal');
+  });
+  it('[en] a dangling operator is left unconsumed (set x to 5 +)', () => {
+    const set = findAction(parse('set x to 5 +', 'en'), 'set');
+    expect(roleOf(set, 'patient')?.type).toBe('literal');
+  });
+  it('[ja] owner-first possessive patient is untouched (#button の .active を 切り替え)', () => {
+    // toggle.patient does not opt into property-path; the の here is the
+    // ordinary possessive scope, not the of-possessive corpus render.
+    const node = parse('#button の .active を 切り替え', 'ja');
+    const toggle = findAction(node, 'toggle');
+    expect(toggle).not.toBeNull();
+    expect(roleOf(toggle, 'patient')?.type).toBe('selector');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-05T18:54:30.682Z",
-  "commit": "7e9db8ab",
+  "timestamp": "2026-07-06T00:26:09.918Z",
+  "commit": "3287040d",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -638,15 +638,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8462563334743781,
+      "avgConfidence": 0.8514071976477985,
       "avgFidelity": 1,
-      "avgPrecision": 0.9465476190476191,
-      "avgRoleFidelity": 0.9599305106658049,
+      "avgPrecision": 0.9462298050533345,
+      "avgRoleFidelity": 0.9683331440684382,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1068,6 +1068,14 @@
           "success": true,
           "confidence": 0.7894736842105263
         },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
         "set-text-possessive-dot": {
           "success": true,
           "confidence": 0.7894736842105263
@@ -1097,6 +1105,10 @@
           "confidence": 0.7142857142857143
         },
         "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "set-color-variable": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -1184,10 +1196,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "set-color-variable": {
-          "success": true,
-          "confidence": 0.5
-        },
         "first-in-parent": {
           "success": true,
           "confidence": 0.5
@@ -1205,14 +1213,6 @@
           "confidence": 0.5
         },
         "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "two-way-binding": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "computed-value": {
           "success": true,
           "confidence": 0.5
         },
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4423,15 +4423,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8993587865768304,
+      "avgConfidence": 0.9045096507502506,
       "avgFidelity": 1,
-      "avgPrecision": 0.9526747062461347,
-      "avgRoleFidelity": 0.9450495582848523,
+      "avgPrecision": 0.9527017625231909,
+      "avgRoleFidelity": 0.9534521916874857,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -4917,6 +4917,14 @@
           "success": true,
           "confidence": 0.7894736842105263
         },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
         "set-text-possessive-dot": {
           "success": true,
           "confidence": 0.7894736842105263
@@ -4946,6 +4954,10 @@
           "confidence": 0.7142857142857143
         },
         "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "set-color-variable": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -5025,19 +5037,7 @@
           "success": true,
           "confidence": 0.5
         },
-        "set-color-variable": {
-          "success": true,
-          "confidence": 0.5
-        },
         "first-in-parent": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "two-way-binding": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "computed-value": {
           "success": true,
           "confidence": 0.5
         },
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
       "avgPrecision": 0.988771645021645,
-      "avgRoleFidelity": 0.990352221969869,
+      "avgRoleFidelity": 0.9975111666288136,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6319,15 +6319,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8351246080569386,
+      "avgConfidence": 0.8402754722303589,
       "avgFidelity": 1,
-      "avgPrecision": 0.9643939393939395,
-      "avgRoleFidelity": 0.9595330543859957,
+      "avgPrecision": 0.9644209956709957,
+      "avgRoleFidelity": 0.9679356877886289,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6737,6 +6737,14 @@
           "success": true,
           "confidence": 0.7894736842105263
         },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
         "set-text-possessive-dot": {
           "success": true,
           "confidence": 0.7894736842105263
@@ -6762,6 +6770,10 @@
           "confidence": 0.7894736842105263
         },
         "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "set-color-variable": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -6861,10 +6873,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "set-color-variable": {
-          "success": true,
-          "confidence": 0.5
-        },
         "first-in-parent": {
           "success": true,
           "confidence": 0.5
@@ -6882,14 +6890,6 @@
           "confidence": 0.5
         },
         "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "two-way-binding": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "computed-value": {
           "success": true,
           "confidence": 0.5
         },
@@ -6951,15 +6951,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8300741030064334,
+      "avgConfidence": 0.8352249671798537,
       "avgFidelity": 1,
-      "avgPrecision": 0.9643939393939397,
-      "avgRoleFidelity": 0.9561546760076172,
+      "avgPrecision": 0.9644209956709959,
+      "avgRoleFidelity": 0.9645573094102506,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7361,6 +7361,14 @@
           "success": true,
           "confidence": 0.7894736842105263
         },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
         "set-text-possessive-dot": {
           "success": true,
           "confidence": 0.7894736842105263
@@ -7390,6 +7398,10 @@
           "confidence": 0.7777777777777778
         },
         "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "set-color-variable": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -7481,10 +7493,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "set-color-variable": {
-          "success": true,
-          "confidence": 0.5
-        },
         "first-in-parent": {
           "success": true,
           "confidence": 0.5
@@ -7502,14 +7510,6 @@
           "confidence": 0.5
         },
         "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "two-way-binding": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "computed-value": {
           "success": true,
           "confidence": 0.5
         },
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.807173778602348,
       "avgFidelity": 1,
       "avgPrecision": 0.9941829004329004,
-      "avgRoleFidelity": 0.9792035733212205,
+      "avgRoleFidelity": 0.986362517980165,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9481,13 +9481,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7251597608740467,
       "avgFidelity": 1,
-      "avgPrecision": 0.9639301175015461,
-      "avgRoleFidelity": 0.9366036123389068,
+      "avgPrecision": 0.9639571737786023,
+      "avgRoleFidelity": 0.9382494889847832,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.818181818181816,
       "avgFidelity": 1,
       "avgPrecision": 0.9915854978354979,
-      "avgRoleFidelity": 0.9815201756378227,
+      "avgRoleFidelity": 0.9886791202967675,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
       "avgPrecision": 0.986147186147186,
-      "avgRoleFidelity": 0.9817454008630481,
+      "avgRoleFidelity": 0.9889043455219925,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12639,15 +12639,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8340114355151945,
+      "avgConfidence": 0.8391622996886149,
       "avgFidelity": 1,
-      "avgPrecision": 0.9634972170686459,
-      "avgRoleFidelity": 0.9591355981061864,
+      "avgPrecision": 0.9635242733457021,
+      "avgRoleFidelity": 0.9675382315088197,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13053,6 +13053,14 @@
           "success": true,
           "confidence": 0.7894736842105263
         },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
         "set-text-possessive-dot": {
           "success": true,
           "confidence": 0.7894736842105263
@@ -13082,6 +13090,10 @@
           "confidence": 0.7142857142857143
         },
         "go-back": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "set-color-variable": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -13181,10 +13193,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "set-color-variable": {
-          "success": true,
-          "confidence": 0.5
-        },
         "first-in-parent": {
           "success": true,
           "confidence": 0.5
@@ -13202,14 +13210,6 @@
           "confidence": 0.5
         },
         "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "two-way-binding": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "computed-value": {
           "success": true,
           "confidence": 0.5
         },
@@ -13274,12 +13274,12 @@
       "avgConfidence": 0.818594104308388,
       "avgFidelity": 1,
       "avgPrecision": 0.9915854978354978,
-      "avgRoleFidelity": 0.9815201756378227,
+      "avgRoleFidelity": 0.9886791202967673,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 479120,
+      "bundleSize": 480666,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 479120,
+      "size": 480666,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

The set/A2 drill from `docs-internal/HANDOFF-r1-post-cluster-residue.md` — the largest remaining R1 seam. Re-grounded with a fresh probe first, per the #579 lesson: the A2 matchRoleToken theory WAS needed this time, but only for two of the three member patterns; the third (set-color-variable ×11) was an of-possessive marker-coverage gap, not multi-token assembly.

Three aligned fixes:

1. **Of-possessive genitive markers ×10 languages** (`it di, pl z, uk з, th ของ, ja の, ko 의, bn র, hi का, qu pa, tr nin`) in `OF_POSSESSIVE_MARKERS`, plus the `property-path` `expectedTypes` opt-in on the hand-crafted it/pl/ru/th/uk set destination tokens (mirrors `set-es-full`). The transformer keeps property-first of-form order in every language; these connectors normalize to *other* senses (`di`→tell, `z`/`з`→style, `pa`/`nin`→destination), invisible to the normalized-form check.
2. **SOV trailing-event guard** (Stage 2, semantic-parser): once fix 1 made `set-XX-generated` whole at position 0, it out-competed the event stages and the trailing event phrase (`クリック で`) dropped. A Stage-2 command match leaving a trailing remainder in an SOV language now prefers `trySOVEventExtraction` — additive by the same contract as the existing BLOCK_BODY/homonym/VSO guards.
3. **Operator-run assembly in matchRoleToken (cluster A2)**: `"Hello, " + my value` / `(… as Number) * (… as Number)` assemble into one expression value. Strictly pairwise — fires only when a binary operator directly follows the first operand — with parenthesized-group (balanced, marker-opaque) and possessive-pair operands. Fixes the **en reference's own noise** (patient silently dropped the `+ my value` tail) and lets the generated SOV set patterns match at position 0 instead of falling to the role-swapping verb-anchoring fallback.

## Numbers

- Corpus probe mean R1 **0.9778 → 0.9812**; baseline `avgRoleFidelity` mean same, `avgPrecision` 0.984 held, parse 3696/3696, degenerate/lossy 0, R2 1.0.
- Per-(lang,pattern) A/B: **58 entries fixed, 0 absolute regressions.** 11 languages up (ja/ko/tr/bn/hi +0.0084, it/pl/ru/th/uk +0.0072, qu +0.0016), none down. bn precision −0.0003 is the honest shape: bn behavior-resizable now parses all 4 real `if`s and 12 real `set`s that the **en reference drops** (a future en-noise drill).
- New residue (reference-enrichment mechanics, not regressions): template-literal-list-build `set.patient:expression` SOV six (loop-body sub-parse), two-way-binding/computed-value qu (mid-clause source phrase), template-literal-interpolation qu.
- 18 guard tests fail without the fix (stash round-trip verified); semantic suite 6523 passed; six-signal `--regression` gate green; baseline regenerated against a fresh populate in this PR. patterns.db not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)