### PR TITLE
fix(multilingual): trailing-optional-slot verb guard — spurious call ×7 cleared, en+16 enriched together (L3 complete) + session-11 docs sync

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+# Internal working docs: blockquote-heavy prose (handoffs, session logs) where
+# prettier's markdown normalization has repeatedly mangled near-ambiguous
+# constructs (line-leading +/* continuations read as list bullets, bold spans
+# split and escaped to \*\*). CI runs no prettier --check, so this only
+# affects the lint-staged hook and editors. Outward-facing markdown (README,
+# docs/, CLAUDE.md) stays formatted.
+docs-internal/

--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -1,5 +1,59 @@
 # Handoff — R1 residue after the five-cluster triage (fronted repeat-while · sw kama homonym · singletons)
 
+> **STATUS UPDATE (2026-07-06, session 11 = L3 of the launch bar): both L3
+> drills LANDED — #595 (spurious on ×7: he עם de-anchor + hi bare-event
+> command peek) and the halt-verb-guard drill in this PR (spurious call ×7,
+> which was en-noise ×17-wide).** Post-session state: baseline avgPrecision
+> **0.9928 → 0.9939** (+0.0011 across two drills), probe mean R1 **0.9831 →
+> 0.9838**, parse 3696/3696, degenerate/lossy 0, R2 1.0. Per-(lang,pattern)
+> A/B across both: **14 spurious + 10 missing cleared, 0 new**; census
+> identical (3404). Remaining >×5 families: **default ×9, for ×9, empty ×8** —
+> L4 must carry ~0.0011 to reach the 0.995 precision bar.
+>
+> 1. **#595 — spurious on ×7 (two mechanisms, as pre-probed).** he ×6: עם
+>    (the WITH/style marker) was listed as an event alternative in FIVE
+>    places — event-he-when alternatives, keywords.on, eventHandler.keyword,
+>    eventMarker, temporalMarkers — so the with-tail left after
+>    fetch-he/render-he captured the head (`עם method:"POST" body:form`)
+>    anchored a phantom second handler (event=expression:"method"). Removed
+>    from all five; the tail now drops exactly like en's (en never lists
+>    "with" as an event word — that asymmetry WAS the bug). Bonus: he render
+>    reclaims the tail-stolen `style` role. hi ×1 (install-behavior):
+>    event-hi-bare + the SOV verb-anchoring fallback fabricated
+>    handler(event=Draggable)+install(patient=को); the bare-event guard's
+>    command peek extended from `reference` to non-event `expression` leads.
+>    The peek stays conservative — window-resize/worker-basic hi (junk-shaped
+>    renders that parse ONLY via the bare anchor) byte-identical, census
+>    intact. 7 guard tests (3 stash-verified).
+> 2. **PR 2 — spurious call ×7 was really an en+16 drop.** The corpus line
+>    (`if event.ctrlKey halt call saveDocument() end`) loses call because
+>    halt's OPTIONAL TRAILING patient slot swallows the juxtaposed verb
+>    (patient=literal:"call") — in en and 16 SVO languages at once; the SOV
+>    seven split verb-first and kept it. Fix: a trailing optional role slot
+>    (nextPatternToken === undefined, now threaded through matchGroupToken →
+>    matchTokenSequence) never captures a keyword token whose normalized form
+>    is in commandSchemas. All 24 languages now capture call with the
+>    IDENTICAL patient=expression:"saveDocument()" — the pre-probe's
+>    role-alignment check made this a zero-honest-dip landing. Scoping
+>    lesson (cost one iteration): an UNSCOPED verb-skip let ja's no-goal
+>    transition variant complete sloppily — a MID-pattern optional slot must
+>    capture-and-FAIL so the verb-anchoring fallback reclaims goal+duration.
+>    Final-slot scoping + a ja lock test. 4 guard tests (2 stash-verified).
+>
+> **L4 next (default ×9 — pre-probed this session, an en-noise INVERSION):**
+> en parses `on load default my @data-count to "0"` WITHOUT the default
+> action; ar/bn/hi/it/ja/ko/th/tl/tr keep it with junk roles (ja/ko fused
+> possessive patient=literal:"私の@data-count" destination=literal:"0"; ar
+> destination=property-path:"undefined"; it roleless via
+> event-handler-it-full). The en enrichment (possessive + property-path +
+> to-marker) must land WITH the nine's alignment — see the in-code NOTE at
+> defaultSchema.destination. Also on the radar: for ×9 (take-class ×6
+> own-arc + behaviors bn ×3 post-launch), empty ×8, morph-with-template
+> render.style missing ×12 (six SOV langs need to GAIN the style capture —
+> en's value is truncated to the param name, a value bug invisible to R0/R1;
+> do NOT fix by removing en's capture). Hygiene: language-grammar.ts is ~890
+> lines stale vs profiles (no drift guard) — regenerate in its own increment.
+
 > **STATUS UPDATE (2026-07-06, session 10 = L2 of the launch bar): all three
 > pre-probed L2 drills LANDED — #592 (breakpoint ×6 + halt ×3), #593 (bn জন্য
 > transition-half of for ×14→×9) and the goal-less transition variant ×6 in

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -9,7 +9,7 @@
 > [BEHAVIORS_CONSOLIDATION_PLAN.md](BEHAVIORS_CONSOLIDATION_PLAN.md). Read this first,
 > then dive into those for the per-arc detail.
 
