### PR TITLE
fix(parser): fold `worker`, the last body-dropping feature block

### DIFF
--- a/docs-internal/HANDOFF_body-block-drops.md
+++ b/docs-internal/HANDOFF_body-block-drops.md
@@ -1,11 +1,18 @@
 # Handoff: `eventsource` / `socket` / `worker` / `live` / `intercept` drop their whole body at confidence 1.0
 
-> ## STATUS (2026-07-09) — four of five fixed; `worker` remains
+> ## STATUS (2026-07-09) — RESOLVED, all five fixed
 >
-> **Landed:** `live`, `eventsource`, `socket`, `intercept` now fold into a `feature`
-> semantic node that captures the body, in all 24 languages. `--diagnose-coverage`
-> firing rate **158 (4.3%) → 56 (1.5%)**; the remaining firings are `worker` (18) and
-> `bind` (31, unrelated). Multilingual `--regression` gate exits 0.
+> **Landed in two PRs.** All five commands now fold into a `feature` semantic node
+> that captures the body, in all 24 languages. `--diagnose-coverage` firing rate
+> **158 (4.3%) → 38 (1.0%)**; every remaining firing is `bind` (unrelated — see the
+> bottom of this note). Multilingual `--regression` exits 0, with R1 role-fidelity up
+> in all 24 languages and R0-precision up for the SOV six.
+>
+> - **PR 1** — `live`, `eventsource`, `socket`, `intercept`.
+> - **PR 2** — `worker`, plus SOV verb-final `def` support and an sw lexicon fix.
+>
+> **`Multilingual Validation` is now a required status check on `main`** (the
+> branch-protection gap noted at the bottom of this doc — closed).
 >
 > **Two corrections to the analysis below — read before trusting it:**
 >
@@ -39,22 +46,26 @@
 > new parser): R1 **+0.0004** (4 more patterns scored, all at 1.000), R0-precision
 > **+0.0119** for the SOV six (ja/ko/tr/qu reach exactly 1.000000).
 >
-> **Remaining (PR 2): `worker`.** It is deliberately excluded from `FEATURE_ACTIONS`.
-> Folding it in English alone would enrich the English reference action set while the
-> other 23 languages still dropped their bodies. It needs:
+> **PR 2 (`worker`) — two things it turned up that were not predicted:**
 >
-> - SOV verb-final `def` support: `tryParseBlock` matches `def` only at token 0, but SOV
->   renders `add(a, b) を def`. Mirror the `behavior` `sovKeywordIdx` branch, validated by
->   `(params)` presence rather than PascalCase (def names are lowercase). Thread
->   `keywordIdx`/`sovFinal` into `parseDefBlock` so `bodyStart` skips the verb-final keyword.
-> - Add `'worker'` to `FEATURE_ACTIONS` + `NAMED_FEATURES` (`bodyStart = nameIdx + 1`).
-> - Reshape `worker-basic` (`init-db.ts`) multi-line, in the SAME change — multi-line seeds
->   without the fold make `worker` PARSE-FAIL in ja/ko/tr/bn/qu (a parse-rate regression).
-> - Regenerate the baseline.
+> 1. **The SOV verb-final `def` guard cannot just be "a patient marker precedes the
+>    keyword."** `worker`'s own ja body is `Calculator を worker … add(a, b) を def …`,
+>    whose *body-level* `def` is also marker-preceded — so a loose guard makes
+>    `tryParseBlock` claim the entire worker block as a `def` named `Calculator`. The
+>    head must be CONTIGUOUS: name + balanced params + exactly one marker + keyword
+>    (expected index 2, actual 10 → rejected). See `sovHeadKeywordIndex`.
+> 2. **A live sw lexicon gap, surfaced only once `return` finally had to parse.** The
+>    i18n dict emitted `rudi` ("go back") while the semantic profile reads
+>    `rudisha`/`rejea` — so sw could not parse its own `return`, and its `worker` body
+>    dropped (fidelity 1/3 → degenerate). Fixed by realigning the dict to `rudisha`
+>    (kept clear of `rudia` = `repeat`) and pruning `sw:return:rudi` from
+>    `lexicon-emit-mismatch.test.ts`'s allowlist, which self-prunes. This is the LIVE
+>    category that test documents; the corpus never exercised it before.
 >
 > `worker` body segments route to `parsers.statement` (→ `parseInternal` → Stage 0 →
 > `tryParseBlock` → `parseDefBlock`). Note `parseStatements` skips Stage 0, so
-> `parsers.body` would NOT reach the def machinery.
+> `parsers.body` would NOT reach the def machinery. Its segments are sliced THROUGH
+> their `end` (a `def` owns its terminator); handler segments are not.
 >
 > **Unrelated, still open:** `bind` accounts for 31 of the 56 remaining `unconsumed-input`
 > firings — a `then`-chain of two `bind`s where the pattern matches the first and drops
