### PR TITLE
fix(multilingual): he עם de-anchor + hi bare-event command peek — spurious on ×7 cleared (L3 drill 1)

### DIFF
--- a/packages/semantic/src/generators/profiles/he.ts
+++ b/packages/semantic/src/generators/profiles/he.ts
@@ -81,7 +81,9 @@ export const hebrewProfile: LanguageProfile = {
     hide: { primary: 'הסתר', alternatives: ['החבא'], normalized: 'hide' },
     transition: { primary: 'מעבר', alternatives: ['הנפש'], normalized: 'transition' },
     // Events
-    on: { primary: 'ב', alternatives: ['עם'], normalized: 'on' },
+    // NOTE: עם is he's WITH/style marker, NOT an event word — listing it as an
+    // `on` alternative anchored phantom handlers on `עם method:"POST"` tails.
+    on: { primary: 'ב', normalized: 'on' },
     trigger: { primary: 'הפעל', alternatives: ['שגר'], normalized: 'trigger' },
     send: { primary: 'שלח', normalized: 'send' },
     // DOM focus
@@ -177,13 +179,13 @@ export const hebrewProfile: LanguageProfile = {
     prefixes: ['ה', 'ו', 'ב', 'כ', 'ל', 'מ', 'ש'], // Common Hebrew prefixes
   },
   eventHandler: {
-    keyword: { primary: 'ב', alternatives: ['עם'], normalized: 'on' },
+    keyword: { primary: 'ב', normalized: 'on' },
     sourceMarker: { primary: 'מ', alternatives: ['מאת'], position: 'before' },
     conditionalKeyword: { primary: 'כאשר', alternatives: ['כש', 'אם'] },
     // Event marker: ב (at/upon), used in SVO pattern
     // Pattern: ב [event] [verb] [patient] על [destination?]
     // Example: בלחיצה החלף .active על #button
-    eventMarker: { primary: 'ב', alternatives: ['כש', 'עם'], position: 'before' },
-    temporalMarkers: ['כאשר', 'כש', 'עם'], // temporal conjunctions (when)
+    eventMarker: { primary: 'ב', alternatives: ['כש'], position: 'before' },
+    temporalMarkers: ['כאשר', 'כש'], // temporal conjunctions (when); עם is the WITH marker, not temporal
   },
 };

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -773,9 +773,12 @@ export class SemanticParserImpl implements ISemanticParser {
           // are bare identifiers like click/keyup). This is a bare COMMAND whose
           // fronted operand the bare-event pattern grabbed: the SOV `bind`
           // (`$greeting को #name-input में bind` → mis-anchors `$greeting` as the
-          // event). Prefer a full command parse when one exists; if no command
+          // event). Same for a non-event `expression` lead (`Draggable को इंस्टॉल`
+          // mis-anchors `Draggable` as the event and the verb-anchoring fallback
+          // fabricates a junk install body — phantom handler, R0-precision).
+          // Prefer a full command parse when one exists; if no command
           // matches, keep the existing event-handler build (no parse-rate change).
-          if (ev?.type === 'reference') {
+          if (ev?.type === 'reference' || ev?.type === 'expression') {
             tokens.reset(eventStart); // rewind past the consumed bare event
             const commandPatterns = sortedPatterns.filter(p => p.command !== 'on');
             const cmdPeek = patternMatcher.matchBest(tokens, commandPatterns);

--- a/packages/semantic/src/patterns/event-handler.ts
+++ b/packages/semantic/src/patterns/event-handler.ts
@@ -2082,7 +2082,9 @@ function getEventHandlerPatternsHe(): LanguagePattern[] {
       template: {
         format: 'כאשר {event} {body}',
         tokens: [
-          { type: 'literal', value: 'כאשר', alternatives: ['כש', 'עם'] },
+          // עם is he's WITH marker (fetch/render `עם method:"POST"` tails) — an
+          // event alternative here anchored phantom second handlers on those tails.
+          { type: 'literal', value: 'כאשר', alternatives: ['כש'] },
           { type: 'role', role: 'event' },
         ],
       },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -11569,3 +11569,107 @@ describe('goal-less transition variant (omitRoleVariants): `transition *max-heig
     expect(String(role(tr!, 'duration')?.value)).toBe('500ms');
   });
 });
+
+describe('he עם de-anchoring + hi bare-event command peek (spurious on ×7 drill, L3)', () => {
+  const role = (
+    node: Record<string, any> | null | undefined,
+    r: string
+  ): { type?: string; value?: unknown; raw?: unknown } | undefined =>
+    node?.roles instanceof Map ? node.roles.get(r) : undefined;
+
+  const actionsOf = (node: unknown): string[] => {
+    const flat: string[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec.action);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'eventHandlers', 'initBlock', 'initCommands']) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return flat;
+  };
+
+  const findAction = (node: unknown, action: string): Record<string, any> | undefined => {
+    let hit: Record<string, any> | undefined;
+    const walk = (n: unknown): void => {
+      if (hit || !n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (rec.action === action) { hit = rec; return; }
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'eventHandlers', 'initBlock', 'initCommands']) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return hit;
+  };
+
+  it('[he] fetch-with-method: the עם tail never spawns a phantom second handler', () => {
+    // עם is he's WITH marker; listing it as a "when"/on event alternative let
+    // the unconsumed `עם method:"POST" body:form` tail anchor event-he-when
+    // (event=expression:"method") — a phantom second `on` (spurious on ×6).
+    const node = parse('ב שליחה הבא את /api/form עם method:"POST" body:form', 'he');
+    const actions = actionsOf(node);
+    expect(actions.filter(a => a === 'on')).toHaveLength(1);
+    expect(actions).toContain('fetch');
+  });
+
+  it('[he] render-template-with-data: single handler AND the style role reclaimed from the stolen tail', () => {
+    const node = parse('ב לחיצה רנדר את #user-list עם users: $data אז שים את זה על #container', 'he');
+    const actions = actionsOf(node);
+    expect(actions.filter(a => a === 'on')).toHaveLength(1);
+    const render = findAction(node, 'render');
+    expect(render).toBeDefined();
+    // Pre-fix the phantom split consumed the עם phrase — style was lost.
+    expect(String(role(render!, 'style')?.raw ?? role(render!, 'style')?.value)).toBe('users');
+    expect(findAction(node, 'put')).toBeDefined();
+  });
+
+  it('[he] swap-content: עם still works as the with/style marker (both-ways lock)', () => {
+    const node = parse('ב לחיצה החלף את #a עם #b', 'he') as unknown as Record<string, any>;
+    const actions = actionsOf(node);
+    expect(actions.filter(a => a === 'on')).toHaveLength(1);
+    const swap = findAction(node, 'swap');
+    expect(swap).toBeDefined();
+    expect(String(role(swap!, 'patient')?.value)).toBe('#b');
+  });
+
+  it('[he] כאשר still anchors event-he-when (the surviving alternative)', () => {
+    const node = parse('כאשר click הסתר את #modal', 'he') as unknown as Record<string, any>;
+    expect(node.kind).toBe('event-handler');
+    expect(String(role(node, 'event')?.value)).toBe('click');
+    expect(findAction(node, 'hide')).toBeDefined();
+  });
+
+  it('[hi] install-behavior: `Draggable को इंस्टॉल` is an install command, not a phantom handler', () => {
+    // event-hi-bare (single `{event}` token) grabbed the leading identifier as
+    // the event and the SOV verb-anchoring fallback fabricated a junk install
+    // body (patient=literal:"को") — spurious on ×1. The bare-event guard's
+    // command peek now also covers non-event `expression` leads.
+    const node = parse('Draggable को इंस्टॉल', 'hi') as unknown as Record<string, any>;
+    expect(node.action).toBe('install');
+    expect(String(role(node, 'patient')?.raw ?? role(node, 'patient')?.value)).toBe('Draggable');
+    expect(actionsOf(node)).not.toContain('on');
+  });
+
+  it('[hi] a genuine bare literal event still wraps a handler', () => {
+    const node = parse('क्लिक .active को टॉगल', 'hi') as unknown as Record<string, any>;
+    expect(node.kind).toBe('event-handler');
+    expect(String(role(node, 'event')?.value)).toBe('click');
+    expect(findAction(node, 'toggle')).toBeDefined();
+  });
+
+  it('[hi] window-resize corpus line still parses (census / parse-rate lock)', () => {
+    // This junk-shaped render (`debounced at 200ms` survives untranslated) parses
+    // ONLY via event-hi-bare's expression anchor; the guard must stay a PEEK —
+    // when no command pattern matches the full stream, the handler build is kept.
+    const node = parse('debounced at 200ms adjustLayout() को आकार_बदलें पर कॉल विंडो से', 'hi');
+    expect(node).not.toBeNull();
+    expect(actionsOf(node)).toContain('call');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-06T18:25:37.797Z",
-  "commit": "e613b855",
+  "timestamp": "2026-07-06T23:31:05.453Z",
+  "commit": "454e60c2",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3793,13 +3793,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8284065141207998,
       "avgFidelity": 1,
-      "avgPrecision": 0.987012987012987,
-      "avgRoleFidelity": 0.9887387387387386,
+      "avgPrecision": 0.9983766233766234,
+      "avgRoleFidelity": 0.990990990990991,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.9045096507502506,
       "avgFidelity": 1,
-      "avgPrecision": 0.9693993506493506,
-      "avgRoleFidelity": 0.9567406692406693,
+      "avgPrecision": 0.9726461038961038,
+      "avgRoleFidelity": 0.9601190476190474,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486658,
+      "bundleSize": 486667,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 486658,
+      "size": 486667,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

L3 drill 1 of the launch bar: the last remaining >×5 spurious family after `default`/`for`/`empty`/`call` — **spurious `on` ×7** — cleared via two mechanisms:

### he ×6 — עם de-anchored from event patterns
All six are with-phrase patterns (fetch-with-method/-headers/-method-body, fetch-formdata, render-template-with-data, morph-with-template). עם is he's WITH/style marker, but it was **also** listed as an event alternative in `event-he-when`, `keywords.on`, `eventHandler.keyword`, `eventMarker`, and `temporalMarkers`. The unconsumed `עם method:"POST" …` tail after fetch-he/render-he captured the head anchored a phantom second handler (`event=expression:"method"`). עם is removed from every event-anchoring site (ב/כאשר/כש remain); the with-phrase tail now drops exactly like en's does. Bonus: he render reclaims the stolen `style` role (missing `render.style:expression` ×14→×12).

### hi ×1 — bare-event guard command peek extended to expression leads
`event-hi-bare` (single `{event}` token) grabbed the leading identifier of `Draggable को इंस्टॉल` as the event, and the SOV verb-anchoring fallback fabricated a junk install body (patient=को). The existing bare-event mis-anchor guard's command peek was gated to `reference` leads only; extended to non-event `expression` leads. The peek stays conservative: window-resize / worker-basic hi (junk-shaped renders that parse ONLY via the bare anchor) are byte-identical — census intact.

## Verification

- A/B per-(lang,pattern) corpus diff: **spurious on ×7 cleared + 3 missing entries cleared (he render.style ×2, hi install.patient ×1), ZERO new entries**; parse-coverage census identical (3404)
- Baseline avgPrecision **0.9928 → 0.9934**, probe mean R1 0.9831 → 0.9833, parse 3696/3696, degenerate/lossy 0
- Six-signal `--regression` gate green; baseline regenerated against a fresh populate
- 7 guard tests (3 stash-verified failing pre-fix; 4 both-ways locks: he עם-as-with swap, he כאשר handler, hi bare literal event, hi census lock)
- Full semantic suite: 6591 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)