### PR TITLE
fix(multilingual): default-value full drill — spurious default ×9 cleared, all 24 aligned in one step; avgPrecision 0.9953, launch-bar ≥0.995 REACHED (L4)

### DIFF
--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -1,5 +1,48 @@
 # Handoff — R1 residue after the five-cluster triage (fronted repeat-while · sw kama homonym · singletons)
 
+> **STATUS UPDATE (2026-07-06, session 12 = L4 of the launch bar): the
+> default-value full drill LANDED (this PR) — spurious default ×9 cleared
+> with all 24 languages aligned in ONE step, plus the qu spurious before ×1
+> bonus. avgPrecision 0.9939 → 0.9953: LAUNCH BAR item 3 (≥0.995) REACHED.**
+> Post-session state: probe mean R1 0.9838 held, parse 3696/3696,
+> degenerate/lossy 0, R2 1.0, census 3404, A/B 10 cleared / 0 new, gate
+> green, baseline regenerated.
+>
+> 1. **The en-noise inversion resolved without a single honest dip.** Three
+>    mechanisms: (1) defaultSchema roles enriched to set-parallel shape —
+>    destination admits selector/reference/expression/property-path (the
+>    possessive matchers), BOTH roles carry a complete 24-language
+>    markerOverride table matching the dict renders (de zu ≠ set's auf, sw
+>    kwa ≠ kwenye, SOV dest markers ja を / ko 를 / tr i / hi को). All 24 now
+>    parse `on load default my @data-count to "0"` with byte-identical roles
+>    (destination=property-path{me,@data-count}, patient=literal:"0"); the
+>    SOV four ride the existing sov-2role-dest-first event patterns the
+>    instant their markers exist. (2) NEW general machinery: the #592
+>    hyphen-compound fold generalized to `tryMatchShatteredCompound` (seps
+>    `-` and `_`, particle segments accepted) — ru по_умолчанию and uk
+>    за_замовчуванням form across their tokenizers' by-design `_` splits.
+>    (3) qu profile default primary → dict render ñawpaq_kaq (this also
+>    killed the qu spurious `before` — the ñawpaq shard read as first);
+>    sw += bare msingi. 9 guard tests (8 stash-verified, 1 both-ways
+>    negative); lexicon-emit-mismatch allowlist pruned (its qu/sw default
+>    entries self-flagged as now-parsing).
+>
+> **L5 next — two arcs, in order:** (a) **empty ×8 (bn/hi/tr), pre-probed
+> this session, transformer-side CONFIRMED:** the SOV reorder displaces the
+> `is empty` predicate adjective INTO the next command's argument zone (hi
+> `अगर मेरा मान है जोड़ें .error को खाली मैं में` — खाली lands after the add
+> patient; bn খালি / tr boş identical), and the displaced adjective anchors
+> `empty-{lang}-generated` and STEALS a neighboring role (hi steals the add's
+> .error as its patient). Fix transformer-side (keep the predicate adjective
+> inside the condition clause under reorder), then re-probe the parse side
+> against the NEW renders + repopulate; behavior-sortable hi/tr is the same
+> mechanism in a behavior body. (b) **the big R1-missing families** for bar
+> item 4 (0.9838 → ≥0.985): add.patient:selector ×20,
+> toggle.patient:expression ×19, fetch.source:literal ×18,
+> set.patient:literal ×16, bind.source:property-path ×14. Bar item 2 also
+> still carries for ×9 (take-class ×6 own-arc — cross-language + transformer
+> probe BOTH sides first — + wait-payload behaviors ×3 post-launch).
+
 > **STATUS UPDATE (2026-07-06, session 11 = L3 of the launch bar): both L3
 > drills LANDED — #595 (spurious on ×7: he עם de-anchor + hi bare-event
 > command peek) and the halt-verb-guard drill in this PR (spurious call ×7,

--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -37,11 +37,28 @@
 > inside the condition clause under reorder), then re-probe the parse side
 > against the NEW renders + repopulate; behavior-sortable hi/tr is the same
 > mechanism in a behavior body. (b) **the big R1-missing families** for bar
-> item 4 (0.9838 → ≥0.985): add.patient:selector ×20,
-> toggle.patient:expression ×19, fetch.source:literal ×18,
-> set.patient:literal ×16, bind.source:property-path ×14. Bar item 2 also
-> still carries for ×9 (take-class ×6 own-arc — cross-language + transformer
-> probe BOTH sides first — + wait-payload behaviors ×3 post-launch).
+> item 4 (0.9838 → ≥0.985) — the top three were pre-probed at session-12
+> close: **add ×20 and toggle ×19 are the SAME root cause in OPPOSITE
+> directions** — `@attribute` tokens type-diverge between en's patterns and
+> the generated event patterns (add `@disabled`: en=selector, other 18
+> =expression via the lax no-expectedTypes event-role slots; toggle
+> `@aria-expanded`: en toggle-en-full=expression, others=selector). One
+> canonical `@attr` typing (shared value-builder, not per-pattern
+> expectedTypes) could clear BOTH — ≈0.0012 R1, i.e. the whole bar-4 gap —
+> but it changes the en reference either way, so budget both-sides A/B + R2
+> (attribute toggles are in the curated subset). The add SOV trio (hi/ja/ko)
+> ALSO mis-captures destination (`reference:"me"` instead of
+> `selector:"<button/>"` — the trailing `in me` wins). **fetch ×18 is two
+> UNRELATED sub-arcs:** event-debounce (bn/hi/ja/ko/qu/tr) is a template-
+> literal shatter — `/api/search?q=${my value}` breaks at the interpolation
+> space, en KEEPS A TRUNCATED source `"/api/search?q=${my"` (an R0-invisible
+> en value bug, morph-lesson shape) while the SOV six capture garbage
+> `"}"` — a tokenizer arc, fix must repair en's value too; fetch-with-\*
+> (pl/ru/uk ×12) mis-roles the with-tail — URL lands in patient and
+> source=expression:"method" junk (the #595 with-phrase family, pl/ru/uk
+> never got the he treatment). Bar item 2 also still carries for ×9
+> (take-class ×6 own-arc — cross-language + transformer probe BOTH sides
+> first — + wait-payload behaviors ×3 post-launch).
 
 > **STATUS UPDATE (2026-07-06, session 11 = L3 of the launch bar): both L3
 > drills LANDED — #595 (spurious on ×7: he עם de-anchor + hi bare-event

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -9,7 +9,7 @@
 > [BEHAVIORS_CONSOLIDATION_PLAN.md](BEHAVIORS_CONSOLIDATION_PLAN.md). Read this first,
 > then dive into those for the per-arc detail.
 
