### PR TITLE
fix(multilingual): bn জন্য duration postposition + fused-body phantom-for guard — for ×14→×9 (L2 drill 2)

### DIFF
--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1574,6 +1574,14 @@ export class SemanticParserImpl implements ISemanticParser {
               dNode.metadata
             );
             tokens.advance();
+            // Consume a trailing rendered duration postposition (bn `500ms
+            // জন্য` — the transformer renders `over` as the for-postposition
+            // AFTER the time literal). Left in place it anchors a phantom bare
+            // `for` command in the remaining body tokens (the wait-for
+            // precedent below, same particle). জন্য tokenizes as a PARTICLE
+            // (no `normalized`), so also match the profile's for-keyword
+            // surface form.
+            this.consumeForPostposition(tokens, language);
           }
         }
 
@@ -1669,19 +1677,8 @@ export class SemanticParserImpl implements ISemanticParser {
               // Consume a trailing rendered `for`-postposition (bn `transitionend
               // জন্য` — the transformer renders the wait-for keyword AFTER the
               // event in postpositional languages). Left in place it anchors a
-              // phantom bare `for` command in the remaining body tokens. জন্য
-              // tokenizes as a PARTICLE (no `normalized`), so also match the
-              // profile's for-keyword surface form.
-              const post = tokens.peek();
-              if (post) {
-                const postNorm = (post.normalized ?? '').toLowerCase();
-                const forKw = tryGetProfile(language)?.keywords?.for;
-                const isForWord =
-                  postNorm === 'for' ||
-                  post.value === forKw?.primary ||
-                  (forKw?.alternatives ?? []).includes(post.value);
-                if (isForWord) tokens.advance();
-              }
+              // phantom bare `for` command in the remaining body tokens.
+              this.consumeForPostposition(tokens, language);
             }
           }
         }
@@ -3122,6 +3119,28 @@ export class SemanticParserImpl implements ISemanticParser {
     }
 
     flushClause();
+
+    // Drop phantom BARE `for` clauses — the parseBodyWithClauses guard,
+    // mirrored on this fused-body path: a lone for-homonym token (bn `জন্য`,
+    // both the for-keyword and a duration/benefactive postposition) orphaned
+    // from its phrase anchors a `for` command node with ZERO roles and no
+    // body (slide-toggle's then-clause `*max-height কে সংক্রমণ 300ms জন্য` —
+    // spurious vs the en reference). Real for heads always carry roles or a
+    // body; the loop-end-debt walk above has already finished, so a dropped
+    // phantom can't desync it. Scoped to `for` ONLY (see the clause-path
+    // guard: a bare `repeat` is a legitimate recovery intermediate).
+    for (let i = commands.length - 1; i >= 0; i--) {
+      const c = commands[i] as CommandSemanticNode & { body?: unknown[] };
+      if (
+        c.kind === 'command' &&
+        c.action === 'for' &&
+        (!(c.roles instanceof Map) || c.roles.size === 0) &&
+        (!Array.isArray(c.body) || c.body.length === 0)
+      ) {
+        commands.splice(i, 1);
+      }
+    }
+
     return commands;
   }
 
@@ -3869,6 +3888,26 @@ export class SemanticParserImpl implements ISemanticParser {
   /**
    * Check if a token is a 'then' keyword in the given language.
    */
+  /**
+   * Consume the next token when it is the language's rendered `for` word (bn
+   * `জন্য`, tr `için`) trailing a just-reclaimed phrase (a wait-for event, a
+   * transition duration). The word doubles as the for-loop keyword, so left in
+   * the stream it anchors a phantom bare `for` command in the remaining body
+   * tokens. Homonym particles carry no `normalized`, so the profile's surface
+   * forms are matched too.
+   */
+  private consumeForPostposition(tokens: TokenStream, language: string): void {
+    const post = tokens.peek();
+    if (!post) return;
+    const postNorm = (post.normalized ?? '').toLowerCase();
+    const forKw = tryGetProfile(language)?.keywords?.for;
+    const isForWord =
+      postNorm === 'for' ||
+      post.value === forKw?.primary ||
+      (forKw?.alternatives ?? []).includes(post.value);
+    if (isForWord) tokens.advance();
+  }
+
   private isThenKeyword(value: string, language: string): boolean {
     const v = value.toLowerCase();
     const thenKeywords: Record<string, Set<string>> = {

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -11415,3 +11415,80 @@ describe('breakpoint bare-keyword registration + hyphen-compound keyword fold (b
     expect(role(bp!, 'patient')).toBeUndefined();
   });
 });