-## Where we are (2026-07-06 baseline · post session-10 / L2 · `browser-priority`)
+## Where we are (2026-07-06 baseline · post session-11 / L3 · `browser-priority`)
 
 Authoritative source: `packages/testing-framework/baselines/multilingual-priority.json`
 (its `timestamp` + `commit` fields stamp each regen). 24 langs × 154 patterns = 3696.
@@ -21,8 +21,8 @@ Authoritative source: `packages/testing-framework/baselines/multilingual-priorit
 | lossy passes (0.5 ≤ fid < 1.0) | **0**                  | band cleared (#495–#506), holding                         |
 | faithful (fid = 1.0)           | **3696**               | every parsing pattern is faithful                         |
 | avgFidelity (R0-recall)        | **1.000**              | saturated                                                 |
-| avgPrecision (R0 trust floor)  | **0.993**              | session-10 / L2 drills: 0.9910 → 0.9928 (three drills)    |
-| avgRoleFidelity (R1)           | **0.983**              | 0.9831, held through session-10                           |
+| avgPrecision (R0 trust floor)  | **0.994**              | session-11 / L3 drills: 0.9928 → 0.9939 (two drills)      |
+| avgRoleFidelity (R1)           | **0.984**              | 0.9831 → 0.9838 (L3 side-effect: reclaimed roles)         |
 | avgExecutionFidelity (R2)      | **1.000**              | 47-pattern curated subset fully reproduces en DOM effects |
 
 The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recall ·
@@ -40,13 +40,13 @@ normal usage). The bar, all four together:
 1. **All en-facing parser gaps closed.** Every remaining en-noise inversion is
    a real English-parser bug (en `go back` / `add "content"` didn't parse
    until #588/#589) — user-visible to English users regardless of the metric.
-2. **Every spurious family larger than ×5 cleared** (post-session-10 inventory:
+2. **Every spurious family larger than ×5 cleared** (post-session-11 inventory:
    ~~morph ×18~~ ✓L1, for ×14→×9 (transition half ✓L2; remainder = take-class
    ×6 own-arc + wait-payload behaviors ×3 post-launch), ~~add ×11 draggable~~
-   ✓L1, default ×9, empty ×8, call ×7, on ×7 he, ~~transition ×6~~ ✓L2,
-   ~~breakpoint ×6~~ ✓L2 (+halt ×3 sibling).
-3. **avgPrecision ≥ 0.995** (0.9928 as of session 10).
-4. **avgRoleFidelity ≥ 0.985** (0.9831 as of session 10) — the big R1-missing
+   ✓L1, default ×9, empty ×8, ~~call ×7~~ ✓L3, ~~on ×7 he~~ ✓L3,
+   ~~transition ×6~~ ✓L2, ~~breakpoint ×6~~ ✓L2 (+halt ×3 sibling).
+3. **avgPrecision ≥ 0.995** (0.9939 as of session 11).
+4. **avgRoleFidelity ≥ 0.985** (0.9838 as of session 11) — the big R1-missing
    families (add.patient:selector ×20, toggle.patient:expression ×19,
    fetch.source:literal ×18, set.patient:literal ×16,
    bind.source:property-path ×14) carry most of this.
@@ -58,7 +58,7 @@ across sessions 4–8, full discipline included). Sequencing:
 | ------- | -------------------------------------------------------------------- | ------------------------- |
 | L1 ✓    | morph ×18 + draggable add fold+cleanup ×11 (#590 + session-9 PR 2)   | precision 0.9891 → 0.9910 |
 | L2 ✓    | breakpoint ×6+halt ×3 + bn `for` transition-half ×5 + transition ×6  | precision 0.9910 → 0.9928 |
-| L3      | he/zh marker cluster (on ×7 he, call ×7; toggle shrank to ×1 in L2)  | precision, en gaps        |
+| L3 ✓    | on ×7 he/hi (#595) + call ×7 halt-verb-guard (session-11 PR 2)       | precision 0.9928 → 0.9939 |
 | L4      | default-value full drill (13 langs, markers + possessives)           | en gaps, R1               |
 | L5–L6   | big R1-missing families (add/toggle patient, fetch/bind source, set) | R1 → ≥0.985               |
 
@@ -69,6 +69,9 @@ possibly part of L4) rather than L1+L2 alone. L2 actual: +0.0018 for 20
 entries (#592, #593, session-10 PR 3) — on the same slope; after L2 the
 remaining >×5 inventory is default ×9, for ×9 (two sub-arcs, see bar item 2),
 empty ×8, call ×7, on ×7 he, so L3+L4 must carry ~0.0022 to reach 0.995.
+L3 actual: +0.0011 for 14 spurious + 10 missing entries cleared (#595 +
+session-11 PR 2) — remaining >×5 inventory is default ×9 (en-noise inversion,
+the L4 drill), for ×9, empty ×8, so L4 must carry ~0.0011 to reach 0.995.
 
 **Post-launch track (ratchet-protected, not launch-blocking):** SOV-six role
 polish (qu/hi ~0.956 R1), tr remove.patient block-walk leak, spurious empty
@@ -79,6 +82,56 @@ fail CI.
 Caveats: each en enrichment can mint honest-dip entries (bounded by the
 census/A-B discipline; historically <1 session total), and this scopes the
 fidelity grind only — docs/demo/npm-publish polish is separate scope.
+
+> **Update 2026-07-06f (SESSION 11 = L3, two drills: #595 and this PR;
+> avgPrecision 0.9928 → 0.9939, probe mean R1 0.9831 → 0.9838; A/B 14
+> spurious and 10 missing cleared / 0 new across the two; census identical
+> (3404); gate green; baseline regenerated per-PR.)**
+>
+> - **#595 — spurious on ×7 (he ×6 + hi ×1, two mechanisms as pre-probed).**
+>   he: עם is the WITH/style marker but was ALSO an event alternative in five
+>   places (event-he-when, keywords.on, eventHandler.keyword, eventMarker,
+>   temporalMarkers) — the unconsumed with-tail after fetch-he/render-he
+>   anchored a phantom second handler. עם removed from every event-anchoring
+>   site; the tail now drops exactly like en's. Bonus: he render reclaims the
+>   stolen `style` role (missing render.style ×14→×12). hi (install-behavior):
+>   event-hi-bare grabbed the leading `Draggable` as the event and the SOV
+>   verb-anchoring fallback fabricated a junk install body — the existing
+>   bare-event guard's command PEEK extended from `reference` to non-event
+>   `expression` leads; window-resize/worker-basic hi (junk renders that parse
+>   ONLY via the bare anchor) stay byte-identical, census intact.
+> - **PR 2 — spurious call ×7 was en-noise ×17-wide (bar item 1).** halt's
+>   optional trailing patient swallowed the juxtaposed next verb
+>   (`… halt call saveDocument()` → patient=literal:"call") in en AND 16 SVO
+>   languages; the SOV seven split verb-first and kept call. New
+>   pattern-matcher guard: a TRAILING optional role slot (nextPatternToken
+>   undefined, threaded through groups) never captures a keyword whose
+>   normalized form is a registered command action. All 24 languages now
+>   capture call with the identical patient=expression:"saveDocument()" —
+>   zero honest dips. The FINAL-slot scoping is load-bearing: an earlier
+>   unscoped draft let ja's no-goal transition variant complete sloppily
+>   (mid-pattern duration/style slots must capture-and-FAIL so the
+>   verb-anchoring fallback reclaims goal+duration — locked by test).
+> - **L4 pre-probed (default ×9 = an en-noise INVERSION, bar item 1):** en
+>   itself parses `on load default my @data-count to "0"` WITHOUT the default
+>   action (reference wrong); ar/bn/hi/it/ja/ko/th/tl/tr keep it but with
+>   misaligned junk roles (ja/ko fused possessive patient=literal:"私の@data-count"
+>   destination=literal:"0"; ar destination=property-path:"undefined"; it via
+>   event-handler-it-full, roleless). The en enrichment (possessive +
+>   property-path + to-marker) must land WITH the nine's role alignment — the
+>   in-code NOTE at defaultSchema.destination stands, ~2 roles × 9 langs of
+>   honest dips if en-only.
+> - **morph-with-template missing ×7 re-probed post-he-drill (now ×12 across
+>   render-template-with-data + morph-with-template, six SOV langs):** en's
+>   style capture is real but value-truncated (`style=expression:"row"` — the
+>   param NAME; `$data` dropped, a value bug invisible to R0/R1). The six need
+>   to GAIN style:expression (SOV with-phrase capture), NOT en losing it —
+>   en-side removal would delete genuine template-param info. L4+ scope.
+> - **Hygiene flag:** `packages/semantic/src/parser/generated/language-grammar.ts`
+>   is ~890 lines stale vs current profiles (regeneration produces real new
+>   keyword entries; no CI drift guard exists). Deliberately NOT folded into
+>   the L3 PRs (עם stays in the map either way — zero semantic overlap);
+>   regenerate in its own increment, ideally with a drift guard.
 
 > **Update 2026-07-06e (SESSION 10 = L2, three drills across #592, #593 and
 > this PR; avgPrecision 0.9910 → 0.9928, probe mean R1 0.9831 held; A/B 20

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -173,7 +173,12 @@ export class PatternMatcher {
   private matchTokenSequence(
     tokens: TokenStream,
     patternTokens: PatternToken[],
-    captured: Map<SemanticRole, SemanticValue>
+    captured: Map<SemanticRole, SemanticValue>,
+    // What follows the sequence itself — a GROUP's last inner token must see the
+    // token after the group as its `next` (the trailing-slot verb guard in
+    // matchRoleToken keys on nextPatternToken === undefined meaning "pattern
+    // truly ends here", and a mid-pattern single-token group is not the end).
+    nextAfterSequence?: PatternToken
   ): boolean {
     // Skip leading conjunctions for Arabic (proclitics: و, ف, ول, وب, etc.)
     // BUT NOT if the pattern explicitly expects a conjunction (proclitic patterns)
@@ -208,7 +213,12 @@ export class PatternMatcher {
         this.tryConsumeEventSourceClause(tokens, captured, patternToken);
       }
 
-      const matched = this.matchPatternToken(tokens, patternToken, captured, patternTokens[i + 1]);
+      const matched = this.matchPatternToken(
+        tokens,
+        patternToken,
+        captured,
+        patternTokens[i + 1] ?? nextAfterSequence
+      );
 
       sourceWindow =
         patternToken.type === 'role' && patternToken.role === 'event'
@@ -292,7 +302,7 @@ export class PatternMatcher {
         return this.matchRoleToken(tokens, patternToken, captured, nextPatternToken);
 
       case 'group':
-        return this.matchGroupToken(tokens, patternToken, captured);
+        return this.matchGroupToken(tokens, patternToken, captured, nextPatternToken);
 
       default:
         return false;
@@ -532,6 +542,32 @@ export class PatternMatcher {
       const norm = (token.normalized ?? token.value).toLowerCase();
       if (PatternMatcher.POSITIONAL_OR_SCOPE_KEYWORDS.has(norm)) {
         return patternToken.optional || false;
+      }
+    }
+
+    // A TRAILING optional role slot never captures a bare command VERB. halt's
+    // optional patient (`halt {patient}`, patient is the pattern's last token)
+    // otherwise swallows the juxtaposed next command's keyword — `… halt call
+    // saveDocument()` → patient=literal:"call" — and the call drops from the en
+    // reference AND every same-path language (window-keydown, en + 16 SVO
+    // languages; the SOV seven split verb-first and kept it). Scoped to the
+    // FINAL slot only (nextPatternToken undefined): a mid-pattern optional slot
+    // must keep capturing the verb and failing the pattern — that failure is
+    // load-bearing (ja `opacity を 遷移 0 に 300ms`: the no-goal variant's
+    // duration/style slots capture 遷移, the pattern fails, and the richer
+    // verb-anchoring fallback reclaims goal+duration; skipping instead lets the
+    // sloppy pattern complete and strand the tail). Also away from
+    // `event`/`action` roles, which carry their own bespoke guards above.
+    if (
+      patternToken.optional &&
+      nextPatternToken === undefined &&
+      patternToken.role !== 'event' &&
+      patternToken.role !== 'action' &&
+      token.kind === 'keyword'
+    ) {
+      const verbNorm = (token.normalized ?? token.value).toLowerCase();
+      if (verbNorm in commandSchemas) {
+        return true; // skip the optional slot; the verb starts the next command
       }
     }
 
