### PR TITLE
fix(core): make @hyperfixi/core importable in bare Node (dom-globals shim)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,12 @@ jobs:
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           fi
 
+      # Bare-Node import of @hyperfixi/core (+ /commands, /behaviors): guards
+      # the dom-globals shim ordering ahead of morphlex's module-scope
+      # `Element.prototype` access (see packages/core/src/lib/dom-globals-shim.ts).
+      - name: Bare-Node import check (core)
+        run: node scripts/check-node-import.mjs
+
   # ============================================
   # Job 3: Lint & Typecheck
   # ============================================

--- a/docs-internal/MORPHLEX_NODE_SAFETY.md
+++ b/docs-internal/MORPHLEX_NODE_SAFETY.md
@@ -1,0 +1,164 @@
+# Handoff: make `@hyperfixi/core` Node/SSR-safe (morphlex) + evaluate morph alternatives
+
+> **STATUS (2026-07-08): RESOLVED — shipped in 2.7.2.**
+>
+> - **Decision 1 (shipped):** guarded DOM-globals shim
+>   (`packages/core/src/lib/dom-globals-shim.ts`), hardened beyond the proposal below —
+>   morph-adapter imports and *uses* the shim's exported `domGlobalsEnsured` const so the
+>   package's `"sideEffects": false` can't let downstream statement-level treeshakers
+>   (Rollup/Vite SSR) drop the shim while retaining morphlex. Covers `.`, `./commands`,
+>   and `./behaviors` (the last also inlines morphlex — not in the original analysis).
+>   Regression guards: `scripts/check-node-import.mjs` (per-PR, in the CI
+>   `export-validation` job) + a core import check in the release-smoke `node-smoke.mjs`.
+>   morphlex range bumped `^1.0.5` → `^1.4.0`. Reactivity's dynamic import kept as
+>   defense-in-depth.
+> - **Decision 2 (settled): keep morphlex.** Only morphlex has native `preserveChanges`
+>   (all 4 call sites rely on it); it's actively maintained (1.4.0, 2026-03), small
+>   (~2.4 KB gz), and algorithmically current (id-set + LIS + moveBefore — same family as
+>   the idiomorph-derived morph htmx v4 beta inlined). Alternatives evaluated: idiomorph
+>   (Node-safe, +1 KB, dirty-input preservation must be reimplemented via hooks), morphdom,
+>   nanomorph (unmaintained), fixi's paxi.js (42-line vendorable, implicit input
+>   preservation, no options/moveBefore), native `moveBefore()` alone (Safari hasn't
+>   shipped it). Revisit triggers: head-merge need, morphlex maintenance stall, or
+>   htmx-v4/fixi byte-alignment for the hx-compat layer. Follow-up: file the one-line
+>   upstream guard PR against `yippee-fun/morphlex`
+>   (`typeof Element !== 'undefined' && "moveBefore" in Element.prototype`).
+
+**For a fresh Claude Code session. Enter plan mode and produce a plan covering the two
+decisions below. They are separable — you can ship Decision 1 without settling Decision 2.**
+
+---
+
+## TL;DR
+
+Importing `@hyperfixi/core`'s main index in bare Node/SSR throws
+`ReferenceError: Element is not defined`. Root cause: the vendored `morphlex`
+(`^1.0.5`) runs `"moveBefore" in Element.prototype` at **module scope**, and core's
+index reaches it (via the `swap` command). This is pre-existing; it surfaced during
+the 2.7.x release when `@hyperfixi/reactivity`'s `bind` started importing core's
+index and the release smoke test's Node-import check failed.
+
+Two decisions:
+1. **Node-safety hardening** — small, low-risk. Ship a guarded DOM-globals shim (proposal below).
+2. **morphlex vs alternatives** — architecture call. Evaluate whether to keep morphlex or replace it.
+
+## Context: what already shipped (do not redo)
+
+- **`@hyperfixi/core@2.7.1` is published** (all ~35 packages synced; `latest`).
+  2.7.0 = element-scoped `:name` + numeric `increment @attr`; 2.7.1 = hotfix below.
+- **2.7.1 reactivity workaround is in place and sufficient for now:** `bind`
+  (`packages/reactivity/src/bind.ts`) loads `getElementScopeMap` via a **dynamic**
+  `import('@hyperfixi/core')` *inside the evaluator* (which only runs in a browser),
+  instead of a static top-level import — so the reactivity package imports cleanly
+  in Node. The general core-index Node-safety gap remains open; that's this task.
+- Downstream `~/projects/_hyper_min` is already bumped to `@hyperfixi/core@^2.7.1`.
+
+## Root cause (verified)
+
+- `packages/core/src/lib/morph-adapter.ts` does `import { morph, morphInner } from 'morphlex'`.
+- morphlex's bundled code has `var SUPPORTS_MOVE_BEFORE = "moveBefore" in Element.prototype;`
+  at module top level → evaluates on import → throws in Node (no `Element`).
+- Reachability into the index: `swap` command → `lib/swap-executor.ts` /
+  `commands/dom/process-partials.ts` → `lib/morph-adapter.ts` → `morphlex`;
+  `commands/index` → core `src/index.ts`.
+- The morph *functions* are already browser-only (`morphInner` calls
+  `document.createElement`). Only the eager module-load evaluation is the problem.
+- Confirmed a dummy `Element` is enough: with `globalThis.Element ??= class {}` set
+  before import, `await import('@hyperfixi/core')` succeeds in Node (53 exports).
+  (Re-verify this yourself — figures/paths drift.)
+
+## Decision 1 — proposed fix: guarded DOM-globals shim (NOT yet shipped)
+
+Add a side-effect module and import it **before** morphlex so it evaluates first.
+Placement in `morph-adapter.ts` (not just `index.ts`) is deliberate: ESM evaluates
+imported modules in declaration order, so putting the shim first in the module that
+*owns* the morphlex import covers **every** entry path that reaches morphlex — the
+main index, the `/commands` and `/dom` subpath exports, and any plugin that pulls them.
+
+```ts
+// packages/core/src/lib/dom-globals-shim.ts
+// Vendored morph libs do module-scope DOM feature-detection
+// (`"moveBefore" in Element.prototype`) that throws in bare Node/SSR. Provide dummy
+// constructors when there's no DOM so the *import* doesn't crash; a real browser keeps
+// its real globals. This does NOT make morph work headless — morph still needs a real
+// DOM to run; it only prevents the import-time crash.
+if (typeof globalThis.Element === 'undefined') (globalThis as any).Element = class {};
+// Add Node/HTMLElement too if a rebuilt bundle still throws on a different global.
+```
+
+```ts
+// morph-adapter.ts — shim import must be FIRST, before morphlex
+import './dom-globals-shim';
+import { morph as morphlexMorph, morphInner as morphlexMorphInner } from 'morphlex';
+```
+
+**Caveats / must-verify:**
+- Global mutation, but guarded (`typeof … === 'undefined'`) so it only fires in a
+  no-DOM env; no-op in browsers.
+- **Verify bundler order:** rebuild core (`npm run build --prefix packages/core`) and
+  confirm the shim's code appears *before* morphlex in `dist/index.mjs`, then test
+  `node --input-type=module -e "import('@hyperfixi/core').then(()=>console.log('ok'))"`
+  with **no** external shim. (The earlier proof used an external pre-import; the built
+  order is the thing to confirm.)
+- Decide whether to **revert reactivity's dynamic import back to a static import** once
+  core is Node-safe (single mechanism), or keep it as defense-in-depth. Recommendation:
+  keep reactivity as-is (it works); the shim is the general fix.
+- Consider adding a **Node-import regression test**: extend the release smoke fixture
+  (`examples/release-smoke/fixtures/node-smoke.mjs`) with an `await import('@hyperfixi/core')`
+  check, and/or a plain vitest that imports the index under Node.
+- Rejected alternative: lazy `await import('morphlex')` in morph-adapter — forces
+  `executeSwap()` (currently **sync**, `lib/swap-executor.ts`) to become async, rippling
+  to all `swap` callers. Too invasive for no gain over the shim.
+
+## Decision 2 — morphlex vs alternatives (the open architecture question)
+
+Evaluate whether to keep `morphlex` or replace it. Candidates to compare:
+- **Idiomorph** (what htmx uses) — DOM morphing, `head` merging, id-set matching.
+- **morphdom** — the original; widely used, simple.
+- **nanomorph** — tiny.
+- **Native `Element.moveBefore()`** — the very API morphlex feature-detects; leaning on
+  it (with fallback) may reduce/replace the dep.
+
+**Evaluation criteria:**
+1. **Node/SSR-safety** — does importing it evaluate DOM globals at module scope? (The
+   whole reason we're here. Prefer libs that don't, or that we can shim once.)
+2. **Feature parity with what we actually use** — critically `preserveChanges`
+   (in-flight form-input preservation during swaps). We pass `preserveChanges: true`
+   from `commands/dom/swap.ts` (3 sites) and `process-partials.ts`, and default it true
+   in `morph-adapter.ts`. Any replacement must preserve modified form inputs during
+   morph, or we need to reimplement that.
+3. **Bundle size** (gzipped) — morph goes into the big browser bundles; compare deltas.
+4. **Maintenance / API stability / types.**
+5. **Migration cost** — `morph-adapter.ts` is a thin, single seam (good); the swap
+   command and `process-partials` are the only consumers.
+
+Deliverable for Decision 2: a recommendation (keep morphlex + shim, or switch), with
+the size/parity/safety trade-off and a migration sketch if switching.
+
+## Key files
+
+- `packages/core/src/lib/morph-adapter.ts` — the single morphlex seam (`morph`, `morphInner`).
+- `packages/core/src/lib/swap-executor.ts` — `executeSwap()` (**sync**), calls morphAdapter.
+- `packages/core/src/commands/dom/swap.ts`, `commands/dom/process-partials.ts` — consumers; pass `preserveChanges: true`.
+- `packages/core/src/index.ts` — main library entry (what breaks in Node).
+- `packages/core/package.json` — `"morphlex": "^1.0.5"`; browser-bundle + build scripts.
+- `examples/release-smoke/fixtures/node-smoke.mjs` — the Node-import gate that caught this.
+
+## Constraints / gotchas (read the saved memories)
+
+- **Do not break the browser bundles.** morph must keep working in `hyperfixi.js` /
+  `hyperfixi-hx-v4.js`. Rebuild and run the relevant Playwright morph/swap specs.
+- **Publishing is monorepo-wide and heavy** — `scripts/set-version.cjs <ver>` syncs ALL
+  ~35 packages; the publish workflow gates on a Node-import release smoke test; the
+  `publish.yml` build order must keep `semantic` before the `domain-*` packages. See the
+  saved memory `publish-release-gotchas` before any release. This fix would ship as **2.7.2**.
+- Core suite is large (~7000 tests, timeout-wrapped; esbuild-daemon hang is expected —
+  see root CLAUDE.md). Validate core + reactivity + a morph/swap Playwright spec.
+
+## Suggested order
+
+1. Enter plan mode; re-verify the root cause and the shim-order claim against the current tree.
+2. Plan Decision 1 (shim + regression test) as the shippable near-term fix.
+3. Plan Decision 2 (morph-lib evaluation) — can be a follow-up; note if the choice would
+   change the Decision-1 approach (e.g. a Node-safe replacement might remove the need for a shim).
+4. Present the plan; on approval, implement, validate, and ship as 2.7.2.

