### PR TITLE
fix(semantic): burn down the R3 value-bug families (F1-F8)

### DIFF
--- a/docs-internal/HANDOFF_transformer-rendering.md
+++ b/docs-internal/HANDOFF_transformer-rendering.md
@@ -1,0 +1,239 @@
+# Handoff: the transformer-rendering arc (SOV reorder stranding)
+
+> **For a fresh session.** Read this, then CLAUDE.md ("Multilingual parse rate ≠
+> fidelity" and "Running the multilingual `--regression` gate locally"), then
+> `docs-internal/MULTILINGUAL_NEXT_STEPS.md` § "R3-discovered value-bug
+> families" (item 7 re-filed here) and § "Colon-event-names follow-ups"
+> (item 2, the qu behavior-resizable side-quest — same family). Branch from
+> `main` **after PR #635** (`fix/r3-value-bug-families`) merges — the `it.fails`
+> locks, the parser tolerances, and the triage below all land there.
+
+## Why this arc
+
+The i18n `GrammarTransformer`'s SOV/agglutinative reorder sometimes renders
+fragments **outside their clause**: a wait verb emitted mid-line or first in a
+verb-final language, a from-phrase stranded after the verb, a block terminator
+dropped inside the *following* clause's object phrase. The parser then either
+captures the stranded fragment as a role VALUE (junk trigger events) or is
+forced to carry tolerance code for grammatically wrong input.
+
+Two prior arcs bounded the blast radius parser-side (#633/#634 markers, #635
+value-bug families) and **deliberately re-filed the rendering defects here**
+instead of adding more parser tolerance — the guard-encrusted loop/wait/fused
+machinery is the wrong place to absorb what is a rendering bug. This arc fixes
+the renderer.
+
+Every defect below was verified by parsing the actual patterns.db corpus text
+and dumping roles + `metadata.patternId` (2026-07-10, PR #635 session). The
+malformed lines are quoted verbatim.
+
+## The defects (three shapes, one family)
+
+The en reference for behavior-sortable lines 15–17 (from
+`sqlite3 packages/patterns-reference/data/patterns.db "SELECT raw_code FROM
+code_examples WHERE id='behavior-sortable'"`):
+
+```
+repeat until event pointerup from document
+  wait for pointermove(clientY) or pointerup(clientY) from document
+  trigger sortable:move on me
+```
+
+### (a) Or-run wait lines rendered verb-first / verb-medial (tr, qu)
+
+- **tr** (SOV — verb should be final):
+  `bekle pointermove(clientY) veya pointerup(clientY) belge den`
+  — `bekle` (wait) is **first**, the or-run and from-phrase stranded after it.
+  Consequence: the next line's trigger captures the stranded `belge`
+  (document) as its event → R3 row `tr: missing trigger.event=sortable:move`.
+- **qu**: `qillqa manta suyay pointermove(clientY) utaq pointerup(clientY)`
+  — `suyay` (wait) is **medial**, the or-run stranded post-verb.
+  Consequence: the middle trigger glues the whole stranded run into its event
+  (`(clientY)utaqpointerup(clientY)sortable:move`) → R3 rows `qu: missing
+  trigger.event=sortable:move, trigger.event=sortable:start`.
+- Contrast: the same languages render *simple* wait lines fine (`200ms কে
+  অপেক্ষা`-style verb-final). The trigger is the **or-run + from-phrase**
+  combination — suspect the reorder can't place a multi-argument
+  `wait for X or Y from Z` and bails to en order (tr) or half-reorders (qu).
+
+### (b) From-phrases postposed after the verb (tr)
+
+- tr repeat header: `kadar olay pointerup i tekrarla belge den`
+  (en: `repeat until event pointerup from document`) — `belge den` (from
+  document) strands **after** `tekrarla` (repeat). Feeds the same junk-capture
+  as (a); also the loop-end slicing puts tr's missed `remove.patient` next to
+  the stranded junk.
+
+### (c) Block terminators rendered inside the following clause's object phrase (bn, qu, tr)
+
+- **bn repeat-while**: `… তারপর 200ms শেষ কে অপেক্ষা` — the terminator শেষ
+  (end) sits between the duration and wait's object marker. It belongs after
+  the verb: `… 200ms কে অপেক্ষা শেষ`, exactly how bn renders
+  repeat-until-event / repeat-forever / stagger-animation. (The parser now
+  tolerates this — see "Parser-tolerance interplay" — but the render is still
+  wrong.)
+- **qu behavior-resizable**: the inline-if's inner set's verb-final tail
+  `man churanay` renders **after** `tukuy` (end):
+  `sichus newWidth < minWidth chayqa newWidth ta minWidth tukuy man churanay`.
+  The conditional fold eats up to `tukuy` and strands the tail — the two style
+  sets (`noqaq *width/*height …`) drop; 10 of en's 12 sets parse. This is the
+  open side-quest of the colon-event arc (NEXT_STEPS § follow-ups item 2),
+  assessed there as "the `end` belongs after the verb — transformer/corpus
+  rendering bug, not parser tolerance".
+- **tr behavior-sortable**: the loop's `son` (end) lands directly before the
+  `remove` line's patient, whose positional reading then prefixes it —
+  `remove.patient="last .{dragClass}"` vs en `.{dragClass}` → R3 row
+  `tr: missing remove.patient=.{dragClass}`.
+
+### Known-affected rows (the current scoreboard)
+
+- R3 report (`Role values (R3)` console section): `behavior-sortable` qu ×2 +
+  tr ×2 — the ONLY non-wontfix rows left after #635 (swap-content ×8 is the
+  documented F6 wontfix; do not chase those).
+- Multiset-recall: qu `behavior-resizable` (10/12 sets) — the one sub-1.0 row.
+- Cosmetic-but-wrong renders the parser now tolerates: bn repeat-while (c).
+- **Check siblings before declaring done:** behavior-draggable has the same
+  `repeat until event pointerup from document` + or-run wait shape (with
+  clientX AND clientY). It doesn't flag today — verify whether its tr/qu
+  renders are clean or merely masked, and whether fixing (a)/(b) changes them.
+
+## Where the code lives
+
+- **Renderer:** `packages/i18n/src/grammar/transformer.ts`
+  (`GrammarTransformer`). Known internals from prior arcs: line-by-line
+  translation (a block construct written single-line in the seed scrambles —
+  #627 arc); `BLOCK_HEAD_KEYWORDS` (line ~562) only covers
+  `live`/`when`/`unless`; `applyPrimaryRole` ~1337–1363;
+  `COMMAND_PRIMARY_ROLES` in `packages/i18n/src/constants.ts`. **The
+  wait/or-run/from-phrase reorder path has NOT been explored — start there.**
+  Suspect the semantic-role segmentation of `wait for X or Y from Z` (three
+  phrases) and `repeat until event E from S`.
+- **Profiles/word order:** `packages/i18n/src/grammar/profiles/` (tr, qu, bn).
+- **Corpus pipeline:** `packages/patterns-reference/scripts/sync-translations.ts`
+  builds each translation via `new GrammarTransformer('en', language)` (cached,
+  line ~125). `npm run populate --prefix packages/patterns-reference` re-renders
+  patterns.db from the dicts + transformer — **that is how a transformer fix
+  reaches the corpus**.
+- **Direct probe without populate:** in `packages/i18n`, transform a single en
+  line with `GrammarTransformer` (see `grammar.test.ts` conventions), or use
+  `MultilingualHyperscript.translate(en, 'en', 'tr')` from
+  `@hyperfixi/core/multilingual`. Iterate at this level; only populate when the
+  render looks right.
+
+## The locks, and the fixture subtlety when flipping them
+
+All in `packages/semantic/test/multilingual-roadmap-fixes.test.ts`:
+
+1. § "R3 value-bug families" → `describe('F7: …')`:
+   `it.fails('[qu] behavior-sortable: all three trigger events by VALUE …')`
+   and `it.fails('[tr] behavior-sortable: sortable:move + bare remove patient …')`,
+   plus a **passing** guard (`[qu/tr] … command-level actions all survive`)
+   that must stay green.
+2. § "colon-qualified event names …":
+   `it.fails('[qu] behavior-resizable: the two style sets still drop …')`, with
+   its passing sibling asserting `set >= 10` / triggers-by-value.
+
+**CRITICAL:** these fixtures hard-code the *current malformed* corpus text.
+Fixing the transformer changes patterns.db but NOT the fixtures — the
+`it.fails` will keep expected-failing on the old text and will NOT flip by
+themselves. The flip procedure is:
+
+1. Fix transformer → ordered build → `populate`.
+2. Re-pull the qu/tr sortable + qu resizable renders from patterns.db
+   (`SELECT hyperscript FROM pattern_translations WHERE code_example_id=… AND
+   language=…`).
+3. Replace the fixtures with the NEW renders, convert `it.fails` → `it`
+   (and raise the resizable sibling's `set` floor from `>= 10` to `toBe(12)`).
+4. Decide whether to keep a copy of the OLD malformed text as a parser
+   tolerance lock (recommended for the bn repeat-while shape — see below) or
+   drop it.
+
+## Parser-tolerance interplay (#635 — do not undo)
+
+PR #635 added parser tolerances that must SURVIVE this arc (they're locked by
+unit tests pinned to the old corpus shapes, which remain valid inputs):
+
+- `processGroup` (semantic-parser.ts) skips stray block terminators in SOV
+  value groups (bn `200ms শেষ কে`), with a selector lookahead preserving
+  positional-`last` (`শেষ <li/>`, `son .item`).
+- `matchRoleToken` (pattern-matcher.ts) rejects keyword-kind `then` / a
+  non-positional `end` as any role value.
+- The F3 fused-path trailing-destination reclaim and `in`-qualifier handling.
+
+Fixing the renders makes these tolerances *less exercised*, not wrong. Note
+one interaction: tr's `remove.patient="last .{dragClass}"` is produced BY the
+positional lookahead tolerating the stranded `son` — once the render is fixed,
+the prefix disappears on the new corpus, while the old-text tests keep passing
+as tolerance locks.
+
+## Method
+
+1. **Probe the render, not the parse, first**: for each defect, transform the
+   en line directly (GrammarTransformer / translate) and iterate until the
+   output is verb-final with the from-phrase/or-run inside the clause and the
+   terminator after the verb. Add i18n unit tests in
+   `packages/i18n/src/grammar/grammar.test.ts` conventions for each fixed shape
+   (tr/qu wait+or+from, tr repeat-until-from, bn trailing-end-in-body, qu
+   inline-if verb-final tail before `tukuy`).
+2. **Then re-render + re-parse**: ordered build →
+   `npm run populate --prefix packages/patterns-reference` → probe the parsed
+   corpus bodies per language (throwaway `.mts` inside
+   `packages/testing-framework` or `packages/semantic`, walk
+   body/statements/thenBranch/elseBranch/branches/eventHandlers/initBlock,
+   print `role=value(type)` + `metadata.patternId`, `process.exit(0)`, delete
+   before commit).
+3. **Sweep**: full sweep WITHOUT `--regression` (redirect to a file, check
+   `$?`, never pipe to `tail`); the R3 `behavior-sortable` rows and the
+   multiset qu `behavior-resizable` row must vanish and **no new rows appear
+   in ANY signal** — a corpus re-render moves every language's text, so read
+   the whole report (parse-rate, precision, R0/R1/R2), not just R3.
+4. Flip the locks per the fixture procedure above; flip/retire the NEXT_STEPS
+   entries (§ R3 families item 7, § colon-event follow-ups item 2, and the F2
+   rendering note); mark this handoff resolved.
+5. `--regression` green → `--save-baseline` on the freshly populated db →
+   `npx prettier --write baselines/multilingual-priority.json` → audit the
+   baseline diff line-by-line (only attributable fields may move) → commit
+   baseline, **never patterns.db**.
+
+## Traps (inherited + arc-specific)
+
+- **Corpus rewrites couple to the fidelity baseline** (memory:
+  corpus-rewrites-couple-to-fidelity): a transformer change re-renders EVERY
+  pattern in that language, not just the target rows. Expect mixed per-language
+  deltas and attribute each; "fixing en-reference-adjacent noise makes some
+  numbers go down honestly" applies here too. Resweep and inspect
+  lossy/degenerate/exec — never trust exit 0 alone.
+- **The transformer translates line-by-line** — reorder logic is per-line, but
+  defect (c) manifests as a terminator landing inside the *next* phrase of the
+  SAME line's rendering (`… wait 200ms end` is one en line). Check where the
+  trailing `end` is attached during segmentation before assuming cross-line
+  handling.
+- Sequence strictly: src → `npm run test:multilingual:build-deps` → `populate`
+  → sweep. The gate and `--save-baseline` REFUSE on any guarded package whose
+  `src/` is newer than dist; `git stash` (including lint-staged's backup
+  stashes during commit) bumps mtimes — rebuild after committing, before
+  sweeping.
+- After touching **i18n**, rebuild i18n AND everything downstream in the
+  ordered chain (populate consumes the built transformer). `semantic/dist`
+  resolves `@lokascript/framework` at runtime — same rebuild rule if framework
+  is touched.
+- tsx probes hang without `process.exit(0)`; probes must run with cwd inside
+  the package whose src they import.
+- ko/ja curated `isEndKeyword` sets deliberately EXCLUDE the exit/end
+  collision words, and bn's excludes শেষ (dual-use positional `last`) — if the
+  fix changes which terminator word is emitted, re-check
+  `semantic-parser.ts` `isEndKeyword`/`isBlockEndToken` alignment.
+
+## Definition of done
+
+- tr/qu behavior-sortable wait + repeat-header lines render verb-final with
+  from-phrase/or-run inside the clause; bn repeat-while renders `200ms কে
+  অপেক্ষা শেষ`; qu resizable renders `man churanay` before `tukuy`.
+- i18n unit tests lock each fixed rendering shape.
+- The four R3 behavior-sortable rows and the qu resizable multiset row are
+  gone; the ONLY remaining R3 rows are swap-content ×8 (F6 wontfix). qu/tr/bn
+  avgValueRecall rise accordingly; no other signal drops.
+- All three `it.fails` locks flipped to hard asserts on refreshed fixtures
+  (resizable `set` count 12); old-shape parser-tolerance tests retained.
+- NEXT_STEPS updated (items retired with outcomes); this handoff marked
+  resolved in its header; baseline regenerated + prettier'd + committed.

--- a/docs-internal/HANDOFF_value-bug-families.md
+++ b/docs-internal/HANDOFF_value-bug-families.md
@@ -1,0 +1,187 @@
+# Handoff: burn down the R3-discovered value-bug families
+
+> **RESOLVED 2026-07-10** (fix/r3-value-bug-families). F1–F5 + F8 fixed, F6
+> wontfix'd, F7 re-filed to the transformer arc — per-family outcomes and the
+> corrected root causes (F2 was NOT the tokenizer; F5's markerVariants
+> hypothesis could not work; F4 was the fused VSO event pattern, not
+> markerlessFetch) live in `docs-internal/MULTILINGUAL_NEXT_STEPS.md`
+> § "R3-discovered value-bug families". Unit locks:
+> `packages/semantic/test/multilingual-roadmap-fixes.test.ts` § "R3 value-bug
+> families". Kept for the probe method + traps sections below.
+>
+> **For a fresh session.** Read this, then CLAUDE.md ("Multilingual parse rate ≠
+> fidelity" — R3 is signal 8 — and "Running the multilingual `--regression` gate
+> locally"), then `docs-internal/MULTILINGUAL_NEXT_STEPS.md` § "R3-discovered
+> value-bug families". Branch from `main` at or after `0f562a50` (#634, the R3
+> arc) — the signal, the report tooling, and the triage below all landed there.
+
+## Why this arc
+
+The R3 value-recall signal (#634) compares language-invariant role VALUES
+(selectors, sigil refs, time literals, colon-qualified event names, URLs)
+verbatim against the en reference. Its first sweep surfaced **50 sub-1.0
+instances across 18 patterns** — all triaged with live probes into the families
+below, all **baseline-recorded** (the ratchet only catches *further*
+regressions; it will not push these down). Most are invisible to every other
+signal: right actions, right role types, wrong value. Several have real runtime
+consequences. Current floor: cross-language avgValueRecall **0.9861**
+(authoritative numbers: `packages/testing-framework/baselines/multilingual-priority.json`).
+
+Every family below was verified by parsing the actual corpus text and dumping
+roles — the captures shown are real, not inferred.
+
+## The families (probe evidence → suspected cause), in suggested order
+
+### F1 — connective swallowed as `increment.quantity` (highest value)
+
+- **Where:** ar/it/ms/pl/tl/vi × `repeat-until-event`; bn-excluded set
+  it/ms/pl/ru/uk/vi × `repeat-while`. 14 instances, 8 languages.
+- **Probe:** it `… incrementare #counter allora aspettare 200ms …` →
+  `increment: patient="#counter"(selector) | quantity="then"(literal)`.
+  pl identical (`wtedy` → `"then"`). en gets `quantity=1` via the schema
+  default (`fillSchemaDefaults`); these languages capture the **normalized
+  connective** as an explicit quantity.
+- **Runtime:** increment by `"then"` — NaN-shaped. This is a live behavior
+  divergence, not just a signature mismatch.
+- **Suspect:** the SVO-generated increment pattern captures the trailing
+  token into the optional `quantity` role with no numeric constraint. Look at
+  the increment schema's quantity role (`command-schemas.ts` — compare how
+  other numeric roles constrain `expectedTypes`/dataType) and at where
+  generated patterns should treat normalized connectives (`then`) as
+  stop-tokens for role capture. Note ru/uk fire only on `repeat-while` and
+  ar/tl only on `repeat-until-event` — check both corpus renderings when
+  verifying.
+
+### F2 — bn duration-glue (single tokenizer, contained)
+
+- **Where:** bn × 6 patterns: `repeat-until-event` (100ms), `repeat-while`
+  (200ms), `repeat-forever` (1s), `copy-to-clipboard` (2s),
+  `stagger-animation` (100ms), `tell-other-element` (200ms).
+- **Probe:** bn repeat-while → `wait: duration="200msশেষ"(literal)` — the
+  block terminator শেষ (end) glued onto the latin-digit token.
+- **Suspect:** the Bengali tokenizer's character classification does not
+  break at the latin/digit→Bengali script transition. Fix in
+  `packages/semantic/src/tokenizers/` (bn); compare how other non-Latin
+  tokenizers handle script-boundary breaks. bn currently sits at
+  avgValueRecall 0.958 — this family is most of the residue.
+
+### F3 — SOV `in me` qualifier glue/drop (hardest — hottest SOV path)
+
+- **Where:** bn/hi/ja/ko/qu × `form-disable-on-submit`.
+- **Probe:** en → `add.destination="<button/>"` + `put.destination="<button/>"`.
+  ja/bn → `add: destination="me"(reference)` (the `<button/> in me` phrase
+  LOST; destination fell back to the schema default) and
+  `put: destination="<button/>inme"(selector)` — glued, whitespace elided,
+  type still `selector` so **R1 scores the put perfect**.
+- **Two sub-defects:** (a) the SOV reorder loses add's qualifier phrase
+  entirely; (b) the CSS-selector extraction glues `<button/>` + untranslated
+  `in me` into one token. Note the corpus renderings keep literal English
+  `in me` inline — if the fix ends up touching corpus/renderer text, remember
+  **corpus rewrites couple to the fidelity baseline** (memory:
+  corpus-rewrites-couple-to-fidelity): resweep and inspect, don't trust exit 0.
+- **Regression-sensitive:** this is the SOV event/role anchoring path that
+  previous arcs treated carefully. Guard R0/precision/parse-rate.
+
+### F4 — pl/ru/uk `fetch` URL mis-role
+
+- **Where:** pl/ru/uk × `fetch-with-method`, `fetch-with-headers`,
+  `fetch-with-method-body`, `fetch-formdata` (12 instances).
+- **Probe:** pl `pobierz /api/form z method:"POST" body:form` →
+  `fetch: patient="/api/form" | source="method"`. en →
+  `fetch: source="/api/form" | style="method"`.
+- **Suspect:** the Slavic *with*-preposition (`z`/`с`/`з`) is being read as
+  the fetch `source` marker, displacing the URL into `patient`. Check the
+  pl/ru/uk profile role markers vs the fetch schema (`patterns/fetch.ts` has
+  the per-language pattern shapes; `sovFetch` precedent shows how markers were
+  fixed for other languages). Partially R1-visible (role types differ), fully
+  R3-visible. Runtime-relevant: the fetch target is wrong.
+
+### F5 — hi `transition` duration drop (likely small)
+
+- **Where:** hi × `transition-opacity/transform/color`, `fade-out-remove`.
+- **Probe:** hi `opacity को क्लिक पर संक्रमण 0 में 500ms …` →
+  `transition: patient | goal=0 | destination` — **no duration role at all**
+  (en has `duration="500ms"`). The `में` marker before `500ms` is not being
+  read as transition's over/duration marker.
+- **Suspect:** transition schema duration-role marker for hi — possibly the
+  same `markerVariants` one-liner shape as the hi/qu/bn trigger fixes
+  (`command-schemas.ts`, #588 machinery). R1-visible (role missing) but
+  sub-threshold in aggregate; R3 pinpoints it.
+
+### F6 — `swap` role-binding flip (decide: align or wontfix)
+
+- **Where:** ar/bn/hi/ja/ko/qu/tl/tr × `swap-content` (8 instances, the
+  single biggest pattern).
+- **Probe:** en `swap #a with #b` → `destination="#a" | patient="#b"` (note:
+  arguably backwards). ja `#a を … #b で` → `patient="#a" | destination="#b"`
+  — the transformer marks `#a` accusative. Same role-type SET, so R1 is
+  totally blind; runtime-benign (swap is symmetric).
+- **Decision needed:** align the en swap schema's positional role mapping
+  with the transformer's marking (moves the baseline; watch R1), or document
+  as permanent noise. Don't special-case the R3 walker per-action — if
+  wontfix, record the rationale in NEXT_STEPS and leave the rows visible.
+
+### F7 / F8 — residue (optional)
+
+- **F7:** qu misses `trigger.event=sortable:move`+`sortable:start`; tr misses
+  `sortable:move` + `remove.patient=.{dragClass}` (`behavior-sortable`).
+  Sibling of the FIXED bn accusative gap (#634) — but bn's fix was markers;
+  qu/tr are likely reorder placement. Also adjacent to the open qu
+  `behavior-resizable` side-quest (NEXT_STEPS § Colon-event-names follow-ups
+  item 2, locked by `it.fails` in `multilingual-roadmap-fixes.test.ts`).
+- **F8:** ms `ulang 3 kali …` → `repeat: loopType=3`, no `quantity` (en:
+  `quantity=3, loopType="times"`). R1-visible; single row.
+
+## Method (reuse this loop per family)
+
+1. **Corpus text:** `sqlite3 packages/patterns-reference/data/patterns.db
+   "SELECT raw_code FROM code_examples WHERE id='<pattern>'"` and
+   `"SELECT language, hyperscript FROM pattern_translations WHERE
+   code_example_id='<pattern>' AND language IN (…)"`.
+2. **Probe:** a throwaway `.mts` file placed **inside
+   `packages/testing-framework/`** (workspace module resolution; `.mts` so tsx
+   allows top-level await), importing `MultilingualHyperscript` from
+   `@hyperfixi/core/multilingual` + `fillSchemaDefaults` from
+   `@lokascript/semantic`, walking `body/statements/thenBranch/elseBranch/
+   branches/eventHandlers/initBlock` and printing
+   `role=(value.value ?? value.raw ?? value.name)(type)` per command. End with
+   `process.exit(0)` (tsx probes hang otherwise). Delete before committing.
+3. **Fix + unit test** in `packages/semantic` (follow the
+   `multilingual-roadmap-fixes.test.ts` / `draggable-patterns.test.ts`
+   conventions; lock any gap you find-but-don't-fix with `it.fails`).
+4. **Sweep feedback:** ordered build → populate → full sweep **without**
+   `--regression`. The console "Role values (R3)" section lists every
+   `pattern / lang / missing action.role=value` row — your fixed rows should
+   vanish and no new rows appear. Per-pattern detail also serializes to
+   `test-results/results.json` (`valueRecall`, `valueRecallMissing`; the roles
+   themselves serialize as `{}` — never read those from JSON).
+
+## Traps (all hard-won; do not relearn)
+
+- **Sequence strictly:** src changes → `npm run test:multilingual:build-deps`
+  → `npm run populate --prefix packages/patterns-reference` → sweep. The gate
+  and `--save-baseline` REFUSE on any guarded package whose `src/` is newer
+  than its dist. `git stash` bumps mtimes and trips it. Never pipe the gate to
+  `tail`; redirect to a file and check `$?`.
+- `semantic/dist` resolves `@lokascript/framework` at **runtime** — after
+  touching framework, rebuild both or semantic tests throw
+  `this.<fn> is not a function`.
+- **Every fix here RAISES avgValueRecall** (and possibly avgRoleFidelity /
+  avgPrecision) → the gate will NOT fail, but regenerate the baseline anyway
+  (`--save-baseline` on a freshly populated db, then
+  `npx prettier --write baselines/multilingual-priority.json`) so the ratchet
+  floor rises with you. Commit the baseline, **never** `patterns.db`. One
+  regen at the end is fine if the families land as one PR; per-PR if split.
+- F3/F4 touch the hottest SOV/marker paths — watch parse-rate, precision, and
+  the R2 execution rows in the sweep output, not just R3.
+
+## Definition of done (suggested)
+
+- F1–F5 fixed, each with unit tests; their R3 report rows gone.
+- F6 decided (schema/renderer aligned **or** wontfix documented in
+  NEXT_STEPS); F7/F8 fixed or explicitly re-filed.
+- Full `--regression` gate green; baseline regenerated + prettier'd +
+  committed; NEXT_STEPS § "R3-discovered value-bug families" updated with
+  per-family outcomes; this handoff marked resolved in its header.
+- Stretch target: cross-language avgValueRecall = 1.000 minus documented
+  wontfixes (bn should reach 1.0 once F2 lands).

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -2628,49 +2628,98 @@ languages including en (was split everywhere). Follow-up status:
    (`behavior-draggable/resizable/sortable`), and the fix healed those rows too
    (bn avgValueRecall 0.917 → 0.958).
 
-## R3-discovered value-bug families (opened 2026-07-10)
+## R3-discovered value-bug families (opened 2026-07-10, burned down 2026-07-10)
 
 The first R3 sweep surfaced 50 sub-1.0 instances across 18 patterns — all triaged
-(probe transcript in the R3 arc). Every family is **invisible to R0/R1** (right
-actions, right role types) except where noted. Baseline-recorded, so the ratchet
-only fires on _further_ regressions; burning these down is follow-up work, roughly
-in value order:
+(probe transcript in the R3 arc), then burned down in the value-bug-families arc
+(`docs-internal/HANDOFF_value-bug-families.md`, resolved). Per-family outcomes —
+F1–F5 + F8 **fixed** (unit-locked in `multilingual-roadmap-fixes.test.ts` § "R3
+value-bug families"), F6 **wontfix** (documented), F7 **re-filed**:
 
-1. **Connective swallowed as `increment.quantity`** (ar/it/ms/pl/ru/uk/tl/vi ×
-   `repeat-until-event`/`repeat-while`). `zwiększ #counter wtedy czekaj` parses with
-   `quantity="then"` — the normalized connective captured as increment's quantity
-   (en gets the schema default `1`). Runtime divergence: increment by `"then"` is
-   NaN-shaped. Likely one guard in the SVO two-role generation or a
-   quantity-role type constraint (`expectedTypes` number).
-2. **bn duration-glue** (`repeat-while`/`repeat-until-event`/`repeat-forever`/
-   `copy-to-clipboard`/`stagger-animation`/`tell-other-element`). bn tokenizer glues
-   the block terminator onto the preceding duration: `wait.duration="200msশেষ"`.
-   Tokenizer boundary bug (Bengali script adjacency).
-3. **SOV `in me` qualifier glue/drop** (bn/hi/ja/ko/qu × `form-disable-on-submit`).
-   en: `add.destination=<button/>` + `put.destination=<button/>` (with an `in me`
-   qualifier). SOV: add's destination falls back to default `me` (phrase lost) and
-   put's destination captures glued `<button/>inme`. Type stays `selector`, so R1
-   scores the put perfect — R3-only.
-4. **pl/ru/uk `fetch` URL mis-role** (4 fetch patterns). `pobierz /api/form z
-   method:"POST"` parses `patient=/api/form, source=method` — URL and with-clause
-   land in swapped roles (en: `source=/api/form, style=method`). Partially
-   R1-visible; runtime-relevant (fetch target wrong).
-5. **hi `transition` duration drop** (4 transition patterns). hi's rendering drops
-   `500ms` from roles entirely (`में` marker gap). R1-visible as missing role;
-   R3 pinpoints the value.
-6. **`swap` role-binding flip** (ar/bn/hi/ja/ko/qu/tl/tr × `swap-content`). en parses
-   `swap #a with #b` as `destination=#a, patient=#b`; SOV/VSO renderings mark `#a`
-   as patient — same role-type SET, so R1 is blind. Runtime-benign (swap is
-   symmetric) but flags the en swap schema's role mapping disagreeing with the
-   transformer's marking. Fix = align schema/renderer, or normalize symmetric
-   commands in the signature.
-7. **qu/tr behavior trigger-event residue** (`behavior-sortable`: qu misses
-   `sortable:move`+`sortable:start`, tr misses `sortable:move` +
-   `remove.patient=.{dragClass}`). Sibling of the fixed bn gap; likely reorder
-   placement rather than markers.
-8. **ms `repeat 3 kali` count swallowed** (`repeat-times`). ms parses
-   `loopType=3` with no `quantity` (en: `quantity=3, loopType=times`). R1-visible;
-   listed for completeness.
+1. ~~**Connective swallowed as `increment.quantity`**~~ **FIXED** (ar/it/ms/pl/ru/
+   uk/tl/vi × `repeat-until-event`/`repeat-while`). The generated patterns'
+   trailing marker-less optional `{quantity}` slot captured the normalized
+   connective (`quantity="then"` — increment by NaN at runtime). Fixed by a
+   `matchRoleToken` guard: a keyword-kind token normalized `then` (or a
+   non-positional `end`) is never a role value — optional slots skip and the
+   schema default fills (`quantity=1`), required slots fail the pattern.
+   Deliberately narrower than CLAUSE_BOUNDARY_KEYWORDS: `and` collides with the
+   untranslated English pronoun `I` (pl `i`), and `end` keeps its
+   positional-`last` reading before a selector. Also aligned the it/vi hand
+   increment patterns' string `'1'` defaults to number `1` (they now win
+   matchBest).
+2. ~~**bn duration-glue**~~ **FIXED — two mechanisms, neither the tokenizer**
+   (the handoff's hypothesis was wrong; the bn tokenizer splits fine).
+   (a) `repeat-while` only: the reorder renders wait's object phrase as
+   `200ms শেষ কে` (terminator INSIDE the phrase — see the transformer defect
+   note below) and the SOV verb-anchoring's `processGroup` joined the pair
+   whitespace-free into `duration="200msশেষ"`. Fixed by skipping stray
+   terminator-shaped tokens during value accumulation (positional `শেষ
+   <selector>` keeps its `last` reading via selector lookahead).
+   (b) The other five rows were family-1's mechanism: the generated verb-first
+   wait's duration slot captured তারপর/শেষ (`duration="then"`/`"end"`) while
+   dropping the real `2s/1s/100ms কে` prefix — fixed by the same
+   matchRoleToken guard. bn should now sit at avgValueRecall 1.0.
+3. ~~**SOV `in me` qualifier glue/drop**~~ **FIXED** (bn/hi/ja/ko/qu ×
+   `form-disable-on-submit`). en's add/put schemas have no scope role, so the en
+   reference DROPS `in me`; two SOV defects fixed to match: (a) put's
+   verb-anchoring glue (`<button/>inme`) — `tokensToSemanticValue` now truncates
+   a selector-LED group at a later `in` token; (b) add's fused-path drop
+   (destination silently defaulted to `me` — the fronted patient sits outside
+   the [verb..boundary] re-parse slice, so the superset gate rejects the swap
+   and the postposed phrase was never reclaimed) — added the missing trailing
+   DESTINATION/SOURCE reclaim on the fused path plus an `in`-qualifier skip in
+   `tryAttachTrailingRole` (destination-strict, primary-marker-gated).
+4. ~~**pl/ru/uk `fetch` URL mis-role**~~ **FIXED** (4 fetch patterns ×3 langs).
+   Root cause: pl `z` / uk `з` are BOTH the profile's source and style markers
+   (ru `с` is style-primary and a source-alternative), so the fused generic VSO
+   event pattern bound the URL to `{patient}` (fetch has no patient role) and
+   read the with-OPTIONS head as `source`. Fixed by a fetch-specific relabel in
+   `normalizeCommandRoles` (patient + expression-typed source + empty style is
+   schema-impossible except via this mis-parse → source→style, patient→source).
+   Profile markers deliberately untouched (global blast radius).
+5. ~~**hi `transition` duration drop**~~ **FIXED** (4 transition patterns). The
+   handoff's `markerVariants` one-liner could not work (hi profile has no
+   duration roleMarker; the match is the fused SOV 2-role pattern which ends at
+   `{goal}`). Fixed in the trailing-DURATION reclaim: skip exactly one particle
+   when a TIME-shaped literal directly follows it (`में 500ms` — the
+   prepositional sibling of the bn `জন্য` postposition).
+6. **`swap` role-binding flip — WONTFIX** (ar/bn/hi/ja/ko/qu/tl/tr ×
+   `swap-content`, 8 rows, permanent R3 noise). en parses `swap #a with #b` as
+   `destination=#a, patient=#b` (swapSchema: destination bare-marked svoPos 2,
+   patient with-word svoPos 3); the SOV/VSO transformer marks `#a` accusative →
+   the roles land flipped. Same role-type SET (R1-blind) and swap is
+   runtime-symmetric for the element shape, so this is signature noise, not a
+   behavior bug. Aligning would require flipping destination/patient across the
+   en hand pattern + swapSchema for ALL SVO languages together AND auditing the
+   ast-builder swap mapper / core runtime / renderer round-trip — deemed not
+   worth the regression surface for zero runtime effect (decision 2026-07-10).
+   The 8 rows stay visible in the R3 report; do NOT special-case the R3 walker.
+   If a future arc flips it, regenerate the baseline and watch R1/R2.
+7. **qu/tr behavior trigger-event residue — RE-FILED to the transformer arc**
+   (`behavior-sortable`). Probing shows the command-level action multiset
+   matches en in both languages; only VALUES around the loop's wait line
+   corrupt, each adjacent to a malformed render: tr renders the repeat header's
+   from-phrase AFTER the verb (`kadar olay pointerup i tekrarla belge den`) and
+   the wait line verb-FIRST (`bekle pointermove(clientY) veya … belge den` —
+   the middle trigger captures the stranded `belge` as its event; the loop's
+   `son` before `remove` gives the patient a spurious `last` prefix); qu
+   renders the wait verb-MEDIAL (`qillqa manta suyay pointermove(clientY) utaq
+   …` — the middle trigger glues the whole stranded or-run). Same
+   transformer-rendering family as the open qu `behavior-resizable` side-quest
+   (item 2 of the colon-event follow-ups above) and the bn repeat-while
+   terminator placement (family 2a). Locked by two `it.fails` in
+   `multilingual-roadmap-fixes.test.ts` § "R3 value-bug families" F7 (flip when
+   the transformer rendering is repaired). **Transformer-arc worklist:** fix the
+   SOV/agglutinative reorder stranding (a) or-run wait lines rendered
+   verb-first/verb-medial (tr/qu), (b) from-phrases postposed after the verb
+   (tr `belge den`), (c) block terminators rendered inside the following
+   clause's object phrase (bn `200ms শেষ কে অপেক্ষা`, qu resizable's `tukuy man
+   churanay`).
+8. ~~**ms `repeat 3 kali` count swallowed**~~ **FIXED**. The `repeat-ms-times`
+   HEAD's count word was left as English `times`, so `ulang 3 kali` fell through
+   to the generated positional repeat (`loopType=3`, no quantity). Localized to
+   `kali` (the th/vi/tl precedent).
 
 ## Recommended sequence
 

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -2697,7 +2697,7 @@ value-bug families"), F6 **wontfix** (documented), F7 **re-filed**:
    The 8 rows stay visible in the R3 report; do NOT special-case the R3 walker.
    If a future arc flips it, regenerate the baseline and watch R1/R2.
 7. **qu/tr behavior trigger-event residue — RE-FILED to the transformer arc**
-   (`behavior-sortable`). Probing shows the command-level action multiset
+   (`behavior-sortable`; handoff: `docs-internal/HANDOFF_transformer-rendering.md`). Probing shows the command-level action multiset
    matches en in both languages; only VALUES around the loop's wait line
    corrupt, each adjacent to a malformed render: tr renders the repeat header's
    from-phrase AFTER the verb (`kadar olay pointerup i tekrarla belge den`) and

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -540,6 +540,33 @@ export class PatternMatcher {
       }
     }
 
+    // A sequence CONNECTIVE (`then`) or stray BLOCK TERMINATOR (`end`), by
+    // normalized form, is never a role VALUE on any command. The trailing
+    // marker-less optional {quantity} slot of the generated increment
+    // patterns otherwise swallows the normalized connective that opens the
+    // next statement (it `allora`, pl `wtedy`, ar `ثم` → quantity:literal=
+    // "then" — increment by NaN at runtime; repeat-while/repeat-until-event
+    // across it/ms/pl/ru/uk/ar/tl/vi), and the generated verb-first wait
+    // duration slot swallows a following তারপর/শেষ the same way (bn
+    // duration="then"/"end" ×5 — R3 families F1/F2). Kind-gated to `keyword`
+    // so a string literal "then" (kind `literal`) is untouched; en
+    // connectives normalize identically, so the reference parse and every
+    // translation change symmetrically. Multi-token literal phrases (`at end
+    // of`) match via matchLiteralToken and never reach this. Deliberately NOT
+    // the full CLAUSE_BOUNDARY_KEYWORDS set: `and` collides with the
+    // untranslated English pronoun `I` (pl `i` = and — the unless-condition
+    // corpus), and `end` keeps its positional-`last` reading before a
+    // selector (bn `শেষ <li/>`, the isBlockEndToken lookahead). An optional
+    // slot skips (the schema default fills, e.g. quantity=1); a required slot
+    // fails the pattern — the same net effect as the load-bearing
+    // capture-and-fail (see the trailing-verb guard below).
+    if (token.kind === 'keyword') {
+      const connNorm = (token.normalized ?? token.value).toLowerCase();
+      if (connNorm === 'then' || (connNorm === 'end' && tokens.peek(1)?.kind !== 'selector')) {
+        return patternToken.optional || false;
+      }
+    }
+
     // A `duration` slot is never a positional/scope keyword. The temporal
     // `in {duration}` idiom (`in 2s`) otherwise greedily swallows a *locative*
     // `in closest <form/>` (the scope of `focus first <input/> in closest <form/>`)

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1677,8 +1677,22 @@ export class SemanticParserImpl implements ISemanticParser {
           r => r.role === 'duration' && !r.required
         );
         if (hasOptionalDuration && !dNode.roles.has('duration')) {
-          const trailing = tokens.peek();
-          if (trailing && /^\d+(\.\d+)?(ms|s)$/i.test(trailing.value)) {
+          const timeRe = /^\d+(\.\d+)?(ms|s)$/i;
+          let trailing = tokens.peek();
+          // hi renders `over 500ms` with the marker BEFORE the time literal
+          // (`में 500ms` — the prepositional sibling of the bn trailing জন্য
+          // postposition consumed below). Skip exactly one particle when a
+          // TIME-shaped literal directly follows it; ja/ko/bn keep the bare
+          // adjacent-literal path unchanged.
+          let markerSkip = false;
+          if (trailing && trailing.kind === 'particle') {
+            const after = tokens.peek(1);
+            if (after && timeRe.test(after.value)) {
+              markerSkip = true;
+              trailing = after;
+            }
+          }
+          if (trailing && timeRe.test(trailing.value)) {
             commandNode = createCommandNode(
               actionName as ActionType,
               {
@@ -1691,6 +1705,7 @@ export class SemanticParserImpl implements ISemanticParser {
               },
               dNode.metadata
             );
+            if (markerSkip) tokens.advance();
             tokens.advance();
             // Consume a trailing rendered duration postposition (bn `500ms
             // জন্য` — the transformer renders `over` as the for-postposition

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1843,6 +1843,18 @@ export class SemanticParserImpl implements ISemanticParser {
             }
           }
         }
+
+        // Trailing DESTINATION/SOURCE reclaim — the add/put/remove sibling of
+        // the quantity/duration/responseType/wait reclaims above. The SOV
+        // reorder fronts the patient (`@disabled を 送信 で 追加 <button/> in
+        // me に`), so the [verb..boundary] re-parse's superset gate rejects
+        // the swap (the fronted patient sits outside the slice) and the
+        // postposed destination phrase is left unconsumed — the role silently
+        // defaults to `me` (form-disable-on-submit ×4 SOV). Same guarded
+        // helper as the parseClause call site: schema-declared role,
+        // absent-or-`me`-default only, destination matched by PRIMARY marker
+        // only, strict value shapes.
+        this.tryAttachTrailingRole(tokens, commandNode as CommandSemanticNode, language);
       }
 
       // Check if pattern has continuation marker (then-chains).
@@ -2718,6 +2730,32 @@ export class SemanticParserImpl implements ISemanticParser {
           if (v) roles.set(role, v);
           return;
         }
+        // Postpositional with an untranslated scope qualifier the transformer
+        // keeps inline: `<value> in <x> <marker>` (`<button/> in me に`,
+        // form-disable-on-submit ×4 SOV). en's add/put schemas have no scope
+        // role and DROP the qualifier (`add @disabled to <button/> in me` →
+        // destination="<button/>"), so attach the bare value and consume
+        // through the marker — the same en-lossiness. Strict (destination)
+        // only, single-token qualifier object, and the marker must close the
+        // phrase, so `in closest <form/>` (no adjacent marker) is untouched.
+        if (strict && isValue(tok0, strict)) {
+          const tok2 = stream.peek(2);
+          const tok3 = stream.peek(3);
+          if (
+            (tok1.normalized ?? tok1.value).toLowerCase() === 'in' &&
+            tok2 &&
+            !isMarker(tok2) &&
+            isMarker(tok3)
+          ) {
+            const v = this.tokenToSemanticValue(tok0);
+            stream.advance();
+            stream.advance();
+            stream.advance();
+            stream.advance();
+            if (v) roles.set(role, v);
+            return;
+          }
+        }
       } else {
         // Prepositional `<marker> <value>` (SVO th: จาก/ใน body).
         if (isMarker(tok0) && isValue(tok1, strict)) {
@@ -3047,8 +3085,27 @@ export class SemanticParserImpl implements ISemanticParser {
     if (tokens.length === 0) return null;
 
     // Filter out noise tokens (whitespace, etc.)
-    const meaningful = tokens.filter(t => (t.kind as string) !== 'whitespace');
+    let meaningful = tokens.filter(t => (t.kind as string) !== 'whitespace');
     if (meaningful.length === 0) return null;
+
+    // en-alignment: add/put declare NO scope role (only `set` does), so the
+    // en reference silently DROPS an `in me`/`in <x>` scope qualifier and
+    // captures the bare selector (`add @disabled to <button/> in me` →
+    // destination="<button/>"). The SOV corpus keeps the qualifier inline
+    // untranslated (`<button/> in me に`), and the whitespace-eliding join
+    // below would glue it into "<button/>inme" — same type, so only R3 sees
+    // it. A selector-led group truncates at a later `in`: en byte-alignment.
+    // Selector head required, so positional phrases (`first <li/> in me`)
+    // and non-selector runs are untouched.
+    if (
+      meaningful.length >= 2 &&
+      (meaningful[0].kind === 'selector' || /^[#.@*<]/.test(meaningful[0].value))
+    ) {
+      const inIdx = meaningful.findIndex(
+        (t, i) => i > 0 && (t.normalized ?? t.value).toLowerCase() === 'in'
+      );
+      if (inIdx > 0) meaningful = meaningful.slice(0, inIdx);
+    }
 
     // Single token — use its type directly
     if (meaningful.length === 1) {

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -2899,15 +2899,32 @@ export class SemanticParserImpl implements ISemanticParser {
     postVerbTokens: LanguageToken[],
     markerToRole: Map<string, string>,
     action: string,
-    _language: string
+    language: string
   ): Record<string, SemanticValue> {
     const roles: Record<string, SemanticValue> = {};
+
+    // A block terminator the SOV reorder absorbed into a role phrase (bn
+    // repeat-while renders wait's object phrase as `200ms শেষ কে` — the
+    // terminator belongs after the verb) is structural residue, never part
+    // of a value: joined in it glues (`200msশেষ`), alone it fabricates a
+    // phantom trailing role. Recognized like isBlockEndToken (curated
+    // isEndKeyword surface OR keyword normalized `end`), but the positional
+    // lookahead applies to BOTH modes: a value group is exactly where a
+    // positional-`last` phrase lives (bn `শেষ <li/>`, tr `son .item`), so any
+    // terminator-shaped token followed by a selector keeps its positional
+    // reading.
+    const isStrayTerminator = (t: LanguageToken, next: LanguageToken | undefined): boolean =>
+      (this.isEndKeyword(t.value, language) ||
+        (t.kind === 'keyword' && (t.normalized ?? '').toLowerCase() === 'end')) &&
+      !(next && next.kind === 'selector');
 
     // Process a group of tokens: collect value tokens until a marker is found
     const processGroup = (tokens: LanguageToken[]) => {
       let valueTokens: LanguageToken[] = [];
 
-      for (const token of tokens) {
+      for (let i = 0; i < tokens.length; i++) {
+        const token = tokens[i];
+        if (isStrayTerminator(token, tokens[i + 1])) continue;
         const role = markerToRole.get(token.value);
         if (role && token.kind === 'particle' && valueTokens.length > 0) {
           // This is a marker — assign the preceding value tokens to this role

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -334,6 +334,34 @@ function normalizeCommandRoles(node: SemanticNode, boundIdentifiers?: Set<string
       }
     }
 
+    // fetch: the Slavic with/from preposition collision (pl `z`, ru `с`, uk
+    // `з` — the profile's source AND style markers share a surface). The
+    // fused generic VSO event pattern (fetch-event-{pl,ru,uk}-vso) binds the
+    // leading URL to {patient} — fetch has NO patient role — and its
+    // source-marked group reads the with-OPTIONS head as `source`
+    // (`pobierz /api/form z method:"POST" …` → patient="/api/form",
+    // source="method"; en: source="/api/form", style="method"). The generic
+    // primary-role relabel above cannot fire because `source` is occupied.
+    // A patient + expression-typed source + empty style IS that mis-parse —
+    // no legitimate fetch form produces it — so shift source→style and
+    // patient→source (tell/transition relabel precedent).
+    if (node.action === 'fetch') {
+      const roles = node.roles as Map<SemanticRole, SemanticValue>;
+      const pat = roles.get('patient');
+      const src = roles.get('source');
+      if (
+        pat &&
+        src &&
+        (pat.type === 'literal' || pat.type === 'expression') &&
+        src.type === 'expression' &&
+        !roles.has('style')
+      ) {
+        roles.delete('patient');
+        roles.set('style', src);
+        roles.set('source', pat);
+      }
+    }
+
     // transition: the SOV body-walker's verb-anchoring binds the postposed
     // goal phrase (`0 に` / `0 에`) to `destination` — に/에 is the generic
     // destination particle — as a LITERAL, which is schema-invalid (a

--- a/packages/semantic/src/patterns/increment.ts
+++ b/packages/semantic/src/patterns/increment.ts
@@ -209,7 +209,7 @@ function getIncrementPatternsIt(): LanguagePattern[] {
         quantity: {
           marker: 'di',
           markerAlternatives: ['per'],
-          default: { type: 'literal', value: '1' },
+          default: { type: 'literal', value: 1 },
         },
       },
     },
@@ -231,7 +231,7 @@ function getIncrementPatternsIt(): LanguagePattern[] {
       },
       extraction: {
         patient: { position: 1 },
-        quantity: { default: { type: 'literal', value: '1' } },
+        quantity: { default: { type: 'literal', value: 1 } },
       },
     },
   ];
@@ -447,7 +447,7 @@ function getIncrementPatternsVi(): LanguagePattern[] {
         quantity: {
           marker: 'thêm',
           markerAlternatives: ['lên'],
-          default: { type: 'literal', value: '1' },
+          default: { type: 'literal', value: 1 },
         },
       },
     },
@@ -465,7 +465,7 @@ function getIncrementPatternsVi(): LanguagePattern[] {
       },
       extraction: {
         patient: { position: 1 },
-        quantity: { default: { type: 'literal', value: '1' } },
+        quantity: { default: { type: 'literal', value: 1 } },
       },
     },
   ];

--- a/packages/semantic/src/patterns/repeat.ts
+++ b/packages/semantic/src/patterns/repeat.ts
@@ -78,7 +78,7 @@ const VERB_FIRST_REPEAT_TIMES: Array<[string, string, string, string?]> = [
   ['ar', 'كرر', 'times'],
   ['he', 'חזור', 'times', 'את'],
   ['id', 'ulangi', 'times'],
-  ['ms', 'ulang', 'times'],
+  ['ms', 'ulang', 'kali'],
   ['sw', 'rudia', 'times'],
   ['th', 'ทำซ้ำ', 'ครั้ง'],
   ['vi', 'lặp lại', 'lần'],

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -12683,6 +12683,49 @@ describe('R3 value-bug families (docs-internal/HANDOFF_value-bug-families.md)', 
     });
   });
 
+  describe('F3: SOV `in me` qualifier glue/drop (form-disable-on-submit)', () => {
+    // The corpus keeps the literal English `in me` scope qualifier inline in
+    // every SOV render. en's add/put schemas have NO scope role, so the en
+    // reference DROPS it (destination="<button/>"). Two SOV defects, both
+    // R1-invisible (same role type):
+    //  (b) put: verb-anchoring joined `[<button/>, in, me]` whitespace-free
+    //      into destination="<button/>inme" — fixed by the selector-led
+    //      `in`-truncation in tokensToSemanticValue;
+    //  (a) add: the fused event pattern ends at the verb, the fronted patient
+    //      sits outside the [verb..boundary] re-parse slice (superset gate),
+    //      and the postposed `<button/> in me に` phrase dropped — destination
+    //      silently defaulted to `me`. Fixed by the trailing
+    //      DESTINATION/SOURCE reclaim on the fused path.
+    const FORM_DISABLE: Array<[string, string]> = [
+      ['en', 'on submit add @disabled to <button/> in me put "Submitting..." into <button/> in me'],
+      ['ja', '@disabled を 送信 で 追加 <button/> in me に それから "Submitting..." を <button/> in me に 置く'],
+      ['ko', '@disabled 를 제출 할 때 추가 <button/> in me 에 그러면 "Submitting..." 를 <button/> in me 에 넣다'],
+      ['hi', '@disabled को जमा पर जोड़ें <button/> in me में फिर "Submitting..." को <button/> in me में रखें'],
+      ['bn', '@disabled কে জমা এ যোগ <button/> in me তে তারপর "Submitting..." কে <button/> in me তে রাখুন'],
+      ['qu', '@disabled ta <button/> in me man kachay pi yapay chayqa "Submitting..." ta <button/> in me man churay'],
+    ];
+
+    it.each(FORM_DISABLE)('[%s] add AND put destination is the bare <button/> selector', (lang, line) => {
+      const nodes = collect(parse(line, lang));
+      const add = first(nodes, 'add');
+      const put = first(nodes, 'put');
+      expect(role(add, 'destination')?.value, `${lang} add destination`).toBe('<button/>');
+      expect(role(add, 'patient')?.value, `${lang} add patient`).toBe('@disabled');
+      expect(role(put, 'destination')?.value, `${lang} put destination`).toBe('<button/>');
+      expect(role(put, 'patient')?.value, `${lang} put patient`).toBe('Submitting...');
+    });
+
+    it('[en] positional phrase control: `first <li/> in me` is not truncated', () => {
+      // The truncation is gated to selector-LED groups; a positional keyword
+      // head keeps its full phrase reading.
+      const nodes = collect(parse('on click add .sel to first <li/> in me', 'en'));
+      const add = first(nodes, 'add');
+      expect(role(add, 'patient')?.value).toBe('.sel');
+      const dest = role(add, 'destination');
+      expect(String(dest?.raw ?? dest?.value ?? '')).not.toBe('me');
+    });
+  });
+
   describe('F4: pl/ru/uk fetch URL mis-role (with-preposition collision)', () => {
     // pl `z` / uk `з` are BOTH the profile's source and style markers (ru `с`
     // is style-primary and a source-alternative), so the fused generic VSO

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -12652,6 +12652,37 @@ describe('R3 value-bug families (docs-internal/HANDOFF_value-bug-families.md)', 
   const first = (nodes: Record<string, any>[], action: string): Record<string, any> | undefined =>
     nodes.find(n => n.action === action);
 
+  describe('F2: bn stray block terminator glued into role values', () => {
+    // The bn repeat-while corpus renders wait's object phrase as
+    // `200ms শেষ কে অপেক্ষা` — the i18n reorder absorbs the block terminator
+    // INTO the phrase (it belongs after the verb; transformer defect noted in
+    // MULTILINGUAL_NEXT_STEPS). The SOV verb-anchoring's group extraction
+    // joined the pair whitespace-free into duration="200msশেষ". Stray
+    // terminators are now skipped during value accumulation (positional
+    // `শেষ <selector>` = `last <x>` keeps its reading via the selector
+    // lookahead). The five sibling bn wait rows (duration="then"/"end") are
+    // the F1 connective-capture family, locked in the F1 describe below.
+    it('[bn] repeat-while: wait duration is 200ms, terminator not glued', () => {
+      const nodes = collect(
+        parse(
+          'যতক্ষণ #counter.innerText < 10 কে ক্লিক এ পুনরাবৃত্তি তারপর #counter কে বৃদ্ধি তারপর 200ms শেষ কে অপেক্ষা',
+          'bn'
+        )
+      );
+      const wait = first(nodes, 'wait');
+      expect(role(wait, 'duration')?.value).toBe('200ms');
+      // No role value anywhere retains the terminator.
+      for (const n of nodes) {
+        if (!(n.roles instanceof Map)) continue;
+        for (const [, v] of n.roles) {
+          expect(String((v as any)?.value ?? '')).not.toContain('শেষ');
+        }
+      }
+      const inc = first(nodes, 'increment');
+      expect(role(inc, 'patient')?.value).toBe('#counter');
+    });
+  });
+
   describe('F5: hi transition duration drop', () => {
     // hi matches the fused SOV 2-role transition pattern, which ends at {goal};
     // the duration renders as `में 500ms` — a particle BEFORE the time literal,

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -12652,6 +12652,68 @@ describe('R3 value-bug families (docs-internal/HANDOFF_value-bug-families.md)', 
   const first = (nodes: Record<string, any>[], action: string): Record<string, any> | undefined =>
     nodes.find(n => n.action === action);
 
+  describe('F1: connective/terminator swallowed as a role value', () => {
+    // The generated increment patterns' trailing marker-less optional
+    // {quantity} slot captured the normalized connective opening the NEXT
+    // statement (it `allora`, pl `wtedy` → quantity:literal="then" —
+    // increment by NaN at runtime), and the generated verb-first bn wait's
+    // duration slot swallowed a following তারপর/শেষ the same way. The
+    // matchRoleToken guard now rejects a keyword-kind normalized `then` (and
+    // a non-positional `end`) as a role value; the schema/extraction default
+    // fills instead (quantity=1), byte-aligned with en.
+    const INCREMENT_LINES: Array<[string, string]> = [
+      ['it', 'su clic ripetere mentre #counter.innerText < 10 allora incrementare #counter allora aspettare 200ms fine'],
+      ['ms', 'apabila click ulang selagi #counter.innerText < 10 kemudian tambah_satu #counter kemudian tunggu 200ms tamat'],
+      ['pl', 'gdy kliknięcie powtórz dopóki #counter.innerText < 10 wtedy zwiększ #counter wtedy czekaj 200ms koniec'],
+      ['ru', 'при клик повторить пока #counter.innerText < 10 затем увеличить #counter затем ждать 200ms конец'],
+      ['uk', 'при клік повторити поки #counter.innerText < 10 тоді збільшити #counter тоді чекати 200ms кінець'],
+      ['vi', 'khi nhấp lặp lại trong khi #counter.innerText < 10 rồi tăng #counter rồi chờ 200ms kết thúc'],
+      ['ar', 'عند فأرة أسفل كرر حتى حدث فأرة أعلى ثم زِد #counter ثم انتظر 100ms النهاية'],
+      ['tl', 'kapag mousedown ulitin hanggang pangyayari mouseup pagkatapos dagdagan #counter pagkatapos maghintay 100ms wakas'],
+    ];
+
+    it.each(INCREMENT_LINES)('[%s] repeat body: increment quantity defaults to 1, never "then"', (lang, line) => {
+      const nodes = collect(parse(line, lang));
+      const inc = first(nodes, 'increment');
+      expect(role(inc, 'patient')?.value, `${lang} increment patient`).toBe('#counter');
+      const q = role(inc, 'quantity')?.value;
+      // The generated pattern's extraction default fills 1; a hand pattern may
+      // leave it absent for fillSchemaDefaults — either way, never the connective.
+      if (q !== undefined) expect(q, `${lang} increment quantity`).toBe(1);
+      const wait = first(nodes, 'wait');
+      expect(role(wait, 'duration')?.value, `${lang} wait duration`).toMatch(/^\d+ms$/);
+    });
+
+    // The five bn wait rows the handoff filed under F2: same mechanism, the
+    // verb-first wait duration slot capturing তারপর (then) / শেষ (end).
+    const BN_WAIT_LINES: Array<[string, string, string]> = [
+      ['copy-to-clipboard', 'navigator.clipboard.writeText(#code.innerText) কে ক্লিক এ কল তারপর "Copied!" কে আমি তে রাখুন তারপর 2s কে অপেক্ষা তারপর "Copy" কে আমি তে রাখুন', '2s'],
+      ['repeat-forever', 'লোড এ পুনরাবৃত্তি চিরকাল .pulse কে টগল তারপর 1s কে অপেক্ষা শেষ', '1s'],
+      ['repeat-until-event', 'mousedown এ পুনরাবৃত্তি ঘটনা mouseup কে পর্যন্ত তারপর #counter কে বৃদ্ধি তারপর 100ms কে অপেক্ষা শেষ', '100ms'],
+      ['stagger-animation', 'লোড এ পুনরাবৃত্তি item এ .item কে জন্য সূচক দিয়ে তারপর .visible কে যোগ item তে তারপর 100ms কে অপেক্ষা শেষ', '100ms'],
+      ['tell-other-element', '#panel কে ক্লিক এ বলুন তারপর .open কে যোগ তারপর 200ms কে অপেক্ষা তারপর .visible কে যোগ', '200ms'],
+    ];
+
+    it.each(BN_WAIT_LINES)('[bn] %s: wait duration is the real time literal', (_pattern, line, duration) => {
+      const nodes = collect(parse(line, 'bn'));
+      const wait = first(nodes, 'wait');
+      expect(role(wait, 'duration')?.value).toBe(duration);
+    });
+
+    it('both-ways locks: explicit quantities survive the guard', () => {
+      const en = first(collect(parse('increment #counter by 5', 'en')), 'increment');
+      expect(role(en, 'quantity')?.value).toBe(5);
+      const it_ = first(collect(parse('incrementare #counter di 5', 'it')), 'increment');
+      expect(role(it_, 'quantity')?.value).toBe(5);
+    });
+
+    it('[en] at-end control: the multi-token literal manner phrase is untouched', () => {
+      const put = first(collect(parse('on click put "x" at end of #log', 'en')), 'put');
+      expect(role(put, 'manner')?.value).toBe('at end of');
+      expect(role(put, 'destination')?.value).toBe('#log');
+    });
+  });
+
   describe('F2: bn stray block terminator glued into role values', () => {
     // The bn repeat-while corpus renders wait's object phrase as
     // `200ms শেষ কে অপেক্ষা` — the i18n reorder absorbs the block terminator

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -12683,6 +12683,41 @@ describe('R3 value-bug families (docs-internal/HANDOFF_value-bug-families.md)', 
     });
   });
 
+  describe('F4: pl/ru/uk fetch URL mis-role (with-preposition collision)', () => {
+    // pl `z` / uk `з` are BOTH the profile's source and style markers (ru `с`
+    // is style-primary and a source-alternative), so the fused generic VSO
+    // event pattern binds the leading URL to {patient} — fetch has no patient
+    // role — and reads the with-OPTIONS head as `source`. The fetch relabel in
+    // normalizeCommandRoles shifts the schema-impossible combo back to en's
+    // shape: source=<URL>, style=<options-head>.
+    const FETCH_LINES: Array<[string, string, string, string, string]> = [
+      // [lang, pattern, corpus line, expected source, expected style head]
+      ['pl', 'fetch-with-method', 'gdy wyślij pobierz /api/form z method:"POST" body:form', '/api/form', 'method'],
+      ['ru', 'fetch-with-method', 'при отправка загрузить /api/form с method:"POST" body:form', '/api/form', 'method'],
+      ['uk', 'fetch-with-method', 'при надсилання завантажити /api/form з method:"POST" body:form', '/api/form', 'method'],
+      ['pl', 'fetch-with-headers', 'gdy kliknięcie pobierz /api/me z headers:{Authorization:`Bearer ${$token}`} jako JSON wtedy umieść jego.name do ja', '/api/me', 'headers'],
+      ['pl', 'fetch-with-method-body', 'gdy kliknięcie pobierz /api/users z method:"POST", body:"name=Joe"', '/api/users', 'method'],
+      ['pl', 'fetch-formdata', 'gdy wyślij pobierz /api/submit z method:"POST", body:(closest <form/> jako FormData)', '/api/submit', 'method'],
+      ['ru', 'fetch-formdata', 'при отправка загрузить /api/submit с method:"POST", body:(closest <form/> как FormData)', '/api/submit', 'method'],
+      ['uk', 'fetch-formdata', 'при надсилання завантажити /api/submit з method:"POST", body:(closest <form/> як FormData)', '/api/submit', 'method'],
+    ];
+
+    it.each(FETCH_LINES)('[%s] %s: URL is source, options head is style', (lang, _pattern, line, url, styleHead) => {
+      const nodes = collect(parse(line, lang));
+      const f = first(nodes, 'fetch');
+      expect(role(f, 'source')?.value).toBe(url);
+      expect(String(role(f, 'style')?.raw ?? role(f, 'style')?.value)).toContain(styleHead);
+      expect(role(f, 'patient')).toBeUndefined();
+    });
+
+    it('[pl] fetch-basic control: the plain-source path is untouched', () => {
+      const nodes = collect(parse('gdy kliknięcie pobierz /api/data wtedy umieść to do #result', 'pl'));
+      const f = first(nodes, 'fetch');
+      expect(role(f, 'source')?.value).toBe('/api/data');
+      expect(role(f, 'style')).toBeUndefined();
+    });
+  });
+
   describe('F5: hi transition duration drop', () => {
     // hi matches the fused SOV 2-role transition pattern, which ends at {goal};
     // the duration renders as `में 500ms` — a particle BEFORE the time literal,

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -12652,6 +12652,41 @@ describe('R3 value-bug families (docs-internal/HANDOFF_value-bug-families.md)', 
   const first = (nodes: Record<string, any>[], action: string): Record<string, any> | undefined =>
     nodes.find(n => n.action === action);
 
+  describe('F5: hi transition duration drop', () => {
+    // hi matches the fused SOV 2-role transition pattern, which ends at {goal};
+    // the duration renders as `में 500ms` — a particle BEFORE the time literal,
+    // where the trailing-DURATION reclaim (built for ja/ko's bare adjacent
+    // literal) never looked. The reclaim now skips exactly one particle when a
+    // TIME-shaped literal directly follows it.
+    const HI_LINES: Array<[string, string, string, unknown]> = [
+      // [pattern, corpus line, expected duration, expected goal]
+      ['transition-opacity', 'opacity को क्लिक पर संक्रमण 0 में 500ms फिर मैं को हटाएं', '500ms', 0],
+      ['transition-transform', 'transform को क्लिक पर संक्रमण "scale(1.2)" में 300ms', '300ms', 'scale(1.2)'],
+      ['transition-color', '*background-color को क्लिक पर संक्रमण "blue" में 500ms', '500ms', 'blue'],
+      ['fade-out-remove', 'opacity को क्लिक पर संक्रमण 0 में 300ms फिर मैं को हटाएं', '300ms', 0],
+    ];
+
+    it.each(HI_LINES)('[hi] %s: duration reclaimed through में', (_pattern, line, duration, goal) => {
+      const nodes = collect(parse(line, 'hi'));
+      const tr = first(nodes, 'transition');
+      expect(role(tr, 'duration')?.value).toBe(duration);
+      expect(role(tr, 'goal')?.value).toBe(goal);
+    });
+
+    it('[hi] fade-out-remove: the trailing remove survives the reclaim', () => {
+      const nodes = collect(parse('opacity को क्लिक पर संक्रमण 0 में 300ms फिर मैं को हटाएं', 'hi'));
+      const rm = first(nodes, 'remove');
+      expect(role(rm, 'patient')?.value).toBe('me');
+    });
+
+    it('[ja] control: bare adjacent time literal path unchanged', () => {
+      const nodes = collect(parse('クリック で opacity を 遷移 0 に 300ms', 'ja'));
+      const tr = first(nodes, 'transition');
+      expect(role(tr, 'duration')?.value).toBe('300ms');
+      expect(role(tr, 'goal')?.value).toBe(0);
+    });
+  });
+
   describe('F8: ms repeat-times count word', () => {
     // `ulang 3 kali` fell through the repeat-ms-times HEAD (whose count word
     // was left as English `times`) to the generated positional repeat, which

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -12612,3 +12612,60 @@ describe('colon-qualified event names: full behavior bodies capture every trigge
     expect(count(nodes, 'set')).toBe(12);
   });
 });
+
+describe('R3 value-bug families (docs-internal/HANDOFF_value-bug-families.md)', () => {
+  // The R3 value-recall signal compares language-invariant role VALUES verbatim
+  // against the en reference. Its first sweep surfaced eight bug families —
+  // right actions, right role types, wrong or dropped VALUES — invisible to
+  // every recall/role-type signal. These lock the corpus-shaped inputs per
+  // family. Corpus strings are canonical patterns.db pattern_translations rows.
+  const CHILD_FIELDS = [
+    'body',
+    'statements',
+    'thenBranch',
+    'elseBranch',
+    'branches',
+    'eventHandlers',
+    'initBlock',
+    'initCommands',
+  ];
+
+  const collect = (node: unknown): Record<string, any>[] => {
+    const flat: Record<string, any>[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec);
+      for (const f of CHILD_FIELDS) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return flat;
+  };
+
+  const role = (n: Record<string, any> | undefined, r: string): any =>
+    n && n.roles instanceof Map ? n.roles.get(r) : undefined;
+
+  const first = (nodes: Record<string, any>[], action: string): Record<string, any> | undefined =>
+    nodes.find(n => n.action === action);
+
+  describe('F8: ms repeat-times count word', () => {
+    // `ulang 3 kali` fell through the repeat-ms-times HEAD (whose count word
+    // was left as English `times`) to the generated positional repeat, which
+    // bound the count to loopType (`loopType=3`, no quantity — en reference:
+    // quantity=3, loopType="times").
+    it('[ms] repeat-times: ulang 3 kali captures quantity=3, loopType="times"', () => {
+      const nodes = collect(
+        parse('apabila click ulang 3 kali kemudian tambah "<p>Line</p>" ke saya', 'ms')
+      );
+      const rpt = first(nodes, 'repeat');
+      expect(role(rpt, 'quantity')?.value).toBe(3);
+      expect(role(rpt, 'loopType')?.value).toBe('times');
+      // The loop body must survive the head re-parse swap.
+      expect(first(nodes, 'add')).toBeDefined();
+    });
+  });
+});

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -12858,6 +12858,102 @@ describe('R3 value-bug families (docs-internal/HANDOFF_value-bug-families.md)', 
     });
   });
 
+  describe('F7: qu/tr behavior-sortable trigger residue (re-filed to the transformer arc)', () => {
+    // KNOWN RESIDUE — re-filed, not a parser gap (see MULTILINGUAL_NEXT_STEPS
+    // § R3 families, item 7). The command-level action multiset matches en in
+    // BOTH languages; only the VALUES around the loop's wait line corrupt,
+    // and every miss sits adjacent to a malformed i18n render:
+    //   tr line 15: `kadar olay pointerup i tekrarla belge den` — the
+    //     from-phrase strands AFTER the verb (en: repeat until event
+    //     pointerup from document);
+    //   tr line 16: `bekle pointermove(clientY) veya pointerup(clientY)
+    //     belge den` — verb-FIRST in an SOV language, or-run + from-phrase
+    //     stranded post-verb (the middle trigger captures the stranded
+    //     `belge` as its event);
+    //   qu line 16: `qillqa manta suyay pointermove(clientY) utaq
+    //     pointerup(clientY)` — verb-MEDIAL, or-run stranded post-verb (the
+    //     middle trigger glues the whole stranded run into its event).
+    // Same family as the qu behavior-resizable it.fails above (the reorder
+    // renders fragments outside their clause). These flip when the
+    // transformer rendering is repaired.
+    const QU_SORTABLE = [
+      'Sortable(dragClass) ta behavior',
+      '    init',
+      '        sichus dragClass kanqa mana_riqsisqa',
+      '            dragClass ta "sorting" man churanay',
+      '        tukuy',
+      '    tukuy',
+      '    noqa manta pointerdown(clientY) pi',
+      '        item ta the target.closest("li") man churanay',
+      '        sichus item kanqa chusaq',
+      '            lluqsiy',
+      '        tukuy',
+      '        the ruway ta sayay',
+      '        .{dragClass} ta item man yapay',
+      '        sortable:start ta noqa man kichay',
+      '        hayk_akama ruway pointerup ta qillqa manta kutipay',
+      '            qillqa manta suyay pointermove(clientY) utaq pointerup(clientY)',
+      '            sortable:move ta noqa man kichay',
+      '        tukuy',
+      '        .{dragClass} ta item manta qichuy',
+      '        sortable:end ta noqa man kichay',
+      '    tukuy',
+      'tukuy',
+    ].join('\n');
+
+    const TR_SORTABLE = [
+      'Sortable(dragClass) i behavior',
+      '    init',
+      '        eğer dragClass dir tanımsız',
+      '            dragClass i "sorting" e ayarla',
+      '        son',
+      '    son',
+      '    pointerdown(clientY) de ben den',
+      '        item i the target.closest("li") e ayarla',
+      '        eğer item dir boş',
+      '            çık',
+      '        son',
+      '        the olay i durdur',
+      '        .{dragClass} i ekle item e',
+      '        sortable:start i tetikle ben e',
+      '        kadar olay pointerup i tekrarla belge den',
+      '            bekle pointermove(clientY) veya pointerup(clientY) belge den',
+      '            sortable:move i tetikle ben e',
+      '        son',
+      '        .{dragClass} i kaldır item den',
+      '        sortable:end i tetikle ben e',
+      '    son',
+      'son',
+    ].join('\n');
+
+    const triggerValues = (nodes: Record<string, any>[]): string[] =>
+      nodes.filter(n => n.action === 'trigger').map(n => String(role(n, 'event')?.raw ?? role(n, 'event')?.value ?? '?'));
+
+    it.fails('[qu] behavior-sortable: all three trigger events by VALUE (reorder residue)', () => {
+      const nodes = collect(parse(QU_SORTABLE, 'qu'));
+      expect(triggerValues(nodes).sort()).toEqual(
+        ['sortable:start', 'sortable:move', 'sortable:end'].sort()
+      );
+    });
+
+    it.fails('[tr] behavior-sortable: sortable:move + bare remove patient (reorder residue)', () => {
+      const nodes = collect(parse(TR_SORTABLE, 'tr'));
+      expect(triggerValues(nodes)).toContain('sortable:move');
+      const rm = first(nodes, 'remove');
+      expect(role(rm, 'patient')?.value).toBe('.{dragClass}');
+    });
+
+    it('[qu/tr] behavior-sortable: command-level actions all survive (only values corrupt)', () => {
+      const enActions = collect(parse(TR_SORTABLE, 'tr')).map(n => n.action);
+      for (const [lang, src] of [['qu', QU_SORTABLE], ['tr', TR_SORTABLE]] as const) {
+        const acts = collect(parse(src, lang)).map(n => n.action);
+        expect(acts.filter(a => a === 'trigger').length, `${lang} trigger count`).toBe(3);
+        expect(acts, `${lang} has remove`).toContain('remove');
+      }
+      expect(enActions).toContain('repeat');
+    });
+  });
+
   describe('F8: ms repeat-times count word', () => {
     // `ulang 3 kali` fell through the repeat-ms-times HEAD (whose count word
     // was left as English `times`) to the generated positional repeat, which

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-10T15:55:59.322Z",
-  "commit": "cf858d71",
+  "timestamp": "2026-07-10T20:46:52.059Z",
+  "commit": "3542bc6c",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -11,12 +11,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9907407407407408,
-      "avgValueRecall": 0.9874213836477987,
+      "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -644,13 +644,13 @@
       "avgFidelity": 1,
       "avgPrecision": 0.9989716846334493,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.972004357298475,
-      "avgValueRecall": 0.9583333333333333,
+      "avgRoleFidelity": 0.9730936819172112,
+      "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1284,7 +1284,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1909,7 +1909,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2543,7 +2543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3177,7 +3177,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3811,7 +3811,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4439,13 +4439,13 @@
       "avgFidelity": 1,
       "avgPrecision": 0.9978354978354977,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9627450980392157,
-      "avgValueRecall": 0.960691823899371,
+      "avgRoleFidelity": 0.9698257080610021,
+      "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5079,7 +5079,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5708,12 +5708,12 @@
       "avgPrecision": 0.997835497835498,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9930750077808902,
-      "avgValueRecall": 0.9937106918238995,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6341,13 +6341,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.972004357298475,
-      "avgValueRecall": 0.9842767295597484,
+      "avgRoleFidelity": 0.9730936819172112,
+      "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6975,13 +6975,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9687363834422658,
-      "avgValueRecall": 0.9842767295597484,
+      "avgRoleFidelity": 0.9698257080610021,
+      "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7609,13 +7609,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9847494553376908,
-      "avgValueRecall": 0.988993710691824,
+      "avgRoleFidelity": 0.9858387799564271,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8243,13 +8243,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9841425459072518,
-      "avgValueRecall": 0.9559748427672957,
+      "avgRoleFidelity": 0.9961251167133521,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8883,7 +8883,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9512,12 +9512,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 0.9995004995004996,
       "avgRoleFidelity": 0.953034547152194,
-      "avgValueRecall": 0.9805031446540879,
+      "avgValueRecall": 0.9867924528301886,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10145,13 +10145,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9863834422657953,
-      "avgValueRecall": 0.9591194968553459,
+      "avgRoleFidelity": 0.9983660130718954,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10785,7 +10785,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11419,7 +11419,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12048,12 +12048,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9907407407407408,
-      "avgValueRecall": 0.9874213836477987,
+      "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12687,7 +12687,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13315,13 +13315,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9863834422657953,
-      "avgValueRecall": 0.9591194968553459,
+      "avgRoleFidelity": 0.9983660130718954,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13950,12 +13950,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9883442265795209,
-      "avgValueRecall": 0.9937106918238995,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14589,7 +14589,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 495608,
+      "bundleSize": 496661,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15212,7 +15212,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 495608,
+      "size": 496661,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Burns down all eight R3-discovered value-bug families from `docs-internal/HANDOFF_value-bug-families.md` (the #634 triage): **F1–F5 + F8 fixed** (each unit-locked), **F6 wontfix'd** (documented), **F7 re-filed** to the transformer arc (locked with `it.fails`). Cross-language **avgValueRecall 0.9861 → 0.9964**; the only remaining sub-1.0 rows are the two documented residues.

Four handoff hypotheses were corrected by probe-first verification (`metadata.patternId` per language):

- **F2** was NOT the bn tokenizer — only 1 of 6 rows was the parser's whitespace-eliding join; the other 5 were F1's connective-capture mechanism.
- **F5**'s proposed `markerVariants` one-liner could not fire (hi has no duration roleMarker; the match is a fused SOV pattern) — fixed in the trailing-DURATION reclaim instead.
- **F4** was the fused generic VSO event pattern (not `markerlessFetch`) — fixed with a scoped relabel, profiles untouched.
- **F7** is transformer-rendering junk (verb-first/verb-medial wait lines, stranded from-phrases), not a parser gap.

## Fixes (one commit per family)

| Family | Fix | Where |
|---|---|---|
| F8 | ms repeat count word `times` → `kali` | `patterns/repeat.ts` |
| F5 | duration reclaim skips one particle before a time literal (hi `में 500ms`) | `semantic-parser.ts` |
| F2 | SOV role-group extraction skips stray block terminators (selector lookahead keeps positional-`last`) | `semantic-parser.ts` |
| F4 | fetch relabel: schema-impossible `patient`+expression-`source`+no-`style` → `source`/`style` (pl/ru/uk with-preposition collision; runtime-relevant — the fetch URL was mis-roled) | `semantic-parser.ts` |
| F3 | (b) selector-led groups truncate at untranslated `in` (`<button/>inme` glue); (a) missing trailing DESTINATION/SOURCE reclaim on the fused event path + `in`-qualifier skip in `tryAttachTrailingRole` | `semantic-parser.ts` |
| F1 | `matchRoleToken` guard: keyword-kind `then` / non-positional `end` is never a role value (was `increment.quantity="then"` → NaN at runtime, ×8 languages; also bn wait `duration="then"/"end"` ×5). Narrower than CLAUSE_BOUNDARY_KEYWORDS by design — `and` collides with the English pronoun `I` (pl `i`), `end` keeps positional-`last` before a selector. Also aligns it/vi hand increment defaults to number `1` | `pattern-matcher.ts`, `patterns/increment.ts` |
| F6 | wontfix + rationale (swap is runtime-symmetric; aligning touches en pattern + swapSchema for all SVO langs + ast-builder/runtime surfaces) | NEXT_STEPS |
| F7 | re-filed to the transformer arc with the three rendering defects named; locked with 2 `it.fails` next to the qu-resizable lock | NEXT_STEPS + tests |

## Verification

- `packages/semantic`: 92 files, 6956 passed, 3 expected fails (the qu-resizable lock + the two new F7 locks), 0 real failures.
- Full sweep on a freshly populated db: parse 3696/3696; parseRate / avgFidelity / avgPrecision / avgMultisetRecall / R2 **byte-flat vs baseline**; avgValueRecall up in 13 languages (pl/ru/uk → 1.0, bn 0.958 → 0.991, hi 0.961 → 0.991); avgRoleFidelity up in 8.
- `--regression` gate green; baseline regenerated (`--save-baseline` + prettier) with an audited diff — only valueRecall/roleFidelity/timestamp/commit/bundleSize moved.
- `npm run test:check` workspace-wide: all packages green.
- New unit locks in `multilingual-roadmap-fixes.test.ts` § "R3 value-bug families" (8-language increment table, bn wait rows, 6-language form-disable table, pl/ru/uk fetch table, hi transitions, ms repeat, at-end/positional/fetch-basic controls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)