### PR TITLE
fix(multilingual): then-boundary if fold — mid-clause if blocks span the then-conjunction (behavior-resizable en-noise drill)

### DIFF
--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1767,6 +1767,11 @@ export class SemanticParserImpl implements ISemanticParser {
     // Nesting depth of block openers (`if`/`unless`/`while`/`for`/`repeat`)
     // accumulated into the pending clause — see the depth-aware `end` note below.
     let pendingBlockDepth = 0;
+    // Kind of each open block, parallel to pendingBlockDepth (LIFO — an `end`
+    // closes the innermost opener). While an `if` block is open, a conjunction
+    // is BLOCK CONTENT, not a clause boundary — see the then-boundary note in
+    // the conjunction branch below.
+    const pendingOpenerKinds: Array<'if' | 'other'> = [];
 
     while (!tokens.isAtEnd()) {
       const current = tokens.peek();
@@ -1846,6 +1851,28 @@ export class SemanticParserImpl implements ISemanticParser {
       // keep accumulating so the whole body reaches the per-clause parser.
       if (isEnd && pendingBlockDepth > 0) {
         pendingBlockDepth--;
+        pendingOpenerKinds.pop();
+        currentClauseTokens.push(current);
+        tokens.advance();
+        continue;
+      }
+
+      // Then-boundary suppression for an OPEN mid-clause `if` block. The `then`
+      // between an if-head and its branch is a CONJUNCTION, so the naive split
+      // below would land the if-head clause-FINAL with no branch tokens — the
+      // mid-clause fold in parseClause then has nothing to fold (empty branch →
+      // null), the flat `if` truncates its condition to the first token, the
+      // branch command becomes the NEXT clause, and the if's owed `end` desyncs
+      // the debt bookkeeping until a later `end` terminates the walk early
+      // (behavior-resizable en: the walk broke at the 3rd of 4 ifs, dropping
+      // every following command — bn parsed MORE of the body than the en
+      // reference, so bn's flags were en deficits). While an `if` block is open
+      // in the pending clause, a conjunction is block content: keep
+      // accumulating so the whole `if … then … end` block reaches parseClause,
+      // whose mid-clause fold (tryParseConditionalBlock) splits condition/
+      // branch at the `then` and consumes the matching `end`. Ifs opened at a
+      // clause BOUNDARY never get here — the leading fold consumes them whole.
+      if (isConjunction && pendingOpenerKinds.includes('if')) {
         currentClauseTokens.push(current);
         tokens.advance();
         continue;
@@ -1880,6 +1907,11 @@ export class SemanticParserImpl implements ISemanticParser {
               (!Array.isArray(rec.body) || rec.body.length === 0)
             );
           }).length;
+          // Re-derive the opener kinds too: only blockless LOOP heads survive a
+          // clause boundary (an open `if` suppresses the boundary above, so no
+          // `if` debt can be pending here).
+          pendingOpenerKinds.length = 0;
+          for (let k = 0; k < pendingBlockDepth; k++) pendingOpenerKinds.push('other');
         }
         tokens.advance(); // Consume conjunction token
         continue;
@@ -1959,6 +1991,11 @@ export class SemanticParserImpl implements ISemanticParser {
           cv === 'repeat'
         ) {
           pendingBlockDepth++;
+          // `unless` counts as 'other': the mid-clause fold only folds `if`
+          // (folding unless would relabel its action — see
+          // tryParseConditionalBlock), so suppressing then-boundaries for an
+          // open `unless` would glue clauses with no fold to reassemble them.
+          pendingOpenerKinds.push(this.isIfKeyword(cv, language) ? 'if' : 'other');
         }
       }
       currentClauseTokens.push(current);

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -10700,3 +10700,97 @@ describe('nested-behavior sub-parse drill', () => {
     expect(actions.filter(a => a === 'for')).toHaveLength(0);
   });
 });