@@ -2109,14 +2145,20 @@ export class PatternMatcher {
   private matchGroupToken(
     tokens: TokenStream,
     patternToken: PatternToken & { type: 'group' },
-    captured: Map<SemanticRole, SemanticValue>
+    captured: Map<SemanticRole, SemanticValue>,
+    nextPatternToken?: PatternToken
   ): boolean {
     const mark = tokens.mark();
 
     // Track which roles were captured before this group
     const capturedBefore = new Set(captured.keys());
 
-    const success = this.matchTokenSequence(tokens, patternToken.tokens, captured);
+    const success = this.matchTokenSequence(
+      tokens,
+      patternToken.tokens,
+      captured,
+      nextPatternToken
+    );
 
     if (!success) {
       tokens.reset(mark);

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -11673,3 +11673,72 @@ describe('he עם de-anchoring + hi bare-event command peek (spurious on ×7 dri
     expect(actionsOf(node)).toContain('call');
   });
 });
+
+describe('trailing optional slot never captures a command verb (halt swallows juxtaposed call — spurious call ×7 / en-noise drill, L3)', () => {
+  const role = (
+    node: Record<string, any> | null | undefined,
+    r: string
+  ): { type?: string; value?: unknown; raw?: unknown } | undefined =>
+    node?.roles instanceof Map ? node.roles.get(r) : undefined;
+
+  const walkNodesL3 = (node: unknown): Record<string, any>[] => {
+    const flat: Record<string, any>[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'eventHandlers', 'initBlock', 'initCommands']) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return flat;
+  };
+
+  it('[en] window-keydown: the if-branch keeps BOTH halt and call with the call patient captured', () => {
+    // halt-en-generated's optional trailing patient swallowed the juxtaposed
+    // `call` keyword (patient=literal:"call") and saveDocument() stranded —
+    // the en reference lost the call, reading the seven SOV keepers as
+    // spurious call ×7 while 16 SVO languages silently dropped it too.
+    const node = parse('on keydown[key=="s"] from window if event.ctrlKey halt call saveDocument() end', 'en');
+    const nodes = walkNodesL3(node);
+    const halt = nodes.find(r => r.action === 'halt');
+    expect(halt).toBeDefined();
+    expect(role(halt!, 'patient')).toBeUndefined();
+    const call = nodes.find(r => r.action === 'call');
+    expect(call).toBeDefined();
+    expect(String(role(call!, 'patient')?.raw ?? role(call!, 'patient')?.value)).toBe('saveDocument()');
+  });
+
+  it('[de] the same-path SVO language enriches together with en (no honest dip)', () => {
+    const node = parse('bei keydown[key=="s"] von fenster falls event.ctrlKey anhalten aufrufen saveDocument() ende', 'de');
+    const nodes = walkNodesL3(node);
+    expect(nodes.find(r => r.action === 'halt')).toBeDefined();
+    const call = nodes.find(r => r.action === 'call');
+    expect(call).toBeDefined();
+    expect(String(role(call!, 'patient')?.raw ?? role(call!, 'patient')?.value)).toBe('saveDocument()');
+  });
+
+  it('[en] halt still captures its legitimate non-verb patients (both-ways lock)', () => {
+    const theEvent = parse('halt the event', 'en') as unknown as Record<string, any>;
+    expect(theEvent.action).toBe('halt');
+    expect(String(role(theEvent, 'patient')?.value)).toBe('event');
+    const bubbling = parse('halt bubbling', 'en') as unknown as Record<string, any>;
+    expect(bubbling.action).toBe('halt');
+    expect(String(role(bubbling, 'patient')?.raw ?? role(bubbling, 'patient')?.value)).toBe('bubbling');
+  });
+
+  it('[ja] a mid-pattern optional group slot still captures-and-fails on a verb (goal reclaim lock)', () => {
+    // The guard is scoped to the pattern's FINAL slot (nextPatternToken
+    // undefined, threaded through groups): the ja no-goal variant's mid-pattern
+    // duration/style group slots must keep capturing 遷移 and failing the
+    // pattern so the verb-anchoring fallback reclaims goal+duration.
+    const node = parse('クリック で 私 から もし effect である "fade" opacity を 遷移 0 に 300ms 終わり', 'ja');
+    const transition = walkNodesL3(node).find(r => r.action === 'transition');
+    expect(transition).toBeDefined();
+    expect(String(role(transition!, 'goal')?.value)).toBe('0');
+    expect(String(role(transition!, 'duration')?.value)).toBe('300ms');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-06T23:31:05.453Z",
-  "commit": "454e60c2",
+  "timestamp": "2026-07-06T23:43:30.029Z",
+  "commit": "2ff17cf6",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8579007041413049,
       "avgFidelity": 1,
-      "avgPrecision": 0.9741881348498995,
-      "avgRoleFidelity": 0.9716216216216217,
+      "avgPrecision": 0.9758115114732762,
+      "avgRoleFidelity": 0.9733108108108108,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1270,7 +1270,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.828035456606883,
+      "avgConfidence": 0.8261801690373097,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgRoleFidelity": 0.9838320463320464,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1345,10 +1345,6 @@
           "confidence": 1
         },
         "default-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
           "success": true,
           "confidence": 1
         },
@@ -1692,6 +1688,10 @@
           "success": true,
           "confidence": 0.7142857142857143
         },
