### PR TITLE
fix(multilingual): event-head param-phrase consumption — parameterized SOV handler heads (behavior-sortable drill)

### DIFF
--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -1657,6 +1657,42 @@ export class PatternMatcher {
       ) {
         return createPropertyPath(createReference(baseLower), fusedProps.join('.'));
       }
+      if (fusedIsMethodCall) {
+        // Consume the balanced call parens into the expression. Left in the
+        // stream they broke the surrounding SOV pattern — the marker expected
+        // after the role slot (`… に 設定`) met `(` instead, the whole set
+        // pattern died, and the command fell to the role-swapping
+        // verb-anchoring fallback (behavior-sortable `set item to the
+        // target.closest("li")`, session-5 residue). The paren tokens are
+        // plain identifiers in the multilingual tokenizers, so this balances
+        // by VALUE, mirroring tryConsumeRunOperand's group logic.
+        const callMark = tokens.mark();
+        const callParts: string[] = [];
+        let parenDepth = 0;
+        let closed = false;
+        while (!tokens.isAtEnd()) {
+          const t = tokens.peek();
+          if (!t) break;
+          if (t.value === '(') parenDepth++;
+          else if (t.value === ')') {
+            callParts.push(t.value);
+            tokens.advance();
+            parenDepth--;
+            if (parenDepth === 0) {
+              closed = true;
+            }
+            if (closed) break;
+            continue;
+          }
+          callParts.push(t.value);
+          tokens.advance();
+        }
+        if (closed) {
+          fusedChain += callParts.join('');
+        } else {
+          tokens.reset(callMark); // unbalanced — leave the parens unconsumed
+        }
+      }
       return { type: 'expression', raw: fusedChain } as SemanticValue;
     }
 
@@ -2111,6 +2147,25 @@ export class PatternMatcher {
 
       if (nextToken && (nextToken.kind === 'selector' || nextToken.kind === 'identifier')) {
         // Keep the position after "the" - effectively skipping it
+        return;
+      }
+
+      // `the <ref>.<prop>` where the reference base tokenizes as a KEYWORD and
+      // the property as a fused `.`-selector (`the target .closest ("li")` in
+      // the non-English tokenizers — en fuses `target.closest` into one
+      // identifier and takes the branch above). Without the skip the role slot
+      // captures the bare article and the pattern dies on the following
+      // keyword (behavior-sortable's `set item to the target.closest("li")`).
+      // Gated on the property-access SHAPE (keyword + `.`-selector), so `the
+      // <event-noun> <marker>` keeps the leaked-article handling below.
+      const afterNext = tokens.peek(1);
+      if (
+        nextToken &&
+        nextToken.kind === 'keyword' &&
+        afterNext &&
+        afterNext.kind === 'selector' &&
+        /^\.[a-zA-Z_]/.test(afterNext.value)
+      ) {
         return;
       }
 

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -3271,12 +3271,18 @@ export class SemanticParserImpl implements ISemanticParser {
       const value = token.value.toLowerCase();
       const normalized = token.normalized?.toLowerCase();
       const isEvent =
-        (!!normalized && SemanticParserImpl.KNOWN_EVENTS.has(normalized)) ||
+        (!!normalized &&
+          (SemanticParserImpl.KNOWN_EVENTS.has(normalized) ||
+            WAITABLE_EVENT_WORDS.has(normalized))) ||
         SemanticParserImpl.KNOWN_EVENTS.has(value) ||
+        WAITABLE_EVENT_WORDS.has(value) ||
         nativeEventNames.has(value);
       if (!isEvent) continue;
 
-      const next = tokens[i + 1];
+      // A param phrase (`pointerdown(clientY)`) sits between the event keyword
+      // and its marker — skip it, mirroring trySOVEventExtraction.
+      const paramLen = this.matchEventParamPhrase(tokens, i + 1).len;
+      const next = tokens[i + 1 + paramLen];
       if (
         next &&
         (next.kind === 'particle' || next.kind === 'keyword') &&
@@ -3284,7 +3290,7 @@ export class SemanticParserImpl implements ISemanticParser {
       ) {
         return true;
       }
-      if (this.matchEventMarkerPhrase(tokens, i + 1, language) > 0) return true;
+      if (this.matchEventMarkerPhrase(tokens, i + 1 + paramLen, language) > 0) return true;
     }
     return false;
   }
@@ -3317,7 +3323,59 @@ export class SemanticParserImpl implements ISemanticParser {
       markers: new Set(['manta']),
       windowTokens: new Set(['k_iri', 'ventana', 'window', 'document']),
     },
+    hi: {
+      markers: new Set(['से']),
+      windowTokens: new Set(['विंडो', 'दस्तावेज़', 'window', 'document']),
+    },
   };
