### PR TITLE
fix(multilingual): canonical @attr typing — add ×20 + toggle ×19 + set ×7 cleared in one step; avgRoleFidelity 0.9862, launch-bar ≥0.985 REACHED (L5)

### DIFF
--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -1,5 +1,45 @@
 # Handoff — R1 residue after the five-cluster triage (fronted repeat-while · sw kama homonym · singletons)
 
+> **STATUS UPDATE (2026-07-06, session 13 = L5 of the launch bar): the
+> canonical `@attr` typing drill LANDED (this PR) — avgRoleFidelity 0.9838 →
+> 0.9862, LAUNCH BAR item 4 (≥0.985) REACHED. Bar items 1/3/4 now all hold;
+> only item 2 remains (spurious for ×9 + empty ×8).**
+> Post-session state: parse 3696/3696, degenerate/lossy 0, avgPrecision
+> 0.9953 held, R2 1.0, census 3404, A/B 44 missing cleared / 0 new, gate
+> green, baseline regenerated.
+>
+> 1. **One rule cleared three families (44 entries).** As pre-probed at
+>    session-12 close, add ×20 and toggle ×19 were the same root cause in
+>    opposite directions — and set.destination:selector ×7 (set-attribute
+>    ar/bn/hi/ja/ko/tl/tr) turned out to be its third face. `@attr` tokens
+>    type-diverged per capturing slot: selector-expecting slots hit the
+>    pattern-matcher's gated @→selector conversion; lax no-expectedTypes slots
+>    (the generated event-role slots + toggle-en-full's patient) fell through
+>    to identifier→expression. The fix: `tokenToSemanticValue` now types ANY
+>    `@`-prefixed identifier as a selector (the canonical typing — mirrors
+>    semantic-parser's own value path and the css-selector extractor); the
+>    per-slot conversion block is deleted; a narrow @-gated compatibility rule
+>    in the strict expectedTypes check keeps `['reference','expression']`-only
+>    slots (bind destination) capturing @attrs — as selectors. en moved WITH
+>    the other languages on toggle/set (its lax-slot expression reading was
+>    half the asymmetry), so both-directions A/B was run: zero honest dips,
+>    zero new entries, census identical. R2 green (attribute toggles are in
+>    the curated subset). 5 guards (3 stash-verified flips + 2 both-ways
+>    negatives); the hi set-attribute roadmap test updated from the `.raw`
+>    expression reading to the canonical selector shape.
+> 2. **Deliberately not taken:** add.destination ×4 (bn/hi/ja/ko — the SOV
+>    renders embed en-ish `<button/> in me` before the destination particle
+>    and the slot captures the adjacent `me`; post-launch tail now that the
+>    bar is exceeded), toggle.destination ×2 (qu/th simple patterns).
+> 3. **L6 = the last launch-bar increment (item 2):** (a) empty ×8 bn/hi/tr —
+>    transformer-side, CONFIRMED and fully pre-probed in the session-12 L5
+>    paragraph below (the SOV reorder displaces the `is empty` predicate
+>    adjective into the next command's argument zone; fix keeps it inside the
+>    condition clause, then re-probe parse side against NEW renders +
+>    repopulate; behavior-sortable hi/tr same mechanism). (b) for ×9's
+>    take-class ×6 own-arc (probe BOTH transformer and parse sides first);
+>    wait-payload behaviors ×3 stay post-launch.
+
 > **STATUS UPDATE (2026-07-06, session 12 = L4 of the launch bar): the
 > default-value full drill LANDED (this PR) — spurious default ×9 cleared
 > with all 24 languages aligned in ONE step, plus the qu spurious before ×1

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -9,7 +9,7 @@
 > [BEHAVIORS_CONSOLIDATION_PLAN.md](BEHAVIORS_CONSOLIDATION_PLAN.md). Read this first,
 > then dive into those for the per-arc detail.
 
-## Where we are (2026-07-06 baseline · post session-12 / L4 · `browser-priority`)
+## Where we are (2026-07-06 baseline · post session-13 / L5 · `browser-priority`)
 
 Authoritative source: `packages/testing-framework/baselines/multilingual-priority.json`
 (its `timestamp` + `commit` fields stamp each regen). 24 langs × 154 patterns = 3696.
@@ -22,14 +22,14 @@ Authoritative source: `packages/testing-framework/baselines/multilingual-priorit
 | faithful (fid = 1.0)           | **3696**               | every parsing pattern is faithful                         |
 | avgFidelity (R0-recall)        | **1.000**              | saturated                                                 |
 | avgPrecision (R0 trust floor)  | **0.995**              | session-12 / L4: 0.9939 → 0.9953 — **bar 3 reached**      |
-| avgRoleFidelity (R1)           | **0.984**              | 0.9838 held through L4                                    |
+| avgRoleFidelity (R1)           | **0.986**              | session-13 / L5: 0.9838 → 0.9862 — **bar 4 reached**      |
 | avgExecutionFidelity (R2)      | **1.000**              | 47-pattern curated subset fully reproduces en DOM effects |
 
 The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recall ·
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
-**Direction now: stop adding gate signals; spend them down.** R1 remains the
-dimension with headroom (SOV six ~0.95); R0-precision's spurious-action
-families are the next un-mined seam.
+**Direction now: stop adding gate signals; spend them down.** Bar items 3 and 4
+are both reached and gate-held; the remaining launch work is bar item 2
+(spurious for ×9 + empty ×8).
 
 ## LAUNCH BAR (adopted 2026-07-06, post session 8)
 
@@ -48,10 +48,13 @@ normal usage). The bar, all four together:
    sibling). Remaining: for ×9, empty ×8.
 3. **avgPrecision ≥ 0.995** — **REACHED session 12: 0.9953.** The six-signal
    gate holds it from here.
-4. **avgRoleFidelity ≥ 0.985** (0.9838 as of session 12) — the big R1-missing
-   families (add.patient:selector ×20, toggle.patient:expression ×19,
-   fetch.source:literal ×18, set.patient:literal ×16,
-   bind.source:property-path ×14) carry most of this.
+4. **avgRoleFidelity ≥ 0.985** — **REACHED session 13: 0.9862.** The canonical
+   `@attr` typing drill cleared add.patient ×18 + toggle.patient ×19 +
+   set.destination ×7 in one step (44 entries, all three families were the
+   same slot-dependent type divergence). The remaining big families
+   (fetch.source:literal ×18, set.patient:literal ×16,
+   bind.source:property-path ×14, render.style ×12) are now post-launch
+   polish — the gate holds the bar from here.
 
 Estimated **4–6 sessions** at the observed velocity (~30 A/B entries/session
 across sessions 4–8, full discipline included). Sequencing:
@@ -62,7 +65,8 @@ across sessions 4–8, full discipline included). Sequencing:
 | L2 ✓    | breakpoint ×6+halt ×3 + bn `for` transition-half ×5 + transition ×6  | precision 0.9910 → 0.9928 |
 | L3 ✓    | on ×7 he/hi (#595) + call ×7 halt-verb-guard (session-11 PR 2)       | precision 0.9928 → 0.9939 |
 | L4 ✓    | default-value full drill (24 langs: schema markers + \_-fold)        | precision 0.9939 → 0.9953 |
-| L5–L6   | big R1-missing families (add/toggle patient, fetch/bind source, set) | R1 → ≥0.985               |
+| L5 ✓    | canonical @attr typing (add/toggle patient + set.destination, ×44)   | R1 0.9838 → 0.9862        |
+| L6      | bar item 2 remainder: empty ×8 (transformer-side) + for ×9 take-half | spurious >×5 → 0          |
 
 L1 actual precision movement (+0.0019 for 29 entries) ran well under the
 table's ~0.997 sketch — the remaining seven >×5 families plus the tail carry
@@ -78,6 +82,14 @@ L4 actual: +0.0014 for 10 spurious cleared (default ×9 + the qu before ×1
 bonus from the ñawpaq_kaq underscore fold) — **the ≥0.995 bar is reached**;
 remaining >×5 inventory is for ×9 and empty ×8 (bar item 2), and L5–L6 carry
 the R1 bar (0.9838 → ≥0.985).
+L5 actual: **+0.0024 for 44 R1-missing entries cleared in ONE parser-side
+step** (the pre-probed add ×20 / toggle ×19 opposite-direction asymmetry was
+indeed one root cause — slot-dependent `@attr` typing — and set.destination ×7
+was the same bug in a third family; the two hi add entries that remain belong
+to the empty-arc role steal). Zero honest dips, zero new A/B entries, census
+identical — **the ≥0.985 R1 bar is reached**. Remaining launch work is bar
+item 2 only: empty ×8 (transformer-side, pre-probed session 12) + for ×9
+(take-class ×6 own-arc; wait-payload ×3 post-launch).
 
 **Post-launch track (ratchet-protected, not launch-blocking):** SOV-six role
 polish (qu/hi ~0.956 R1), tr remove.patient block-walk leak, spurious empty
@@ -88,6 +100,42 @@ fail CI.
 Caveats: each en enrichment can mint honest-dip entries (bounded by the
 census/A-B discipline; historically <1 session total), and this scopes the
 fidelity grind only — docs/demo/npm-publish polish is separate scope.
+
+> **Update 2026-07-06h (SESSION 13 = L5, one drill: canonical `@attr` typing
+> in the shared value-builder; avgRoleFidelity 0.9838 → 0.9862 — LAUNCH BAR
+> item 4 (≥0.985) REACHED; avgPrecision 0.9953 held; A/B 44 missing cleared /
+> 0 new; census identical (3404); gate green incl. R2; baseline regenerated.)**
+>
+> - **The add ×20 / toggle ×19 opposite-direction asymmetry was ONE bug, and
+>   set.destination ×7 was its third face.** `@attr` tokens (kind
+>   `identifier`) were typed per-slot: a slot whose expectedTypes included
+>   `selector` hit the pattern-matcher's @→selector conversion; a LAX slot (no
+>   expectedTypes — the generated event-role slots, and toggle-en-full's
+>   patient) fell to the identifier→expression fall-through. Same token,
+>   different type depending on which pattern captured it: add `@disabled`
+>   en=selector / 18 langs=expression, toggle `@aria-expanded` the exact
+>   opposite, set-attribute `@disabled` destination diverged ar/bn/hi/ja/ko/
+>   tl/tr. The fix is ONE canonical rule in the shared value-builder
+>   (`tokenToSemanticValue`): an `@`-prefixed identifier is ALWAYS a selector
+>   (mirrors semantic-parser's own value path and the css-selector extractor).
+>   The old conversion block is deleted; slots that expect only
+>   `['reference','expression']` (bind's destination) still capture an @attr —
+>   as the canonical selector — via a narrow @-gated compatibility rule in the
+>   strict expectedTypes check. All 24 languages now byte-identical on
+>   form-disable-on-submit, accordion-toggle, toggle-aria-expanded,
+>   toggle-visibility, and set-attribute. 5 guards (3 stash-verified flips +
+>   2 both-ways); 1 existing hi set-attribute test updated to the canonical
+>   shape (was locked to the `.raw` expression reading).
+> - **Not taken (post-launch tail):** add.destination:selector ×4 (bn/hi/ja/ko
+>   — the SOV renders keep the en-ish `<button/> in me` phrase and the slot
+>   captures the `me` adjacent to the destination particle; the bar is already
+>   exceeded without it). toggle.destination ×2 (qu/th simple patterns drop
+>   the destination). The remaining big R1 families (fetch ×18 two sub-arcs,
+>   set.patient:literal ×16, bind ×14, render.style ×12) keep their own-arc
+>   notes in the session-12 block below.
+> - **Remaining launch work: bar item 2 only** — empty ×8 (bn/hi/tr,
+>   transformer-side, pre-probed session 12 — see the L5 paragraph of the
+>   handoff doc) + for ×9's take-class ×6 own-arc.
 
 > **Update 2026-07-06g (SESSION 12 = L4, one drill: the default-value full
 > drill in this PR; avgPrecision 0.9939 → 0.9953 — LAUNCH BAR item 3 (≥0.995)

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -808,23 +808,6 @@ export class PatternMatcher {
       }
     }
 
-    // Attribute selectors (`@attr`) tokenize with kind `identifier`, not
-    // `selector` — and that kind is load-bearing: roles like bind's `@property`
-    // (expectedTypes ['reference','expression']) rely on the identifier reading.
-    // But when a role *explicitly expects a selector* (e.g. add/remove/toggle's
-    // patient), an `@`-identifier is an attribute selector — so convert it here,
-    // gated on the role opting into `selector`. This lets `add @disabled to
-    // <button/>` fill its patient without disturbing the non-selector @-roles.
-    if (
-      token.kind === 'identifier' &&
-      token.value.startsWith('@') &&
-      patternToken.expectedTypes?.includes('selector')
-    ) {
-      captured.set(patternToken.role, createSelector(token.value));
-      tokens.advance();
-      return true;
-    }
-
     // Try to extract a semantic value from the token
     const value = this.tokenToSemanticValue(token);
     if (!value) {
@@ -834,7 +817,23 @@ export class PatternMatcher {
     // Validate expected types if specified
     if (patternToken.expectedTypes && patternToken.expectedTypes.length > 0) {
       if (!patternToken.expectedTypes.includes(value.type)) {
-        return patternToken.optional || false;
+        // Canonical `@attr` typing: an attribute reference is ALWAYS a
+        // selector (tokenToSemanticValue), regardless of which slot captures
+        // it — the old slot-dependent reading (selector when the slot expected
+        // one, expression when lax) made the SAME token type-diverge between
+        // en's patterns and the generated event-role slots (add `@disabled`
+        // en=selector / 18 langs=expression; toggle `@aria-expanded` the exact
+        // opposite). Slots that relied on the identifier/expression reading
+        // (bind's `@property`, expectedTypes ['reference','expression']) still
+        // capture it — as the canonical selector.
+        const isAttrRef =
+          value.type === 'selector' && String((value as { value: unknown }).value).startsWith('@');
+        const slotTakesExpr = patternToken.expectedTypes.some(
+          t => t === 'expression' || t === 'reference'
+        );
+        if (!(isAttrRef && slotTakesExpr)) {
+          return patternToken.optional || false;
+        }
       }
     }
 
@@ -2255,6 +2254,14 @@ export class PatternMatcher {
         return createLiteral(token.normalized || token.value);
 
       case 'identifier':
+        // Canonical `@attr` typing: an attribute reference is a selector no
+        // matter which slot captures it (mirrors semantic-parser's own
+        // tokenToSemanticValue and the css-selector extractor). The former
+        // slot-dependent reading typed the SAME token differently between
+        // en's patterns and the lax generated event-role slots.
+        if (token.value.startsWith('@')) {
+          return createSelector(token.value);
+        }
         // Check if it's a variable reference (:local or $global)
         // Note: these don't match the ReferenceValue union but are used as a
         // reference token downstream — this cast preserves existing behavior

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -496,13 +496,16 @@ describe('ar measure keyword alignment (undiacritized قس)', () => {
   });
 });
 
-describe('Attribute selectors (@attr) in selector-expecting roles (form-disable)', () => {
-  // `@disabled` tokenizes with kind `identifier` (load-bearing — bind's
-  // `@property` relies on the identifier reading, expectedTypes
-  // ['reference','expression']). When a role explicitly expects a `selector`
-  // (add/remove/toggle patient), an `@`-identifier is an attribute selector and
-  // is now accepted. This clears `add @disabled to <button/>`, which gated the
-  // form-disable-on-submit body. See docs-internal/MULTILINGUAL_ROADMAP.md.
+describe('Attribute selectors (@attr) — canonical selector typing in every slot', () => {
+  // `@disabled` tokenizes with kind `identifier`, but its SemanticValue type is
+  // canonically `selector` regardless of which pattern slot captures it (the
+  // shared value-builder, pattern-matcher.tokenToSemanticValue). The old
+  // slot-dependent reading (selector when the slot expected one, expression
+  // when the slot was lax) made the SAME token type-diverge between en's
+  // patterns and the generated event-role slots — add `@disabled` en=selector
+  // vs 18 langs=expression, toggle `@aria-expanded` the exact opposite — the
+  // launch-bar L5 R1 drill. Slots that expect ['reference','expression'] only
+  // (bind's destination) still capture an @attr — as the canonical selector.
   it('parses `add @disabled to <button/>` (attribute patient)', () => {
     expect(canParse('add @disabled to <button/>', 'en')).toBe(true);
     expect(parse('add @disabled to <button/>', 'en').action).toBe('add');
@@ -513,9 +516,44 @@ describe('Attribute selectors (@attr) in selector-expecting roles (form-disable)
   });
 
   it('does not change bind, whose @property is a non-selector role', () => {
-    // bind's destination is expectedTypes ['reference','expression'] — the @attr
-    // conversion is gated to selector-expecting roles, so bind is untouched.
+    // bind's destination is expectedTypes ['reference','expression'] — an
+    // @attr is still accepted there (captured as the canonical selector).
     expect(parse('$color を #pickerの 値 に バインド', 'ja').action).toBe('bind');
+  });
+
+  const roleOf = (node: unknown, role: string) => {
+    const cmd = ((node as { body?: unknown[] }).body ?? [node])[0] as {
+      roles?: Map<string, { type?: string; value?: unknown }>;
+    };
+    return cmd.roles?.get(role);
+  };
+
+  it('en toggle via a LAX slot types @attr as selector (toggle-en-full patient)', () => {
+    // The en reference flip of the L5 drill: toggle-en-full's patient slot has
+    // no expectedTypes, so `@aria-expanded` read as expression while the
+    // generated toggle patterns of other languages read selector — 19 R1
+    // entries from one token. Canonical typing: selector everywhere.
+    const node = parse('on click toggle @aria-expanded on me', 'en');
+    expect(roleOf(node, 'patient')).toMatchObject({ type: 'selector', value: '@aria-expanded' });
+  });
+
+  it('en add via a selector-expecting slot types @attr as selector (unchanged direction)', () => {
+    const node = parse('on submit add @disabled to <button/> in me', 'en');
+    expect(roleOf(node, 'patient')).toMatchObject({ type: 'selector', value: '@disabled' });
+  });
+
+  it('en set destination @attr is a selector (set-attribute family, ×7 alignment)', () => {
+    const node = parse('on click set @disabled to true', 'en');
+    expect(roleOf(node, 'destination')).toMatchObject({ type: 'selector', value: '@disabled' });
+  });
+
+  it('a lax generated event-role slot (de vso) types @attr as selector', () => {
+    // de rides add-event-de-vso (no expectedTypes on the wrapped patient slot)
+    // and read expression pre-drill; must match en's selector byte-for-byte.
+    // (Corpus render of form-disable-on-submit, first clause.)
+    const node = parse('bei absenden hinzufügen @disabled zu <button/> in me', 'de');
+    expect(node.action).toBe('on');
+    expect(roleOf(node, 'patient')).toMatchObject({ type: 'selector', value: '@disabled' });
   });
 
   const formDisable: Array<[string, string]> = [
@@ -6731,10 +6769,12 @@ describe('hi set-family marker alignment (S6 — fronted target before event)', 
 
   it('[hi] set-attribute: destination=@disabled, patient=true', () => {
     const cmd = setBody('@disabled को क्लिक पर सेट सच में') as
-      | { action?: string; roles?: Map<string, { raw?: string; value?: unknown }> }
+      | { action?: string; roles?: Map<string, { type?: string; raw?: string; value?: unknown }> }
       | undefined;
     expect(cmd?.action).toBe('set');
-    expect(cmd?.roles?.get('destination')?.raw).toBe('@disabled');
+    // canonical @attr typing: an attribute reference is a selector in EVERY
+    // slot (`.raw` was the old slot-dependent expression reading)
+    expect(cmd?.roles?.get('destination')).toMatchObject({ type: 'selector', value: '@disabled' });
     expect(cmd?.roles?.get('patient')?.value).toBe('true');
   });
 });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-07T00:29:42.374Z",
-  "commit": "a9e4fcf5",
+  "timestamp": "2026-07-07T01:15:34.206Z",
+  "commit": "614c8f02",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9,12 +9,12 @@
       "avgConfidence": 0.8394563407500147,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9870495495495494,
+      "avgRoleFidelity": 0.9898648648648649,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -641,12 +641,12 @@
       "avgConfidence": 0.8579007041413049,
       "avgFidelity": 1,
       "avgPrecision": 0.9790582647200294,
-      "avgRoleFidelity": 0.9733108108108108,
+      "avgRoleFidelity": 0.9772522522522522,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.8261801690373097,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9838320463320464,
+      "avgRoleFidelity": 0.9860842985842987,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8319521748093155,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9904279279279278,
+      "avgRoleFidelity": 0.9915540540540541,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8228818800247351,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9838320463320464,
+      "avgRoleFidelity": 0.9860842985842987,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3794,12 +3794,12 @@
       "avgConfidence": 0.8295609152752009,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9926801801801801,
+      "avgRoleFidelity": 0.9966216216216216,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4426,12 +4426,12 @@
       "avgConfidence": 0.9077564039970039,
       "avgFidelity": 1,
       "avgPrecision": 0.9775162337662338,
-      "avgRoleFidelity": 0.9618082368082366,
+      "avgRoleFidelity": 0.9657496782496782,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.8371057513914636,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9862451737451738,
+      "avgRoleFidelity": 0.9884974259974261,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8346320346320326,
       "avgFidelity": 1,
       "avgPrecision": 0.997835497835498,
-      "avgRoleFidelity": 0.9979086229086228,
+      "avgRoleFidelity": 0.9990347490347491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8500157319706186,
       "avgFidelity": 1,
       "avgPrecision": 0.9859307359307362,
-      "avgRoleFidelity": 0.9733108108108108,
+      "avgRoleFidelity": 0.9772522522522522,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6954,12 @@
       "avgConfidence": 0.8449652269201134,
       "avgFidelity": 1,
       "avgPrecision": 0.9859307359307362,
-      "avgRoleFidelity": 0.9699324324324325,
+      "avgRoleFidelity": 0.9738738738738738,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8358688930117478,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9881756756756759,
+      "avgRoleFidelity": 0.990427927927928,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8064728921871758,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9867599742599743,
+      "avgRoleFidelity": 0.9878861003861006,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8850,12 @@
       "avgConfidence": 0.7977324263038529,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9893018018018019,
+      "avgRoleFidelity": 0.9915540540540541,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9482,12 @@
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
       "avgPrecision": 0.985930735930736,
-      "avgRoleFidelity": 0.9578667953667953,
+      "avgRoleFidelity": 0.9576415701415699,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.8174809317666439,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9890765765765768,
+      "avgRoleFidelity": 0.9902027027027028,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10746,12 +10746,12 @@
       "avgConfidence": 0.8001649144506268,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9893018018018019,
+      "avgRoleFidelity": 0.9915540540540541,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.8390022675736938,
       "avgFidelity": 1,
       "avgPrecision": 0.9978354978354977,
-      "avgRoleFidelity": 0.9893018018018017,
+      "avgRoleFidelity": 0.9902027027027028,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12010,12 +12010,12 @@
       "avgConfidence": 0.8239183073548376,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9938063063063062,
+      "avgRoleFidelity": 0.9966216216216216,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12642,12 +12642,12 @@
       "avgConfidence": 0.8489025594288746,
       "avgFidelity": 1,
       "avgPrecision": 0.9829274891774892,
-      "avgRoleFidelity": 0.9729133545310015,
+      "avgRoleFidelity": 0.9768547959724427,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13274,12 +13274,12 @@
       "avgConfidence": 0.8178932178932158,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9890765765765765,
+      "avgRoleFidelity": 0.9902027027027028,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13906,12 +13906,12 @@
       "avgConfidence": 0.8042465471036879,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9930180180180183,
+      "avgRoleFidelity": 0.9941441441441443,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14538,12 +14538,12 @@
       "avgConfidence": 0.9840032982890127,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.989060489060489,
+      "avgRoleFidelity": 0.9930019305019305,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487255,
+      "bundleSize": 487320,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 487255,
+      "size": 487320,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Session 13 = L5 of the launch bar: the canonical `@attr` typing drill. **Launch-bar item 4 (avgRoleFidelity ≥ 0.985) is REACHED: 0.9838 → 0.9862.** Bar items 1/3/4 now all hold; only item 2 remains (spurious for ×9 + empty ×8).

### Root cause — one bug, three faces

`@attr` tokens (kind `identifier`) were typed **per capturing slot**:

- a slot whose `expectedTypes` included `selector` hit the pattern-matcher's gated `@`→selector conversion → **selector**
- a lax no-expectedTypes slot (the generated event-role slots, toggle-en-full's patient) fell through to the identifier→expression fall-through → **expression**

Same token, opposite divergence directions: add `@disabled` en=selector / 18 langs=expression; toggle `@aria-expanded` en=expression / ~16 langs=selector; set-attribute `@disabled` destination diverged ar/bn/hi/ja/ko/tl/tr.

### Fix (parser-side, one rule)

- `tokenToSemanticValue` (the shared value-builder) now types ANY `@`-prefixed identifier as a **selector** — mirrors semantic-parser's own value path and the css-selector extractor's attribute-reference framing.
- The per-slot `@`→selector conversion block is deleted.
- A narrow `@`-gated compatibility rule in the strict expectedTypes check keeps `['reference','expression']`-only slots (bind's destination) capturing @attrs — as the canonical selector.

All 24 languages are now byte-identical on form-disable-on-submit, accordion-toggle, toggle-aria-expanded, toggle-visibility, and set-attribute.

### Validation (full discipline)

- **Per-(lang,pattern) A/B both directions** (the en reference moved on toggle/set): 44 missing entries cleared (`add.patient:selector` ×18, `toggle.patient:expression` ×19, `set.destination:selector` ×7 bonus), **0 new**, census 3404 identical. The 2 surviving hi add entries belong to the empty-arc role steal (L6).
- **Six-signal `--regression` gate green** incl. R2 (attribute toggles are in the curated subset); baseline regenerated against a fresh populate in this PR.
- Baseline: parse 3696/3696, degenerate/lossy 0, avgFidelity 1.000, avgPrecision 0.9953 held, avgRoleFidelity **0.9862**, R2 1.000.
- Semantic suite 6604 passed; core suite 7012 passed.
- 5 guards (3 stash-verified behavior flips + 2 both-ways negatives); the hi set-attribute roadmap test updated from the `.raw` expression reading to the canonical selector shape.

### Deliberately not taken (post-launch tail)

`add.destination:selector` ×4 (bn/hi/ja/ko — SOV renders embed en-ish `<button/> in me` and the slot captures the adjacent `me`), `toggle.destination` ×2 (qu/th simple patterns). Bar already exceeded without them.

### Docs

Session-13 status blocks folded into `docs-internal/HANDOFF-r1-post-cluster-residue.md` and `docs-internal/MULTILINGUAL_NEXT_STEPS.md` (status table, LAUNCH BAR items 4 ✓ + sequencing table L5 ✓ row, update block 2026-07-06h).

🤖 Generated with [Claude Code](https://claude.com/claude-code)