### PR TITLE
fix(multilingual): add patient accepts literal content — repeat-times ×11 spurious family (en-noise) + session-8 docs sync

### DIFF
--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -1,5 +1,73 @@
 # Handoff — R1 residue after the five-cluster triage (fronted repeat-while · sw kama homonym · singletons)
 
+> **STATUS UPDATE (2026-07-06, session 8): two spurious en-noise families
+> LANDED — #588 (go ×21: en optional to-marker + he/zh patient-particle
+> markerVariants) and the add drill in this PR (add ×22→×11: patient literal
+> admission cleared the repeat-times half).** Post-session state: probe mean
+> R1 **0.9829** (held), baseline avgPrecision **0.9851 → 0.9891** (+0.0040
+> across the two drills), parse 3696/3696, degenerate/lossy 0, R2 1.0.
+> Per-(lang,pattern) A/B across both PRs: **32 spurious entries cleared,
+> 0 new**; parse-coverage census identical before/after (3404 pairs).
+>
+> 1. **#588 — go ×21 (en-noise, built as diagnosed — but the pre-probe showed
+>    THREE droppers, not one).** en renders go's destination bare
+>    (`renderOverride: ''` → `go back`) while the generated go-en pattern
+>    REQUIRED the `to` literal — en PARSE NULL in isolation; 21 languages
+>    captured `destination="back"` via lax event-fused paths. he/zh were the
+>    other two droppers, sibling reason: the transformer renders `back` with
+>    their PATIENT particle (`לך את back` / `前往 把 back`) while go-url keeps
+>    the destination marker (`על` / `到`). Three aligned pieces, all scoped to
+>    goSchema.destination: (a) the pattern-generator markerOverride branch now
+>    honors per-command `markerOptional` (marker words wrap in an optional
+>    group) — en `go back` and `go to url "/page"` both parse; (b) the
+>    default-marker branch + extraction rules merge per-command
+>    `markerVariants[code]` as marker alternatives (the SOV two-role
+>    generators already did); (c) `markerOptional: { en: true }`,
+>    `markerVariants: { he: ['את'], zh: ['把'] }`. All three enriched
+>    together — zero honest dips. No pre-existing schema hits the new
+>    default-branch merge (put-en / set-tr markerVariants sit on
+>    override-branch roles). 6 guard tests (3 stash-verified fail-without-fix;
+>    3 lock the marked forms).
+> 2. **add repeat-times ×11 (this PR) — the session-7 "loop-body attachment"
+>    guess was WRONG.** Probed: `repeat forever toggle .pulse` composes fine
+>    (head-only repeat + sibling via the clause loop), and en
+>    `add "hello" to me` is NULL in ISOLATION — the patient slot
+>    (`expectedTypes: ['selector']`) rejected ANY string literal.
+>    addSchema.patient += 'literal' (transition/append precedent) cleared en +
+>    the 12 generated-path languages together (ar/de/es/fr/he/id/ms/pt/sw/th/
+>    tl/zh — the remove.source shared-schema pattern again); the 11 lax-path
+>    languages' captures now match. 3 guard tests (2 stash-verified).
+>
+> **Residue updated after session 8:**
+>
+> - **behavior-draggable add ×11 (the other half of add ×22) is a DIFFERENT
+>   mechanism — deferred, do not conflate with the cleared repeat-times
+>   half.** The style-object patient `add { left: ${clientX - xoff}px; … }`
+>   shatters into ~12 identifier tokens in en (a standalone `{` identifier —
+>   NO collision with `.{cls}`, which tokenizes as ONE selector token), so the
+>   generated pattern can't capture it; needs a brace-run literal fold in
+>   matchRoleToken. BUT an en-only fold trades spurious ×11 for missing ×11:
+>   the lax-path languages carry junk roles there (ja
+>   `source=(clientX,clientY)またはpointerup…` wait-line leak +
+>   `destination=literal:"draggable:move"` next-line grab vs en's
+>   destination=reference:"me" schema default → type mismatch → new missing
+>   entries). The fold and the SOV junk-role cleanup must land TOGETHER.
+> - **default ×9 — probed deeper, still open.** defaultSchema.destination +
+>   'property-path' fixes en `default my @data-count to "0"` (parallel to
+>   set-en-possessive; verified at src level) but ONLY en: all 13
+>   currently-dropping languages stay NULL on their rendered possessive+marker
+>   shapes (de `standard mein @data-count zu "0"`, es `predeterminar mi
+@data-count a "0"`, …) — their generated patterns demand profile markers
+>   the render omits, and their possessive shapes don't fold. An en-only
+>   enrichment would mint ~26 honest-dip A/B entries. Needs the full
+>   default-value drill (per-language markers + possessive matching).
+>   In-code NOTE at defaultSchema.destination.
+> - **morph ×18 — untouched this session** (probe the render with-phrase
+>   before diagnosing, per the session-7 note below).
+> - Everything else from the session-7 block below stands (tr remove.patient
+>   block-walk leak; spurious empty tr/hi/bn + sortable hi/tr
+>   transformer-side; wait-line param leak ja; SOV halt ×6 stretch).
+
 > **STATUS UPDATE (2026-07-06, session 7): the en remove.source drill LANDED as
 > #586** — batched with the es/pt remove.patient gate (same site). Post-session
 > state: probe mean R1 **0.9829** (0.9825 → +0.0004), baseline avgPrecision

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -9,7 +9,7 @@
 > [BEHAVIORS_CONSOLIDATION_PLAN.md](BEHAVIORS_CONSOLIDATION_PLAN.md). Read this first,
 > then dive into those for the per-arc detail.
 
