### PR TITLE
docs(multilingual): sync handoff + NEXT_STEPS with #586 (session-7 remove drill)

### DIFF
--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -1,5 +1,71 @@
 # Handoff — R1 residue after the five-cluster triage (fronted repeat-while · sw kama homonym · singletons)
 
+> **STATUS UPDATE (2026-07-06, session 7): the en remove.source drill LANDED as
+> #586** — batched with the es/pt remove.patient gate (same site). Post-session
+> state: probe mean R1 **0.9829** (0.9825 → +0.0004), baseline avgPrecision
+> **0.9851** (held), parse 3696/3696, degenerate/lossy 0, R2 1.0.
+> Per-(lang,pattern) A/B: **16 fixed, 0 new**; parse-coverage census identical
+> before/after (3404 pairs — run it whenever the probe's roleCount moves).
+>
+> 1. **remove.source ×12 — the en-noise diagnosis, built.** The source slot's
+>    `expectedTypes: ['selector','reference']` rejected the bare identifier
+>    (`item` types as `expression` via tokenToSemanticValue) and the optional
+>    slot skipped → schema `me` default. THREE aligned pieces: (a) removeSchema
+>    source += 'expression' — the pre-fix probe showed the 9 me-default
+>    languages (ar/de/fr/he/id/ms/sw/tl/zh) defaulted for the SAME schema
+>    reason as en, so the shared-schema fix enriched en and all nine together
+>    (zero honest dips, better than the resizable-drill expectation); (b) the
+>    marker-role collision gate below; (c) normalizeCommandRoles
+>    bound-identifier retype extended destination → destination+source
+>    (bn/hi/ja/ko/th typed `item` as bare literal on the SOV capture path).
+>    All 24 languages now capture `source:expression="item"`.
+> 2. **remove.patient es/pt — genitive/from-marker collision, gated.** The
+>    mechanism was tryMatchPossessiveSelectorExpression (owner-first), NOT the
+>    property-first of-possessive read the session-6 block guessed: es/pt `de`
+>    (particle, normalized `source`) is the profile POSSESSIVE marker, so
+>    `quitar .{dragClass} de item` folded as ".{dragClass}'s item" → phantom
+>    property-path patient. New gate: reject the profile-possessive fold when
+>    the marker normalizes to `source` AND the command's schema declares a
+>    source role. **Deliberately source-ONLY**: the first draft gated on ANY
+>    declared role and qu `pa` / tr `ın` (both normalize `destination`) killed
+>    qu/tr bind-explicit-property + bind-non-form-display to NULL — invisible
+>    to the missing/spurious A/B (a null parse just vanishes), caught only by
+>    the coverage census. Guard test locks the bind folds. Collateral fix:
+>    modal-close-escape es/pt hide.patient (the compound's trailing
+>    `quitar .modal-open de cuerpo` un-poisoned the clause chain).
+>
+> 5 guard tests appended (4 stash-verified fail-without-fix; 1 locks qu/tr
+> bind possessives against gate over-broadening).
+>
+> **Residue updated after session 7:**
+>
+> - **tr remove.patient (`expression:"last .{dragClass}"`) is NOT the es/pt
+>   site — probed:** the tr line parses clean in ISOLATION (patient=selector,
+>   remove-tr-generated-simple); in corpus the repeat-block's `son` (tr `end`,
+>   ALSO tr's positional `last` — the bn শেষ / ar آخر family; `son` IS in
+>   isEndKeyword's tr set, so this is walker bookkeeping, not the keyword set)
+>   leaks into the remove clause head and fuses as a positional read
+>   (`last .{dragClass}`). Block-walk desync, for a future arc — do NOT touch
+>   the end-keyword sets for it.
+> - behavior-sortable remove.source/remove.patient families are CLEARED
+>   (×12 + es/pt); sortable's remaining flags are the spurious `empty` hi/tr
+>   (transformer-side, locked) + bn `for`.
+> - wait-line param leak (ja trigger.source junk literal) — unchanged, the
+>   body-side sibling of the #584 head fix.
+> - **The four spurious families were PROBED (not built) this session — ALL
+>   FOUR are en-noise inversions** (#6–#9; en drops the command, the flagged
+>   languages parse it): `go ×21` (en `go back` THROWS — go-en requires the
+>   `to` marker; `go to top` parses), `default ×9` (en `default my @data-count
+to "0"` THROWS in isolation), `add ×22` (one-line `repeat 3 times add … to
+me` parses head-only in en — quantity+loopType, body dropped), `morph ×18`
+>   (en drops the then-chained `morph #target to it` after `render … with
+row: $data`; en's render also grabs a `style:expression="row"` role the
+>   translations lack — probe the with-phrase when drilling). Each needs the
+>   who-passes-via-what pre-probe before enriching en (this session's lesson:
+>   same-schema languages can enrich together with en, zero honest dips).
+> - Everything else from the session-6 block below stands (SOV halt ×6 —
+>   stretch, compound-level fronted-role re-association).
+
 > **STATUS UPDATE (2026-07-06, session 6): both planned drills LANDED — #583
 > (then-boundary if fold, the behavior-resizable en-noise drill) and #584
 > (event-head param-phrase consumption, the behavior-sortable drill).**

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -9,27 +9,66 @@
 > [BEHAVIORS_CONSOLIDATION_PLAN.md](BEHAVIORS_CONSOLIDATION_PLAN.md). Read this first,
 > then dive into those for the per-arc detail.
 
-## Where we are (2026-07-06 baseline · post session-6 behavior drills · `browser-priority`)
+## Where we are (2026-07-06 baseline · post session-7 remove drill · `browser-priority`)
 
 Authoritative source: `packages/testing-framework/baselines/multilingual-priority.json`
 (its `timestamp` + `commit` fields stamp each regen). 24 langs × 154 patterns = 3696.
 
-| Signal                         | Value                  | Notes                                                            |
-| ------------------------------ | ---------------------- | ---------------------------------------------------------------- |
-| parse rate                     | **3696 / 3696 (100%)** | zero hard fails, holding                                         |
-| degenerate passes (fid < 0.5)  | **0**                  | band cleared (#492/#493), holding                                |
-| lossy passes (0.5 ≤ fid < 1.0) | **0**                  | band cleared (#495–#506), holding                                |
-| faithful (fid = 1.0)           | **3696**               | every parsing pattern is faithful                                |
-| avgFidelity (R0-recall)        | **1.000**              | saturated                                                        |
-| avgPrecision (R0 trust floor)  | **0.985**              | session-6 resizable drill: 0.9849 → 0.9851 (bn up)               |
-| avgRoleFidelity (R1)           | **0.982**              | session-6 sortable drill: 0.9824 → 0.9825 (sortable families ×9) |
-| avgExecutionFidelity (R2)      | **1.000**              | 47-pattern curated subset fully reproduces en DOM effects        |
+| Signal                         | Value                  | Notes                                                     |
+| ------------------------------ | ---------------------- | --------------------------------------------------------- |
+| parse rate                     | **3696 / 3696 (100%)** | zero hard fails, holding                                  |
+| degenerate passes (fid < 0.5)  | **0**                  | band cleared (#492/#493), holding                         |
+| lossy passes (0.5 ≤ fid < 1.0) | **0**                  | band cleared (#495–#506), holding                         |
+| faithful (fid = 1.0)           | **3696**               | every parsing pattern is faithful                         |
+| avgFidelity (R0-recall)        | **1.000**              | saturated                                                 |
+| avgPrecision (R0 trust floor)  | **0.985**              | held through session-7 (0.9851)                           |
+| avgRoleFidelity (R1)           | **0.983**              | session-7 remove drill: 0.9825 → 0.9829 (remove/hide ×16) |
+| avgExecutionFidelity (R2)      | **1.000**              | 47-pattern curated subset fully reproduces en DOM effects |
 
 The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recall ·
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.** R1 remains the
 dimension with headroom (SOV six ~0.95); R0-precision's spurious-action
 families are the next un-mined seam.
+
+> **Update 2026-07-06b (SESSION 7: the en remove.source drill + es/pt
+> remove.patient gate — #586; probe mean R1 0.9825 → 0.9829, avgPrecision
+> 0.9851 held; per-(lang,pattern) A/B 16 fixed / 0 new; parse-coverage census
+> identical (3404); gate green; baseline regenerated.)**
+>
+> - **remove.source ×12 (en-noise, built as diagnosed).** The source slot
+>   rejected the bare identifier (`item` types `expression`; slot expected
+>   selector/reference) → `me` schema default. removeSchema source +=
+>   'expression' enriched en AND the nine same-default languages together —
+>   all 24 langs now capture `source:expression="item"`, zero honest dips.
+>   Plus the bound-identifier literal→expression retype extended to `source`
+>   (the SOV five typed `item` as bare literal).
+> - **remove.patient es/pt — the mechanism was owner-first, not
+>   property-first:** es/pt `de` is the profile POSSESSIVE marker (normalized
+>   `source`), so tryMatchPossessiveSelectorExpression folded
+>   `.{dragClass} de item` into a phantom property-path patient. New
+>   marker-role collision gate, **deliberately source-only** — gating on any
+>   declared role NULLed qu/tr bind patterns (qu `pa`/tr `ın` normalize
+>   `destination`; caught by the coverage census, not the missing/spurious
+>   A/B — a null parse just vanishes; census now part of the discipline).
+> - **Residue sharpened:** tr remove.patient (`last .{dragClass}`) is a
+>   block-walk leak — the repeat-block's `son` (tr `end`, ALSO positional
+>   `last`; already in isEndKeyword) leaks into the next clause head. NOT a
+>   keyword-set fix; a future walker arc.
+> - **The four undrilled spurious families were all PROBED this session —
+>   every one is an en-noise inversion (en drops the command; the flagged
+>   languages parse it):** `go ×21` — en `go back` THROWS in isolation (the
+>   go-en pattern requires the `to` marker; `go to top` parses); `default ×9`
+>   — en `default my @data-count to "0"` THROWS in isolation (the en pattern
+>   never matches the possessive+attr shape); `add ×22` — the one-line
+>   `repeat 3 times add … to me` parses head-only in en (quantity+loopType,
+>   body dropped; repeat-times + behavior-draggable); `morph ×18` — en drops
+>   the then-chained `morph #target to it` after `render … with row: $data`
+>   (the SOV six keep it; en's render also grabs a `style` role ja lacks —
+>   check the with-phrase when drilling). Four separate en-side fixes; each
+>   will need the who-passes-via-what pre-probe before enriching en (the
+>   session-7 lesson: same-schema languages can enrich together). Next up
+>   otherwise: SOV halt ×6 (stretch), wait-line param leak (value-level).
 
 > **Update 2026-07-06 (SESSION 6: the two planned behavior drills — #583
 > then-boundary if fold + #584 event-head param-phrase; probe mean R1 0.9825,


### PR DESCRIPTION
Docs-only sync after #586 (the session-7 remove drill), the #585 pattern:

- **HANDOFF-r1-post-cluster-residue.md**: session-7 status block — the three aligned pieces (schema `expression` acceptance, source-only marker-role collision gate, bound-identifier source retype), the coverage-census lesson (a null parse is invisible to the missing/spurious A/B), residue updates (tr `son` block-walk leak; the four spurious families probed: all en-noise inversions #6–#9).
- **MULTILINGUAL_NEXT_STEPS.md**: header/table refresh (R1 0.9829, precision 0.9851 held) + session-7 update block with the probed mechanisms for the next drills (`go back` throws, `default` throws, one-line repeat body drop, then-chained morph drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)