### PR TITLE
fix(parser): parse a top-level command sequence, not just its first command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,7 +291,7 @@ the committed baseline:
 > not truth. Current plan + per-arc history:
 > `docs-internal/MULTILINGUAL_NEXT_STEPS.md`.
 
-The `--regression` gate ratchets on **six** signals (each fails CI; each guarded so
+The `--regression` gate ratchets on **seven** signals (each fails CI; each guarded so
 an un-regenerated baseline never retro-flags — a baseline lacking a signal's field
 yields a 0 delta):
 
@@ -306,11 +306,27 @@ yields a 0 delta):
    _adds_ phantom/spurious commands the source never had (a phantom `toggle` ahead of
    a real one) — invisible to every recall-based signal above. Multiset-aware, so a
    _duplicated_ phantom (`[toggle, toggle]`) is seen too.
-5. **role-fidelity ratchet (R1)** — a per-language **avgRoleFidelity** drop > 0.02
+5. **multiset-recall ratchet (R0-recall-multiset)** — a per-language
+   **avgMultisetRecall** drop > 0.02. Signals 2–4 all score the **deduped** action
+   Set, so a parse that drops a _repeated_ command scores a perfect 1.0: reference
+   `[bind, bind]` collapses to `{bind}`, which `[bind]` satisfies in full. That is how
+   `bind-two-way` recorded fidelity 1.0 in all 24 languages while every one of them
+   parsed only the first of its two `bind`s (the top-level command-sequence fix that
+   added this signal). Counting duplicates makes the drop visible. Ten rows sit below 1.0 today — `behavior-draggable` / `behavior-resizable`
+   in hi/ja/ko/ms/qu (hi/ja/ko/qu lose a `trigger`, ms a `measure`, qu also two `set`s).
+   All pre-existing, all one root cause — the non-en tokenizers split a colon-qualified
+   custom event name (`draggable:start` → `draggable` + `:start`, the local-variable
+   sigil). Now frozen; see `docs-internal/HANDOFF_colon-event-names.md`.
+6. **role-fidelity ratchet (R1)** — a per-language **avgRoleFidelity** drop > 0.02
    (`action.role:valueType` recall vs the en reference; catches a parse that keeps the
-   verb but drops/mistypes a role).
-6. **execution ratchet (R2)** — a curated-subset pattern whose jsdom DOM effect
+   verb but drops/mistypes a role). Note this is a Set too, so it shares signal 5's
+   blind spot for repeated roles.
+7. **execution ratchet (R2)** — a curated-subset pattern whose jsdom DOM effect
    matched the en reference and now diverges (pass→fail; tolerance 0).
+
+None of the recall-based signals can see a regression in the **English reference
+itself** — en defines the reference, so a parser change that truncates every language
+identically (as the top-level-sequence bug did) moves nothing. Only tests catch that.
 
 After an _intentional_ fidelity change, regenerate the baseline (`--save-baseline`).
 **The baseline must be regenerated against a freshly `populate`d patterns.db** — a

--- a/docs-internal/HANDOFF_colon-event-names.md
+++ b/docs-internal/HANDOFF_colon-event-names.md
@@ -1,0 +1,130 @@
+# Handoff: a colon-qualified custom event name is split by every non-en tokenizer
+
+## Context
+
+Surfaced by the **multiset-recall ratchet** (R0-recall-multiset), added alongside the
+top-level command-sequence fix — the first signal able to see a *dropped duplicate*
+command. It flagged ten rows that every prior signal scored a perfect 1.0:
+
+| row                   | languages     | multiset recall |
+| --------------------- | ------------- | --------------- |
+| `behavior-draggable`  | hi ja ko ms qu | 0.9375         |
+| `behavior-resizable`  | hi ja ko ms   | 0.9615          |
+| `behavior-resizable`  | qu            | 0.8846          |
+
+These are **pre-existing** — verified byte-identical before and after the bind-possessive
+and top-level command-sequence fixes, across all 24 languages. They are **not** a
+duplicate-command bug, despite being found by a duplicate-counting signal. They are one
+root cause with word-order-dependent symptoms.
+
+---
+
+## Root cause
+
+`:name` is hyperscript's **local-variable sigil**. A custom event name such as
+`draggable:start` therefore looks like `draggable` followed by the local variable
+`:start`. Only the **English** tokenizer keeps it whole:
+
+```text
+en   trigger[keyword]  draggable:start[identifier]              ✓ whole
+ms   cetuskan[keyword] draggable[identifier]  :start[identifier]   ✗ split
+ja   draggable[identifier] :start[identifier] を[particle] 引き金[keyword]  ✗ split
+ko   draggable[identifier] :start[identifier] 를[particle] 트리거[keyword]  ✗ split
+qu   draggable[identifier] :start[identifier] ta[particle] kichay[keyword]  ✗ split
+```
+
+Reproduce:
+
+```bash
+node --input-type=module -e "
+const { tokenize } = await import('./packages/semantic/dist/index.js');
+for (const [l, s] of [['en','trigger draggable:start'],['ms','cetuskan draggable:start']])
+  console.log(l, tokenize(s, l).tokens.map(t => t.value + '[' + t.kind + ']').join('  '));
+"
+```
+
+## Symptoms diverge by word order
+
+`behavior-draggable`'s handler body is `trigger draggable:start` … `measure x` …
+`trigger draggable:move` … `trigger draggable:end`. English captures three triggers with
+the right names. The others do not:
+
+```text
+en  triggers: ["draggable:start", "draggable:move", "draggable:end"]
+ms  triggers: ["draggable",       "draggable",      "draggable"]      ← names TRUNCATED
+ja  triggers: ["x",               "draggable:move"]                   ← one LOST, one WRONG
+ko  triggers: ["x",               "draggable:move"]
+qu  triggers: ["x",               "draggable:move"]
+hi  triggers: ["x",               "draggable:move"]
+```
+
+- **ms (verb-first)**: `trigger` captures `draggable` and the orphaned `:start` dangles
+  into the next clause, where it swallows `ukur x` (`measure x`). Hence: three triggers
+  (right count, **wrong values**) and one **missing `measure`**.
+- **hi/ja/ko/qu (verb-final)**: the object-marked role (`を`/`를`/`को`/`ta`) captures
+  `:start` rather than the compound name; one `trigger` is lost outright and the *next*
+  trigger mis-captures `x` (the `measure` operand). Hence: one **missing `trigger`**.
+- **qu `behavior-resizable`** additionally loses two `set`s — likely the same cascade,
+  worth confirming separately rather than assuming.
+
+Note `draggable:move` survives everywhere. Only the triggers adjacent to a following
+command are corrupted, which is consistent with an orphaned `:start` / `:end` token
+being re-consumed by the neighbouring clause.
+
+## Why no existing signal saw it
+
+The ms case is the sharp one: the trigger **count** is right and the role signature is
+right (`trigger.event:literal` either way). Only the **value** is wrong —
+`draggable` instead of `draggable:start`. Every ratchet signal compares actions and role
+*types*, never role *values* (values are legitimately translated, so they cannot be
+compared cross-language directly). So:
+
+- R0-recall / R0-precision / R1: blind to the ms value corruption entirely.
+- R0-recall-multiset: sees it only via the **side-effect** (the swallowed `measure`).
+- R2 (execution): `behavior-*` rows are not in `EXECUTION_SUBSET`.
+
+**This is a value bug that the harness structurally cannot see.** The dropped commands
+are the tip; a corpus-wide audit of role *values* against the en reference (comparing
+only the language-invariant ones — selectors, `:`/`$` refs, numbers, custom event names)
+would be a genuinely new signal (R3?) and is probably the higher-leverage follow-up.
+
+---
+
+## Suggested approach
+
+The fix belongs in the **tokenizers**, not the parser. A colon that is *immediately
+preceded by an identifier character* is a qualifier, not a variable sigil:
+`draggable:start` is one token; a leading `:start` (after whitespace or at input start)
+is a local-variable reference.
+
+- Look for the English rule that already does this and lift it into `BaseTokenizer`
+  (`packages/semantic/src/tokenizers/base.ts`) so all 24 inherit it, rather than
+  patching 23 tokenizers.
+- Beware the two other `:` uses: `on click(x): …`? (none), and the CSS pseudo-class in
+  selectors (`#x:hover`), which tokenizes inside a selector token and must stay whole.
+- `packages/semantic/src/tokenizers/english.ts` is the reference behaviour.
+
+## Definition of done
+
+- `tokenize('trigger draggable:start', lang).tokens` yields one identifier
+  `draggable:start` in **all 24 languages**; a bare `:start` still tokenizes as a
+  local-variable reference.
+- `behavior-draggable` / `behavior-resizable` capture three triggers with the **correct
+  names** in all 24 languages, and lose no `measure` / `set`.
+- `avgMultisetRecall` returns to 1.000 for hi/ja/ko/ms/qu (a rise never fails the
+  ratchet; regenerate the baseline and attribute it).
+- A test asserting on the trigger **role values**, not just the action set — that is the
+  only thing that would have caught this.
+
+## Traps
+
+- **`--diagnose-coverage` will not show this.** It instruments only the Stage-2
+  plain-command path; these drops happen inside behavior/handler bodies. It reads 0
+  firings today and will still read 0 while the bug is live.
+- **The action-set assertion is not enough.** ms has the right action counts for
+  `trigger`; assert the captured event names.
+- Standard multilingual traps still apply — see CLAUDE.md, "Running the multilingual
+  `--regression` gate locally": real exit codes (never pipe `--regression` to `tail`, it
+  masks the gate's stale-dist *refusal* as a pass), `git stash` bumps mtimes and trips
+  the src-newer-than-dist guard, `prettier --write` the regenerated baseline, and don't
+  commit `patterns.db`.

