### PR TITLE
fix(multilingual): goal-less transition variant (omitRoleVariants) — spurious transition ×6 cleared (L2 complete) + session-10 docs sync

### DIFF
--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -44,11 +44,12 @@
 > `event-he-when` (event=expression:"method"); fix is he-side with-phrase
 > consumption (or keep event-he-when off the עם tail). The seventh entry is
 > install-behavior hi, a different mechanism — probe separately. call ×7
-> (window-keydown, one pattern) is EN-SIDE (bar item 1): en drops `call
-saveDocument()` JUXTAPOSED after `halt` inside the if-branch (`if
-event.ctrlKey halt call saveDocument() end` — the conditional fold keeps
-> halt only), while the seven keep it — an en enrichment, so budget for the
-> he/hi/bn/ja/ko/qu/tr role alignment in the same PR (the morph lesson).
+> (window-keydown, one pattern) is EN-SIDE (bar item 1): en drops the
+> JUXTAPOSED call after halt inside the if-branch — the corpus line is
+> `if event.ctrlKey halt call saveDocument() end` and the conditional fold
+> keeps halt only — while the seven keep it. An en enrichment, so budget
+> for the he/hi/bn/ja/ko/qu/tr role alignment in the same PR (the morph
+> lesson).
 > Also on the L3/L4 radar: morph-with-template
 > missing ×7 (en render `#row with row: $data` grabs a junk
 > style:expression="row" param-name role — en-side mis-capture, separate

--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -36,7 +36,20 @@
 >
 > **L3 next (he/zh marker cluster, pre-probe first): on ×7 he — note
 > morph-with-template is one of its patterns — and call ×7; toggle he/zh
-> already shrank to ×1.** Also on the L3/L4 radar: morph-with-template
+> already shrank to ×1.** Both were mechanism-probed at session-10 close:
+> the he `on` ×6 are all with-phrase patterns (fetch-with-method/-headers/
+> -method-body/-formdata, render-template-with-data, morph-with-template) —
+> the he render `עם method:"POST" body:form` tail is left unconsumed by
+> fetch-he and SPLITS into a phantom second event-handler anchored by
+> `event-he-when` (event=expression:"method"); fix is he-side with-phrase
+> consumption (or keep event-he-when off the עם tail). The seventh entry is
+> install-behavior hi, a different mechanism — probe separately. call ×7
+> (window-keydown, one pattern) is EN-SIDE (bar item 1): en drops `call
+saveDocument()` JUXTAPOSED after `halt` inside the if-branch (`if
+event.ctrlKey halt call saveDocument() end` — the conditional fold keeps
+> halt only), while the seven keep it — an en enrichment, so budget for the
+> he/hi/bn/ja/ko/qu/tr role alignment in the same PR (the morph lesson).
+> Also on the L3/L4 radar: morph-with-template
 > missing ×7 (en render `#row with row: $data` grabs a junk
 > style:expression="row" param-name role — en-side mis-capture, separate
 > from the cleared morph family); take-class-from-siblings spurious for ×6

--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -1,5 +1,53 @@
 # Handoff — R1 residue after the five-cluster triage (fronted repeat-while · sw kama homonym · singletons)
 
+> **STATUS UPDATE (2026-07-06, session 10 = L2 of the launch bar): all three
+> pre-probed L2 drills LANDED — #592 (breakpoint ×6 + halt ×3), #593 (bn জন্য
+> transition-half of for ×14→×9) and the goal-less transition variant ×6 in
+> this PR.** Post-session state: baseline avgPrecision **0.9910 → 0.9928**
+> (+0.0018 across three drills), probe mean R1 **0.9831 held**, parse
+> 3696/3696, degenerate/lossy 0, R2 1.0. Per-(lang,pattern) A/B across all
+> three: **20 spurious cleared, 0 new**; census identical (3404).
+> Remaining >×5 families: default ×9, for ×9 (two sub-arcs below), empty ×8,
+> call ×7, on ×7 he. Note toggle he/zh shrank to ×1 during L2.
+>
+> 1. **#592 — breakpoint (bareKeyword, the #582 exit precedent) + the
+>    hyphen-compound seam.** ms/sw/vi's spurious halt came from tokenizers
+>    shattering `titik-henti`-style compounds into word/-/word runs with the
+>    tail being their halt PRIMARY. New machinery, reusable: matchLiteralToken
+>    hyphen-run fold; matchRoleToken {action}-slot fold (fused it-full
+>    patterns); generateEventHandlerPatterns skips roleless schemas (junk
+>    patient="then" otherwise); he en-loanword alternative. 7 guard tests,
+>    all stash-verified.
+> 2. **#593 — bn জন্য duration postposition.** consumeForPostposition after
+>    the fused duration reclaim (factored from the wait-for reclaim's
+>    identical inline code); parseBodyWithGrammarPatterns gained the
+>    zero-role phantom-`for` drop parseBodyWithClauses already had. 4 guard
+>    tests (3 stash-verified, 1 both-ways real-for lock).
+> 3. **PR 3 — transition ×6 was NOT a splitter arc.** The goal-less form
+>    (`transition *max-height over 300ms`, valid hyperscript) was PARSE NULL
+>    in en isolation. New schema field `omitRoleVariants: ['goal']` generates a
+>    SEPARATE lower-priority no-goal variant per language (base−8, below the
+>    simple variant) — avoids the documented optional-goal skippable-group
+>    regression (schema NOTE kept). 18 languages parse via
+>    transition-\*-generated-no-goal; the SOV six keep their lax captures;
+>    the destination default aligns via fillSchemaDefaults. 5 guard tests
+>    (3 stash-verified, 2 goal-ful locks incl. the es marker-language
+>    do-not-repeat regression shape).
+>
+> **L3 next (he/zh marker cluster, pre-probe first): on ×7 he — note
+> morph-with-template is one of its patterns — and call ×7; toggle he/zh
+> already shrank to ×1.** Also on the L3/L4 radar: morph-with-template
+> missing ×7 (en render `#row with row: $data` grabs a junk
+> style:expression="row" param-name role — en-side mis-capture, separate
+> from the cleared morph family); take-class-from-siblings spurious for ×6
+> (en drops the `for me` phrase — an en-facing gap, bar item 1 — AND the
+> transformer renders it as a separate then-clause `তারপর আমি কে জন্য`;
+> fixing en alone would mint missing entries in every language, so this
+> drill needs cross-language alignment or a transformer-side render fix —
+> probe both sides first). Post-launch track unchanged, now also carrying
+> draggable/sortable/resizable bn spurious for ×3 (the wait-or payload leak
+> — the SAME unconsumed or-run payload session 9 flagged for ko).
+
 > **STATUS UPDATE (2026-07-06, session 9 = L1 of the launch bar): the two
 > biggest spurious families LANDED — #590 (morph ×18: schema role-layout swap
 > plus reference admission) and the draggable add ×11 drill in this PR

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -9,7 +9,7 @@
 > [BEHAVIORS_CONSOLIDATION_PLAN.md](BEHAVIORS_CONSOLIDATION_PLAN.md). Read this first,
 > then dive into those for the per-arc detail.
 