--- a/docs-internal/MORPHLEX_NODE_SAFETY.md
+++ b/docs-internal/MORPHLEX_NODE_SAFETY.md
@@ -23,6 +23,13 @@
 >   htmx-v4/fixi byte-alignment for the hx-compat layer. Follow-up: file the one-line
 >   upstream guard PR against `yippee-fun/morphlex`
 >   (`typeof Element !== 'undefined' && "moveBefore" in Element.prototype`).
+> - **Vendor-if-needed escape hatch:** morphlex is **MIT** (© 2024 Joel Drapper), so if a
+>   revisit trigger fires we can copy the 1.4.0 source into core, apply the Node guard
+>   inline, and drop both the npm dep and the shim — legally clean. The only obligation is
+>   retaining morphlex's MIT license + copyright notice alongside the vendored source
+>   (e.g. `packages/core/src/lib/vendor/morphlex/LICENSE` or a file header). fixi's
+>   paxi.js is even more permissive (BSD-0, no notice retention) if the micro-morph route
+>   is ever taken. No license action is needed for the current npm-dep + shim approach.
 
 **For a fresh Claude Code session. Enter plan mode and produce a plan covering the two
 decisions below. They are separable — you can ship Decision 1 without settling Decision 2.**

--- a/examples/release-smoke/fixtures/node-smoke.mjs
+++ b/examples/release-smoke/fixtures/node-smoke.mjs
@@ -8,9 +8,10 @@
  *
  * Prints one `PASS <desc>` / `FAIL <desc>` line per check; exits 1 if any fail.
  *