-## Where we are (2026-07-06 baseline · post session-11 / L3 · `browser-priority`)
+## Where we are (2026-07-06 baseline · post session-12 / L4 · `browser-priority`)
 
 Authoritative source: `packages/testing-framework/baselines/multilingual-priority.json`
 (its `timestamp` + `commit` fields stamp each regen). 24 langs × 154 patterns = 3696.
@@ -21,8 +21,8 @@ Authoritative source: `packages/testing-framework/baselines/multilingual-priorit
 | lossy passes (0.5 ≤ fid < 1.0) | **0**                  | band cleared (#495–#506), holding                         |
 | faithful (fid = 1.0)           | **3696**               | every parsing pattern is faithful                         |
 | avgFidelity (R0-recall)        | **1.000**              | saturated                                                 |
-| avgPrecision (R0 trust floor)  | **0.994**              | session-11 / L3 drills: 0.9928 → 0.9939 (two drills)      |
-| avgRoleFidelity (R1)           | **0.984**              | 0.9831 → 0.9838 (L3 side-effect: reclaimed roles)         |
+| avgPrecision (R0 trust floor)  | **0.995**              | session-12 / L4: 0.9939 → 0.9953 — **bar 3 reached**      |
+| avgRoleFidelity (R1)           | **0.984**              | 0.9838 held through L4                                    |
 | avgExecutionFidelity (R2)      | **1.000**              | 47-pattern curated subset fully reproduces en DOM effects |
 
 The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recall ·
@@ -40,13 +40,15 @@ normal usage). The bar, all four together:
 1. **All en-facing parser gaps closed.** Every remaining en-noise inversion is
    a real English-parser bug (en `go back` / `add "content"` didn't parse
    until #588/#589) — user-visible to English users regardless of the metric.
-2. **Every spurious family larger than ×5 cleared** (post-session-11 inventory:
+2. **Every spurious family larger than ×5 cleared** (post-session-12 inventory:
    ~~morph ×18~~ ✓L1, for ×14→×9 (transition half ✓L2; remainder = take-class
    ×6 own-arc + wait-payload behaviors ×3 post-launch), ~~add ×11 draggable~~
-   ✓L1, default ×9, empty ×8, ~~call ×7~~ ✓L3, ~~on ×7 he~~ ✓L3,
-   ~~transition ×6~~ ✓L2, ~~breakpoint ×6~~ ✓L2 (+halt ×3 sibling).
-3. **avgPrecision ≥ 0.995** (0.9939 as of session 11).
-4. **avgRoleFidelity ≥ 0.985** (0.9838 as of session 11) — the big R1-missing
+   ✓L1, ~~default ×9~~ ✓L4 (+before ×1 qu bonus), empty ×8, ~~call ×7~~ ✓L3,
+   ~~on ×7 he~~ ✓L3, ~~transition ×6~~ ✓L2, ~~breakpoint ×6~~ ✓L2 (+halt ×3
+   sibling). Remaining: for ×9, empty ×8.
+3. **avgPrecision ≥ 0.995** — **REACHED session 12: 0.9953.** The six-signal
+   gate holds it from here.
+4. **avgRoleFidelity ≥ 0.985** (0.9838 as of session 12) — the big R1-missing
    families (add.patient:selector ×20, toggle.patient:expression ×19,
    fetch.source:literal ×18, set.patient:literal ×16,
    bind.source:property-path ×14) carry most of this.
@@ -59,7 +61,7 @@ across sessions 4–8, full discipline included). Sequencing:
 | L1 ✓    | morph ×18 + draggable add fold+cleanup ×11 (#590 + session-9 PR 2)   | precision 0.9891 → 0.9910 |
 | L2 ✓    | breakpoint ×6+halt ×3 + bn `for` transition-half ×5 + transition ×6  | precision 0.9910 → 0.9928 |
 | L3 ✓    | on ×7 he/hi (#595) + call ×7 halt-verb-guard (session-11 PR 2)       | precision 0.9928 → 0.9939 |
-| L4      | default-value full drill (13 langs, markers + possessives)           | en gaps, R1               |
+| L4 ✓    | default-value full drill (24 langs: schema markers + \_-fold)        | precision 0.9939 → 0.9953 |
 | L5–L6   | big R1-missing families (add/toggle patient, fetch/bind source, set) | R1 → ≥0.985               |
 
 L1 actual precision movement (+0.0019 for 29 entries) ran well under the
@@ -72,6 +74,10 @@ empty ×8, call ×7, on ×7 he, so L3+L4 must carry ~0.0022 to reach 0.995.
 L3 actual: +0.0011 for 14 spurious + 10 missing entries cleared (#595 +
 session-11 PR 2) — remaining >×5 inventory is default ×9 (en-noise inversion,
 the L4 drill), for ×9, empty ×8, so L4 must carry ~0.0011 to reach 0.995.
+L4 actual: +0.0014 for 10 spurious cleared (default ×9 + the qu before ×1
+bonus from the ñawpaq_kaq underscore fold) — **the ≥0.995 bar is reached**;
+remaining >×5 inventory is for ×9 and empty ×8 (bar item 2), and L5–L6 carry
+the R1 bar (0.9838 → ≥0.985).
 
 **Post-launch track (ratchet-protected, not launch-blocking):** SOV-six role
 polish (qu/hi ~0.956 R1), tr remove.patient block-walk leak, spurious empty
@@ -82,6 +88,49 @@ fail CI.
 Caveats: each en enrichment can mint honest-dip entries (bounded by the
 census/A-B discipline; historically <1 session total), and this scopes the
 fidelity grind only — docs/demo/npm-publish polish is separate scope.
+
+> **Update 2026-07-06g (SESSION 12 = L4, one drill: the default-value full
+> drill in this PR; avgPrecision 0.9939 → 0.9953 — LAUNCH BAR item 3 (≥0.995)
+> REACHED; probe mean R1 0.9838 held; A/B 10 spurious cleared / 0 new; census
+> identical (3404); gate green; baseline regenerated.)**
+>
+> - **The default ×9 en-noise inversion cleared with all 24 languages aligned
+>   in one step.** Three mechanisms, exactly as pre-probed: (1)
+>   `defaultSchema.destination` admitted only `reference` — now the full
+>   set-parallel list (selector/reference/expression/property-path, opting in
+>   the possessive matchers) plus a complete 24-language markerOverride table
+>   on BOTH roles (dict-driven: default renders de `zu` where set uses `auf`,
+>   sw `kwa` vs `kwenye`; SOV destination markers ja を / ko 를 / tr i / hi को
+>   mirror set's). en went from dropping the action (the wrong reference) to
+>   `destination=property-path{me,@data-count} patient=literal:"0"`, and every
+>   language matched byte-identically — zero honest dips, zero new A/B
+>   entries. (2) ru/uk NULLed because their tokenizers split `_` by design
+>   (по_умолчанию → по/_/умолчанию): the #592 hyphen-compound fold is now a
+>   general shattered-compound fold (`tryMatchShatteredCompound`, seps `-` and
+>   `_`, particle segments accepted — ru по / uk за lead their compounds). (3)
+>   two profile↔dict keyword mismatches: qu default primary realigned to the
+>   dict render `ñawpaq_kaq` (qallariy kept as alternative — NB the qu dict
+>   uses qallariy for RESET), sw gained the bare `msingi` dict render. The qu
+>   fix also cleared **spurious before ×1** (the ñawpaq shard read as
+>   "first/before") — the drill's bonus entry. 9 guard tests (8
+>   stash-verified); the lexicon-emit-mismatch allowlist self-flagged its two
+>   now-parsing entries and was pruned.
+> - **empty ×8 pre-probed for L5 (bn/hi/tr — transformer-side CONFIRMED):**
+>   the SOV reorder DISPLACES the `is empty` predicate adjective into the
+>   following command's argument zone — hi input-validation renders
+>   `अगर मेरा मान है जोड़ें .error को खाली मैं में` (खाली after the add
+>   patient; bn খালি / tr boş identical). Parse side: the displaced adjective
+>   anchors `empty-{lang}-generated` AND STEALS a neighboring role (hi
+>   patient=selector:".error" — the add's patient; bn/tr patient=reference:
+>   "me"). The fix must be transformer-side (keep the predicate adjective
+>   inside the condition clause when reordering); the parse side then needs
+>   re-probing against the NEW renders + repopulate. behavior-sortable hi/tr
+>   is the same mechanism inside a behavior body.
+> - Remaining bar work: item 2 (for ×9 = take-class ×6 own-arc + wait-payload
+>   behaviors ×3; empty ×8 above) and item 4 (R1 0.9838 → ≥0.985 via the big
+>   R1-missing families: add.patient:selector ×20, toggle.patient:expression
+>   ×19, fetch.source:literal ×18, set.patient:literal ×16,
+>   bind.source:property-path ×14).
 
 > **Update 2026-07-06f (SESSION 11 = L3, two drills: #595 and this PR;
 > avgPrecision 0.9928 → 0.9939, probe mean R1 0.9831 → 0.9838; A/B 14

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -128,9 +128,21 @@ fidelity grind only — docs/demo/npm-publish polish is separate scope.
 >   is the same mechanism inside a behavior body.
 > - Remaining bar work: item 2 (for ×9 = take-class ×6 own-arc + wait-payload
 >   behaviors ×3; empty ×8 above) and item 4 (R1 0.9838 → ≥0.985 via the big
->   R1-missing families: add.patient:selector ×20, toggle.patient:expression
->   ×19, fetch.source:literal ×18, set.patient:literal ×16,
->   bind.source:property-path ×14).
+>   R1-missing families). **Top-three R1 families pre-probed at session-12
+>   close:** add ×20 and toggle ×19 are the SAME root cause in opposite
+>   directions — `@attribute` type inference diverges between en's patterns
+>   and the lax generated event-role slots (add `@disabled`: en=selector /
+>   others=expression; toggle `@aria-expanded`: en=expression /
+>   others=selector). One canonical `@attr` typing in the shared
+>   value-builder could clear both (≈0.0012 R1 = the whole bar-4 gap); it
+>   changes the en reference, so budget both-sides A/B + R2. The add SOV trio
+>   (hi/ja/ko) also mis-captures destination (`reference:"me"` vs
+>   `selector:"<button/>"`). fetch ×18 is two unrelated sub-arcs:
+>   event-debounce is a template-literal shatter (`${my value}` breaks at the
+>   space; en itself keeps a TRUNCATED source — an R0-invisible en value bug)
+>   and fetch-with-\* pl/ru/uk ×12 mis-roles the with-tail (URL→patient,
+>   source="method" junk — the #595 with-phrase family). Full detail in the
+>   handoff doc.
 
 > **Update 2026-07-06f (SESSION 11 = L3, two drills: #595 and this PR;
 > avgPrecision 0.9928 → 0.9939, probe mean R1 0.9831 → 0.9838; A/B 14

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -2091,19 +2091,17 @@ export const defaultSchema: CommandSchema = {
       role: 'destination',
       description: 'The variable to set default for',
       required: true,
-      // NOTE (probed 2026-07-06, session 8): adding 'property-path' here fixes
-      // en `default my @data-count to "0"` (destination=property-path via the
-      // possessive matcher, exactly parallel to set-en-possessive) — but ONLY
-      // en: all 13 currently-dropping SVO/VSO languages still NULL on their
-      // rendered possessive+marker shapes (de `standard mein @data-count zu`,
-      // es `predeterminar mi @data-count a`, …), so an en-only enrichment
-      // would mint ~26 honest-dip A/B entries. Admit property-path only as
-      // part of the full default-value drill (per-language markers +
-      // possessive matching).
-      expectedTypes: ['reference'],
+      // Full default-value drill (session 12): property-path opts this role
+      // into the possessive matchers (`default my @data-count to "0"`),
+      // exactly parallel to set's destination. Enriched together with the
+      // per-language markers below so all 24 languages align in one step
+      // (an en-only enrichment would have minted honest-dip A/B entries in
+      // every still-dropping language).
+      expectedTypes: ['selector', 'reference', 'expression', 'property-path'],
       svoPosition: 1,
       sovPosition: 1,
-      // Same overrides as SET: no marker before variable in VSO/SVO
+      // Same overrides as SET: no marker before variable in VSO/SVO;
+      // SOV languages mark the variable with their patient/accusative marker.
       markerOverride: {
         en: '',
         ar: '',
@@ -2111,6 +2109,24 @@ export const defaultSchema: CommandSchema = {
         sw: '',
         bn: 'কে',
         qu: 'ta',
+        ja: 'を',
+        ko: '를',
+        tr: 'i',
+        hi: 'को',
+        de: '',
+        es: '',
+        fr: '',
+        it: '',
+        pt: '',
+        pl: '',
+        ru: '',
+        uk: '',
+        vi: '',
+        id: '',
+        ms: '',
+        th: '',
+        zh: '把',
+        he: 'את',
       },
     },
     {
@@ -2120,14 +2136,35 @@ export const defaultSchema: CommandSchema = {
       expectedTypes: ['literal', 'expression'],
       svoPosition: 2,
       sovPosition: 2,
-      // Same overrides as SET: value gets destination preposition
+      // Same shape as SET: the value carries the language's "to" marker.
+      // Markers mirror what the transformer actually renders for default
+      // (dict-driven), which differs from set in places (de zu vs auf,
+      // sw kwa vs kwenye).
       markerOverride: {
         en: 'to',
         ar: 'إلى',
         tl: 'sa',
-        sw: 'kwenye',
+        sw: 'kwa',
         bn: 'তে',
         qu: 'man',
+        ja: 'に',
+        ko: '에',
+        tr: 'e',
+        hi: 'में',
+        de: 'zu',
+        es: 'a',
+        fr: 'à',
+        it: 'in',
+        pt: 'para',
+        pl: 'do',
+        ru: 'в',
+        uk: 'в',
+        vi: 'vào',
+        id: 'ke',
+        ms: 'ke',
+        th: 'ใน',
+        zh: '到',
+        he: 'על',
       },
     },
   ],

--- a/packages/semantic/src/generators/profiles/quechua.ts
+++ b/packages/semantic/src/generators/profiles/quechua.ts
@@ -144,7 +144,10 @@ export const quechuaProfile: LanguageProfile = {
     js: { primary: 'js', normalized: 'js' },
     async: { primary: 'mana waqtalla', normalized: 'async' },
     tell: { primary: 'niy', alternatives: [], normalized: 'tell' },
-    default: { primary: 'qallariy', normalized: 'default' },
+    // The qu dict renders default as ñawpaq_kaq ("the prior one"); qallariy
+    // ("to begin") kept as alternative for back-compat — but note the qu dict
+    // uses qallariy for RESET, so primary must stay ñawpaq_kaq.
+    default: { primary: 'ñawpaq_kaq', alternatives: ['qallariy'], normalized: 'default' },
     init: { primary: 'qallarichiy', normalized: 'init' },
     behavior: { primary: 'ruwana', normalized: 'behavior' },
     install: { primary: 'tarpuy', normalized: 'install' },

--- a/packages/semantic/src/generators/profiles/swahili.ts
+++ b/packages/semantic/src/generators/profiles/swahili.ts
@@ -135,7 +135,9 @@ export const swahiliProfile: LanguageProfile = {
     js: { primary: 'js', alternatives: ['javascript'], normalized: 'js' },
     async: { primary: 'isiyo sawia', normalized: 'async' },
     tell: { primary: 'sema', alternatives: ['ambia'], normalized: 'tell' },
-    default: { primary: 'chaguo-msingi', normalized: 'default' },
+    // The sw dict renders default as bare `msingi` (chaguo-msingi is the full
+    // compound); both accepted.
+    default: { primary: 'chaguo-msingi', alternatives: ['msingi'], normalized: 'default' },
     init: { primary: 'anzisha', alternatives: ['anza'], normalized: 'init' },
     behavior: { primary: 'tabia', normalized: 'behavior' },
     install: { primary: 'sakinisha', normalized: 'install' },

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -345,16 +345,19 @@ export class PatternMatcher {
       }
     }
 
-    // Hyphen-compound fold: many keyword translations are hyphen compounds
-    // (ms `titik-henti`, es `punto-interrupción`) that the tokenizers shatter
-    // into word/-/word runs — and the tail word can be ANOTHER command's
-    // keyword (ms `henti` → halt), so the run mis-anchors that command
-    // instead. Join the run and compare it to any hyphen-bearing expected
-    // value; only fires after every single-token match above has failed.
+    // Hyphen/underscore-compound fold: many keyword translations are compounds
+    // (ms `titik-henti`, es `punto-interrupción`, ru `по_умолчанию`,
+    // qu `ñawpaq_kaq`) that the tokenizers shatter into word/sep/word runs —
+    // and a segment can be ANOTHER command's keyword (ms `henti` → halt,
+    // qu `ñawpaq` → first), so the run mis-anchors that command instead.
+    // Join the run and compare it to any separator-bearing expected value;
+    // only fires after every single-token match above has failed.
     for (const value of [patternToken.value, ...(patternToken.alternatives ?? [])]) {
-      if (value.includes('-') && this.tryMatchHyphenCompound(tokens, value)) {
-        this.totalKeywordMatches++;
-        return true;
+      for (const sep of ['-', '_'] as const) {
+        if (value.includes(sep) && this.tryMatchShatteredCompound(tokens, value, sep)) {
+          this.totalKeywordMatches++;
+          return true;
+        }
       }
     }
 
@@ -403,19 +406,25 @@ export class PatternMatcher {
   }
 
   /**
-   * Match a hyphen-compound keyword (`titik-henti`) against a shattered token
-   * run (`titik` `-` `henti`): word segments must be identifier/keyword tokens
-   * equal to the expected segments (case-insensitive), separators lone `-`
-   * tokens. Consumes the run on success, resets the stream on failure.
+   * Match a compound keyword (`titik-henti`, `по_умолчанию`) against a
+   * shattered token run (`titik` `-` `henti` / `по` `_` `умолчанию`): word
+   * segments must be identifier/keyword/particle tokens equal to the expected
+   * segments (case-insensitive; particle because prepositions like ru `по` /
+   * uk `за` lead some underscore compounds), separators lone `sep` tokens.
+   * Consumes the run on success, resets the stream on failure.
    */
-  private tryMatchHyphenCompound(tokens: TokenStream, expected: string): boolean {
-    const segments = expected.split('-');
+  private tryMatchShatteredCompound(
+    tokens: TokenStream,
+    expected: string,
+    sep: '-' | '_'
+  ): boolean {
+    const segments = expected.split(sep);
     if (segments.length < 2 || segments.some(s => s.length === 0)) return false;
     const mark = tokens.mark();
     for (let i = 0; i < segments.length; i++) {
       if (i > 0) {
-        const sep = tokens.peek();
-        if (!sep || sep.value !== '-') {
+        const sepToken = tokens.peek();
+        if (!sepToken || sepToken.value !== sep) {
           tokens.reset(mark);
           return false;
         }
@@ -424,7 +433,7 @@ export class PatternMatcher {
       const word = tokens.peek();
       if (
         !word ||
-        (word.kind !== 'identifier' && word.kind !== 'keyword') ||
+        (word.kind !== 'identifier' && word.kind !== 'keyword' && word.kind !== 'particle') ||
         word.value.toLowerCase() !== segments[i]!.toLowerCase()
       ) {
         tokens.reset(mark);

--- a/packages/semantic/test/lexicon-emit-mismatch.test.ts
+++ b/packages/semantic/test/lexicon-emit-mismatch.test.ts
@@ -97,7 +97,9 @@ const KNOWN_MISMATCHES = new Set([
   'qu:break:p_akiy',
   'qu:catch:hapsiy',
   'qu:continue:purichiy',
-  'qu:default:ñawpaq_kaq',
+  // qu:default resolved (default-value drill, L4): profile primary realigned to
+  // the dict render ñawpaq_kaq + the underscore-compound fold forms it from the
+  // shattered ñawpaq/_/kaq run.
   'qu:on:kaqpi',
   'qu:open:kichay',
   'qu:pushUrl:url_tanqay',
@@ -120,7 +122,8 @@ const KNOWN_MISMATCHES = new Set([
   'sw:async:sainkroni',
   'sw:catch:shika',
   'sw:copy:nakili',
-  'sw:default:msingi',
+  // sw:default resolved (default-value drill, L4): `msingi` (the dict render)
+  // added as a profile alternative alongside chaguo-msingi.
   'sw:pushUrl:sukumaUrl',
   'sw:replaceUrl:badilishaUrl',
   'sw:return:rudi',

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -11742,3 +11742,104 @@ describe('trailing optional slot never captures a command verb (halt swallows ju
     expect(String(role(transition!, 'duration')?.value)).toBe('300ms');
   });
 });
+
+describe('default-value full drill: possessive destination + per-language markers + underscore-compound fold (spurious default ×9 / en-noise inversion, L4)', () => {
+  const role = (
+    node: Record<string, any> | null | undefined,
+    r: string
+  ): { type?: string; value?: unknown; raw?: unknown; object?: any; property?: string } | undefined =>
+    node?.roles instanceof Map ? node.roles.get(r) : undefined;
+
+  const walkNodesL4 = (node: unknown): Record<string, any>[] => {
+    const flat: Record<string, any>[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'eventHandlers', 'initBlock', 'initCommands']) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return flat;
+  };
+
+  const expectAlignedDefault = (nodes: Record<string, any>[]) => {
+    const dflt = nodes.find(r => r.action === 'default');
+    expect(dflt).toBeDefined();
+    const dest = role(dflt!, 'destination');
+    expect(dest?.type).toBe('property-path');
+    expect(dest?.object?.value).toBe('me');
+    expect(dest?.property).toBe('@data-count');
+    const patient = role(dflt!, 'patient');
+    expect(patient?.type).toBe('literal');
+    expect(String(patient?.value)).toBe('0');
+    return dflt!;
+  };
+
+  it('[en] the reference itself keeps the default action (the en-noise inversion: en used to drop it)', () => {
+    // Before the drill, `on load default my @data-count to "0"` parsed as a
+    // bare `on load` handler — the reference was WRONG, so the nine languages
+    // that kept default read as spurious default ×9. defaultSchema.destination
+    // now admits property-path (possessive matcher, parallel to set).
+    const node = parse('on load default my @data-count to "0"', 'en');
+    const nodes = walkNodesL4(node);
+    expect(nodes.find(r => r.action === 'on')).toBeDefined();
+    expectAlignedDefault(nodes);
+  });
+
+  it('[ja] SOV event-fused variant aligns (dest を … で 既定 patient に)', () => {
+    const nodes = walkNodesL4(parse('私の @data-count を 読み込み で 既定 "0" に', 'ja'));
+    expect(nodes.find(r => r.action === 'on')).toBeDefined();
+    expectAlignedDefault(nodes);
+  });
+
+  it('[de] SVO marker alignment (default renders zu, not set’s auf)', () => {
+    const nodes = walkNodesL4(parse('bei laden standard mein @data-count zu "0"', 'de'));
+    expectAlignedDefault(nodes);
+  });
+
+  it('[ru] underscore-compound keyword folds (по_умолчанию shatters to по/_/умолчанию)', () => {
+    // The ru tokenizer splits on `_` by design (see RUSSIAN_EXTRAS fused-event
+    // note); the literal matcher now folds word/_/word runs the same way it
+    // folds hyphen compounds (#592). The leading segment is a PARTICLE (по),
+    // which the fold must accept.
+    const nodes = walkNodesL4(parse('при загрузка по_умолчанию мой @data-count в "0"', 'ru'));
+    expectAlignedDefault(nodes);
+  });
+
+  it('[uk] same fold, uk shape (за_замовчуванням)', () => {
+    const nodes = walkNodesL4(parse('при завантаження за_замовчуванням мій @data-count в "0"', 'uk'));
+    expectAlignedDefault(nodes);
+  });
+
+  it('[qu] ñawpaq_kaq folds to default — and no spurious before/first from the ñawpaq shard', () => {
+    // Before the drill the qu line minted spurious `before` ×1: the ñawpaq
+    // shard (keyword "first") mis-anchored. The profile primary is now the
+    // dict render ñawpaq_kaq; the underscore fold forms it from the run.
+    const nodes = walkNodesL4(parse('noqaq @data-count ta "0" man apakuy pi ñawpaq_kaq', 'qu'));
+    expectAlignedDefault(nodes);
+    expect(nodes.find(r => r.action === 'before')).toBeUndefined();
+  });
+
+  it('[sw] bare msingi (the dict render) is accepted alongside chaguo-msingi', () => {
+    const nodes = walkNodesL4(parse('kwenye pakia msingi yangu @data-count kwa "0"', 'sw'));
+    expectAlignedDefault(nodes);
+  });
+
+  it('[ru] the fold needs the FULL run — a bare leading particle never anchors default (both-ways lock)', () => {
+    // `по` alone (no _/умолчанию continuation) must not fold into по_умолчанию.
+    const nodes = walkNodesL4(parse('при загрузка по мой @data-count в "0"', 'ru'));
+    expect(nodes.find(r => r.action === 'default')).toBeUndefined();
+  });
+
+  it('[en] simple variable form parses too (destination=expression)', () => {
+    // destination now admits expression, so the non-possessive hyperscript
+    // form works in isolation as well.
+    const node = parse('default x to "5"', 'en') as unknown as Record<string, any>;
+    expect(node?.action).toBe('default');
+    expect(String(role(node, 'patient')?.value)).toBe('5');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-06T23:43:30.029Z",
-  "commit": "2ff17cf6",
+  "timestamp": "2026-07-07T00:29:42.374Z",
+  "commit": "a9e4fcf5",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -8,13 +8,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8394563407500147,
       "avgFidelity": 1,
-      "avgPrecision": 0.9967532467532467,
+      "avgPrecision": 1,
       "avgRoleFidelity": 0.9870495495495494,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8579007041413049,
       "avgFidelity": 1,
-      "avgPrecision": 0.9758115114732762,
+      "avgPrecision": 0.9790582647200294,
       "avgRoleFidelity": 0.9733108108108108,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3791,7 +3791,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8284065141207998,
+      "avgConfidence": 0.8295609152752009,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgRoleFidelity": 0.9926801801801801,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -3814,6 +3814,10 @@
           "confidence": 1
         },
         "transition-transform": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
           "success": true,
           "confidence": 1
         },
@@ -4058,10 +4062,6 @@
           "confidence": 0.8222222222222222
         },
         "get-value": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "default-value": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -4423,15 +4423,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.9045096507502506,
+      "avgConfidence": 0.9077564039970039,
       "avgFidelity": 1,
-      "avgPrecision": 0.9742694805194805,
+      "avgPrecision": 0.9775162337662338,
       "avgRoleFidelity": 0.9618082368082366,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -4546,6 +4546,10 @@
           "confidence": 1
         },
         "log-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
           "success": true,
           "confidence": 1
         },
@@ -5033,10 +5037,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "default-value": {
-          "success": true,
-          "confidence": 0.5
-        },
         "first-in-parent": {
           "success": true,
           "confidence": 0.5
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5689,13 +5689,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8346320346320326,
       "avgFidelity": 1,
-      "avgPrecision": 0.9945887445887447,
+      "avgPrecision": 0.997835497835498,
       "avgRoleFidelity": 0.9979086229086228,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6319,15 +6319,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8467689787238654,
+      "avgConfidence": 0.8500157319706186,
       "avgFidelity": 1,
-      "avgPrecision": 0.9826839826839829,
+      "avgPrecision": 0.9859307359307362,
       "avgRoleFidelity": 0.9733108108108108,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6446,6 +6446,10 @@
           "confidence": 1
         },
         "log-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
           "success": true,
           "confidence": 1
         },
@@ -6857,10 +6861,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "default-value": {
-          "success": true,
-          "confidence": 0.5
-        },
         "async-block": {
           "success": true,
           "confidence": 0.5
@@ -6951,15 +6951,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8417184736733602,
+      "avgConfidence": 0.8449652269201134,
       "avgFidelity": 1,
-      "avgPrecision": 0.9826839826839829,
+      "avgPrecision": 0.9859307359307362,
       "avgRoleFidelity": 0.9699324324324325,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7078,6 +7078,10 @@
           "confidence": 1
         },
         "log-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
           "success": true,
           "confidence": 1
         },
@@ -7481,10 +7485,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "default-value": {
-          "success": true,
-          "confidence": 0.5
-        },
         "async-block": {
           "success": true,
           "confidence": 0.5
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8215,7 +8215,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8053184910327746,
+      "avgConfidence": 0.8064728921871758,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgRoleFidelity": 0.9867599742599743,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8262,6 +8262,10 @@
           "confidence": 1
         },
         "send-with-detail": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
           "success": true,
           "confidence": 1
         },
@@ -8430,10 +8434,6 @@
           "confidence": 0.8222222222222222
         },
         "go-url": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "default-value": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -8847,7 +8847,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7965780251494518,
+      "avgConfidence": 0.7977324263038529,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgRoleFidelity": 0.9893018018018019,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8894,6 +8894,10 @@
           "confidence": 1
         },
         "send-with-detail": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
           "success": true,
           "confidence": 1
         },
@@ -9058,10 +9062,6 @@
           "confidence": 0.8222222222222222
         },
         "go-url": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "default-value": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -9481,13 +9481,13 @@
       "parseRate": 1,
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
-      "avgPrecision": 0.9826839826839827,
+      "avgPrecision": 0.985930735930736,
       "avgRoleFidelity": 0.9578667953667953,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10111,7 +10111,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8163265306122427,
+      "avgConfidence": 0.8174809317666439,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgRoleFidelity": 0.9890765765765768,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10158,6 +10158,10 @@
           "confidence": 1
         },
         "send-with-detail": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
           "success": true,
           "confidence": 1
         },
@@ -10334,10 +10338,6 @@
           "confidence": 0.8222222222222222
         },
         "go-url": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "default-value": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -10743,7 +10743,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7990105132962256,
+      "avgConfidence": 0.8001649144506268,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgRoleFidelity": 0.9893018018018019,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10790,6 +10790,10 @@
           "confidence": 1
         },
         "send-with-detail": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
           "success": true,
           "confidence": 1
         },
@@ -10954,10 +10958,6 @@
           "confidence": 0.8222222222222222
         },
         "go-url": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "default-value": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -11377,13 +11377,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8390022675736938,
       "avgFidelity": 1,
-      "avgPrecision": 0.9945887445887446,
+      "avgPrecision": 0.9978354978354977,
       "avgRoleFidelity": 0.9893018018018017,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12009,13 +12009,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8239183073548376,
       "avgFidelity": 1,
-      "avgPrecision": 0.9967532467532467,
+      "avgPrecision": 1,
       "avgRoleFidelity": 0.9938063063063062,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12639,15 +12639,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8456558061821213,
+      "avgConfidence": 0.8489025594288746,
       "avgFidelity": 1,
-      "avgPrecision": 0.9796807359307359,
+      "avgPrecision": 0.9829274891774892,
       "avgRoleFidelity": 0.9729133545310015,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12762,6 +12762,10 @@
           "confidence": 1
         },
         "log-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
           "success": true,
           "confidence": 1
         },
@@ -13177,10 +13181,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "default-value": {
-          "success": true,
-          "confidence": 0.5
-        },
         "async-block": {
           "success": true,
           "confidence": 0.5
@@ -13271,15 +13271,15 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8167388167388147,
+      "avgConfidence": 0.8178932178932158,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9890765765765768,
+      "avgRoleFidelity": 0.9890765765765765,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13326,6 +13326,10 @@
           "confidence": 1
         },
         "send-with-detail": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
           "success": true,
           "confidence": 1
         },
@@ -13490,10 +13494,6 @@
           "confidence": 0.8222222222222222
         },
         "go-url": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "default-value": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -13903,7 +13903,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8030921459492868,
+      "avgConfidence": 0.8042465471036879,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgRoleFidelity": 0.9930180180180183,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13950,6 +13950,10 @@
           "confidence": 1
         },
         "send-with-detail": {
+          "success": true,
+          "confidence": 1
+        },
+        "default-value": {
           "success": true,
           "confidence": 1
         },
@@ -14118,10 +14122,6 @@
           "confidence": 0.8222222222222222
         },
         "multiple-events": {
-          "success": true,
-          "confidence": 0.8222222222222222
-        },
-        "default-value": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 486814,
+      "bundleSize": 487255,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 486814,
+      "size": 487255,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Session 12 = **L4 of the launch bar**: the `default ×9` en-noise inversion, cleared with **all 24 languages aligned in a single step** — plus a bonus `before ×1` (qu). **avgPrecision 0.9939 → 0.9953: launch-bar item 3 (≥0.995) is reached.**

The family was an inversion: en itself dropped the `default` action from `on load default my @data-count to "0"` (the reference was wrong), while ar/bn/hi/it/ja/ko/th/tl/tr kept it with junk roles. Landing en's enrichment together with everyone's alignment produced zero honest dips.

### Mechanisms (as pre-probed at session-11 close)

1. **`defaultSchema` enriched to set-parallel shape** — destination admits `selector/reference/expression/property-path` (opting in the possessive matchers, per the in-code NOTE), and both roles carry a complete 24-language `markerOverride` table matching the dict renders (de `zu` ≠ set's `auf`, sw `kwa` ≠ `kwenye`; SOV destination markers ja を / ko 를 / tr i / hi को mirror set's). The SOV four ride the existing `sov-2role-dest-first` event patterns the instant their markers exist.
2. **Shattered-compound fold generalized** — the #592 hyphen fold is now `tryMatchShatteredCompound` (separators `-` and `_`, particle segments accepted): ru `по_умолчанию` / uk `за_замовчуванням` form across their tokenizers' by-design `_` splits.
3. **Profile↔dict keyword realigns** — qu default primary → `ñawpaq_kaq` (dict render; `qallariy` kept as alternative — NB the qu dict uses qallariy for *reset*), sw += bare `msingi`. The qu fix also cleared **spurious `before` ×1** (the `ñawpaq` shard read as "first").

All 24 languages now parse the corpus line with byte-identical roles: `destination=property-path{me,@data-count}`, `patient=literal:"0"`.

## Validation

- **Per-(lang,pattern) A/B (dist before/after):** 10 spurious cleared (`default` ×9 + `before` ×1 qu), **zero new entries**, census **3404** identical
- **Baseline:** avgPrecision **0.9939 → 0.9953** (bar ≥0.995 ✓), avgFidelity 1.000, R1 0.9838 held, parse 3696/3696, degenerate/lossy 0, R2 1.0 — regenerated with `--save-baseline` against a fresh `populate`
- **Six-signal `--regression` gate:** green
- **Guard tests:** 9 new (8 stash-verified fail-without-fix, 1 both-ways negative — a bare leading particle never anchors default); `lexicon-emit-mismatch` allowlist pruned (its qu/sw default entries self-flagged as now-parsing)
- **Semantic suite:** 6604 passed / 86 files; typecheck clean

## Docs (folded in, per no-docs-only-PRs)

Session-12 handoff status block + NEXT_STEPS (status table, LAUNCH BAR L4 ✓ with actuals, 2026-07-06g update block), including the **empty ×8 pre-probe for L5**: transformer-side confirmed — the SOV reorder displaces the `is empty` predicate adjective into the next command's argument zone, where it anchors `empty-{lang}-generated` and *steals a neighboring role* (hi grabs the add's `.error` patient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)