### PR TITLE
feat(domain-voice): behavior verbs from the multilingual layer + framework generator fix

### DIFF
--- a/docs-internal/sessions/DOMAIN_VOICE_STRUCTURAL_REVIEW.md
+++ b/docs-internal/sessions/DOMAIN_VOICE_STRUCTURAL_REVIEW.md
@@ -1,0 +1,135 @@
+# domain-voice structural review
+
+**Date:** 2026-07-08 · **Status:** findings recorded; 2 framework fixes landed, the rest deferred
+**Sibling:** [`DOMAIN_REVIEW.md`](./DOMAIN_REVIEW.md) (an earlier review of sql/bdd/jsx that predates the framework↔semantic bridge and never covered voice)
+
+## Context
+
+Extending `@lokascript/domain-voice` with the UI-behavior verbs (`toggle`/`add`/`remove`/`show`/`hide`,
+sourced from the `@lokascript/semantic` profiles rather than hand-authored) required **three** adapters
+to reuse semantic's reference command schemas:
+[`invertRolePositions`, `acceptExpression`, `withMarker`](../../packages/domain-voice/src/schemas/behavior.ts).
+Three adapters to reuse five schemas is a smell, so we investigated whether the package needs a
+structural review. It does — but the review's main value is that **two of the three adapters
+compensate for framework/semantic-level issues, not voice bugs.** This doc records the findings so they
+aren't rediscovered, splits them by owner, and marks what was fixed vs deferred.
+
+The behavior-verb work itself is correct (426 tests green) and shipped as-is; the adapters are honest,
+well-commented glue.
+
+## The three adapters, by root cause
+
+| Adapter | Root cause | Owner |
+|---|---|---|
+| `invertRolePositions` | Framework pattern generator sorts role positions **descending** (higher = earlier); semantic reference schemas + semantic's own generator sort **ascending**. Literal inverses. | framework/semantic |
+| `acceptExpression` | **No** framework-based domain tokenizer emits `selector`-typed values; semantic preserves `selectorKind`. | framework-wide gap |
+| `withMarker` | Voice's own `SCHEMA_OWNED_MARKERS` suppresses destination markers; reused schemas relied on the profile default. | voice-specific (fine as-is) |
+
+## Findings
+
+### Framework-level
+
+**F1 — Position-convention inversion, documented backwards in two places. → FIXED.**
+The framework generator sorts role positions descending
+([`pattern-generator.ts` `sortRolesByWordOrder`](../../packages/framework/src/generation/pattern-generator.ts), `b - a`);
+every native framework domain authors that way (e.g. [`domain-sql` `get`](../../packages/domain-sql/src/schemas/index.ts)
+carries an explicit "descending: higher = earlier" comment). Semantic's reference schemas and its own
+sorter ([`role-positioning.ts`](../../packages/semantic/src/parser/utils/role-positioning.ts), `a - b`)
+are the inverse (1-based, lower = earlier). This was "documented" in four places, **two of them wrong**:
+[`DOMAIN_AUTHOR_GUIDE.md`](../../packages/framework/docs/DOMAIN_AUTHOR_GUIDE.md) said "lower = earlier"
+(and its worked example was authored ascending), and semantic's
+[`command-schemas.ts` `RoleSpec`](../../packages/semantic/src/generators/command-schemas.ts) doc said
+"higher = earlier". Neither warned that the two subsystems are opposites — the exact trap behind
+`invertRolePositions`. **Fixed:** both docs now match their own code and cross-warn about the inversion.
+
+**F2 — `format`/`tokens` generator inconsistency. → FIXED.**
+In the framework generator, `buildTokens` ordered roles with `sortRolesByWordOrder` (descending) but
+`buildFormatString` iterated **declaration** order. They disagreed for any schema whose declaration
+order ≠ descending-position order — silently producing a `format` string that didn't match the tokens
+(e.g. Japanese `type` rendered `を {patient} に {destination} 入力` in `format` while the tokens — and
+actual Japanese — are `に {destination} を {patient} 入力`). `format` is display-only (the matcher reads
+only `template.tokens`), so parsing was never wrong; the *documentation string* was. **Fixed:**
+`buildFormatString` now sorts identically. Impact was purely cosmetic and verified format-only across
+all 8 framework domains (60 golden blocks corrected, 0 token/extraction changes). Semantic has its own
+generator, so the multilingual fidelity ratchet was untouched.
+
+**F3 — Selector-typing gap (framework-wide). → DEFERRED (needs design).**
+No framework-based domain tokenizer emits `selector`-kind tokens: `ExtractionResult` has no `kind`
+field, and the base tokenizer always re-derives kind via `classifyToken`, which only returns
+`keyword|literal|operator|identifier`
+([`base-tokenizer.ts`](../../packages/framework/src/core/tokenization/base-tokenizer.ts)). So `.active`/
+`#box` are `identifier`→`expression` in every domain, and the `selectorKind` (class/id/attribute) that
+semantic preserves ([`semantic/src/types.ts` `SelectorValue`](../../packages/semantic/src/types.ts)) is
+lost. Native domains hide this by declaring `expression` (the wildcard in `isTypeCompatible`) in
+`expectedTypes`; the only roles authored as bare `['selector']` are semantic's reference schemas, which
+is why reusing them needed `acceptExpression`. This also **defeats the framework's own determiner-skip**
+(`skipNoiseWords` only fires before a `selector`-kind token
+[`pattern-matcher.ts`](../../packages/framework/src/core/pattern-matching/pattern-matcher.ts)) — the
+root cause of the brief's `click the submit button` capturing `the`.
+_Possible direction (not decided):_ add an optional `kind` to `ExtractionResult` and honor it in the
+base tokenizer, so a domain's CSS extractor can emit `selector`-typed tokens. Framework-wide + ratchet-
+adjacent — deserves a deliberate pass, not a reactive one.
+
+### Voice-level
+
+**V1 — Value model is all-`string`/`expression`; `selectorKind` lost for every verb. → DEFERRED.**
+Consequence of F3 as it lands in voice: `.active`/`#box` are `expression`-typed for *every* selector
+verb (click/focus/read/select/…), not just the new ones, and `VoiceActionSpec`
+([`types.ts`](../../packages/domain-voice/src/types.ts)) flattens everything to strings. Acceptable for
+the current page-control scope; a limitation if voice is meant to be a richer DOM-control DSL.
+
+**V2 — 19 verbs parse, only 14 generate JS / render. → DEFERRED.**
+[`voice-generator.ts`](../../packages/domain-voice/src/generators/voice-generator.ts) is a per-action
+`switch` whose `default` emits a no-op comment; [`voice-renderer.ts`](../../packages/domain-voice/src/generators/voice-renderer.ts)
+is another per-action switch with a `-- Unknown` default. The five behavior verbs parse (they're in
+`allSchemas`) but hit both defaults — they produce no executable JS and don't round-trip through
+`renderVoice`. (The protocol-JSON / explicit round-trip *does* cover them.) Real `classList` codegen +
+renderer coverage is the natural next increment.
+
+**V3 — Verb keywords double-authored (drift-prone). → DEFERRED → single-lexicon.**
+The same verb keyword lives in `vocab/*` (parsing, 154 entries across 11 langs) **and** the renderer's
+`COMMAND_KEYWORDS` (rendering, 154 entries), with no shared source — a mismatch only surfaces as a
+round-trip test failure. Voice already did *half* the consolidation (its renderer derives *markers*
+from schemas via `buildMarkerLookup`); the verb table is the remaining half. This is the
+[single-lexicon aspiration](../FRAMEWORK_SEMANTIC_BRIDGE_PLAN.md) (bridge plan §"Vocab-authoring
+ergonomics"), which **names domain-voice as the foothold to generalize**.
+
+**V4 — Doc drift. → QUICK / OPTIONAL.**
+domain-voice has no `CLAUDE.md`/`README`, and its `package.json` says "8 languages / 14 commands"
+(actual: 11 languages / 19 schemas). Cheap to fix whenever.
+
+### Already tracked — link, don't re-litigate
+
+- **Single-lexicon consolidation** — [`FRAMEWORK_SEMANTIC_BRIDGE_PLAN.md`](../FRAMEWORK_SEMANTIC_BRIDGE_PLAN.md) §"Vocab-authoring ergonomics (backlog)"; voice is the named foothold. Covers V3.
+- **`AbstractCodeGenerator`** — [`DOMAIN_REVIEW.md`](./DOMAIN_REVIEW.md) §4 (per-domain switch boilerplate), proposed, priority #7, unbuilt. Related to V2.
+- **`compilation-service` `AbstractOperation` IR** — [`operations/types.ts`](../../packages/compilation-service/src/operations/types.ts) already defines `ToggleClassOp/ShowOp/HideOp/NavigateOp/FocusOp/HistoryBack/ForwardOp`, heavily overlapping voice's verbs, but is unconnected to the domain DSLs. A candidate backend for V2 if voice's codegen is ever consolidated.
+
+## Prioritization
+
+| Finding | Value | Risk / cost | When |
+|---|---|---|---|
+| F1 docs, F2 generator bug | High (prevents re-hitting the trap; corrects wrong output) | Low (docs + format-only) | **Done this pass** |
+| V4 doc drift | Low | Trivial | Anytime |
+| V2 codegen/renderer coverage | High (user-visible: verbs that parse should *do* something) | Medium (voice-local) | Next voice pass |
+| V3 verb-keyword single-lexicon | Medium (kills drift) | Medium (voice-local; tracked) | With/after V2 |
+| F3 selector-typing → V1 value model | High (fixes a class of bugs incl. `click the …`) | **Higher** (framework-wide, ratchet-adjacent) | Deliberate framework pass |
+
+## Recommended sequence
+
+1. **This pass (done):** F1 + F2 — cheap, safe, high-leverage; unblocks correct schema reuse.
+2. **Next voice increment:** V2 (real `classList` codegen + renderer for the behavior verbs) then V3
+   (fold the renderer verb table onto the schema/vocab source — extend voice's existing
+   `buildMarkerLookup` foothold to verbs). Both voice-local, no ratchet exposure. V4 alongside.
+3. **Separate framework pass (design first):** F3 — add extractor-provided token `kind` so domains can
+   emit `selector`-typed values; this simultaneously restores the determiner-skip and lets voice drop
+   `acceptExpression`. Framework-wide and ratchet-adjacent, so scope it deliberately, with full
+   cross-domain + multilingual verification, not as a reactive change.
+
+## What this pass changed
+
+- **Fixed:** F1 (both position-convention docs corrected + cross-warned), F2 (`buildFormatString`
+  sorts like `buildTokens`). Verified: framework 789 tests green; all 8 framework-domain goldens
+  regenerated as **format-only** (0 token/extraction changes); every domain suite green; semantic
+  behavior unchanged (comment-only edit → fidelity ratchet untouched).
+- **Deferred with rationale:** F3, V1, V2, V3, V4 (above).
+- **Untouched:** the behavior-verb work (ships as-is); voice's value model and codegen.

--- a/packages/domain-bdd/src/__test__/golden/generated-patterns.golden.json
+++ b/packages/domain-bdd/src/__test__/golden/generated-patterns.golden.json
@@ -424,7 +424,7 @@
         "command": "when",
         "priority": 100,
         "template": {
-          "format": "{action_type} を {target} で {value} したら",
+          "format": "を {target} {action_type} で {value} したら",
           "tokens": [
             {
               "type": "group",
@@ -802,7 +802,7 @@
         "command": "when",
         "priority": 100,
         "template": {
-          "format": "{action_type} 를 {target} 로 {value} 만약",
+          "format": "를 {target} {action_type} 로 {value} 만약",
           "tokens": [
             {
               "type": "group",
@@ -1180,7 +1180,7 @@
         "command": "when",
         "priority": 100,
         "template": {
-          "format": "{action_type} üzerinde {target} ile {value} olduğunda",
+          "format": "üzerinde {target} {action_type} ile {value} olduğunda",
           "tokens": [
             {
               "type": "group",

--- a/packages/domain-behaviorspec/src/__test__/golden/generated-patterns.golden.json
+++ b/packages/domain-behaviorspec/src/__test__/golden/generated-patterns.golden.json
@@ -545,7 +545,7 @@
         "command": "when",
         "priority": 100,
         "template": {
-          "format": "{actor} {action} を {target} に {destination} 操作",
+          "format": "{actor} を {target} {action} に {destination} 操作",
           "tokens": [
             {
               "type": "role",
@@ -616,7 +616,7 @@
         "command": "expect",
         "priority": 100,
         "template": {
-          "format": "{target} {assertion} と {value} 期待",
+          "format": "{target} と {value} {assertion} 期待",
           "tokens": [
             {
               "type": "role",
@@ -1023,7 +1023,7 @@
         "command": "when",
         "priority": 100,
         "template": {
-          "format": "{actor} {action} 을 {target} 에 {destination} 동작",
+          "format": "{actor} 을 {target} {action} 에 {destination} 동작",
           "tokens": [
             {
               "type": "role",
@@ -1094,7 +1094,7 @@
         "command": "expect",
         "priority": 100,
         "template": {
-          "format": "{target} {assertion} 으로 {value} 기대",
+          "format": "{target} 으로 {value} {assertion} 기대",
           "tokens": [
             {
               "type": "role",
@@ -1740,7 +1740,7 @@
         "command": "when",
         "priority": 100,
         "template": {
-          "format": "{actor} {action} üzerinde {target} içine {destination} eylem",
+          "format": "{actor} üzerinde {target} {action} içine {destination} eylem",
           "tokens": [
             {
               "type": "role",
@@ -1811,7 +1811,7 @@
         "command": "expect",
         "priority": 100,
         "template": {
-          "format": "{target} {assertion} diyen {value} bekle",
+          "format": "{target} diyen {value} {assertion} bekle",
           "tokens": [
             {
               "type": "role",

--- a/packages/domain-flow/src/__test__/golden/generated-patterns.golden.json
+++ b/packages/domain-flow/src/__test__/golden/generated-patterns.golden.json
@@ -1130,7 +1130,7 @@
         "command": "submit",
         "priority": 100,
         "template": {
-          "format": "{patient} に {destination} で {style} 送信",
+          "format": "に {destination} {patient} で {style} 送信",
           "tokens": [
             {
               "type": "role",
@@ -1188,7 +1188,7 @@
         "command": "transform",
         "priority": 100,
         "template": {
-          "format": "{patient} で {instrument} 変換",
+          "format": "で {instrument} {patient} 変換",
           "tokens": [
             {
               "type": "role",
@@ -1298,7 +1298,7 @@
         "command": "perform",
         "priority": 100,
         "template": {
-          "format": "{patient} で {source} 実行",
+          "format": "で {source} {patient} 実行",
           "tokens": [
             {
               "type": "group",
@@ -2048,7 +2048,7 @@
         "command": "submit",
         "priority": 100,
         "template": {
-          "format": "{patient} 로 {destination} 로 {style} 제출",
+          "format": "로 {destination} {patient} 로 {style} 제출",
           "tokens": [
             {
               "type": "role",
@@ -2106,7 +2106,7 @@
         "command": "transform",
         "priority": 100,
         "template": {
-          "format": "{patient} 로 {instrument} 변환",
+          "format": "로 {instrument} {patient} 변환",
           "tokens": [
             {
               "type": "role",
@@ -2216,7 +2216,7 @@
         "command": "perform",
         "priority": 100,
         "template": {
-          "format": "{patient} 로 {source} 실행",
+          "format": "로 {source} {patient} 실행",
           "tokens": [
             {
               "type": "group",
@@ -2966,7 +2966,7 @@
         "command": "submit",
         "priority": 100,
         "template": {
-          "format": "{patient} e {destination} olarak {style} gönder",
+          "format": "e {destination} {patient} olarak {style} gönder",
           "tokens": [
             {
               "type": "role",
@@ -3024,7 +3024,7 @@
         "command": "transform",
         "priority": 100,
         "template": {
-          "format": "{patient} ile {instrument} dönüştür",
+          "format": "ile {instrument} {patient} dönüştür",
           "tokens": [
             {
               "type": "role",
@@ -3134,7 +3134,7 @@
         "command": "perform",
         "priority": 100,
         "template": {
-          "format": "{patient} ile {source} yürüt",
+          "format": "ile {source} {patient} yürüt",
           "tokens": [
             {
               "type": "group",

--- a/packages/domain-jsx/src/__test__/golden/generated-patterns.golden.json
+++ b/packages/domain-jsx/src/__test__/golden/generated-patterns.golden.json
@@ -721,7 +721,7 @@
         "command": "render",
         "priority": 100,
         "template": {
-          "format": "{source} に {destination} 描画",
+          "format": "に {destination} {source} 描画",
           "tokens": [
             {
               "type": "role",
@@ -805,7 +805,7 @@
         "command": "effect",
         "priority": 100,
         "template": {
-          "format": "{callback} で {deps} エフェクト",
+          "format": "で {deps} {callback} エフェクト",
           "tokens": [
             {
               "type": "group",
@@ -1303,7 +1303,7 @@
         "command": "render",
         "priority": 100,
         "template": {
-          "format": "{source} 에 {destination} 렌더링",
+          "format": "에 {destination} {source} 렌더링",
           "tokens": [
             {
               "type": "role",
@@ -1387,7 +1387,7 @@
         "command": "effect",
         "priority": 100,
         "template": {
-          "format": "{callback} 에서 {deps} 효과",
+          "format": "에서 {deps} {callback} 효과",
           "tokens": [
             {
               "type": "group",
@@ -1885,7 +1885,7 @@
         "command": "render",
         "priority": 100,
         "template": {
-          "format": "{source} e {destination} isle",
+          "format": "e {destination} {source} isle",
           "tokens": [
             {
               "type": "role",
@@ -1969,7 +1969,7 @@
         "command": "effect",
         "priority": 100,
         "template": {
-          "format": "{callback} de {deps} etki",
+          "format": "de {deps} {callback} etki",
           "tokens": [
             {
               "type": "group",

--- a/packages/domain-learn/src/__test__/golden/generated-patterns.golden.json
+++ b/packages/domain-learn/src/__test__/golden/generated-patterns.golden.json
@@ -526,7 +526,7 @@
         "command": "add",
         "priority": 100,
         "template": {
-          "format": "{patient} {destination} 追加",
+          "format": "{destination} {patient} 追加",
           "tokens": [
             {
               "type": "role",
@@ -559,7 +559,7 @@
         "command": "remove",
         "priority": 100,
         "template": {
-          "format": "{patient} {source} 削除",
+          "format": "{source} {patient} 削除",
           "tokens": [
             {
               "type": "role",
@@ -592,7 +592,7 @@
         "command": "toggle",
         "priority": 100,
         "template": {
-          "format": "{patient} {destination} 切り替え",
+          "format": "{destination} {patient} 切り替え",
           "tokens": [
             {
               "type": "role",
@@ -625,7 +625,7 @@
         "command": "put",
         "priority": 100,
         "template": {
-          "format": "{patient} {destination} 置",
+          "format": "{destination} {patient} 置",
           "tokens": [
             {
               "type": "role",
@@ -658,7 +658,7 @@
         "command": "set",
         "priority": 100,
         "template": {
-          "format": "を {destination} に {patient} 設定",
+          "format": "に {patient} を {destination} 設定",
           "tokens": [
             {
               "type": "role",
@@ -845,7 +845,7 @@
         "command": "send",
         "priority": 100,
         "template": {
-          "format": "{patient} に {destination} 送",
+          "format": "に {destination} {patient} 送",
           "tokens": [
             {
               "type": "group",
@@ -968,7 +968,7 @@
         "command": "take",
         "priority": 100,
         "template": {
-          "format": "{patient} {source} 取",
+          "format": "{source} {patient} 取",
           "tokens": [
             {
               "type": "role",
@@ -2587,7 +2587,7 @@
         "command": "add",
         "priority": 100,
         "template": {
-          "format": "{patient} 에 {destination} 추가",
+          "format": "에 {destination} {patient} 추가",
           "tokens": [
             {
               "type": "group",
@@ -2632,7 +2632,7 @@
         "command": "remove",
         "priority": 100,
         "template": {
-          "format": "{patient} 에서 {source} 제거",
+          "format": "에서 {source} {patient} 제거",
           "tokens": [
             {
               "type": "group",
@@ -2677,7 +2677,7 @@
         "command": "toggle",
         "priority": 100,
         "template": {
-          "format": "{patient} 에 {destination} 토글",
+          "format": "에 {destination} {patient} 토글",
           "tokens": [
             {
               "type": "group",
@@ -2722,7 +2722,7 @@
         "command": "put",
         "priority": 100,
         "template": {
-          "format": "{patient} 에 {destination} 넣",
+          "format": "에 {destination} {patient} 넣",
           "tokens": [
             {
               "type": "group",
@@ -2767,7 +2767,7 @@
         "command": "set",
         "priority": 100,
         "template": {
-          "format": "를 {destination} 으로 {patient} 설정",
+          "format": "으로 {patient} 를 {destination} 설정",
           "tokens": [
             {
               "type": "role",
@@ -2954,7 +2954,7 @@
         "command": "send",
         "priority": 100,
         "template": {
-          "format": "{patient} 에게 {destination} 보내",
+          "format": "에게 {destination} {patient} 보내",
           "tokens": [
             {
               "type": "group",
@@ -3083,7 +3083,7 @@
         "command": "take",
         "priority": 100,
         "template": {
-          "format": "{patient} 에서 {source} 가져오",
+          "format": "에서 {source} {patient} 가져오",
           "tokens": [
             {
               "type": "group",
@@ -3670,7 +3670,7 @@
         "command": "add",
         "priority": 100,
         "template": {
-          "format": "{patient} a {destination} ekle",
+          "format": "a {destination} {patient} ekle",
           "tokens": [
             {
               "type": "group",
@@ -3716,7 +3716,7 @@
         "command": "remove",
         "priority": 100,
         "template": {
-          "format": "{patient} dan {source} kaldir",
+          "format": "dan {source} {patient} kaldir",
           "tokens": [
             {
               "type": "group",
@@ -3762,7 +3762,7 @@
         "command": "toggle",
         "priority": 100,
         "template": {
-          "format": "{patient} da {destination} degistir",
+          "format": "da {destination} {patient} degistir",
           "tokens": [
             {
               "type": "group",
@@ -3808,7 +3808,7 @@
         "command": "put",
         "priority": 100,
         "template": {
-          "format": "{patient} a {destination} koy",
+          "format": "a {destination} {patient} koy",
           "tokens": [
             {
               "type": "group",
@@ -3854,7 +3854,7 @@
         "command": "set",
         "priority": 100,
         "template": {
-          "format": "{destination} e {patient} ayarla",
+          "format": "e {patient} {destination} ayarla",
           "tokens": [
             {
               "type": "role",
@@ -4029,7 +4029,7 @@
         "command": "send",
         "priority": 100,
         "template": {
-          "format": "{patient} -e {destination} gonder",
+          "format": "-e {destination} {patient} gonder",
           "tokens": [
             {
               "type": "group",
@@ -4162,7 +4162,7 @@
         "command": "take",
         "priority": 100,
         "template": {
-          "format": "{patient} dan {source} al",
+          "format": "dan {source} {patient} al",
           "tokens": [
             {
               "type": "group",

--- a/packages/domain-llm/src/__test__/golden/generated-patterns.golden.json
+++ b/packages/domain-llm/src/__test__/golden/generated-patterns.golden.json
@@ -449,7 +449,7 @@
         "command": "ask",
         "priority": 100,
         "template": {
-          "format": "{patient} から {source} として {manner} 聞く",
+          "format": "から {source} {patient} として {manner} 聞く",
           "tokens": [
             {
               "type": "group",
@@ -577,7 +577,7 @@
         "command": "analyze",
         "priority": 100,
         "template": {
-          "format": "{patient} として {manner} 分析",
+          "format": "として {manner} {patient} 分析",
           "tokens": [
             {
               "type": "literal",
@@ -891,7 +891,7 @@
         "command": "ask",
         "priority": 100,
         "template": {
-          "format": "{patient} 에서 {source} 로 {manner} 질문",
+          "format": "에서 {source} {patient} 로 {manner} 질문",
           "tokens": [
             {
               "type": "group",
@@ -1019,7 +1019,7 @@
         "command": "analyze",
         "priority": 100,
         "template": {
-          "format": "{patient} 로 {manner} 분석",
+          "format": "로 {manner} {patient} 분석",
           "tokens": [
             {
               "type": "role",
@@ -1333,7 +1333,7 @@
         "command": "ask",
         "priority": 100,
         "template": {
-          "format": "{patient} dan {source} olarak {manner} sor",
+          "format": "dan {source} {patient} olarak {manner} sor",
           "tokens": [
             {
               "type": "group",
@@ -1461,7 +1461,7 @@
         "command": "analyze",
         "priority": 100,
         "template": {
-          "format": "{patient} olarak {manner} çözümle",
+          "format": "olarak {manner} {patient} çözümle",
           "tokens": [
             {
               "type": "role",

--- a/packages/domain-sql/src/__test__/golden/generated-patterns.golden.json
+++ b/packages/domain-sql/src/__test__/golden/generated-patterns.golden.json
@@ -567,7 +567,7 @@
         "command": "select",
         "priority": 100,
         "template": {
-          "format": "{columns} から {source} 条件 {condition} 選択",
+          "format": "から {source} {columns} 条件 {condition} 選択",
           "tokens": [
             {
               "type": "role",
@@ -626,7 +626,7 @@
         "command": "insert",
         "priority": 100,
         "template": {
-          "format": "{values} に {destination} 挿入",
+          "format": "に {destination} {values} 挿入",
           "tokens": [
             {
               "type": "role",
@@ -1133,7 +1133,7 @@
         "command": "select",
         "priority": 100,
         "template": {
-          "format": "{columns} 에서 {source} 조건 {condition} 선택",
+          "format": "에서 {source} {columns} 조건 {condition} 선택",
           "tokens": [
             {
               "type": "role",
@@ -1192,7 +1192,7 @@
         "command": "insert",
         "priority": 100,
         "template": {
-          "format": "{values} 에 {destination} 삽입",
+          "format": "에 {destination} {values} 삽입",
           "tokens": [
             {
               "type": "role",
@@ -1699,7 +1699,7 @@
         "command": "select",
         "priority": 100,
         "template": {
-          "format": "{columns} den {source} koşul {condition} seç",
+          "format": "den {source} {columns} koşul {condition} seç",
           "tokens": [
             {
               "type": "role",
@@ -1758,7 +1758,7 @@
         "command": "insert",
         "priority": 100,
         "template": {
-          "format": "{values} e {destination} ekle",
+          "format": "e {destination} {values} ekle",
           "tokens": [
             {
               "type": "role",

--- a/packages/domain-todo/src/__test__/golden/generated-patterns.golden.json
+++ b/packages/domain-todo/src/__test__/golden/generated-patterns.golden.json
@@ -210,7 +210,7 @@
         "command": "add",
         "priority": 100,
         "template": {
-          "format": "を {item} に {list} 追加",
+          "format": "に {list} を {item} 追加",
           "tokens": [
             {
               "type": "group",
@@ -432,7 +432,7 @@
         "command": "add",
         "priority": 100,
         "template": {
-          "format": "를 {item} 에 {list} 추가",
+          "format": "에 {list} 를 {item} 추가",
           "tokens": [
             {
               "type": "group",
@@ -654,7 +654,7 @@
         "command": "add",
         "priority": 100,
         "template": {
-          "format": "{item} e {list} ekle",
+          "format": "e {list} {item} ekle",
           "tokens": [
             {
               "type": "group",

--- a/packages/domain-voice/src/__test__/golden/generated-patterns.golden.json
+++ b/packages/domain-voice/src/__test__/golden/generated-patterns.golden.json
@@ -431,6 +431,253 @@
           "patient": {}
         }
       }
+    ],
+    "toggle": [
+      {
+        "id": "toggle-en-generated",
+        "language": "en",
+        "command": "toggle",
+        "priority": 100,
+        "template": {
+          "format": "toggle {patient} on {destination}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "toggle"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "on"
+                },
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "on"
+          }
+        }
+      }
+    ],
+    "add": [
+      {
+        "id": "add-en-generated",
+        "language": "en",
+        "command": "add",
+        "priority": 100,
+        "template": {
+          "format": "add {patient} to {destination}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "add"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "literal", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "to"
+                },
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "to"
+          }
+        }
+      }
+    ],
+    "remove": [
+      {
+        "id": "remove-en-generated",
+        "language": "en",
+        "command": "remove",
+        "priority": 100,
+        "template": {
+          "format": "remove {patient} from {source}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "remove"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "from"
+                },
+                {
+                  "type": "role",
+                  "role": "source",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "source": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "from"
+          }
+        }
+      }
+    ],
+    "show": [
+      {
+        "id": "show-en-generated",
+        "language": "en",
+        "command": "show",
+        "priority": 100,
+        "template": {
+          "format": "show {patient} with {style}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "show"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "with"
+                },
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "with"
+          }
+        }
+      }
+    ],
+    "hide": [
+      {
+        "id": "hide-en-generated",
+        "language": "en",
+        "command": "hide",
+        "priority": 100,
+        "template": {
+          "format": "hide {patient} with {style}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "hide"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "with"
+                },
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "with"
+          }
+        }
+      }
     ]
   },
   "es": {
@@ -863,6 +1110,253 @@
           "patient": {}
         }
       }
+    ],
+    "toggle": [
+      {
+        "id": "toggle-es-generated",
+        "language": "es",
+        "command": "toggle",
+        "priority": 100,
+        "template": {
+          "format": "alternar {patient} en {destination}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "alternar"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "en"
+                },
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "en"
+          }
+        }
+      }
+    ],
+    "add": [
+      {
+        "id": "add-es-generated",
+        "language": "es",
+        "command": "add",
+        "priority": 100,
+        "template": {
+          "format": "agregar {patient} en {destination}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "agregar"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "literal", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "en"
+                },
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "en"
+          }
+        }
+      }
+    ],
+    "remove": [
+      {
+        "id": "remove-es-generated",
+        "language": "es",
+        "command": "remove",
+        "priority": 100,
+        "template": {
+          "format": "quitar {patient} de {source}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "quitar"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "de"
+                },
+                {
+                  "type": "role",
+                  "role": "source",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "source": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "de"
+          }
+        }
+      }
+    ],
+    "show": [
+      {
+        "id": "show-es-generated",
+        "language": "es",
+        "command": "show",
+        "priority": 100,
+        "template": {
+          "format": "mostrar {patient} con {style}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "mostrar"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "con"
+                },
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "con"
+          }
+        }
+      }
+    ],
+    "hide": [
+      {
+        "id": "hide-es-generated",
+        "language": "es",
+        "command": "hide",
+        "priority": 100,
+        "template": {
+          "format": "ocultar {patient} con {style}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "ocultar"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "con"
+                },
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "con"
+          }
+        }
+      }
     ]
   },
   "ja": {
@@ -937,7 +1431,7 @@
         "command": "type",
         "priority": 100,
         "template": {
-          "format": "を {patient} に {destination} 入力",
+          "format": "に {destination} を {patient} 入力",
           "tokens": [
             {
               "type": "group",
@@ -1277,7 +1771,7 @@
         "command": "search",
         "priority": 100,
         "template": {
-          "format": "を {patient} で {destination} 検索",
+          "format": "で {destination} を {patient} 検索",
           "tokens": [
             {
               "type": "group",
@@ -1344,6 +1838,253 @@
         },
         "extraction": {
           "patient": {}
+        }
+      }
+    ],
+    "toggle": [
+      {
+        "id": "toggle-ja-generated",
+        "language": "ja",
+        "command": "toggle",
+        "priority": 100,
+        "template": {
+          "format": "に {destination} {patient} 切り替え",
+          "tokens": [
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                },
+                {
+                  "type": "literal",
+                  "value": "に"
+                }
+              ]
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "expression"]
+            },
+            {
+              "type": "literal",
+              "value": "切り替え"
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "に"
+          }
+        }
+      }
+    ],
+    "add": [
+      {
+        "id": "add-ja-generated",
+        "language": "ja",
+        "command": "add",
+        "priority": 100,
+        "template": {
+          "format": "に {destination} {patient} 追加",
+          "tokens": [
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                },
+                {
+                  "type": "literal",
+                  "value": "に"
+                }
+              ]
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "literal", "expression"]
+            },
+            {
+              "type": "literal",
+              "value": "追加"
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "に"
+          }
+        }
+      }
+    ],
+    "remove": [
+      {
+        "id": "remove-ja-generated",
+        "language": "ja",
+        "command": "remove",
+        "priority": 100,
+        "template": {
+          "format": "{source} から {patient} 削除",
+          "tokens": [
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "role",
+                  "role": "source",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                },
+                {
+                  "type": "literal",
+                  "value": "から"
+                }
+              ]
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "literal",
+              "value": "削除"
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "source": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "から"
+          }
+        }
+      }
+    ],
+    "show": [
+      {
+        "id": "show-ja-generated",
+        "language": "ja",
+        "command": "show",
+        "priority": 100,
+        "template": {
+          "format": "{patient} {style} で 表示",
+          "tokens": [
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                },
+                {
+                  "type": "literal",
+                  "value": "で"
+                }
+              ]
+            },
+            {
+              "type": "literal",
+              "value": "表示"
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "で"
+          }
+        }
+      }
+    ],
+    "hide": [
+      {
+        "id": "hide-ja-generated",
+        "language": "ja",
+        "command": "hide",
+        "priority": 100,
+        "template": {
+          "format": "{patient} {style} で 隠す",
+          "tokens": [
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                },
+                {
+                  "type": "literal",
+                  "value": "で"
+                }
+              ]
+            },
+            {
+              "type": "literal",
+              "value": "隠す"
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "で"
+          }
         }
       }
     ]
@@ -1793,6 +2534,253 @@
           "patient": {}
         }
       }
+    ],
+    "toggle": [
+      {
+        "id": "toggle-ar-generated",
+        "language": "ar",
+        "command": "toggle",
+        "priority": 100,
+        "template": {
+          "format": "بدّل {patient} على {destination}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "بدّل"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "على"
+                },
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "على"
+          }
+        }
+      }
+    ],
+    "add": [
+      {
+        "id": "add-ar-generated",
+        "language": "ar",
+        "command": "add",
+        "priority": 100,
+        "template": {
+          "format": "أضف {patient} على {destination}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "أضف"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "literal", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "على"
+                },
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "على"
+          }
+        }
+      }
+    ],
+    "remove": [
+      {
+        "id": "remove-ar-generated",
+        "language": "ar",
+        "command": "remove",
+        "priority": 100,
+        "template": {
+          "format": "احذف {patient} من {source}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "احذف"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "من"
+                },
+                {
+                  "type": "role",
+                  "role": "source",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "source": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "من"
+          }
+        }
+      }
+    ],
+    "show": [
+      {
+        "id": "show-ar-generated",
+        "language": "ar",
+        "command": "show",
+        "priority": 100,
+        "template": {
+          "format": "اظهر {patient} بـ {style}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "اظهر"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "بـ"
+                },
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "بـ"
+          }
+        }
+      }
+    ],
+    "hide": [
+      {
+        "id": "hide-ar-generated",
+        "language": "ar",
+        "command": "hide",
+        "priority": 100,
+        "template": {
+          "format": "اخف {patient} بـ {style}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "اخف"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "بـ"
+                },
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "بـ"
+          }
+        }
+      }
     ]
   },
   "ko": {
@@ -1867,7 +2855,7 @@
         "command": "type",
         "priority": 100,
         "template": {
-          "format": "을 {patient} 에 {destination} 입력",
+          "format": "에 {destination} 을 {patient} 입력",
           "tokens": [
             {
               "type": "group",
@@ -2207,7 +3195,7 @@
         "command": "search",
         "priority": 100,
         "template": {
-          "format": "을 {patient} 에서 {destination} 검색",
+          "format": "에서 {destination} 을 {patient} 검색",
           "tokens": [
             {
               "type": "group",
@@ -2274,6 +3262,253 @@
         },
         "extraction": {
           "patient": {}
+        }
+      }
+    ],
+    "toggle": [
+      {
+        "id": "toggle-ko-generated",
+        "language": "ko",
+        "command": "toggle",
+        "priority": 100,
+        "template": {
+          "format": "에 {destination} {patient} 토글",
+          "tokens": [
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                },
+                {
+                  "type": "literal",
+                  "value": "에"
+                }
+              ]
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "expression"]
+            },
+            {
+              "type": "literal",
+              "value": "토글"
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "에"
+          }
+        }
+      }
+    ],
+    "add": [
+      {
+        "id": "add-ko-generated",
+        "language": "ko",
+        "command": "add",
+        "priority": 100,
+        "template": {
+          "format": "에 {destination} {patient} 추가",
+          "tokens": [
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                },
+                {
+                  "type": "literal",
+                  "value": "에"
+                }
+              ]
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "literal", "expression"]
+            },
+            {
+              "type": "literal",
+              "value": "추가"
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "에"
+          }
+        }
+      }
+    ],
+    "remove": [
+      {
+        "id": "remove-ko-generated",
+        "language": "ko",
+        "command": "remove",
+        "priority": 100,
+        "template": {
+          "format": "{source} 에서 {patient} 제거",
+          "tokens": [
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "role",
+                  "role": "source",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                },
+                {
+                  "type": "literal",
+                  "value": "에서"
+                }
+              ]
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "literal",
+              "value": "제거"
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "source": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "에서"
+          }
+        }
+      }
+    ],
+    "show": [
+      {
+        "id": "show-ko-generated",
+        "language": "ko",
+        "command": "show",
+        "priority": 100,
+        "template": {
+          "format": "{patient} {style} 로 보이다",
+          "tokens": [
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                },
+                {
+                  "type": "literal",
+                  "value": "로"
+                }
+              ]
+            },
+            {
+              "type": "literal",
+              "value": "보이다"
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "로"
+          }
+        }
+      }
+    ],
+    "hide": [
+      {
+        "id": "hide-ko-generated",
+        "language": "ko",
+        "command": "hide",
+        "priority": 100,
+        "template": {
+          "format": "{patient} {style} 로 숨기다",
+          "tokens": [
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                },
+                {
+                  "type": "literal",
+                  "value": "로"
+                }
+              ]
+            },
+            {
+              "type": "literal",
+              "value": "숨기다"
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "로"
+          }
         }
       }
     ]
@@ -2705,6 +3940,253 @@
           "patient": {}
         }
       }
+    ],
+    "toggle": [
+      {
+        "id": "toggle-zh-generated",
+        "language": "zh",
+        "command": "toggle",
+        "priority": 100,
+        "template": {
+          "format": "切换 {patient} 在 {destination}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "切换"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "在"
+                },
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "在"
+          }
+        }
+      }
+    ],
+    "add": [
+      {
+        "id": "add-zh-generated",
+        "language": "zh",
+        "command": "add",
+        "priority": 100,
+        "template": {
+          "format": "添加 {patient} 在 {destination}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "添加"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "literal", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "在"
+                },
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "在"
+          }
+        }
+      }
+    ],
+    "remove": [
+      {
+        "id": "remove-zh-generated",
+        "language": "zh",
+        "command": "remove",
+        "priority": 100,
+        "template": {
+          "format": "移除 {patient} 从 {source}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "移除"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "从"
+                },
+                {
+                  "type": "role",
+                  "role": "source",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "source": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "从"
+          }
+        }
+      }
+    ],
+    "show": [
+      {
+        "id": "show-zh-generated",
+        "language": "zh",
+        "command": "show",
+        "priority": 100,
+        "template": {
+          "format": "显示 {patient} 用 {style}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "显示"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "用"
+                },
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "用"
+          }
+        }
+      }
+    ],
+    "hide": [
+      {
+        "id": "hide-zh-generated",
+        "language": "zh",
+        "command": "hide",
+        "priority": 100,
+        "template": {
+          "format": "隐藏 {patient} 用 {style}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "隐藏"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "用"
+                },
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "用"
+          }
+        }
+      }
     ]
   },
   "tr": {
@@ -2773,7 +4255,7 @@
         "command": "type",
         "priority": 100,
         "template": {
-          "format": "{patient} ya {destination} yaz",
+          "format": "ya {destination} {patient} yaz",
           "tokens": [
             {
               "type": "group",
@@ -3077,7 +4559,7 @@
         "command": "search",
         "priority": 100,
         "template": {
-          "format": "{patient} da {destination} ara",
+          "format": "da {destination} {patient} ara",
           "tokens": [
             {
               "type": "group",
@@ -3138,6 +4620,253 @@
         },
         "extraction": {
           "patient": {}
+        }
+      }
+    ],
+    "toggle": [
+      {
+        "id": "toggle-tr-generated",
+        "language": "tr",
+        "command": "toggle",
+        "priority": 100,
+        "template": {
+          "format": "e {destination} {patient} değiştir",
+          "tokens": [
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                },
+                {
+                  "type": "literal",
+                  "value": "e"
+                }
+              ]
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "expression"]
+            },
+            {
+              "type": "literal",
+              "value": "değiştir"
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "e"
+          }
+        }
+      }
+    ],
+    "add": [
+      {
+        "id": "add-tr-generated",
+        "language": "tr",
+        "command": "add",
+        "priority": 100,
+        "template": {
+          "format": "e {destination} {patient} ekle",
+          "tokens": [
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                },
+                {
+                  "type": "literal",
+                  "value": "e"
+                }
+              ]
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "literal", "expression"]
+            },
+            {
+              "type": "literal",
+              "value": "ekle"
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "e"
+          }
+        }
+      }
+    ],
+    "remove": [
+      {
+        "id": "remove-tr-generated",
+        "language": "tr",
+        "command": "remove",
+        "priority": 100,
+        "template": {
+          "format": "{source} den {patient} kaldır",
+          "tokens": [
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "role",
+                  "role": "source",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                },
+                {
+                  "type": "literal",
+                  "value": "den"
+                }
+              ]
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "literal",
+              "value": "kaldır"
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "source": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "den"
+          }
+        }
+      }
+    ],
+    "show": [
+      {
+        "id": "show-tr-generated",
+        "language": "tr",
+        "command": "show",
+        "priority": 100,
+        "template": {
+          "format": "{patient} {style} le göster",
+          "tokens": [
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                },
+                {
+                  "type": "literal",
+                  "value": "le"
+                }
+              ]
+            },
+            {
+              "type": "literal",
+              "value": "göster"
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "le"
+          }
+        }
+      }
+    ],
+    "hide": [
+      {
+        "id": "hide-tr-generated",
+        "language": "tr",
+        "command": "hide",
+        "priority": 100,
+        "template": {
+          "format": "{patient} {style} le gizle",
+          "tokens": [
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                },
+                {
+                  "type": "literal",
+                  "value": "le"
+                }
+              ]
+            },
+            {
+              "type": "literal",
+              "value": "gizle"
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "le"
+          }
         }
       }
     ]
@@ -3578,6 +5307,253 @@
           "patient": {}
         }
       }
+    ],
+    "toggle": [
+      {
+        "id": "toggle-fr-generated",
+        "language": "fr",
+        "command": "toggle",
+        "priority": 100,
+        "template": {
+          "format": "basculer {patient} sur {destination}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "basculer"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "sur"
+                },
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "sur"
+          }
+        }
+      }
+    ],
+    "add": [
+      {
+        "id": "add-fr-generated",
+        "language": "fr",
+        "command": "add",
+        "priority": 100,
+        "template": {
+          "format": "ajouter {patient} sur {destination}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "ajouter"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "literal", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "sur"
+                },
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "sur"
+          }
+        }
+      }
+    ],
+    "remove": [
+      {
+        "id": "remove-fr-generated",
+        "language": "fr",
+        "command": "remove",
+        "priority": 100,
+        "template": {
+          "format": "supprimer {patient} de {source}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "supprimer"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "de"
+                },
+                {
+                  "type": "role",
+                  "role": "source",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "source": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "de"
+          }
+        }
+      }
+    ],
+    "show": [
+      {
+        "id": "show-fr-generated",
+        "language": "fr",
+        "command": "show",
+        "priority": 100,
+        "template": {
+          "format": "montrer {patient} avec {style}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "montrer"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "avec"
+                },
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "avec"
+          }
+        }
+      }
+    ],
+    "hide": [
+      {
+        "id": "hide-fr-generated",
+        "language": "fr",
+        "command": "hide",
+        "priority": 100,
+        "template": {
+          "format": "cacher {patient} avec {style}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "cacher"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "avec"
+                },
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "avec"
+          }
+        }
+      }
     ]
   },
   "de": {
@@ -4005,6 +5981,253 @@
         },
         "extraction": {
           "patient": {}
+        }
+      }
+    ],
+    "toggle": [
+      {
+        "id": "toggle-de-generated",
+        "language": "de",
+        "command": "toggle",
+        "priority": 100,
+        "template": {
+          "format": "umschalten {patient} auf {destination}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "umschalten"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "auf"
+                },
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "auf"
+          }
+        }
+      }
+    ],
+    "add": [
+      {
+        "id": "add-de-generated",
+        "language": "de",
+        "command": "add",
+        "priority": 100,
+        "template": {
+          "format": "hinzufügen {patient} auf {destination}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "hinzufügen"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "literal", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "auf"
+                },
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "auf"
+          }
+        }
+      }
+    ],
+    "remove": [
+      {
+        "id": "remove-de-generated",
+        "language": "de",
+        "command": "remove",
+        "priority": 100,
+        "template": {
+          "format": "entfernen {patient} von {source}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "entfernen"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "von"
+                },
+                {
+                  "type": "role",
+                  "role": "source",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "source": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "von"
+          }
+        }
+      }
+    ],
+    "show": [
+      {
+        "id": "show-de-generated",
+        "language": "de",
+        "command": "show",
+        "priority": 100,
+        "template": {
+          "format": "zeigen {patient} mit {style}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "zeigen"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "mit"
+                },
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "mit"
+          }
+        }
+      }
+    ],
+    "hide": [
+      {
+        "id": "hide-de-generated",
+        "language": "de",
+        "command": "hide",
+        "priority": 100,
+        "template": {
+          "format": "verbergen {patient} mit {style}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "verbergen"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "mit"
+                },
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "mit"
+          }
         }
       }
     ]
@@ -4436,6 +6659,253 @@
           "patient": {}
         }
       }
+    ],
+    "toggle": [
+      {
+        "id": "toggle-pt-generated",
+        "language": "pt",
+        "command": "toggle",
+        "priority": 100,
+        "template": {
+          "format": "alternar {patient} em {destination}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "alternar"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "em"
+                },
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "em"
+          }
+        }
+      }
+    ],
+    "add": [
+      {
+        "id": "add-pt-generated",
+        "language": "pt",
+        "command": "add",
+        "priority": 100,
+        "template": {
+          "format": "adicionar {patient} em {destination}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "adicionar"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "literal", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "em"
+                },
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "em"
+          }
+        }
+      }
+    ],
+    "remove": [
+      {
+        "id": "remove-pt-generated",
+        "language": "pt",
+        "command": "remove",
+        "priority": 100,
+        "template": {
+          "format": "remover {patient} de {source}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "remover"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "de"
+                },
+                {
+                  "type": "role",
+                  "role": "source",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "source": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "de"
+          }
+        }
+      }
+    ],
+    "show": [
+      {
+        "id": "show-pt-generated",
+        "language": "pt",
+        "command": "show",
+        "priority": 100,
+        "template": {
+          "format": "mostrar {patient} com {style}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "mostrar"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "com"
+                },
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "com"
+          }
+        }
+      }
+    ],
+    "hide": [
+      {
+        "id": "hide-pt-generated",
+        "language": "pt",
+        "command": "hide",
+        "priority": 100,
+        "template": {
+          "format": "ocultar {patient} com {style}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "ocultar"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "com"
+                },
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "com"
+          }
+        }
+      }
     ]
   },
   "ru": {
@@ -4863,6 +7333,253 @@
         },
         "extraction": {
           "patient": {}
+        }
+      }
+    ],
+    "toggle": [
+      {
+        "id": "toggle-ru-generated",
+        "language": "ru",
+        "command": "toggle",
+        "priority": 100,
+        "template": {
+          "format": "переключить {patient} в {destination}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "переключить"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "в"
+                },
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "в"
+          }
+        }
+      }
+    ],
+    "add": [
+      {
+        "id": "add-ru-generated",
+        "language": "ru",
+        "command": "add",
+        "priority": 100,
+        "template": {
+          "format": "добавить {patient} в {destination}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "добавить"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "literal", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "в"
+                },
+                {
+                  "type": "role",
+                  "role": "destination",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "destination": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "в"
+          }
+        }
+      }
+    ],
+    "remove": [
+      {
+        "id": "remove-ru-generated",
+        "language": "ru",
+        "command": "remove",
+        "priority": 100,
+        "template": {
+          "format": "удалить {patient} из {source}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "удалить"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "из"
+                },
+                {
+                  "type": "role",
+                  "role": "source",
+                  "optional": true,
+                  "expectedTypes": ["selector", "reference", "expression"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {},
+          "source": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            },
+            "marker": "из"
+          }
+        }
+      }
+    ],
+    "show": [
+      {
+        "id": "show-ru-generated",
+        "language": "ru",
+        "command": "show",
+        "priority": 100,
+        "template": {
+          "format": "показать {patient} с {style}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "показать"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "с"
+                },
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "с"
+          }
+        }
+      }
+    ],
+    "hide": [
+      {
+        "id": "hide-ru-generated",
+        "language": "ru",
+        "command": "hide",
+        "priority": 100,
+        "template": {
+          "format": "скрыть {patient} с {style}",
+          "tokens": [
+            {
+              "type": "literal",
+              "value": "скрыть"
+            },
+            {
+              "type": "role",
+              "role": "patient",
+              "optional": false,
+              "expectedTypes": ["selector", "reference", "expression"]
+            },
+            {
+              "type": "group",
+              "optional": true,
+              "tokens": [
+                {
+                  "type": "literal",
+                  "value": "с"
+                },
+                {
+                  "type": "role",
+                  "role": "style",
+                  "optional": true,
+                  "expectedTypes": ["literal"]
+                }
+              ]
+            }
+          ]
+        },
+        "extraction": {
+          "patient": {
+            "default": {
+              "type": "reference",
+              "value": "me"
+            }
+          },
+          "style": {
+            "marker": "с"
+          }
         }
       }
     ]

--- a/packages/domain-voice/src/__test__/voice-domain.test.ts
+++ b/packages/domain-voice/src/__test__/voice-domain.test.ts
@@ -21,7 +21,12 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { createVoiceDSL, renderVoice, toVoiceActionSpec, voiceCodeGenerator } from '../index';
 import type { MultilingualDSL } from '@lokascript/framework';
-import { extractRoleValue } from '@lokascript/framework';
+import {
+  extractRoleValue,
+  toProtocolJSON,
+  fromProtocolJSON,
+  renderExplicit,
+} from '@lokascript/framework';
 
 describe('Voice Domain', () => {
   let voice: MultilingualDSL;
@@ -1230,6 +1235,103 @@ describe('Voice Domain', () => {
       const spec = toVoiceActionSpec(node, 'en');
       expect(spec.action).toBe('navigate');
       expect(spec.target).toBe('home');
+    });
+  });
+
+  // ===========================================================================
+  // Behavior verbs (toggle/add/remove/show/hide) — sourced from the
+  // @lokascript/semantic profiles, not hand-authored. See src/vocab/behavior-verbs.ts
+  // and src/schemas/behavior.ts.
+  // ===========================================================================
+
+  describe('Behavior verbs (sourced from multilingual layer)', () => {
+    // English (SVO) — the brief's acceptance criteria
+    it('parses "toggle .active on #box" (patient + destination)', () => {
+      const { node, confidence } = voice.parseWithConfidence('toggle .active on #box', 'en');
+      expect(node.action).toBe('toggle');
+      expect(extractRoleValue(node, 'patient')).toBe('.active');
+      expect(extractRoleValue(node, 'destination')).toBe('#box');
+      expect(confidence).toBeGreaterThanOrEqual(0.7);
+    });
+
+    it('parses bare "toggle .active" (destination defaults to me)', () => {
+      const node = voice.parse('toggle .active', 'en');
+      expect(node.action).toBe('toggle');
+      expect(extractRoleValue(node, 'patient')).toBe('.active');
+      expect(extractRoleValue(node, 'destination')).toBe('me');
+    });
+
+    it('parses "add .highlighted to #box"', () => {
+      const node = voice.parse('add .highlighted to #box', 'en');
+      expect(node.action).toBe('add');
+      expect(extractRoleValue(node, 'patient')).toBe('.highlighted');
+      expect(extractRoleValue(node, 'destination')).toBe('#box');
+    });
+
+    it('parses "remove .x from #box" (captured as source, not destination)', () => {
+      const node = voice.parse('remove .x from #box', 'en');
+      expect(node.action).toBe('remove');
+      expect(extractRoleValue(node, 'patient')).toBe('.x');
+      expect(extractRoleValue(node, 'source')).toBe('#box');
+    });
+
+    it('parses "show #panel"', () => {
+      const node = voice.parse('show #panel', 'en');
+      expect(node.action).toBe('show');
+      expect(extractRoleValue(node, 'patient')).toBe('#panel');
+    });
+
+    it('parses "hide .menu"', () => {
+      const node = voice.parse('hide .menu', 'en');
+      expect(node.action).toBe('hide');
+      expect(extractRoleValue(node, 'patient')).toBe('.menu');
+    });
+
+    // Cross-order — proves the destination marker derived from the semantic slice
+    // works in non-SVO word orders (not an English-only addition).
+    it('parses German "umschalten .active auf #box" (derived marker auf)', () => {
+      const node = voice.parse('umschalten .active auf #box', 'de');
+      expect(node.action).toBe('toggle');
+      expect(extractRoleValue(node, 'patient')).toBe('.active');
+      expect(extractRoleValue(node, 'destination')).toBe('#box');
+    });
+
+    it('parses Japanese SOV "#box に .active 切り替え" (derived marker に)', () => {
+      const node = voice.parse('#box に .active 切り替え', 'ja');
+      expect(node.action).toBe('toggle');
+      expect(extractRoleValue(node, 'patient')).toBe('.active');
+      expect(extractRoleValue(node, 'destination')).toBe('#box');
+    });
+
+    // Round-trip (the brief's acceptance): SemanticNode ↔ protocol JSON, + explicit render.
+    it('round-trips toggle through protocol JSON', () => {
+      const node = voice.parse('toggle .active on #box', 'en');
+      const proto = toProtocolJSON(node);
+      expect(proto).toBeTruthy();
+      const back = fromProtocolJSON(proto);
+      expect(back.action).toBe('toggle');
+      expect(extractRoleValue(back, 'patient')).toBe('.active');
+      expect(extractRoleValue(back, 'destination')).toBe('#box');
+      expect(JSON.stringify(toProtocolJSON(back))).toBe(JSON.stringify(proto));
+    });
+
+    it('renders toggle/add/remove to explicit syntax', () => {
+      expect(renderExplicit(voice.parse('toggle .active on #box', 'en'))).toBe(
+        '[toggle patient:.active destination:#box]'
+      );
+      expect(renderExplicit(voice.parse('add .x to #y', 'en'))).toBe(
+        '[add patient:.x destination:#y]'
+      );
+      expect(renderExplicit(voice.parse('remove .x from #y', 'en'))).toBe(
+        '[remove patient:.x source:#y]'
+      );
+    });
+
+    // No-regression guard: existing page-control verbs still parse.
+    it('still parses existing verbs (click, navigate, scroll)', () => {
+      expect(voice.parse('click #login-btn', 'en').action).toBe('click');
+      expect(voice.parse('navigate to home', 'en').action).toBe('navigate');
+      expect(voice.parse('scroll down', 'en').action).toBe('scroll');
     });
   });
 });

--- a/packages/domain-voice/src/schemas/behavior.ts
+++ b/packages/domain-voice/src/schemas/behavior.ts
@@ -1,0 +1,135 @@
+/**
+ * Behavior-verb schemas for voice — REUSED from the `@lokascript/semantic`
+ * reference schemas rather than re-authored.
+ *
+ * `toggle`/`add` need a thin per-language `markerOverride` wrapper because voice
+ * suppresses the slice's `destination` marker (see `../vocab/shared.ts`
+ * `SCHEMA_OWNED_MARKERS`), and the reference schemas don't carry a full
+ * per-language destination marker map. The markers are DERIVED from the same
+ * grammar slices (via `deriveRoleMarkers`), so they stay sourced from the
+ * multilingual layer, not hand-authored.
+ *
+ * `remove`'s trailing target is captured as `source` (not `destination`), which
+ * voice does NOT suppress — so its marker wrapper is a verified no-op, applied
+ * uniformly for defensiveness. `show`/`hide` have only a (bare, suppressed)
+ * `patient` + an optional markerless `style` literal, so they need no marker
+ * wrapper — but, like all five, are still adapted to voice's position/type
+ * conventions via `adaptForVoice` (see below).
+ */
+
+import type { CommandSchema } from '@lokascript/framework';
+import { deriveRoleMarkers } from '@lokascript/framework';
+import {
+  toggleSchema,
+  addSchema,
+  removeSchema,
+  showSchema,
+  hideSchema,
+} from '@lokascript/semantic';
+import { VOICE_LANGUAGES } from '../vocab';
+
+/**
+ * Build a `{ lang: marker }` map for a semantic `role`, derived from each wired
+ * language's grammar slice. Any `markerOverride` the reference schema already
+ * authored wins over the derived default.
+ */
+function sliceMarkerOverride(
+  role: string,
+  reference: Readonly<Record<string, string>> = {}
+): Record<string, string> {
+  const derived: Record<string, string> = {};
+  for (const [lang, { slice }] of Object.entries(VOICE_LANGUAGES)) {
+    const marker = deriveRoleMarkers(slice, { [role]: role })[role];
+    if (marker) derived[lang] = marker;
+  }
+  return { ...derived, ...reference };
+}
+
+/**
+ * Reinstate a per-language `markerOverride` for `role`, sourced from the slices.
+ * The pattern generator reads `roleSpec.markerOverride[lang]` before the
+ * (suppressed) profile default, so this cleanly restores the marker for exactly
+ * this schema without un-suppressing it for the existing voice schemas.
+ */
+function withMarker(schema: CommandSchema, role: string): CommandSchema {
+  const reference = schema.roles.find(r => r.role === role)?.markerOverride ?? {};
+  const markerOverride = sliceMarkerOverride(role, reference);
+  return {
+    ...schema,
+    roles: schema.roles.map(r => (r.role === role ? { ...r, markerOverride } : r)),
+  };
+}
+
+/**
+ * Convert the reference schema's position convention to voice's.
+ *
+ * The framework pattern generator orders role tokens by DESCENDING position
+ * (higher svoPosition/sovPosition = earlier — see `sortRolesByWordOrder` in
+ * `@lokascript/framework` pattern-generator). Voice's own schemas follow that
+ * convention, but the reused `@lokascript/semantic` reference schemas use
+ * ASCENDING 1-based positions (position 1 = first). Inverting each role's
+ * position (`n + 1 - pos`) makes voice's generator emit the correct surface
+ * order — `toggle {patient} on {destination}`, not `toggle on {destination} {patient}`.
+ */
+function invertRolePositions(schema: CommandSchema): CommandSchema {
+  const n = schema.roles.length;
+  return {
+    ...schema,
+    roles: schema.roles.map(r => ({
+      ...r,
+      ...(r.svoPosition != null && { svoPosition: n + 1 - r.svoPosition }),
+      ...(r.sovPosition != null && { sovPosition: n + 1 - r.sovPosition }),
+    })),
+  };
+}
+
+/**
+ * Let voice's selector tokens satisfy the reused schemas.
+ *
+ * Voice tokenizes CSS selectors (`.active`, `#box`) as identifier→`expression`
+ * values — its established model (see the `click` command, whose patient is
+ * `expression`-typed). The reference schemas' selector-capturing roles expect
+ * only `selector`/`reference`, which an `expression`-typed value fails. Add
+ * `expression` (a wildcard in `isTypeCompatible`) to every role that already
+ * accepts a `selector`, so voice's selector tokens match. The literal-only
+ * `style` role is left untouched.
+ */
+function acceptExpression(schema: CommandSchema): CommandSchema {
+  return {
+    ...schema,
+    roles: schema.roles.map(r =>
+      r.expectedTypes?.includes('selector') && !r.expectedTypes.includes('expression')
+        ? { ...r, expectedTypes: [...r.expectedTypes, 'expression'] }
+        : r
+    ),
+  };
+}
+
+/** Adapt a reused reference schema to voice's generator + tokenizer conventions. */
+function adaptForVoice(schema: CommandSchema): CommandSchema {
+  return acceptExpression(invertRolePositions(schema));
+}
+
+// toggle/add: adapt to voice conventions, then reinstate the slice-derived
+// destination marker (suppressed by voice's SCHEMA_OWNED_MARKERS).
+export const voiceToggleSchema: CommandSchema = withMarker(
+  adaptForVoice(toggleSchema),
+  'destination'
+);
+export const voiceAddSchema: CommandSchema = withMarker(adaptForVoice(addSchema), 'destination');
+// remove: `source` is not suppressed by voice — the withMarker call is a verified
+// no-op, applied uniformly for symmetry.
+export const voiceRemoveSchema: CommandSchema = withMarker(adaptForVoice(removeSchema), 'source');
+// show/hide: only patient (bare) + optional markerless style literal — no marker
+// wrapper needed.
+export const voiceShowSchema: CommandSchema = adaptForVoice(showSchema);
+export const voiceHideSchema: CommandSchema = adaptForVoice(hideSchema);
+
+/** The five behavior-verb schemas, in stable order. */
+export const behaviorSchemas: CommandSchema[] = [
+  voiceToggleSchema,
+  voiceAddSchema,
+  voiceRemoveSchema,
+  voiceShowSchema,
+  voiceHideSchema,
+];

--- a/packages/domain-voice/src/schemas/index.ts
+++ b/packages/domain-voice/src/schemas/index.ts
@@ -1,5 +1,6 @@
 import { defineCommand, defineRole } from '@lokascript/framework';
 import type { CommandSchema } from '@lokascript/framework';
+import { behaviorSchemas } from './behavior';
 
 // =============================================================================
 // navigate — Go to URL, page section, or ARIA landmark
@@ -524,4 +525,19 @@ export const allSchemas: CommandSchema[] = [
   openSchema,
   searchSchema,
   helpSchema,
+  // UI-behavior verbs sourced from the multilingual layer (see ./behavior).
+  // Appended last: first-schema-wins in match order, and these have distinct
+  // leading keywords, so they cannot regress the 14 page-control schemas above.
+  ...behaviorSchemas,
 ];
+
+// Re-export the behavior-verb schemas (reused from @lokascript/semantic with
+// slice-derived destination/source markers).
+export {
+  voiceToggleSchema,
+  voiceAddSchema,
+  voiceRemoveSchema,
+  voiceShowSchema,
+  voiceHideSchema,
+  behaviorSchemas,
+} from './behavior';

--- a/packages/domain-voice/src/vocab/behavior-verbs.ts
+++ b/packages/domain-voice/src/vocab/behavior-verbs.ts
@@ -1,0 +1,83 @@
+/**
+ * UI-behavior verbs (toggle/add/remove/show/hide) sourced from the
+ * `@lokascript/semantic` language profiles voice already imports as grammar
+ * slices — NOT hand-authored per language. A profile's `keywords` entry is
+ * structurally identical to the framework's {@link DomainKeywordTranslation},
+ * so sourcing is a structural pick.
+ *
+ * Primary-only: the `marker-tokenization` lint rule (R7) requires every keyword
+ * to tokenize as a single token, and a few slice *alternatives* split (ja `hide`
+ * `非表示にする`, tr `toggle` `aç/kapat`). We therefore drop `alternatives` here
+ * and source `{ primary }` only.
+ */
+
+import type {
+  DomainKeywordTranslation,
+  DomainVocabulary,
+  GrammarProfileSlice,
+} from '@lokascript/framework';
+
+/** Behavior verbs to source from the multilingual layer, in stable order. */
+export const BEHAVIOR_VERBS = ['toggle', 'add', 'remove', 'show', 'hide'] as const;
+
+/**
+ * A raw semantic `LanguageProfile` still carries its keyword table; the
+ * framework's `GrammarProfileSlice` deliberately omits `keywords`, so widen it
+ * back here. Callers MUST pass the raw slice import (e.g. `englishProfile`), not
+ * `VOICE_LANGUAGES[code].slice` (which is typed `GrammarProfileSlice`).
+ */
+type KeywordedSlice = GrammarProfileSlice & {
+  readonly keywords?: Readonly<Record<string, DomainKeywordTranslation>>;
+};
+
+/**
+ * Pick the behavior verbs from a profile's keyword table as primary-only
+ * {@link DomainKeywordTranslation} entries. Skips any verb the profile lacks.
+ */
+export function pickBehaviorVerbs(slice: KeywordedSlice): Record<string, DomainKeywordTranslation> {
+  const picked: Record<string, DomainKeywordTranslation> = {};
+  for (const verb of BEHAVIOR_VERBS) {
+    const entry = slice.keywords?.[verb];
+    if (!entry?.primary) continue;
+    picked[verb] = { primary: entry.primary, normalized: entry.normalized ?? verb };
+  }
+  return picked;
+}
+
+/**
+ * The behavior verbs' destination/source marker primaries, sourced from the
+ * slice. These must be registered as tokenizer keywords so they classify as
+ * keywords (not identifiers) and parse: `destination` is suppressed by voice's
+ * `SCHEMA_OWNED_MARKERS`, so its marker is otherwise absent from the keyword set
+ * (e.g. Turkish dative `e`); `source` is already retained, included for symmetry
+ * (deduped). Does NOT affect pattern generation — `buildPatternProfile` reads
+ * `keywords`/`roleMarkers`, not `tokenizerKeywords`.
+ */
+function behaviorMarkerWords(slice: KeywordedSlice): string[] {
+  const words: string[] = [];
+  for (const role of ['destination', 'source'] as const) {
+    const primary = slice.roleMarkers?.[role]?.primary;
+    if (primary) words.push(primary);
+  }
+  return words;
+}
+
+/**
+ * Merge sourced behavior verbs into a domain vocabulary. Domain-authored
+ * keywords are spread last, so hand-authored entries always win on collision.
+ * The behavior verbs' destination/source marker primaries are added to
+ * `tokenizerKeywords` so the slice-derived schema markers tokenize as keywords.
+ */
+export function withBehaviorVerbs(
+  slice: KeywordedSlice,
+  vocab: DomainVocabulary
+): DomainVocabulary {
+  const tokenizerKeywords = [
+    ...new Set([...(vocab.tokenizerKeywords ?? []), ...behaviorMarkerWords(slice)]),
+  ];
+  return {
+    ...vocab,
+    keywords: { ...pickBehaviorVerbs(slice), ...vocab.keywords },
+    tokenizerKeywords,
+  };
+}

--- a/packages/domain-voice/src/vocab/index.ts
+++ b/packages/domain-voice/src/vocab/index.ts
@@ -33,6 +33,7 @@ import { frVocabulary } from './fr';
 import { deVocabulary } from './de';
 import { ptVocabulary } from './pt';
 import { ruVocabulary } from './ru';
+import { withBehaviorVerbs } from './behavior-verbs';
 
 export { enVocabulary } from './en';
 export { esVocabulary } from './es';
@@ -52,18 +53,25 @@ export interface VoiceLanguageSource {
   readonly vocab: DomainVocabulary;
 }
 
-/** Grammar slice + voice vocabulary per supported language. */
+/**
+ * Grammar slice + voice vocabulary per supported language.
+ *
+ * Each vocab is augmented with the UI-behavior verbs (toggle/add/remove/show/
+ * hide) sourced from its own grammar slice via {@link withBehaviorVerbs} — the
+ * raw slice import is passed (it still carries `.keywords`, which the widened
+ * `GrammarProfileSlice` type drops). Hand-authored voice verbs win on collision.
+ */
 export const VOICE_LANGUAGES: Readonly<Record<string, VoiceLanguageSource>> = {
-  en: { slice: enSlice, vocab: enVocabulary },
-  es: { slice: esSlice, vocab: esVocabulary },
-  ja: { slice: jaSlice, vocab: jaVocabulary },
-  ar: { slice: arSlice, vocab: arVocabulary },
-  ko: { slice: koSlice, vocab: koVocabulary },
-  zh: { slice: zhSlice, vocab: zhVocabulary },
-  tr: { slice: trSlice, vocab: trVocabulary },
-  fr: { slice: frSlice, vocab: frVocabulary },
+  en: { slice: enSlice, vocab: withBehaviorVerbs(enSlice, enVocabulary) },
+  es: { slice: esSlice, vocab: withBehaviorVerbs(esSlice, esVocabulary) },
+  ja: { slice: jaSlice, vocab: withBehaviorVerbs(jaSlice, jaVocabulary) },
+  ar: { slice: arSlice, vocab: withBehaviorVerbs(arSlice, arVocabulary) },
+  ko: { slice: koSlice, vocab: withBehaviorVerbs(koSlice, koVocabulary) },
+  zh: { slice: zhSlice, vocab: withBehaviorVerbs(zhSlice, zhVocabulary) },
+  tr: { slice: trSlice, vocab: withBehaviorVerbs(trSlice, trVocabulary) },
+  fr: { slice: frSlice, vocab: withBehaviorVerbs(frSlice, frVocabulary) },
   // Bridge-era languages (arc Phase 2 expansion) — one vocab file each.
-  de: { slice: deSlice, vocab: deVocabulary },
-  pt: { slice: ptSlice, vocab: ptVocabulary },
-  ru: { slice: ruSlice, vocab: ruVocabulary },
+  de: { slice: deSlice, vocab: withBehaviorVerbs(deSlice, deVocabulary) },
+  pt: { slice: ptSlice, vocab: withBehaviorVerbs(ptSlice, ptVocabulary) },
+  ru: { slice: ruSlice, vocab: withBehaviorVerbs(ruSlice, ruVocabulary) },
 };

--- a/packages/framework/docs/DOMAIN_AUTHOR_GUIDE.md
+++ b/packages/framework/docs/DOMAIN_AUTHOR_GUIDE.md
@@ -101,13 +101,13 @@ export const createSchema = defineCommand({
       role: 'name',
       required: true,
       expectedTypes: ['expression'],
-      svoPosition: 1,
+      svoPosition: 2, // higher = earlier: name appears first
     }),
     defineRole({
       role: 'type',
       required: false,
       expectedTypes: ['expression'],
-      svoPosition: 2,
+      svoPosition: 1, // lower = later: type appears after name
       markerOverride: {
         en: 'as',
         es: 'como',
@@ -121,7 +121,7 @@ export const createSchema = defineCommand({
 **Key concepts:**
 
 - `primaryRole` — the main argument (appears right after the keyword in SVO)
-- `svoPosition` — order in SVO languages (lower = earlier in surface form, matching the pattern generator's sort)
+- `svoPosition` — order in SVO languages (**higher = earlier** in surface form, matching the pattern generator's descending sort). NB: `@lokascript/semantic`'s reference schemas use the _opposite_ 1-based convention (lower = earlier); reusing them in a framework domain requires inverting positions.
 - `markerOverride` — the preposition/particle before this role per language
   - SVO: `create "mydb" as database` → "as" marks the `type` role
   - SOV: `"mydb" を データベース として 作成` → "として" marks the `type` role

--- a/packages/framework/src/generation/pattern-generator.ts
+++ b/packages/framework/src/generation/pattern-generator.ts
@@ -272,7 +272,11 @@ function buildFormatString(
     parts.push(keyword);
   }
 
-  for (const role of schema.roles) {
+  // Order roles the same way buildTokens does (descending position). Iterating
+  // declaration order here would disagree with the token order whenever a
+  // schema's roles are declared in a different order than their positions imply.
+  const sortedRoles = sortRolesByWordOrder(schema.roles, profile.wordOrder);
+  for (const role of sortedRoles) {
     const marker = getMarkerForRole(role, profile);
     const roleName = `{${role.role}}`;
 

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -26,9 +26,18 @@ export interface RoleSpec {
   readonly expectedTypes: Array<ExpectedType>;
   /** Default value if not provided */
   readonly default?: SemanticValue;
-  /** Position hint for SVO languages (higher = earlier) */
+  /**
+   * Position hint for SVO languages. **1-based ascending: lower = earlier**
+   * (position 1 = first), matching semantic's own sorter
+   * (`parser/utils/role-positioning.ts`, `a - b`).
+   *
+   * WARNING: the `@lokascript/framework` pattern generator sorts the OPPOSITE
+   * way (descending, higher = earlier). Reusing these schemas in a
+   * framework-based domain requires inverting positions — see
+   * `packages/domain-voice/src/schemas/behavior.ts` `invertRolePositions`.
+   */
   readonly svoPosition?: number;
-  /** Position hint for SOV languages (higher = earlier) */
+  /** Position hint for SOV languages (1-based ascending: lower = earlier). See {@link svoPosition}. */
   readonly sovPosition?: number;
   /**
    * Override the default role marker for this command.


### PR DESCRIPTION
## Summary

Extends `@lokascript/domain-voice` with the UI-behavior verbs (`toggle`/`add`/`remove`/`show`/`hide`) it previously couldn't parse, **sourcing them from the existing `@lokascript/semantic` multilingual layer** rather than hand-authoring per language. Extending it surfaced two framework-level issues, fixed here, plus a structural-review doc.

Branched off `main` (the unrelated core-version work on the previous branch is excluded).

## Commits

1. **feat(domain-voice)** — behavior verbs sourced from the multilingual layer
2. **fix(framework)** — align pattern-generator `format` with token order + correct contradictory position-convention docs
3. **docs** — domain-voice structural review

## Feature: behavior verbs

`parseWithConfidence('toggle .active on #box', 'en')` now returns `action: 'toggle', patient: '.active', destination: '#box'` at confidence 1.0 (previously threw *No pattern matched*). Same for `add .x to #y`, `remove .x from #y` (captured as `source`), `show #panel`, `hide .menu`.

- Verbs sourced from the semantic profiles voice already imports (`pickBehaviorVerbs`) — **no new hand-authored per-language tables**.
- Reference schemas reused from `@lokascript/semantic`, adapted to voice's conventions (`adaptForVoice`): position inversion, expression-typed selectors, and slice-derived destination markers (`deriveRoleMarkers`).
- Works across all 11 wired languages (verified en/de/ja/es); protocol-JSON round-trip covered.

## Fix: framework pattern-generator + docs

Reusing the semantic schemas exposed that `buildFormatString` built `template.format` from role **declaration** order while `buildTokens` sorts by **descending position** — so `format` disagreed with `tokens` for any schema whose declaration order ≠ position order. `buildFormatString` now sorts identically.

- `format` is display-only (the matcher consumes `tokens`) → **parsing is unaffected**.
- Semantic uses its own generator → **the multilingual fidelity ratchet is untouched**.
- Regenerates 8 domain goldens (**format-only**).

Also corrects two docs that described their own code backwards — framework's `DOMAIN_AUTHOR_GUIDE` (svoPosition is higher = earlier) and semantic's `RoleSpec` (1-based, lower = earlier) — and adds the missing warning that the two subsystems sort positions in **opposite** directions (so reused semantic schemas must invert).

## Test evidence

- **framework:** 789 pass
- **all 9 affected domain suites green:** bdd 153 · behaviorspec 195 · flow 312 · jsx 215 · learn 186 · llm 230 · sql 281 · todo 127 · voice 426
- every non-voice golden diff verified **format-only** (0 beyond-format); voice golden = 55 new behavior blocks + 6 format-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
