### PR TITLE
fix(parser): stop `bind`'s possessive source dropping its owner selector in 7 languages

### DIFF
--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -739,7 +739,13 @@ export const bindSchema: CommandSchema = {
       role: 'source',
       description: 'The element or property to bind to',
       required: true,
-      expectedTypes: ['selector', 'reference', 'expression'],
+      // 'property-path' opts this role into the "of"-possessive matcher, so the
+      // property-first render of `bind $x to #y's prop` (es `valor de #picker`,
+      // ar `قيمة لـ #picker`) keeps its owner selector instead of collapsing to
+      // the bare property word; see pattern-matcher tryMatchOfPossessiveExpression.
+      // The selector-first languages (en `#picker's value`, ja `#pickerの 値`)
+      // already reached property-path through tryMatchPossessiveSelectorExpression.
+      expectedTypes: ['selector', 'reference', 'expression', 'property-path'],
       svoPosition: 2,
       sovPosition: 2,
       // Element mirrors `set`/`add`/`put`'s value ("to") marking per language.

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -1149,6 +1149,10 @@ export class PatternMatcher {
     pl: new Set(['z']),
     uk: new Set(['з']),
     th: new Set(['ของ']),
+    // Arabic genitive connector, laam + tatweel. Distinct from the possessive
+    // pronoun لي (laam + ya) that tryMatchPostNominalPossessiveExpression reads
+    // for `set my textContent`, so listing it here cannot steal that fold.
+    ar: new Set(['لـ']),
     ja: new Set(['の']),
     ko: new Set(['의']),
     bn: new Set(['র']),
@@ -1273,9 +1277,45 @@ export class PatternMatcher {
   }
 
   /**
+   * Whether a token is a possessive pronoun in the active profile (`my`, `لي`,
+   * `yangu`) rather than a property name.
+   */
+  private isPossessorToken(token: { value: string; normalized?: string }): boolean {
+    if (!this.currentProfile) return false;
+    for (const cand of [token.value, token.normalized].filter(Boolean) as string[]) {
+      if (
+        getPossessiveReference(this.currentProfile, cand) ??
+        getPossessiveReference(this.currentProfile, cand.toLowerCase())
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Whether a bare identifier can head a possessive property phrase — `valor de
+   * #picker`, `textContent von #status`.
+   *
+   * Sigil-led identifiers are values, not properties: `$x`/`:x` tokenize as
+   * references and `@x`/`*x`/`.x`/`#x` as selectors, so `$total de #x` must never
+   * fold into a property-path. Structural keywords, role-marker concepts and
+   * possessive pronouns belong to other matchers and are never property names.
+   */
+  private isBareWordPropertyHead(token: LanguageToken): boolean {
+    if (token.kind !== 'identifier') return false;
+    if (/^[$:@#.*]/.test(token.value)) return false;
+    if (this.isStructuralKeyword(token.value)) return false;
+    if (token.normalized && this.isStructuralKeyword(token.normalized)) return false;
+    if (token.normalized && this.isRoleMarkerConcept(token.normalized)) return false;
+    return !this.isPossessorToken(token);
+  }
+
+  /**
    * Try to match a prepositional "of" possessive:
-   *   <property-selector> <of-marker> <owner-selector>
-   * e.g. "*--primary-color of #theme" → property-path(#theme, *--primary-color).
+   *   <property> <of-marker> <owner-selector>
+   * e.g. "*--primary-color of #theme" → property-path(#theme, *--primary-color),
+   * or "valor de #picker" → property-path(#picker, valor).
    *
    * This is the surface the i18n transformer emits for "set the X of #y to Z"
    * across languages (`set #y's X` would be the alternative, but the transformer
@@ -1283,7 +1323,14 @@ export class PatternMatcher {
    */
   private tryMatchOfPossessiveExpression(tokens: TokenStream): SemanticValue | null {
     const property = tokens.peek();
-    if (!property || property.kind !== 'selector') return null;
+    if (!property) return null;
+    // A selector head is the historical form (`*--primary-color of #theme`). A
+    // bare-word head is the property-first render the transformer emits for
+    // `#picker's value` in es/pt/fr/de/id/sw/ar (`valor de #picker`), which
+    // otherwise captured the property word alone as an expression and dropped
+    // the owner. Selector-first languages (en `#picker's value`, ja `#pickerの
+    // 値`) never reach here: their owner check below rejects the property word.
+    if (property.kind !== 'selector' && !this.isBareWordPropertyHead(property)) return null;
 
     const mark = tokens.mark();
     tokens.advance();
@@ -1477,18 +1524,6 @@ export class PatternMatcher {
     if (!this.currentProfile) return null;
     if (this.currentProfile.possessive?.markerPosition !== 'after-object') return null;
 
-    const isPossessor = (t: { value: string; normalized?: string }): boolean => {
-      for (const cand of [t.value, t.normalized].filter(Boolean) as string[]) {
-        if (
-          getPossessiveReference(this.currentProfile!, cand) ??
-          getPossessiveReference(this.currentProfile!, cand.toLowerCase())
-        ) {
-          return true;
-        }
-      }
-      return false;
-    };
-
     const propertyToken = tokens.peek();
     if (!propertyToken) return null;
 
@@ -1508,7 +1543,7 @@ export class PatternMatcher {
       (propertyToken.kind === 'selector' &&
         (propertyToken.value.startsWith('*') || propertyToken.value.startsWith('@'))) ||
       isDotSelector;
-    if (!isPropHead || isPossessor(propertyToken)) return null;
+    if (!isPropHead || this.isPossessorToken(propertyToken)) return null;
 
     const mark = tokens.mark();
 

--- a/packages/semantic/test/bind-command.test.ts
+++ b/packages/semantic/test/bind-command.test.ts
@@ -11,7 +11,12 @@
  */
 import { describe, it, expect } from 'vitest';
 import { parse, canParse } from '../src';
-import type { CommandSemanticNode, CompoundSemanticNode } from '../src/types';
+import type {
+  CommandSemanticNode,
+  CompoundSemanticNode,
+  PropertyPathValue,
+  SelectorValue,
+} from '../src/types';
 
 describe('bind command', () => {
   it('parses "bind :greeting to #name-input" into action + roles', () => {
@@ -27,6 +32,13 @@ describe('bind command', () => {
 
     expect(node.action).toBe('bind');
     expect(node.roles.get('destination')?.value).toBe(':color');
+    // Assert the SOURCE too: only checking the destination is what let the
+    // owner-dropping bug hide in the seven property-first languages. Per-language
+    // coverage lives in bind-possessive-source.test.ts.
+    const source = node.roles.get('source') as PropertyPathValue | undefined;
+    expect(source?.type).toBe('property-path');
+    expect(source?.property).toBe('value');
+    expect((source?.object as SelectorValue | undefined)?.value).toBe('#picker');
   });
 
   it('parses a then-chain of two binds into a compound', () => {

--- a/packages/semantic/test/bind-possessive-source.test.ts
+++ b/packages/semantic/test/bind-possessive-source.test.ts
@@ -1,0 +1,124 @@
+/**
+ * `bind <var> to <element>'s <property>` — the possessive SOURCE role.
+ *
+ * These tests deliberately do NOT assert "does it parse". It always parsed, at
+ * confidence 1.0 — the bug was that seven languages captured only the property
+ * WORD and silently dropped the owner selector, leaving `de #picker` unconsumed:
+ *
+ *     en : bind.source:property-path(#picker, value)     ✓
+ *     es : bind.source:expression("valor")               ✗  `de #picker` dropped
+ *
+ * They assert on the captured role TYPE and on the OWNER surviving into it, plus
+ * the absence of the `unconsumed-input` diagnostic.
+ *
+ * Two renderings exist across the 24 languages, and both must land on the same
+ * `property-path`:
+ *   - selector-first (en `#picker's value`, ja `#pickerの 値`) — handled by
+ *     tryMatchPossessiveSelectorExpression, correct before this fix;
+ *   - property-first (es `valor de #picker`, ar `قيمة لـ #picker`) — handled by
+ *     tryMatchOfPossessiveExpression, which required a selector property head
+ *     and so never fired on a bare word.
+ */
+import { describe, it, expect } from 'vitest';
+import { parse } from '../src';
+import type { CommandSemanticNode, PropertyPathValue, SelectorValue } from '../src/types';
+
+/** Parse and return the `source` role, asserting the node is a bind command. */
+function bindSource(code: string, language: string) {
+  const node = parse(code, language) as CommandSemanticNode;
+  expect(node.action).toBe('bind');
+  return node.roles.get('source');
+}
+
+function unconsumedSpans(code: string, language: string): string[] {
+  const node = parse(code, language);
+  return (node.diagnostics ?? []).filter(d => d.code === 'unconsumed-input').map(d => d.message);
+}
+
+/** `bind $color to #picker's value` — corpus row `bind-explicit-property`. */
+const EXPLICIT_PROPERTY: Array<[language: string, code: string, property: string]> = [
+  // Selector-first renderings — these already worked; they are regression locks.
+  ['en', "bind $color to #picker's value", 'value'],
+  ['ja', '$color を #pickerの 値 に バインド', '値'],
+  ['ko', '$color 를 #picker의 값 에 바인드', '값'],
+  ['zh', '绑定 $color 到 #picker的 值', '值'],
+  // Property-first renderings — these dropped the owner before this fix.
+  ['es', 'bind $color a valor de #picker', 'valor'],
+  ['pt', 'bind $color para valor de #picker', 'valor'],
+  ['fr', 'bind $color à valeur de #picker', 'valeur'],
+  ['de', 'bind $color zu wert von #picker', 'wert'],
+  ['id', 'bind $color ke nilai dari #picker', 'nilai'],
+  ['sw', 'bind $color kwa thamani ya #picker', 'thamani'],
+  ['ar', 'اربط $color إلى قيمة لـ #picker', 'قيمة'],
+];
+
+/** `bind $message to #status's textContent` — corpus row `bind-non-form-display`. */
+const NON_FORM_DISPLAY: Array<[language: string, code: string]> = [
+  ['es', 'bind $message a textContent de #status'],
+  ['pt', 'bind $message para textContent de #status'],
+  ['fr', 'bind $message à textContent de #status'],
+  ['de', 'bind $message zu textContent von #status'],
+  ['id', 'bind $message ke textContent dari #status'],
+  ['sw', 'bind $message kwa textContent ya #status'],
+  ['ar', 'اربط $message إلى textContent لـ #status'],
+];
+
+describe('bind: possessive source captures the owner (bind-explicit-property)', () => {
+  it.each(EXPLICIT_PROPERTY)('%s captures property-path(#picker, %s)', (lang, code, property) => {
+    const source = bindSource(code, lang) as PropertyPathValue | undefined;
+
+    expect(source?.type).toBe('property-path');
+    expect(source?.property).toBe(property);
+    expect((source?.object as SelectorValue)?.value).toBe('#picker');
+  });
+
+  it.each(EXPLICIT_PROPERTY)('%s consumes its whole input', (lang, code) => {
+    expect(unconsumedSpans(code, lang)).toEqual([]);
+  });
+});
+
+describe('bind: possessive source captures the owner (bind-non-form-display)', () => {
+  it.each(NON_FORM_DISPLAY)('%s captures property-path(#status, textContent)', (lang, code) => {
+    const source = bindSource(code, lang) as PropertyPathValue | undefined;
+
+    expect(source?.type).toBe('property-path');
+    expect(source?.property).toBe('textContent');
+    expect((source?.object as SelectorValue)?.value).toBe('#status');
+  });
+
+  it.each(NON_FORM_DISPLAY)('%s consumes its whole input', (lang, code) => {
+    expect(unconsumedSpans(code, lang)).toEqual([]);
+  });
+});
+
+describe('bind: a bare element source is NOT folded into a property-path', () => {
+  // `bind-auto-detect` has no possessive. Opening `bind.source` to the
+  // of-possessive matcher must not make a lone selector grow a phantom owner,
+  // nor let the post-nominal matcher (same gate) read the next token as a
+  // possessor in the `after-object` profiles (ar/id/sw).
+  const AUTO_DETECT: Array<[language: string, code: string]> = [
+    ['en', 'bind $greeting to #name-input'],
+    ['es', 'bind $greeting a #name-input'],
+    ['ar', 'اربط $greeting إلى #name-input'],
+    ['id', 'bind $greeting ke #name-input'],
+    ['sw', 'bind $greeting kwa #name-input'],
+  ];
+
+  it.each(AUTO_DETECT)('%s keeps a bare selector source', (lang, code) => {
+    const source = bindSource(code, lang);
+
+    expect(source?.type).toBe('selector');
+    expect((source as SelectorValue | undefined)?.value).toBe('#name-input');
+  });
+});
+
+describe('bind: a reference-shaped source head is never a property', () => {
+  // `$total`/`:total` tokenize as bare identifiers, so a naive bare-word
+  // property head would fold `$total de #x` into property-path(#x, $total).
+  // isBareWordPropertyHead rejects sigil-led identifiers.
+  it('does not fold a $-global into an of-possessive property', () => {
+    const source = bindSource('bind $color a $total', 'es');
+
+    expect(source?.type).not.toBe('property-path');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-10T03:10:24.619Z",
-  "commit": "0d0ed099",
+  "timestamp": "2026-07-10T08:19:02.397Z",
+  "commit": "d6296e77",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9,12 +9,12 @@
       "avgConfidence": 0.8394563407500147,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9842047930283225,
+      "avgRoleFidelity": 0.9907407407407408,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -646,7 +646,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1273,12 @@
       "avgConfidence": 0.8261801690373097,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9805477746654219,
+      "avgRoleFidelity": 0.9870837223778401,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1903,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2530,12 @@
       "avgConfidence": 0.8319521748093155,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9858387799564271,
+      "avgRoleFidelity": 0.9923747276688454,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3162,12 @@
       "avgConfidence": 0.8228818800247351,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9805477746654219,
+      "avgRoleFidelity": 0.9870837223778401,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3799,7 +3799,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4431,7 +4431,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5058,12 @@
       "avgConfidence": 0.8371057513914636,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9828820417055713,
+      "avgRoleFidelity": 0.9894179894179896,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5695,7 +5695,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6327,7 +6327,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6959,7 +6959,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7591,7 +7591,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8223,7 +8223,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8850,12 @@
       "avgConfidence": 0.7977324263038529,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9858387799564271,
+      "avgRoleFidelity": 0.9923747276688454,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9487,7 +9487,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10119,7 +10119,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10746,12 +10746,12 @@
       "avgConfidence": 0.8001649144506268,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgRoleFidelity": 0.9858387799564271,
+      "avgRoleFidelity": 0.9923747276688454,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11383,7 +11383,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12015,7 +12015,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12647,7 +12647,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13279,7 +13279,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13911,7 +13911,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14543,7 +14543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 493633,
+      "bundleSize": 494031,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15166,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 493633,
+      "size": 494031,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
`bind $color to #picker's value` captured a `property-path` source in the 17 languages that render the possessive **selector-first** (en `#picker's value`, ja `#pickerの 値`). The seven that render it **property-first** captured only the property WORD and silently dropped the owner:

```
en : bind.source:property-path(#picker, value)   ✓
es : bind.source:expression("valor")             ✗  `de #picker` unconsumed
```

Affected: **ar, de, es, fr, id, pt, sw**.

## Root cause — two independent blockers

1. **`bindSchema.source.expectedTypes` lacked `'property-path'`**, so the entire of-possessive branch in `matchRoleToken` — gated on `expectedTypes?.includes('property-path')` — never ran for `bind`. Only `set.destination` opted in.
2. **`tryMatchOfPossessiveExpression` required a `selector` property head** (`*--primary-color of #theme`). The property head in all seven languages tokenizes as a bare `identifier`:

```
es  valor[identifier]   de[particle/source]    #picker[selector]
de  wert[identifier]    von[keyword/source]    #picker[selector]
ar  قيمة[identifier]    لـ[identifier/—]       #picker[selector]   ← no ar of-marker entry
sw  thamani[identifier] ya[identifier]         #picker[selector]
```

Also adds the Arabic genitive connector `لـ` to `OF_POSSESSIVE_MARKERS`. The other six already resolved (es/pt/fr `de`, de `von`, id `dari` normalize to `source`; sw `ya` was listed).

## Why this is safe

- **The bare-word head is hardened.** `isBareWordPropertyHead` rejects sigil-led identifiers (`$x`, `:x`, `@x` are references/selectors, not properties), structural keywords, role-marker concepts, and possessive pronouns — the same predicate `tryMatchPostNominalPossessiveExpression` already applied inline, now factored out and shared. So `bind $color a $total` can never fold to a property-path.
- **Selector-first languages are provably untouched.** The relaxed matcher still requires a `selector` OWNER after the marker. For `#pickerの 値` the token after `の` is the property word, so it rejects and control falls through to `tryMatchPossessiveSelectorExpression` exactly as before.
- **`set` is untouched.** No `set-*` row in any language presents `<identifier> <of-marker> <selector>` at the destination. In `set the *--primary-color of #theme`, `the` is now accepted as a head but bails immediately (next token is a selector, not an of-marker) and resets the stream. `set` is also in the R2 `EXECUTION_SUBSET`, so a regression would trip the execution ratchet.
- **No `markerRoleCollision` analogue needed.** That guard exists because es/pt `de` is both the genitive connector and `remove`'s from-marker. `bind`'s own source markers are `a/para/à/zu/ke/kwa/إلى` — checked against every of-marker, no overlap.
- `ar`'s `لـ` (laam+tatweel) is a distinct string from the possessive pronoun `لي` (laam+ya) that `set my textContent` relies on, so `post-nominal-possessive.test.ts` is unaffected.

## Measured

Fresh `patterns.db`, ordered build:

- **`--diagnose-coverage`: 38 → 24 firings.** The 14 removed are exactly `bind-explicit-property` + `bind-non-form-display` × 7 languages. The remaining 24 are `bind-two-way`, a separate defect fixed in the follow-up PR.
- **`--regression` exits 0** against the pre-change baseline (a rise never fails the ratchet).
- **Baseline regenerated, fully attributed:** `avgRoleFidelity` rises **+0.006536 in exactly ar, de, es, fr, id, pt, sw** and is byte-identical in the other 16. `avgFidelity`, `avgPrecision`, `avgExecutionFidelity`, `avgConfidence`, `lossyPasses`, `degeneratePasses` and `executionFailures` are unchanged in **every** language. The only other diff is `bundleSize` (+398 B).

## Tests

Assert on the captured role **type** and on the **owner** surviving into it — never on "does it parse". It always parsed, at confidence 1.0. Verified failing without the fix: **28 of 42 new assertions fail**; the 14 that pass are the selector-first regression locks and the negative locks (`bind-auto-detect` must keep a bare selector; a `$`-global must never become a property).

`bind-command.test.ts`'s possessive case asserted only the *destination* — which is what let this hide. It now asserts the source too.

Suites: semantic 6700 ✓ · typecheck ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)