--- a/packages/core/src/api/top-level-sequence.test.ts
+++ b/packages/core/src/api/top-level-sequence.test.ts
@@ -1,0 +1,77 @@
+/**
+ * top-level-sequence.test.ts
+ *
+ * A top-level command sequence used to be truncated to its first command on the
+ * MULTILINGUAL entry point. `hyperscript.compile(src, { language })` — and with it
+ * `hyperfixi.execute` / `translate` — takes the semantic direct path, where Stage 2
+ * matched the first command and returned. Measured on the pre-fix parser:
+ *
+ *   es  alternar .a entonces alternar .b   ->  command          (1)  + warning
+ *   en  show #a then show #b               ->  CommandSequence  (2)
+ *
+ * The English path was shielded by accident, not by design: core's parser calls
+ * `skipToCommandBoundary()` after a semantic hit and resumes at the next command,
+ * so its own loop recovers the commands the semantic parser dropped. Only code that
+ * consumes the semantic node directly — every non-English entry point — lost them.
+ *
+ * These tests assert on the number of commands reaching the AST, not on "does it
+ * compile". It always compiled, at confidence 1.0.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { hyperscript } from './hyperscript-api.js';
+
+/** Commands reaching the AST: a CommandSequence's children, or 1 for a bare command. */
+function commandCount(ast: unknown): number {
+  const node = ast as { type?: string; commands?: unknown[] };
+  if (node?.type === 'CommandSequence') return node.commands?.length ?? 0;
+  return node?.type ? 1 : 0;
+}
+
+describe('multilingual path: a top-level sequence keeps every command', () => {
+  it('captures both commands in a then-chained Spanish sequence', async () => {
+    const result = await hyperscript.compile('alternar .a entonces alternar .b', {
+      language: 'es',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.meta.parser).toBe('semantic');
+    expect(commandCount(result.ast)).toBe(2);
+  });
+
+  it('captures both commands in a JUXTAPOSED Spanish sequence', async () => {
+    // The English corpus form of `bind-two-way` has no conjunction at all, so a
+    // `then`-keyword-only fix would pass 23 languages and fail English.
+    const result = await hyperscript.compile('alternar .a alternar .b', { language: 'es' });
+
+    expect(result.ok).toBe(true);
+    expect(commandCount(result.ast)).toBe(2);
+  });
+
+  it('no longer warns about unconsumed input once the sequence is captured', async () => {
+    const result = await hyperscript.compile('alternar .a entonces alternar .b', {
+      language: 'es',
+    });
+
+    expect(result.meta.warnings).toBeUndefined();
+  });
+
+  it('leaves a single command as a single command', async () => {
+    const result = await hyperscript.compile('alternar .a', { language: 'es' });
+
+    expect(result.ok).toBe(true);
+    expect(commandCount(result.ast)).toBe(1);
+  });
+});
+
+describe('the English path was already whole, and stays whole', () => {
+  it.each([
+    ['then-chained', 'show #a then show #b'],
+    ['juxtaposed', 'show #a show #b'],
+  ])('%s', async (_label, code) => {
+    const result = await hyperscript.compile(code, { language: 'en' });
+
+    expect(result.ok).toBe(true);
+    expect(commandCount(result.ast)).toBe(2);
+  });
+});

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1031,6 +1031,61 @@ export class SemanticParserImpl implements ISemanticParser {
           return withDiagnostics(result, diagnostics);
         }
       }