-## Where we are (2026-07-06 baseline · post session-9 / L1 · `browser-priority`)
+## Where we are (2026-07-06 baseline · post session-10 / L2 · `browser-priority`)
 
 Authoritative source: `packages/testing-framework/baselines/multilingual-priority.json`
 (its `timestamp` + `commit` fields stamp each regen). 24 langs × 154 patterns = 3696.
@@ -21,8 +21,8 @@ Authoritative source: `packages/testing-framework/baselines/multilingual-priorit
 | lossy passes (0.5 ≤ fid < 1.0) | **0**                  | band cleared (#495–#506), holding                         |
 | faithful (fid = 1.0)           | **3696**               | every parsing pattern is faithful                         |
 | avgFidelity (R0-recall)        | **1.000**              | saturated                                                 |
-| avgPrecision (R0 trust floor)  | **0.991**              | session-9 / L1 drills: 0.9891 → 0.9910 (morph+draggable)  |
-| avgRoleFidelity (R1)           | **0.983**              | 0.9831, held through session-9                            |
+| avgPrecision (R0 trust floor)  | **0.993**              | session-10 / L2 drills: 0.9910 → 0.9928 (three drills)    |
+| avgRoleFidelity (R1)           | **0.983**              | 0.9831, held through session-10                           |
 | avgExecutionFidelity (R2)      | **1.000**              | 47-pattern curated subset fully reproduces en DOM effects |
 
 The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recall ·
@@ -40,11 +40,13 @@ normal usage). The bar, all four together:
 1. **All en-facing parser gaps closed.** Every remaining en-noise inversion is
    a real English-parser bug (en `go back` / `add "content"` didn't parse
    until #588/#589) — user-visible to English users regardless of the metric.
-2. **Every spurious family larger than ×5 cleared** (post-session-9 inventory:
-   ~~morph ×18~~ ✓L1, for ×14 bn, ~~add ×11 draggable~~ ✓L1, default ×9,
-   empty ×8, call ×7, on ×7 he, transition ×6, breakpoint ×6).
-3. **avgPrecision ≥ 0.995** (0.9910 as of session 9).
-4. **avgRoleFidelity ≥ 0.985** (0.9831 as of session 9) — the big R1-missing
+2. **Every spurious family larger than ×5 cleared** (post-session-10 inventory:
+   ~~morph ×18~~ ✓L1, for ×14→×9 (transition half ✓L2; remainder = take-class
+   ×6 own-arc + wait-payload behaviors ×3 post-launch), ~~add ×11 draggable~~
+   ✓L1, default ×9, empty ×8, call ×7, on ×7 he, ~~transition ×6~~ ✓L2,
+   ~~breakpoint ×6~~ ✓L2 (+halt ×3 sibling).
+3. **avgPrecision ≥ 0.995** (0.9928 as of session 10).
+4. **avgRoleFidelity ≥ 0.985** (0.9831 as of session 10) — the big R1-missing
    families (add.patient:selector ×20, toggle.patient:expression ×19,
    fetch.source:literal ×18, set.patient:literal ×16,
    bind.source:property-path ×14) carry most of this.
@@ -55,15 +57,18 @@ across sessions 4–8, full discipline included). Sequencing:
 | Session | Clusters                                                             | Bar signals moved         |
 | ------- | -------------------------------------------------------------------- | ------------------------- |
 | L1 ✓    | morph ×18 + draggable add fold+cleanup ×11 (#590 + session-9 PR 2)   | precision 0.9891 → 0.9910 |
-| L2      | bn `for` ×14 + transition ×6 + breakpoint ×6 (pre-probed session 9)  | precision                 |
-| L3      | he/zh marker cluster (on ×7 he, toggle he/zh, call ×7)               | precision, en gaps        |
+| L2 ✓    | breakpoint ×6+halt ×3 + bn `for` transition-half ×5 + transition ×6  | precision 0.9910 → 0.9928 |
+| L3      | he/zh marker cluster (on ×7 he, call ×7; toggle shrank to ×1 in L2)  | precision, en gaps        |
 | L4      | default-value full drill (13 langs, markers + possessives)           | en gaps, R1               |
 | L5–L6   | big R1-missing families (add/toggle patient, fetch/bind source, set) | R1 → ≥0.985               |
 
 L1 actual precision movement (+0.0019 for 29 entries) ran well under the
 table's ~0.997 sketch — the remaining seven >×5 families plus the tail carry
 more of the gap than estimated; expect the ≥0.995 bar to need L2 AND L3 (and
-possibly part of L4) rather than L1+L2 alone.
+possibly part of L4) rather than L1+L2 alone. L2 actual: +0.0018 for 20
+entries (#592, #593, session-10 PR 3) — on the same slope; after L2 the
+remaining >×5 inventory is default ×9, for ×9 (two sub-arcs, see bar item 2),
+empty ×8, call ×7, on ×7 he, so L3+L4 must carry ~0.0022 to reach 0.995.
 
 **Post-launch track (ratchet-protected, not launch-blocking):** SOV-six role
 polish (qu/hi ~0.956 R1), tr remove.patient block-walk leak, spurious empty
@@ -75,12 +80,53 @@ Caveats: each en enrichment can mint honest-dip entries (bounded by the
 census/A-B discipline; historically <1 session total), and this scopes the
 fidelity grind only — docs/demo/npm-publish polish is separate scope.
 
-> **Update 2026-07-06d (SESSION 9 = L1: the two biggest spurious families —
-> #590 morph ×18 role-layout swap and the draggable add ×11 brace-fold drill
-> in the session's second PR; avgPrecision 0.9891 → 0.9910, probe mean R1
-> 0.9829 → 0.9831; A/B 29 spurious cleared / 0 new; census identical (3404);
-> gate green; baselines regenerated per-PR.)**
+> **Update 2026-07-06e (SESSION 10 = L2, three drills across #592, #593 and
+> this PR; avgPrecision 0.9910 → 0.9928, probe mean R1 0.9831 held; A/B 20
+> spurious cleared / 0 new across the three; census identical (3404); gate
+> green; baseline regenerated per-PR.)**
 >
+> - **#592 — breakpoint ×6 + halt ×3 (en-noise, the #582 exit precedent as
+>   diagnosed, plus a tokenization seam).** Roleless breakpointSchema
+>   generated NO pattern (getDefinedSchemas filters zero-role schemas) →
+>   `bareKeyword: true`. But the pre-probe showed the ms/sw/vi halt sibling is
+>   a HYPHEN-COMPOUND shatter: tokenizers split `titik-henti` into word/-/word
+>   and the tail word IS their halt primary (henti/simama/dừng) → spurious
+>   halt via halt-\*-generated. Three aligned pieces rode along so en's
+>   enrichment minted zero missing entries: a matchLiteralToken hyphen-run
+>   fold (joins the run against hyphen-bearing expected keywords — 13
+>   languages' breakpoint words are compounds); a matchRoleToken {action}-slot
+>   fold (it's event-handler-it-full captures the verb as ONE token; shattered
+>   `punto-interruzione` left a junk `punto` action); and
+>   generateEventHandlerPatterns now SKIPS roleless schemas (every fused shape
+>   hardwires a required patient — fusing swallowed the `then` connective as
+>   junk patient). he profile got the en-loanword `breakpoint` alternative
+>   (its i18n dict has no entry; the transformer passes en through).
+> - **#593 — bn `for` transition-half ×5 (bn-side, as diagnosed).** bn renders
+>   `over 300ms` as `300ms জন্য` and জন্য is ALSO bn's for-keyword; the
+>   duration reclaim consumed the literal but left the postposition → phantom
+>   roleless `for` in the compound split. consumeForPostposition (factored
+>   from the wait-for reclaim's identical inline code) now runs after the
+>   duration reclaim; parseBodyWithGrammarPatterns gained the zero-role
+>   phantom-`for` drop parseBodyWithClauses already had (slide-toggle's body
+>   walks the fused toggle head's path). Remaining for ×9 = take-class ×6
+>   (en drops the `for me` phrase — en-facing gap — AND the transformer
+>   renders it as a separate then-clause; own arc) and
+>   draggable/sortable/resizable bn ×3 (wait-or payload leak, post-launch).
+> - **PR 3 — transition ×6 (en-noise; NOT the feared splitter arc).**
+>   slide-toggle's `transition *max-height over 300ms` was PARSE NULL in en
+>   ISOLATION — no juxtaposition gap at all: the generated pattern requires
+>   the `to {goal}` phrase this goal-less (valid) form omits. Making goal
+>   optional is the documented skippable-group re-binding regression (schema
+>   NOTE, do-not-repeat) — instead a new schema field `omitRoleVariants`
+>   generates a SEPARATE lower-priority variant with the role omitted
+>   entirely (no skippable group to re-bind). 18 languages now parse it via
+>   transition-\*-generated-no-goal; the SOV six keep their lax captures;
+>   fillSchemaDefaults aligns the destination default. Goal-ful forms locked
+>   (en + es marker-language guard tests).
+>   #590 morph ×18 role-layout swap and the draggable add ×11 brace-fold drill
+>   in the session's second PR; avgPrecision 0.9891 → 0.9910, probe mean R1
+>   0.9829 → 0.9831; A/B 29 spurious cleared / 0 new; census identical (3404);
+>   gate green; baselines regenerated per-PR.)\*\*
 > - **#590 — morph ×18.** en `morph #list to it` NULL in isolation (content
 >   slot rejected `reference`) — but the schema ALSO carried its roles swapped
 >   vs the i18n transformer's marking (element=patient を/를/i,

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -115,6 +115,16 @@ export interface CommandSchema {
    * generated and the construct parses (body handled like other block bodies).
    */
   readonly bareKeyword?: boolean;
+  /**
+   * Generate an EXTRA, lower-priority pattern variant per listed role with
+   * that role (and its marker phrase) omitted entirely. For a REQUIRED role
+   * whose phrase is legitimately absent in valid hyperscript (`transition
+   * *max-height over 300ms` — no `to {goal}`): making the role optional
+   * inside the main pattern wraps its marker group as skippable and the bare
+   * value re-binds by particle metadata (verified regression, see the
+   * transition goal NOTE); a separate variant has no skippable group at all.
+   */
+  readonly omitRoleVariants?: ReadonlyArray<SemanticRole>;
   /** Notes about special handling */
   readonly notes?: string;
   /**
@@ -1616,6 +1626,9 @@ export const transitionSchema: CommandSchema = {
   description: 'Transition an element with animation',
   category: 'dom-visibility',
   primaryRole: 'patient',
+  // Goal-less `transition {patient} over {duration}` (slide-toggle) parses via
+  // a separate generated variant — see the goal role's required NOTE.
+  omitRoleVariants: ['goal'],
   roles: [
     {
       role: 'patient',
@@ -1648,7 +1661,9 @@ export const transitionSchema: CommandSchema = {
       // optional wraps its marker group as skippable and the bare value then
       // re-binds by particle metadata (`a 0` → destination:literal=0),
       // clobbering goal+duration capture in every marker language — verified
-      // regression, do not repeat. The goal-less form stays a residue item.
+      // regression, do not repeat. The goal-less form is covered by the
+      // SEPARATE `omitRoleVariants: ['goal']` pattern instead (no skippable
+      // group to re-bind).
       required: true,
       expectedTypes: ['literal', 'expression'],
       svoPosition: 2,

--- a/packages/semantic/src/generators/pattern-generator.ts
+++ b/packages/semantic/src/generators/pattern-generator.ts
@@ -230,6 +230,27 @@ export function generatePatternVariants(
     }
   }
 
+  // Omit-role variants: an EXTRA pattern per schema-listed role with that
+  // role (and its marker phrase) removed entirely. Covers a REQUIRED role
+  // whose phrase is legitimately absent in valid hyperscript (transition's
+  // goal: `transition *max-height over 300ms`, slide-toggle) — making the
+  // role optional inside the main pattern is the verified skippable-group
+  // re-binding regression (see the transition goal NOTE); a separate variant
+  // has no skippable group at all. Priority sits below the simple variant so
+  // any text carrying the role phrase always prefers the fuller patterns.
+  for (const omitted of schema.omitRoleVariants ?? []) {
+    const variantSchema: CommandSchema = {
+      ...schema,
+      roles: schema.roles.filter(r => r.role !== omitted),
+    };
+    const variant = generatePattern(variantSchema, profile, config);
+    patterns.push({
+      ...variant,
+      id: `${schema.action}-${profile.code}-generated-no-${omitted}`,
+      priority: (config.basePriority ?? 100) - 8,
+    });
+  }
+
   // Verb-first fallback for SOV languages (lower priority than the above).
   if (config.generateVerbFirstVariants !== false) {
     const verbFirst = generateVerbFirstPattern(schema, profile, config);

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -11492,3 +11492,80 @@ describe('bn জন্য duration postposition: consumed after the duration rec
     expect(actionsOf(node)).toContain('for');
   });
 });
+
+describe('goal-less transition variant (omitRoleVariants): `transition *max-height over 300ms` (spurious transition ×6, slide-toggle)', () => {
+  const role = (
+    node: Record<string, any> | null | undefined,
+    r: string
+  ): { type?: string; value?: unknown; raw?: unknown } | undefined =>
+    node?.roles instanceof Map ? node.roles.get(r) : undefined;
+
+  const findAction = (node: unknown, action: string): Record<string, any> | undefined => {
+    let hit: Record<string, any> | undefined;
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object' || hit) return;
+      const rec = n as Record<string, any>;
+      if (rec.action === action) {
+        hit = rec;
+        return;
+      }
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+      }
+    };
+    walk(node);
+    return hit;
+  };
+
+  it('[en] goal-less transition parses via the no-goal variant (was PARSE NULL)', () => {
+    // The goal role is required, deliberately (making it optional is the
+    // verified skippable-group re-binding regression — see the schema NOTE);
+    // the omit-role variant is a SEPARATE pattern with no goal group at all.
+    const node = parse('transition *max-height over 300ms', 'en') as unknown as Record<string, any>;
+    expect(node.action).toBe('transition');
+    expect(role(node, 'patient')?.type).toBe('selector');
+    expect(String(role(node, 'duration')?.value)).toBe('300ms');
+    expect(role(node, 'goal')).toBeUndefined();
+  });
+
+  it('[en] slide-toggle: the JUXTAPOSED trailing transition (no `then`) survives in the body', () => {
+    // en dropped the whole clause (the SOV six kept it via lax paths →
+    // precision-flagged spurious transition ×6 against the empty reference).
+    const node = parse(
+      'on click toggle .collapsed on next .panel transition *max-height over 300ms',
+      'en'
+    );
+    expect(findAction(node, 'toggle')).toBeDefined();
+    const tr = findAction(node, 'transition');
+    expect(tr).toBeDefined();
+    expect(String(role(tr!, 'duration')?.value)).toBe('300ms');
+  });
+
+  it('[en] the goal-ful form still parses via the FULL pattern with goal captured (no variant steal)', () => {
+    const node = parse('transition opacity to 0 over 500ms', 'en') as unknown as Record<string, any>;
+    expect(node.action).toBe('transition');
+    expect(String(role(node, 'goal')?.value)).toBe('0');
+    expect(String(role(node, 'duration')?.value)).toBe('500ms');
+  });
+
+  it('[es] corpus slide-toggle: bare-duration goal-less transition parses in a marker language', () => {
+    const node = parse('en clic alternar .collapsed a siguiente .panel entonces transición *max-height 300ms', 'es');
+    const tr = findAction(node, 'transition');
+    expect(tr).toBeDefined();
+    expect(role(tr!, 'patient')?.type).toBe('selector');
+    expect(String(role(tr!, 'duration')?.value)).toBe('300ms');
+    expect(findAction(node, 'toggle')).toBeDefined();
+  });
+
+  it('[es] the marker-language goal-ful transition keeps goal+duration (the do-not-repeat regression lock)', () => {
+    // transition-color, es render: goal `a "blue"` + bare duration. The
+    // optional-goal attempt re-bound `a "blue"` → destination and clobbered
+    // goal+duration in every marker language; the separate variant must not.
+    const node = parse('en clic transición *background-color a "blue" 500ms', 'es');
+    const tr = findAction(node, 'transition');
+    expect(tr).toBeDefined();
+    expect(String(role(tr!, 'goal')?.value)).toBe('blue');
+    expect(String(role(tr!, 'duration')?.value)).toBe('500ms');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-06T18:14:48.772Z",
-  "commit": "4cb1247b",
+  "timestamp": "2026-07-06T18:25:37.797Z",
+  "commit": "e613b855",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8579007041413049,
       "avgFidelity": 1,
-      "avgPrecision": 0.9720236326853975,
+      "avgPrecision": 0.9741881348498995,
       "avgRoleFidelity": 0.9716216216216217,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.9045096507502506,
       "avgFidelity": 1,
-      "avgPrecision": 0.9672348484848484,
+      "avgPrecision": 0.9693993506493506,
       "avgRoleFidelity": 0.9567406692406693,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6321,13 +6321,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8467689787238654,
       "avgFidelity": 1,
-      "avgPrecision": 0.978896103896104,
+      "avgPrecision": 0.9810606060606063,
       "avgRoleFidelity": 0.9716216216216217,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6953,13 +6953,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8417184736733602,
       "avgFidelity": 1,
-      "avgPrecision": 0.978896103896104,
+      "avgPrecision": 0.9810606060606063,
       "avgRoleFidelity": 0.9682432432432433,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9481,13 +9481,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
-      "avgPrecision": 0.9788961038961039,
+      "avgPrecision": 0.9810606060606061,
       "avgRoleFidelity": 0.9561776061776062,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12641,13 +12641,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8456558061821213,
       "avgFidelity": 1,
-      "avgPrecision": 0.9758928571428573,
+      "avgPrecision": 0.9780573593073594,
       "avgRoleFidelity": 0.9712241653418122,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486441,
+      "bundleSize": 486658,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 486441,
+      "size": 486658,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

L2 drill 3 (final) of the launch-bar burn-down — and it was **not** the feared juxtaposed-clause splitter arc: slide-toggle's `transition *max-height over 300ms` (goal-less, valid hyperscript) was **PARSE NULL in en isolation**. The generated transition pattern requires the `to {goal}` phrase this form omits, so en silently dropped the command while the SOV six kept it via lax paths — spurious transition ×6.

Making goal optional inside the main pattern is the documented skippable-group re-binding regression (the schema's do-not-repeat NOTE, kept). Instead:

- New `CommandSchema.omitRoleVariants` — generates a **separate**, lower-priority variant per listed role with that role (and its marker phrase) omitted entirely; no skippable group exists to re-bind.
- `transitionSchema` opts in with `['goal']`: 18 languages parse the goal-less form via `transition-*-generated-no-goal`, the SOV six keep their lax captures, and the destination default aligns via `fillSchemaDefaults` on both comparison sides.

With #592 (breakpoint ×6 + halt ×3) and #593 (bn জন্য, for ×14→×9), **L2 is complete**. Session-10 docs sync folded in per discipline (handoff status block, NEXT_STEPS status table + LAUNCH BAR inventory/actuals, L3 pre-probe notes).

## Verification

- A/B per-(lang,pattern) vs the drill-2 dist: **6 spurious cleared, 0 new**; census identical (3404); probe mean R1 0.9831 held.
- Baseline (regenerated against a fresh populate, committed): avgPrecision **0.9922 → 0.9928** (session total 0.9910 → 0.9928), parse 3696/3696, degenerate/lossy 0, R2 1.0.
- Six-signal `--regression` gate green; semantic suite 6579 passed; typecheck clean (build exit 0 after fixing an exactOptionalPropertyTypes violation).
- 5 guard tests: 3 stash-verified fail-without-fix + 2 goal-ful locks (en, plus the es marker-language shape from the original regression).
- Mirrors checked: adapter `generate:syntax` no-drift, i18n COMMAND_PRIMARY_ROLES untouched (goal stays required; no primaryRole change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)