### PR TITLE
fix(multilingual): empty ×8 both-sides drill — predicate adjective stays in the condition; avgPrecision 0.9957 (L6)

### DIFF
--- a/docs-internal/HANDOFF-r1-post-cluster-residue.md
+++ b/docs-internal/HANDOFF-r1-post-cluster-residue.md
@@ -1,9 +1,20 @@
 # Handoff — R1 residue after the five-cluster triage (fronted repeat-while · sw kama homonym · singletons)
 
-> **STATUS UPDATE (2026-07-06, session 13 = L5 of the launch bar): the
-> canonical `@attr` typing drill LANDED (this PR) — avgRoleFidelity 0.9838 →
-> 0.9862, LAUNCH BAR item 4 (≥0.985) REACHED. Bar items 1/3/4 now all hold;
-> only item 2 remains (spurious for ×9 + empty ×8).**
+> **STATUS UPDATE (2026-07-06, session 13 = L5 + L6 of the launch bar): TWO
+> drills landed — #598 (canonical `@attr` typing: avgRoleFidelity 0.9838 →
+> 0.9862, LAUNCH BAR item 4 REACHED) and the empty ×8 both-sides drill (this
+> PR: spurious empty ×8 + hi add ×2 role-steal cleared; avgPrecision 0.9953 →
+> 0.9957, R1 0.9863). Bar items 1/3/4 hold; item 2 is down to ONE family:
+> for ×9 (take-class ×6 own-arc + wait-payload ×3 post-launch).**
+>
+> 0. **L6 drill (this PR) in brief — full detail in NEXT_STEPS 2026-07-06i:**
+>    transformer condition/body scans cut `if my value is empty …` at the
+>    copula (`empty` is a command keyword) → shared predicate-adjective guard;
+>    parse-side SOV verb-lookup exception re-split the healed adjacency
+>    (खाली/boş/খালি double as command verbs) → `CONDITION_PREDICATES` excluded
+>    (this alone cleared behavior-sortable hi/tr); qu ripple (shattered
+>    `ch_usaq` fused into add.patient) → fused `chusaq` dict render + kanqa in
+>    the surface-copula set. 13 stash-verified guards; zero new A/B entries.**
 > Post-session state: parse 3696/3696, degenerate/lossy 0, avgPrecision
 > 0.9953 held, R2 1.0, census 3404, A/B 44 missing cleared / 0 new, gate
 > green, baseline regenerated.

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -9,7 +9,7 @@
 > [BEHAVIORS_CONSOLIDATION_PLAN.md](BEHAVIORS_CONSOLIDATION_PLAN.md). Read this first,
 > then dive into those for the per-arc detail.
 
-## Where we are (2026-07-06 baseline · post session-13 / L5 · `browser-priority`)
+## Where we are (2026-07-06 baseline · post session-13 / L5+L6 · `browser-priority`)
 
 Authoritative source: `packages/testing-framework/baselines/multilingual-priority.json`
 (its `timestamp` + `commit` fields stamp each regen). 24 langs × 154 patterns = 3696.