+      // Top-level command SEQUENCE guard: `parseInternal` has no program layer for
+      // plain commands, so a sequence is truncated to its first command at top
+      // level while parsing correctly INSIDE any block:
+      //
+      //   add .a to #x then add .b to #y   handler: [on, add, add]   top: [add]
+      //   bind $n to #a bind $n to #b      handler: [on, bind, bind] top: [bind]
+      //
+      // Stage 2 matches the first command and returns; the rest is dropped, and
+      // the `unconsumed-input` diagnostic below is the only trace. Stage 4
+      // (tryCompoundCommandParsing) can't help: it is only reached when Stage 2
+      // finds NO match, and it requires a `then`/`else` keyword — but the English
+      // form is JUXTAPOSED (only the translations insert a conjunction), so a
+      // then-only fix would pass 23 languages and fail English. tryParseProgram
+      // (Stage 0.5) bails unless every segment is an event-handler, by design.
+      //
+      // parseBodyWithClauses already handles both the then-chained and the
+      // juxtaposed form — that is precisely why the same input parses inside a
+      // handler. Route to it. Additive by the same discipline as every other
+      // guard in this stage: it returns null unless the remainder genuinely
+      // parses into a second command, so a real single command with an
+      // unparseable tail (`set x to 5 +`, `fetch /api with { … }`) is byte-
+      // identical to before and still reports `unconsumed-input`.
+      //
+      // Deliberately placed AFTER the SOV trailing-event guard above. A
+      // multi-command SOV body with a fused trailing event
+      // (`.active を 切り替え それから .b を 削除 クリック で`) parses here as a bare
+      // two-command sequence, silently dropping the `on click` wrapper; the SOV
+      // guard must claim it first. (The single-command SOV case does not
+      // distinguish the two orderings — the >1 gate below is false either way.)
+      //
+      // Excluded for BLOCK_BODY_ACTIONS. A block command's body legitimately
+      // trails its flat pattern match — `repeat 3 times toggle .x end` leaves
+      // `toggle .x end` unconsumed — and the clause parser reads that body as a
+      // SIBLING clause, yielding `compound[repeat, toggle]`: a loop with no body
+      // beside a stray toggle. That is a worse parse, not a better one. Whether
+      // the body should instead NEST into the block is a separate, pre-existing
+      // defect of the same family as the feature blocks fixed in #628/#629; it
+      // still reports `unconsumed-input` below, so it stays visible rather than
+      // being papered over by a flatten.
+      if (
+        commandMatch.consumedTokens < tokens.tokens.length &&
+        !BLOCK_BODY_ACTIONS.has(commandMatch.pattern.command)
+      ) {
+        const sequence = this.tryTopLevelCommandSequence(tokens, commandPatterns, language);
+        if (sequence) {
+          diagnostics.push(
+            parseDiagnostic(
+              `top-level command sequence: ${sequence.statements.length} commands`,
+              'info',
+              'stage-top-level-sequence'
+            )
+          );
+          return withDiagnostics(sequence, diagnostics);
+        }
+      }
       diagnostics.push(
         parseDiagnostic(
           `command pattern matched: ${commandMatch.pattern.id} (confidence: ${commandMatch.confidence.toFixed(2)})`,
@@ -2121,6 +2176,56 @@ export class SemanticParserImpl implements ISemanticParser {
     }
 
     return clauses;
+  }
+
+  /**
+   * Re-parse a Stage-2 input that left a trailing remainder as a top-level
+   * command SEQUENCE (`add .a to #x then add .b to #y`, `bind $n to #a bind $n
+   * to #b`). Returns the compound node, or null to fall through to the
+   * single-command path unchanged.
+   *
+   * Returns null unless the clause parser recovers **more than one** command —
+   * that is the whole additive guarantee. A single command with an unparseable
+   * tail yields one clause and falls through, so it still builds exactly as
+   * before and still reports `unconsumed-input`.
+   *
+   * The stream is rebuilt from scratch: Stage 2's stream has already been
+   * advanced past the first command by `matchBest`. Mirrors
+   * {@link tryCompoundCommandParsing}, which does the same for its own re-parse.
+   */
+  private tryTopLevelCommandSequence(
+    tokens: ReturnType<typeof tokenizeInternal>,
+    commandPatterns: LanguagePattern[],
+    language: string
+  ): CompoundSemanticNode | null {
+    let body: SemanticNode[];
+    try {
+      const freshStream = new TokenStreamImpl(tokens.tokens as LanguageToken[], language);
+      body = this.parseBodyWithClauses(freshStream, commandPatterns, language);
+    } catch {
+      return null;
+    }
+
+    // parseBodyWithClauses returns `[compound]` for >1 clause, else the clauses
+    // themselves (0 or 1). Anything but the compound means there was no sequence.
+    if (body.length !== 1 || body[0].kind !== 'compound') return null;
+    const compound = body[0] as CompoundSemanticNode;
+    if (compound.statements.length < 2) return null;
+
+    // Carry a real confidence. `parseWithConfidence` reads
+    // `node.metadata?.confidence ?? 0.8`, and createCompoundNode sets none — so
+    // without this a faithful two-command sequence would report 0.8 and could
+    // fall under the bridge's 0.5 threshold once a weak clause pulls the mean
+    // down. Set it HERE rather than inside parseBodyWithClauses: that call is
+    // shared with event-handler / `def` / behavior bodies, whose own confidence
+    // is computed separately over the flattened statements.
+    const confidences = compound.statements.map(s => s.metadata?.confidence ?? 0.75);
+    const confidence = confidences.reduce((a, b) => a + b, 0) / confidences.length;
+
+    return createCompoundNode(compound.statements, compound.chainType, {
+      sourceLanguage: language,
+      confidence,
+    });
   }
 
   /**
@@ -3241,14 +3346,10 @@ export class SemanticParserImpl implements ISemanticParser {
 
     if (body.length === 0) return null;
 
-    // Return the compound node (or single command if only one clause parsed)
-    if (body.length === 1) {
-      return body[0];
-    }
-    return createCompoundNode(body, 'then', {
-      sourceLanguage: language,
-      confidence: 0.65,
-    });
+    // Always a single element: parseBodyWithClauses wraps >1 clause into ONE
+    // compound and otherwise returns the lone clause. (A `createCompoundNode`
+    // re-wrap used to sit here for a `body.length > 1` case that cannot occur.)
+    return body[0];
   }
 
   // ==========================================================================

--- a/packages/semantic/test/bind-command.test.ts
+++ b/packages/semantic/test/bind-command.test.ts
@@ -42,17 +42,19 @@ describe('bind command', () => {
   });
 
   it('parses a then-chain of two binds into a compound', () => {
+    // Was written to tolerate a single-command fallback, and read `.commands`
+    // (a CompoundSemanticNode exposes `.statements`) — so it passed vacuously
+    // while the parser dropped the second bind, and would have thrown the
+    // moment it stopped. Assert the sequence unconditionally.
     const node = parse('bind :name to #input-a then bind :name to #input-b', 'en') as
       | CompoundSemanticNode
       | CommandSemanticNode;
 
-    if (node.kind === 'compound') {
-      const actions = node.commands.map(c => (c as CommandSemanticNode).action);
-      expect(actions).toEqual(['bind', 'bind']);
-    } else {
-      // Single-clause fallback still yields a bind command.
-      expect((node as CommandSemanticNode).action).toBe('bind');
-    }
+    expect(node.kind).toBe('compound');
+    const actions = (node as CompoundSemanticNode).statements.map(
+      c => (c as CommandSemanticNode).action
+    );
+    expect(actions).toEqual(['bind', 'bind']);
   });
 
   it('canParse reports true for a basic bind', () => {

--- a/packages/semantic/test/top-level-command-sequence.test.ts
+++ b/packages/semantic/test/top-level-command-sequence.test.ts
@@ -1,0 +1,195 @@
+/**
+ * A top-level command SEQUENCE parses to every command, not just the first.
+ *
+ * These tests deliberately do NOT assert "does it parse". It always parsed, at
+ * confidence 1.0 — `parseInternal` had no program layer for plain commands, so
+ * Stage 2 matched the first command and returned, dropping the rest in silence:
+ *
+ *                                     inside a handler        top level
+ *   add .a to #x then add .b to #y    [on, add, add]  ✓       [add]       ✗
+ *   bind $n to #a bind $n to #b       [on, bind, bind] ✓      [bind]      ✗
+ *
+ * They assert on the captured command list, on the lowered AST, and on the
+ * derived confidence.
+ *
+ * Note the English corpus form is JUXTAPOSED (`bind … bind …`); only the
+ * translations insert a conjunction (es `entonces`, fr `alors`). A then-only fix
+ * would pass 23 languages and fail English, so both forms are covered here.
+ *
+ * This drop was invisible to the multilingual fidelity ratchet: every language
+ * dropped the second `bind` identically, so the action signatures agreed and the
+ * row scored fidelity 1.0. `collectActions` is a Set, so `[bind, bind]` and
+ * `[bind]` are indistinguishable to R0-recall and R1 alike. The per-language
+ * coverage below is the proof the ratchet could not give.
+ */
+import { describe, it, expect } from 'vitest';
+import { parse, parseSemantic, buildAST } from '../src';
+import type { CommandSemanticNode, CompoundSemanticNode, SemanticNode } from '../src/types';
+
+/** Flatten every command action in a parsed tree (mirrors fidelity.ts CHILD_FIELDS). */
+function actionsOf(node: unknown, depth = 0): string[] {
+  if (!node || typeof node !== 'object' || depth > 32) return [];
+  const rec = node as Record<string, unknown>;
+  const out: string[] = [];
+  if (typeof rec.action === 'string' && rec.action !== 'compound') out.push(rec.action);
+  for (const field of [
+    'body',
+    'statements',
+    'thenBranch',
+    'elseBranch',
+    'eventHandlers',
+  ] as const) {
+    const child = rec[field];
+    if (Array.isArray(child)) for (const c of child) out.push(...actionsOf(c, depth + 1));
+    else if (child && typeof child === 'object') out.push(...actionsOf(child, depth + 1));
+  }
+  return out;
+}
+
+function hasUnconsumedInput(node: SemanticNode): boolean {
+  return (node.diagnostics ?? []).some(d => d.code === 'unconsumed-input');
+}
+
+describe('top-level command sequence: every command is captured', () => {
+  it('splits a then-chained sequence (was truncated to the first command)', () => {
+    const node = parse('add .a to #x then add .b to #y', 'en') as CompoundSemanticNode;
+
+    expect(node.kind).toBe('compound');
+    expect(node.statements.map(s => (s as CommandSemanticNode).action)).toEqual(['add', 'add']);
+    expect(hasUnconsumedInput(node)).toBe(false);
+  });
+
+  it('splits a JUXTAPOSED sequence — the English corpus form, which has no `then`', () => {
+    const node = parse(
+      'bind $name to #input-a bind $name to #input-b',
+      'en'
+    ) as CompoundSemanticNode;
+
+    expect(node.kind).toBe('compound');
+    expect(node.statements.map(s => (s as CommandSemanticNode).action)).toEqual(['bind', 'bind']);
+    expect(hasUnconsumedInput(node)).toBe(false);
+  });
+
+  it('carries a real confidence, not the `?? 0.8` default for a metadata-less compound', () => {
+    // createCompoundNode sets no confidence; parseWithConfidence falls back to 0.8.
+    // The guard sets the mean of its clauses, so a clean two-command sequence is 1.0.
+    const result = parseSemantic('add .a to #x then add .b to #y', 'en');
+
+    expect(result.node?.kind).toBe('compound');
+    expect(result.confidence).toBe(1);
+  });
+});
+
+describe('top-level command sequence: AST lowering', () => {
+  it('lowers to a CommandSequence, never a Program', () => {
+    const { ast } = buildAST(parse('add .a to #x then add .b to #y', 'en')) as {
+      ast: { type: string; commands?: unknown[] };
+    };
+
+    expect(ast.type).toBe('CommandSequence');
+    expect(ast.commands).toHaveLength(2);
+  });
+
+  it('a multi-handler program is still a Program', () => {
+    const { ast } = buildAST(parse('on click toggle .a end on keyup toggle .b end', 'en')) as {
+      ast: { type: string };
+    };
+
+    expect(ast.type).toBe('Program');
+  });
+});
+
+/**
+ * The 24 corpus translations of `bind-two-way`, inlined: `@hyperfixi/patterns-reference`
+ * depends on this package, so importing it here would be a dependency cycle. The
+ * DB-driven equivalent is the `multilingual-validation` sweep.
+ *
+ * Every language must capture BOTH binds. Before this fix each dropped one
+ * identically, which is exactly why the ratchet read the row as faithful.
+ */
+const BIND_TWO_WAY: Array<[language: string, code: string]> = [
+  ['ar', 'اربط $name إلى #input-a ثم اربط $name إلى #input-b'],
+  ['bn', '$name কে #input-a তে বাইন্ড তারপর $name কে #input-b তে বাইন্ড'],
+  ['de', 'bind $name zu #input-a dann bind $name zu #input-b'],
+  ['en', 'bind $name to #input-a bind $name to #input-b'],
+  ['es', 'bind $name a #input-a entonces bind $name a #input-b'],
+  ['fr', 'bind $name à #input-a alors bind $name à #input-b'],
+  ['he', 'קשור $name ל #input-a אז קשור $name ל #input-b'],
+  ['hi', '$name को #input-a में bind फिर $name को #input-b में bind'],
+  ['id', 'bind $name ke #input-a lalu bind $name ke #input-b'],
+  ['it', 'bind $name in #input-a allora bind $name in #input-b'],
+  ['ja', '$name を #input-a に バインド それから $name を #input-b に バインド'],
+  ['ko', '$name 를 #input-a 에 바인드 그러면 $name 를 #input-b 에 바인드'],
+  ['ms', 'bind $name ke #input-a kemudian bind $name ke #input-b'],
+  ['pl', 'bind $name do #input-a wtedy bind $name do #input-b'],
+  ['pt', 'bind $name para #input-a então bind $name para #input-b'],
+  ['qu', '$name ta #input-a man bind chayqa $name ta #input-b man bind'],
+  ['ru', 'bind $name в #input-a затем bind $name в #input-b'],
+  ['sw', 'bind $name kwa #input-a kisha bind $name kwa #input-b'],
+  ['th', 'bind $name ใน #input-a แล้ว bind $name ใน #input-b'],
+  ['tl', 'bind $name sa #input-a pagkatapos bind $name sa #input-b'],
+  ['tr', '$name i #input-a e bind ardından $name i #input-b e bind'],
+  ['uk', 'bind $name в #input-a тоді bind $name в #input-b'],
+  ['vi', 'bind $name vào #input-a rồi bind $name vào #input-b'],
+  ['zh', '绑定 $name 到 #input-a 那么 绑定 $name 到 #input-b'],
+];
+
+describe('top-level command sequence: all 24 languages (bind-two-way)', () => {
+  it.each(BIND_TWO_WAY)('%s captures both binds', (lang, code) => {
+    const node = parse(code, lang);
+
+    expect(node.kind).toBe('compound');
+    expect(actionsOf(node)).toEqual(['bind', 'bind']);
+    expect(hasUnconsumedInput(node)).toBe(false);
+  });
+});
+
+describe('top-level command sequence: the guard is additive', () => {
+  it('leaves a genuine single command untouched', () => {
+    const node = parse('toggle .active', 'en');
+
+    expect(node.kind).toBe('command');
+    expect((node as CommandSemanticNode).action).toBe('toggle');
+  });
+
+  it('leaves a single command whose tail is NOT a command untouched, and still warns', () => {
+    // The remainder must parse into a second command for the guard to fire.
+    const node = parse('set x to 5 +', 'en');
+
+    expect(node.kind).toBe('command');
+    expect(actionsOf(node)).toEqual(['set']);
+    expect(hasUnconsumedInput(node)).toBe(true);
+  });
+
+  it('does not flatten a block body into a sibling clause', () => {
+    // `repeat 3 times toggle .x end` leaves `toggle .x end` unconsumed. The clause
+    // parser would read it as a SIBLING (`compound[repeat, toggle]` — a loop with
+    // no body). BLOCK_BODY_ACTIONS is excluded from the guard, so the pre-existing
+    // body-drop stays visible via `unconsumed-input` rather than being flattened.
+    const node = parse('repeat 3 times toggle .x end', 'en');
+
+    expect(node.kind).toBe('command');
+    expect((node as CommandSemanticNode).action).toBe('repeat');
+    expect(hasUnconsumedInput(node)).toBe(true);
+  });
+
+  it('does not change a sequence nested inside an event handler', () => {
+    const node = parse('on click add .a to #x then add .b to #y', 'en');
+
+    expect(node.kind).toBe('event-handler');
+    expect(actionsOf(node)).toEqual(['on', 'add', 'add']);
+  });
+});
+
+describe('top-level command sequence: the SOV trailing-event guard still wins', () => {
+  it('keeps the `on click` wrapper on a multi-command SOV body with a fused trailing event', () => {
+    // `.active を 切り替え それから .b を 削除 クリック で` = "on click: toggle .active
+    // then remove .b". parseBodyWithClauses alone yields compound[toggle, remove]
+    // and loses the handler, so the SOV guard must claim this input first. This
+    // is the input that pins the guard ORDER inside Stage 2.
+    const node = parse('.active を 切り替え それから .b を 削除 クリック で', 'ja');
+
+    expect(node.kind).toBe('event-handler');
+    expect(actionsOf(node)).toEqual(['on', 'toggle', 'remove']);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-10T08:19:02.397Z",
-  "commit": "d6296e77",
+  "timestamp": "2026-07-10T08:34:34.505Z",
+  "commit": "e007ff48",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -9,12 +9,13 @@
       "avgConfidence": 0.8394563407500147,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9907407407407408,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -641,12 +642,13 @@
       "avgConfidence": 0.8579007041413049,
       "avgFidelity": 1,
       "avgPrecision": 0.9989716846334493,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.972004357298475,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1273,12 +1275,13 @@
       "avgConfidence": 0.8261801690373097,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9870837223778401,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1903,7 +1906,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2530,12 +2533,13 @@
       "avgConfidence": 0.8319521748093155,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9923747276688454,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3162,12 +3166,13 @@
       "avgConfidence": 0.8228818800247351,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9870837223778401,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3794,12 +3799,13 @@
       "avgConfidence": 0.8295609152752009,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9907407407407406,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4426,12 +4432,13 @@
       "avgConfidence": 0.9077564039970039,
       "avgFidelity": 1,
       "avgPrecision": 0.9978354978354977,
+      "avgMultisetRecall": 0.9993444055944055,
       "avgRoleFidelity": 0.9627450980392157,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5058,12 +5065,13 @@
       "avgConfidence": 0.8371057513914636,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9894179894179896,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5690,12 +5698,13 @@
       "avgConfidence": 0.8346320346320326,
       "avgFidelity": 1,
       "avgPrecision": 0.997835497835498,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9930750077808902,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6322,12 +6331,13 @@
       "avgConfidence": 0.8500157319706186,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 0.9993444055944055,
       "avgRoleFidelity": 0.972004357298475,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6954,12 +6964,13 @@
       "avgConfidence": 0.8449652269201134,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 0.9993444055944055,
       "avgRoleFidelity": 0.9687363834422658,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7586,12 +7597,13 @@
       "avgConfidence": 0.8358688930117478,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 0.9993444055944055,
       "avgRoleFidelity": 0.9847494553376908,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8218,12 +8230,13 @@
       "avgConfidence": 0.8064728921871758,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9841425459072518,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8850,12 +8863,13 @@
       "avgConfidence": 0.7977324263038529,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9923747276688454,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9482,12 +9496,13 @@
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 0.9988449050949051,
       "avgRoleFidelity": 0.953034547152194,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10114,12 +10129,13 @@
       "avgConfidence": 0.8174809317666439,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9863834422657953,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10746,12 +10762,13 @@
       "avgConfidence": 0.8001649144506268,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9923747276688454,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11378,12 +11395,13 @@
       "avgConfidence": 0.8390022675736938,
       "avgFidelity": 1,
       "avgPrecision": 0.9978354978354977,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9845315904139433,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12010,12 +12028,13 @@
       "avgConfidence": 0.8239183073548376,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9907407407407408,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12642,12 +12661,13 @@
       "avgConfidence": 0.8489025594288746,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9716198897859796,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13274,12 +13294,13 @@
       "avgConfidence": 0.8178932178932158,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9863834422657953,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13906,12 +13927,13 @@
       "avgConfidence": 0.8042465471036879,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9883442265795209,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14538,12 +14560,13 @@
       "avgConfidence": 0.9840032982890127,
       "avgFidelity": 1,
       "avgPrecision": 1,
+      "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9872393401805166,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 494031,
+      "bundleSize": 494587,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15166,7 +15189,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 494031,
+      "size": 494587,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/src/multilingual/cli.ts
+++ b/packages/testing-framework/src/multilingual/cli.ts
@@ -417,6 +417,19 @@ async function main(): Promise<void> {
           r => r.avgPrecisionDelta < -AVG_PRECISION_DROP_TOLERANCE
         );
 
+        // R0-recall-multiset ratchet: the mirror of the precision ratchet. Every
+        // signal above is computed on a deduped SET, so a parse that drops a
+        // REPEATED command scores a perfect 1.0 — reference `[bind, bind]`
+        // collapses to `{bind}`, which `[bind]` satisfies in full. That is exactly
+        // how `bind-two-way` recorded fidelity 1.0 in all 24 languages while every
+        // one of them parsed only the first of its two binds. Counting duplicates
+        // makes the drop visible. Deltas are 0 unless the baseline carries
+        // avgMultisetRecall, so an un-regenerated baseline never retro-flags.
+        const AVG_MULTISET_RECALL_DROP_TOLERANCE = 0.02;
+        const multisetRecallDrops = allResults.filter(
+          r => r.avgMultisetRecallDelta < -AVG_MULTISET_RECALL_DROP_TOLERANCE
+        );
+
         // R1 — role-fidelity ratchet (§8): same semantics as the avgFidelity
         // ratchet, on the role-recall signal (action.role:valueType vs the en
         // reference). Deltas are 0 unless the baseline carries avgRoleFidelity,
@@ -515,6 +528,21 @@ async function main(): Promise<void> {
           failed = true;
         }
 
+        if (multisetRecallDrops.length > 0) {
+          console.error(
+            `\n✗ avgMultisetRecall dropped > ${AVG_MULTISET_RECALL_DROP_TOLERANCE} in ` +
+              `${multisetRecallDrops.length} language(s) — a parse started dropping a ` +
+              `REPEATED command (invisible to the Set-based fidelity/roleFidelity):`
+          );
+          for (const r of multisetRecallDrops) {
+            console.error(
+              `   ${r.language}: ΔavgMultisetRecall ${r.avgMultisetRecallDelta.toFixed(4)}`
+            );
+          }
+          console.error(`   (if intentional, regenerate the baseline with --save-baseline)`);
+          failed = true;
+        }
+
         if (roleFidelityDrops.length > 0) {
           console.error(
             `\n✗ avgRoleFidelity dropped > ${AVG_ROLE_FIDELITY_DROP_TOLERANCE} in ` +
@@ -547,7 +575,8 @@ async function main(): Promise<void> {
         } else {
           console.log(
             `\n✓ No regression vs baseline ` +
-              `(parse-rate ${REGRESSION_TOLERANCE_PTS}pts, fidelity + correctness + execution ratchets).`
+              `(parse-rate ${REGRESSION_TOLERANCE_PTS}pts, fidelity + correctness + ` +
+              `precision + multiset-recall + role + execution ratchets).`
           );
           exitCode = 0;
         }

--- a/packages/testing-framework/src/multilingual/fidelity.test.ts
+++ b/packages/testing-framework/src/multilingual/fidelity.test.ts
@@ -3,6 +3,7 @@ import {
   collectActions,
   collectActionsMultiset,
   computeFidelity,
+  computeMultisetRecall,
   computePrecision,
   spuriousActions,
   FIDELITY_THRESHOLD,
@@ -118,6 +119,41 @@ describe('computePrecision', () => {
     expect(computePrecision(['on'], [])).toBeUndefined();
   });
 });
+
+describe('computeMultisetRecall', () => {
+  it('catches the dropped duplicate that Set-based recall is blind to', () => {
+    // The `bind-two-way` shape. EN `bind $n to #a bind $n to #b` is [bind, bind];
+    // a parse that truncates to the first command yields [bind]. Every Set-based
+    // signal reads this as perfect — which is why the row recorded fidelity 1.0
+    // across all 24 languages while every one of them dropped half its body.
+    const en = ['bind', 'bind'];
+    const truncated = ['bind'];
+
+    expect(computeFidelity(collectSet(en), collectSet(truncated))).toBe(1); // recall is fooled
+    expect(computePrecision(en, truncated)).toBe(1); // precision is fooled too
+    expect(computeMultisetRecall(en, truncated)).toBe(0.5); // this is not
+  });
+
+  it('scores a faithful (reordered) parse 1.0', () => {
+    expect(computeMultisetRecall(['bind', 'bind'], ['bind', 'bind'])).toBe(1);
+    expect(computeMultisetRecall(['add', 'on', 'remove'], ['on', 'remove', 'add'])).toBe(1);
+  });
+
+  it('is not fooled by an added duplicate (that is precision’s job)', () => {
+    // A candidate with a phantom extra still has full recall; precision catches it.
+    expect(computeMultisetRecall(['bind'], ['bind', 'bind'])).toBe(1);
+    expect(computePrecision(['bind'], ['bind', 'bind'])).toBe(0.5);
+  });
+
+  it('returns undefined when there is no reference to score against', () => {
+    expect(computeMultisetRecall([], ['bind'])).toBeUndefined();
+  });
+});
+
+/** The deduped Set signature `collectActions` produces, from a multiset. */
+function collectSet(actions: readonly string[]): string[] {
+  return [...new Set(actions)].sort();
+}
 
 describe('spuriousActions', () => {
   it('lists the hallucinated commands a render/parse introduced', () => {

--- a/packages/testing-framework/src/multilingual/fidelity.ts
+++ b/packages/testing-framework/src/multilingual/fidelity.ts
@@ -122,6 +122,39 @@ export function computeFidelity(
 }
 
 /**
+ * R0-recall on the **multiset** in [0, 1]: the fraction of the reference's
+ * actions — counting duplicates — also present in the candidate.
+ *
+ * {@link computeFidelity} scores the deduped Set signature, so a candidate that
+ * drops a REPEATED command scores 1.0: reference `[bind, bind]` collapses to
+ * `{bind}`, which `[bind]` satisfies in full. That is how `bind-two-way` sat at
+ * fidelity 1.0 across all 24 languages while every one of them parsed only the
+ * first of its two `bind`s. R1 (role signatures) is a Set too, and is equally
+ * blind. {@link computePrecision} catches the mirror case — a candidate that ADDS
+ * a duplicate — so before this signal existed the ratchet saw spurious commands
+ * but never dropped ones.
+ *
+ * Pass multisets (see {@link collectActionsMultiset}) on both sides.
+ * Returns `undefined` when the reference has no actions to compare against.
+ */
+export function computeMultisetRecall(
+  reference: readonly string[],
+  candidate: readonly string[]
+): number | undefined {
+  if (reference.length === 0) return undefined;
+  const cand = actionCounts(candidate);
+  let matched = 0;
+  for (const a of reference) {
+    const remaining = cand.get(a) ?? 0;
+    if (remaining > 0) {
+      matched++;
+      cand.set(a, remaining - 1);
+    }
+  }
+  return matched / reference.length;
+}
+
+/**
  * Structural **precision** in [0, 1]: the fraction of the *candidate's* actions
  * that are justified by the reference (multiset-aware). The complement of
  * {@link computeFidelity}'s recall — it falls below 1.0 when a parse/render adds

--- a/packages/testing-framework/src/multilingual/orchestrator.ts
+++ b/packages/testing-framework/src/multilingual/orchestrator.ts
@@ -20,7 +20,12 @@ import type {
   Reporter,
   BundleInfo,
 } from './types';
-import { computeFidelity, computePrecision, FIDELITY_THRESHOLD } from './fidelity';
+import {
+  computeFidelity,
+  computePrecision,
+  computeMultisetRecall,
+  FIDELITY_THRESHOLD,
+} from './fidelity';
 
 const execAsync = promisify(exec);
 
@@ -277,6 +282,7 @@ export class TestOrchestrator {
       const lossy: string[] = [];
       const scores: number[] = [];
       const precisionScores: number[] = [];
+      const multisetRecallScores: number[] = [];
       const roleScores: number[] = [];
 
       for (const result of lang.parseResults) {
@@ -294,12 +300,20 @@ export class TestOrchestrator {
 
         // R0-precision — fraction of THIS parse's actions justified by the en
         // multiset reference (catches phantom/spurious commands recall misses).
+        // R0-recall-multiset — the mirror: fraction of the en reference's actions,
+        // counting duplicates, present here (catches a DROPPED repeated command,
+        // which the Set-based fidelity/roleFidelity above cannot see).
         const multisetRef = multisetReference.get(result.pattern.codeExampleId);
         if (multisetRef && result.actionMultisetSignature) {
           const precision = computePrecision(multisetRef, result.actionMultisetSignature);
           if (precision !== undefined) {
             result.precision = precision;
             precisionScores.push(precision);
+          }
+          const multisetRecall = computeMultisetRecall(multisetRef, result.actionMultisetSignature);
+          if (multisetRecall !== undefined) {
+            result.multisetRecall = multisetRecall;
+            multisetRecallScores.push(multisetRecall);
           }
         }
 
@@ -319,6 +333,10 @@ export class TestOrchestrator {
       lang.avgPrecision =
         precisionScores.length > 0
           ? precisionScores.reduce((a, b) => a + b, 0) / precisionScores.length
+          : undefined;
+      lang.avgMultisetRecall =
+        multisetRecallScores.length > 0
+          ? multisetRecallScores.reduce((a, b) => a + b, 0) / multisetRecallScores.length
           : undefined;
       lang.avgRoleFidelity =
         roleScores.length > 0

--- a/packages/testing-framework/src/multilingual/reporters/regression-reporter.ts
+++ b/packages/testing-framework/src/multilingual/reporters/regression-reporter.ts
@@ -118,6 +118,12 @@ export class RegressionReporter implements Reporter {
         langResult.avgPrecision !== undefined && baselineLang.avgPrecision !== undefined
           ? langResult.avgPrecision - baselineLang.avgPrecision
           : 0;
+      // R0-recall-multiset — same both-sides guard. Negative = a repeated command
+      // is now being dropped, which avgFidelity (a Set) cannot see.
+      const avgMultisetRecallDelta =
+        langResult.avgMultisetRecall !== undefined && baselineLang.avgMultisetRecall !== undefined
+          ? langResult.avgMultisetRecall - baselineLang.avgMultisetRecall
+          : 0;
       // R1 — only meaningful when BOTH sides carry role data; an un-regenerated
       // baseline (no avgRoleFidelity yet) must never retro-flag.
       const avgRoleFidelityDelta =
@@ -163,6 +169,7 @@ export class RegressionReporter implements Reporter {
         avgConfidenceDelta,
         avgFidelityDelta,
         avgPrecisionDelta,
+        avgMultisetRecallDelta,
         avgRoleFidelityDelta,
         avgExecutionFidelityDelta,
         bundleSizeDelta: bundleSizeDelta !== undefined ? bundleSizeDelta : undefined,
@@ -364,6 +371,10 @@ export class RegressionReporter implements Reporter {
         // R0-precision — fraction of each parse's actions justified by the en
         // reference (phantom-command signal recall can't see). Recorded + ratcheted.
         avgPrecision: langResult.avgPrecision ?? undefined,
+        // R0-recall-multiset — the mirror of precision: a DROPPED repeated command
+        // (`[bind, bind]` parsed as `[bind]`) is invisible to the Set-based
+        // avgFidelity and avgRoleFidelity. Recorded + ratcheted.
+        avgMultisetRecall: langResult.avgMultisetRecall ?? undefined,
         // R1 — role fidelity (role name + value type vs the en reference).
         // Recorded + ratcheted; burn-down is NOT part of the parsing-track goal.
         avgRoleFidelity: langResult.avgRoleFidelity ?? undefined,

--- a/packages/testing-framework/src/multilingual/types.ts
+++ b/packages/testing-framework/src/multilingual/types.ts
@@ -164,6 +164,15 @@ export interface ParseResult {
   precision?: number;
 
   /**
+   * R0-recall on the MULTISET vs the English reference, in [0, 1]. `fidelity`
+   * above scores the deduped Set, so a parse that drops a REPEATED command
+   * (`[bind, bind]` → `[bind]`) still scores 1.0. This counts duplicates, and is
+   * the mirror of `precision`: together they see both a dropped and an added
+   * copy of a command. `undefined` when there is no usable English reference.
+   */
+  multisetRecall?: number;
+
+  /**
    * R1 — role fidelity vs the English reference, in [0, 1]: the fraction of the
    * English parse's role-signature entries also present here. Catches a parse
    * that finds the right commands with the WRONG roles (swapped
@@ -210,6 +219,14 @@ export interface LanguageResults {
    * change started injecting phantom/spurious commands (invisible to recall).
    */
   avgPrecision?: number | undefined;
+
+  /**
+   * R0-recall-multiset — mean `multisetRecall` over successful parses with an
+   * English reference. Recorded + ratcheted alongside avgFidelity: a drop means a
+   * parser change started dropping a REPEATED command, which the Set-based
+   * avgFidelity and avgRoleFidelity cannot see.
+   */
+  avgMultisetRecall?: number | undefined;
 
   /**
    * R1 — mean `roleFidelity` over successful parses with an English reference.
@@ -304,6 +321,8 @@ export interface Baseline {
         avgFidelity?: number | undefined;
         /** R0-precision — mean precision vs the English reference (see ParseResult.precision). */
         avgPrecision?: number | undefined;
+        /** R0-recall-multiset — mean multisetRecall vs the English reference (see ParseResult.multisetRecall). */
+        avgMultisetRecall?: number | undefined;
         /** R1 — mean role fidelity vs the English reference (see ParseResult.roleFidelity). */
         avgRoleFidelity?: number | undefined;
         /** R2 — mean execution fidelity over the curated execution subset (see LanguageResults.avgExecutionFidelity). */
@@ -341,6 +360,8 @@ export interface RegressionResult {
   avgFidelityDelta: number;
   /** R0-precision — absolute change in avgPrecision (current − baseline). 0 when either side lacks data. Negative = phantom commands introduced. */
   avgPrecisionDelta: number;
+  /** R0-recall-multiset — absolute change in avgMultisetRecall (current − baseline). 0 when either side lacks data. Negative = a repeated command is being dropped. */
+  avgMultisetRecallDelta: number;
   /** R1 — absolute change in avgRoleFidelity (current − baseline). 0 when either side lacks data. */
   avgRoleFidelityDelta: number;
   /** R2 — absolute change in avgExecutionFidelity (current − baseline). 0 when either side lacks data. */


### PR DESCRIPTION
> **Stacked on #630.** Base is `fix/bind-possessive-source`; retarget to `main` once that merges. Together they take `--diagnose-coverage` from 38 firings to **0**.

A command sequence parsed correctly **inside** any block and was truncated to its first command at **top level**:

```
                                 inside a handler        top level
add .a to #x then add .b to #y   [on, add, add]  ✓       [add]     ✗
bind $n to #a bind $n to #b      [on, bind, bind] ✓      [bind]    ✗
```

`parseInternal` has no program layer for plain commands. Stage 2 matches the first command pattern and returns; the `unconsumed-input` diagnostic is the only trace.

## Why the existing stages miss it

- **Stage 4** (`tryCompoundCommandParsing`) only runs when Stage 2 finds *no* match, and it requires a `then`/`else` keyword — but the English corpus form is **juxtaposed** (`bind … bind …`; only the translations insert a conjunction). A then-only fix would pass 23 languages and fail English.
- **Stage 0.5** (`tryParseProgram`) bails unless every segment is an event-handler, by design (`multi-handler-program.test.ts` pins "a then-chain is a `CommandSequence`, never a `Program`").

`parseBodyWithClauses` already handles **both** forms — that is exactly why the same input parses inside a handler. Stage 2 now routes to it when the match leaves a remainder, returning the compound **only** when the clause parser recovers more than one command.

## Two exclusions, both load-bearing

**Placed after the SOV trailing-event guard.** `.active を 切り替え それから .b を 削除 クリック で` ("on click: toggle .active then remove .b") parses through `parseBodyWithClauses` as a bare `compound[toggle, remove]`, dropping the handler wrapper. Verified the guard *would* fire on it; only the earlier SOV guard prevents the drop.

**Skipped for `BLOCK_BODY_ACTIONS`.** A block's body legitimately trails its flat pattern match (`repeat 3 times toggle .x end` leaves `toggle .x end` unconsumed), and the clause parser reads that body as a **sibling** — `compound[repeat, toggle]`, a loop with no body beside a stray toggle. That body-drop is a separate pre-existing defect of the #628/#629 family; it stays visible via `unconsumed-input` rather than being papered over by a flatten. *(Caught by two existing tests during development.)*

## Additive by construction

A single command whose tail is not a command (`set x to 5 +`, `fetch … with { … }`) yields one clause, falls through, and still reports `unconsumed-input` — byte-identical to before.

## Confidence

`createCompoundNode` sets none and `parseWithConfidence` falls back to `?? 0.8`, so the sequence gets the **mean of its clauses** — set on the returned node, not inside the shared `parseBodyWithClauses`, whose compound is also built for event-handler / `def` / behavior bodies. Also drops the **unreachable** `confidence: 0.65` re-wrap in `tryCompoundCommandParsing` (`parseBodyWithClauses` returns at most one element, so its `body.length > 1` branch cannot run).

## The exposure is the multilingual path

Measured on the pre-fix parser:

```
es  alternar .a entonces alternar .b  ->  command          (1) + warning
en  show #a then show #b              ->  CommandSequence  (2)
```

English was shielded **by accident**: core's parser calls `skipToCommandBoundary()` after a semantic hit and resumes at the next command, so its own loop recovers what the semantic parser dropped. Only code consuming the semantic node directly — every non-English entry point (`hyperfixi.execute`, `translate`) — lost commands.

## This drop was invisible to the ratchet, so the ratchet grew an eye

`collectActions` returns a **deduped Set**. Reference `[bind, bind]` collapses to `{bind}`, which a truncated `[bind]` satisfies in full, so R0-recall scores 1.0. `computePrecision` is multiset-aware but only catches an **added** duplicate. R1's role signature is a Set too.

All three were blind, before *and* after — confirmed empirically: regenerating the baseline moved `avgFidelity`, `avgPrecision`, `avgRoleFidelity`, `avgExecutionFidelity` and `avgConfidence` by **exactly zero** in all 23 scored languages.

So this adds a **7th ratchet signal**, `avgMultisetRecall` — R0-recall on the action multiset, the mirror of precision. Both-sides guarded like the other five, so an un-regenerated baseline never retro-flags. **Proven to fail CI:** perturbing one language's baseline value exits 1 and names it; removing the field from another leaves it unflagged.

### It immediately paid for itself

It surfaced **ten rows** every prior signal scored 1.0 — `behavior-draggable` / `behavior-resizable` in hi/ja/ko/ms/qu (recall 0.88–0.96). hi/ja/ko/qu lose a `trigger`, ms loses a `measure`, qu also two `set`s.

One root cause: the **non-en tokenizers split a colon-qualified custom event name** (`draggable:start` → `draggable` + `:start`, the local-variable sigil), and the orphaned `:start` is re-consumed by the neighbouring clause. `ms` also silently corrupts the trigger **names** (all three become `draggable`) — a **value** bug no ratchet signal can see, since roles are compared by type, never by value.

Verified **pre-existing** (byte-identical before and after this change, all 24 languages). Baselined as-is so they cannot get worse; written up in `docs-internal/HANDOFF_colon-event-names.md` as its own arc.

**Caveat recorded in CLAUDE.md:** no recall-based signal can see a regression in the English *reference* itself. A parser change that truncates every language identically — precisely this bug — moves nothing. Only tests catch that.

## Measured

- **`--diagnose-coverage`: 24 → 0 firings** (0.0% of 3696). With #630's 14, the full 38 are accounted for.
- **`--regression` exits 0** on all seven ratchets.
- Baseline regenerated: no existing signal moved; `avgMultisetRecall` added.

## Tests

Assert on the captured command list, the lowered AST and the derived confidence — never on "does it parse". It always parsed, at confidence 1.0. **Verified failing without the fix: 29 assertions**, including all 24 `bind-two-way` translations.

`bind-command.test.ts` held a landmine: it read `node.commands` on a compound (the field is `.statements`) inside an `if (node.kind === 'compound')` whose `else` branch tolerated a single command. It passed **vacuously** while the parser dropped the second bind, and would have thrown `TypeError` the moment it stopped. Now asserts the sequence unconditionally.

Suites: semantic 6734 ✓ · core 7199 ✓ · testing-framework 201 ✓ · typechecks ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)