+        "tell-command": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "call-function": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2527,7 +2527,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8338074623788887,
+      "avgConfidence": 0.8319521748093155,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgRoleFidelity": 0.9904279279279278,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -2602,10 +2602,6 @@
           "confidence": 1
         },
         "default-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
           "success": true,
           "confidence": 1
         },
@@ -2957,6 +2953,10 @@
           "success": true,
           "confidence": 0.7142857142857143
         },
+        "tell-command": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "call-function": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -3159,7 +3159,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8247371675943084,
+      "avgConfidence": 0.8228818800247351,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgRoleFidelity": 0.9838320463320464,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3234,10 +3234,6 @@
           "confidence": 1
         },
         "default-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
           "success": true,
           "confidence": 1
         },
@@ -3570,6 +3566,10 @@
           "confidence": 0.7142857142857143
         },
         "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-command": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -3793,13 +3793,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8284065141207998,
       "avgFidelity": 1,
-      "avgPrecision": 0.9983766233766234,
-      "avgRoleFidelity": 0.990990990990991,
+      "avgPrecision": 1,
+      "avgRoleFidelity": 0.9926801801801801,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.9045096507502506,
       "avgFidelity": 1,
-      "avgPrecision": 0.9726461038961038,
-      "avgRoleFidelity": 0.9601190476190474,
+      "avgPrecision": 0.9742694805194805,
+      "avgRoleFidelity": 0.9618082368082366,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5055,7 +5055,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.838961038961037,
+      "avgConfidence": 0.8371057513914636,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgRoleFidelity": 0.9862451737451738,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5134,10 +5134,6 @@
           "confidence": 1
         },
         "default-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
           "success": true,
           "confidence": 1
         },
