### PR TITLE
fix(multilingual): morph role layout aligns with the transformer's marking — spurious ×18 cleared (en-noise, largest launch-bar family)

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -31,13 +31,51 @@ R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelit
 dimension with headroom (SOV six ~0.95); R0-precision's spurious-action
 families are the next un-mined seam.
 
-> \*\*Update 2026-07-06c (SESSION 8: two spurious en-noise drills — #588 go ×21
+## LAUNCH BAR (adopted 2026-07-06, post session 8)
+
+Target for the publicized launch — **not** R1 = 1.0 (that tail is asymptotic;
+the SOV-six role-typing subtleties past this bar are invisible in demos and
+normal usage). The bar, all four together:
+
+1. **All en-facing parser gaps closed.** Every remaining en-noise inversion is
+   a real English-parser bug (en `go back` / `add "content"` didn't parse
+   until #588/#589) — user-visible to English users regardless of the metric.
+2. **Every spurious family larger than ×5 cleared** (post-session-8 inventory:
+   morph ×18, for ×14 bn, add ×11 draggable, default ×9, empty ×8, call ×7,
+   on ×7 he, transition ×6, breakpoint ×6).
+3. **avgPrecision ≥ 0.995** (0.9891 as of session 8).
+4. **avgRoleFidelity ≥ 0.985** (0.9829 as of session 8) — the big R1-missing
+   families (add.patient:selector ×20, toggle.patient:expression ×19,
+   fetch.source:literal ×18, set.patient:literal ×16,
+   bind.source:property-path ×14) carry most of this.
+
+Estimated **4–6 sessions** at the observed velocity (~30 A/B entries/session
+across sessions 4–8, full discipline included). Sequencing:
+
+| Session | Clusters                                                             | Bar signals moved  |
+| ------- | -------------------------------------------------------------------- | ------------------ |
+| L1      | morph ×18 (probe with-phrase first) + draggable add fold+cleanup ×11 | precision → ~0.997 |
+| L2      | bn `for` ×14 + transition ×6 + breakpoint ×6 (bn/SOV cluster)        | precision          |
+| L3      | he/zh marker cluster (on ×7 he, toggle he/zh, call ×7)               | precision, en gaps |
+| L4      | default-value full drill (13 langs, markers + possessives)           | en gaps, R1        |
+| L5–L6   | big R1-missing families (add/toggle patient, fetch/bind source, set) | R1 → ≥0.985        |
+
+**Post-launch track (ratchet-protected, not launch-blocking):** SOV-six role
+polish (qu/hi ~0.956 R1), tr remove.patient block-walk leak, spurious empty
+tr/hi/bn (transformer-side), wait-line param leak ja, SOV halt ×6, the R1
+long tail. The six-signal gate holds the bar once reached — regressions
+fail CI.
+
+Caveats: each en enrichment can mint honest-dip entries (bounded by the
+census/A-B discipline; historically <1 session total), and this scopes the
+fidelity grind only — docs/demo/npm-publish polish is separate scope.
+
+> **Update 2026-07-06c (SESSION 8: two spurious en-noise drills — #588 go ×21
+> and the add repeat-times ×11 drill in #589; avgPrecision 0.9851 → 0.9891,
+> probe mean R1 0.9829 held; A/B 32 spurious cleared / 0 new; census identical
+> (3404); gate green throughout; baseline regenerated per-PR.)**
 >
-> - the add repeat-times ×11 drill in this PR; avgPrecision 0.9851 → 0.9891,
->   probe mean R1 0.9829 held; A/B 32 spurious cleared / 0 new; census identical
->   (3404); gate green throughout; baseline regenerated per-PR.)\*\*
->
-> * **#588 — go ×21 (en-noise, the pre-probe found THREE droppers).** The
+> - **#588 — go ×21 (en-noise, the pre-probe found THREE droppers).** The
 >   go-en pattern required the `to` marker en's own render drops (`go back` —
 >   PARSE NULL in isolation); he/zh dropped it too (the transformer marks
 >   `back` with their PATIENT particle את/把 while go-url keeps על/到). Fix at
