### PR TITLE
test(multilingual): add R3 invariant role-VALUE recall signal + bn trigger fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,7 +291,7 @@ the committed baseline:
 > not truth. Current plan + per-arc history:
 > `docs-internal/MULTILINGUAL_NEXT_STEPS.md`.
 
-The `--regression` gate ratchets on **seven** signals (each fails CI; each guarded so
+The `--regression` gate ratchets on **eight** signals (each fails CI; each guarded so
 an un-regenerated baseline never retro-flags — a baseline lacking a signal's field
 yields a 0 delta):
 
@@ -326,10 +326,29 @@ yields a 0 delta):
    blind spot for repeated roles.
 7. **execution ratchet (R2)** — a curated-subset pattern whose jsdom DOM effect
    matched the en reference and now diverges (pass→fail; tolerance 0).
+8. **value-recall ratchet (R3)** — a per-language **avgValueRecall** drop > 0.02.
+   Signals 1–7 compare actions and role _types_; values are never compared (they are
+   legitimately translated), so a parse with the right action counts and right role
+   types but a silently WRONG role value — ms capturing `trigger` events named
+   `draggable` instead of `draggable:start`, the colon-event-names class — scores
+   perfect on all of them. R3 compares the subset of values that is
+   **language-invariant by construction** (selectors, `:`/`$`/`^` sigil refs,
+   numbers/time literals, colon-qualified event names, URLs — whole-surface
+   code-shaped, no whitespace/interpolation) **verbatim** against the en reference,
+   as an `action.role=value` multiset (a dropped duplicate value is visible).
+   Blind-spot inversion: if the **en reference itself** corrupts a value, every
+   language flags at once — a 24-language R3 firestorm on one pattern means
+   "suspect the en parse first" (useful signal, unlike R0 where en corruption moves
+   nothing). Known sub-1.0 rows (all triaged, tracked in
+   `docs-internal/MULTILINGUAL_NEXT_STEPS.md` § "R3-discovered value-bug families"):
+   symmetric `swap` role-binding flips, connective-swallowed `increment.quantity`,
+   bn duration-glue, SOV `in me` qualifier glue, pl/ru/uk `fetch` URL mis-role,
+   hi `transition` duration drop, bn/qu/tr behavior trigger events.
 
 None of the recall-based signals can see a regression in the **English reference
 itself** — en defines the reference, so a parser change that truncates every language
 identically (as the top-level-sequence bug did) moves nothing. Only tests catch that.
+(Exception: R3, whose en-corruption failure mode is the all-languages firestorm above.)
 
 After an _intentional_ fidelity change, regenerate the baseline (`--save-baseline`).
 **The baseline must be regenerated against a freshly `populate`d patterns.db** — a