@@ -5489,6 +5485,10 @@
           "success": true,
           "confidence": 0.7142857142857143
         },
+        "tell-command": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "call-function": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -5687,7 +5687,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8364873222016058,
+      "avgConfidence": 0.8346320346320326,
       "avgFidelity": 1,
       "avgPrecision": 0.9945887445887447,
       "avgRoleFidelity": 0.9979086229086228,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5770,10 +5770,6 @@
           "confidence": 1
         },
         "default-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
           "success": true,
           "confidence": 1
         },
@@ -6114,6 +6110,10 @@
           "confidence": 0.7142857142857143
         },
         "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-command": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -6321,13 +6321,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8467689787238654,
       "avgFidelity": 1,
-      "avgPrecision": 0.9810606060606063,
-      "avgRoleFidelity": 0.9716216216216217,
+      "avgPrecision": 0.9826839826839829,
+      "avgRoleFidelity": 0.9733108108108108,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6953,13 +6953,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8417184736733602,
       "avgFidelity": 1,
-      "avgPrecision": 0.9810606060606063,
-      "avgRoleFidelity": 0.9682432432432433,
+      "avgPrecision": 0.9826839826839829,
+      "avgRoleFidelity": 0.9699324324324325,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7583,7 +7583,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8377241805813213,
+      "avgConfidence": 0.8358688930117478,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgRoleFidelity": 0.9881756756756759,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7658,10 +7658,6 @@
           "confidence": 1
         },
         "default-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
           "success": true,
           "confidence": 1
         },
