### PR TITLE
fix(multilingual): go accepts the bare/patient-marked destination — en optional to-marker + he/zh markerVariants (spurious-go drill)

### DIFF
--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -1582,6 +1582,13 @@ export const goSchema: CommandSchema = {
       sovPosition: 1,
       markerOverride: { en: 'to' }, // "go to /page" (parsing)
       renderOverride: { en: '' }, // "go /page" (rendering — no preposition)
+      // `go back` renders the destination bare in en (history nav has no `to`),
+      // and he/zh render it with their PATIENT marker (לך את back / 前往 把 back)
+      // while go-url keeps the destination marker (לך על url / 前往 到 url) —
+      // the corpus is ground truth, so en's `to` is optional and he/zh accept
+      // the patient particle as a destination-marker alternative, scoped to go.
+      markerOptional: { en: true },
+      markerVariants: { he: ['את'], zh: ['把'] },
     },
   ],
 };
@@ -2047,6 +2054,15 @@ export const defaultSchema: CommandSchema = {
       role: 'destination',
       description: 'The variable to set default for',
       required: true,
+      // NOTE (probed 2026-07-06, session 8): adding 'property-path' here fixes
+      // en `default my @data-count to "0"` (destination=property-path via the
+      // possessive matcher, exactly parallel to set-en-possessive) — but ONLY
+      // en: all 13 currently-dropping SVO/VSO languages still NULL on their
+      // rendered possessive+marker shapes (de `standard mein @data-count zu`,
+      // es `predeterminar mi @data-count a`, …), so an en-only enrichment
+      // would mint ~26 honest-dip A/B entries. Admit property-path only as
+      // part of the full default-value drill (per-language markers +
+      // possessive matching).
       expectedTypes: ['reference'],
       svoPosition: 1,
       sovPosition: 1,

--- a/packages/semantic/src/generators/pattern-generator.ts
+++ b/packages/semantic/src/generators/pattern-generator.ts
@@ -675,33 +675,41 @@ function buildRoleToken(roleSpec: RoleSpec, profile: LanguageProfile): PatternTo
   if (overrideMarker !== undefined) {
     // Command-specific marker override. Multi-word markers (e.g. "partials in",
     // "with title") split into one literal token per word so the matcher
-    // consumes them sequentially.
+    // consumes them sequentially. A per-command markerOptional wraps each word
+    // in an optional group (`go to /page` and `go back` both parse — the
+    // render side drops the preposition, so the parse side can't require it).
     const markerWords = overrideMarker ? overrideMarker.split(/\s+/).filter(Boolean) : [];
     const position = defaultMarker?.position ?? 'before';
+    const optionalMarker = roleSpec.markerOptional?.[profile.code] === true;
+    const pushWord = (word: string): void => {
+      const literal: PatternToken = { type: 'literal', value: word };
+      tokens.push(optionalMarker ? { type: 'group', optional: true, tokens: [literal] } : literal);
+    };
     if (position === 'before') {
-      for (const word of markerWords) {
-        tokens.push({ type: 'literal', value: word });
-      }
+      for (const word of markerWords) pushWord(word);
       tokens.push(roleValueToken);
     } else {
       tokens.push(roleValueToken);
-      for (const word of markerWords) {
-        tokens.push({ type: 'literal', value: word });
-      }
+      for (const word of markerWords) pushWord(word);
     }
   } else if (defaultMarker) {
     // When the profile allows colloquial marker-dropping, the marker becomes an
     // optional group so `.active değiştir` parses as well as `.active i değiştir`.
     // The marked form still matches the marker literal directly (higher
     // confidence); the unmarked form falls back through the optional group.
-    const asMarker = (): PatternToken =>
-      defaultMarker.alternatives
-        ? {
-            type: 'literal',
-            value: defaultMarker.primary,
-            alternatives: defaultMarker.alternatives,
-          }
+    // Per-command markerVariants merge in as extra alternatives (the SOV
+    // two-role generators already do this — see event-handlers-sov.ts): the
+    // transformer can render a role with a particle the profile default
+    // doesn't cover (he את / zh 把 before go's destination in `go back`).
+    const variantAlts = roleSpec.markerVariants?.[profile.code] ?? [];
+    const asMarker = (): PatternToken => {
+      const alternatives = [
+        ...new Set([...(defaultMarker.alternatives ?? []), ...variantAlts]),
+      ].filter(a => a !== defaultMarker.primary);
+      return alternatives.length
+        ? { type: 'literal', value: defaultMarker.primary, alternatives }
         : { type: 'literal', value: defaultMarker.primary };
+    };
     const pushMarker = (marker: PatternToken): void => {
       tokens.push(
         profile.markersOptional || roleSpec.markerOptional?.[profile.code]
@@ -750,8 +758,13 @@ function buildExtractionRules(
       // Use the override marker
       rules[roleSpec.role] = overrideMarker ? { marker: overrideMarker } : {};
     } else if (defaultMarker && defaultMarker.primary) {
-      rules[roleSpec.role] = defaultMarker.alternatives
-        ? { marker: defaultMarker.primary, markerAlternatives: defaultMarker.alternatives }
+      // Merge per-command markerVariants as alternatives (mirrors buildRoleToken)
+      const variantAlts = roleSpec.markerVariants?.[profile.code] ?? [];
+      const markerAlternatives = [
+        ...new Set([...(defaultMarker.alternatives ?? []), ...variantAlts]),
+      ].filter(a => a !== defaultMarker.primary);
+      rules[roleSpec.role] = markerAlternatives.length
+        ? { marker: defaultMarker.primary, markerAlternatives }
         : { marker: defaultMarker.primary };
     } else {
       rules[roleSpec.role] = {};

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -10992,3 +10992,61 @@ describe('remove source slot: bare-identifier acceptance + genitive/from-marker 
     expect(walkNodes(tr).find(r => r.action === 'bind')).toBeDefined();
   });
 });
+
+describe('go destination marker: en bare form + he/zh patient-particle variants', () => {
+  const role = (
+    node: Record<string, any> | null | undefined,
+    r: string
+  ): { type?: string; value?: unknown; raw?: unknown } | undefined =>
+    node?.roles instanceof Map ? node.roles.get(r) : undefined;
+
+  it('[en] `go back` parses without the `to` marker', () => {
+    // en RENDERS go's destination bare (renderOverride ''), but the generated
+    // pattern required the `to` literal — so the en reference dropped `go back`
+    // entirely (PARSE NULL in isolation) while 21 languages captured
+    // destination="back" via their lax event-fused paths, and were then
+    // precision-flagged as "spurious go" against the empty reference (go ×21,
+    // the largest en-noise inversion of the session-7 probe set).
+    const node = parse('go back', 'en') as unknown as Record<string, any>;
+    expect(node.action).toBe('go');
+    expect(role(node, 'destination')?.type).toBe('expression');
+    expect(String(role(node, 'destination')?.raw)).toBe('back');
+  });
+
+  it('[en] `go to url "/page"` still parses with the marker (marked form locked)', () => {
+    const node = parse('go to url "/page"', 'en') as unknown as Record<string, any>;
+    expect(node.action).toBe('go');
+    expect(String(role(node, 'destination')?.raw ?? role(node, 'destination')?.value)).toContain(
+      'url'
+    );
+  });
+
+  for (const [lang, line] of [
+    ['he', 'לך את back'],
+    ['zh', '前往 把 back'],
+  ] as const) {
+    it(`[${lang}] \`${line}\`: the rendered patient particle marks go's destination`, () => {
+      // The transformer renders `back` with the PATIENT particle (he את /
+      // zh 把) while go-url keeps the destination marker (he על / zh 到) —
+      // both must parse. markerVariants on goSchema.destination admits the
+      // particle as a marker alternative, scoped to go only.
+      const node = parse(line, lang) as unknown as Record<string, any>;
+      expect(node.action).toBe('go');
+      expect(role(node, 'destination')?.type).toBe('expression');
+      expect(String(role(node, 'destination')?.raw)).toBe('back');
+    });
+  }
+
+  for (const [lang, line] of [
+    ['he', 'לך על url "/page"'],
+    ['zh', '前往 到 url "/page"'],
+  ] as const) {
+    it(`[${lang}] \`${line}\`: the primary destination marker still parses (go-url locked)`, () => {
+      const node = parse(line, lang) as unknown as Record<string, any>;
+      expect(node.action).toBe('go');
+      expect(String(role(node, 'destination')?.raw ?? role(node, 'destination')?.value)).toContain(
+        'url'
+      );
+    });
+  }
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-06T13:40:59.694Z",
-  "commit": "0cdeddeb",
+  "timestamp": "2026-07-06T14:40:51.710Z",
+  "commit": "0a999ed9",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -8,13 +8,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8362095875032615,
       "avgFidelity": 1,
-      "avgPrecision": 0.9935064935064936,
+      "avgPrecision": 0.9967532467532467,
       "avgRoleFidelity": 0.9870495495495494,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8579007041413049,
       "avgFidelity": 1,
-      "avgPrecision": 0.9489143889879185,
+      "avgPrecision": 0.9521611422346717,
       "avgRoleFidelity": 0.9710585585585586,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1272,13 +1272,13 @@
       "parseRate": 1,
       "avgConfidence": 0.828035456606883,
       "avgFidelity": 1,
-      "avgPrecision": 0.9967532467532467,
+      "avgPrecision": 1,
       "avgRoleFidelity": 0.9838320463320464,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2529,13 +2529,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8338074623788887,
       "avgFidelity": 1,
-      "avgPrecision": 0.9967532467532467,
+      "avgPrecision": 1,
       "avgRoleFidelity": 0.9904279279279278,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3161,13 +3161,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8247371675943084,
       "avgFidelity": 1,
-      "avgPrecision": 0.9967532467532467,
+      "avgPrecision": 1,
       "avgRoleFidelity": 0.9838320463320464,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.9045096507502506,
       "avgFidelity": 1,
-      "avgPrecision": 0.952732683982684,
+      "avgPrecision": 0.9559794372294372,
       "avgRoleFidelity": 0.9561776061776062,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5057,13 +5057,13 @@
       "parseRate": 1,
       "avgConfidence": 0.838961038961037,
       "avgFidelity": 1,
-      "avgPrecision": 0.9967532467532467,
+      "avgPrecision": 1,
       "avgRoleFidelity": 0.9862451737451738,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5689,13 +5689,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
-      "avgPrecision": 0.988771645021645,
+      "avgPrecision": 0.9920183982683983,
       "avgRoleFidelity": 0.9979086229086228,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6321,13 +6321,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8467689787238654,
       "avgFidelity": 1,
-      "avgPrecision": 0.9643939393939397,
+      "avgPrecision": 0.9676406926406929,
       "avgRoleFidelity": 0.9710585585585586,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6953,13 +6953,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8417184736733602,
       "avgFidelity": 1,
-      "avgPrecision": 0.9643939393939397,
+      "avgPrecision": 0.9676406926406929,
       "avgRoleFidelity": 0.9676801801801802,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7585,13 +7585,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
-      "avgPrecision": 0.9945887445887446,
+      "avgPrecision": 0.9978354978354977,
       "avgRoleFidelity": 0.9876126126126128,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8217,13 +8217,13 @@
       "parseRate": 1,
       "avgConfidence": 0.807173778602348,
       "avgFidelity": 1,
-      "avgPrecision": 0.9941829004329004,
+      "avgPrecision": 0.9974296536796536,
       "avgRoleFidelity": 0.9867599742599743,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8849,13 +8849,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7984333127190251,
       "avgFidelity": 1,
-      "avgPrecision": 0.9967532467532467,
+      "avgPrecision": 1,
       "avgRoleFidelity": 0.9893018018018019,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9481,13 +9481,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
-      "avgPrecision": 0.9643939393939395,
+      "avgPrecision": 0.9676406926406927,
       "avgRoleFidelity": 0.9556145431145432,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10113,13 +10113,13 @@
       "parseRate": 1,
       "avgConfidence": 0.818181818181816,
       "avgFidelity": 1,
-      "avgPrecision": 0.9941829004329004,
+      "avgPrecision": 0.9974296536796536,
       "avgRoleFidelity": 0.9890765765765768,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10745,13 +10745,13 @@
       "parseRate": 1,
       "avgConfidence": 0.800865800865799,
       "avgFidelity": 1,
-      "avgPrecision": 0.9945887445887447,
+      "avgPrecision": 0.997835497835498,
       "avgRoleFidelity": 0.9893018018018019,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11377,13 +11377,13 @@
       "parseRate": 1,
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
-      "avgPrecision": 0.989177489177489,
+      "avgPrecision": 0.9924242424242423,
       "avgRoleFidelity": 0.9893018018018017,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12009,13 +12009,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8206715541080843,
       "avgFidelity": 1,
-      "avgPrecision": 0.9935064935064936,
+      "avgPrecision": 0.9967532467532467,
       "avgRoleFidelity": 0.9938063063063062,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12641,13 +12641,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8456558061821213,
       "avgFidelity": 1,
-      "avgPrecision": 0.9635822510822512,
+      "avgPrecision": 0.9668290043290044,
       "avgRoleFidelity": 0.9706611022787494,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13273,13 +13273,13 @@
       "parseRate": 1,
       "avgConfidence": 0.818594104308388,
       "avgFidelity": 1,
-      "avgPrecision": 0.9941829004329004,
+      "avgPrecision": 0.9974296536796536,
       "avgRoleFidelity": 0.9890765765765765,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13905,13 +13905,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
-      "avgPrecision": 0.9920183982683983,
+      "avgPrecision": 0.9952651515151516,
       "avgRoleFidelity": 0.9930180180180183,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 483834,
+      "bundleSize": 484178,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 483834,
+      "size": 484178,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Clears the **largest spurious-precision family** from the session-7 probe set: `go ×21` (go-back, every flagged language) — an **en-noise inversion** confirmed by the who-passes-via-what pre-probe.

**Mechanism.** en renders go's destination bare (`renderOverride: ''` → `go back`), but the generated `go-en` pattern **required** the `to` literal — so the en reference dropped `go back` entirely (PARSE NULL in isolation) while 21 languages captured `destination="back"` via their lax event-fused paths, and were precision-flagged against the empty reference. The pre-probe showed **he/zh were the only other droppers**, for the sibling reason: the transformer renders `back` with their **patient** particle (`לך את back` / `前往 把 back`) while go-url keeps the destination marker (`על` / `到`). All three enrich together — zero honest dips.

## Changes

- **pattern-generator, markerOverride branch**: honors per-command `markerOptional` — each override-marker word wraps in an optional group (`go back` and `go to url "/page"` both parse; the marked form still matches directly).
- **pattern-generator, default-marker branch + extraction rules**: per-command `markerVariants[code]` merge in as marker alternatives (the SOV two-role generators already did this).
- **goSchema.destination**: `markerOptional: { en: true }`, `markerVariants: { he: ['את'], zh: ['把'] }`. No pre-existing schema hits the new default-branch merge path (put-en / set-tr variants sit on override-branch roles).
- **7 guard tests** appended (3 stash-verified fail-without-fix; 4 lock the marked go-url forms against over-broadening).

## Validation

- Semantic suite **6548 passed**; core **7012**; i18n **912**.
- Per-(lang,pattern) corpus A/B: **spurious go ×21 cleared, zero new entries** (the diff between before/after snapshots is exactly the family's removal).
- Parse-coverage census identical: **3404 pairs**.
- Probe mean R1 held **0.9829**; six-signal `--regression` gate **green**.
- Baseline regenerated against a fresh populate: **avgPrecision 0.9851 → 0.9881**, parse 3696/3696, degenerate/lossy 0, R2 1.0 held. (patterns.db not committed, per policy.)

## Probed and deferred

`default ×9`: admitting `property-path` on defaultSchema.destination fixes **en only** (`default my @data-count to "0"` parses, parallel to set-en-possessive) — but all 13 currently-dropping languages stay NULL on their rendered possessive shapes (de `standard mein @data-count zu "0"`, es `predeterminar mi @data-count a "0"`, …), so the en-only enrichment would mint ~26 honest-dip A/B entries. Documented in-code; needs the full default-value drill (per-language markers + possessive matching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)