- * NOTE: @hyperfixi/core and @hyperfixi/components reference browser globals
- * (`Element`) at module scope and cannot be imported in bare Node — they are
- * verified by the browser-bundle stage of run.mjs instead.
+ * NOTE: @hyperfixi/components references browser globals (`Element`) at
+ * module scope and cannot be imported in bare Node — it is verified by the
+ * browser-bundle stage of run.mjs instead. @hyperfixi/core is Node-safe
+ * since 2.7.2 (dom-globals shim ahead of morphlex) and is checked below.
  */
 
 let failed = 0;
@@ -28,6 +29,14 @@ async function check(desc, fn) {
 function assert(cond, msg) {
   if (!cond) throw new Error(msg);
 }
+
+await check('@hyperfixi/core — bare-Node import (dom-globals shim)', async () => {
+  const m = await import('@hyperfixi/core');
+  assert(typeof m.getElementScopeMap === 'function', 'getElementScopeMap missing');
+  const commands = await import('@hyperfixi/core/commands');
+  assert(typeof commands.swap === 'function', 'commands.swap missing');
+  return `${Object.keys(m).length} exports + /commands`;
+});
 
 await check('@hyperfixi/speech — plugin + commands', async () => {
   const m = await import('@hyperfixi/speech');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperfixi/monorepo",
-  "version": "2.6.0",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperfixi/monorepo",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -17734,18 +17734,18 @@
     },
     "packages/aot-compiler": {
       "name": "@hyperfixi/aot-compiler",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/framework": "^2.6.0",
+        "@lokascript/framework": "^2.7.1",
         "fast-glob": "^3.3.2"
       },
       "bin": {
         "hyperfixi-aot": "dist/cli/index.js"
       },
       "devDependencies": {
-        "@hyperfixi/core": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0",
+        "@hyperfixi/core": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1",
         "@types/node": "^20.11.0",
         "commander": "^14.0.3",
         "tsup": "^8.0.1",
@@ -17753,8 +17753,8 @@
         "vitest": "^4.1.5"
       },
       "peerDependencies": {
-        "@hyperfixi/core": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0"
+        "@hyperfixi/core": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1"
       },
       "peerDependenciesMeta": {
         "@hyperfixi/core": {
@@ -17767,37 +17767,37 @@
     },
     "packages/behaviors": {
       "name": "@hyperfixi/behaviors",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "devDependencies": {
-        "@hyperfixi/core": "^2.6.0",
+        "@hyperfixi/core": "^2.7.1",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
         "vitest": "^4.1.5"
       },
       "peerDependencies": {
-        "@hyperfixi/core": "^2.6.0"
+        "@hyperfixi/core": "^2.7.1"
       }
     },
     "packages/compilation-service": {
       "name": "@lokascript/compilation-service",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/framework": "^2.6.0",
+        "@lokascript/framework": "^2.7.1",
         "hono": "^4.11.7"
       },
       "devDependencies": {
         "@hono/node-server": "^2.0.0",
-        "@hyperfixi/aot-compiler": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0",
+        "@hyperfixi/aot-compiler": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1",
         "@types/node": "^20.11.0",
         "tsup": "^8.0.1",
         "typescript": "^5.3.3",
         "vitest": "^4.1.5"
       },
       "peerDependencies": {
-        "@lokascript/semantic": "^2.6.0"
+        "@lokascript/semantic": "^2.7.1"
       },
       "peerDependenciesMeta": {
         "@lokascript/semantic": {
@@ -17818,11 +17818,11 @@
     },
     "packages/components": {
       "name": "@hyperfixi/components",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@hyperfixi/core": "^2.6.0",
-        "@hyperfixi/reactivity": "^2.6.0"
+        "@hyperfixi/core": "^2.7.1",
+        "@hyperfixi/reactivity": "^2.7.1"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -17837,12 +17837,12 @@
     },
     "packages/core": {
       "name": "@hyperfixi/core",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/intent": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0",
-        "morphlex": "^1.0.5",
+        "@lokascript/intent": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1",
+        "morphlex": "^1.4.0",
         "tslib": "^2.8.1"
       },
       "devDependencies": {
@@ -17878,8 +17878,8 @@
         "node": ">=24"
       },
       "peerDependencies": {
-        "@hyperfixi/patterns-reference": "^2.6.0",
-        "@lokascript/framework": "^2.6.0"
+        "@hyperfixi/patterns-reference": "^2.7.1",
+        "@lokascript/framework": "^2.7.1"
       },
       "peerDependenciesMeta": {
         "@hyperfixi/patterns-reference": {
@@ -18376,11 +18376,11 @@
     },
     "packages/developer-tools": {
       "name": "@hyperfixi/developer-tools",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@hyperfixi/core": "^2.6.0",
-        "@lokascript/i18n": "^2.6.0",
+        "@hyperfixi/core": "^2.7.1",
+        "@lokascript/i18n": "^2.7.1",
         "boxen": "^7.1.0",
         "chalk": "^5.3.0",
         "chokidar": "^3.5.0",
@@ -19039,14 +19039,14 @@
     },
     "packages/domain-bdd": {
       "name": "@lokascript/domain-bdd",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/framework": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0"
+        "@lokascript/framework": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1"
       },
       "devDependencies": {
-        "@lokascript/domain-toolkit": "^2.6.0",
+        "@lokascript/domain-toolkit": "^2.7.1",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19058,14 +19058,14 @@
     },
     "packages/domain-behaviorspec": {
       "name": "@lokascript/domain-behaviorspec",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/framework": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0"
+        "@lokascript/framework": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1"
       },
       "devDependencies": {
-        "@lokascript/domain-toolkit": "^2.6.0",
+        "@lokascript/domain-toolkit": "^2.7.1",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19077,19 +19077,19 @@
     },
     "packages/domain-config": {
       "name": "@lokascript/domain-config",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/domain-bdd": "^2.6.0",
-        "@lokascript/domain-behaviorspec": "^2.6.0",
-        "@lokascript/domain-flow": "^2.6.0",
-        "@lokascript/domain-jsx": "^2.6.0",
-        "@lokascript/domain-learn": "^2.6.0",
-        "@lokascript/domain-llm": "^2.6.0",
-        "@lokascript/domain-sql": "^2.6.0",
-        "@lokascript/domain-todo": "^2.6.0",
-        "@lokascript/domain-voice": "^2.6.0",
-        "@lokascript/framework": "^2.6.0"
+        "@lokascript/domain-bdd": "^2.7.1",
+        "@lokascript/domain-behaviorspec": "^2.7.1",
+        "@lokascript/domain-flow": "^2.7.1",
+        "@lokascript/domain-jsx": "^2.7.1",
+        "@lokascript/domain-learn": "^2.7.1",
+        "@lokascript/domain-llm": "^2.7.1",
+        "@lokascript/domain-sql": "^2.7.1",
+        "@lokascript/domain-todo": "^2.7.1",
+        "@lokascript/domain-voice": "^2.7.1",
+        "@lokascript/framework": "^2.7.1"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -19100,14 +19100,14 @@
     },
     "packages/domain-flow": {
       "name": "@lokascript/domain-flow",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/framework": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0"
+        "@lokascript/framework": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1"
       },
       "devDependencies": {
-        "@lokascript/domain-toolkit": "^2.6.0",
+        "@lokascript/domain-toolkit": "^2.7.1",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19119,14 +19119,14 @@
     },
     "packages/domain-jsx": {
       "name": "@lokascript/domain-jsx",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/framework": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0"
+        "@lokascript/framework": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1"
       },
       "devDependencies": {
-        "@lokascript/domain-toolkit": "^2.6.0",
+        "@lokascript/domain-toolkit": "^2.7.1",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19138,14 +19138,14 @@
     },
     "packages/domain-learn": {
       "name": "@lokascript/domain-learn",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/framework": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0"
+        "@lokascript/framework": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1"
       },
       "devDependencies": {
-        "@lokascript/domain-toolkit": "^2.6.0",
+        "@lokascript/domain-toolkit": "^2.7.1",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19157,14 +19157,14 @@
     },
     "packages/domain-llm": {
       "name": "@lokascript/domain-llm",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/framework": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0"
+        "@lokascript/framework": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1"
       },
       "devDependencies": {
-        "@lokascript/domain-toolkit": "^2.6.0",
+        "@lokascript/domain-toolkit": "^2.7.1",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19176,14 +19176,14 @@
     },
     "packages/domain-sql": {
       "name": "@lokascript/domain-sql",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/framework": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0"
+        "@lokascript/framework": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1"
       },
       "devDependencies": {
-        "@lokascript/domain-toolkit": "^2.6.0",
+        "@lokascript/domain-toolkit": "^2.7.1",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19195,14 +19195,14 @@
     },
     "packages/domain-todo": {
       "name": "@lokascript/domain-todo",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/framework": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0"
+        "@lokascript/framework": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1"
       },
       "devDependencies": {
-        "@lokascript/domain-toolkit": "^2.6.0",
+        "@lokascript/domain-toolkit": "^2.7.1",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19211,11 +19211,11 @@
     },
     "packages/domain-toolkit": {
       "name": "@lokascript/domain-toolkit",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "dependencies": {
-        "@lokascript/framework": "^2.6.0",
-        "@lokascript/intent": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0"
+        "@lokascript/framework": "^2.7.1",
+        "@lokascript/intent": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -19226,14 +19226,14 @@
     },
     "packages/domain-voice": {
       "name": "@lokascript/domain-voice",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/framework": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0"
+        "@lokascript/framework": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1"
       },
       "devDependencies": {
-        "@lokascript/domain-toolkit": "^2.6.0",
+        "@lokascript/domain-toolkit": "^2.7.1",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19242,10 +19242,10 @@
     },
     "packages/framework": {
       "name": "@lokascript/framework",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/intent": "^2.6.0"
+        "@lokascript/intent": "^2.7.1"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -19260,10 +19260,10 @@
     },
     "packages/hyperscript-adapter": {
       "name": "@lokascript/hyperscript-adapter",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/semantic": "^2.6.0"
+        "@lokascript/semantic": "^2.7.1"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -19280,10 +19280,10 @@
     },
     "packages/hyperscript-tools-i18n": {
       "name": "@hyperscript-tools/i18n",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/i18n": "^2.6.0"
+        "@lokascript/i18n": "^2.7.1"
       },
       "bin": {
         "hyperscript-i18n": "dist/cli.js"
@@ -19299,11 +19299,11 @@
     },
     "packages/i18n": {
       "name": "@lokascript/i18n",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@hyperfixi/core": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0",
+        "@hyperfixi/core": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1",
         "esbuild": "^0.28.0",
         "happy-dom": "^20.8.9",
         "vite": "^7.1.12"
@@ -19783,7 +19783,7 @@
     },
     "packages/intent": {
       "name": "@lokascript/intent",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -19797,13 +19797,13 @@
     },
     "packages/intent-element": {
       "name": "@hyperfixi/intent-element",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/intent": "^2.6.0"
+        "@lokascript/intent": "^2.7.1"
       },
       "devDependencies": {
-        "@hyperfixi/core": "^2.6.0",
+        "@hyperfixi/core": "^2.7.1",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -19813,7 +19813,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@hyperfixi/core": "^2.6.0"
+        "@hyperfixi/core": "^2.7.1"
       },
       "peerDependenciesMeta": {
         "@hyperfixi/core": {
@@ -19823,10 +19823,10 @@
     },
     "packages/intercept": {
       "name": "@hyperfixi/intercept",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@hyperfixi/core": "^2.6.0"
+        "@hyperfixi/core": "^2.7.1"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -19841,7 +19841,7 @@
     },
     "packages/language-server": {
       "name": "@lokascript/language-server",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
         "vscode-languageserver": "^9.0.1",
@@ -19851,8 +19851,8 @@
         "lokascript-language-server": "dist/server.js"
       },
       "devDependencies": {
-        "@hyperfixi/core": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0",
+        "@hyperfixi/core": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1",
         "@types/node": "^20.0.0",
         "@vitest/coverage-v8": "^4.0.0",
         "tsup": "^8.0.0",
@@ -19861,8 +19861,8 @@
         "vitest": "^4.1.5"
       },
       "peerDependencies": {
-        "@hyperfixi/core": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0"
+        "@hyperfixi/core": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1"
       },
       "peerDependenciesMeta": {
         "@hyperfixi/core": {
@@ -19875,10 +19875,10 @@
     },
     "packages/language-server-hyperscript": {
       "name": "@hyperscript-tools/language-server",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/language-server": "^2.6.0"
+        "@lokascript/language-server": "^2.7.1"
       },
       "bin": {
         "hyperscript-language-server": "dist/server.js"
@@ -19893,26 +19893,26 @@
     },
     "packages/mcp-multilingual-intent": {
       "name": "@lokascript/mcp-multilingual-intent",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^2.0.0",
-        "@hyperfixi/patterns-reference": "^2.6.0",
-        "@lokascript/framework": "^2.6.0",
+        "@hyperfixi/patterns-reference": "^2.7.1",
+        "@lokascript/framework": "^2.7.1",
         "hono": "^4.6.0"
       },
       "bin": {
         "mcp-multilingual-intent": "dist/index.js"
       },
       "devDependencies": {
-        "@lokascript/domain-bdd": "^2.6.0",
-        "@lokascript/domain-behaviorspec": "^2.6.0",
-        "@lokascript/domain-flow": "^2.6.0",
-        "@lokascript/domain-jsx": "^2.6.0",
-        "@lokascript/domain-llm": "^2.6.0",
-        "@lokascript/domain-sql": "^2.6.0",
-        "@lokascript/domain-todo": "^2.6.0",
-        "@lokascript/domain-voice": "^2.6.0",
+        "@lokascript/domain-bdd": "^2.7.1",
+        "@lokascript/domain-behaviorspec": "^2.7.1",
+        "@lokascript/domain-flow": "^2.7.1",
+        "@lokascript/domain-jsx": "^2.7.1",
+        "@lokascript/domain-llm": "^2.7.1",
+        "@lokascript/domain-sql": "^2.7.1",
+        "@lokascript/domain-todo": "^2.7.1",
+        "@lokascript/domain-voice": "^2.7.1",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "tsx": "^4.0.0",
@@ -19920,14 +19920,14 @@
         "vitest": "^4.1.5"
       },
       "peerDependencies": {
-        "@lokascript/domain-bdd": "^2.6.0",
-        "@lokascript/domain-behaviorspec": "^2.6.0",
-        "@lokascript/domain-flow": "^2.6.0",
-        "@lokascript/domain-jsx": "^2.6.0",
-        "@lokascript/domain-llm": "^2.6.0",
-        "@lokascript/domain-sql": "^2.6.0",
-        "@lokascript/domain-todo": "^2.6.0",
-        "@lokascript/domain-voice": "^2.6.0"
+        "@lokascript/domain-bdd": "^2.7.1",
+        "@lokascript/domain-behaviorspec": "^2.7.1",
+        "@lokascript/domain-flow": "^2.7.1",
+        "@lokascript/domain-jsx": "^2.7.1",
+        "@lokascript/domain-llm": "^2.7.1",
+        "@lokascript/domain-sql": "^2.7.1",
+        "@lokascript/domain-todo": "^2.7.1",
+        "@lokascript/domain-voice": "^2.7.1"
       },
       "peerDependenciesMeta": {
         "@lokascript/domain-bdd": {
@@ -19968,15 +19968,15 @@
     },
     "packages/mcp-server": {
       "name": "@hyperfixi/mcp-server",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@hyperfixi/patterns-reference": "^2.6.0",
-        "@lokascript/compilation-service": "^2.6.0",
-        "@lokascript/domain-config": "^2.6.0",
-        "@lokascript/framework": "^2.6.0",
-        "@lokascript/planner": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0",
+        "@hyperfixi/patterns-reference": "^2.7.1",
+        "@lokascript/compilation-service": "^2.7.1",
+        "@lokascript/domain-config": "^2.7.1",
+        "@lokascript/framework": "^2.7.1",
+        "@lokascript/planner": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1",
         "@modelcontextprotocol/sdk": "^1.25.0",
         "yaml": "^2.8.3"
       },
@@ -19984,21 +19984,21 @@
         "hyperfixi-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@hyperfixi/core": "^2.6.0",
-        "@hyperfixi/patterns-reference": "^2.6.0",
-        "@hyperfixi/server-bridge": "^2.6.0",
-        "@lokascript/compilation-service": "^2.6.0",
-        "@lokascript/domain-bdd": "^2.6.0",
-        "@lokascript/domain-behaviorspec": "^2.6.0",
-        "@lokascript/domain-flow": "^2.6.0",
-        "@lokascript/domain-jsx": "^2.6.0",
-        "@lokascript/domain-learn": "^2.6.0",
-        "@lokascript/domain-llm": "^2.6.0",
-        "@lokascript/domain-sql": "^2.6.0",
-        "@lokascript/domain-todo": "^2.6.0",
-        "@lokascript/domain-voice": "^2.6.0",
-        "@lokascript/framework": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0",
+        "@hyperfixi/core": "^2.7.1",
+        "@hyperfixi/patterns-reference": "^2.7.1",
+        "@hyperfixi/server-bridge": "^2.7.1",
+        "@lokascript/compilation-service": "^2.7.1",
+        "@lokascript/domain-bdd": "^2.7.1",
+        "@lokascript/domain-behaviorspec": "^2.7.1",
+        "@lokascript/domain-flow": "^2.7.1",
+        "@lokascript/domain-jsx": "^2.7.1",
+        "@lokascript/domain-learn": "^2.7.1",
+        "@lokascript/domain-llm": "^2.7.1",
+        "@lokascript/domain-sql": "^2.7.1",
+        "@lokascript/domain-todo": "^2.7.1",
+        "@lokascript/domain-voice": "^2.7.1",
+        "@lokascript/framework": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "tsx": "^4.0.0",
@@ -20006,21 +20006,21 @@
         "vitest": "^4.1.5"
       },
       "peerDependencies": {
-        "@hyperfixi/core": "^2.6.0",
-        "@hyperfixi/patterns-reference": "^2.6.0",
-        "@hyperfixi/server-bridge": "^2.6.0",
-        "@lokascript/compilation-service": "^2.6.0",
-        "@lokascript/domain-bdd": "^2.6.0",
-        "@lokascript/domain-behaviorspec": "^2.6.0",
-        "@lokascript/domain-flow": "^2.6.0",
-        "@lokascript/domain-jsx": "^2.6.0",
-        "@lokascript/domain-learn": "^2.6.0",
-        "@lokascript/domain-llm": "^2.6.0",
-        "@lokascript/domain-sql": "^2.6.0",
-        "@lokascript/domain-todo": "^2.6.0",
-        "@lokascript/domain-voice": "^2.6.0",
-        "@lokascript/framework": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0"
+        "@hyperfixi/core": "^2.7.1",
+        "@hyperfixi/patterns-reference": "^2.7.1",
+        "@hyperfixi/server-bridge": "^2.7.1",
+        "@lokascript/compilation-service": "^2.7.1",
+        "@lokascript/domain-bdd": "^2.7.1",
+        "@lokascript/domain-behaviorspec": "^2.7.1",
+        "@lokascript/domain-flow": "^2.7.1",
+        "@lokascript/domain-jsx": "^2.7.1",
+        "@lokascript/domain-learn": "^2.7.1",
+        "@lokascript/domain-llm": "^2.7.1",
+        "@lokascript/domain-sql": "^2.7.1",
+        "@lokascript/domain-todo": "^2.7.1",
+        "@lokascript/domain-voice": "^2.7.1",
+        "@lokascript/framework": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1"
       },
       "peerDependenciesMeta": {
         "@hyperfixi/core": {
@@ -20072,7 +20072,7 @@
     },
     "packages/mcp-server-hyperscript": {
       "name": "@hyperscript-tools/mcp-server",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.0"
@@ -20090,10 +20090,10 @@
     },
     "packages/multilingual-hyperscript": {
       "name": "@hyperscript-tools/multilingual",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/hyperscript-adapter": "^2.6.0"
+        "@lokascript/hyperscript-adapter": "^2.7.1"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -20103,16 +20103,16 @@
     },
     "packages/patterns-reference": {
       "name": "@hyperfixi/patterns-reference",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/semantic": "^2.6.0",
+        "@lokascript/semantic": "^2.7.1",
         "better-sqlite3": "^12.6.2"
       },
       "devDependencies": {
-        "@hyperfixi/core": "*",
-        "@hyperfixi/reactivity": "*",
-        "@hyperfixi/realtime": "*",
+        "@hyperfixi/core": "^2.7.1",
+        "@hyperfixi/reactivity": "^2.7.1",
+        "@hyperfixi/realtime": "^2.7.1",
         "@types/better-sqlite3": "^7.6.0",
         "@types/node": "^20.0.0",
         "hyperscript.org": "0.9.93",
@@ -20328,7 +20328,7 @@
     },
     "packages/planner": {
       "name": "@lokascript/planner",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^8.0.0",
@@ -20341,10 +20341,10 @@
     },
     "packages/playground": {
       "name": "@lokascript/playground",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "dependencies": {
-        "@hyperfixi/core": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0"
+        "@hyperfixi/core": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1"
       },
       "devDependencies": {
         "vite": "^6.3.5"
@@ -20467,10 +20467,10 @@
     },
     "packages/reactivity": {
       "name": "@hyperfixi/reactivity",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@hyperfixi/core": "^2.6.0"
+        "@hyperfixi/core": "^2.7.1"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -20485,10 +20485,10 @@
     },
     "packages/realtime": {
       "name": "@hyperfixi/realtime",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@hyperfixi/core": "^2.6.0"
+        "@hyperfixi/core": "^2.7.1"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -20503,10 +20503,10 @@
     },
     "packages/semantic": {
       "name": "@lokascript/semantic",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/framework": "^2.6.0",
+        "@lokascript/framework": "^2.7.1",
         "nearley": "^2.20.1"
       },
       "devDependencies": {
@@ -20523,7 +20523,7 @@
     },
     "packages/server-bridge": {
       "name": "@hyperfixi/server-bridge",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
         "glob": "^11.0.0"
@@ -20543,10 +20543,10 @@
     },
     "packages/smart-bundling": {
       "name": "@hyperfixi/smart-bundling",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@hyperfixi/core": "^2.6.0",
+        "@hyperfixi/core": "^2.7.1",
         "@rollup/plugin-terser": "^1.0.0",
         "acorn": "^8.10.0",
         "acorn-walk": "^8.2.0",
@@ -21038,10 +21038,10 @@
     },
     "packages/speech": {
       "name": "@hyperfixi/speech",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@hyperfixi/core": "^2.6.0"
+        "@hyperfixi/core": "^2.7.1"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -21056,12 +21056,12 @@
     },
     "packages/testing-framework": {
       "name": "@hyperfixi/testing-framework",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@hyperfixi/core": "^2.6.0",
-        "@hyperfixi/patterns-reference": "^2.6.0",
-        "@lokascript/semantic": "^2.6.0",
+        "@hyperfixi/core": "^2.7.1",
+        "@hyperfixi/patterns-reference": "^2.7.1",
+        "@lokascript/semantic": "^2.7.1",
         "diff": "^8.0.3",
         "esbuild": "^0.28.0",
         "happy-dom": "^20.8.9",
@@ -21559,7 +21559,7 @@
     },
     "packages/types-browser": {
       "name": "@hyperfixi/types-browser",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.8.3"
@@ -21567,10 +21567,10 @@
     },
     "packages/vite-plugin": {
       "name": "@hyperfixi/vite-plugin",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
-        "@hyperfixi/core": "^2.6.0",
+        "@hyperfixi/core": "^2.7.1",
         "glob": "^11.0.0"
       },
       "devDependencies": {
@@ -21583,7 +21583,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@hyperfixi/server-bridge": "^2.6.0",
+        "@hyperfixi/server-bridge": "^2.7.1",
         "vite": ">=4.0.0"
       },
       "peerDependenciesMeta": {
@@ -21712,14 +21712,14 @@
     },
     "packages/vscode-extension": {
       "name": "lokascript-vscode",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1",
         "ws": "^8.0.0"
       },
       "devDependencies": {
-        "@lokascript/semantic": "^2.6.0",
+        "@lokascript/semantic": "^2.7.1",
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.85.0",
         "@types/ws": "^8.0.0",
@@ -21733,7 +21733,7 @@
     },
     "packages/vscode-extension-hyperscript": {
       "name": "hyperscript-vscode",
-      "version": "2.6.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -287,7 +287,7 @@
   "dependencies": {
     "@lokascript/intent": "^2.7.1",
     "@lokascript/semantic": "^2.7.1",
-    "morphlex": "^1.0.5",
+    "morphlex": "^1.4.0",
     "tslib": "^2.8.1"
   },
   "peerDependencies": {

--- a/packages/core/src/lib/dom-globals-shim.ts
+++ b/packages/core/src/lib/dom-globals-shim.ts
@@ -1,0 +1,30 @@
+/**
+ * Guarded DOM-globals shim for Node/SSR safety.
+ *
+ * morphlex (1.4.0) evaluates `"moveBefore" in Element.prototype` at module
+ * scope, which throws `ReferenceError: Element is not defined` in bare
+ * Node/SSR. Defining a dummy `Element` before morphlex's module body runs
+ * prevents the import-time crash. It does NOT make morphing work headless —
+ * morph still needs a real DOM. No-op in browsers (and happy-dom/jsdom).
+ *
+ * `Element` is deliberately the ONLY global shimmed: it is the only DOM
+ * global morphlex touches at module scope, and every extra fake global risks
+ * fooling `typeof X !== 'undefined'` environment detection elsewhere in the
+ * process. If a morphlex upgrade adds more module-scope globals, the
+ * bare-Node import check (scripts/check-node-import.mjs) fails in CI —
+ * extend the guard here then.
+ */
+function ensureDomGlobals(): boolean {
+  if (typeof (globalThis as { Element?: unknown }).Element === 'undefined') {
+    (globalThis as { Element?: unknown }).Element = class {};
+  }
+  return true;
+}
+
+/**
+ * Always `true`. Imported and *used* by morph-adapter so statement-level
+ * treeshakers honoring this package's `"sideEffects": false` (Rollup/Vite)
+ * cannot drop the shim while retaining morphlex. Do NOT convert the consumer
+ * to a bare side-effect import.
+ */
+export const domGlobalsEnsured: boolean = ensureDomGlobals();

--- a/packages/core/src/lib/morph-adapter.ts
+++ b/packages/core/src/lib/morph-adapter.ts
@@ -5,6 +5,9 @@
  * when the server re-renders a region during typing.
  */
 
+// MUST stay the first import: ESM evaluates dependencies in declaration
+// order, so the shim runs before morphlex's module-scope Element access.
+import { domGlobalsEnsured } from './dom-globals-shim';
 import { morph as morphlexMorph, morphInner as morphlexMorphInner } from 'morphlex';
 
 export interface MorphOptions {
@@ -17,7 +20,9 @@ export interface MorphOptions {
 }
 
 function toMorphlexOptions(options?: MorphOptions): { preserveChanges: boolean } {
-  return { preserveChanges: options?.preserveChanges ?? true };
+  // domGlobalsEnsured is always true; using it creates a hard data dependency
+  // on the shim (see dom-globals-shim.ts).
+  return { preserveChanges: domGlobalsEnsured && (options?.preserveChanges ?? true) };
 }
 
 export const morphAdapter = {

--- a/scripts/check-node-import.mjs
+++ b/scripts/check-node-import.mjs
@@ -1,0 +1,53 @@
+/**
+ * Bare-Node import check for @hyperfixi/core.
+ *
+ * Guards the Node/SSR-safety of core's published entry points. morphlex does
+ * module-scope DOM feature-detection (`"moveBefore" in Element.prototype`)
+ * that threw `ReferenceError: Element is not defined` in bare Node until the
+ * dom-globals shim (packages/core/src/lib/dom-globals-shim.ts) was added.
+ * This check fails if that shim is dropped, reordered after morphlex, or a
+ * dependency upgrade introduces a new module-scope DOM global.
+ *
+ * Runs from the repo root against built dist via workspace resolution
+ * (CI: export-validation job, after build artifacts are restored).
+ * Prints one `PASS <desc>` / `FAIL <desc>` line per check; exits 1 if any fail.
+ */
+
+let failed = 0;
+
+async function check(desc, fn) {
+  try {
+    const detail = await fn();
+    console.log(`PASS ${desc}${detail ? ` (${detail})` : ''}`);
+  } catch (e) {
+    console.log(`FAIL ${desc} — ${e.message}`);
+    failed++;
+  }
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+
+await check('@hyperfixi/core — bare-Node import (main index)', async () => {
+  const m = await import('@hyperfixi/core');
+  assert(typeof m.getElementScopeMap === 'function', 'getElementScopeMap missing');
+  const exportCount = Object.keys(m).length;
+  assert(exportCount > 40, `only ${exportCount} exports (expected > 40)`);
+  return `${exportCount} exports`;
+});
+
+await check('@hyperfixi/core/commands — bare-Node import', async () => {
+  const m = await import('@hyperfixi/core/commands');
+  assert(typeof m.swap === 'function', 'swap factory missing');
+  assert(typeof m.morph === 'function', 'morph factory missing');
+  return 'swap + morph factories';
+});
+
+await check('@hyperfixi/core/behaviors — bare-Node import', async () => {
+  const m = await import('@hyperfixi/core/behaviors');
+  assert(typeof m.registerHistorySwap === 'function', 'registerHistorySwap missing');
+  return 'registerHistorySwap';
+});
+
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## Problem

Importing `@hyperfixi/core` — or its `/commands` and `/behaviors` subpaths — in bare Node/SSR throws `ReferenceError: Element is not defined`. morphlex evaluates `"moveBefore" in Element.prototype` at module scope, and core's entry points reach it eagerly (swap/process-partials → `lib/morph-adapter.ts`). Surfaced during the 2.7.x release; 2.7.1 shipped a reactivity-side workaround, this closes the general gap. Ships as **2.7.2**.

## Fix

- **`packages/core/src/lib/dom-globals-shim.ts`** (new): guarded shim — defines a dummy `Element` only when none exists (no-op in browsers). Evaluated ahead of morphlex via declaration-order import in `morph-adapter.ts`, the single morphlex seam, so every bundle that inlines morphlex is covered (`.`, `./commands`, `./behaviors`, browser bundles).
- **Tree-shake hardening:** morph-adapter imports and *uses* the shim's exported `domGlobalsEnsured` const. With the package's `"sideEffects": false`, a bare side-effect import could be dropped by downstream statement-level treeshakers (Rollup/Vite SSR — the very environment this targets) while morphlex is retained; a real data dependency can't be severed.
- **morphlex `^1.0.5` → `^1.4.0`** — aligns the declared range with the tested/installed version. Lockfile also trues up stale 2.6.0 workspace entries left behind by the 2.7.1 release.
- Reactivity's dynamic-import workaround stays (defense-in-depth).

## Regression guards

- **Per-PR:** `scripts/check-node-import.mjs`, run as a new step in the `export-validation` CI job (dist artifacts already restored there). Asserts bare-Node import of all three entry points + key exports.
- **At publish:** `examples/release-smoke/fixtures/node-smoke.mjs` now imports `@hyperfixi/core` (+`/commands`); only `@hyperfixi/components` remains excluded. Passes from 2.7.2 tarballs onward (expected).

## Decision 2 (morph library) — resolved: keep morphlex

Evaluated idiomorph, morphdom, nanomorph, fixi's paxi.js, and native `moveBefore()` (full analysis in `docs-internal/MORPHLEX_NODE_SAFETY.md`, committed here with status). morphlex is the only lib with native `preserveChanges` (all 4 call sites rely on it), is actively maintained, and matches the algorithm family htmx v4 beta inlined. Follow-up: file the one-line guard PR upstream.

## Validation

- Shim precedes inlined morphlex in all 6 Node-consumable dist bundles (offset-checked)
- `node scripts/check-node-import.mjs`: 3/3 PASS (53 exports on main index)
- Core suite 7041 passed / 149 skipped; dom commands 459 passed; reactivity 45 passed
- Playwright `htmx-like-examples.spec.ts --project=comprehensive`: 25 passed
- `npm run typecheck --prefix packages/core`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)