@@ -8010,6 +8006,10 @@
           "confidence": 0.7142857142857143
         },
         "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-command": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -8215,7 +8215,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.807173778602348,
+      "avgConfidence": 0.8053184910327746,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgRoleFidelity": 0.9867599742599743,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8262,10 +8262,6 @@
           "confidence": 1
         },
         "send-with-detail": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
           "success": true,
           "confidence": 1
         },
@@ -8669,6 +8665,10 @@
           "success": true,
           "confidence": 0.7142857142857143
         },
+        "tell-command": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "call-function": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -8847,7 +8847,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7984333127190251,
+      "avgConfidence": 0.7965780251494518,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgRoleFidelity": 0.9893018018018019,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8894,10 +8894,6 @@
           "confidence": 1
         },
         "send-with-detail": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
           "success": true,
           "confidence": 1
         },
@@ -9270,6 +9266,10 @@
           "confidence": 0.7142857142857143
         },
         "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-command": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -9481,13 +9481,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
-      "avgPrecision": 0.9810606060606061,
-      "avgRoleFidelity": 0.9561776061776062,
+      "avgPrecision": 0.9826839826839827,
+      "avgRoleFidelity": 0.9578667953667953,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10111,7 +10111,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.818181818181816,
+      "avgConfidence": 0.8163265306122427,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgRoleFidelity": 0.9890765765765768,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10158,10 +10158,6 @@
           "confidence": 1
         },
         "send-with-detail": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
           "success": true,
           "confidence": 1
         },