+
+describe('bn জন্য duration postposition: consumed after the duration reclaim, never a phantom `for` (spurious for drill)', () => {
+  const actionsOf = (node: unknown): string[] => {
+    const flat: string[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec.action);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'eventHandlers', 'initBlock', 'initCommands']) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return flat;
+  };
+  const rolesOf = (node: unknown, action: string): Map<string, any> | undefined => {
+    let hit: Map<string, any> | undefined;
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object' || hit) return;
+      const rec = n as Record<string, any>;
+      if (rec.action === action && rec.roles instanceof Map) { hit = rec.roles; return; }
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+      }
+    };
+    walk(node);
+    return hit;
+  };
+
+  it('[bn] transition-transform: `300ms জন্য` reclaims the duration AND consumes the postposition', () => {
+    // bn renders `over 300ms` as `300ms জন্য`; the fused pattern's duration
+    // reclaim consumed the time literal but left জন্য — which is ALSO bn's
+    // for-loop keyword, so it anchored a phantom ROLELESS `for` command in
+    // the compound split (spurious for, the transition-family half).
+    const node = parse('transform কে ক্লিক এ সংক্রমণ "scale(1.2)" তে 300ms জন্য', 'bn');
+    const actions = actionsOf(node);
+    expect(actions).toContain('transition');
+    expect(actions).not.toContain('for');
+    expect(String(rolesOf(node, 'transition')?.get('duration')?.value)).toBe('300ms');
+  });
+
+  it('[bn] transition-opacity: the then-chain after the postposition survives', () => {
+    const node = parse('opacity কে ক্লিক এ সংক্রমণ 0 তে 500ms জন্য তারপর আমি কে সরান', 'bn');
+    const actions = actionsOf(node);
+    expect(actions).toContain('transition');
+    expect(actions).toContain('remove');
+    expect(actions).not.toContain('for');
+  });
+
+  it('[bn] slide-toggle then-clause: the grammar-patterns body walker drops a ZERO-role phantom `for`', () => {
+    // This body goes through parseBodyWithGrammarPatterns (fused toggle head),
+    // which lacked the parseBodyWithClauses zero-role-for guard — the orphaned
+    // জন্য after `সংক্রমণ 300ms` anchored a bare `for` alongside the real
+    // transition.
+    const node = parse(
+      '.collapsed কে ক্লিক এ টগল পরবর্তী .panel তে তারপর *max-height কে সংক্রমণ 300ms জন্য',
+      'bn'
+    );
+    const actions = actionsOf(node);
+    expect(actions).toContain('toggle');
+    expect(actions).toContain('transition');
+    expect(actions).not.toContain('for');
+  });
+
+  it('[bn] a REAL for head still parses (the guard only drops roleless, bodyless nodes)', () => {
+    // template-literal-list-build, corpus-rendered: the for head `item এ
+    // $items কে জন্য` carries roles, so the phantom guard must not touch it.
+    const node = parse(
+      '$html কে "" তে সেট ক্লিক এ তারপর item এ $items কে জন্য তারপর $html কে সেট $html + `<li>${item.name}</li>` শেষ তে তারপর #list.innerHTML কে $html তে সেট',
+      'bn'
+    );
+    expect(actionsOf(node)).toContain('for');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-06T17:55:58.050Z",
-  "commit": "19e1a78f",
+  "timestamp": "2026-07-06T18:14:48.772Z",
+  "commit": "4cb1247b",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8579007041413049,
       "avgFidelity": 1,
-      "avgPrecision": 0.9633656240273888,
+      "avgPrecision": 0.9720236326853975,
       "avgRoleFidelity": 0.9716216216216217,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486154,
+      "bundleSize": 486441,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 486154,
+      "size": 486441,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

L2 drill 2 of the launch-bar burn-down: the bn `for` spurious family's transition half (pre-probed session 9, bn-side).

bn renders `over 300ms` as `300ms জন্য`, and জন্য ("for") is **also** bn's for-loop keyword. The fused-path duration reclaim consumed the time literal but left the postposition, which anchored a phantom ROLELESS `for` command in the compound split — spurious vs the en reference across transition-opacity/-transform/-color, fade-out-remove, and slide-toggle's then-clause.

- **`consumeForPostposition`** (factored from the wait-for reclaim's identical inline handling): after the duration reclaim, a trailing rendered for-word is consumed (জন্য tokenizes as a PARTICLE with no `normalized`, so profile surface forms are matched).
- **`parseBodyWithGrammarPatterns` gains the zero-role phantom-`for` drop** that `parseBodyWithClauses` already had — slide-toggle's body goes through the fused toggle head's walker, which lacked the guard. Real for heads carry roles or a body and survive (locked by a corpus-shaped test).

Remaining spurious for ×9 is two **other** arcs, deliberately untouched: take-class-from-siblings ×6 (en silently drops the `for me` phrase + the transformer renders it as a separate then-clause) and behavior-draggable/sortable/resizable bn ×3 (the wait-or payload leak, post-launch track).

## Verification

- A/B per-(lang,pattern) vs the drill-1 dist: **5 spurious cleared, 0 new**; census identical (3404); probe mean R1 0.9831 held.
- Baseline (regenerated against a fresh populate, committed): avgPrecision **0.9919 → 0.9922**, parse 3696/3696, degenerate/lossy 0, R2 1.0.
- Six-signal `--regression` gate green; semantic suite 6579 passed.
- 4 guard tests: 3 stash-verified fail-without-fix, 1 both-ways lock (real bn for head survives the guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)