### PR TITLE
docs(multilingual): sync handoff + NEXT_STEPS with #583/#584 (session-6 behavior drills)

### DIFF
--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -1,5 +1,79 @@
 # Handoff — R1 residue after the five-cluster triage (fronted repeat-while · sw kama homonym · singletons)
 
+> **STATUS UPDATE (2026-07-06, session 6): both planned drills LANDED — #583
+> (then-boundary if fold, the behavior-resizable en-noise drill) and #584
+> (event-head param-phrase consumption, the behavior-sortable drill).**
+> Post-session state: probe mean R1 **0.9825** (0.9824 → held → +0.0001),
+> baseline avgPrecision **0.9851**, parse 3696/3696, degenerate/lossy 0,
+> R2 1.0. Per-(lang,pattern) A/B across both PRs: **12 fixed, 0 new**.
+>
+> 1. **#583 — then-boundary if fold (behavior-resizable, en-noise as
+>    diagnosed).** The `then` between a mid-clause if-head and its branch is a
+>    CONJUNCTION, so parseBodyWithClauses split the block at it: if-head
+>    clause-FINAL → mid-clause fold nulls → flat `if` truncates the condition →
+>    the owed `end` desyncs the debt bookkeeping → an `end` broke the walk at
+>    the 3rd of 4 clamp ifs (en dropped the 4th clamp, both `set my
+*width/*height`, the last two triggers — bn's "spurious" flags were en
+>    deficits, the fourth en-noise inversion in a row). Fix: opener-KIND stack
+>    parallel to pendingBlockDepth; while an `if` is open mid-clause, a
+>    conjunction is block content — the whole `if … then … end` block reaches
+>    parseClause's #576 fold. `unless` counts as 'other' (the fold only folds
+>    `if`). A/B: 3 fixed (bn spurious set/trigger/if), 0 new.
+> 2. **#584 — event-head param-phrase (behavior-sortable, exactly the
+>    session-5 sharpened diagnosis).** Five aligned pieces, all at the event
+>    HEAD: (a) matchEventParamPhrase consumes `( ident [, ident]* )` between
+>    event keyword and marker (first pass + ko phrase branch +
+>    hasSOVEventMarkerHead), captured as parameterNames; (b)
+>    WAITABLE_EVENT_WORDS accepted alongside KNOWN_EVENTS in the SOV extraction
+>    (pointerdown wasn't recognizable AT ALL — that's why the `)` anchored),
+>    guarded so an event name directly after the `event` KEYWORD stays a
+>    loop/wait payload (`repeat until event pointerup …`); (c) rendered
+>    `from me` pair stripping — after event+marker (ja 私 から, ko 나 에서,
+>    tr ben den, bn আমি থেকে, hi मैं से — new hi SOV_SOURCE_MARKERS entry) and
+>    fronted (qu noqa manta), gated to pronoun/window references so
+>    `triggerEl から` still reaches the body (behavior-removable's recovery);
+>    (d) tryMatchPropertyAccessExpression folds a fused method call's parens
+>    into the expression (`target.closest("li")`) — left in the stream they
+>    broke the following SOV marker and set-XX-generated died to role-swapping
+>    verb-anchoring; (e) skipNoiseWords skips `the` before a keyword-base
+>    property access (`the target .closest …`). A/B: 9 fixed
+>    (add.destination:expression ×5 bn/hi/ja/ko/tr + set.patient:expression ×4
+>    ja/ko/qu/tr), 0 new.
+>
+> 7 guard tests appended to `packages/semantic/test/multilingual-roadmap-fixes.test.ts`
+> (6 fail without the fixes — stash-verified; 1 locks the ko repeat-until-event
+> head against the WAITABLE expansion).
+>
+> **Residue updated after session 6:**
+>
+> - **behavior-sortable remove.source:reference ×12
+>   (bn/hi/it/ja/ko/pl/qu/ru/th/tr/uk/vi) is EN-NOISE, newly probed:** en's
+>   `remove .{dragClass} from item` — even in ISOLATION — silently drops
+>   `item` (the source slot rejects the bare identifier) and the source
+>   DEFAULTS to `reference:"me"` (schema default, NOT a next-line grab).
+>   Translations capturing `source:expression="item"` (it, and ja/ko
+>   post-#584) are RIGHTER than the reference. A future en drill: make
+>   remove-en-generated's source slot accept the identifier — but CHECK which
+>   languages currently pass via the same me-default first (they'd flip to
+>   missing when en enriches; the resizable-drill discipline).
+> - **behavior-sortable remove.patient:selector ×3 (es/pt/tr), probed:** the
+>   of-possessive matcher folds `quitar .{dragClass} de item` into
+>   `patient = property-path:"undefined"` — es `de` is BOTH the genitive
+>   connector (#580's marker table) and remove's from-marker. Needs a
+>   command-schema gate on the of-possessive read (remove has no property-path
+>   role), not a marker change.
+> - **wait-line param leak (ja trigger.source spurious literal):** the
+>   `wait pointermove(clientY) or pointerup(clientY) from document` line still
+>   leaks `(clientY)またはpointerup(clientY)ドキュメント` into the FOLLOWING
+>   trigger's source role — the wait event's param phrase is a body-side
+>   sibling of the #584 head fix (matchRoleToken's event role, not
+>   trySOVEventExtraction). Small, self-contained follow-up.
+> - spurious `empty` tr/hi/bn ×6 + behavior-sortable hi/tr — transformer-side,
+>   unchanged, locked for a transformer arc.
+> - Everything else from the session-5 block below stands (SOV halt ×6,
+>   set/A2 qu tail, template-literal-list-build SOV six, spurious
+>   add/go/morph/default families — undrilled).
+
 > **STATUS UPDATE (2026-07-05, session 5): the nested-behavior sub-parse drill
 > LANDED as #582** (probe mean R1 **0.9812 → 0.9824**; per-(lang,pattern) A/B:
 > **46 entries fixed, 0 new**; six-signal gate green; baseline regenerated).

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -9,27 +9,61 @@
 > [BEHAVIORS_CONSOLIDATION_PLAN.md](BEHAVIORS_CONSOLIDATION_PLAN.md). Read this first,
 > then dive into those for the per-arc detail.
 
-## Where we are (2026-07-05 baseline · post session-4 set/A2 + empty drills · `browser-priority`)
+## Where we are (2026-07-06 baseline · post session-6 behavior drills · `browser-priority`)
 
 Authoritative source: `packages/testing-framework/baselines/multilingual-priority.json`
 (its `timestamp` + `commit` fields stamp each regen). 24 langs × 154 patterns = 3696.
 
-| Signal                         | Value                  | Notes                                                                |
-| ------------------------------ | ---------------------- | -------------------------------------------------------------------- |
-| parse rate                     | **3696 / 3696 (100%)** | zero hard fails, holding                                             |
-| degenerate passes (fid < 0.5)  | **0**                  | band cleared (#492/#493), holding                                    |
-| lossy passes (0.5 ≤ fid < 1.0) | **0**                  | band cleared (#495–#506), holding                                    |
-| faithful (fid = 1.0)           | **3696**               | every parsing pattern is faithful                                    |
-| avgFidelity (R0-recall)        | **1.000**              | saturated                                                            |
-| avgPrecision (R0 trust floor)  | **0.985**              | session-4 copula drill: 0.984 → 0.9849 (8 languages +0.0026)         |
-| avgRoleFidelity (R1)           | **0.981**              | session-4 set/A2 drill: 0.9778 → 0.9812 (11 languages up, none down) |
-| avgExecutionFidelity (R2)      | **1.000**              | 47-pattern curated subset fully reproduces en DOM effects            |
+| Signal                         | Value                  | Notes                                                            |
+| ------------------------------ | ---------------------- | ---------------------------------------------------------------- |
+| parse rate                     | **3696 / 3696 (100%)** | zero hard fails, holding                                         |
+| degenerate passes (fid < 0.5)  | **0**                  | band cleared (#492/#493), holding                                |
+| lossy passes (0.5 ≤ fid < 1.0) | **0**                  | band cleared (#495–#506), holding                                |
+| faithful (fid = 1.0)           | **3696**               | every parsing pattern is faithful                                |
+| avgFidelity (R0-recall)        | **1.000**              | saturated                                                        |
+| avgPrecision (R0 trust floor)  | **0.985**              | session-6 resizable drill: 0.9849 → 0.9851 (bn up)               |
+| avgRoleFidelity (R1)           | **0.982**              | session-6 sortable drill: 0.9824 → 0.9825 (sortable families ×9) |
+| avgExecutionFidelity (R2)      | **1.000**              | 47-pattern curated subset fully reproduces en DOM effects        |
 
 The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recall ·
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.** R1 remains the
 dimension with headroom (SOV six ~0.95); R0-precision's spurious-action
 families are the next un-mined seam.
+
+> **Update 2026-07-06 (SESSION 6: the two planned behavior drills — #583
+> then-boundary if fold + #584 event-head param-phrase; probe mean R1 0.9825,
+> baseline avgPrecision 0.9851; per-(lang,pattern) A/B 12 fixed / 0 new across
+> both; gate green throughout; baselines regenerated per-PR.)**
+>
+> - **#583 — then-boundary if fold (behavior-resizable en-noise).** A
+>   mid-clause `if … then … end` block was split at its `then` CONJUNCTION by
+>   parseBodyWithClauses: the if-head landed clause-final (fold nulls, flat if
+>   truncates the condition), the branch became the next clause, and the owed
+>   `end` desynced the walk — en broke at the 3rd of 4 clamp ifs and dropped
+>   everything after. Opener-KIND stack: while an `if` is open mid-clause, a
+>   conjunction is block content, so the whole block reaches the #576 fold.
+>   bn's spurious set/trigger/if flags at resizable were en deficits —
+>   the fourth consecutive en-noise inversion.
+> - **#584 — event-head param-phrase (behavior-sortable).** `pointerdown(clientY)`
+>   tokenizes as 4+ tokens, so the SOV event-marker check never fired; the `)`
+>   anchored as the event and the leaked keyword-led `私 から` run killed the
+>   handler set (and unbound `item` broke add.destination). Fixed at the HEAD:
+>   param-phrase consumption (→ parameterNames), WAITABLE_EVENT_WORDS
+>   recognition (guarded: after the `event` KEYWORD it's a loop payload),
+>   rendered-`from me` pair stripping (trailing + qu fronted; new hi source
+>   markers), fused method-call paren folding (`target.closest("li")`), and a
+>   `the`-skip before keyword-base property access. 9 entries fixed
+>   (set.patient ×4 + add.destination ×5), 0 new.
+> - **Residue sharpened (full detail in the handoff session-6 block):**
+>   sortable `remove.source ×12` is EN-NOISE (en's source slot rejects the
+>   bare `item` identifier and DEFAULTS to `reference:"me"` — schema default,
+>   probed in isolation; fix en's slot, but first check which languages pass
+>   via the same default); `remove.patient ×3` es/pt/tr is an
+>   of-possessive/from-marker ambiguity (needs a schema gate, not a marker
+>   change); the wait-line param leak (ja trigger.source junk literal) is the
+>   body-side sibling of the #584 head fix — value-level only, invisible to
+>   R0/R1.
 
 > **Update 2026-07-05e (SESSION 5: the nested-behavior sub-parse drill — #582;
 > probe mean R1 0.9812 → 0.9824, per-(lang,pattern) A/B 46 fixed / 0 new, gate


### PR DESCRIPTION
## Summary

Doc sync for the two session-6 drills (the #578 precedent):

- **Session-6 status block** in `HANDOFF-r1-post-cluster-residue.md`: #583 (then-boundary if fold — behavior-resizable en-noise) and #584 (event-head param-phrase — behavior-sortable), with mechanisms, A/B results (12 fixed / 0 new), and the guard-test inventory.
- **Update block + "Where we are" table** in `MULTILINGUAL_NEXT_STEPS.md`: probe mean R1 0.9825, avgPrecision 0.9851, parse 3696/3696, degenerate/lossy 0, R2 1.0.
- **Residue sharpened from fresh probes**: sortable `remove.source ×12` is en-noise (the source slot rejects the bare `item` identifier and schema-defaults to `me` — probed in isolation, NOT a next-line grab); `remove.patient ×3` es/pt/tr is an of-possessive/from-marker ambiguity (schema gate needed); the wait-line param leak is value-level only, invisible to R0/R1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)