@@ -10577,6 +10573,10 @@
           "success": true,
           "confidence": 0.7142857142857143
         },
+        "tell-command": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "call-function": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -10743,7 +10743,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.800865800865799,
+      "avgConfidence": 0.7990105132962256,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgRoleFidelity": 0.9893018018018019,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10790,10 +10790,6 @@
           "confidence": 1
         },
         "send-with-detail": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
           "success": true,
           "confidence": 1
         },
@@ -11174,6 +11170,10 @@
           "confidence": 0.7142857142857143
         },
         "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-command": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -11375,7 +11375,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.840857555143267,
+      "avgConfidence": 0.8390022675736938,
       "avgFidelity": 1,
       "avgPrecision": 0.9945887445887446,
       "avgRoleFidelity": 0.9893018018018017,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11450,10 +11450,6 @@
           "confidence": 1
         },
         "default-value": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
           "success": true,
           "confidence": 1
         },
@@ -11810,6 +11806,10 @@
           "confidence": 0.7142857142857143
         },
         "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-command": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12641,13 +12641,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8456558061821213,
       "avgFidelity": 1,
-      "avgPrecision": 0.9780573593073594,
-      "avgRoleFidelity": 0.9712241653418122,
+      "avgPrecision": 0.9796807359307359,
+      "avgRoleFidelity": 0.9729133545310015,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13271,15 +13271,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.818594104308388,
+      "avgConfidence": 0.8167388167388147,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9890765765765765,
+      "avgRoleFidelity": 0.9890765765765768,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13326,10 +13326,6 @@
           "confidence": 1
         },
         "send-with-detail": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
           "success": true,
           "confidence": 1
         },
