### PR TITLE
fix(multilingual): rendered-copula condition guard — the spurious `empty` ×16 precision drill

### DIFF
--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -1,5 +1,61 @@
 # Handoff — R1 residue after the five-cluster triage (fronted repeat-while · sw kama homonym · singletons)
 
+> **STATUS UPDATE (2026-07-05, session 4): the set/A2 cluster and the spurious-`empty`
+> family LANDED as #580 (set of-possessive + A2 operator-run assembly) and the
+> follow-up copula PR.** Post-session state: probe mean R1 **0.9812** (was 0.9778),
+> baseline avgPrecision mean **0.9849** (was 0.984), parse 3696/3696,
+> degenerate/lossy 0, R2 1.0. Per-language A/B across both PRs: 11 languages up on
+> R1 (ja/ko/tr/bn/hi +0.0084, it/pl/ru/th/uk +0.0072, qu +0.0016), 8 up on
+> precision (+0.0026 each), zero meaningfully down.
+>
+> 1. **set/A2 (#580) — the re-probe changed the plan again (the #579 lesson
+>    repeated):** set-color-variable ×11 was NOT multi-token assembly but an
+>    of-possessive marker-coverage gap — 10 languages' genitive connectors
+>    (it `di`→tell, pl `z`/uk `з`→style, th `ของ`, ja `の`, ko `의`, bn `র`,
+>    hi `का`, qu `pa`/tr `nin`→destination) were invisible to the
+>    normalized-form check, and the hand-crafted it/pl/ru/th/uk set destination
+>    tokens never opted into property-path (set-es-full had it; its siblings
+>    didn't). Two knock-on mechanisms: (a) once set-XX-generated became whole at
+>    position 0, it beat the event stages and the trailing SOV event phrase
+>    dropped — a Stage-2 guard now prefers trySOVEventExtraction when a command
+>    match leaves a trailing remainder in an SOV language; (b) two-way-binding /
+>    computed-value DID need the A2 theory: matchRoleToken now assembles
+>    strictly-pairwise operator runs (`"Hello, " + my value`, parenthesized
+>    groups, possessive-pair operands) — which also fixed the EN reference's own
+>    silent `+ my value` tail drop. 58 (lang,pattern) entries fixed.
+> 2. **Spurious `empty` ×28 → ×12 (copula PR) — mechanism NOT inverted this
+>    time (unlike #577):** en was right; 8 languages grew a phantom `empty me`
+>    because their rendered copulas tokenize as bare identifiers (fr `est`,
+>    ru `есть`, pt `é`, uk `є`, tl `ay`, ms `adalah`, th `เป็น`) — or normalize
+>    to an unrelated sense (ar `هو`→`it`) — so the condition split fired at the
+>    predicate word, which doubles as the empty/null COMMAND keyword. New
+>    `CONDITION_COPULAS_SURFACE` set, matched by surface value and gated to a
+>    predicate continuation (norm empty/null/undefined) — the ar pronoun reading
+>    (`إذا هو اضبط …` = `if it set …`) still splits at the command verb
+>    (fetch-do-not-throw guard test locks it).
+>
+> **Residue updated after session 4:**
+>
+> - spurious `empty` remainder ×12: tr/hi/bn ×6 (transformer-side scrambling —
+>   the predicate lands INSIDE the then-branch: tr `… ekle .error i boş ben e`;
+>   parser-side copulas are behavior-neutral there, locked in the set for when
+>   the render heals) + behavior-sortable ×6 ar/hi/id/sw/th/tr (nested behavior
+>   sub-parse: the flat if-head truncates `jika item adalah kosong` and the
+>   leftover `kosong` re-parses as an `empty` command — the same nested-behavior
+>   drill site as behavior-removable's transition roles).
+> - set/A2 residue: template-literal-list-build `set.patient:expression` SOV six
+>   (the loop-BODY sub-parse can't match the now-enriched en middle set);
+>   two-way-binding / computed-value qu (its render interposes the source phrase
+>   `ta .quantity manta` mid-clause, so set-qu-generated can't match);
+>   template-literal-interpolation qu (possessive-head destination in fallback).
+> - **SOV halt.patient ×6 re-probed, shapes confirmed** (ja drops `halt`
+>   entirely; tr captures `halt.patient:expression="the"` and crosses call/halt
+>   roles) — still needs compound-level fronted-role re-association; untouched.
+> - **NEW en-noise site discovered:** behavior-resizable en drops one of the four
+>   `if`s and all four if-branch `set`s that bn (and likely others) now parse —
+>   the bn "spurious" flags there are en deficits. A future behavior-body en
+>   drill, same discipline as #576.
+
 > **STATUS UPDATE (2026-07-05, session 3): two more residue items LANDED as #576
 > (mid-clause if fold) and #577 (transition family alignment).** Post-#577
 > state: probe mean R1 **0.9768**, avgPrecision mean **0.9764 → 0.9840** (every

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -9,27 +9,56 @@
 > [BEHAVIORS_CONSOLIDATION_PLAN.md](BEHAVIORS_CONSOLIDATION_PLAN.md). Read this first,
 > then dive into those for the per-arc detail.
 
-## Where we are (2026-07-05 baseline · post #577 · `browser-priority`)
+## Where we are (2026-07-05 baseline · post session-4 set/A2 + empty drills · `browser-priority`)
 
 Authoritative source: `packages/testing-framework/baselines/multilingual-priority.json`
 (its `timestamp` + `commit` fields stamp each regen). 24 langs × 154 patterns = 3696.
 
-| Signal                         | Value                  | Notes                                                                    |
-| ------------------------------ | ---------------------- | ------------------------------------------------------------------------ |
-| parse rate                     | **3696 / 3696 (100%)** | zero hard fails, holding                                                 |
-| degenerate passes (fid < 0.5)  | **0**                  | band cleared (#492/#493), holding                                        |
-| lossy passes (0.5 ≤ fid < 1.0) | **0**                  | band cleared (#495–#506), holding                                        |
-| faithful (fid = 1.0)           | **3696**               | every parsing pattern is faithful                                        |
-| avgFidelity (R0-recall)        | **1.000**              | saturated                                                                |
-| avgPrecision (R0 trust floor)  | **0.984**              | #577 transition drill: 0.976 → 0.984, every language up                  |
-| avgRoleFidelity (R1)           | **0.977**              | was 0.837 on 2026-06-21; #577 enriched the en reference (see note below) |
-| avgExecutionFidelity (R2)      | **1.000**              | 47-pattern curated subset fully reproduces en DOM effects                |
+| Signal                         | Value                  | Notes                                                                |
+| ------------------------------ | ---------------------- | -------------------------------------------------------------------- |
+| parse rate                     | **3696 / 3696 (100%)** | zero hard fails, holding                                             |
+| degenerate passes (fid < 0.5)  | **0**                  | band cleared (#492/#493), holding                                    |
+| lossy passes (0.5 ≤ fid < 1.0) | **0**                  | band cleared (#495–#506), holding                                    |
+| faithful (fid = 1.0)           | **3696**               | every parsing pattern is faithful                                    |
+| avgFidelity (R0-recall)        | **1.000**              | saturated                                                            |
+| avgPrecision (R0 trust floor)  | **0.985**              | session-4 copula drill: 0.984 → 0.9849 (8 languages +0.0026)         |
+| avgRoleFidelity (R1)           | **0.981**              | session-4 set/A2 drill: 0.9778 → 0.9812 (11 languages up, none down) |
+| avgExecutionFidelity (R2)      | **1.000**              | 47-pattern curated subset fully reproduces en DOM effects            |
 
 The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recall ·
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.** R1 remains the
 dimension with headroom (SOV six ~0.95); R0-precision's spurious-action
 families are the next un-mined seam.
+
+> **Update 2026-07-05d (SESSION 4: the set/A2 drill + the spurious-`empty` copula
+> drill — #580 + follow-up; probe mean R1 0.9778 → 0.9812, avgPrecision 0.984 →
+> 0.9849; per-language A/B zero regressions across both; gate green throughout.)**
+>
+> - **#580 — set of-possessive + A2 operator-run assembly.** The re-probe re-scoped
+>   the plan (the #579 lesson repeating): set-color-variable ×11 was an
+>   of-possessive MARKER gap (10 genitive connectors invisible to the
+>   normalized-form check; it/pl/ru/th/uk hand-crafted destination tokens missing
+>   the property-path opt-in that set-es-full already had), plus a new Stage-2
+>   SOV trailing-event guard (a position-0 command match must not swallow the
+>   trailing event phrase). two-way-binding/computed-value DID need A2:
+>   matchRoleToken assembles strictly-pairwise operator runs — which also fixed
+>   the EN reference's own silent `+ my value` tail drop. 58 entries fixed;
+>   ja/ko/tr/bn/hi +0.0084 R1 each.
+> - **Copula drill — spurious `empty` ×28 → ×12, mechanism NOT inverted** (en was
+>   right): 8 languages' rendered copulas tokenize as bare identifiers (fr est,
+>   ru есть, pt é, uk є, tl ay, ms adalah, th เป็น) or normalize to another sense
+>   (ar هو → `it`), so the condition split fired at the empty/null predicate,
+>   which doubles as the empty COMMAND keyword → phantom `empty me`. New
+>   CONDITION_COPULAS_SURFACE set, matched by surface value, gated to predicate
+>   continuations so ar's pronoun reading still splits (`if it set …`).
+> - **Residue (see HANDOFF-r1-post-cluster-residue.md session-4 block for
+>   detail):** empty tr/hi/bn ×6 (transformer scrambles the predicate into the
+>   then-branch) + behavior-sortable ×6 (nested behavior sub-parse); set/A2 qu
+>   tail (mid-clause source phrase) + template-literal-list-build SOV six
+>   (loop-body sub-parse vs enriched en); SOV halt ×6 re-probed and confirmed
+>   (compound-level fronted-role re-association, untouched); NEW en-noise site:
+>   behavior-resizable en drops an if + its 4 branch sets that bn now parses.
 
 > **Update 2026-07-05c (SESSION 3: if.condition en-noise + the transition precision
 > drill — #576 / #577; avgPrecision 0.976 → 0.984, every language up; probe mean R1

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -3836,6 +3836,40 @@ export class SemanticParserImpl implements ISemanticParser {
   ]);
 
   /**
+   * Rendered copulas that tokenize as bare IDENTIFIERS (no normalization), or —
+   * ar هو — normalize to an unrelated sense (`it`), so {@link CONDITION_COPULAS}
+   * can't catch them. Without these, the i18n-rendered `if my value <copula>
+   * <empty-word> add …` split the condition at the predicate — the empty-word
+   * doubles as the language's `empty`/`null` COMMAND keyword — and a phantom
+   * `empty me` command opened the then-branch (if-empty / input-validation, the
+   * spurious-`empty` ×22 R0-precision family).
+   *
+   * Unlike the normalized copulas above, these suppress the split ONLY when the
+   * next token is a predicate ADJECTIVE (normalizes to empty/null/undefined):
+   * several are ambiguous with other senses (ar هو is also the pronoun `it`, and
+   * `إذا هو اضبط …` = `if it set …` needs the split at the command verb). The
+   * SOV members (bn হয়, hi है, tr dir) are behavior-neutral today — their
+   * transformer scrambles the predicate away from the copula — but lock the
+   * same contract should the render heal.
+   */
+  private static readonly CONDITION_COPULAS_SURFACE = new Set([
+    'est', // fr
+    'есть', // ru
+    'є', // uk
+    'é', // pt
+    'ay', // tl
+    'هو', // ar (keyword norm=`it` — matched by surface VALUE)
+    'adalah', // ms
+    'เป็น', // th
+    'হয়', // bn
+    'है', // hi
+    'dir', // tr
+  ]);
+
+  /** Predicate adjectives (normalized) that follow a copula inside a condition. */
+  private static readonly CONDITION_PREDICATES = new Set(['empty', 'null', 'undefined']);
+
+  /**
    * Condition operators that join two operands inside an `if` condition
    * expression (`I match .x`, `me contains .y`, `#m exists`). An operator can
    * never begin a then-branch command, so the condition extraction must not
@@ -3949,7 +3983,14 @@ export class SemanticParserImpl implements ISemanticParser {
       }
       if (bodyDepth === 0 && condTokens.length > 0) {
         const prev = (blockTokens[i - 1].normalized ?? blockTokens[i - 1].value).toLowerCase();
+        const prevValue = blockTokens[i - 1].value.toLowerCase();
         const cur = (t.normalized ?? t.value).toLowerCase();
+        // Surface-value copulas (fr est, ru есть, ar هو, …) only guard a
+        // PREDICATE continuation — several double as other senses (هو = `it`).
+        const prevIsCopula =
+          SemanticParserImpl.CONDITION_COPULAS.has(prev) ||
+          (SemanticParserImpl.CONDITION_COPULAS_SURFACE.has(prevValue) &&
+            SemanticParserImpl.CONDITION_PREDICATES.has(cur));
         // A condition operator (`match`/`contains`/`exists`/…) is part of the
         // expression, never a then-branch command head — don't truncate at it
         // even if a verb-last SOV command pattern spuriously matches the span.
@@ -3970,7 +4011,7 @@ export class SemanticParserImpl implements ISemanticParser {
           sovVerbLookup !== null && sovVerbLookup.has(t.value.toLowerCase());
         if (
           !SemanticParserImpl.CONDITION_OPERATORS.has(cur) &&
-          (!SemanticParserImpl.CONDITION_COPULAS.has(prev) || curIsSovCommandVerb) &&
+          (!prevIsCopula || curIsSovCommandVerb) &&
           (this.tokensBeginCommand(blockTokens.slice(i), commandPatterns, language) ||
             this.sovCommandStartsAt(blockTokens.slice(i), sovVerbLookup))
         ) {

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -10464,3 +10464,73 @@ describe('set of-possessive destination + operator-run patient (the set/A2 drill
     expect(roleOf(toggle, 'patient')?.type).toBe('selector');
   });
 });
+
+describe('condition copulas: rendered identifier copulas keep the predicate in the condition', () => {
+  // if-empty / input-validation: `if my value is empty add .error to me …`.
+  // The rendered copulas (fr est, ru есть, pt é, uk є, tl ay, ms adalah,
+  // th เป็น) tokenize as bare identifiers — and ar هو normalizes to `it` — so
+  // the copula guard missed them, the condition split fired at the predicate
+  // (vide/пустой/فارغ… doubles as the empty/null COMMAND keyword), and a
+  // phantom `empty me` command opened the then-branch in 8 languages
+  // (spurious-`empty` ×16, the R0-precision family).
+  function allActions(n: unknown, acc: string[] = []): string[] {
+    if (!n || typeof n !== 'object') return acc;
+    const rec = n as Record<string, any>;
+    if (typeof rec.action === 'string' && rec.action !== 'compound') acc.push(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      const c = rec[f];
+      if (Array.isArray(c)) for (const x of c) allActions(x, acc);
+      else if (c && typeof c === 'object') allActions(c, acc);
+    }
+    return acc;
+  }
+
+  const cases: Array<[string, string]> = [
+    [
+      'fr',
+      'sur défocaliser si mon valeur est vide ajouter .error à moi alors mettre "Required" à suivant .error-message fin',
+    ],
+    [
+      'ru',
+      'при размыть если мой значение есть пустой добавить .error в я затем положить "Required" в следующий .error-message конец',
+    ],
+    [
+      'ar',
+      'عند ضبابية إذا لي قيمة هو فارغ أضف .error إلى أنا ثم ضع "Required" إلى التالي .error-message النهاية',
+    ],
+    [
+      'ms',
+      'apabila kabur jika saya_punya nilai adalah kosong tambah .error ke saya kemudian letak "Required" ke seterusnya .error-message tamat',
+    ],
+  ];
+  for (const [lang, input] of cases) {
+    it(`[${lang}] if-empty has no phantom empty command`, () => {
+      const actions = allActions(parse(input, lang));
+      expect(actions.filter(a => a === 'empty')).toHaveLength(0);
+      expect(actions).toContain('if');
+      expect(actions).toContain('add');
+      expect(actions).toContain('put');
+    });
+  }
+
+  it('[ar] هو as the PRONOUN condition still splits at the command verb (fetch-do-not-throw)', () => {
+    // `إذا هو اضبط $users إلى هو` = `if it set $users to it` — هو here is the
+    // bare condition, not a copula; the then-branch set must not be swallowed.
+    const actions = allActions(
+      parse('احضر /api/users عند نقر كـJSON do ليس ارم ثم إذا هو اضبط $users إلى هو النهاية', 'ar')
+    );
+    expect(actions).toContain('set');
+    expect(actions.filter(a => a === 'empty')).toHaveLength(0);
+  });
+
+  it('[en] the reference shape is unchanged (condition keeps `empty`, add opens the branch)', () => {
+    const node = parse(
+      'on blur if my value is empty add .error to me put "Required" into next .error-message end',
+      'en'
+    );
+    const actions = allActions(node);
+    expect(actions.filter(a => a === 'empty')).toHaveLength(0);
+    expect(actions).toContain('add');
+    expect(actions).toContain('put');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-06T00:26:09.918Z",
-  "commit": "3287040d",
+  "timestamp": "2026-07-06T00:41:22.941Z",
+  "commit": "b5e3b004",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -8,13 +8,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8399201626424081,
       "avgFidelity": 1,
-      "avgPrecision": 0.9904761904761905,
+      "avgPrecision": 0.9930735930735931,
       "avgRoleFidelity": 0.9870495495495494,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3161,13 +3161,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
-      "avgPrecision": 0.9941558441558441,
+      "avgPrecision": 0.9967532467532467,
       "avgRoleFidelity": 0.9838320463320464,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7585,13 +7585,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
-      "avgPrecision": 0.9919913419913419,
+      "avgPrecision": 0.9945887445887446,
       "avgRoleFidelity": 0.9876126126126128,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8849,13 +8849,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7984333127190251,
       "avgFidelity": 1,
-      "avgPrecision": 0.9941558441558441,
+      "avgPrecision": 0.9967532467532467,
       "avgRoleFidelity": 0.9875529941706412,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10113,13 +10113,13 @@
       "parseRate": 1,
       "avgConfidence": 0.818181818181816,
       "avgFidelity": 1,
-      "avgPrecision": 0.9915854978354979,
+      "avgPrecision": 0.9941829004329004,
       "avgRoleFidelity": 0.9886791202967675,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11377,13 +11377,13 @@
       "parseRate": 1,
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
-      "avgPrecision": 0.986147186147186,
+      "avgPrecision": 0.9887445887445886,
       "avgRoleFidelity": 0.9889043455219925,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12009,13 +12009,13 @@
       "parseRate": 1,
       "avgConfidence": 0.824382129247231,
       "avgFidelity": 1,
-      "avgPrecision": 0.9909090909090909,
+      "avgPrecision": 0.9935064935064936,
       "avgRoleFidelity": 0.9938063063063062,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13273,13 +13273,13 @@
       "parseRate": 1,
       "avgConfidence": 0.818594104308388,
       "avgFidelity": 1,
-      "avgPrecision": 0.9915854978354978,
+      "avgPrecision": 0.9941829004329004,
       "avgRoleFidelity": 0.9886791202967673,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 480666,
+      "bundleSize": 481013,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 480666,
+      "size": 481013,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

The next-largest undrilled R0-precision family after #577: spurious `empty` ×28. Probed the mechanism first per the session plan — **not inverted this time** (unlike #577's transition family): the en reference is right, and 8 languages grew a phantom `empty me` command.

**Mechanism:** the conditional split's copula guard (`X is empty …` → don't split at the predicate) only checked `normalized ?? value`. The rendered copulas tokenize as bare **identifiers** (fr `est`, ru `есть`, pt `é`, uk `є`, tl `ay`, ms `adalah`, th `เป็น`) — or normalize to an unrelated sense (ar `هو` → `it`) — so the split fired at the predicate word, which doubles as each language's `empty`/`null` **command** keyword, opening the then-branch with a phantom `empty me`.

**Fix:** a `CONDITION_COPULAS_SURFACE` set consulted by surface value, gated to a predicate continuation (norm `empty`/`null`/`undefined`). The gating matters: ar `هو` is also the pronoun *it*, and a broad match swallowed the then-branch `set` after a genuine `if it …` condition (fetch-do-not-throw) — caught in the A/B, now locked by a guard test. The SOV members (bn `হয়`, hi `है`, tr `dir`) are behavior-neutral today (their transformer scrambles the predicate away from the copula; the existing `curIsSovCommandVerb` escape already splits at the command verb) but lock the contract should the render heal.

## Numbers

- Spurious `empty` **×28 → ×12** — 16 cleared (8 languages × if-empty + input-validation), all at en action-multiset parity.
- Baseline `avgPrecision` mean **0.984 → 0.9849** (the 8 languages +0.0026 each); probe mean R1 held at **0.9812**; **zero new missing-role entries corpus-wide** (final A/B: 16 fixed / 0 new).
- Remainder documented as residue: tr/hi/bn ×6 (transformer-side — the predicate lands *inside* the then-branch), behavior-sortable ×6 (nested behavior sub-parse, same drill site as behavior-removable's transition roles).
- 4 guard tests fail without the fix (stash round-trip verified); semantic suite 6529 passed; six-signal `--regression` gate green; baseline regenerated against a fresh populate post-rebase. patterns.db not committed.
- Docs: session-4 status blocks in `HANDOFF-r1-post-cluster-residue.md` + `MULTILINGUAL_NEXT_STEPS.md` (covers #580 as well).

🤖 Generated with [Claude Code](https://claude.com/claude-code)