+
+describe('then-boundary if fold: an open mid-clause `if` block spans the then-conjunction', () => {
+  function walkNodes(n: unknown, acc: Record<string, any>[] = []): Record<string, any>[] {
+    if (!n || typeof n !== 'object') return acc;
+    const rec = n as Record<string, any>;
+    if (typeof rec.action === 'string') acc.push(rec);
+    for (const f of [
+      'body',
+      'statements',
+      'thenBranch',
+      'elseBranch',
+      'eventHandlers',
+      'initBlock',
+    ]) {
+      const c = rec[f];
+      if (Array.isArray(c)) for (const x of c) walkNodes(x, acc);
+      else if (c && typeof c === 'object') walkNodes(c, acc);
+    }
+    return acc;
+  }
+  const role = (node: Record<string, any>, r: string): { type?: string; value?: unknown; raw?: unknown } | undefined =>
+    node.roles instanceof Map ? node.roles.get(r) : undefined;
+
+  it('[en] a mid-clause `if x < y then … end` folds with its full condition', () => {
+    // The `then` is a CONJUNCTION: the old clause split landed the if-head
+    // clause-FINAL with no branch tokens, so the mid-clause fold had nothing to
+    // fold (null) and the flat `if` truncated the condition to its first token.
+    const node = parse(
+      'on click set count to 1 if count < 2 then set count to 2 end add .done to me',
+      'en'
+    );
+    const conditional = walkNodes(node).find(r => r.kind === 'conditional');
+    expect(conditional).toBeDefined();
+    expect(String(role(conditional!, 'condition')?.raw ?? '')).toBe('count < 2');
+    const branchSets = walkNodes({ statements: conditional!.thenBranch }).filter(
+      r => r.action === 'set'
+    );
+    expect(branchSets).toHaveLength(1);
+    const actions = walkNodes(node).map(r => r.action);
+    expect(actions).toContain('add');
+  });
+
+  it('[en] behavior-resizable: the four clamp ifs fold and the loop tail survives', () => {
+    // Db-faithful handler segment. Without the then-boundary suppression the
+    // if-blocks' owed `end`s desynced the debt bookkeeping and an `end` broke
+    // the walk after the 3rd if — dropping the 4th clamp, both `set my
+    // *width/*height`, and the last two triggers (bn parsed MORE of this body
+    // than the en reference; its "spurious" set/trigger/if flags were en
+    // deficits).
+    const node = parse(
+      'on pointerdown(clientX, clientY) from me\n' +
+        '    halt the event\n' +
+        '    trigger resizable:start\n' +
+        '    measure width\n' +
+        '    set startWidth to it\n' +
+        '    measure height\n' +
+        '    set startHeight to it\n' +
+        '    set startX to clientX\n' +
+        '    set startY to clientY\n' +
+        '    repeat until event pointerup from document\n' +
+        '      wait for pointermove(clientX, clientY) or pointerup(clientX, clientY) from document\n' +
+        '      set newWidth to startWidth + clientX - startX\n' +
+        '      set newHeight to startHeight + clientY - startY\n' +
+        '      if newWidth < minWidth then set newWidth to minWidth end\n' +
+        '      if newWidth > maxWidth then set newWidth to maxWidth end\n' +
+        '      if newHeight < minHeight then set newHeight to minHeight end\n' +
+        '      if newHeight > maxHeight then set newHeight to maxHeight end\n' +
+        '      set my *width to newWidth + "px"\n' +
+        '      set my *height to newHeight + "px"\n' +
+        '      trigger resizable:resize\n' +
+        '    end\n' +
+        '    trigger resizable:end',
+      'en'
+    );
+    const all = walkNodes(node);
+    const conditionals = all.filter(r => r.kind === 'conditional');
+    expect(conditionals).toHaveLength(4);
+    for (const c of conditionals) {
+      // Full comparison captured, not the first-token truncation.
+      expect(String(role(c, 'condition')?.raw ?? '')).toMatch(/[<>]/);
+      const branchSets = walkNodes({ statements: c.thenBranch }).filter(r => r.action === 'set');
+      expect(branchSets).toHaveLength(1);
+    }
+    const events = all
+      .filter(r => r.action === 'trigger')
+      .map(t => String(role(t, 'event')?.value ?? ''));
+    expect(events).toContain('resizable:start');
+    expect(events).toContain('resizable:resize');
+    expect(events).toContain('resizable:end');
+    // The post-if siblings survive: 4 leading sets + 4 clamp sets + the two
+    // style sets.
+    expect(all.filter(r => r.action === 'set').length).toBeGreaterThanOrEqual(10);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-06T01:52:37.379Z",
-  "commit": "6eefb312",
+  "timestamp": "2026-07-06T12:28:48.433Z",
+  "commit": "fe591b33",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8514071976477985,
       "avgFidelity": 1,
-      "avgPrecision": 0.9472038310273605,
+      "avgPrecision": 0.9488873327108622,
       "avgRoleFidelity": 0.9702636459989401,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 481885,
+      "bundleSize": 482045,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 481885,
+      "size": 482045,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

The behavior-resizable en-noise drill from `docs-internal/HANDOFF-r1-post-cluster-residue.md` (session-5 residue, mechanism diagnosed there; this PR builds it).

The `then` between a mid-clause if-head and its branch is a CONJUNCTION, so `parseBodyWithClauses` split the block at it:

- the if-head landed clause-FINAL with no branch tokens — the #576 mid-clause fold had nothing to fold and nulled, so the flat `if` truncated its condition to the first token (`if newWidth < minWidth` → `condition="newWidth"`);
- the branch `set` became the NEXT clause;
- the if's owed `end` desynced the debt bookkeeping (the conjunction-boundary re-derivation only counts blockless loop heads) until a later `end` terminated the walk early.

At behavior-resizable the **en reference** broke at the 3rd of 4 clamp ifs — dropping the 4th clamp set, both `set my *width/*height`, and the last two triggers. bn parsed MORE of the body than en: its "spurious" set/trigger/if flags were en deficits (the #576/#577/#582 en-noise pattern again — fix en first).

## Fix

Track opener KINDS parallel to `pendingBlockDepth` (LIFO, an `end` closes the innermost opener). While an `if` block is open in the pending clause, a conjunction is **block content**, not a clause boundary — the whole `if … then … end` block reaches `parseClause`, whose existing #576 mid-clause fold splits condition/branch at the `then` and consumes the matching `end`. `unless` deliberately counts as `'other'` (the fold only folds `if`; suppressing for unless would glue clauses with no fold to reassemble them).

## Validation

- **Per-(lang,pattern) A/B vs main:** 3 fixed (bn spurious set/trigger/if at behavior-resizable), **0 new**; probe mean R1 held at 0.9824. en now parses all 4 clamp conditionals with full conditions + folded branches, both style sets, and all three triggers.
- **Six-signal `--regression` gate:** green against the committed baseline.
- **Baseline regenerated** against a fresh populate in this PR (avgPrecision 0.9849 → 0.9851, avgRoleFidelity held 0.9824).
- **Guard tests:** 2 appended to `multilingual-roadmap-fixes.test.ts`, both fail without the fix (stash round-trip verified). Full semantic suite green (6538 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)