### PR TITLE
fix(protocol): keep `__proto__` as an ordinary role name in the TS parser

### DIFF
--- a/protocol/test-fixtures/basic.json
+++ b/protocol/test-fixtures/basic.json
@@ -75,5 +75,41 @@
         "patient": { "type": "selector", "value": ".active" }
       }
     }
+  },
+  {
+    "id": "basic-007",
+    "description": "Role named __proto__ is an ordinary role, not a prototype write",
+    "input": "[toggle __proto__:.active]",
+    "expected": {
+      "kind": "command",
+      "action": "toggle",
+      "roles": {
+        "__proto__": { "type": "selector", "value": ".active" }
+      }
+    }
+  },
+  {
+    "id": "basic-008",
+    "description": "Flag named __proto__ is an ordinary flag role",
+    "input": "[column +__proto__]",
+    "expected": {
+      "kind": "command",
+      "action": "column",
+      "roles": {
+        "__proto__": { "type": "flag", "name": "__proto__", "enabled": true }
+      }
+    }
+  },
+  {
+    "id": "basic-009",
+    "description": "Role named constructor is an ordinary role",
+    "input": "[toggle constructor:.active]",
+    "expected": {
+      "kind": "command",
+      "action": "toggle",
+      "roles": {
+        "constructor": { "type": "selector", "value": ".active" }
+      }
+    }
   }
 ]

--- a/protocol/typescript/src/json.ts
+++ b/protocol/typescript/src/json.ts
@@ -164,7 +164,9 @@ export function fromJSON(data: Record<string, unknown>): SemanticNode {
   const action = (data['action'] as string) ?? '';
   const rawRoles = (data['roles'] as Record<string, unknown>) ?? {};
 
-  const roles: Record<string, SemanticValue> = {};
+  // Null-prototype: JSON.parse turns a `"__proto__"` member into an own enumerable
+  // key, so Object.entries surfaces it and a plain-object target would hijack.
+  const roles: Record<string, SemanticValue> = Object.create(null) as Record<string, SemanticValue>;
   for (const [roleName, rv] of Object.entries(rawRoles)) {
     if (rv && typeof rv === 'object' && !Array.isArray(rv)) {
       roles[roleName] = convertJSONValue(rv as Record<string, unknown>);
@@ -364,7 +366,9 @@ function deserializeNodeArray(arr: unknown): SemanticNode[] {
 }
 
 function marshalRoles(roles: Record<string, SemanticValue>): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
+  // Null-prototype for the same reason as fromJSON: a role literally named
+  // `__proto__` must survive serialization as an ordinary key.
+  const result: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
   for (const [k, v] of Object.entries(roles)) {
     result[k] = marshalValue(v);
   }

--- a/protocol/typescript/src/parser.ts
+++ b/protocol/typescript/src/parser.ts
@@ -83,7 +83,12 @@ export function parseExplicit(text: string, opts?: ParseOptions): SemanticNode {
   }
 
   const command = tokens[0].toLowerCase();
-  const roles: Record<string, SemanticValue> = {};
+  // Role names come from untrusted input. A plain object literal would route a
+  // role named `__proto__` through Object.prototype's setter, silently dropping
+  // the role and reparenting this object. The dict/map-based reference parsers
+  // (Python/Go/Rust) keep such a name as an ordinary key; a null-prototype
+  // object makes this parser agree with them.
+  const roles: Record<string, SemanticValue> = Object.create(null) as Record<string, SemanticValue>;
 
   for (let i = 1; i < tokens.length; i++) {
     const token = tokens[i];


### PR DESCRIPTION
## The bug

`protocol/typescript` built its `roles` map as a plain object literal, so a role named `__proto__` was routed through `Object.prototype`'s setter: the role was **silently dropped** and the object's prototype was reparented to the `SemanticValue`.

```ts
parseExplicit('[toggle __proto__:.active]').roles
// {}  ← the role vanished; Object.getPrototypeOf(roles) is now the value
```

The dict/map-based reference parsers (Python, Go, Rust) keep such a name as an ordinary key. So this was a **cross-language conformance divergence with no fixture covering it** — the four parsers disagreed on the same input.

## The fix

`Object.create(null)` for the roles map makes the TypeScript parser agree with the other three. `fromJSON` and `marshalRoles` need the same treatment: `JSON.parse` turns a `"__proto__"` member into an own enumerable key, so `Object.entries` surfaces it and a plain-object target would hijack.

This is **not** a global-pollution bug — `({}).type` stays `undefined` — but the parse result is wrong, and any consumer that deep-merges `roles` into a plain object inherits the hazard. Production `@lokascript/intent` is unaffected (it uses a `Map`); the exposure is the reference parser external adopters would import. htmx's HCON guards the same three names by name.

## Tests

Adds `basic-007/008/009` (role, flag, and `constructor`) to `test-fixtures/basic.json`, which every runner already loads — so all four parsers are now pinned to the same answer.

Verified: protocol TS **122**, Python **174**, Go, Rust.
(Python also reports 4 pre-existing `type_constraints` failures — confirmed present on a pristine tree, unrelated to this change.)

Found while investigating htmx v4's HCON, which drops these keys explicitly.