@@ -21,15 +21,16 @@ Authoritative source: `packages/testing-framework/baselines/multilingual-priorit
 | lossy passes (0.5 ≤ fid < 1.0) | **0**                  | band cleared (#495–#506), holding                         |
 | faithful (fid = 1.0)           | **3696**               | every parsing pattern is faithful                         |
 | avgFidelity (R0-recall)        | **1.000**              | saturated                                                 |
-| avgPrecision (R0 trust floor)  | **0.995**              | session-12 / L4: 0.9939 → 0.9953 — **bar 3 reached**      |
+| avgPrecision (R0 trust floor)  | **0.996**              | bar 3 reached L4 (0.9953); L6 empty drill → 0.9957        |
 | avgRoleFidelity (R1)           | **0.986**              | session-13 / L5: 0.9838 → 0.9862 — **bar 4 reached**      |
 | avgExecutionFidelity (R2)      | **1.000**              | 47-pattern curated subset fully reproduces en DOM effects |
 
 The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recall ·
 R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
 **Direction now: stop adding gate signals; spend them down.** Bar items 3 and 4
-are both reached and gate-held; the remaining launch work is bar item 2
-(spurious for ×9 + empty ×8).
+are both reached and gate-held; the remaining launch work is bar item 2's
+last family: spurious for ×9 (take-class ×6 own-arc + wait-payload ×3
+post-launch) — empty ×8 cleared in the session-13 L6 drill.
 
 ## LAUNCH BAR (adopted 2026-07-06, post session 8)
 
@@ -66,7 +67,8 @@ across sessions 4–8, full discipline included). Sequencing:
 | L3 ✓    | on ×7 he/hi (#595) + call ×7 halt-verb-guard (session-11 PR 2)       | precision 0.9928 → 0.9939 |
 | L4 ✓    | default-value full drill (24 langs: schema markers + \_-fold)        | precision 0.9939 → 0.9953 |
 | L5 ✓    | canonical @attr typing (add/toggle patient + set.destination, ×44)   | R1 0.9838 → 0.9862        |
-| L6      | bar item 2 remainder: empty ×8 (transformer-side) + for ×9 take-half | spurious >×5 → 0          |
+| L6 ✓    | empty ×8 both-sides drill (+hi add ×2 role-steal; same session)      | precision 0.9953 → 0.9957 |
+| L7      | bar item 2 last family: for ×9 take-class half (probe both sides)    | spurious >×5 → 0          |
 
 L1 actual precision movement (+0.0019 for 29 entries) ran well under the
 table's ~0.997 sketch — the remaining seven >×5 families plus the tail carry
@@ -90,6 +92,13 @@ to the empty-arc role steal). Zero honest dips, zero new A/B entries, census
 identical — **the ≥0.985 R1 bar is reached**. Remaining launch work is bar
 item 2 only: empty ×8 (transformer-side, pre-probed session 12) + for ×9
 (take-class ×6 own-arc; wait-payload ×3 post-launch).
+L6 actual (same session, PR 2): **empty ×8 + the hi add.patient ×2 role-steal
+cleared in one both-sides drill** — precision 0.9953 → 0.9957, R1 0.9862 →
+0.9863, zero new A/B entries (a qu ripple was caught by the A/B discipline and
+fixed in the same increment: the healed render order let the shattering
+`ch_usaq` fuse with `.error`; dict now emits the fused `chusaq` + qu kanqa
+joined the surface-copula set). Remaining launch work: for ×9's take-class ×6
+own-arc ONLY.
 
 **Post-launch track (ratchet-protected, not launch-blocking):** SOV-six role
 polish (qu/hi ~0.956 R1), tr remove.patient block-walk leak, spurious empty
@@ -100,6 +109,43 @@ fail CI.
 Caveats: each en enrichment can mint honest-dip entries (bounded by the
 census/A-B discipline; historically <1 session total), and this scopes the
 fidelity grind only — docs/demo/npm-publish polish is separate scope.
+
+> **Update 2026-07-06i (SESSION 13 = L6, drill 2 in the same session: the
+> empty ×8 both-sides drill in this PR; avgPrecision 0.9953 → 0.9957;
+> avgRoleFidelity 0.9862 → 0.9863 (the hi add ×2 role-steal rode along); A/B
+> 10 cleared (8 spurious empty + 2 missing) / 0 new; census identical (3404);
+> gate green; baseline regenerated.)**
+>
+> - **The displacement was the transformer's condition/body scan, exactly as
+>   pre-probed — `empty` is itself a hyperscript command (v0.9.90).** The
+>   body-start scans (`transformBlockBody` + `extractBlockStructure`'s unless
+>   path) cut `if my value is empty add .error to me` at the first command
+>   keyword — `empty`, right after the copula — so the adjective landed in the
+>   add's argument zone. The fix is a shared copula guard
+>   (`isPredicateAdjectivePosition`): a command-keyword candidate immediately
+>   after a copula is a predicate adjective, never the body's first verb. The
+>   healed SOV renders also reorder the then-branch correctly now (hi
+>   `.error को जोड़ें` patient-first, was verb-first junk).
+> - **The parse side needed the mirror: the SOV verb-lookup exception (built
+>   for ko's old DISPLACED renders) re-split the healed `<copula> <predicate>`
+>   adjacency** because खाली/boş/খালি double as the language's empty/null
+>   COMMAND verb. `CONDITION_PREDICATES` is now excluded from that exception —
+>   this alone also cleared behavior-sortable hi/tr (`if item is null` renders
+>   condition-final खाली; null and empty share the word), which never needed a
+>   render change. ko's real-verb-after-copula case still splits (locked by
+>   test).
+> - **qu ripple caught by the zero-new-entries A/B discipline:** the healed
+>   order put qu's `ch_usaq` right before `.error`, and its tokenizer's
+>   by-design `_` split let the `usaq` shard fuse into the add's patient
+>   (`expression:"usaq.error"` — 2 NEW entries). Dict now emits the fused
+>   `chusaq` (the qu tokenizer already recognized it, norm `null` — the #535
+>   fused-forms route), and qu `kanqa` joined `CONDITION_COPULAS_SURFACE`
+>   (the bn হয় / hi है / tr dir mechanism). Final A/B: zero new entries.
+> - 13 guards across the two sides (6 i18n incl. a both-ways negative; 7
+>   semantic incl. the ko displaced-verb lock), all stash-verified.
+> - **Remaining launch-bar work (item 2): for ×9's take-class ×6 own-arc
+>   only** — probe BOTH transformer and parse sides first; wait-payload
+>   behaviors ×3 stay post-launch.
 
 > **Update 2026-07-06h (SESSION 13 = L5, one drill: canonical `@attr` typing
 > in the shared value-builder; avgRoleFidelity 0.9838 → 0.9862 — LAUNCH BAR

--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -176,7 +176,7 @@ export const qu: Dictionary = {
   values: {
     true: 'cheqaq',
     false: 'llulla',
-    null: 'ch_usaq',
+    null: 'chusaq',
     undefined: 'mana_riqsisqa',
     it: 'chay',
     its: 'chaypaq',
@@ -221,7 +221,7 @@ export const qu: Dictionary = {
     children: 'wawakuna',
     within: 'ukupi',
     no: 'mana_kanchu',
-    empty: 'ch_usaq',
+    empty: 'chusaq',
     some: 'wakin',
     'starts with': 'qallarisqa wan',
     'ends with': 'tukusqa wan',

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -2390,3 +2390,69 @@ describe('tr/hi/qu fused (no-underscore) mouse events (mousedown/mouseup)', () =
     expect(t.transform('on mousedown toggle .x')).not.toContain('rat_ñitiy');
   });
 });
+
+describe('Predicate adjective stays inside the condition clause (empty ×8 bn/hi/tr)', () => {
+  // `empty` is ALSO a hyperscript command (v0.9.90), so the block-body scans
+  // (transformBlockBody, extractBlockStructure's unless path) cut the condition
+  // of `if my value is empty add .error to me` at `is` and displaced the
+  // adjective into the add's argument zone — where it anchored a spurious
+  // `empty-{lang}-generated` parse and stole a neighboring role (hi took the
+  // add's `.error` patient). A command-keyword candidate immediately after a
+  // copula is a predicate adjective, never the body's first verb.
+  const IF_EMPTY = 'on blur if my value is empty add .error to me else remove .error from me end';
+
+  it('[hi] keeps है खाली adjacent inside the condition, verb after', () => {
+    const out = new GrammarTransformer('en', 'hi').transform(IF_EMPTY);
+    expect(out).toContain('है खाली'); // copula + predicate stay adjacent
+    // the adjective precedes the then-branch (no displacement past .error)
+    expect(out.indexOf('खाली')).toBeLessThan(out.indexOf('.error'));
+  });
+
+  it('[tr] keeps dir boş adjacent inside the condition', () => {
+    const out = new GrammarTransformer('en', 'tr').transform(IF_EMPTY);
+    expect(out).toContain('dir boş');
+    expect(out.indexOf('boş')).toBeLessThan(out.indexOf('.error'));
+  });
+
+  it('[bn] keeps হয় খালি adjacent inside the condition', () => {
+    const out = new GrammarTransformer('en', 'bn').transform(IF_EMPTY);
+    expect(out).toContain('হয় খালি');
+    expect(out.indexOf('খালি')).toBeLessThan(out.indexOf('.error'));
+  });
+
+  it('unless-path body scan applies the same copula guard', () => {
+    // extractBlockStructure's unless heuristic shares the scan: the condition
+    // runs through the predicate adjective to the real body verb.
+    const out = new GrammarTransformer('en', 'hi').transform(
+      'unless my value is empty add .error to me'
+    );
+    expect(out.indexOf('खाली')).toBeLessThan(out.indexOf('.error'));
+  });
+
+  it('a real body verb right after the condition still starts the body', () => {
+    // No copula before `add` — the scan must still cut there (byte-identical
+    // pre/post for conditions without a trailing predicate adjective).
+    const out = new GrammarTransformer('en', 'hi').transform(
+      'on blur if my value add .error to me end'
+    );
+    expect(out).toContain('.error');
+  });
+});
+
+describe('qu fused (no-underscore) empty/null value word (chusaq)', () => {
+  // The qu semantic tokenizer splits on `_` by design, so the old `ch_usaq`
+  // shattered (ch / _ / usaq) and the `usaq` shard fused with the following
+  // selector once the predicate-adjective guard healed the render order —
+  // `add` captured patient=expression:"usaq.error" (input-validation/if-empty
+  // qu). The dict now emits the fused `chusaq`, which the tokenizer already
+  // recognizes (norm `null`). Mirrors the #535 ru/uk fused-event route and the
+  // L4 qu ñawpaq_kaq dict↔profile realignment.
+  it('emits chusaq (fused) for is-empty conditions', () => {
+    const out = new GrammarTransformer('en', 'qu').transform(
+      'on blur if my value is empty add .error to me else remove .error from me end'
+    );
+    expect(out).toContain('kanqa chusaq');
+    expect(out).not.toContain('ch_usaq');
+    expect(out.indexOf('chusaq')).toBeLessThan(out.indexOf('.error'));
+  });
+});

--- a/packages/i18n/src/grammar/transformer.ts
+++ b/packages/i18n/src/grammar/transformer.ts
@@ -51,6 +51,37 @@ function getCommandKeywordsForLocale(locale: string): Set<string> {
 }
 
 /**
+ * English copula forms. A command keyword IMMEDIATELY after one of these is a
+ * predicate adjective, not a command verb: in `if my value is empty add .error
+ * to me` the `empty` belongs to the condition (`empty` is also a hyperscript
+ * command, v0.9.90). Without this guard the condition/body scans cut the
+ * condition at `is` and displace the adjective into the body's argument zone,
+ * where it anchors a spurious `empty-{lang}-generated` parse AND steals a
+ * neighboring role (the empty ×8 bn/hi/tr family). Source-locale copulas are
+ * added via the dictionary in `isPredicateAdjectivePosition`.
+ */
+const EN_COPULAS = ['is', 'are', 'was', 'were', 'am', 'be'];
+
+function getCopulasForLocale(locale: string): Set<string> {
+  const copulas = new Set(EN_COPULAS);
+  if (locale !== 'en') {
+    for (const form of EN_COPULAS) {
+      copulas.add(translateWord(form, 'en', locale).toLowerCase());
+    }
+  }
+  return copulas;
+}
+
+/**
+ * True when tokens[i] sits right after a copula — a predicate-adjective
+ * position that must never be read as the start of a body command.
+ */
+function isPredicateAdjectivePosition(tokens: string[], i: number, copulas: Set<string>): boolean {
+  const prev = tokens[i - 1]?.toLowerCase();
+  return !!prev && copulas.has(prev);
+}
+
+/**
  * Repair a FRONTED Hebrew accusative marker in transformed output.
  *
  * When an event-handler body leads with a command-modifier (`on click once add …`,
@@ -171,11 +202,14 @@ function extractBlockStructure(input: string, sourceLocale: string): BlockStruct
   // `unless <cond> <body>`: condition runs up to the first command
   // keyword in `inner`. Heuristic — works because hyperscript bodies
   // always start with a command verb, and `unless` conditions rarely
-  // contain bare command keywords as values.
+  // contain bare command keywords as values. A candidate right after a
+  // copula (`… is empty`) is a predicate adjective inside the condition,
+  // not a body verb — skip it.
   const commands = getCommandKeywordsForLocale(sourceLocale);
+  const copulas = getCopulasForLocale(sourceLocale);
   let bodyStart = -1;
   for (let i = 0; i < inner.length; i++) {
-    if (commands.has(inner[i].toLowerCase())) {
+    if (commands.has(inner[i].toLowerCase()) && !isPredicateAdjectivePosition(inner, i, copulas)) {
       bodyStart = i;
       break;
     }
@@ -2230,8 +2264,14 @@ export class GrammarTransformer {
     const tail = hasEnd ? blockTokens[blockTokens.length - 1] : '';
     const inner = blockTokens.slice(1, hasEnd ? -1 : undefined);
 
+    // Skip predicate-adjective positions (`… is empty`): the adjective is
+    // part of the condition clause, not the body's first verb — cutting there
+    // displaced it into the next command's argument zone (empty ×8 bn/hi/tr).
     const commands = getCommandKeywordsForLocale(src);
-    let bodyStart = inner.findIndex(t => commands.has(t.toLowerCase()));
+    const copulas = getCopulasForLocale(src);
+    let bodyStart = inner.findIndex(
+      (t, i) => commands.has(t.toLowerCase()) && !isPredicateAdjectivePosition(inner, i, copulas)
+    );
     if (bodyStart < 0) bodyStart = inner.length;
 
     const clause = inner.slice(0, bodyStart).join(' ');

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -4146,6 +4146,7 @@ export class SemanticParserImpl implements ISemanticParser {
     'হয়', // bn
     'है', // hi
     'dir', // tr
+    'kanqa', // qu (bare identifier, no norm; guards `kanqa chusaq` = `is empty/null`)
   ]);
 
   /** Predicate adjectives (normalized) that follow a copula inside a condition. */
@@ -4313,9 +4314,20 @@ export class SemanticParserImpl implements ISemanticParser {
         // Allow the split after a copula when a real SOV command-VERB keyword opens
         // here — gated to SOV (verb lookup present) and an actual verb-lookup hit, so
         // SVO `X is empty <cmd>` (a predicate, not a verb, after the copula) is
-        // byte-identical to before.
+        // byte-identical to before. EXCEPT when the verb-lookup hit is itself a
+        // condition PREDICATE word (hi खाली / tr boş → `null`, bn খালি →
+        // `empty` — each doubles as the language's empty/null COMMAND verb):
+        // with the transformer's predicate-adjective guard the renders now keep
+        // `<copula> <predicate>` adjacent inside the condition, and the verb
+        // exception would re-split there — re-minting the spurious `empty`
+        // command this whole guard exists to prevent (empty ×8 bn/hi/tr, incl.
+        // the behavior-sortable `if item is null` shape). A REAL then-branch
+        // verb after a copula (the ko displaced shape this exception was built
+        // for) never normalizes to a predicate word, so ko is untouched.
         const curIsSovCommandVerb =
-          sovVerbLookup !== null && sovVerbLookup.has(t.value.toLowerCase());
+          sovVerbLookup !== null &&
+          sovVerbLookup.has(t.value.toLowerCase()) &&
+          !SemanticParserImpl.CONDITION_PREDICATES.has(cur);
         if (
           !SemanticParserImpl.CONDITION_OPERATORS.has(cur) &&
           (!prevIsCopula || curIsSovCommandVerb) &&

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -11883,3 +11883,95 @@ describe('default-value full drill: possessive destination + per-language marker
     expect(String(role(node, 'patient')?.value)).toBe('5');
   });
 });
+
+describe('Condition-final predicate adjective never anchors a spurious empty (empty ×8)', () => {
+  // The transformer now keeps `<copula> <predicate>` adjacent inside an if
+  // condition (hi `मेरा मान है खाली`, tr `benim değer dir boş`). The
+  // tryParseConditionalBlock copula guard already suppressed the split there —
+  // but its SOV verb-lookup exception (built for ko's old DISPLACED renders,
+  // where a real then-branch verb landed right after the copula) re-split when
+  // the predicate word doubles as the language's empty/null COMMAND verb
+  // (खाली/boş → `null`, খালি → `empty`). The exception now excludes
+  // CONDITION_PREDICATES, so the healed renders parse without the phantom
+  // `empty` command that stole a neighboring role.
+  const collectActions = (n: unknown, out: string[] = []): string[] => {
+    if (!n || typeof n !== 'object') return out;
+    const rec = n as Record<string, unknown>;
+    if (typeof rec.action === 'string') out.push(rec.action);
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      const c = rec[f];
+      if (Array.isArray(c)) for (const x of c) collectActions(x, out);
+      else if (c && typeof c === 'object') collectActions(c, out);
+    }
+    return out;
+  };
+
+  const RENDERS: Array<[string, string]> = [
+    ['hi', 'धुंधला पर अगर मेरा मान है खाली .error को जोड़ें मैं में वरना .error को हटाएं मैं से समाप्त'],
+    ['tr', 'bulanık de eğer benim değer dir boş .error i ekle ben e yoksa .error i kaldır ben den son'],
+    ['bn', 'ঝাপসা এ যদি আমার মান হয় খালি .error কে যোগ আমি তে নতুবা .error কে সরান আমি থেকে শেষ'],
+  ];
+  for (const [lang, render] of RENDERS) {
+    it(`[${lang}] input-validation render parses [on,if,add,remove] with no empty`, () => {
+      const node = parse(render, lang);
+      const actions = collectActions(node).sort();
+      expect(actions).toEqual(['add', 'if', 'on', 'remove']);
+    });
+  }
+
+  it('[hi] the add keeps its own patient (no role steal)', () => {
+    const node = parse(RENDERS[0][1], 'hi') as Record<string, unknown>;
+    const dumped = JSON.stringify(
+      collectActions(node) // sanity: structure walked
+    );
+    expect(dumped).toContain('add');
+    // walk to the then-branch add and check patient
+    const body = (node as { body?: Array<Record<string, unknown>> }).body ?? [];
+    const cond = body.find(n => n.action === 'if') as
+      | { thenBranch?: Array<{ action?: string; roles?: Map<string, { type?: string; value?: unknown }> }> }
+      | undefined;
+    const add = cond?.thenBranch?.find(c => c.action === 'add');
+    expect(add?.roles?.get('patient')).toMatchObject({ type: 'selector', value: '.error' });
+  });
+
+  it('[hi] the behavior-sortable condition shape (`अगर item है खाली`) stays inside the if', () => {
+    // `if item is null` renders condition-final खाली on its own line — the same
+    // predicate word; it must not open a phantom empty command in the body.
+    const node = parse('अगर item है खाली\n  बाहर\nसमाप्त', 'hi');
+    const actions = collectActions(node);
+    expect(actions).not.toContain('empty');
+  });
+
+  it('[ko] the displaced-verb exception still splits at a REAL verb after the copula', () => {
+    // The exception this fix narrows was built for ko renders where the
+    // then-branch verb lands directly after the copula. A real verb (추가 =
+    // add, not a predicate word) must still start the body — the add survives.
+    const node = parse('흐림 할 때 만약 내 값 이다 추가 .error 를 나 에 종료', 'ko');
+    const actions = collectActions(node);
+    expect(actions).toContain('add');
+  });
+});
+
+describe('qu kanqa chusaq predicate stays inside the condition (empty-arc qu ripple)', () => {
+  // kanqa (is) tokenizes as a bare identifier — registered in
+  // CONDITION_COPULAS_SURFACE like bn হয় / hi है / tr dir — and chusaq (the
+  // fused dict render) normalizes to `null`, a CONDITION_PREDICATE. The add
+  // must keep its own patient (.error), not fuse with a predicate shard.
+  it('[qu] input-validation render: add keeps patient .error, no empty', () => {
+    const node = parse(
+      'paqariy pi sichus noqaq chanin kanqa chusaq .error ta noqa man yapay manachus .error ta noqa manta qichuy tukuy',
+      'qu'
+    ) as { body?: Array<Record<string, unknown>> };
+    const cond = (node.body ?? []).find(n => n.action === 'if') as
+      | {
+          thenBranch?: Array<{
+            action?: string;
+            roles?: Map<string, { type?: string; value?: unknown }>;
+          }>;
+        }
+      | undefined;
+    const add = cond?.thenBranch?.find(c => c.action === 'add');
+    expect(add?.roles?.get('patient')).toMatchObject({ type: 'selector', value: '.error' });
+    expect(JSON.stringify(cond?.thenBranch?.map(c => c.action))).not.toContain('empty');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-07T01:15:34.206Z",
-  "commit": "614c8f02",
+  "timestamp": "2026-07-07T01:49:19.026Z",
+  "commit": "c18fa4c1",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -14,7 +14,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8579007041413049,
       "avgFidelity": 1,
-      "avgPrecision": 0.9790582647200294,
+      "avgPrecision": 0.9816556673174323,
       "avgRoleFidelity": 0.9772522522522522,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,7 +1278,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,7 +2535,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3167,7 +3167,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.9077564039970039,
       "avgFidelity": 1,
-      "avgPrecision": 0.9775162337662338,
-      "avgRoleFidelity": 0.9657496782496782,
+      "avgPrecision": 0.9805194805194806,
+      "avgRoleFidelity": 0.9676801801801802,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5063,7 +5063,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8855,7 +8855,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10751,7 +10751,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12641,13 +12641,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8489025594288746,
       "avgFidelity": 1,
-      "avgPrecision": 0.9829274891774892,
+      "avgPrecision": 0.9859307359307362,
       "avgRoleFidelity": 0.9768547959724427,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 487320,
+      "bundleSize": 487360,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 487320,
+      "size": 487360,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Session 13 drill 2 (= L6 of the launch bar): the **empty ×8 both-sides drill**, pre-probed at session-12 close. Spurious `empty` ×8 (input-validation + if-empty bn/hi/tr, behavior-sortable hi/tr) and the hi `add.patient` ×2 role-steal cleared together. **avgPrecision 0.9953 → 0.9957; launch-bar item 2 is down to its last family (for ×9).**

### Root cause — three aligned pieces

1. **Transformer (the pre-probed displacement):** the condition/body scans (`transformBlockBody` + `extractBlockStructure`'s unless path) cut `if my value is empty add .error to me` at the first *command keyword* — which is `empty` itself (a hyperscript command since v0.9.90), sitting right after the copula. The predicate adjective was displaced into the add's argument zone (hi `जोड़ें .error को खाली मैं में`), where it anchored `empty-{lang}-generated` and stole a neighboring role. Fix: shared `isPredicateAdjectivePosition` guard — a command-keyword candidate immediately after a copula is a predicate adjective, never the body's first verb. Bonus: the healed SOV renders now reorder the then-branch correctly (patient-first, was verb-first junk).

2. **Parser (the mirror):** `tryParseConditionalBlock`'s SOV verb-lookup exception — built for ko's old *displaced* renders where a real then-branch verb landed after the copula — re-split the healed `<copula> <predicate>` adjacency, because खाली/boş/খালি double as the language's empty/null COMMAND verb. `CONDITION_PREDICATES` is now excluded from that exception. This alone also cleared **behavior-sortable hi/tr** (`if item is null` renders condition-final खाली — null and empty share the word; no render change needed). ko's real-verb case still splits (locked by test).

3. **qu ripple, caught by the zero-new-entries A/B discipline:** the healed order put qu's `ch_usaq` right before `.error`, and the qu tokenizer's by-design `_` split let the `usaq` shard fuse into the add's patient (2 NEW A/B entries on the first pass). The dict now emits the fused `chusaq` (the tokenizer already recognized it, norm `null` — the #535 fused-forms route), and `kanqa` joined `CONDITION_COPULAS_SURFACE` (the bn হয় / hi है / tr dir mechanism). Final A/B: zero new entries.

### Validation (full discipline)

- **Per-(lang,pattern) A/B vs post-#598:** 10 cleared (spurious `empty` ×8 + hi `add.patient:selector` ×2), **0 new**, census 3404 identical.
- **All-24 sweep** on input-validation + if-empty: every language's action multiset matches en (`[on,if,add,remove]` / `[on,if,add,put]`).
- Baseline: parse 3696/3696, degenerate/lossy 0, avgFidelity 1.000, avgPrecision **0.9957**, avgRoleFidelity 0.9863, R2 1.000. Six-signal gate green; baseline regenerated against a fresh populate in this PR.
- Suites: i18n 918, semantic 6615 — all green.
- **13 guards** (6 i18n incl. both-ways negatives; 7 semantic incl. the ko displaced-verb lock and the behavior-sortable condition shape), all stash-verified.

### Docs

Session-13 L6 blocks folded into `docs-internal/MULTILINGUAL_NEXT_STEPS.md` (status table, LAUNCH BAR item 2 inventory, sequencing table L6 ✓ row, update block 2026-07-06i) and `docs-internal/HANDOFF-r1-post-cluster-residue.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)