@@ -250,6 +261,11 @@ npm run typecheck --prefix packages/semantic
   precondition, because a zero-required-role schema scores 1.0 unconditionally and would swing
   hardest under a coverage penalty. If it lands, re-evaluate whether Stages 0 / 0.5 of
   `parseInternal` can be simplified — they exist only because this signal was missing.
-- **Branch protection gap**: `main` requires only `Build All Packages`, `Lint & Typecheck`,
-  `Unit Tests`, `Export Validation`. `Multilingual Validation` is **not** a required context, so
-  the fidelity ratchet can fail and the PR still merges. Worth adding.
+- ~~**Branch protection gap**~~ — **CLOSED.** `Multilingual Validation` is now a required
+  status check on `main`, alongside `Build All Packages`, `Lint & Typecheck`, `Unit Tests`,
+  and `Export Validation` (`strict: true` preserved). This is what let #627's ~0.006 R1
+  drift merge unnoticed. Safe for doc-only PRs: `ci.yml` deliberately carries no
+  workflow-level `paths-ignore`, so the workflow always runs and the job's `if:
+  needs.changes.outputs.code == 'true'` skip reports a completed check run with
+  conclusion `skipped`, which branch protection treats as passing. (A workflow-level
+  path filter would instead leave the check "Expected" forever.)

--- a/packages/i18n/src/dictionaries/sw.ts
+++ b/packages/i18n/src/dictionaries/sw.ts
@@ -36,7 +36,10 @@ export const sw: Dictionary = {
     wait: 'ngoja',
     fetch: 'leta',
     call: 'ita',
-    return: 'rudi',
+    // `rudisha` (transitive, "give back a value"), not `rudi` ("go back"): the
+    // semantic profile reads `rudisha`/`rejea`, so emitting `rudi` produced sw code
+    // the parser could not read back. Kept clear of `rudia` (= `repeat`).
+    return: 'rudisha',
     make: 'tengeneza', // auditor: dict emitted a word the profile reads differently
     log: 'andika',
     throw: 'tupa',

--- a/packages/patterns-reference/scripts/init-db.ts
+++ b/packages/patterns-reference/scripts/init-db.ts
@@ -1319,7 +1319,10 @@ const SEED_EXAMPLES: SeedExample[] = [
   {
     id: 'worker-basic',
     title: 'Web Worker Definition',
-    raw_code: 'worker Calculator def add(a, b) return a + b end end',
+    // Multi-line for the same reason as eventsource-basic above: the i18n
+    // transformer translates a block line-by-line. Each `def` sub-block closes with
+    // its own `end`, plus a final one for the feature.
+    raw_code: 'worker Calculator\n  def add(a, b)\n    return a + b\n  end\nend',
     description: 'Define a Web Worker in hyperscript and call its methods like a normal object',
     feature: 'realtime',
     engine: 'both',

--- a/packages/semantic/src/parser/block-parser.ts
+++ b/packages/semantic/src/parser/block-parser.ts
@@ -18,6 +18,7 @@ import type {
   LanguageToken,
   SemanticNode,
   EventHandlerSemanticNode,
+  DefSemanticNode,
   FeatureAction,
 } from '../types';
 import { createBehaviorNode, createDefNode, createCompoundNode, createFeatureNode } from '../types';
@@ -218,6 +219,55 @@ function resolveNameTokenIndex(
   return idx < tokens.length ? idx : -1;
 }
 
+/** Identifier form of a `def` name (optionally namespaced, e.g. `utils.calc`). */
+const DEF_NAME = /^[a-zA-Z_$][\w$]*(?:\.[a-zA-Z_$][\w$]*)*$/;
+
+/**
+ * Where an SOV verb-final keyword must sit for `<name>[(params)] <patient-marker>
+ * <keyword>` to be the block's head: immediately after the name, its balanced
+ * parameter list (if any), and exactly one marker. Returns -1 on an unbalanced list.
+ */
+function sovHeadKeywordIndex(tokens: readonly LanguageToken[]): number {
+  let afterName = 1;
+  if (tokens[1]?.value === '(') {
+    let depth = 0;
+    let j = 1;
+    for (; j < tokens.length; j++) {
+      if (tokens[j].value === '(') depth++;
+      else if (tokens[j].value === ')' && --depth === 0) break;
+    }
+    if (j >= tokens.length) return -1;
+    afterName = j + 1;
+  }
+  return afterName + 1; // skip the single patient marker
+}
+
+/**
+ * Is `keywordIdx` an SOV verb-final block head — `<name>[(params)] <patient-marker>
+ * <keyword>`?
+ *
+ * The head must be CONTIGUOUS. Requiring only "a patient marker sits before the
+ * keyword" is not enough: `worker`'s own ja body is `Calculator を worker … add(a,
+ * b) を def …`, whose *body-level* `def` is also marker-preceded, so a loose guard
+ * makes `tryParseBlock` claim the whole worker block as a `def` named `Calculator`.
+ * Pinning the keyword to the position right after the name + params + one marker
+ * rejects that (expected index 2, actual 10) while still accepting the real def
+ * sub-block once `worker` hands it over as its own segment.
+ */
+function isSovVerbFinalHead(
+  tokens: readonly LanguageToken[],
+  keywordIdx: number,
+  language: string
+): boolean {
+  const profile = tryGetProfile(language);
+  if (profile?.wordOrder !== 'SOV') return false;
+  if (!DEF_NAME.test(tokens[0].value)) return false;
+  if (keywordIdx !== sovHeadKeywordIndex(tokens)) return false;
+  const patientForms = markerSurfaceForms(profile.roleMarkers?.patient);
+  if (patientForms.size === 0) return false;
+  return tokenMatches(tokens[keywordIdx - 1], patientForms);
+}
+
 /**
  * Attempt to parse `input` as a block construct (`behavior`/`def`). Returns null
  * (fast) for non-block input so the caller falls through to single-statement
@@ -255,7 +305,19 @@ export function tryParseBlock(
     return parseBehaviorBlock(input, language, tokens, parsers, sovKeywordIdx);
   }
   if (tokenMatches(tokens[0], defForms)) {
-    return parseDefBlock(input, language, tokens, parsers);
+    return parseDefBlock(input, language, tokens, parsers, 0);
+  }
+  // SOV verb-final `def`, the same reorder as `behavior` above (ja `add(a, b) を
+  // def`, ko `를`, hi `को`, bn `কে`, tr `i`, qu `ta`). It cannot reuse the
+  // PascalCase guard — function names are lowercase (`parseDefBlock` accepts any
+  // identifier) — so the head is identified structurally instead: the token
+  // immediately before the keyword must be the language's patient marker, which is
+  // exactly what the transformer emits between the name and the displaced verb.
+  // Reached via `worker`'s body segments, which route through `parsers.statement`
+  // (→ Stage 0), the only path that sees this layer.
+  const sovDefIdx = tokens.findIndex((t, i) => i > 0 && tokenMatches(t, defForms));
+  if (sovDefIdx > 0 && isSovVerbFinalHead(tokens, sovDefIdx, language)) {
+    return parseDefBlock(input, language, tokens, parsers, sovDefIdx);
   }
   return null;
 }