@@ -13737,6 +13733,10 @@
           "success": true,
           "confidence": 0.7142857142857143
         },
+        "tell-command": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "call-function": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -13903,7 +13903,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8049474335188601,
+      "avgConfidence": 0.8030921459492868,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgRoleFidelity": 0.9930180180180183,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13950,10 +13950,6 @@
           "confidence": 1
         },
         "send-with-detail": {
-          "success": true,
-          "confidence": 1
-        },
-        "tell-command": {
           "success": true,
           "confidence": 1
         },
@@ -14334,6 +14330,10 @@
           "confidence": 0.7142857142857143
         },
         "log-element": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
+        "tell-command": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486667,
+      "bundleSize": 486814,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 486667,
+      "size": 486814,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

L3 drill 2 (final drill of the L3 cluster): **spurious call ×7** on window-keydown — which the pre-probe revealed to be an **en+16-language drop** (bar item 1, en-facing parser gap), not a seven-language excess.

The corpus line `if event.ctrlKey halt call saveDocument() end` lost its `call` because halt's optional **trailing** patient slot swallowed the juxtaposed next command's keyword (`patient=literal:"call"`), stranding `saveDocument()` — in en and 16 SVO languages at once. The SOV seven split verb-first and kept it, so the en-referenced metric read them as spurious.

### Fix
`matchRoleToken`: a trailing optional role slot (`nextPatternToken === undefined`, now threaded through `matchGroupToken` → `matchTokenSequence` so a group's last inner token sees what follows the group) never captures a keyword token whose normalized form is a registered command action. Scoped away from `event`/`action` roles (bespoke guards exist) and — load-bearing — from **mid-pattern** optional slots: those must keep capturing the verb and *failing* the pattern so richer fallbacks win (ja `opacity を 遷移 0 に 300ms`: the no-goal variant's duration/style slots capture 遷移 → pattern fails → verb-anchoring reclaims goal+duration; locked by test — an unscoped draft regressed exactly this and was caught by the existing nested-behavior guard tests).

All 24 languages now capture call with the **identical** `patient=expression:"saveDocument()"` (pre-probed role alignment — zero honest dips).

## Verification

- A/B per-(lang,pattern): **spurious call ×7 + missing halt.patient:literal ×7 cleared, ZERO new entries**; census identical (3404)
- Baseline avgPrecision **0.9934 → 0.9939** (session total 0.9928 → 0.9939); probe mean R1 0.9833 → 0.9838; parse 3696/3696; degenerate/lossy 0
- Six-signal `--regression` gate green; baseline regenerated against a fresh populate
- 4 guard tests (2 stash-verified failing pre-fix; halt-legitimate-patient and ja mid-pattern locks both ways)
- Full semantic suite: 6591 passed

## Docs (folded per no-docs-only-PRs)

Session-11 handoff status block + NEXT_STEPS: L3 ✓ with actuals in the LAUNCH BAR table, remaining >×5 inventory (default ×9, for ×9, empty ×8), L4 default-×9 pre-probe findings (en-noise inversion), render.style ×12 re-probe note, language-grammar.ts staleness hygiene flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)