@@ -45,13 +83,13 @@ families are the next un-mined seam.
 >   per-command `markerOptional` (en), default branch + extraction rules merge
 >   per-command `markerVariants` as marker alternatives (he/zh) — the SOV
 >   generators already did. All three enriched together, zero honest dips.
-> * **add repeat-times ×11 (this PR) — the "loop-body attachment" hypothesis
+> - **add repeat-times ×11 (#589) — the "loop-body attachment" hypothesis
 >   was WRONG.** en `add "hello" to me` is NULL in isolation — the patient
 >   slot was selector-only and rejected every string literal (`repeat forever
 toggle .pulse` composes fine, so the loop machinery was innocent).
 >   addSchema.patient += 'literal' (transition/append precedent) enriched en +
 >   12 generated-path languages together.
-> * **Residue sharpened:** behavior-draggable add ×11 is a brace-run fold
+> - **Residue sharpened:** behavior-draggable add ×11 is a brace-run fold
 >   (`{ left: ${…}px; }` shatters to ~12 identifier tokens; `.{cls}` is safe —
 >   one selector token) that must land WITH the SOV junk-role cleanup (ja's
 >   junk destination=`"draggable:move"` vs en's `me` default would flip

--- a/packages/hyperscript-adapter/src/generated/syntax-table.ts
+++ b/packages/hyperscript-adapter/src/generated/syntax-table.ts
@@ -43,7 +43,7 @@ export const SYNTAX: Record<string, readonly [string, string][]> = {
   log: [['patient', '']],
   make: [['patient', '']],
   measure: [['patient', ''], ['source', 'of']],
-  morph: [['destination', ''], ['patient', 'to']],
+  morph: [['patient', ''], ['destination', 'to']],
   on: [['event', ''], ['source', 'from']],
   open: [['style', 'as'], ['patient', '']],
   pick: [['patient', ''], ['source', 'from']],

--- a/packages/i18n/src/constants.ts
+++ b/packages/i18n/src/constants.ts
@@ -67,7 +67,9 @@ export const COMMAND_PRIMARY_ROLES: Readonly<Record<string, SemanticRole>> = {
   tell: 'destination',
   default: 'destination',
   swap: 'destination',
-  morph: 'destination',
+  // morph deliberately absent: its schema primaryRole is `patient` (the
+  // element being morphed — aligned with the transformer's patient marking
+  // in the session-9 role-layout swap), and patient is the default.
   bind: 'destination',
 } as const;
 

--- a/packages/semantic/src/ast-builder/command-mappers.ts
+++ b/packages/semantic/src/ast-builder/command-mappers.ts
@@ -750,22 +750,25 @@ const swapMapper: CommandMapper = {
 /**
  * Morph command mapper.
  *
- * Semantic: morph destination:#element source:"<div>new</div>"
+ * Semantic: morph patient:#element destination:"<div>new</div>"
  * AST: { name: 'morph', args: ["<div>new</div>"], modifiers: { on: #element } }
+ *
+ * Role layout follows morphSchema: patient = the element being morphed,
+ * destination = the content/element to morph into (`morph #list to it`).
  */
 const morphMapper: CommandMapper = {
   action: 'morph',
   toAST(node, _builder) {
     const source = convertRoleValue(node, 'source'); // New HTML
-    const destination = convertRoleValue(node, 'destination'); // Target element
-    const patient = convertRoleValue(node, 'patient');
+    const destination = convertRoleValue(node, 'destination'); // Content target
+    const patient = convertRoleValue(node, 'patient'); // Element to morph
 
     const args: ExpressionNode[] = [];
     const modifiers: Record<string, ExpressionNode> = {};
 
-    const content = source ?? patient;
+    const content = source ?? destination;
     if (content) args.push(content);
-    if (destination) modifiers['on'] = destination;
+    if (patient) modifiers['on'] = patient;
 
     return createCommandNode('morph', args, modifiers);
   },

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -2301,16 +2301,22 @@ export const swapSchema: CommandSchema = {
  *
  * Patterns:
  * - EN: morph #target to <html>
- * - EN: morph me into #template
+ * - EN: morph #list to it
+ *
+ * Role layout matches the i18n transformer's marking (the element being
+ * morphed takes the object/patient marker — ja を, ko 를, tr i — and the
+ * content target takes the destination marker — ja に, ko 에, tr e), so the
+ * generated patterns and the SOV verb-anchoring captures agree. `reference`
+ * on destination admits the then-chained `morph #list to it` corpus shape.
  */
 export const morphSchema: CommandSchema = {
   action: 'morph',
   description: 'Morph an element into another using DOM diffing',
   category: 'dom-content',
-  primaryRole: 'destination',
+  primaryRole: 'patient',
   roles: [
     {
-      role: 'destination',
+      role: 'patient',
       description: 'The element to morph',
       required: true,
       expectedTypes: ['selector', 'reference'],
@@ -2319,13 +2325,13 @@ export const morphSchema: CommandSchema = {
       markerOverride: { en: '' }, // "morph #target ..." (no preposition)
     },
     {
-      role: 'patient',
+      role: 'destination',
       description: 'The target content/element to morph into',
       required: true,
-      expectedTypes: ['literal', 'expression', 'selector'],
+      expectedTypes: ['literal', 'expression', 'selector', 'reference'],
       svoPosition: 2,
       sovPosition: 2,
-      markerOverride: { en: 'to' }, // "morph #target to <html>"
+      markerOverride: { en: 'to' }, // "morph #target to it"
     },
   ],
 };

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -330,6 +330,26 @@ function normalizeCommandRoles(node: SemanticNode, boundIdentifiers?: Set<string
       }
     }
 
+    // morph: the SOV verb-anchoring path fuses a positional word with a tag
+    // selector and types the patient as one bare literal (ja `最も近い<form/>`,
+    // tr `enyakın<form/>`) where matchBest — and the en reference — type the
+    // spaced form (`closest <form/>`) as `expression`. A patient literal
+    // embedding a `<tag/>` shape is an element expression, not a string.
+    // Gated to `morph` and to values containing a tag selector, so a real
+    // string-content patient is never touched (transition-retype precedent).
+    if (node.action === 'morph') {
+      const roles = node.roles as Map<SemanticRole, SemanticValue>;
+      const pat = roles.get('patient');
+      if (
+        pat &&
+        pat.type === 'literal' &&
+        typeof pat.value === 'string' &&
+        /<[a-zA-Z][^>]*\/?>/.test(pat.value)
+      ) {
+        roles.set('patient', { type: 'expression', raw: pat.value } as SemanticValue);
+      }
+    }
+
     // wait: a duration that IS a known waitable event name is an EVENT wait —
     // `wait for transitionend` (en `wait-en-for-event` head) vs the
     // marker-less translations (`esperar transitionend`), whose generated

--- a/packages/semantic/test/ast-builder.test.ts
+++ b/packages/semantic/test/ast-builder.test.ts
@@ -672,12 +672,14 @@ describe('Tier 3 Command Mappers', () => {
 
   describe('morph mapper', () => {
     it('should map morph command', () => {
+      // morphSchema layout: patient = the element being morphed,
+      // source/destination = the content to morph into.
       const node: CommandSemanticNode = {
         kind: 'command',
         action: 'morph',
         roles: new Map([
           ['source', { type: 'literal', value: '<div>Morphed</div>', dataType: 'string' }],
-          ['destination', { type: 'selector', value: '#element', selectorKind: 'id' }],
+          ['patient', { type: 'selector', value: '#element', selectorKind: 'id' }],
         ]),
       };
 

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -11098,3 +11098,106 @@ describe('add patient: literal content admission', () => {
     expect(String(role(node, 'patient')?.value)).toBe('.foo');
   });
 });
+
+describe('morph role layout: patient=element / destination=content, reference admission', () => {
+  const role = (
+    node: Record<string, any> | null | undefined,
+    r: string
+  ): { type?: string; value?: unknown; raw?: unknown } | undefined =>
+    node?.roles instanceof Map ? node.roles.get(r) : undefined;
+
+  it('[en] `morph #list to it` parses (reference content target)', () => {
+    // The content slot lacked `reference` in expectedTypes, so the corpus
+    // shape `morph #list to it` parsed NULL in en and 17 generated-path
+    // languages — while the 6 lax-path languages captured it and were
+    // precision-flagged as "spurious morph" against the empty en reference
+    // (the morph ×18 family, en-noise). The schema also carried the roles
+    // swapped vs the i18n transformer's marking (element=patient を/를/i,
+    // content=destination に/에/e), so an admission without the swap would
+    // have flipped spurious ×18 into missing ×36.
+    const node = parse('morph #list to it', 'en') as unknown as Record<string, any>;
+    expect(node.action).toBe('morph');
+    expect(role(node, 'patient')?.type).toBe('selector');
+    expect(String(role(node, 'patient')?.value)).toBe('#list');
+    expect(role(node, 'destination')?.type).toBe('reference');
+  });
+
+  it('[en] then-chained morph stays attached (morph-fetch-result shape)', () => {
+    const node = parse('on click fetch /api/items then morph #list to it', 'en');
+    const flat: Record<string, any>[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'eventHandlers']) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    expect(flat.find(r => r.action === 'fetch')).toBeDefined();
+    const morph = flat.find(r => r.action === 'morph');
+    expect(morph).toBeDefined();
+    expect(role(morph!, 'patient')?.type).toBe('selector');
+    expect(role(morph!, 'destination')?.type).toBe('reference');
+  });
+
+  it('[de] `verwandeln #list zu es` parses via the generated pattern (same-schema enrichment)', () => {
+    // The 17 generated-path droppers failed for the same schema reason as en
+    // (reference rejection on the content slot) — one shared-schema change
+    // enriches them together (#586/#589 precedent).
+    const node = parse('verwandeln #list zu es', 'de') as unknown as Record<string, any>;
+    expect(node.action).toBe('morph');
+    expect(role(node, 'patient')?.type).toBe('selector');
+    expect(role(node, 'destination')?.type).toBe('reference');
+  });
+
+  const findMorph = (node: unknown): Record<string, any> | undefined => {
+    const flat: Record<string, any>[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'eventHandlers']) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return flat.find(r => r.action === 'morph');
+  };
+
+  it('[ja] lax-path capture keeps the marker-aligned layout (corpus morph-fetch-result line)', () => {
+    // The SOV verb-anchoring path (reachable in the fused-event context; the
+    // bare line does not parse standalone) always read the transformer's
+    // markers correctly (を=patient, に=destination); the schema swap makes
+    // the generated/en layout agree with it instead of fighting it.
+    const node = parse('/api/items を クリック で フェッチ それから #list を 変形 それ に', 'ja');
+    const morph = findMorph(node);
+    expect(morph).toBeDefined();
+    expect(role(morph!, 'patient')?.type).toBe('selector');
+    expect(String(role(morph!, 'patient')?.value)).toBe('#list');
+    expect(role(morph!, 'destination')?.type).toBe('reference');
+  });
+
+  it('[ja] fused positional+tag patient retypes literal → expression (corpus morph-form-update line)', () => {
+    // ja fuses `最も近い` + `<form/>` into one bare literal on the lax path;
+    // en types the spaced `closest <form/>` as expression. The
+    // normalizeCommandRoles retype (transition-patient precedent) aligns the
+    // type; a plain string-content patient is never touched.
+    const node = parse('/api/save を 送信 で フェッチ それから 最も近い <form/> を 変形 それ に', 'ja');
+    const morph = findMorph(node);
+    expect(morph).toBeDefined();
+    expect(role(morph!, 'patient')?.type).toBe('expression');
+    expect(role(morph!, 'destination')?.type).toBe('reference');
+  });
+
+  it('[en] `morph #list to #other` still parses (selector content locked)', () => {
+    const node = parse('morph #list to #other', 'en') as unknown as Record<string, any>;
+    expect(node.action).toBe('morph');
+    expect(role(node, 'patient')?.type).toBe('selector');
+    expect(role(node, 'destination')?.type).toBe('selector');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-06T14:56:22.166Z",
-  "commit": "63c71b08",
+  "timestamp": "2026-07-06T15:59:07.341Z",
+  "commit": "dc5bba2f",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8579007041413049,
       "avgFidelity": 1,
-      "avgPrecision": 0.954325644399174,
-      "avgRoleFidelity": 0.9710585585585586,
+      "avgPrecision": 0.9608191508926803,
+      "avgRoleFidelity": 0.9716216216216217,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3793,13 +3793,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8284065141207998,
       "avgFidelity": 1,
-      "avgPrecision": 0.9864718614718616,
-      "avgRoleFidelity": 0.9881756756756757,
+      "avgPrecision": 0.987012987012987,
+      "avgRoleFidelity": 0.9887387387387386,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.9045096507502506,
       "avgFidelity": 1,
-      "avgPrecision": 0.9581439393939395,
-      "avgRoleFidelity": 0.9561776061776062,
+      "avgPrecision": 0.9646374458874459,
+      "avgRoleFidelity": 0.9567406692406693,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6321,13 +6321,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8467689787238654,
       "avgFidelity": 1,
-      "avgPrecision": 0.9698051948051951,
-      "avgRoleFidelity": 0.9710585585585586,
+      "avgPrecision": 0.9762987012987014,
+      "avgRoleFidelity": 0.9716216216216217,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6953,13 +6953,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8417184736733602,
       "avgFidelity": 1,
-      "avgPrecision": 0.9698051948051951,
-      "avgRoleFidelity": 0.9676801801801802,
+      "avgPrecision": 0.9762987012987014,
+      "avgRoleFidelity": 0.9682432432432433,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9481,13 +9481,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
-      "avgPrecision": 0.969805194805195,
-      "avgRoleFidelity": 0.9556145431145432,
+      "avgPrecision": 0.9762987012987012,
+      "avgRoleFidelity": 0.9561776061776062,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12641,13 +12641,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8456558061821213,
       "avgFidelity": 1,
-      "avgPrecision": 0.9689935064935067,
-      "avgRoleFidelity": 0.9706611022787494,
+      "avgPrecision": 0.9754870129870131,
+      "avgRoleFidelity": 0.9712241653418122,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484188,
+      "bundleSize": 484386,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 484188,
+      "size": 484386,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Session-9 / L1 (first of two launch-bar increments): the **morph ×18 spurious family** — the largest remaining and the last unprobed — is cleared. Also carries the pending NEXT_STEPS **LAUNCH BAR** section (adopted 2026-07-06) + the prettier-mangle repair of the session-8 block.

### Mechanism (probe-first, per discipline)

`probe-who` on all three morph patterns showed en **and 17 generated-path languages** drop the then-chained morph (`morph #list to it` is PARSE NULL in en isolation; `morph #list to #other` parses) while the 6 lax-path languages capture it — en-noise, the go/add shape again (#588/#589). The session-7 render-with-phrase suspicion was checked first: en's `render … with row: $data` style-grab is a **separate** mechanism (the pre-existing missing ×7 family, untouched here) — morph fails in pure isolation.

### Fix (two aligned pieces, one mechanism)

1. **`morphSchema` role swap + reference admission.** The schema carried destination=element / patient=content — the *opposite* of the i18n transformer's marking (element takes the patient particle ja `を` / ko `를` / tr `i`; content target takes the destination marker `に`/`에`/`e`), which the SOV lax captures follow. Swapped to patient=element / destination=content and added `reference` to the content slot (`to it`). The shared-schema change enriches en + all 17 generated-path languages **together**; the lax six now agree role-for-role. (An en-only admission without the swap would have flipped spurious ×18 into missing ×36.) `morphMapper` updated to the same layout — it previously executed the six's captures with element/content transposed (invisible to R2; morph isn't in the curated subset).
2. **`normalizeCommandRoles` morph retype** (transition-patient precedent): the lax path fuses positional word + tag selector into one bare literal (ja `最も近い<form/>`) where en types the spaced `closest <form/>` as expression — a tag-bearing morph patient literal retypes to expression so morph-form-update aligns type-for-type.

### Verification

- **A/B vs pre-change dist:** 18 spurious cleared / **0 new** entries; parse-coverage census identical (**3404**).
- **Probe mean R1:** 0.9829 → **0.9831**.
- **Baseline regenerated against a fresh populate:** avgPrecision **0.9891 → 0.9908** (launch bar: ≥ 0.995), parse 3696/3696, degenerate/lossy 0, R2 1.0.
- **Six-signal `--regression` gate green**; full semantic suite 6563 passed; typecheck clean.
- **6 guard tests** (4 stash-verified fail-without-fix; ja marker-layout + en selector-content locks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)