--- a/docs-internal/HANDOFF_role-value-audit.md
+++ b/docs-internal/HANDOFF_role-value-audit.md
@@ -1,0 +1,162 @@
+# Handoff: R3 role-VALUE audit — the signal class the harness structurally cannot see
+
+> **RESOLVED (2026-07-10).** Landed as designed: `collectRoleValueSignature` +
+> `avgValueRecall` ratchet (signal 8 in CLAUDE.md's list), baseline regenerated,
+> revert-validation proved the signal (reverted-#633 sweep flags the ms rows R0/R1
+> score perfect). The bn standalone-trigger side-quest also landed (trigger
+> `markerVariants` + flipped `it.fails`); it additionally healed bn's behavior
+> trigger-event values on the corpus. Sweep triage produced six live value-bug
+> families — see `MULTILINGUAL_NEXT_STEPS.md` § "R3-discovered value-bug families".
+> Kept for design rationale; the walker doc comment carries the same exclusions.
+>
+> **For a fresh session.** Read this, then CLAUDE.md ("Multilingual parse rate ≠
+> fidelity" + "Running the multilingual `--regression` gate locally"), then
+> `docs-internal/MULTILINGUAL_NEXT_STEPS.md` § "Colon-event-names follow-ups".
+> Branch from `main` **after PR #633 merges** — this signal only reads clean on top
+> of those fixes.
+
+## Why this is the next arc
+
+The colon-event-names arc (#633, `HANDOFF_colon-event-names.md`, resolved) proved a
+whole class of live defect no ratchet signal can see: **right action counts, right
+role types, wrong role VALUE**. ms captured `trigger` events named `draggable`
+instead of `draggable:start` — correct action multiset, correct
+`trigger.event:literal` signature, silently wrong runtime behavior. It surfaced only
+via a side-effect (a swallowed `measure`), and 18 other languages had the same value
+corruption with *no* side-effect, i.e. **zero signal**. Every existing ratchet
+compares actions and role *types* — values are legitimately translated, so they were
+never compared cross-language.
+
+The insight that makes R3 feasible: a large subset of role values is
+**language-invariant by construction** — code, not prose. Selectors (`.active`,
+`#count`), sigil refs (`:x`, `$y`, `^z`), numbers and time literals (`200ms`),
+colon-qualified event names (`draggable:start`), URLs (`/api/data`). Those can be
+compared against the en reference verbatim.
+
+Post-#633 the known value bugs are fixed, so the corpus should read ~1.0 — the point
+of landing R3 now is to **hold** that (and the 18 silently-fixed languages) against
+regression. Only unit tests guard event-name values today, and only for the
+draggable/resizable rows.
+
+## Design (mirror the R1 wiring exactly)
+
+All four touch points follow the existing `roleSignature` (R1) plumbing:
+
+1. **`packages/testing-framework/src/multilingual/fidelity.ts`** — add
+   `collectRoleValueSignature(node): string[]` next to `collectRoleSignature`
+   (:220). Walk with the same `CHILD_FIELDS` (:24 — includes
+   `eventHandlers`/`initBlock`; ad-hoc walkers that omit them see behavior bodies as
+   empty). Emit a **multiset** of `` `${action}.${role}=${value}` `` entries,
+   **filtered to invariant-shaped values only** (see filter below). Score with the
+   existing `computeMultisetRecall` (:140) — the colon arc showed dedup hides
+   dropped duplicates.
+2. **`validators/parse-validator.ts`** — collect it live at :105–108 alongside
+   `actionMultisetSignature`/`roleSignature` (roles are `Map`s and serialize to `{}`
+   in results.json — they MUST be collected at parse time, per the warning at
+   fidelity.ts:214–218).
+3. **`orchestrator.ts`** — build the en reference map and per-pattern recall exactly
+   like `roleReference`/`roleFidelity` (:273–274, :322–323); aggregate
+   `lang.avgValueRecall` next to `avgMultisetRecall`/`avgRoleFidelity` (:337–341).
+4. **`cli.ts`** — ratchet: per-language `avgValueRecall` drop > 0.02, guarded so a
+   baseline lacking the field yields a 0 delta (copy the
+   `AVG_MULTISET_RECALL_DROP_TOLERANCE` block, :427–430, and its reporting,
+   :533–539). Baseline field lands via `--save-baseline`.
+
+### The invariant filter (the actual design work)
+
+Start conservative — include a value only when its **whole surface form** is
+code-shaped:
+
+- selectors: starts with `#` `.` `[` `<` `@` `*` (any role type whose value matches)
+- sigil refs: `/^[:$^][A-Za-z_]\w*$/`
+- numbers / time literals: `/^\d+(\.\d+)?(ms|s|m|h)?$/`
+- colon-qualified event names: `/^[A-Za-z_][\w-]*:[\w-]+$/` (the #633 class)
+- URLs / paths: `/^(\.{0,2}\/|https?:)/`
+
+Deliberately EXCLUDE in v1: bare words (identifiers like `startX` are usually
+invariant but property/variable names occasionally get localized in seeds), string
+literals (message strings are legitimately translated), whole `expression` raws
+(mixed native words + code — `次 .item`). A v2 could extract invariant *tokens* out
+of expression raws; don't start there. Normalized reference values (`me`, `it`) are
+mostly `fillSchemaDefaults` injections on both sides — noise; exclude.
+
+**Expect the filter to need one iteration.** Run report-mode first (below); every
+sub-1.0 row is either a real bug (good — file it) or a legit translation difference
+your filter wrongly includes (tighten it, document the exclusion in the walker's
+doc comment).
+
+### Blind-spot note (put it in the CLAUDE.md signal description)
+
+R3-recall fires when a *translation* loses/corrupts an invariant value. If the **en
+reference itself** corrupts a value, every language flags at once — a 24-language R3
+firestorm on one pattern means "suspect the en parse first", which is itself useful
+signal (unlike R0, where en corruption moves nothing).
+
+## Implementation order
+
+1. Walker + unit tests in `packages/testing-framework` (synthetic nodes: duplicate
+   values, each filter branch in/out, behavior-shaped nodes exercising
+   `eventHandlers`/`initBlock`).
+2. **Report mode before gate**: wire collection + aggregation, print per-language
+   `avgValueRecall` + the failing `pattern:lang=value` rows (mirror how
+   `--diagnose-coverage` reports without gating). Sweep, iterate the filter until
+   every remaining firing is explained.
+3. **Fail-without-fix validation**: on a throwaway branch, `git revert -n a7298b2e`
+   (the #633 fix commit), rebuild framework + semantic (`npm run
+   test:multilingual:build-deps`), re-`populate`, sweep — R3 must flag the ms
+   draggable/resizable rows (`draggable` ≠ `draggable:start`) that R0/R1 score
+   perfect. This is the proof the signal sees what the others cannot. Then discard
+   the branch, rebuild, re-populate.
+4. Wire the ratchet + `--save-baseline` on a **freshly populated** patterns.db,
+   `npx prettier --write baselines/multilingual-priority.json`, commit baseline —
+   **not** patterns.db.
+5. Docs: add R3 as signal 8 in CLAUDE.md's ratchet list (with the en-firestorm
+   note); mark the R3 item done in `MULTILINGUAL_NEXT_STEPS.md` § follow-ups.
+
+## Definition of done
+
+- `collectRoleValueSignature` unit-tested; multiset semantics verified (a dropped
+  duplicate value is visible).
+- Post-#633 sweep reads ~1.0 with every sub-1.0 row explained (bug filed or filter
+  exclusion documented).
+- Reverted-#633 sweep flags the ms rows (signal proves out).
+- Ratchet wired, guarded for old baselines, baseline regenerated + prettier'd.
+- CLAUDE.md + NEXT_STEPS updated.
+
+## Traps (hard-won this arc — details in the memory file and repo CLAUDE.md)
+
+- **`--save-baseline`/`--regression` REFUSE if any guarded package's src changed
+  after `populate`** — even a dead-file deletion. Sequence strictly: src changes →
+  ordered build → populate → sweep.
+- `semantic/dist` resolves `@lokascript/framework` at **runtime** — rebuilding
+  framework alone changes what semantic-dist probes do. For old-vs-new A/B, revert
+  sources and rebuild; don't assume dist is a time capsule.
+- Never pipe the gate to `tail` (masks the refusal exit code); redirect to a file
+  and check `$?`. `git stash` bumps mtimes and trips the staleness guard.
+- Roles serialize to `{}` in results.json — collect signatures live, never from the
+  JSON.
+- `pattern_roles.role_value`/`role_type` columns exist in patterns.db as an
+  alternative reference source — probably ignore for v1 (the live en parse is the
+  reference everywhere else), but know it's there.
+
+## Smaller side-quests (independent; pick up if R3 stalls)
+
+1. **qu `behavior-resizable` style-sets** — the one remaining sub-1.0 multiset row
+   (0.99950). The qu reorder renders inline `if … then set … end` as `sichus …
+   chayqa … tukuy man churanay` — block terminator BEFORE the inner set's
+   verb-final tail — so the conditional fold strands `man churanay` and the two
+   following style sets are swallowed (10/12 sets). Likely an **i18n transformer /
+   corpus rendering** bug (`end` belongs after the verb), not parser tolerance;
+   check `grammar/transformer.ts` (`BLOCK_HEAD_KEYWORDS` covers only
+   `live`/`when`/`unless`) and remember corpus rewrites couple to the fidelity
+   baseline. Locked by an `it.fails` in
+   `packages/semantic/test/multilingual-roadmap-fixes.test.ts` that flips when
+   repaired.
+2. **bn standalone trigger** — `draggable:start কে ট্রিগার` throws; same accusative
+   gap hi/qu had. Probably one line: add `bn: ['কে']` to the trigger schema's
+   `markerVariants` (`packages/semantic/src/generators/command-schemas.ts`, trigger
+   event role). Flip the `it.fails` in `test/draggable-patterns.test.ts`. Verify
+   bn's corpus rows stay 1.0 (they are today).
+3. **Input-coverage scoring penalty** — has its own section + 5 preconditions in
+   `MULTILINGUAL_NEXT_STEPS.md` ("Input coverage — the confidence model's blind
+   spot"). Bigger than it looks (all-stage coverage or asymmetric bias).

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -2594,19 +2594,20 @@ colon-split (framework `BaseTokenizer.mergeColonQualifiedNames`), hi/qu trigger
 accusative markers (trigger schema `markerVariants`), and the ms `it.<command-verb>`
 phantom possessive (COMMAND_ACTION_KEYWORDS guard in `tryMatchPossessiveExpression`).
 CSS pseudo-class selectors (`#x:hover`, `.a:not(.b)`) also tokenize whole now, in all 24
-languages including en (was split everywhere). Three follow-ups remain:
+languages including en (was split everywhere). Follow-up status:
 
-1. **R3 role-VALUE audit (highest leverage).** The ms symptom — right action counts,
-   right role types, WRONG role value (`draggable` instead of `draggable:start`) — is
-   structurally invisible to every ratchet signal: R0/R1 compare actions and role
-   _types_, never values (values are legitimately translated). A corpus-wide audit
-   comparing **language-invariant** role values (selectors, `:`/`$` refs, numbers,
-   colon-qualified event names) against the en reference would close the whole bug
-   class. Net-new wiring, mirroring R1: a value-signature walker in
-   `packages/testing-framework/src/multilingual/fidelity.ts`, a field in
-   `validators/parse-validator.ts`, aggregation in `orchestrator.ts`, ratchet in
-   `cli.ts`. (`pattern_roles.role_value` in patterns.db is an alternative reference
-   source.) Needs its own baseline regen.
+1. ~~**R3 role-VALUE audit (highest leverage).**~~ **DONE** (2026-07-10, the R3 arc —
+   `docs-internal/HANDOFF_role-value-audit.md`, resolved). Landed exactly as designed:
+   `collectRoleValueSignature` walker in
+   `packages/testing-framework/src/multilingual/fidelity.ts` (invariant-shaped values
+   only — whole-surface code, no whitespace/`${` interpolation), live collection in
+   `validators/parse-validator.ts`, `avgValueRecall` aggregation + per-pattern
+   `valueRecallMissing` diagnostics in `orchestrator.ts`, console report section, and
+   the `--regression` ratchet (drop > 0.02, both-sides-guarded). Signal **proven** by
+   revert-validation: with `a7298b2e` (#633) reverted, R3 flags the ms/19-language
+   `trigger.event=draggable` corruption rows that R0/R1 score perfect (avgValueRecall
+   0.9861 → 0.9611). The first full sweep also surfaced six live value-bug families —
+   see "R3-discovered value-bug families" below.
 
 2. **qu behavior-resizable style-sets (the one remaining multiset row).** The qu
    reorder renders each inline `if X then set Y to Z end` with the inner set's
@@ -2618,11 +2619,58 @@ languages including en (was split everywhere). Three follow-ups remain:
    `it.fails` in `packages/semantic/test/multilingual-roadmap-fixes.test.ts` that flips
    when repaired.
 
-3. **bn standalone trigger.** `draggable:start কে ট্রিগার` (accusative-marked event)
-   still throws standalone — same gap hi/qu had before the trigger `markerVariants`
-   fix; adding bn's `কে` is probably the same one-line change, but bn's corpus rows are
-   already faithful (multiset 1.0), so it moved nothing and wasn't included. Locked by
-   an `it.fails` in `packages/semantic/test/draggable-patterns.test.ts`.
+3. ~~**bn standalone trigger.**~~ **DONE** (2026-07-10, same arc). The predicted
+   one-liner: `bn: ['কে']` added to the trigger schema's event `markerVariants`
+   (`packages/semantic/src/generators/command-schemas.ts`), `it.fails` flipped to a
+   full-capture assertion in `packages/semantic/test/draggable-patterns.test.ts`.
+   Better than expected: bn's corpus rows were only multiset-1.0-faithful — R3 showed
+   their behavior trigger-event VALUES were silently dropped
+   (`behavior-draggable/resizable/sortable`), and the fix healed those rows too
+   (bn avgValueRecall 0.917 → 0.958).
+
+## R3-discovered value-bug families (opened 2026-07-10)
+
+The first R3 sweep surfaced 50 sub-1.0 instances across 18 patterns — all triaged
+(probe transcript in the R3 arc). Every family is **invisible to R0/R1** (right
+actions, right role types) except where noted. Baseline-recorded, so the ratchet
+only fires on _further_ regressions; burning these down is follow-up work, roughly
+in value order:
+
+1. **Connective swallowed as `increment.quantity`** (ar/it/ms/pl/ru/uk/tl/vi ×
+   `repeat-until-event`/`repeat-while`). `zwiększ #counter wtedy czekaj` parses with
+   `quantity="then"` — the normalized connective captured as increment's quantity
+   (en gets the schema default `1`). Runtime divergence: increment by `"then"` is
+   NaN-shaped. Likely one guard in the SVO two-role generation or a
+   quantity-role type constraint (`expectedTypes` number).
+2. **bn duration-glue** (`repeat-while`/`repeat-until-event`/`repeat-forever`/
+   `copy-to-clipboard`/`stagger-animation`/`tell-other-element`). bn tokenizer glues
+   the block terminator onto the preceding duration: `wait.duration="200msশেষ"`.
+   Tokenizer boundary bug (Bengali script adjacency).
+3. **SOV `in me` qualifier glue/drop** (bn/hi/ja/ko/qu × `form-disable-on-submit`).
+   en: `add.destination=<button/>` + `put.destination=<button/>` (with an `in me`
+   qualifier). SOV: add's destination falls back to default `me` (phrase lost) and
+   put's destination captures glued `<button/>inme`. Type stays `selector`, so R1
+   scores the put perfect — R3-only.
+4. **pl/ru/uk `fetch` URL mis-role** (4 fetch patterns). `pobierz /api/form z
+   method:"POST"` parses `patient=/api/form, source=method` — URL and with-clause
+   land in swapped roles (en: `source=/api/form, style=method`). Partially
+   R1-visible; runtime-relevant (fetch target wrong).
+5. **hi `transition` duration drop** (4 transition patterns). hi's rendering drops
+   `500ms` from roles entirely (`में` marker gap). R1-visible as missing role;
+   R3 pinpoints the value.
+6. **`swap` role-binding flip** (ar/bn/hi/ja/ko/qu/tl/tr × `swap-content`). en parses
+   `swap #a with #b` as `destination=#a, patient=#b`; SOV/VSO renderings mark `#a`
+   as patient — same role-type SET, so R1 is blind. Runtime-benign (swap is
+   symmetric) but flags the en swap schema's role mapping disagreeing with the
+   transformer's marking. Fix = align schema/renderer, or normalize symmetric
+   commands in the signature.
+7. **qu/tr behavior trigger-event residue** (`behavior-sortable`: qu misses
+   `sortable:move`+`sortable:start`, tr misses `sortable:move` +
+   `remove.patient=.{dragClass}`). Sibling of the fixed bn gap; likely reorder
+   placement rather than markers.
+8. **ms `repeat 3 kali` count swallowed** (`repeat-times`). ms parses
+   `loopType=3` with no `quantity` (en: `quantity=3, loopType=times`). R1-visible;
+   listed for completeness.
 
 ## Recommended sequence
 

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -970,14 +970,14 @@ export const triggerSchema: CommandSchema = {
       expectedTypes: ['literal', 'expression'], // expression for custom/namespaced event names
       svoPosition: 1,
       sovPosition: 2,
-      // hi/qu mark trigger's event ACCUSATIVELY (`draggable:start को ट्रिगर`,
-      // `draggable:start ta kichay` — the corpus renderings), but their
-      // profile-wide event marker is the on-handler one (hi पर, qu locative
-      // pi), so the generated SOV pattern never matched and the whole line
-      // fell through to the on-handler reading (hi) or failed outright (qu).
-      // ja/ko were immune only because their event marker IS the object
-      // particle (を / 을·를). #588 markerVariants machinery.
-      markerVariants: { hi: ['को'], qu: ['ta'] },
+      // hi/qu/bn mark trigger's event ACCUSATIVELY (`draggable:start को ट्रिगर`,
+      // `draggable:start ta kichay`, `draggable:start কে ট্রিগার` — the corpus
+      // renderings), but their profile-wide event marker is the on-handler one
+      // (hi पर, qu locative pi, bn এ), so the generated SOV pattern never
+      // matched and the whole line fell through to the on-handler reading (hi)
+      // or failed outright (qu/bn). ja/ko were immune only because their event
+      // marker IS the object particle (を / 을·를). #588 markerVariants machinery.
+      markerVariants: { hi: ['को'], qu: ['ta'], bn: ['কে'] },
     },
     {
       role: 'destination',

--- a/packages/semantic/test/draggable-patterns.test.ts
+++ b/packages/semantic/test/draggable-patterns.test.ts
@@ -76,20 +76,22 @@ describe('Phase 1: Verify Existing Commands', () => {
       }
     );
 
-    // Pre-existing STANDALONE parse gap, unrelated to tokenization (verified
-    // byte-identical before/after the colon-qualifier tokenizer fix): bn
-    // throws on the bare corpus trigger line — its trigger pattern does not
-    // accept the accusative কে-marked event (hi/qu had the same gap, fixed by
-    // the trigger schema's markerVariants). bn's full-body captures are
-    // unaffected (baseline multiset 1.0). `it.fails` flips visibly when the
-    // standalone form starts parsing.
-    const knownStandaloneGaps = [{ lang: 'bn', input: 'draggable:start কে ট্রিগার' }];
+    // bn marks trigger's event ACCUSATIVELY (`draggable:start কে ট্রিগার`),
+    // like hi/qu before it — fixed the same way, via the trigger schema's
+    // markerVariants (bn: কে). The standalone form parses with the full
+    // colon-qualified event name captured.
+    const accusativeStandaloneCases = [{ lang: 'bn', input: 'draggable:start কে ট্রিগার' }];
 
-    it.fails.each(knownStandaloneGaps)(
-      'standalone trigger in $lang is a known parse gap: "$input"',
+    it.each(accusativeStandaloneCases)(
+      'parses standalone accusative-marked trigger in $lang: "$input"',
       ({ lang, input }) => {
         const node = parse(input, lang) as CommandSemanticNode;
         expect(node.action).toBe('trigger');
+        const eventRole = node.roles.get('event') as { raw?: unknown; value?: unknown };
+        expect(
+          String(eventRole?.raw ?? eventRole?.value),
+          `${lang}: captured event name must keep the :qualifier`
+        ).toBe('draggable:start');
       }
     );
   });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-10T15:02:54.733Z",
-  "commit": "129a9b1a",
+  "timestamp": "2026-07-10T15:55:59.322Z",
+  "commit": "cf858d71",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -11,11 +11,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9907407407407408,
+      "avgValueRecall": 0.9874213836477987,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -644,11 +645,12 @@
       "avgPrecision": 0.9989716846334493,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.972004357298475,
+      "avgValueRecall": 0.9583333333333333,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1277,11 +1279,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9870837223778401,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1906,7 +1909,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2535,11 +2538,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9923747276688454,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3168,11 +3172,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9870837223778401,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3801,11 +3806,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9907407407407406,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4434,11 +4440,12 @@
       "avgPrecision": 0.9978354978354977,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9627450980392157,
+      "avgValueRecall": 0.960691823899371,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5067,11 +5074,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9894179894179896,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5700,11 +5708,12 @@
       "avgPrecision": 0.997835497835498,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9930750077808902,
+      "avgValueRecall": 0.9937106918238995,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6333,11 +6342,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.972004357298475,
+      "avgValueRecall": 0.9842767295597484,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6966,11 +6976,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9687363834422658,
+      "avgValueRecall": 0.9842767295597484,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7599,11 +7610,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9847494553376908,
+      "avgValueRecall": 0.988993710691824,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8232,11 +8244,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9841425459072518,
+      "avgValueRecall": 0.9559748427672957,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8865,11 +8878,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9923747276688454,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9498,11 +9512,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 0.9995004995004996,
       "avgRoleFidelity": 0.953034547152194,
+      "avgValueRecall": 0.9805031446540879,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10131,11 +10146,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9863834422657953,
+      "avgValueRecall": 0.9591194968553459,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10764,11 +10780,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9923747276688454,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11397,11 +11414,12 @@
       "avgPrecision": 0.9978354978354977,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9845315904139433,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12030,11 +12048,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9907407407407408,
+      "avgValueRecall": 0.9874213836477987,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12663,11 +12682,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9716198897859796,
+      "avgValueRecall": 0.9867924528301886,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13296,11 +13316,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9863834422657953,
+      "avgValueRecall": 0.9591194968553459,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13929,11 +13950,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9883442265795209,
+      "avgValueRecall": 0.9937106918238995,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14562,11 +14584,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9872393401805166,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495588,
+      "bundleSize": 495608,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15189,7 +15212,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 495588,
+      "size": 495608,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/src/multilingual/cli.ts
+++ b/packages/testing-framework/src/multilingual/cli.ts
@@ -441,6 +441,20 @@ async function main(): Promise<void> {
           r => r.avgRoleFidelityDelta < -AVG_ROLE_FIDELITY_DROP_TOLERANCE
         );
 
+        // R3 — role-VALUE ratchet: same semantics as the role-fidelity ratchet,
+        // on the invariant-value signal (`action.role=value` multiset over the
+        // code-shaped subset: selectors, sigil refs, time literals,
+        // colon-qualified event names, URLs — compared VERBATIM vs the en
+        // reference). A drop means a translation started losing/corrupting an
+        // invariant value (`draggable` captured for `draggable:start`, the #633
+        // class) — invisible to every action/type-based signal above. Deltas
+        // are 0 unless the baseline carries avgValueRecall, so an
+        // un-regenerated baseline never retro-flags.
+        const AVG_VALUE_RECALL_DROP_TOLERANCE = 0.02;
+        const valueRecallDrops = allResults.filter(
+          r => r.avgValueRecallDelta < -AVG_VALUE_RECALL_DROP_TOLERANCE
+        );
+
         // R2 — execution ratchet (§8): curated-subset patterns whose jsdom DOM
         // effects matched the en reference in the baseline but diverge now.
         // Tolerance 0: execution is binary and the harness is deterministic
@@ -557,6 +571,19 @@ async function main(): Promise<void> {
           failed = true;
         }
 
+        if (valueRecallDrops.length > 0) {
+          console.error(
+            `\n✗ avgValueRecall dropped > ${AVG_VALUE_RECALL_DROP_TOLERANCE} in ` +
+              `${valueRecallDrops.length} language(s) — a parse started losing/corrupting ` +
+              `a language-invariant role VALUE (invisible to the action/type-based signals):`
+          );
+          for (const r of valueRecallDrops) {
+            console.error(`   ${r.language}: ΔavgValueRecall ${r.avgValueRecallDelta.toFixed(4)}`);
+          }
+          console.error(`   (if intentional, regenerate the baseline with --save-baseline)`);
+          failed = true;
+        }
+
         if (executionRegressions.length > 0) {
           console.error(
             `\n✗ Execution regression vs baseline (R2): ${executionRegressions.length} ` +
@@ -576,7 +603,7 @@ async function main(): Promise<void> {
           console.log(
             `\n✓ No regression vs baseline ` +
               `(parse-rate ${REGRESSION_TOLERANCE_PTS}pts, fidelity + correctness + ` +
-              `precision + multiset-recall + role + execution ratchets).`
+              `precision + multiset-recall + role + value + execution ratchets).`
           );
           exitCode = 0;
         }

--- a/packages/testing-framework/src/multilingual/fidelity.test.ts
+++ b/packages/testing-framework/src/multilingual/fidelity.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   collectActions,
   collectActionsMultiset,
+  collectRoleValueSignature,
   computeFidelity,
   computeMultisetRecall,
   computePrecision,
@@ -154,6 +155,161 @@ describe('computeMultisetRecall', () => {
 function collectSet(actions: readonly string[]): string[] {
   return [...new Set(actions)].sort();
 }
+
+describe('collectRoleValueSignature', () => {
+  it('emits every invariant-shaped value class, from a roles Map', () => {
+    const node = {
+      kind: 'event-handler',
+      action: 'on',
+      roles: new Map<string, unknown>([
+        ['event', { type: 'expression', raw: 'draggable:start' }], // colon-qualified (the #633 class)
+      ]),
+      body: [
+        {
+          kind: 'command',
+          action: 'toggle',
+          roles: new Map<string, unknown>([
+            ['patient', { type: 'selector', value: '.active', selectorKind: 'class' }],
+          ]),
+        },
+        {
+          kind: 'command',
+          action: 'set',
+          roles: new Map<string, unknown>([
+            ['destination', { type: 'expression', raw: ':x' }], // sigil ref
+          ]),
+        },
+        {
+          kind: 'command',
+          action: 'wait',
+          roles: new Map<string, unknown>([
+            ['duration', { type: 'literal', value: '200ms', dataType: 'duration' }],
+          ]),
+        },
+        {
+          kind: 'command',
+          action: 'fetch',
+          roles: new Map<string, unknown>([['source', { type: 'literal', value: '/api/data' }]]),
+        },
+      ],
+    };
+    expect(collectRoleValueSignature(node)).toEqual([
+      'fetch.source=/api/data',
+      'on.event=draggable:start',
+      'set.destination=:x',
+      'toggle.patient=.active',
+      'wait.duration=200ms',
+    ]);
+  });
+
+  it('excludes non-invariant values: references, prose, bare words, mixed raws, flags, property-paths', () => {
+    const node = {
+      kind: 'command',
+      action: 'put',
+      roles: new Map<string, unknown>([
+        ['destination', { type: 'reference', value: 'me' }], // fillSchemaDefaults noise
+        ['patient', { type: 'literal', value: 'Hello world', dataType: 'string' }], // legitimately translated
+        ['source', { type: 'expression', raw: 'startX' }], // bare identifier — v1 exclusion
+        ['modifier', { type: 'expression', raw: '次 .item' }], // native words + code mixed
+        ['condition', { type: 'expression', raw: '#modal exists' }], // selector-prefixed prose (if-exists class)
+        ['url', { type: 'literal', value: '/api/search?q=${my' }], // truncated template interpolation
+        ['flagRole', { type: 'flag', name: 'async', enabled: true }],
+        [
+          'pathRole',
+          { type: 'property-path', object: { type: 'reference', value: 'me' }, property: 'value' },
+        ],
+      ]),
+    };
+    expect(collectRoleValueSignature(node)).toEqual([]);
+  });
+
+  it('is a multiset — a dropped duplicate value is visible via computeMultisetRecall', () => {
+    // The bind-two-way shape: two `bind`s to two different sigil refs; a
+    // truncating parse keeps only the first. Both entries share NO key with a
+    // Set — but if both bound the SAME ref, dedup would hide the drop:
+    const twoBinds = {
+      action: 'compound',
+      statements: [
+        {
+          action: 'bind',
+          roles: new Map<string, unknown>([['source', { type: 'expression', raw: '$name' }]]),
+        },
+        {
+          action: 'bind',
+          roles: new Map<string, unknown>([['source', { type: 'expression', raw: '$name' }]]),
+        },
+      ],
+    };
+    const oneBind = {
+      action: 'bind',
+      roles: new Map<string, unknown>([['source', { type: 'expression', raw: '$name' }]]),
+    };
+    const ref = collectRoleValueSignature(twoBinds);
+    const cand = collectRoleValueSignature(oneBind);
+    expect(ref).toEqual(['bind.source=$name', 'bind.source=$name']);
+    expect(cand).toEqual(['bind.source=$name']);
+    expect(computeMultisetRecall(ref, cand)).toBe(0.5);
+  });
+
+  it('recurses into behavior-shaped nodes (eventHandlers + initBlock)', () => {
+    // No other walker test exercises these two CHILD_FIELDS; ad-hoc walkers
+    // that omit them see behavior bodies as empty.
+    const behavior = {
+      kind: 'behavior',
+      action: 'behavior',
+      roles: new Map<string, unknown>([['name', { type: 'expression', raw: 'Draggable' }]]),
+      eventHandlers: [
+        {
+          kind: 'event-handler',
+          action: 'on',
+          roles: new Map<string, unknown>([
+            ['event', { type: 'literal', value: 'draggable:start' }],
+          ]),
+          body: [
+            {
+              kind: 'command',
+              action: 'add',
+              roles: new Map<string, unknown>([
+                ['patient', { type: 'selector', value: '.dragging' }],
+              ]),
+            },
+          ],
+        },
+      ],
+      initBlock: [
+        {
+          kind: 'command',
+          action: 'set',
+          roles: new Map<string, unknown>([['destination', { type: 'expression', raw: '*width' }]]),
+        },
+      ],
+    };
+    expect(collectRoleValueSignature(behavior)).toEqual([
+      'add.patient=.dragging',
+      'on.event=draggable:start',
+      'set.destination=*width',
+    ]);
+  });
+
+  it('reads plain-object roles (synthetic/JSON-shaped nodes) too', () => {
+    const node = {
+      action: 'toggle',
+      roles: { patient: { type: 'selector', value: '#count' } },
+    };
+    expect(collectRoleValueSignature(node)).toEqual(['toggle.patient=#count']);
+  });
+
+  it('skips the structural compound wrapper and handles non-object input', () => {
+    const node = {
+      action: 'compound',
+      roles: new Map<string, unknown>([['patient', { type: 'selector', value: '.x' }]]),
+      statements: [{ action: 'toggle', roles: { patient: { type: 'selector', value: '.x' } } }],
+    };
+    expect(collectRoleValueSignature(node)).toEqual(['toggle.patient=.x']);
+    expect(collectRoleValueSignature(null)).toEqual([]);
+    expect(collectRoleValueSignature(undefined)).toEqual([]);
+  });
+});
 
 describe('spuriousActions', () => {
   it('lists the hallucinated commands a render/parse introduced', () => {

--- a/packages/testing-framework/src/multilingual/fidelity.ts
+++ b/packages/testing-framework/src/multilingual/fidelity.ts
@@ -255,3 +255,123 @@ function walkRoles(node: unknown, acc: Set<string>, depth: number): void {
     }
   }
 }
+
+/**
+ * Role-value kinds never emitted by the R3 walker. `reference` values (`me`,
+ * `it`, …) are mostly `fillSchemaDefaults` injections present identically on
+ * both sides — noise. `flag` names and `property-path` properties are bare
+ * identifiers, excluded by v1 (see {@link collectRoleValueSignature}).
+ */
+const VALUE_KIND_EXCLUSIONS = new Set(['reference', 'flag', 'property-path']);
+
+/**
+ * A role value is compared cross-language only when its WHOLE surface form is
+ * code-shaped — language-invariant by construction, never legitimately
+ * translated. Conservative v1 whitelist; when a sweep firing turns out to be a
+ * legit translation difference, tighten here and document the exclusion.
+ */
+const INVARIANT_VALUE_PATTERNS: readonly RegExp[] = [
+  /^[#.[<@*]/, // selectors: #id  .class  [attr]  <tag/>  @attr  *style
+  /^[:$^][A-Za-z_]\w*$/, // sigil refs: :local  $global  ^element
+  /^\d+(\.\d+)?(ms|s|m|h)?$/, // numbers and time literals: 2  1.5  200ms
+  /^[A-Za-z_][\w-]*:[\w-]+$/, // colon-qualified event names: draggable:start
+  /^(\.{0,2}\/|https?:)/, // URLs / paths: /api/data  ./x  ../y  https://…
+];
+
+function isInvariantSurface(surface: string): boolean {
+  // Whole-surface rule, sweep-validated exclusions:
+  // - whitespace ⇒ mixed content. `if #modal exists` captures its condition as
+  //   `#modal exists` — starts selector-shaped, but `exists` is prose that every
+  //   language legitimately translates (16-language false firing without this).
+  // - `${` ⇒ template interpolation. `/api/search?q=${my value}` is an
+  //   expression, and tokenizers split it at different points per language, so
+  //   the captured surface isn't comparable verbatim.
+  if (/\s/.test(surface) || surface.includes('${')) return false;
+  return INVARIANT_VALUE_PATTERNS.some(re => re.test(surface));
+}
+
+/**
+ * The comparable surface form of a role value, or `undefined` when the value
+ * carries none: `.value` for `literal`/`selector` (string/number/boolean
+ * coerced), `.raw` for `expression`. Kinds in {@link VALUE_KIND_EXCLUSIONS}
+ * and values without a string `type` discriminator yield `undefined`.
+ */
+function roleValueSurface(value: unknown): string | undefined {
+  if (value === null || typeof value !== 'object') return undefined;
+  const rec = value as { type?: unknown; value?: unknown; raw?: unknown };
+  if (typeof rec.type !== 'string' || VALUE_KIND_EXCLUSIONS.has(rec.type)) return undefined;
+  if (rec.type === 'expression') {
+    return typeof rec.raw === 'string' ? rec.raw : undefined;
+  }
+  const v = rec.value;
+  return typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean'
+    ? String(v)
+    : undefined;
+}
+
+/**
+ * R3 — role-VALUE signature (invariant values only, multiset).
+ *
+ * R0/R1 compare actions and role *types*; values are never compared because
+ * they are legitimately translated. That leaves a live defect class with zero
+ * signal: right action counts, right role types, wrong role VALUE — the #633
+ * class, where ms captured `trigger` events named `draggable` instead of
+ * `draggable:start` (correct multiset, correct `trigger.event:literal`
+ * signature, silently wrong runtime behavior), and 18 other languages carried
+ * the same corruption with no side-effect at all.
+ *
+ * The subset of values compared here is language-invariant by construction —
+ * code, not prose (see {@link INVARIANT_VALUE_PATTERNS}). Emits a **multiset**
+ * of `` `action.role=value` `` entries (duplicates preserved, sorted); score
+ * with {@link computeMultisetRecall} so a dropped duplicate value is visible.
+ *
+ * Deliberately EXCLUDED in v1: bare-word identifiers (`startX` — usually
+ * invariant, but property/variable names occasionally get localized in seeds),
+ * string literals (message strings are legitimately translated), expression
+ * raws mixing native words + code (`次 .item`), and `reference` values
+ * (`me`/`it` — mostly `fillSchemaDefaults` injections on both sides).
+ *
+ * Blind spot: recall fires when a *translation* loses/corrupts an invariant
+ * value. If the **en reference itself** corrupts a value, every language flags
+ * at once — a 24-language R3 firestorm on one pattern means "suspect the en
+ * parse first" (unlike R0, where en corruption moves nothing).
+ *
+ * The roles container is a ReadonlyMap on live nodes (serializes to {} in
+ * results.json), so collect at validation time, never from the JSON.
+ */
+export function collectRoleValueSignature(node: unknown): string[] {
+  const acc: string[] = [];
+  walkRoleValues(node, acc, 0);
+  return acc.sort();
+}
+
+function walkRoleValues(node: unknown, acc: string[], depth: number): void {
+  if (depth > 64 || node === null || typeof node !== 'object') return;
+
+  const rec = node as Record<string, unknown>;
+  const action = rec.action;
+  if (typeof action === 'string' && !STRUCTURAL_ACTIONS.has(action)) {
+    const roles = rec.roles;
+    const entries: Array<[unknown, unknown]> =
+      roles instanceof Map
+        ? [...roles.entries()]
+        : roles && typeof roles === 'object'
+          ? Object.entries(roles)
+          : [];
+    for (const [role, value] of entries) {
+      if (value === undefined || value === null) continue;
+      const surface = roleValueSurface(value);
+      if (surface === undefined || !isInvariantSurface(surface)) continue;
+      acc.push(`${action}.${String(role)}=${surface}`);
+    }
+  }
+
+  for (const field of CHILD_FIELDS) {
+    const child = rec[field];
+    if (Array.isArray(child)) {
+      for (const c of child) walkRoleValues(c, acc, depth + 1);
+    } else if (child && typeof child === 'object') {
+      walkRoleValues(child, acc, depth + 1);
+    }
+  }
+}

--- a/packages/testing-framework/src/multilingual/orchestrator.ts
+++ b/packages/testing-framework/src/multilingual/orchestrator.ts
@@ -24,6 +24,7 @@ import {
   computeFidelity,
   computePrecision,
   computeMultisetRecall,
+  spuriousActions,
   FIDELITY_THRESHOLD,
 } from './fidelity';
 
@@ -263,6 +264,8 @@ export class TestOrchestrator {
     const multisetReference = new Map<string, string[]>();
     // R1: codeExampleId -> English role signature (action.role:valueType set).
     const roleReference = new Map<string, string[]>();
+    // R3: codeExampleId -> English role-VALUE signature (invariant values, multiset).
+    const roleValueReference = new Map<string, string[]>();
     for (const r of en.parseResults) {
       if (r.success && r.actionSignature && r.actionSignature.length > 0) {
         reference.set(r.pattern.codeExampleId, r.actionSignature);
@@ -272,6 +275,9 @@ export class TestOrchestrator {
       }
       if (r.success && r.roleSignature && r.roleSignature.length > 0) {
         roleReference.set(r.pattern.codeExampleId, r.roleSignature);
+      }
+      if (r.success && r.roleValueSignature && r.roleValueSignature.length > 0) {
+        roleValueReference.set(r.pattern.codeExampleId, r.roleValueSignature);
       }
     }
 
@@ -284,6 +290,7 @@ export class TestOrchestrator {
       const precisionScores: number[] = [];
       const multisetRecallScores: number[] = [];
       const roleScores: number[] = [];
+      const valueRecallScores: number[] = [];
 
       for (const result of lang.parseResults) {
         if (!result.success || !result.actionSignature) continue;
@@ -326,6 +333,23 @@ export class TestOrchestrator {
             roleScores.push(roleFidelity);
           }
         }
+
+        // R3 — invariant role-VALUE recall vs the en value signature (multiset).
+        // Values are compared verbatim: the filtered subset (selectors, sigil
+        // refs, time literals, colon-qualified events, URLs) is code, not prose.
+        const valueRef = roleValueReference.get(result.pattern.codeExampleId);
+        if (valueRef && result.roleValueSignature) {
+          const valueRecall = computeMultisetRecall(valueRef, result.roleValueSignature);
+          if (valueRecall !== undefined) {
+            result.valueRecall = valueRecall;
+            valueRecallScores.push(valueRecall);
+            if (valueRecall < 1) {
+              // Missing = reference entries not covered here (multiset diff;
+              // spuriousActions with the arguments swapped).
+              result.valueRecallMissing = spuriousActions(result.roleValueSignature, valueRef);
+            }
+          }
+        }
       }
 
       lang.avgFidelity =
@@ -341,6 +365,10 @@ export class TestOrchestrator {
       lang.avgRoleFidelity =
         roleScores.length > 0
           ? roleScores.reduce((a, b) => a + b, 0) / roleScores.length
+          : undefined;
+      lang.avgValueRecall =
+        valueRecallScores.length > 0
+          ? valueRecallScores.reduce((a, b) => a + b, 0) / valueRecallScores.length
           : undefined;
       lang.degeneratePasses = degenerate.sort();
       lang.lossyPasses = lossy.sort();

--- a/packages/testing-framework/src/multilingual/reporters/console-reporter.ts
+++ b/packages/testing-framework/src/multilingual/reporters/console-reporter.ts
@@ -158,9 +158,60 @@ export class ConsoleReporter implements Reporter {
     }
 
     this.reportDegeneratePasses(results);
+    this.reportValueRecall(results);
     this.reportExecutionFailures(results);
 
     this.log('');
+  }
+
+  /**
+   * R3 — surface parses that lost/corrupted a language-invariant role VALUE
+   * (selector, sigil ref, time literal, colon-qualified event name, URL) vs
+   * the en reference. These score 1.0 on every action/type-based signal yet
+   * behave differently at runtime, so they're reported separately. Report-only:
+   * the ratchet gate lives in the --regression path.
+   */
+  private reportValueRecall(results: TestResults): void {
+    const scored = results.languageResults.filter(l => l.avgValueRecall !== undefined);
+    if (scored.length === 0) return;
+
+    const avg = scored.reduce((sum, l) => sum + (l.avgValueRecall ?? 0), 0) / scored.length;
+    this.log('');
+    this.log(
+      this.bright(`Role values (R3): avgValueRecall ${avg.toFixed(4)} over invariant values`)
+    );
+
+    // pattern id -> "lang: missing entries" rows
+    const byPattern = new Map<string, string[]>();
+    let instances = 0;
+    for (const lang of scored) {
+      for (const r of lang.parseResults) {
+        if (r.valueRecall === undefined || r.valueRecall >= 1) continue;
+        instances++;
+        let rows = byPattern.get(r.pattern.codeExampleId);
+        if (!rows) {
+          rows = [];
+          byPattern.set(r.pattern.codeExampleId, rows);
+        }
+        rows.push(`${lang.language}: missing ${(r.valueRecallMissing ?? []).join(', ')}`);
+      }
+    }
+    if (byPattern.size === 0) return;
+
+    this.log(
+      this.yellow(
+        `⚠ Invariant value loss: ${instances} instance(s) across ${byPattern.size} pattern(s)`
+      )
+    );
+    this.log(
+      this.dim(
+        '  (an action.role=value present in the en reference is absent — not parse failures)'
+      )
+    );
+    for (const [id, rows] of [...byPattern.entries()].sort((a, b) => b[1].length - a[1].length)) {
+      this.log(`  ${this.dim('-')} ${id}`);
+      for (const row of rows.sort()) this.log(`      ${this.dim(row)}`);
+    }
   }
 
   /**

--- a/packages/testing-framework/src/multilingual/reporters/regression-reporter.ts
+++ b/packages/testing-framework/src/multilingual/reporters/regression-reporter.ts
@@ -130,6 +130,13 @@ export class RegressionReporter implements Reporter {
         langResult.avgRoleFidelity !== undefined && baselineLang.avgRoleFidelity !== undefined
           ? langResult.avgRoleFidelity - baselineLang.avgRoleFidelity
           : 0;
+      // R3 — same both-sides guard. Negative = a language-invariant role VALUE
+      // (selector/sigil/time/colon-event/URL) is now lost or corrupted, which
+      // every action/type-based signal scores as perfect.
+      const avgValueRecallDelta =
+        langResult.avgValueRecall !== undefined && baselineLang.avgValueRecall !== undefined
+          ? langResult.avgValueRecall - baselineLang.avgValueRecall
+          : 0;
       // R2 — same both-sides guard: an un-regenerated baseline (no execution
       // data yet) must never retro-flag.
       const avgExecutionFidelityDelta =
@@ -171,6 +178,7 @@ export class RegressionReporter implements Reporter {
         avgPrecisionDelta,
         avgMultisetRecallDelta,
         avgRoleFidelityDelta,
+        avgValueRecallDelta,
         avgExecutionFidelityDelta,
         bundleSizeDelta: bundleSizeDelta !== undefined ? bundleSizeDelta : undefined,
         newFailures,
@@ -378,6 +386,10 @@ export class RegressionReporter implements Reporter {
         // R1 — role fidelity (role name + value type vs the en reference).
         // Recorded + ratcheted; burn-down is NOT part of the parsing-track goal.
         avgRoleFidelity: langResult.avgRoleFidelity ?? undefined,
+        // R3 — invariant role-VALUE recall (verbatim value comparison over the
+        // code-shaped subset: selectors, sigil refs, time literals,
+        // colon-qualified event names, URLs). Recorded + ratcheted.
+        avgValueRecall: langResult.avgValueRecall ?? undefined,
         // R2 — execution fidelity over the curated subset (DOM effects vs the
         // en reference in jsdom). Recorded + ratcheted; burn-down deferred.
         avgExecutionFidelity: langResult.avgExecutionFidelity ?? undefined,

--- a/packages/testing-framework/src/multilingual/types.ts
+++ b/packages/testing-framework/src/multilingual/types.ts
@@ -145,6 +145,17 @@ export interface ParseResult {
   roleSignature?: string[];
 
   /**
+   * R3 — role-VALUE signature: `action.role=value` multiset, filtered to
+   * language-invariant surface forms (selectors, sigil refs, numbers/time
+   * literals, colon-qualified event names, URLs — code, not prose). The one
+   * value class that CAN be compared verbatim across languages; catches
+   * right-action/right-type/wrong-VALUE corruption (`draggable` captured for
+   * `draggable:start`) that every type-based signal misses. Set by the
+   * validator (roles are a ReadonlyMap — serialize to {} in results.json).
+   */
+  roleValueSignature?: string[];
+
+  /**
    * Structural fidelity vs the English reference parse, in [0, 1]: the fraction
    * of the English parse's distinct actions also present in this language's
    * parse (recall). `1` = same command structure; low values flag a *degenerate*
@@ -179,6 +190,23 @@ export interface ParseResult {
    * patient/destination executes wrongly while action-fidelity scores 1.0).
    */
   roleFidelity?: number;
+
+  /**
+   * R3 — invariant role-VALUE recall vs the English reference, in [0, 1]: the
+   * fraction of the English parse's `roleValueSignature` entries (multiset —
+   * duplicates counted) also present here. Falls below 1.0 when a translation
+   * loses or corrupts a language-invariant value (selector, sigil ref, time
+   * literal, colon-qualified event name, URL) while actions and role types
+   * still match. `undefined` when the en reference has no invariant values.
+   */
+  valueRecall?: number;
+
+  /**
+   * R3 — the en reference's `action.role=value` entries missing from this
+   * parse (multiset difference). Populated only when `valueRecall` < 1, for
+   * diagnostics ("which value was lost/corrupted?").
+   */
+  valueRecallMissing?: string[];
 }
 
 /**
@@ -234,6 +262,14 @@ export interface LanguageResults {
    * of the parsing-track goal (see CORRECTNESS_RELIABILITY_PLAN.md §8).
    */
   avgRoleFidelity?: number | undefined;
+
+  /**
+   * R3 — mean `valueRecall` over successful parses with an English reference.
+   * Recorded + ratcheted alongside avgRoleFidelity: a drop means a translation
+   * started losing/corrupting a language-invariant role VALUE (the #633 class),
+   * which every action/type-based signal above scores as perfect.
+   */
+  avgValueRecall?: number | undefined;
 
   /**
    * R2 — mean executionFidelity over the curated execution subset (see
@@ -325,6 +361,8 @@ export interface Baseline {
         avgMultisetRecall?: number | undefined;
         /** R1 — mean role fidelity vs the English reference (see ParseResult.roleFidelity). */
         avgRoleFidelity?: number | undefined;
+        /** R3 — mean invariant role-VALUE recall vs the English reference (see ParseResult.valueRecall). */
+        avgValueRecall?: number | undefined;
         /** R2 — mean execution fidelity over the curated execution subset (see LanguageResults.avgExecutionFidelity). */
         avgExecutionFidelity?: number | undefined;
         /** R2 — curated-subset pattern IDs whose execution diverged from the en reference. */
@@ -364,6 +402,8 @@ export interface RegressionResult {
   avgMultisetRecallDelta: number;
   /** R1 — absolute change in avgRoleFidelity (current − baseline). 0 when either side lacks data. */
   avgRoleFidelityDelta: number;
+  /** R3 — absolute change in avgValueRecall (current − baseline). 0 when either side lacks data. Negative = an invariant role VALUE is being lost/corrupted. */
+  avgValueRecallDelta: number;
   /** R2 — absolute change in avgExecutionFidelity (current − baseline). 0 when either side lacks data. */
   avgExecutionFidelityDelta: number;
   /**

--- a/packages/testing-framework/src/multilingual/validators/parse-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/parse-validator.ts
@@ -6,7 +6,12 @@ import { MultilingualHyperscript } from '@hyperfixi/core/multilingual';
 import type { SemanticNode } from '@lokascript/semantic';
 import { fillSchemaDefaults } from '@lokascript/semantic';
 import type { PatternTranslation, ParseResult, Validator } from '../types';
-import { collectActions, collectActionsMultiset, collectRoleSignature } from '../fidelity';
+import {
+  collectActions,
+  collectActionsMultiset,
+  collectRoleSignature,
+  collectRoleValueSignature,
+} from '../fidelity';
 
 /**
  * Parse Validator
@@ -106,6 +111,9 @@ export class ParseValidator implements Validator<ParseResult[]> {
         // R1 role signature (role name + value type per command) — collected here
         // because live nodes carry roles as a ReadonlyMap that serializes to {}.
         roleSignature: collectRoleSignature(semanticNode),
+        // R3 role-VALUE signature (invariant-shaped values only, multiset) —
+        // catches right-action/right-type/wrong-VALUE corruption (the #633 class).
+        roleValueSignature: collectRoleValueSignature(semanticNode),
         duration: performance.now() - startTime,
       };
     } catch (error) {


### PR DESCRIPTION
## Summary

Lands the R3 role-VALUE audit arc (`docs-internal/HANDOFF_role-value-audit.md`, now resolved) plus its bn standalone-trigger side-quest.

The colon-event-names arc (#633) proved a defect class no ratchet signal could see: **right action counts, right role types, wrong role VALUE** (ms captured `trigger` events named `draggable` instead of `draggable:start`; 18 other languages carried the same corruption with zero signal). R0/R1 never compare values because values are legitimately translated — but a subset is language-invariant by construction: selectors, sigil refs, numbers/time literals, colon-qualified event names, URLs. R3 compares those **verbatim** against the en reference.

## Changes

- **`collectRoleValueSignature`** walker in `fidelity.ts`: `action.role=value` **multiset** (a dropped duplicate value is visible), filtered to whole-surface code-shaped values; excludes references (`fillSchemaDefaults` noise), bare identifiers, prose, whitespace-mixed and `${}`-interpolated surfaces. Unit tests cover every filter branch, multiset semantics, and behavior-shaped `eventHandlers`/`initBlock` nodes (a first for the walker tests).
- Live collection in `parse-validator.ts` (roles are a ReadonlyMap — serialize to `{}` in results.json), `avgValueRecall` + per-pattern `valueRecallMissing` in `orchestrator.ts`, console report section, and the `--regression` ratchet (drop > 0.02, both-sides-guarded so an un-regenerated baseline never retro-flags). Documented as **signal 8** in CLAUDE.md, including the en-firestorm blind-spot note.
- **bn trigger one-liner**: `bn: ['কে']` in the trigger schema's `markerVariants` (same accusative gap hi/qu had); `it.fails` flipped to a full-capture assertion. R3 shows the fix also heals bn's corpus behavior trigger-event values (bn avgValueRecall 0.917 → 0.958) — invisible to multiset scoring.
- Baseline regenerated against a freshly populated patterns.db (prettier'd; patterns.db itself not committed, per convention).

## Signal proof (fail-without-fix validation)

On a throwaway branch with `a7298b2e` (the #633 fix) reverted, rebuilt, and re-populated: R3 flags the trigger-event corruption in **ms and 18 other languages** (avgValueRecall 0.9861 → 0.9611) while every existing signal scores those rows perfect.

## Bonus: six live value-bug families discovered

The first sweep's 50 sub-1.0 instances are all triaged and filed in `MULTILINGUAL_NEXT_STEPS.md` § "R3-discovered value-bug families" — notably `increment.quantity="then"` (connective swallowed as quantity in 8 languages) and bn duration-glue (`wait.duration="200msশেষ"`).

## Test plan

- [x] testing-framework: 207/207 (incl. 8 new walker tests)
- [x] semantic: 6932 passed, 1 expected-fail (the still-locked qu `behavior-resizable` side-quest), typecheck clean
- [x] Full `--regression` gate exits 0 against the regenerated baseline (value ratchet active in the signal list)
- [x] Revert-validation sweep flags the ms rows (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)