@@ -572,23 +634,35 @@ function parseBehaviorBlock(
   );
 }
 
-/** Parse a `def name(params) … end` block into a DefSemanticNode. */
+/**
+ * Parse a `def name(params) … end` block into a DefSemanticNode.
+ *
+ * `keywordIdx` is the token index of the `def` keyword: 0 for the keyword-led form,
+ * or > 0 for the SOV verb-final form where it is reordered after the name + its
+ * object marker (`add(a, b) を def`) — mirroring `parseBehaviorBlock`.
+ */
 function parseDefBlock(
   input: string,
   language: string,
   tokens: readonly LanguageToken[],
-  parsers: BlockParsers
+  parsers: BlockParsers,
+  keywordIdx: number
 ): SemanticNode | null {
+  const sovFinal = keywordIdx > 0;
   // Function name — any identifier (optionally namespaced, e.g. `utils.calc`).
-  // Skip a leading object marker (he `def את foo`, zh `def 把 foo`) first.
-  const nameIdx = resolveNameTokenIndex(tokens, 0, language);
+  // The SOV verb-final form leads with the name; otherwise it follows the keyword,
+  // skipping a leading object marker (he `def את foo`, zh `def 把 foo`).
+  const nameIdx = sovFinal ? 0 : resolveNameTokenIndex(tokens, keywordIdx, language);
   if (nameIdx < 0) return null;
   const nameToken = tokens[nameIdx];
   const name = nameToken.value;
-  if (!/^[a-zA-Z_$][\w$]*(?:\.[a-zA-Z_$][\w$]*)*$/.test(name)) return null;
+  if (!DEF_NAME.test(name)) return null;
 
   const { parameters, headerEnd } = parseHeader(input, nameToken);
-  let bodyStart = tokens.findIndex(t => t.position.start >= headerEnd);
+  // Body begins after the header for the keyword-led form. For the SOV verb-final
+  // form the keyword (and its preceding object marker) sit between the header and
+  // the body, so start past the keyword token instead.
+  let bodyStart = sovFinal ? keywordIdx + 1 : tokens.findIndex(t => t.position.start >= headerEnd);
   if (bodyStart <= nameIdx) bodyStart = nameIdx + 1;
 
   const endForms = keywordForms(language, 'end');
@@ -648,23 +722,21 @@ function parseDefBlock(
  * confidence 1.0, because `scoreRoleCoverage` returns 1 when a pattern declares
  * no roles.
  *
- * `worker` is deliberately absent: its body is `def … end` sub-blocks, and SOV
- * renders those verb-final (`add(a, b) を def`), which `parseDefBlock` cannot yet
- * locate. Folding `worker` in English alone would enrich the English reference
- * action set while the other 23 languages still dropped their bodies — which is
- * precisely the fidelity-ratchet regression this layer exists to avoid. It lands
- * with SOV `def` support.
+ * Each body family is handled differently — see {@link parseFeatureBlock}.
  */
-const FEATURE_ACTIONS = ['live', 'eventsource', 'socket', 'intercept'] as const;
+const FEATURE_ACTIONS = ['live', 'eventsource', 'socket', 'worker', 'intercept'] as const;
 
 /** Features whose body is a configuration DSL rather than hyperscript commands. */
 const OPAQUE_BODY_FEATURES: ReadonlySet<string> = new Set(['intercept']);
 
 /** Features that declare a PascalCase name adjacent to the keyword. */
-const NAMED_FEATURES: ReadonlySet<string> = new Set(['eventsource', 'socket']);
+const NAMED_FEATURES: ReadonlySet<string> = new Set(['eventsource', 'socket', 'worker']);
 
 /** Features whose body is a sequence of `on <event> … end` handler blocks. */
 const HANDLER_BODY_FEATURES: ReadonlySet<string> = new Set(['eventsource', 'socket']);
+
+/** Features whose body is a sequence of `def name(params) … end` sub-blocks. */
+const DEF_BODY_FEATURES: ReadonlySet<string> = new Set(['worker']);
 
 /**
  * How far into the token stream an SOV verb-final feature keyword can sit. The
@@ -745,6 +817,10 @@ function sourceClauseLength(tokens: readonly LanguageToken[], i: number, languag
  *   forward scan would overshoot the event by one. The head is bounded by the verb
  *   instead: everything up to the keyword, plus `eventsource`'s source clause where
  *   the transformer places it after the verb (`… eventsource /events から`).
+ *
+ * `worker` sits outside both: its head is just `<kw> <Name>` (no url, no trigger),
+ * and its body opens with `def`, so the on-marker scan would run to the block's
+ * `end` and report an empty body.
  */
 function featureBodyStart(
   action: FeatureAction,
@@ -764,6 +840,8 @@ function featureBodyStart(
 
   const nameIdx = resolveNameTokenIndex(tokens, keywordIdx, language);
   if (nameIdx < 0) return -1;
+  if (action === 'worker') return nameIdx + 1;
+
   const onForms = keywordForms(language, 'on');
   const limit = blockEnd >= 0 ? blockEnd : tokens.length;
   for (let j = nameIdx + 1; j < limit; j++) {
@@ -875,34 +953,41 @@ function parseFeatureBlock(
   const confidences: number[] = [];
   let sawClosingEnd = false;
 
-  if (HANDLER_BODY_FEATURES.has(action)) {
+  const isDefBody = DEF_BODY_FEATURES.has(action);
+  if (isDefBody || HANDLER_BODY_FEATURES.has(action)) {
     // Segment the body END-delimited, as parseBehaviorBlock does. `eventsource`
     // closes each handler with its own `end` plus a final one for the feature;
     // `socket`'s single `end` closes both. Treating any depth-0 `end` as "the body
     // was properly terminated" covers both without an off-by-one confidence penalty.
+    //
+    // A `def` sub-block owns its `end` (`parseDefBlock` looks for it and applies a
+    // ×0.8 penalty when missing), so its segment must be sliced THROUGH the
+    // terminator; a handler's `on …` pattern must not see one.
+    const expectedKind = isDefBody ? 'def' : 'event-handler';
     let depth = 0;
     let segStart = bodyStart;
     for (let j = bodyStart; j < tokens.length; j++) {
       const tok = tokens[j];
       if (isEnd(tok)) {
         if (depth > 0) {
-          depth--; // closes a nested if/repeat inside the current handler
+          depth--; // closes a nested if/repeat inside the current segment
           continue;
         }
         sawClosingEnd = true;
         if (j === segStart) break; // the feature's own closing `end`
-        const handlerText = input.slice(tokens[segStart].position.start, tok.position.start).trim();
+        const segEnd = isDefBody ? tok.position.end : tok.position.start;
+        const segText = input.slice(tokens[segStart].position.start, segEnd).trim();
         try {
-          const parsed = parsers.statement(handlerText, language);
-          if (parsed && parsed.kind === 'event-handler') {
-            const handler = parsed as EventHandlerSemanticNode;
-            children.push(handler);
-            // An empty handler body means the sub-parse silently dropped the
+          const parsed = parsers.statement(segText, language);
+          if (parsed && parsed.kind === expectedKind) {
+            const child = parsed as EventHandlerSemanticNode | DefSemanticNode;
+            children.push(child);
+            // An empty sub-block body means the sub-parse silently dropped the
             // commands — don't inherit its misleadingly high confidence.
-            const bodyEmpty = !handler.body || handler.body.length === 0;
-            confidences.push(bodyEmpty ? 0.2 : (handler.metadata?.confidence ?? 0.75));
+            const bodyEmpty = !child.body || child.body.length === 0;
+            confidences.push(bodyEmpty ? 0.2 : (child.metadata?.confidence ?? 0.75));
           } else {
-            confidences.push(0); // parsed, but not a handler — structural miss
+            confidences.push(0); // parsed, but wrong kind — structural miss
           }
         } catch {
           confidences.push(0);

--- a/packages/semantic/src/types.ts
+++ b/packages/semantic/src/types.ts
@@ -355,6 +355,9 @@ export interface DefSemanticNode extends SemanticNode {
 /** Block-structured feature actions — see {@link FeatureSemanticNode}. */
 export type FeatureAction = 'live' | 'eventsource' | 'socket' | 'worker' | 'intercept';
 
+// (kept in the union above so `FeatureSemanticNode.action` covers every feature
+// the fold handles; `worker`'s body is `def` sub-blocks rather than handlers.)
+
 /**
  * A feature semantic node — a top-level block construct whose meaning lives in
  * its BODY rather than in head roles (`live … end`, `eventsource Name from url

--- a/packages/semantic/test/lexicon-emit-mismatch.test.ts
+++ b/packages/semantic/test/lexicon-emit-mismatch.test.ts
@@ -37,7 +37,31 @@ import { getPatternsForLanguage, tryGetProfile } from '../src/registry';
 import { commandSchemas } from '../src/generators/command-schemas';
 import { dictionaries } from '../../i18n/src/dictionaries';
 
-const LANGS = ['ar','bn','de','es','fr','he','hi','id','it','ja','ko','ms','pl','pt','qu','ru','sw','th','tl','tr','uk','vi','zh'];
+const LANGS = [
+  'ar',
+  'bn',
+  'de',
+  'es',
+  'fr',
+  'he',
+  'hi',
+  'id',
+  'it',
+  'ja',
+  'ko',
+  'ms',
+  'pl',
+  'pt',
+  'qu',
+  'ru',
+  'sw',
+  'th',
+  'tl',
+  'tr',
+  'uk',
+  'vi',
+  'zh',
+];
 
 const KNOWN_MISMATCHES = new Set([
   'ar:catch:التقط',
@@ -126,7 +150,10 @@ const KNOWN_MISMATCHES = new Set([
   // added as a profile alternative alongside chaguo-msingi.
   'sw:pushUrl:sukumaUrl',
   'sw:replaceUrl:badilishaUrl',
-  'sw:return:rudi',
+  // sw:return resolved (worker-block arc): the dict emitted `rudi` ("go back"),
+  // which the profile reads as nothing — sw could not parse its own `return`. The
+  // dict now emits `rudisha`, the profile's primary. Surfaced once `worker`'s body
+  // stopped being dropped and `return` finally had to parse.
   'sw:select:chagua',
   // sw:transition resolved (transition precision drill): `mpito` added as a
   // profile alternative — the rendered verb now anchors.
@@ -191,8 +218,7 @@ function readingsFor(lang: string): Map<string, Set<string>> {
     const head = (pat as any).template?.tokens?.[0];
     if (head?.type !== 'literal') continue;
     const fused = pat.command === 'on' && /^([a-z]+)-event-/.exec(pat.id);
-    const credit = (w: string) =>
-      fused && !onWords.has(w.toLowerCase()) ? fused[1] : pat.command;
+    const credit = (w: string) => (fused && !onWords.has(w.toLowerCase()) ? fused[1] : pat.command);
     add(head.value, credit(head.value));
     for (const alt of head.alternatives ?? []) add(alt, credit(alt));
   }
@@ -210,7 +236,8 @@ describe('i18n dict emissions are readable as the action they translate', () => 
         const readAs = read.get(String(word).toLowerCase()) ?? new Set();
         const ok = readAs.has(action);
         const key = `${lang}:${action}:${word}`;
-        if (!ok && !KNOWN_MISMATCHES.has(key)) fresh.push(`${key} → read as [${[...readAs].join(',')}]`);
+        if (!ok && !KNOWN_MISMATCHES.has(key))
+          fresh.push(`${key} → read as [${[...readAs].join(',')}]`);
       }
       expect(fresh, `new dict↔profile mismatches:\n${fresh.join('\n')}`).toEqual([]);
     });
@@ -259,7 +286,9 @@ describe('KNOWN_MISMATCHES stays pruned (no stale allowlist entries)', () => {
       }
       const readAs = readingsForCached(lang).get(String(word).toLowerCase()) ?? new Set<string>();
       if (readAs.has(action)) {
-        stale.push(`${key} — now reads correctly as [${[...readAs].join(',')}]; remove from allowlist`);
+        stale.push(
+          `${key} — now reads correctly as [${[...readAs].join(',')}]; remove from allowlist`
+        );
       }
     }
     expect(

--- a/packages/semantic/test/realtime-blocks.test.ts
+++ b/packages/semantic/test/realtime-blocks.test.ts
@@ -1,7 +1,7 @@
 /**
  * Realtime / Service-Worker Block Tests
  *
- * `eventsource`, `socket`, and `intercept` introduce named, body-bearing
+ * `eventsource`, `socket`, `worker`, and `intercept` introduce named, body-bearing
  * constructs. Their command schemas declare `roles: []` + `bareKeyword: true`,
  * so the generated pattern is a lone keyword literal — which used to match at
  * Stage 2 and swallow the entire body at a *vacuous* confidence 1.0
@@ -16,6 +16,7 @@ import { describe, it, expect } from 'vitest';
 import { parse, buildAST } from '../src';
 import type {
   CommandSemanticNode,
+  DefSemanticNode,
   EventHandlerSemanticNode,
   FeatureSemanticNode,
 } from '../src/types';
@@ -39,6 +40,7 @@ const EVENTSOURCE = 'eventsource ChatStream from /events on message put it into 
 const SOCKET = 'socket ChatSocket ws://localhost:8080 on message put it into #chat end';
 const INTERCEPT =
   'intercept / precache /, /style.css, /app.js as "v1" on /api/* use network-first end';
+const WORKER = 'worker Calculator\n  def add(a, b)\n    return a + b\n  end\nend';
 
 describe('realtime / service-worker blocks', () => {
   describe('eventsource', () => {
@@ -151,7 +153,7 @@ describe('realtime / service-worker blocks', () => {
   });
 
   it('does not fire the unconsumed-input diagnostic any more', () => {
-    for (const src of [EVENTSOURCE, SOCKET, INTERCEPT]) {
+    for (const src of [EVENTSOURCE, SOCKET, INTERCEPT, WORKER]) {
       const diagnostics = parse(src, 'en').diagnostics ?? [];
       expect(diagnostics.filter(d => d.code === 'unconsumed-input')).toHaveLength(0);
     }
@@ -169,12 +171,84 @@ describe('realtime / service-worker blocks', () => {
     expect(parse('def helper(a)\n  return a\nend', 'en').kind).toBe('def');
   });
 
-  it('leaves `worker` on the old bare-keyword path (folded with SOV `def` support)', () => {
-    // Folding worker in English alone would enrich the English reference action
-    // set while the other 23 languages still dropped their bodies — a fidelity
-    // regression. It lands with verb-final `def` support.
-    const node = parse('worker Calculator def add(a, b) return a + b end end', 'en');
-    expect(node.kind).toBe('command');
-    expect(node.action).toBe('worker');
+  describe('worker', () => {
+    it('captures its `def` sub-blocks', () => {
+      const node = parse(WORKER, 'en') as FeatureSemanticNode;
+
+      expect(node.kind).toBe('feature');
+      expect(node.action).toBe('worker');
+      expect(node.name).toBe('Calculator');
+      expect(node.body).toHaveLength(1);
+
+      const def = node.body[0] as DefSemanticNode;
+      expect(def.kind).toBe('def');
+      expect(def.name).toBe('add');
+      expect(def.parameters).toEqual(['a', 'b']);
+      expect(def.body.map(c => c.action)).toEqual(['return']);
+      expect(actionsOf(node)).toEqual(['worker', 'def', 'return']);
+    });
+
+    it('carries the def body into the built AST', () => {
+      const { ast } = buildAST(parse(WORKER, 'en')) as unknown as {
+        ast: { name: string; args: Array<{ type: string; commands?: Array<{ type: string }> }> };
+      };
+      expect(ast.name).toBe('worker');
+      const block = ast.args.find(a => a.type === 'block');
+      expect(block?.commands?.[0]?.type).toBe('def');
+    });
+
+    it('parses the Japanese rendering, whose `def` is also verb-final', () => {
+      const ja = [
+        'Calculator を worker',
+        '  add(a, b) を def',
+        '    a + b を 戻る',
+        '  終わり',
+        '終わり',
+      ].join('\n');
+      const node = parse(ja, 'ja') as FeatureSemanticNode;
+      expect(node.kind).toBe('feature');
+      expect(node.name).toBe('Calculator');
+      expect(actionsOf(node)).toEqual(['worker', 'def', 'return']);
+    });
+
+    it('parses the Swahili rendering (dict emits `rudisha`, which the profile reads)', () => {
+      // Regression guard for the sw lexicon gap: the dict used to emit `rudi`,
+      // which the semantic profile reads as nothing, so sw silently dropped the
+      // def body. Kept distinct from `rudia` (= `repeat`).
+      const sw = [
+        'worker Calculator',
+        '  def add(a, b)',
+        '    rudisha a + b',
+        '  mwisho',
+        'mwisho',
+      ].join('\n');
+      expect(actionsOf(parse(sw, 'sw'))).toEqual(['worker', 'def', 'return']);
+      expect((parse('rudia 3 mara', 'sw') as CommandSemanticNode).action).toBe('repeat');
+    });
+  });
+
+  describe('SOV verb-final `def` head detection', () => {
+    it('parses a bare verb-final def sub-block', () => {
+      const node = parse('add(a, b) を def\n  a + b を 戻る\n終わり', 'ja') as DefSemanticNode;
+      expect(node.kind).toBe('def');
+      expect(node.name).toBe('add');
+      expect(node.parameters).toEqual(['a', 'b']);
+    });
+
+    it('does not claim a `worker` block as a def named after the worker', () => {
+      // `worker`'s ja body contains a marker-preceded `def` (`add(a, b) を def`), so
+      // a guard that only checks "patient marker before the keyword" would let
+      // tryParseBlock swallow the whole block as `def Calculator`. The head must be
+      // contiguous: name + params + exactly one marker + keyword.
+      const ja = 'Calculator を worker\n  add(a, b) を def\n    a + b を 戻る\n  終わり\n終わり';
+      const node = parse(ja, 'ja');
+      expect(node.kind).toBe('feature');
+      expect(node.action).toBe('worker');
+    });
+
+    it('leaves SOV verb-final `behavior` to the behavior layer', () => {
+      const ja = 'Foo(cls) を behavior\n  クリック で .x を トグル\n  終わり\n終わり';
+      expect(parse(ja, 'ja').kind).toBe('behavior');
+    });
   });
 });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-10T01:45:17.150Z",
-  "commit": "a7d6136f",
+  "timestamp": "2026-07-10T03:10:24.619Z",
+  "commit": "0d0ed099",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9,12 +9,12 @@
       "avgConfidence": 0.8394563407500147,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9841008771929826,
+      "avgRoleFidelity": 0.9842047930283225,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -640,13 +640,13 @@
       "parseRate": 1,
       "avgConfidence": 0.8579007041413049,
       "avgFidelity": 1,
-      "avgPrecision": 0.995724931386696,
-      "avgRoleFidelity": 0.9718201754385966,
+      "avgPrecision": 0.9989716846334493,
+      "avgRoleFidelity": 0.972004357298475,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.8261801690373097,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.980419799498747,
+      "avgRoleFidelity": 0.9805477746654219,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8319521748093155,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9857456140350878,
+      "avgRoleFidelity": 0.9858387799564271,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8228818800247351,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.980419799498747,
+      "avgRoleFidelity": 0.9805477746654219,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3794,12 +3794,12 @@
       "avgConfidence": 0.8295609152752009,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9906798245614034,
+      "avgRoleFidelity": 0.9907407407407406,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4425,13 +4425,13 @@
       "parseRate": 1,
       "avgConfidence": 0.9077564039970039,
       "avgFidelity": 1,
-      "avgPrecision": 0.9945887445887446,
-      "avgRoleFidelity": 0.9625,
+      "avgPrecision": 0.9978354978354977,
+      "avgRoleFidelity": 0.9627450980392157,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.8371057513914636,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9827694235588974,
+      "avgRoleFidelity": 0.9828820417055713,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5690,12 @@
       "avgConfidence": 0.8346320346320326,
       "avgFidelity": 1,
       "avgPrecision": 0.997835497835498,
-      "avgRoleFidelity": 0.993029448621554,
+      "avgRoleFidelity": 0.9930750077808902,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6322,12 @@
       "avgConfidence": 0.8500157319706186,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9718201754385966,
+      "avgRoleFidelity": 0.972004357298475,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6954,12 @@
       "avgConfidence": 0.8449652269201134,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9685307017543859,
+      "avgRoleFidelity": 0.9687363834422658,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7586,12 @@
       "avgConfidence": 0.8358688930117478,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9846491228070177,
+      "avgRoleFidelity": 0.9847494553376908,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8218,12 @@
       "avgConfidence": 0.8064728921871758,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9840382205513785,
+      "avgRoleFidelity": 0.9841425459072518,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8850,12 @@
       "avgConfidence": 0.7977324263038529,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9857456140350878,
+      "avgRoleFidelity": 0.9858387799564271,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9482,12 @@
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9527255639097743,
+      "avgRoleFidelity": 0.953034547152194,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10114,12 @@
       "avgConfidence": 0.8174809317666439,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.986293859649123,
+      "avgRoleFidelity": 0.9863834422657953,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10746,12 +10746,12 @@
       "avgConfidence": 0.8001649144506268,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9857456140350878,
+      "avgRoleFidelity": 0.9858387799564271,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11378,12 @@
       "avgConfidence": 0.8390022675736938,
       "avgFidelity": 1,
       "avgPrecision": 0.9978354978354977,
-      "avgRoleFidelity": 0.9844298245614035,
+      "avgRoleFidelity": 0.9845315904139433,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12010,12 +12010,12 @@
       "avgConfidence": 0.8239183073548376,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9906798245614036,
+      "avgRoleFidelity": 0.9907407407407408,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12642,12 +12642,12 @@
       "avgConfidence": 0.8489025594288746,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9714331785345716,
+      "avgRoleFidelity": 0.9716198897859796,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13274,12 +13274,12 @@
       "avgConfidence": 0.8178932178932158,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.986293859649123,
+      "avgRoleFidelity": 0.9863834422657953,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13906,12 +13906,12 @@
       "avgConfidence": 0.8042465471036879,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9882675438596493,
+      "avgRoleFidelity": 0.9883442265795209,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14538,12 +14538,12 @@
       "avgConfidence": 0.9840032982890127,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9871553884711779,
+      "avgRoleFidelity": 0.9872393401805166,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493056,
+      "bundleSize": 493633,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 493056,
+      "size": 493633,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
**Stacked on #628** — base is `fix/feature-block-body-drops`, so this diff shows only the `worker` work. GitHub will retarget to `main` once #628 merges.

Completes the arc. `worker Calculator def add(a, b) return a + b end end` parsed to a bare keyword at confidence 1.0, discarding its `def` sub-blocks.

## What it needed

`worker`'s body is `def … end` sub-blocks, and SOV renders those verb-final (`add(a, b) を def`), which `parseDefBlock` could not locate — it matched `def` only at token 0. So: add verb-final `def` support mirroring `parseBehaviorBlock`, then add `worker` to the fold as a third body family (`DEF_BODY_FEATURES`).

Its segments are sliced **through** their `end`, because a `def` owns its terminator (`parseDefBlock` looks for it and applies ×0.8 when missing) — whereas a handler's `on …` pattern must not see one.

## Two things the handoff didn't predict

**1. The verb-final `def` guard cannot be "a patient marker precedes the keyword."**

That was the plan's proposal (validate by `(params)` presence). It's not sufficient. `worker`'s own ja body is:

```
Calculator を worker
  add(a, b) を def      ← body-level `def`, ALSO marker-preceded
    a + b を 戻る
  終わり
終わり
```

A loose guard makes `tryParseBlock` swallow the entire worker block as a `def` named `Calculator`. The head must be **contiguous**: name + balanced params + exactly one marker + keyword. `sovHeadKeywordIndex` computes the expected position (2); the body-level `def` sits at 10 and is rejected. A regression test pins this.

**2. A live Swahili lexicon gap, invisible until `return` finally had to parse.**

The i18n dictionary emitted `rudi` ("go back") while the semantic profile reads `rudisha`/`rejea` — so **Swahili could not parse its own `return`**. Its worker body dropped, taking fidelity to 1/3 → degenerate. It had been sitting in `lexicon-emit-mismatch.test.ts`'s allowlist as `sw:return:rudi`, in the **LIVE** category that test explicitly documents as "a genuine i18n↔profile gap"; no corpus row had ever exercised it, because `worker`'s body was being dropped anyway.

Fixed by realigning the dict to `rudisha` — the transitive form ("give back a value"), which is what the profile already lists as primary, and which stays clear of `rudia` (= `repeat`). The allowlist entry is pruned; that test self-prunes stale entries, so leaving it would fail.

Fixing the *profile* instead (adding `rudi` as an alternative) was the other option; I chose the dict because `rudi` sits one letter from `rudia`/`repeat`, and because the emission was the thing that was wrong.

## Results

`--diagnose-coverage` firing rate **56 (1.5%) → 38 (1.0%)**. Every remaining firing is `bind` — an unrelated `then`-chain drop. All five feature blocks are now clean; the diagnostic landed in #627, and this closes out everything it found.

All 24 languages produce the identical action set `{worker, def, return}`.

Ratchet vs #628's baseline — **no regressions anywhere**:

| signal | effect |
|---|---|
| R1 role-fidelity | up in **all 24** languages (`worker-basic` enters the denominator at 1.000) |
| R0-precision | up for bn/hi; unchanged elsewhere |
| avgFidelity | 1.0000 held |
| parse rate | 100% held |
| degenerate / lossy | 0 / 0 |
| R2 execution | 1.0000 |

## Verification

The new assertions **fail 6-of-22 against pre-fix source** (parser + dict reverted). They assert on the captured `def` sub-block — its name, its parameters, its body actions — and on the body surviving `buildAST`, never on "does it parse".

Regression guards cover the shared `def`/`behavior` path this touches: keyword-led `def`, SOV verb-final `behavior`, and the worker-not-a-def case above.

- `packages/semantic` 6658 · `core` 7193 · `i18n` 924 · `mcp-server` 420 · `hyperscript-adapter` 207 · `patterns-reference` 117 · `realtime` 24 · `reactivity` 45 · `intercept` 37
- `typecheck` + `eslint` clean; `--regression` exits **0** (checked directly, not through a pipe)
- Baseline regenerated against a freshly `populate`d DB and prettier-formatted; the regenerated `patterns.db` is **not** committed

## Also

`Multilingual Validation` is now a **required status check** on `main`, alongside the existing four (`strict: true` preserved). That gap is how #627's ~0.006 R1 drift merged unnoticed. It is safe for doc-only PRs: `ci.yml` deliberately carries no workflow-level `paths-ignore`, so the workflow always runs, and the job's `if: needs.changes.outputs.code == 'true'` skip reports a completed check run with conclusion `skipped` — which branch protection treats as passing. (A workflow-level path filter would instead leave it "Expected" forever.) Verified against a real docs-only commit on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