+
+  /**
+   * Length (in tokens) and declared names of an event PARAM PHRASE starting at
+   * startIdx: `( ident [, ident]* )`. The tokenizers split
+   * `pointerdown(clientY)` into 4+ tokens (`pointerdown ( clientY )`), so the
+   * SOV event-marker check — which expects the marker DIRECTLY after the event
+   * keyword — never fired on a parameterized event: the custom-event second
+   * pass then anchored the `)` as the event (event:literal=")") and the leaked
+   * keyword-led head run was discarded by flushSkipped, killing the first body
+   * command (behavior-sortable `set item to …`, the session-5 sharpened
+   * diagnosis). Returns len 0 when startIdx isn't an opening paren or the
+   * phrase is malformed (no close-paren, or a non-identifier between).
+   */
+  private matchEventParamPhrase(
+    allTokens: readonly LanguageToken[],
+    startIdx: number
+  ): { len: number; names: string[] } {
+    if (allTokens[startIdx]?.value !== '(') return { len: 0, names: [] };
+    const names: string[] = [];
+    for (let j = startIdx + 1; j < allTokens.length; j++) {
+      const v = allTokens[j].value;
+      if (v === ')') return { len: j - startIdx + 1, names };
+      if (v === ',') continue;
+      if (allTokens[j].kind !== 'identifier') break;
+      names.push(v);
+    }
+    return { len: 0, names: [] };
+  }
+
+  /**
+   * Whether a token is a strippable event-source REFERENCE — a pronoun (`私`/
+   * `나`/`ben`/`আমি`/`मैं`/`noqa`, all normalized `me`/`i`/`it`) or a window/
+   * document token. The en reference drops the handler's `from me` phrase
+   * entirely (event role only), so stripping the rendered pair matches it.
+   * Deliberately NOT identifiers (`triggerEl から` stays in the body, where the
+   * value-led skipped-run recovery reclaims it — behavior-removable relies on
+   * that).
+   */
+  private isStrippableSourceRef(
+    tok: LanguageToken | undefined,
+    windowTokens: Set<string>
+  ): boolean {
+    if (!tok) return false;
+    const norm = tok.normalized?.toLowerCase();
+    if (tok.kind === 'keyword' && (norm === 'me' || norm === 'i' || norm === 'it')) return true;
+    const v = tok.value.toLowerCase();
+    return windowTokens.has(v) || (!!norm && windowTokens.has(norm));
+  }
 
   /**
    * Try to extract a trailing event clause that wraps a block/command body.
@@ -3493,6 +3551,7 @@ export class SemanticParserImpl implements ISemanticParser {
     let eventName = '';
     let keyFilter = '';
     let tokensToRemove = 1; // How many tokens to strip (1 = event only, 2 = event + marker)
+    let parameterNames: string[] = [];
 
     for (let i = 0; i < allTokens.length; i++) {
       const token = allTokens[i];
@@ -3508,15 +3567,34 @@ export class SemanticParserImpl implements ISemanticParser {
         tokenKeyFilter = token.value.slice(bracketIdx);
       }
 
-      // Check if this token is a known event name (by normalized value, native text, or bare value)
+      // Check if this token is a known event name (by normalized value, native
+      // text, or bare value). WAITABLE_EVENT_WORDS is accepted alongside
+      // KNOWN_EVENTS: the pointer/touch/transition families are real handler
+      // triggers (`pointerdown(clientY) で` — behavior-sortable), untranslated
+      // loanwords in every corpus language, and without them the first pass
+      // never anchored a parameterized pointer event (the custom-event second
+      // pass then matched the `)` as the event).
       const normalizedLower = token.normalized?.toLowerCase();
       const isEventByNormalized =
-        normalizedLower && SemanticParserImpl.KNOWN_EVENTS.has(normalizedLower);
+        normalizedLower &&
+        (SemanticParserImpl.KNOWN_EVENTS.has(normalizedLower) ||
+          WAITABLE_EVENT_WORDS.has(normalizedLower));
       const isEventByNative =
         nativeEventNames.has(tokenValue) || nativeEventNames.has(bareEventValue);
-      const isEventByBare = SemanticParserImpl.KNOWN_EVENTS.has(bareEventValue);
+      const isEventByBare =
+        SemanticParserImpl.KNOWN_EVENTS.has(bareEventValue) ||
+        WAITABLE_EVENT_WORDS.has(bareEventValue);
 
       if (isEventByNormalized || isEventByNative || isEventByBare) {
+        // An event name directly after the `event` KEYWORD is a loop/wait
+        // phrase payload (`repeat until event pointerup from document` — ko
+        // `까지 이벤트 pointerup 를 반복 …`), never a handler trigger: skip it
+        // so the Stage-2 loop-head match stands. (Without the WAITABLE
+        // family this could not trigger — pointerup wasn't recognized at all.)
+        const prevTok = allTokens[i - 1];
+        if (prevTok && (prevTok.normalized ?? prevTok.value).toLowerCase() === 'event') {
+          continue;
+        }
         // Resolve the English event name
         let resolvedName: string;
         if (isEventByNormalized) {
@@ -3527,14 +3605,21 @@ export class SemanticParserImpl implements ISemanticParser {
           resolvedName = bareEventValue;
         }
 
+        // A parameterized event (`pointerdown(clientY)`) tokenizes with its
+        // param phrase between the event keyword and the marker — consume it
+        // so the marker check still anchors (and the params don't leak into
+        // the body as a keyword-led run that flushSkipped discards).
+        const paramPhrase = this.matchEventParamPhrase(allTokens, i + 1);
+
         if (eventMarkers.size > 0) {
           // Languages with event markers (JA, TR): require marker after event keyword
-          // The marker may be at i+1 (direct) or i+2 (if there's a bracket key-filter selector between)
-          let markerOffset = 1;
-          const nextToken = allTokens[i + 1];
+          // The marker may be at i+1 (direct), or offset by a param phrase
+          // and/or a bracket key-filter selector between.
+          let markerOffset = 1 + paramPhrase.len;
+          const nextToken = allTokens[i + markerOffset];
           // Skip over bracket selector token (e.g., [key=="Escape"]) between event and marker
           if (nextToken && nextToken.kind === 'selector' && nextToken.value.startsWith('[')) {
-            markerOffset = 2;
+            markerOffset += 1;
           }
           const markerToken = allTokens[i + markerOffset];
           if (
@@ -3544,18 +3629,25 @@ export class SemanticParserImpl implements ISemanticParser {
           ) {
             eventIndex = i;
             eventName = resolvedName;
-            keyFilter = tokenKeyFilter || (markerOffset === 2 ? allTokens[i + 1].value : '');
-            tokensToRemove = markerOffset + 1; // Remove event keyword + optional filter + marker
+            keyFilter =
+              tokenKeyFilter ||
+              (markerOffset === paramPhrase.len + 2 ? allTokens[i + markerOffset - 1].value : '');
+            tokensToRemove = markerOffset + 1; // Remove event keyword + params + optional filter + marker
+            parameterNames = paramPhrase.names;
             break;
           }
         } else {
           // Languages without single-token event markers (KO): event keyword
-          // stands alone, or is followed by an optional marker phrase (할 때),
-          // consumed so it doesn't leak into the body parse.
+          // stands alone, or is followed by an optional param phrase and/or
+          // marker phrase (할 때), consumed so they don't leak into the body parse.
           eventIndex = i;
           eventName = resolvedName;
           keyFilter = tokenKeyFilter;
-          tokensToRemove = 1 + this.matchEventMarkerPhrase(allTokens, i + 1, language);
+          tokensToRemove =
+            1 +
+            paramPhrase.len +
+            this.matchEventMarkerPhrase(allTokens, i + 1 + paramPhrase.len, language);
+          parameterNames = paramPhrase.names;
           break;
         }
       }
@@ -3651,6 +3743,37 @@ export class SemanticParserImpl implements ISemanticParser {
           sourceMarkers.markers.has(afterToken.value)
         ) {
           removeIndices.add(afterEventEnd);
+        } else if (this.isStrippableSourceRef(afterToken, sourceMarkers.windowTokens)) {
+          // Rendered `from me` pair right after event+marker (ja `私 から`,
+          // ko `나 에서`, tr `ben den`, bn `আমি থেকে`, hi `मैं से`). Left in
+          // place it heads the body as a KEYWORD-led run that flushSkipped
+          // discards — taking the first real body command with it
+          // (behavior-sortable's `set item to …`). The en reference drops the
+          // handler's from-phrase entirely, so stripping the pair matches it.
+          const markerAfterRef = allTokens[afterEventEnd + 1];
+          if (
+            markerAfterRef &&
+            (markerAfterRef.kind === 'particle' || markerAfterRef.kind === 'keyword') &&
+            sourceMarkers.markers.has(markerAfterRef.value)
+          ) {
+            removeIndices.add(afterEventEnd);
+            removeIndices.add(afterEventEnd + 1);
+          }
+        }
+      }
+
+      // Fronted `from me` pair immediately BEFORE the event (qu renders the
+      // source phrase first: `noqa manta pointerdown(clientY) pi`). Same
+      // strippable-reference gate as the trailing pair.
+      if (eventIndex >= 2) {
+        const frontMarker = allTokens[eventIndex - 1];
+        if (
+          (frontMarker.kind === 'particle' || frontMarker.kind === 'keyword') &&
+          sourceMarkers.markers.has(frontMarker.value) &&
+          this.isStrippableSourceRef(allTokens[eventIndex - 2], sourceMarkers.windowTokens)
+        ) {
+          removeIndices.add(eventIndex - 2);
+          removeIndices.add(eventIndex - 1);
         }
       }
 
@@ -3693,7 +3816,13 @@ export class SemanticParserImpl implements ISemanticParser {
       metadata.keyFilter = keyFilter;
     }
 
-    return createEventHandler({ type: 'literal', value: eventName }, body, undefined, metadata);
+    return createEventHandler(
+      { type: 'literal', value: eventName },
+      body,
+      undefined,
+      metadata,
+      parameterNames
+    );
   }
 
   /**

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -10794,3 +10794,115 @@ describe('then-boundary if fold: an open mid-clause `if` block spans the then-co
     expect(all.filter(r => r.action === 'set').length).toBeGreaterThanOrEqual(10);
   });
 });
+
+describe('event-head param phrase: parameterized SOV handler heads anchor the real event', () => {
+  function walkNodes(n: unknown, acc: Record<string, any>[] = []): Record<string, any>[] {
+    if (!n || typeof n !== 'object') return acc;
+    const rec = n as Record<string, any>;
+    if (typeof rec.action === 'string') acc.push(rec);
+    for (const f of [
+      'body',
+      'statements',
+      'thenBranch',
+      'elseBranch',
+      'eventHandlers',
+      'initBlock',
+    ]) {
+      const c = rec[f];
+      if (Array.isArray(c)) for (const x of c) walkNodes(x, acc);
+      else if (c && typeof c === 'object') walkNodes(c, acc);
+    }
+    return acc;
+  }
+  const role = (node: Record<string, any>, r: string): { type?: string; value?: unknown; raw?: unknown } | undefined =>
+    node.roles instanceof Map ? node.roles.get(r) : undefined;
+
+  it('[ja] `pointerdown(clientY) で 私 から` anchors pointerdown, not the `)`', () => {
+    // The tokenizers split `pointerdown(clientY)` into 4 tokens, so the SOV
+    // event-marker check (marker DIRECTLY after the event keyword) never fired
+    // on a parameterized event; the custom-event second pass then anchored the
+    // `)` as the event (event:literal=")") and the leaked keyword-led `私 から`
+    // head run was discarded by flushSkipped — killing the first body command.
+    // Db-faithful behavior-sortable handler segment.
+    const node = parse(
+      'pointerdown(clientY) で 私 から\n' +
+        '  item を the target.closest("li") に 設定\n' +
+        '  もし item である null\n' +
+        '    退出\n' +
+        '  終わり\n' +
+        '  the イベント を 停止\n' +
+        '  .{dragClass} を 追加 item に',
+      'ja'
+    );
+    const handler = walkNodes(node).find(r => r.kind === 'event-handler');
+    expect(handler).toBeDefined();
+    expect(String(role(handler!, 'event')?.value)).toBe('pointerdown');
+    expect((handler as { parameterNames?: readonly string[] }).parameterNames).toEqual([
+      'clientY',
+    ]);
+    // The handler set survives with en-aligned role types…
+    const set = walkNodes(node).find(r => r.action === 'set');
+    expect(set).toBeDefined();
+    expect(role(set!, 'destination')?.type).toBe('expression');
+    expect(String(role(set!, 'destination')?.raw ?? role(set!, 'destination')?.value)).toBe(
+      'item'
+    );
+    expect(role(set!, 'patient')?.type).toBe('expression');
+    // …and with `item` bound, the add's destination is the real item, not `me`.
+    const add = walkNodes(node).find(r => r.action === 'add');
+    expect(add).toBeDefined();
+    expect(String(role(add!, 'destination')?.raw ?? role(add!, 'destination')?.value)).toBe(
+      'item'
+    );
+  });
+
+  it('[ko] `pointerdown(clientY) 할 때 나 에서` consumes params + marker phrase + source pair', () => {
+    const node = parse(
+      'pointerdown(clientY) 할 때 나 에서\n  item 를 the target.closest("li") 에 설정',
+      'ko'
+    );
+    const handler = walkNodes(node).find(r => r.kind === 'event-handler');
+    expect(handler).toBeDefined();
+    expect(String(role(handler!, 'event')?.value)).toBe('pointerdown');
+    const set = walkNodes(node).find(r => r.action === 'set');
+    expect(set).toBeDefined();
+    expect(role(set!, 'patient')?.type).toBe('expression');
+  });
+
+  it('[qu] fronted `noqa manta pointerdown(clientY) pi` strips the from-me pair', () => {
+    const node = parse(
+      'noqa manta pointerdown(clientY) pi\n  item ta the target.closest("li") man churanay',
+      'qu'
+    );
+    const handler = walkNodes(node).find(r => r.kind === 'event-handler');
+    expect(handler).toBeDefined();
+    expect(String(role(handler!, 'event')?.value)).toBe('pointerdown');
+    const set = walkNodes(node).find(r => r.action === 'set');
+    expect(set).toBeDefined();
+    expect(role(set!, 'patient')?.type).toBe('expression');
+  });
+
+  it('[ja] the fused method call folds its call parens into the expression', () => {
+    // tryMatchPropertyAccessExpression used to return `target.closest` leaving
+    // `( "li" )` in the stream — the following に marker then failed and the
+    // whole set-ja-generated match died (falling to role-swapping
+    // verb-anchoring).
+    const node = parse('item を the target.closest("li") に 設定', 'ja');
+    expect(node.action).toBe('set');
+    const n = node as unknown as Record<string, any>;
+    expect(role(n, 'destination')?.type).toBe('expression');
+    expect(String(role(n, 'destination')?.raw)).toBe('item');
+    expect(role(n, 'patient')?.type).toBe('expression');
+    expect(String(role(n, 'patient')?.raw)).toContain('target.closest');
+    expect(String(role(n, 'patient')?.raw)).toContain('"li"');
+  });
+
+  it('[ko] `repeat until event pointerup` head still parses as a loop, not a handler', () => {
+    // pointerup is now a recognizable handler event (WAITABLE family) — but an
+    // event name directly after the `event` KEYWORD is a loop phrase payload.
+    const node = parse('까지 이벤트 pointerup 를 반복 문서 에서', 'ko');
+    const all = walkNodes(node);
+    expect(all.find(r => r.kind === 'event-handler')).toBeUndefined();
+    expect(all.find(r => r.action === 'repeat')).toBeDefined();
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,12 +1,12 @@
 {
-  "timestamp": "2026-07-06T12:28:48.433Z",
-  "commit": "fe591b33",
+  "timestamp": "2026-07-06T12:51:46.596Z",
+  "commit": "bfab0bea",
   "languages": {
     "ar": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8399201626424081,
+      "avgConfidence": 0.8362095875032615,
       "avgFidelity": 1,
       "avgPrecision": 0.9935064935064936,
       "avgRoleFidelity": 0.9870495495495494,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -164,10 +164,6 @@
           "success": true,
           "confidence": 1
         },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 1
-        },
         "fade-out-remove": {
           "success": true,
           "confidence": 1
@@ -261,10 +257,6 @@
           "confidence": 1
         },
         "caret-var-on-target": {
-          "success": true,
-          "confidence": 1
-        },
-        "reactive-array-push": {
           "success": true,
           "confidence": 1
         },
@@ -496,6 +488,10 @@
           "success": true,
           "confidence": 0.7142857142857143
         },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "two-way-binding": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -521,6 +517,10 @@
           "confidence": 0.7142857142857143
         },
         "beep-debug-expression": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "reactive-array-push": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -638,15 +638,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8514071976477985,
+      "avgConfidence": 0.8579007041413049,
       "avgFidelity": 1,
-      "avgPrecision": 0.9488873327108622,
-      "avgRoleFidelity": 0.9702636459989401,
+      "avgPrecision": 0.9489143889879185,
+      "avgRoleFidelity": 0.9706611022787494,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -904,6 +904,10 @@
           "success": true,
           "confidence": 1
         },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 1
+        },
         "fade-out-remove": {
           "success": true,
           "confidence": 1
@@ -1013,6 +1017,10 @@
           "confidence": 1
         },
         "caret-var-on-target": {
+          "success": true,
+          "confidence": 1
+        },
+        "reactive-array-push": {
           "success": true,
           "confidence": 1
         },
@@ -1212,10 +1220,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.5
-        },
         "optional-chaining-possessive": {
           "success": true,
           "confidence": 0.5
@@ -1237,10 +1241,6 @@
           "confidence": 0.5
         },
         "pick-text-range": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "reactive-array-push": {
           "success": true,
           "confidence": 0.5
         },
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.9045096507502506,
       "avgFidelity": 1,
-      "avgPrecision": 0.9527056277056277,
-      "avgRoleFidelity": 0.9553826936179877,
+      "avgPrecision": 0.952732683982684,
+      "avgRoleFidelity": 0.9557801498977969,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6319,15 +6319,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8402754722303589,
+      "avgConfidence": 0.8467689787238654,
       "avgFidelity": 1,
-      "avgPrecision": 0.9643939393939395,
-      "avgRoleFidelity": 0.9698661897191309,
+      "avgPrecision": 0.9643939393939397,
+      "avgRoleFidelity": 0.9706611022787494,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6577,6 +6577,10 @@
           "success": true,
           "confidence": 1
         },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 1
+        },
         "fade-out-remove": {
           "success": true,
           "confidence": 1
@@ -6682,6 +6686,10 @@
           "confidence": 1
         },
         "caret-var-on-target": {
+          "success": true,
+          "confidence": 1
+        },
+        "reactive-array-push": {
           "success": true,
           "confidence": 1
         },
@@ -6889,10 +6897,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.5
-        },
         "optional-chaining-possessive": {
           "success": true,
           "confidence": 0.5
@@ -6918,10 +6922,6 @@
           "confidence": 0.5
         },
         "pick-text-range": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "reactive-array-push": {
           "success": true,
           "confidence": 0.5
         },
@@ -6951,15 +6951,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8352249671798537,
+      "avgConfidence": 0.8417184736733602,
       "avgFidelity": 1,
       "avgPrecision": 0.9643939393939397,
-      "avgRoleFidelity": 0.9664878113407525,
+      "avgRoleFidelity": 0.967282723900371,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7213,6 +7213,10 @@
           "success": true,
           "confidence": 1
         },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 1
+        },
         "fade-out-remove": {
           "success": true,
           "confidence": 1
@@ -7306,6 +7310,10 @@
           "confidence": 1
         },
         "caret-var-on-target": {
+          "success": true,
+          "confidence": 1
+        },
+        "reactive-array-push": {
           "success": true,
           "confidence": 1
         },
@@ -7509,10 +7517,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.5
-        },
         "focus-trap": {
           "success": true,
           "confidence": 0.5
@@ -7553,10 +7557,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 0.5
-        },
         "intercept-cache-strategies": {
           "success": true,
           "confidence": 0.5
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9479,15 +9479,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7251597608740467,
+      "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
       "avgPrecision": 0.9643939393939395,
-      "avgRoleFidelity": 0.9548196305549247,
+      "avgRoleFidelity": 0.9552170868347339,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9665,6 +9665,10 @@
           "success": true,
           "confidence": 1
         },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 1
+        },
         "slide-toggle": {
           "success": true,
           "confidence": 1
@@ -9738,6 +9742,10 @@
           "confidence": 1
         },
         "caret-var-increment": {
+          "success": true,
+          "confidence": 1
+        },
+        "reactive-array-push": {
           "success": true,
           "confidence": 1
         },
@@ -9985,10 +9993,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.5
-        },
         "fade-out-remove": {
           "success": true,
           "confidence": 0.5
@@ -10081,10 +10085,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "reactive-array-push": {
-          "success": true,
-          "confidence": 0.5
-        },
         "intercept-cache-strategies": {
           "success": true,
           "confidence": 0.5
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12007,7 +12007,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.824382129247231,
+      "avgConfidence": 0.8206715541080843,
       "avgFidelity": 1,
       "avgPrecision": 0.9935064935064936,
       "avgRoleFidelity": 0.9938063063063062,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12153,10 +12153,6 @@
           "success": true,
           "confidence": 1
         },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 1
-        },
         "fade-out-remove": {
           "success": true,
           "confidence": 1
@@ -12250,10 +12246,6 @@
           "confidence": 1
         },
         "caret-var-on-target": {
-          "success": true,
-          "confidence": 1
-        },
-        "reactive-array-push": {
           "success": true,
           "confidence": 1
         },
@@ -12501,6 +12493,10 @@
           "success": true,
           "confidence": 0.7142857142857143
         },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "two-way-binding": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -12534,6 +12530,10 @@
           "confidence": 0.7142857142857143
         },
         "caret-var-increment": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "reactive-array-push": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -12639,15 +12639,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8391622996886149,
+      "avgConfidence": 0.8456558061821213,
       "avgFidelity": 1,
-      "avgPrecision": 0.9635551948051951,
-      "avgRoleFidelity": 0.9694687334393216,
+      "avgPrecision": 0.9635822510822512,
+      "avgRoleFidelity": 0.9702636459989401,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12897,6 +12897,10 @@
           "success": true,
           "confidence": 1
         },
+        "copy-to-clipboard": {
+          "success": true,
+          "confidence": 1
+        },
         "fade-out-remove": {
           "success": true,
           "confidence": 1
@@ -13002,6 +13006,10 @@
           "confidence": 1
         },
         "caret-var-on-target": {
+          "success": true,
+          "confidence": 1
+        },
+        "reactive-array-push": {
           "success": true,
           "confidence": 1
         },
@@ -13209,10 +13217,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "copy-to-clipboard": {
-          "success": true,
-          "confidence": 0.5
-        },
         "optional-chaining-possessive": {
           "success": true,
           "confidence": 0.5
@@ -13238,10 +13242,6 @@
           "confidence": 0.5
         },
         "pick-text-range": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "reactive-array-push": {
           "success": true,
           "confidence": 0.5
         },
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 482045,
+      "bundleSize": 483617,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 482045,
+      "size": 483617,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

The behavior-sortable event-head drill from `docs-internal/HANDOFF-r1-post-cluster-residue.md` (session-5 sharpened diagnosis: "This is an event-HEAD fix (param-phrase consumption), not body patching").

The tokenizers split `pointerdown(clientY)` into 4+ tokens (`pointerdown ( clientY )`), so `trySOVEventExtraction`'s marker check — which expects the marker DIRECTLY after the event keyword — never fired on a parameterized event. The custom-event second pass then anchored the **`)` as the event** (`event:literal=")"`), and the leaked keyword-led `私 から` head run was discarded by `flushSkipped` — killing the handler's `set item to the target.closest("li")` (set.patient ja/ko/qu/tr ×4); with `item` never bound, the add's destination fell back to `me` (add.destination bn/hi/ja/ko/tr ×5).

## Fix — five aligned pieces, all at the event HEAD

1. **`matchEventParamPhrase`** — consume `( ident [, ident]* )` between the event keyword and its marker (first pass + ko marker-phrase branch + `hasSOVEventMarkerHead`), captured as the handler's `parameterNames`.
2. **WAITABLE_EVENT_WORDS accepted alongside KNOWN_EVENTS** in the SOV extraction — the pointer/touch/transition families are real handler triggers; `pointerdown` wasn't recognizable at all. Guard: an event name directly after the `event` KEYWORD is a loop/wait phrase payload (`repeat until event pointerup …` must stay a loop head).
3. **Rendered `from me` pair stripping**: after event+marker (ja `私 から`, ko `나 에서`, tr `ben den`, bn `আমি থেকে`, hi `मैं से`) and fronted before the event (qu `noqa manta`). Gated to pronoun/window references so `triggerEl から` still reaches the body (behavior-removable relies on that recovery). New hi entry in `SOV_SOURCE_MARKERS`.
4. **Fused method-call paren folding** in `tryMatchPropertyAccessExpression` (`target.closest` + `("li")` → one expression): left in the stream, the parens broke the following SOV marker and the whole `set-XX-generated` match died to role-swapping verb-anchoring.
5. **`skipNoiseWords`** skips `the` before a keyword-base property access (`the target .closest …`) — en fuses `target.closest` into one identifier and already took the skip.

## Validation

- **Per-(lang,pattern) A/B vs merged #583:** 9 fixed — the complete planned families (`add.destination:expression` ×5 bn/hi/ja/ko/tr + `set.patient:expression` ×4 ja/ko/qu/tr, all behavior-sortable), **0 new**; probe mean R1 0.9824 → 0.9825.
- **Six-signal `--regression` gate:** green. **Baseline regenerated** against a fresh populate in this PR.
- **Guard tests:** 5 appended; 4 fail without the fix (stash round-trip verified), the 5th locks the ko `repeat until event pointerup` head against the WAITABLE expansion. Full semantic suite green (6538 passed).
- Residue (updated in the handoff doc): `remove.source ×12` at the same site is **en-noise** (en's remove grabs a phantom `source=reference:"me"` from the following trigger line); `remove.patient ×3` es/pt/tr is an of-possessive/from-marker ambiguity (`quitar .{dragClass} de item` folds into a property-path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)