-## Where we are (2026-07-06 baseline · post session-7 remove drill · `browser-priority`)
+## Where we are (2026-07-06 baseline · post session-8 spurious drills · `browser-priority`)
 
 Authoritative source: `packages/testing-framework/baselines/multilingual-priority.json`
 (its `timestamp` + `commit` fields stamp each regen). 24 langs × 154 patterns = 3696.
@@ -21,8 +21,8 @@ Authoritative source: `packages/testing-framework/baselines/multilingual-priorit
 | lossy passes (0.5 ≤ fid < 1.0) | **0**                  | band cleared (#495–#506), holding                         |
 | faithful (fid = 1.0)           | **3696**               | every parsing pattern is faithful                         |
 | avgFidelity (R0-recall)        | **1.000**              | saturated                                                 |
-| avgPrecision (R0 trust floor)  | **0.985**              | held through session-7 (0.9851)                           |
-| avgRoleFidelity (R1)           | **0.983**              | session-7 remove drill: 0.9825 → 0.9829 (remove/hide ×16) |
+| avgPrecision (R0 trust floor)  | **0.989**              | session-8 spurious drills: 0.9851 → 0.9891 (go+add)       |
+| avgRoleFidelity (R1)           | **0.983**              | 0.9829, held through session-8                            |
 | avgExecutionFidelity (R2)      | **1.000**              | 47-pattern curated subset fully reproduces en DOM effects |
 
 The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recall ·
@@ -30,6 +30,36 @@ R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelit
 **Direction now: stop adding gate signals; spend them down.** R1 remains the
 dimension with headroom (SOV six ~0.95); R0-precision's spurious-action
 families are the next un-mined seam.
+
+> \*\*Update 2026-07-06c (SESSION 8: two spurious en-noise drills — #588 go ×21
+>
+> - the add repeat-times ×11 drill in this PR; avgPrecision 0.9851 → 0.9891,
+>   probe mean R1 0.9829 held; A/B 32 spurious cleared / 0 new; census identical
+>   (3404); gate green throughout; baseline regenerated per-PR.)\*\*
+>
+> * **#588 — go ×21 (en-noise, the pre-probe found THREE droppers).** The
+>   go-en pattern required the `to` marker en's own render drops (`go back` —
+>   PARSE NULL in isolation); he/zh dropped it too (the transformer marks
+>   `back` with their PATIENT particle את/把 while go-url keeps על/到). Fix at
+>   goSchema.destination: pattern-generator markerOverride branch honors
+>   per-command `markerOptional` (en), default branch + extraction rules merge
+>   per-command `markerVariants` as marker alternatives (he/zh) — the SOV
+>   generators already did. All three enriched together, zero honest dips.
+> * **add repeat-times ×11 (this PR) — the "loop-body attachment" hypothesis
+>   was WRONG.** en `add "hello" to me` is NULL in isolation — the patient
+>   slot was selector-only and rejected every string literal (`repeat forever
+toggle .pulse` composes fine, so the loop machinery was innocent).
+>   addSchema.patient += 'literal' (transition/append precedent) enriched en +
+>   12 generated-path languages together.
+> * **Residue sharpened:** behavior-draggable add ×11 is a brace-run fold
+>   (`{ left: ${…}px; }` shatters to ~12 identifier tokens; `.{cls}` is safe —
+>   one selector token) that must land WITH the SOV junk-role cleanup (ja's
+>   junk destination=`"draggable:move"` vs en's `me` default would flip
+>   spurious ×11 into missing ×11). default ×9 needs the full per-language
+>   drill: property-path admission fixes en only; the 13 dropping languages
+>   fail on rendered markers + possessive folds (~26 honest dips if en-only —
+>   in-code NOTE at defaultSchema.destination). morph ×18 untouched. Next up
+>   otherwise: SOV halt ×6 (stretch), wait-line param leak (value-level).
 
 > **Update 2026-07-06b (SESSION 7: the en remove.source drill + es/pt
 > remove.patient gate — #586; probe mean R1 0.9825 → 0.9829, avgPrecision

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -318,7 +318,14 @@ export const addSchema: CommandSchema = {
       role: 'patient',
       description: 'The class or attribute to add',
       required: true,
-      expectedTypes: ['selector'],
+      // `literal` admits quoted HTML/text content (`add "<p>Line</p>" to me`,
+      // repeat-times + behavior-draggable): the selector-only slot rejected the
+      // string and the WHOLE command parsed NULL in en and the generated-path
+      // languages, while 11 lax-path languages captured patient=literal — and
+      // were precision-flagged as "spurious add" against the empty en
+      // reference (add ×22, en-noise). Same admission precedent as
+      // transition.patient / append.patient.
+      expectedTypes: ['selector', 'literal'],
       svoPosition: 1,
       sovPosition: 2,
     },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -11050,3 +11050,51 @@ describe('go destination marker: en bare form + he/zh patient-particle variants'
     });
   }
 });
+
+describe('add patient: literal content admission', () => {
+  const role = (
+    node: Record<string, any> | null | undefined,
+    r: string
+  ): { type?: string; value?: unknown; raw?: unknown } | undefined =>
+    node?.roles instanceof Map ? node.roles.get(r) : undefined;
+
+  it('[en] `add "<p>Line</p>" to me` parses (quoted content patient)', () => {
+    // The selector-only patient slot rejected ANY string literal, so the whole
+    // command parsed NULL in en and the 12 generated-path languages — while 11
+    // lax-path languages captured patient=literal and were precision-flagged
+    // as "spurious add" against the empty en reference (repeat-times half of
+    // the add ×22 family). Admission precedent: transition/append patient.
+    const node = parse('add "<p>Line</p>" to me', 'en') as unknown as Record<string, any>;
+    expect(node.action).toBe('add');
+    expect(role(node, 'patient')?.type).toBe('literal');
+    expect(String(role(node, 'patient')?.value)).toBe('<p>Line</p>');
+    expect(role(node, 'destination')?.type).toBe('reference');
+  });
+
+  it('[en] one-line `repeat 3 times add … to me` keeps the loop body (handler shape)', () => {
+    const node = parse('on click repeat 3 times add "<p>Line</p>" to me', 'en');
+    const flat: Record<string, any>[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'eventHandlers']) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    expect(flat.find(r => r.action === 'repeat')).toBeDefined();
+    const add = flat.find(r => r.action === 'add');
+    expect(add).toBeDefined();
+    expect(role(add!, 'patient')?.type).toBe('literal');
+  });
+
+  it('[en] `add .foo to me` still captures a selector patient (class form locked)', () => {
+    const node = parse('add .foo to me', 'en') as unknown as Record<string, any>;
+    expect(node.action).toBe('add');
+    expect(role(node, 'patient')?.type).toBe('selector');
+    expect(String(role(node, 'patient')?.value)).toBe('.foo');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-06T14:40:51.710Z",
-  "commit": "0a999ed9",
+  "timestamp": "2026-07-06T14:56:22.166Z",
+  "commit": "63c71b08",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8579007041413049,
       "avgFidelity": 1,
-      "avgPrecision": 0.9521611422346717,
+      "avgPrecision": 0.954325644399174,
       "avgRoleFidelity": 0.9710585585585586,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.9045096507502506,
       "avgFidelity": 1,
-      "avgPrecision": 0.9559794372294372,
+      "avgPrecision": 0.9581439393939395,
       "avgRoleFidelity": 0.9561776061776062,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5689,13 +5689,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
-      "avgPrecision": 0.9920183982683983,
+      "avgPrecision": 0.9941829004329006,
       "avgRoleFidelity": 0.9979086229086228,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6321,13 +6321,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8467689787238654,
       "avgFidelity": 1,
-      "avgPrecision": 0.9676406926406929,
+      "avgPrecision": 0.9698051948051951,
       "avgRoleFidelity": 0.9710585585585586,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6953,13 +6953,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8417184736733602,
       "avgFidelity": 1,
-      "avgPrecision": 0.9676406926406929,
+      "avgPrecision": 0.9698051948051951,
       "avgRoleFidelity": 0.9676801801801802,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
       "avgPrecision": 0.9978354978354977,
-      "avgRoleFidelity": 0.9876126126126128,
+      "avgRoleFidelity": 0.9881756756756759,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8217,13 +8217,13 @@
       "parseRate": 1,
       "avgConfidence": 0.807173778602348,
       "avgFidelity": 1,
-      "avgPrecision": 0.9974296536796536,
+      "avgPrecision": 0.9995941558441559,
       "avgRoleFidelity": 0.9867599742599743,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9481,13 +9481,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
-      "avgPrecision": 0.9676406926406927,
+      "avgPrecision": 0.969805194805195,
       "avgRoleFidelity": 0.9556145431145432,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10113,13 +10113,13 @@
       "parseRate": 1,
       "avgConfidence": 0.818181818181816,
       "avgFidelity": 1,
-      "avgPrecision": 0.9974296536796536,
+      "avgPrecision": 0.9995941558441559,
       "avgRoleFidelity": 0.9890765765765768,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12641,13 +12641,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8456558061821213,
       "avgFidelity": 1,
-      "avgPrecision": 0.9668290043290044,
+      "avgPrecision": 0.9689935064935067,
       "avgRoleFidelity": 0.9706611022787494,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13273,13 +13273,13 @@
       "parseRate": 1,
       "avgConfidence": 0.818594104308388,
       "avgFidelity": 1,
-      "avgPrecision": 0.9974296536796536,
+      "avgPrecision": 0.9995941558441559,
       "avgRoleFidelity": 0.9890765765765765,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13905,13 +13905,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
-      "avgPrecision": 0.9952651515151516,
+      "avgPrecision": 0.9974296536796537,
       "avgRoleFidelity": 0.9930180180180183,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484178,
+      "bundleSize": 484188,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 484178,
+      "size": 484188,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Clears the **repeat-times half of the add ×22 spurious family** — and corrects the session-7 handoff's hypothesis: this was **not** loop-body attachment. `repeat forever toggle .pulse` composes fine (head-only repeat + sibling via the clause loop); the real defect is that en `add "hello" to me` parses **NULL in isolation** — `addSchema.patient` was selector-only and rejected every string literal. en and the 12 generated-path languages dropped the whole command, while 11 lax-path languages captured `patient=literal` and were precision-flagged against the empty en reference.

## Changes

- **addSchema.patient**: `['selector']` → `['selector', 'literal']` (the transition/append admission precedent). The pre-fix who-passes probe showed all 13 droppers fail for the same schema reason — the shared-schema fix enriches en + ar/de/es/fr/he/id/ms/pt/sw/th/tl/zh together (the remove.source #586 pattern again), zero honest dips.
- **3 guard tests** (2 stash-verified fail-without-fix; 1 locks the selector class form).
- **Docs**: session-8 status blocks synced into the handoff + NEXT_STEPS (folded into this PR instead of a separate docs-only PR, to save a CI pipeline).

## Validation

- Semantic suite **6554 passed**.
- Per-(lang,pattern) corpus A/B: **spurious add repeat-times ×11 cleared, zero new entries**; census identical (**3404 pairs**); probe mean R1 held **0.9829**.
- Six-signal `--regression` gate **green**; baseline regenerated against a fresh populate: **avgPrecision 0.9881 → 0.9891** (0.9851 → 0.9891 across the session's two drills, with #588), parse 3696/3696, degenerate/lossy 0, R2 1.0 held.

## Probed and deferred

**behavior-draggable add ×11** (the family's other half) is a different mechanism: the style-object patient `add { left: ${clientX - xoff}px; … }` shatters into ~12 identifier tokens (needs a brace-run literal fold in matchRoleToken; `.{cls}` is safe — one selector token), **and** the lax-path languages carry junk roles there (ja `destination="draggable:move"` vs en's `me` default), so an en-only fold would flip spurious ×11 into missing ×11. The fold and the SOV junk-role cleanup must land together. Full notes in the handoff session-8 block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)