### PR TITLE
fix(multilingual): brace-run style-object fold + ko locative/allative marker split — draggable add ×11 cleared (L1 complete)

### DIFF
--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -1,5 +1,82 @@
 # Handoff — R1 residue after the five-cluster triage (fronted repeat-while · sw kama homonym · singletons)
 
+> **STATUS UPDATE (2026-07-06, session 9 = L1 of the launch bar): the two
+> biggest spurious families LANDED — #590 (morph ×18: schema role-layout swap
+> plus reference admission) and the draggable add ×11 drill in this PR
+> (brace-run fold + ko locative/allative marker split).** Post-session state:
+> baseline avgPrecision **0.9891 → 0.9910** (+0.0019 across the two drills),
+> probe mean R1 **0.9831** (0.9829 → +0.0002), parse 3696/3696,
+> degenerate/lossy 0, R2 1.0. Per-(lang,pattern) A/B across both PRs:
+> **29 spurious cleared, 0 new**; parse-coverage census identical (3404).
+> Remaining >×5 families: for ×14 bn, default ×9, empty ×8, call ×7, on ×7 he,
+> transition ×6, breakpoint ×6.
+>
+> 1. **#590 — morph ×18 (en-noise; the "one mechanism with render" guess was
+>    HALF right).** Probed first per discipline: en `morph #list to it` is
+>    PARSE NULL in isolation (`morph #list to #other` parses — the content
+>    slot rejected `reference`), and 17 generated-path languages fail the SAME
+>    schema way; the SOV-lax six capture it. The render `style` mis-capture is
+>    a SEPARATE mechanism (still open, missing ×7). But the schema ALSO
+>    carried its roles swapped vs the i18n transformer's marking (the
+>    transformer marks the morphed element PATIENT — ja を / ko 를 / tr i —
+>    and the content target DESTINATION に/에/e; the lax captures follow the
+>    markers): a reference admission alone would have flipped spurious ×18
+>    into missing ×36. Swap + admission landed together; morphMapper updated
+>    to match (it executed the six's captures with element/content transposed
+>    — R2-invisible, morph isn't in the curated subset); a
+>    normalizeCommandRoles retype aligns the lax five's fused
+>    positional+tag patient (`最も近い<form/>` literal → expression, en types
+>    `closest <form/>` expression). i18n's COMMAND_PRIMARY_ROLES morph entry
+>    dropped (schema primaryRole now patient — the i18n drift guard caught it
+>    in CI; that guard works). 6 guard tests (4 stash-verified).
+> 2. **draggable add ×11 (this PR) — the session-8 two-part diagnosis was
+>    right, but (b) mostly evaporated.** (a) The brace-run fold
+>    (`tryMatchBraceRunLiteral` + matchRoleToken call site): a depth-balanced
+>    `{ … }` identifier-token run folds to ONE literal (depth-tracked for the
+>    nested `${…}` template braces; `.{cls}` is one selector token — no
+>    collision, locked by test). The fold fires for literal-accepting roles
+>    AND roles with no expectedTypes — the handcrafted add-\*-full patient
+>    (it/pl/ru/uk/vi) declares none and had captured the lone `{`. The fold
+>    re-routed ja/tr/bn/hi/qu off the lax path onto their generated patterns,
+>    which killed the feared junk-role cleanup for free. (b) Only ko kept a
+>    junk role: 에서 (SOURCE primary, "at/from") was ALSO a profile-wide
+>    destination alternative, so the wait line's unconsumed tail (`문서 에서`)
+>    satisfied add's optional destination group → destination=문서 instead of
+>    the me default. Removed from the ko profile destination alternatives;
+>    toggle's LOCATIVE destination (`#button 에서 .active 를 토글`) keeps it
+>    per-command via the #588 markerVariants merge (the ko-idioms suite
+>    caught the over-removal — locked). 5 guard tests (3 stash-verified).
+>
+> **Residue updated after session 9 (launch-bar lens):**
+>
+> - **L2 pre-probed this session — all three are en-noise again:**
+>   - **for ×14 bn** (transition-opacity/-transform/-color + fade-out-remove):
+>     bn renders duration `500ms জন্য`, and জন্য ("for") is ALSO bn's
+>     for-loop keyword — the transition pattern consumes duration but leaves
+>     the trailing জন্য, which spawns a phantom ROLELESS `for` command node
+>     in the compound split. Fix candidates: consume the trailing duration
+>     marker in the bn transition group, or never let a lone normalized-`for`
+>     marker token anchor a command (exit-bareKeyword lesson in reverse).
+>   - **transition ×6 (slide-toggle, SOV six):** en DROPS the juxtaposed
+>     trailing command (`… toggle .collapsed on next .panel` then, with NO
+>     `then` keyword, `transition *max-height over 300ms`); the six keep it.
+>     En gap: juxtaposed command after a destination phrase.
+>   - **breakpoint ×6 (+halt ×3 ms/sw/vi, same pattern):** en DROPS the bare
+>     `breakpoint` (roleless schema → NO generated pattern → the #582 exit
+>     bareKeyword precedent is almost certainly the fix); ms/sw/vi's
+>     breakpoint words normalize to halt → their spurious halt ×3 is the
+>     sibling. One drill, two families.
+> - **default ×9 unchanged** (full L4 drill: 13 langs fail on rendered
+>   markers + possessive folds; in-code NOTE at defaultSchema.destination).
+> - **morph-with-template missing ×7 (render style:expression mis-capture
+>   from `with row: $data`) is still open** — now the dominant morph-family
+>   signal; en-side (en captures a junk param-name role the translations
+>   lack). Candidate for L3/L4 batching.
+> - Post-launch track unchanged (tr remove.patient block-walk; spurious empty
+>   tr/hi/bn + sortable hi/tr transformer-side; wait-line param leak ja —
+>   note the ko wait's or-run payload is equally unconsumed, that's what
+>   leaked 문서 에서; SOV halt ×6).
+
 > **STATUS UPDATE (2026-07-06, session 8): two spurious en-noise families
 > LANDED — #588 (go ×21: en optional to-marker + he/zh patient-particle
 > markerVariants) and the add drill in this PR (add ×22→×11: patient literal

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -9,7 +9,7 @@
 > [BEHAVIORS_CONSOLIDATION_PLAN.md](BEHAVIORS_CONSOLIDATION_PLAN.md). Read this first,
 > then dive into those for the per-arc detail.
 
-## Where we are (2026-07-06 baseline · post session-8 spurious drills · `browser-priority`)
+## Where we are (2026-07-06 baseline · post session-9 / L1 · `browser-priority`)
 
 Authoritative source: `packages/testing-framework/baselines/multilingual-priority.json`
 (its `timestamp` + `commit` fields stamp each regen). 24 langs × 154 patterns = 3696.
@@ -21,8 +21,8 @@ Authoritative source: `packages/testing-framework/baselines/multilingual-priorit
 | lossy passes (0.5 ≤ fid < 1.0) | **0**                  | band cleared (#495–#506), holding                         |
 | faithful (fid = 1.0)           | **3696**               | every parsing pattern is faithful                         |
 | avgFidelity (R0-recall)        | **1.000**              | saturated                                                 |
-| avgPrecision (R0 trust floor)  | **0.989**              | session-8 spurious drills: 0.9851 → 0.9891 (go+add)       |
-| avgRoleFidelity (R1)           | **0.983**              | 0.9829, held through session-8                            |
+| avgPrecision (R0 trust floor)  | **0.991**              | session-9 / L1 drills: 0.9891 → 0.9910 (morph+draggable)  |
+| avgRoleFidelity (R1)           | **0.983**              | 0.9831, held through session-9                            |
 | avgExecutionFidelity (R2)      | **1.000**              | 47-pattern curated subset fully reproduces en DOM effects |
 
 The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recall ·
@@ -40,11 +40,11 @@ normal usage). The bar, all four together:
 1. **All en-facing parser gaps closed.** Every remaining en-noise inversion is
    a real English-parser bug (en `go back` / `add "content"` didn't parse
    until #588/#589) — user-visible to English users regardless of the metric.
-2. **Every spurious family larger than ×5 cleared** (post-session-8 inventory:
-   morph ×18, for ×14 bn, add ×11 draggable, default ×9, empty ×8, call ×7,
-   on ×7 he, transition ×6, breakpoint ×6).
-3. **avgPrecision ≥ 0.995** (0.9891 as of session 8).
-4. **avgRoleFidelity ≥ 0.985** (0.9829 as of session 8) — the big R1-missing
+2. **Every spurious family larger than ×5 cleared** (post-session-9 inventory:
+   ~~morph ×18~~ ✓L1, for ×14 bn, ~~add ×11 draggable~~ ✓L1, default ×9,
+   empty ×8, call ×7, on ×7 he, transition ×6, breakpoint ×6).
+3. **avgPrecision ≥ 0.995** (0.9910 as of session 9).
+4. **avgRoleFidelity ≥ 0.985** (0.9831 as of session 9) — the big R1-missing
    families (add.patient:selector ×20, toggle.patient:expression ×19,
    fetch.source:literal ×18, set.patient:literal ×16,
    bind.source:property-path ×14) carry most of this.
@@ -52,13 +52,18 @@ normal usage). The bar, all four together:
 Estimated **4–6 sessions** at the observed velocity (~30 A/B entries/session
 across sessions 4–8, full discipline included). Sequencing:
 
-| Session | Clusters                                                             | Bar signals moved  |
-| ------- | -------------------------------------------------------------------- | ------------------ |
-| L1      | morph ×18 (probe with-phrase first) + draggable add fold+cleanup ×11 | precision → ~0.997 |
-| L2      | bn `for` ×14 + transition ×6 + breakpoint ×6 (bn/SOV cluster)        | precision          |
-| L3      | he/zh marker cluster (on ×7 he, toggle he/zh, call ×7)               | precision, en gaps |
-| L4      | default-value full drill (13 langs, markers + possessives)           | en gaps, R1        |
-| L5–L6   | big R1-missing families (add/toggle patient, fetch/bind source, set) | R1 → ≥0.985        |
+| Session | Clusters                                                             | Bar signals moved         |
+| ------- | -------------------------------------------------------------------- | ------------------------- |
+| L1 ✓    | morph ×18 + draggable add fold+cleanup ×11 (#590 + session-9 PR 2)   | precision 0.9891 → 0.9910 |
+| L2      | bn `for` ×14 + transition ×6 + breakpoint ×6 (pre-probed session 9)  | precision                 |
+| L3      | he/zh marker cluster (on ×7 he, toggle he/zh, call ×7)               | precision, en gaps        |
+| L4      | default-value full drill (13 langs, markers + possessives)           | en gaps, R1               |
+| L5–L6   | big R1-missing families (add/toggle patient, fetch/bind source, set) | R1 → ≥0.985               |
+
+L1 actual precision movement (+0.0019 for 29 entries) ran well under the
+table's ~0.997 sketch — the remaining seven >×5 families plus the tail carry
+more of the gap than estimated; expect the ≥0.995 bar to need L2 AND L3 (and
+possibly part of L4) rather than L1+L2 alone.
 
 **Post-launch track (ratchet-protected, not launch-blocking):** SOV-six role
 polish (qu/hi ~0.956 R1), tr remove.patient block-walk leak, spurious empty
@@ -69,6 +74,42 @@ fail CI.
 Caveats: each en enrichment can mint honest-dip entries (bounded by the
 census/A-B discipline; historically <1 session total), and this scopes the
 fidelity grind only — docs/demo/npm-publish polish is separate scope.
+
+> **Update 2026-07-06d (SESSION 9 = L1: the two biggest spurious families —
+> #590 morph ×18 role-layout swap and the draggable add ×11 brace-fold drill
+> in the session's second PR; avgPrecision 0.9891 → 0.9910, probe mean R1
+> 0.9829 → 0.9831; A/B 29 spurious cleared / 0 new; census identical (3404);
+> gate green; baselines regenerated per-PR.)**
+>
+> - **#590 — morph ×18.** en `morph #list to it` NULL in isolation (content
+>   slot rejected `reference`) — but the schema ALSO carried its roles swapped
+>   vs the i18n transformer's marking (element=patient を/를/i,
+>   content=destination に/에/e — the SOV-lax captures follow the markers), so
+>   admission-without-swap would have flipped spurious ×18 → missing ×36.
+>   Swap + admission enriched en + 17 generated-path languages together;
+>   morphMapper realigned (it executed element/content transposed);
+>   a normalizeCommandRoles retype aligns the lax five's fused
+>   positional+tag patient. Two downstream schema mirrors flagged by their
+>   own drift guards in CI (both fixed in-PR): i18n COMMAND_PRIMARY_ROLES
+>   (morph entry dropped) and hyperscript-adapter's generated syntax-table
+>   (regenerated).
+> - **draggable add ×11 (PR 2).** The brace-run fold
+>   (`tryMatchBraceRunLiteral`): a depth-balanced `{ … }` identifier run folds
+>   to ONE literal (nested `${…}` handled; `.{cls}` is one selector token —
+>   locked). Fires for literal-accepting roles AND no-expectedTypes roles (the
+>   handcrafted add-\*-full patient captured a lone `{`). The fold re-routed
+>   ja/tr/bn/hi/qu onto their generated patterns — the feared SOV junk-role
+>   cleanup shrank to ONE piece: ko 에서 removed from profile-wide destination
+>   alternatives (it is the SOURCE primary; the wait-line tail `문서 에서`
+>   satisfied add's destination group), with toggle's locative destination
+>   keeping it per-command via #588 markerVariants (ko-idioms suite caught
+>   the over-removal).
+> - **L2 pre-probed — all en-noise:** bn জন্য (duration marker = for-loop
+>   keyword) spawns phantom roleless `for` ×14; slide-toggle en drops the
+>   juxtaposed no-`then` trailing transition ×6; breakpoint-command en drops
+>   the roleless bare `breakpoint` (the #582 exit-bareKeyword precedent)
+>   ×6 + the ms/sw/vi halt ×3 sibling. Full notes in the handoff session-9
+>   block.
 
 > **Update 2026-07-06c (SESSION 8: two spurious en-noise drills — #588 go ×21
 > and the add repeat-times ×11 drill in #589; avgPrecision 0.9851 → 0.9891,

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -282,6 +282,14 @@ export const toggleSchema: CommandSchema = {
       default: { type: 'reference', value: 'me' },
       svoPosition: 2,
       sovPosition: 1,
+      // toggle's destination is LOCATIVE ("toggle .active on #button" — at
+      // the element), so ko 에서 ("at") is a legitimate marker HERE. It is no
+      // longer a profile-wide destination alternative: for allative
+      // destinations (add's "to me") 에서 reads as source, and it let an
+      // unconsumed wait-line tail (`문서 에서`) satisfy the next SOV clause's
+      // destination group (behavior-draggable). Per-command merge via the
+      // #588 markerVariants machinery.
+      markerVariants: { ko: ['에서'] },
     },
   ],
   // Runtime error documentation

--- a/packages/semantic/src/generators/profiles/korean.ts
+++ b/packages/semantic/src/generators/profiles/korean.ts
@@ -47,7 +47,13 @@ export const koreanProfile: LanguageProfile = {
   },
   roleMarkers: {
     patient: { primary: '을', alternatives: ['를'], position: 'after' },
-    destination: { primary: '에', alternatives: ['으로', '로', '에서', '의'], position: 'after' },
+    // 에서 is deliberately NOT a destination alternative: it is the SOURCE
+    // primary ("at/from"), and listing it here let an unconsumed wait-line
+    // tail (`문서 에서` — from document) satisfy the next SOV clause's
+    // optional destination group (behavior-draggable's add captured
+    // destination=문서 instead of the schema `me` default). A real Korean
+    // destination renders 에/으로/로/의.
+    destination: { primary: '에', alternatives: ['으로', '로', '의'], position: 'after' },
     source: { primary: '에서', alternatives: ['부터'], position: 'after' },
     style: { primary: '로', alternatives: ['으로'], position: 'after' },
     event: { primary: '을', alternatives: ['를'], position: 'after' }, // Event as object marker

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -640,6 +640,28 @@ export class PatternMatcher {
       return true;
     }
 
+    // Brace-run STYLE-OBJECT literal fold: `{ left: ${clientX - xoff}px; … }`
+    // shatters into ~12+ identifier tokens (behavior-draggable's add patient —
+    // en and the generated-path languages captured only the lone `{` or died
+    // on it, while the SOV lax path fuses the run to ONE literal). A
+    // standalone `{` identifier token is unambiguous: `.{cls}` dynamic class
+    // selectors tokenize as ONE selector token, so no collision. Depth-tracked
+    // for the nested `${…}` template braces; fires for roles that accept a
+    // literal or declare no expectedTypes (the handcrafted add-*-full patient
+    // — capturing a lone `{` is never right), and only when the run closes —
+    // an unbalanced `{` backtracks.
+    if (
+      token.kind === 'identifier' &&
+      token.value === '{' &&
+      (!patternToken.expectedTypes?.length || patternToken.expectedTypes.includes('literal'))
+    ) {
+      const braceRun = this.tryMatchBraceRunLiteral(tokens);
+      if (braceRun) {
+        captured.set(patternToken.role, braceRun);
+        return true;
+      }
+    }
+
     // Attribute selectors (`@attr`) tokenize with kind `identifier`, not
     // `selector` — and that kind is load-bearing: roles like bind's `@property`
     // (expectedTypes ['reference','expression']) rely on the identifier reading.
@@ -1480,6 +1502,43 @@ export class PatternMatcher {
     const norm = token.normalized?.toLowerCase();
     if (norm && BAREKEYWORD_BLOCK_ACTIONS.has(norm)) return false;
     return true;
+  }
+
+  /**
+   * Fold a depth-balanced `{ … }` token run into ONE literal value (see the
+   * call site in matchRoleToken). The tokenizers emit `{`, `}`, `:`, `;`, `$`
+   * as bare identifier tokens, so a CSS style-object argument is otherwise
+   * unmatchable by a single-token role. Depth tracking covers the nested
+   * `${expr}` template braces. Returns null (with the stream reset) when the
+   * run never closes or exceeds the token cap.
+   */
+  private static readonly MAX_BRACE_RUN_TOKENS = 64;
+
+  private tryMatchBraceRunLiteral(tokens: TokenStream): SemanticValue | null {
+    const open = tokens.peek();
+    if (!open || open.kind !== 'identifier' || open.value !== '{') return null;
+
+    const mark = tokens.mark();
+    tokens.advance(); // {
+    const parts: string[] = ['{'];
+    let depth = 1;
+    let guard = 0;
+    while (!tokens.isAtEnd() && guard++ < PatternMatcher.MAX_BRACE_RUN_TOKENS) {
+      const t = tokens.advance();
+      if (!t) break;
+      if (t.value === '{') depth++;
+      else if (t.value === '}') {
+        depth--;
+        if (depth === 0) {
+          parts.push('}');
+          return createLiteral(parts.join(' '));
+        }
+      }
+      parts.push(t.value);
+    }
+
+    tokens.reset(mark);
+    return null;
   }
 
   /**

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -11201,3 +11201,115 @@ describe('morph role layout: patient=element / destination=content, reference ad
     expect(role(node, 'destination')?.type).toBe('selector');
   });
 });
+
+describe('brace-run style-object fold + ko locative/allative marker split (behavior-draggable add)', () => {
+  const role = (
+    node: Record<string, any> | null | undefined,
+    r: string
+  ): { type?: string; value?: unknown; raw?: unknown } | undefined =>
+    node?.roles instanceof Map ? node.roles.get(r) : undefined;
+
+  const findAction = (node: unknown, action: string): Record<string, any> | undefined => {
+    const flat: Record<string, any>[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'eventHandlers', 'initBlock', 'initCommands']) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return flat.find(r => r.action === action);
+  };
+
+  it('[en] `add { left: …px; top: …px; }` folds the brace run into ONE literal patient', () => {
+    // The style-object argument shatters into ~12 identifier tokens (`{`,
+    // `left`, `:`, `$`, `{`, …), so the patient role captured nothing and the
+    // whole command parsed NULL in en — while the SOV lax path fuses the run
+    // and was precision-flagged as "spurious add" against the empty en
+    // reference (the behavior-draggable half of the add ×22 family). The fold
+    // is depth-tracked for the nested `${…}` template braces.
+    const node = parse(
+      'add { left: ${clientX - xoff}px; top: ${clientY - yoff}px; }',
+      'en'
+    ) as unknown as Record<string, any>;
+    expect(node.action).toBe('add');
+    expect(role(node, 'patient')?.type).toBe('literal');
+    expect(String(role(node, 'patient')?.value)).toContain('left');
+    expect(String(role(node, 'patient')?.value)).toContain('top');
+    expect(role(node, 'destination')?.type).toBe('reference');
+  });
+
+  it('[en] `.{cls}` dynamic class selector is untouched (tokenizes as ONE selector token)', () => {
+    const node = parse('add .{cls} to me', 'en') as unknown as Record<string, any>;
+    expect(node.action).toBe('add');
+    expect(role(node, 'patient')?.type).toBe('selector');
+    expect(String(role(node, 'patient')?.value)).toBe('.{cls}');
+  });
+
+  it('[it] handcrafted add-it-full (no expectedTypes on patient) folds the run too', () => {
+    // The handcrafted add-*-full patterns declare no expectedTypes on their
+    // patient role, so the literal-gated fold skipped them and they captured
+    // the lone `{` as an expression (it/pl/ru/uk/vi). Capturing a lone `{` is
+    // never right — the fold also fires for no-expectedTypes roles.
+    const node = parse(
+      'aggiungere { left: ${clientX - xoff}px; top: ${clientY - yoff}px; }',
+      'it'
+    ) as unknown as Record<string, any>;
+    expect(node.action).toBe('add');
+    expect(role(node, 'patient')?.type).toBe('literal');
+    expect(role(node, 'destination')?.type).toBe('reference');
+  });
+
+  it('[ko] full draggable body: add destination defaults to me (에서 no longer a destination alternative)', () => {
+    // ko 에서 is the SOURCE primary ("at/from") but was ALSO listed as a
+    // profile-wide destination alternative, so the wait line's unconsumed
+    // tail (`문서 에서` — from document) satisfied the add clause's optional
+    // destination group: destination=expression:"문서" instead of the schema
+    // `me` default (a missing add.destination:reference vs en). Removed from
+    // the profile; toggle's LOCATIVE destination keeps it per-command via
+    // markerVariants (the #588 merge machinery).
+    const ko = [
+      'Draggable(dragHandle) 를 behavior',
+      '    init',
+      '        만약 없음 dragHandle 그러면 dragHandle 를 나 에 설정',
+      '    끝',
+      '    pointerdown(clientX, clientY) 할 때 dragHandle 에서',
+      '        the 이벤트 를 정지',
+      '        draggable:start 를 트리거',
+      '        x 를 측정',
+      '        startX 를 그것 에 설정',
+      '        y 를 측정',
+      '        startY 를 그것 에 설정',
+      '        xoff 를 clientX - startX 에 설정',
+      '        yoff 를 clientY - startY 에 설정',
+      '        까지 이벤트 pointerup 를 반복 문서 에서',
+      '            대기 pointermove(clientX, clientY) 또는',
+      '                                pointerup(clientX, clientY) 문서 에서',
+      '            { left: ${clientX - xoff}px; top: ${clientY - yoff}px; } 를 추가',
+      '            draggable:move 를 트리거',
+      '        끝',
+      '        draggable:end 를 트리거',
+      '    끝',
+      '끝',
+    ].join('\n');
+    const add = findAction(parse(ko, 'ko'), 'add');
+    expect(add).toBeDefined();
+    expect(role(add!, 'patient')?.type).toBe('literal');
+    expect(role(add!, 'destination')?.type).toBe('reference');
+    expect(String(role(add!, 'destination')?.value)).toBe('me');
+  });
+
+  it('[ko] locative toggle destination still reads 에서 (per-command markerVariants lock)', () => {
+    // `#button 에서 .active 를 토글` — "toggle .active AT #button". The
+    // locative reading is legitimate for toggle even though 에서 left the
+    // profile-wide destination alternatives.
+    const node = parse('#button 에서 .active 를 토글', 'ko') as unknown as Record<string, any>;
+    expect(node.action).toBe('toggle');
+    expect(role(node, 'patient')?.type).toBe('selector');
+    expect(String(role(node, 'destination')?.value)).toBe('#button');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-06T15:59:07.341Z",
-  "commit": "dc5bba2f",
+  "timestamp": "2026-07-06T16:22:38.189Z",
+  "commit": "51e6b9ce",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8579007041413049,
       "avgFidelity": 1,
-      "avgPrecision": 0.9608191508926803,
+      "avgPrecision": 0.9612011218628865,
       "avgRoleFidelity": 0.9716216216216217,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.9045096507502506,
       "avgFidelity": 1,
-      "avgPrecision": 0.9646374458874459,
+      "avgPrecision": 0.9650703463203464,
       "avgRoleFidelity": 0.9567406692406693,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5689,13 +5689,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8364873222016058,
       "avgFidelity": 1,
-      "avgPrecision": 0.9941829004329006,
+      "avgPrecision": 0.9945887445887447,
       "avgRoleFidelity": 0.9979086229086228,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6321,13 +6321,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8467689787238654,
       "avgFidelity": 1,
-      "avgPrecision": 0.9762987012987014,
+      "avgPrecision": 0.9767316017316019,
       "avgRoleFidelity": 0.9716216216216217,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6953,13 +6953,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8417184736733602,
       "avgFidelity": 1,
-      "avgPrecision": 0.9762987012987014,
+      "avgPrecision": 0.9767316017316019,
       "avgRoleFidelity": 0.9682432432432433,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8217,13 +8217,13 @@
       "parseRate": 1,
       "avgConfidence": 0.807173778602348,
       "avgFidelity": 1,
-      "avgPrecision": 0.9995941558441559,
+      "avgPrecision": 1,
       "avgRoleFidelity": 0.9867599742599743,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9481,13 +9481,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
-      "avgPrecision": 0.9762987012987012,
+      "avgPrecision": 0.9767316017316017,
       "avgRoleFidelity": 0.9561776061776062,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10113,13 +10113,13 @@
       "parseRate": 1,
       "avgConfidence": 0.818181818181816,
       "avgFidelity": 1,
-      "avgPrecision": 0.9995941558441559,
+      "avgPrecision": 1,
       "avgRoleFidelity": 0.9890765765765768,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12641,13 +12641,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8456558061821213,
       "avgFidelity": 1,
-      "avgPrecision": 0.9754870129870131,
+      "avgPrecision": 0.9758928571428573,
       "avgRoleFidelity": 0.9712241653418122,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13273,13 +13273,13 @@
       "parseRate": 1,
       "avgConfidence": 0.818594104308388,
       "avgFidelity": 1,
-      "avgPrecision": 0.9995941558441559,
+      "avgPrecision": 1,
       "avgRoleFidelity": 0.9890765765765765,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13905,13 +13905,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
-      "avgPrecision": 0.9974296536796537,
+      "avgPrecision": 0.997835497835498,
       "avgRoleFidelity": 0.9930180180180183,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484386,
+      "bundleSize": 484961,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 484386,
+      "size": 484961,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Session-9 / L1, second increment: the **behavior-draggable add ×11 spurious family** is cleared, completing L1 of the launch bar (with #590's morph ×18). Carries the session-9 docs sync (handoff status block, NEXT_STEPS 2026-07-06d update, LAUNCH BAR progress + L2 pre-probe notes).

### Mechanism (probe-first)

en and the generated-path languages could not capture the style-object patient — `add { left: ${clientX - xoff}px; … }` shatters into ~12 identifier tokens — while the SOV lax path fused it to one literal and was precision-flagged against the empty en reference (the session-8 diagnosis held; its part (b) mostly evaporated, see below).

### Fix

1. **Brace-run literal fold** (`tryMatchBraceRunLiteral` + matchRoleToken call site): a depth-balanced `{ … }` identifier-token run folds to ONE literal — depth-tracked for the nested `${…}` template braces; `.{cls}` tokenizes as one selector token (no collision, locked by test); an unbalanced `{` backtracks. Fires for literal-accepting roles **and** roles with no `expectedTypes` — the handcrafted `add-*-full` patient (it/pl/ru/uk/vi) declares none and had captured the lone `{` as an expression. The fold re-routed ja/tr/bn/hi/qu off the lax verb-anchoring path onto their generated patterns, dissolving most of the anticipated SOV junk-role cleanup.
2. **ko locative/allative marker split**: 에서 (the SOURCE primary, "at/from") was also a profile-wide *destination* alternative, letting the wait line's unconsumed tail (`문서 에서` — from document) satisfy add's optional destination group (destination=문서 instead of the schema `me` default). Removed from the ko profile; toggle's LOCATIVE destination (`#button 에서 .active 를 토글`) keeps it per-command via the #588 markerVariants merge — the ko-idioms suite caught the over-removal, now locked by a guard.

### Verification

- **A/B vs the post-#590 dist:** 11 spurious cleared / **0 new** — the only changed line in the entire corpus report; census identical (**3404**).
- **Probe mean R1 0.9831 held.** Baseline regenerated against a fresh populate: avgPrecision **0.9908 → 0.9910** (session total 0.9891 → 0.9910), parse 3696/3696, degenerate/lossy 0, R2 1.0.
- **Six-signal `--regression` gate green**; full semantic suite 6563 passed (incl. korean-idioms); typecheck clean.
- **5 guard tests** (3 stash-verified fail-without-fix; `.{cls}` + ko locative-toggle locks).

### L2 pre-probe (in the docs)

All three next families are en-noise again: bn জন্য duration-marker/for-loop-keyword homonym (phantom roleless `for` ×14); slide-toggle's juxtaposed no-`then` trailing transition (×6); breakpoint's roleless bare command — the #582 exit-bareKeyword precedent (×6, + the ms/sw/vi halt ×3 sibling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)