### PR TITLE
fix(multilingual): breakpoint bareKeyword + hyphen-compound keyword fold — breakpoint ×6 + halt ×3 spurious cleared (L2 drill 1)

### DIFF
--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -1942,6 +1942,13 @@ export const breakpointSchema: CommandSchema = {
   category: 'control-flow',
   primaryRole: 'patient',
   roles: [],
+  // Roleless: without a bare-keyword pattern NO pattern is generated at all
+  // (getDefinedSchemas filters zero-role schemas), so `on click breakpoint
+  // then …` silently drops the breakpoint in every generated-path language —
+  // while lax event-fused paths (bn/hi/ja/ko/qu/th) keep it, reading as
+  // spurious vs the en reference. Same standalone-safety argument as `exit`:
+  // zero-arg, the single-keyword match can't swallow anything.
+  bareKeyword: true,
 };
 
 // =============================================================================

--- a/packages/semantic/src/generators/pattern-generator.ts
+++ b/packages/semantic/src/generators/pattern-generator.ts
@@ -354,6 +354,14 @@ export function generateEventHandlerPatterns(
     return []; // No translation for this command
   }
 
+  // Roleless (bareKeyword) commands take no patient, but every fused shape
+  // below hardwires a required {patient} role — fusing would swallow the next
+  // token (a `then` connective, the following command's head) as junk patient.
+  // They parse fine via the standard event pattern + bare command in the body.
+  if (commandSchema.roles.length === 0) {
+    return [];
+  }
+
   // Check if this is a two-role command (like put, set)
   const requiredRoles = commandSchema.roles.filter(r => r.required);
   const hasTwoRequiredRoles = requiredRoles.length === 2;

--- a/packages/semantic/src/generators/profiles/he.ts
+++ b/packages/semantic/src/generators/profiles/he.ts
@@ -94,7 +94,10 @@ export const hebrewProfile: LanguageProfile = {
     select: { primary: 'סמן', normalized: 'select' },
     clear: { primary: 'נקה', normalized: 'clear' },
     reset: { primary: 'אפס', normalized: 'reset' },
-    breakpoint: { primary: 'נקודת-עצירה', normalized: 'breakpoint' },
+    // The i18n he dictionary has no breakpoint entry — the transformer passes
+    // the en loanword through verbatim, so parsing must accept it alongside
+    // the native compound.
+    breakpoint: { primary: 'נקודת-עצירה', alternatives: ['breakpoint'], normalized: 'breakpoint' },
     // Navigation
     go: { primary: 'לך', alternatives: ['נווט'], normalized: 'go' },
     scroll: { primary: 'גלול', normalized: 'scroll' },

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -335,7 +335,94 @@ export class PatternMatcher {
       }
     }
 
+    // Hyphen-compound fold: many keyword translations are hyphen compounds
+    // (ms `titik-henti`, es `punto-interrupción`) that the tokenizers shatter
+    // into word/-/word runs — and the tail word can be ANOTHER command's
+    // keyword (ms `henti` → halt), so the run mis-anchors that command
+    // instead. Join the run and compare it to any hyphen-bearing expected
+    // value; only fires after every single-token match above has failed.
+    for (const value of [patternToken.value, ...(patternToken.alternatives ?? [])]) {
+      if (value.includes('-') && this.tryMatchHyphenCompound(tokens, value)) {
+        this.totalKeywordMatches++;
+        return true;
+      }
+    }
+
     return false;
+  }
+
+  /**
+   * Fold a shattered hyphen-compound run into a command action for an {action}
+   * role: join `word (- word)+`, look the joined form up among the current
+   * profile's command keywords (primary or alternatives, case-insensitive),
+   * and return the command's canonical action as a literal. Consumes the run
+   * on success, leaves the stream untouched on failure.
+   */
+  private tryFoldHyphenActionKeyword(tokens: TokenStream): SemanticValue | null {
+    const profile = this.currentProfile;
+    if (!profile) return null;
+    const mark = tokens.mark();
+    const parts: string[] = [];
+    for (;;) {
+      const word = tokens.peek();
+      if (!word || (word.kind !== 'identifier' && word.kind !== 'keyword')) break;
+      parts.push(word.value);
+      tokens.advance();
+      const sep = tokens.peek();
+      if (!sep || sep.value !== '-') break;
+      tokens.advance();
+      parts.push('-');
+    }
+    // A run must end on a word (parts like [w, -, w]); a trailing '-' or a
+    // single word means no compound formed.
+    if (parts.length < 3 || parts[parts.length - 1] === '-') {
+      tokens.reset(mark);
+      return null;
+    }
+    const joined = parts.join('').toLowerCase();
+    for (const [action, kw] of Object.entries(profile.keywords)) {
+      if (
+        kw.primary.toLowerCase() === joined ||
+        kw.alternatives?.some(a => a.toLowerCase() === joined)
+      ) {
+        return createLiteral(action);
+      }
+    }
+    tokens.reset(mark);
+    return null;
+  }
+
+  /**
+   * Match a hyphen-compound keyword (`titik-henti`) against a shattered token
+   * run (`titik` `-` `henti`): word segments must be identifier/keyword tokens
+   * equal to the expected segments (case-insensitive), separators lone `-`
+   * tokens. Consumes the run on success, resets the stream on failure.
+   */
+  private tryMatchHyphenCompound(tokens: TokenStream, expected: string): boolean {
+    const segments = expected.split('-');
+    if (segments.length < 2 || segments.some(s => s.length === 0)) return false;
+    const mark = tokens.mark();
+    for (let i = 0; i < segments.length; i++) {
+      if (i > 0) {
+        const sep = tokens.peek();
+        if (!sep || sep.value !== '-') {
+          tokens.reset(mark);
+          return false;
+        }
+        tokens.advance();
+      }
+      const word = tokens.peek();
+      if (
+        !word ||
+        (word.kind !== 'identifier' && word.kind !== 'keyword') ||
+        word.value.toLowerCase() !== segments[i]!.toLowerCase()
+      ) {
+        tokens.reset(mark);
+        return false;
+      }
+      tokens.advance();
+    }
+    return true;
   }
 
   /**
@@ -357,6 +444,20 @@ export class PatternMatcher {
     const token = tokens.peek();
     if (!token) {
       return patternToken.optional || false;
+    }
+
+    // Action-role hyphen-compound fold (same family as the matchLiteralToken
+    // fold): a fused event pattern's {action} slot captures ONE token, but a
+    // hyphen-compound verb translation (it `punto-interruzione`) shatters into
+    // a word/-/word run — the slot then captures the first fragment as a junk
+    // action and the whole command drops. Join the run; if it is a profile
+    // keyword for a command, capture that command's canonical action instead.
+    if (patternToken.role === 'action' && this.currentProfile && tokens.peek(1)?.value === '-') {
+      const foldedAction = this.tryFoldHyphenActionKeyword(tokens);
+      if (foldedAction) {
+        captured.set(patternToken.role as SemanticRole, foldedAction);
+        return true;
+      }
     }
 
     // Event-anchor guard. An event name is a bare identifier or known event

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -11313,3 +11313,105 @@ describe('brace-run style-object fold + ko locative/allative marker split (behav
     expect(String(role(node, 'destination')?.value)).toBe('#button');
   });
 });
+
+describe('breakpoint bare-keyword registration + hyphen-compound keyword fold (breakpoint ×6 / halt ×3 spurious drill)', () => {
+  const role = (
+    node: Record<string, any> | null | undefined,
+    r: string
+  ): { type?: string; value?: unknown; raw?: unknown } | undefined =>
+    node?.roles instanceof Map ? node.roles.get(r) : undefined;
+
+  const actionsOf = (node: unknown): string[] => {
+    const flat: string[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec.action);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'eventHandlers', 'initBlock', 'initCommands']) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return flat;
+  };
+
+  it('[en] bare `breakpoint` parses via the generated bare-keyword pattern', () => {
+    // breakpointSchema is roleless; without `bareKeyword: true` NO pattern is
+    // generated at all (getDefinedSchemas filters zero-role schemas) and the
+    // command silently drops from every generated-path language.
+    expect((parse('breakpoint', 'en') as unknown as Record<string, any>).action).toBe('breakpoint');
+  });
+
+  it('[en] `on click breakpoint then set …` keeps BOTH body commands', () => {
+    const node = parse('on click breakpoint then set $x to 42', 'en');
+    const actions = actionsOf(node);
+    expect(actions).toContain('breakpoint');
+    expect(actions).toContain('set');
+  });
+
+  it('[ms] `titik-henti` folds to breakpoint — NOT a spurious halt from its embedded halt keyword', () => {
+    // The tokenizers shatter the hyphen compound into `titik` `-` `henti`, and
+    // `henti` is ms's halt primary — so the run mis-anchored halt-ms-generated
+    // (the spurious halt ×3 sibling: ms/sw/vi). The matchLiteralToken hyphen
+    // fold joins the run back into the breakpoint keyword.
+    const node = parse('apabila click titik-henti kemudian tetapkan $x ke 42', 'ms');
+    const actions = actionsOf(node);
+    expect(actions).toContain('breakpoint');
+    expect(actions).not.toContain('halt');
+    expect(actions).toContain('set');
+  });
+
+  it('[vi] `điểm-dừng` folds to breakpoint — NOT a spurious halt', () => {
+    const node = parse('khi nhấp điểm-dừng rồi gán $x vào 42', 'vi');
+    const actions = actionsOf(node);
+    expect(actions).toContain('breakpoint');
+    expect(actions).not.toContain('halt');
+  });
+
+  it('[it] fused {action} slot folds the hyphen run (`punto-interruzione`) to the canonical action', () => {
+    // event-handler-it-full captures the body verb via an {action} role — one
+    // token. The shattered compound left `punto` as a junk action and the
+    // whole command dropped. The matchRoleToken action fold joins the run and
+    // resolves it through the profile keywords.
+    const node = parse('su clic punto-interruzione allora impostare $x in 42', 'it');
+    const actions = actionsOf(node);
+    expect(actions).toContain('breakpoint');
+    expect(actions).toContain('set');
+  });
+
+  it('[he] the en loanword `breakpoint` parses (dict passthrough alternative)', () => {
+    // The i18n he dictionary has no breakpoint entry — the transformer emits
+    // the en word verbatim; the profile lists it as an alternative.
+    const node = parse('ב לחיצה breakpoint אז קבע את $x על 42', 'he');
+    const actions = actionsOf(node);
+    expect(actions).toContain('breakpoint');
+    expect(actions).toContain('set');
+  });
+
+  it('[de] roleless commands generate NO fused event pattern (no junk patient="then")', () => {
+    // Every fused event-handler shape hardwires a required {patient} role, so
+    // fusing a roleless command swallowed the `then` connective as its patient
+    // (`breakpoint-event-de-vso` captured patient=literal:"then"). Roleless
+    // schemas now skip fused generation and parse via the standard event
+    // pattern + bare command in the body.
+    const node = parse('bei klick haltepunkt dann festlegen $x zu 42', 'de') as unknown as Record<string, any>;
+    const actions = actionsOf(node);
+    expect(actions).toContain('breakpoint');
+    expect(actions).toContain('set');
+    const walkFind = (n: unknown): Record<string, any> | undefined => {
+      if (!n || typeof n !== 'object') return undefined;
+      const rec = n as Record<string, any>;
+      if (rec.action === 'breakpoint') return rec;
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) { const hit = walkFind(x); if (hit) return hit; }
+      }
+      return undefined;
+    };
+    const bp = walkFind(node);
+    expect(bp).toBeDefined();
+    expect(role(bp!, 'patient')).toBeUndefined();
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,12 +1,12 @@
 {
-  "timestamp": "2026-07-06T16:22:38.189Z",
-  "commit": "51e6b9ce",
+  "timestamp": "2026-07-06T17:55:58.050Z",
+  "commit": "19e1a78f",
   "languages": {
     "ar": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8362095875032615,
+      "avgConfidence": 0.8394563407500147,
       "avgFidelity": 1,
       "avgPrecision": 0.9967532467532467,
       "avgRoleFidelity": 0.9870495495495494,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -221,6 +221,10 @@
           "confidence": 1
         },
         "on-custom-event-receive": {
+          "success": true,
+          "confidence": 1
+        },
+        "breakpoint-command": {
           "success": true,
           "confidence": 1
         },
@@ -612,10 +616,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "breakpoint-command": {
-          "success": true,
-          "confidence": 0.5
-        },
         "behavior-removable": {
           "success": true,
           "confidence": 0.5
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8579007041413049,
       "avgFidelity": 1,
-      "avgPrecision": 0.9612011218628865,
+      "avgPrecision": 0.9633656240273888,
       "avgRoleFidelity": 0.9716216216216217,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.9045096507502506,
       "avgFidelity": 1,
-      "avgPrecision": 0.9650703463203464,
+      "avgPrecision": 0.9672348484848484,
       "avgRoleFidelity": 0.9567406692406693,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6321,13 +6321,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8467689787238654,
       "avgFidelity": 1,
-      "avgPrecision": 0.9767316017316019,
+      "avgPrecision": 0.978896103896104,
       "avgRoleFidelity": 0.9716216216216217,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6953,13 +6953,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8417184736733602,
       "avgFidelity": 1,
-      "avgPrecision": 0.9767316017316019,
+      "avgPrecision": 0.978896103896104,
       "avgRoleFidelity": 0.9682432432432433,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7585,13 +7585,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8377241805813213,
       "avgFidelity": 1,
-      "avgPrecision": 0.9978354978354977,
+      "avgPrecision": 1,
       "avgRoleFidelity": 0.9881756756756759,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9481,13 +9481,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
-      "avgPrecision": 0.9767316017316017,
+      "avgPrecision": 0.9788961038961039,
       "avgRoleFidelity": 0.9561776061776062,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10745,13 +10745,13 @@
       "parseRate": 1,
       "avgConfidence": 0.800865800865799,
       "avgFidelity": 1,
-      "avgPrecision": 0.997835497835498,
+      "avgPrecision": 1,
       "avgRoleFidelity": 0.9893018018018019,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11377,13 +11377,13 @@
       "parseRate": 1,
       "avgConfidence": 0.840857555143267,
       "avgFidelity": 1,
-      "avgPrecision": 0.9924242424242423,
+      "avgPrecision": 0.9945887445887446,
       "avgRoleFidelity": 0.9893018018018017,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12007,7 +12007,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8206715541080843,
+      "avgConfidence": 0.8239183073548376,
       "avgFidelity": 1,
       "avgPrecision": 0.9967532467532467,
       "avgRoleFidelity": 0.9938063063063062,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12210,6 +12210,10 @@
           "confidence": 1
         },
         "on-custom-event-receive": {
+          "success": true,
+          "confidence": 1
+        },
+        "breakpoint-command": {
           "success": true,
           "confidence": 1
         },
@@ -12628,10 +12632,6 @@
         "event-throttle": {
           "success": true,
           "confidence": 0.5
-        },
-        "breakpoint-command": {
-          "success": true,
-          "confidence": 0.5
         }
       }
     },
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13905,13 +13905,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8049474335188601,
       "avgFidelity": 1,
-      "avgPrecision": 0.997835497835498,
+      "avgPrecision": 1,
       "avgRoleFidelity": 0.9930180180180183,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 484961,
+      "bundleSize": 486154,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 484961,
+      "size": 486154,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

L2 drill 1 of the launch-bar burn-down (both families en-noise, pre-probed session 9):

- **spurious breakpoint ×6** (bn/hi/ja/ko/qu/th): the roleless `breakpointSchema` generated **no pattern at all** (`getDefinedSchemas` filters zero-role schemas), so en dropped the bare `breakpoint` from `on click breakpoint then set $x to 42` while the lax event-fused paths kept it. Fix = `bareKeyword: true`, the exact #582 `exit` precedent.
- **spurious halt ×3** (ms/sw/vi): their breakpoint words are hyphen compounds **containing their halt primary** (titik-**henti** / nukta-**simama** / điểm-**dừng**); the tokenizers shatter the compound into `word - word` and the tail mis-anchored `halt-*-generated`.

Because en now parses breakpoint, every generated-path language had to come along in the same PR (else spurious ×9 flips into missing ×13). Three aligned pieces:

1. **`matchLiteralToken` hyphen-compound fold** — joins a shattered `word (- word)+` run and matches it against hyphen-bearing expected keyword values (es/fr/id/it/pl/pt/ru/uk/tr/ar/ms/sw/vi compounds).
2. **`matchRoleToken` {action}-slot fold** (same family) — `event-handler-it-full` captures the body verb as ONE token; the shattered `punto-interruzione` left a junk `punto` action and dropped the command. The fold resolves the joined run through the profile keywords.
3. **`generateEventHandlerPatterns` skips roleless schemas** — every fused shape hardwires a required `{patient}`, so fusing a roleless command swallowed the `then` connective as junk patient (`breakpoint-event-de-vso` captured `patient=literal:"then"`).
4. **he profile**: `breakpoint` en-loanword alternative (the i18n he dict has no breakpoint entry — the transformer passes the en word through verbatim).

## Verification

- A/B per-(lang,pattern) vs the pre-change dist: **9 spurious cleared, 0 new**; coverage census identical (3404); probe mean R1 0.9831 held.
- Baseline (regenerated against a fresh populate, committed): avgPrecision **0.9910 → 0.9919**, parse 3696/3696, degenerate/lossy 0, R2 1.0.
- Six-signal `--regression` gate green; semantic suite 6568 passed; typecheck clean.
- 7 guard tests, **all stash-verified fail-without-fix**.
- Mirrors checked (session-9 learning): adapter `generate:syntax` no-drift, i18n `COMMAND_PRIMARY_ROLES` untouched (no primaryRole change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)