### PR TITLE
fix(i18n): render SOV wait/repeat-until verb-final, strip stranded terminators (transformer-rendering arc)

### DIFF
--- a/docs-internal/HANDOFF_transformer-rendering.md
+++ b/docs-internal/HANDOFF_transformer-rendering.md
@@ -1,5 +1,19 @@
 # Handoff: the transformer-rendering arc (SOV reorder stranding)
 
+> **RESOLVED 2026-07-10** (branch `fix/transformer-sov-reorder-stranding`).
+> All five scoreboard rows cleared: the four `behavior-sortable` R3 rows
+> (qu ×2, tr ×2), the qu `behavior-resizable` multiset row, plus the bn
+> repeat-while cosmetic render. Outcomes + mechanism notes:
+> `docs-internal/MULTILINGUAL_NEXT_STEPS.md` § "R3-discovered value-bug
+> families" item 7 and § "Colon-event-names follow-ups" item 2. One planning
+> note for posterity: the blanket fix this handoff gestured at (extending the
+> tr/bn `canonicalOrder` wholesale) re-renders the entire corpus into shapes
+> the semantic parser's generated patterns + reclaim tolerances weren't built
+> for (R3 went 12→39 rows) — the landed fix is per-command i18n `rules`
+> (wait/repeat-until), the trailing-`end` strip, two new semantic patterns,
+> and the curated-end role-value guard. The section below is kept as the
+> original problem statement.
+>
 > **For a fresh session.** Read this, then CLAUDE.md ("Multilingual parse rate ≠
 > fidelity" and "Running the multilingual `--regression` gate locally"), then
 > `docs-internal/MULTILINGUAL_NEXT_STEPS.md` § "R3-discovered value-bug

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -2609,15 +2609,16 @@ languages including en (was split everywhere). Follow-up status:
    0.9861 → 0.9611). The first full sweep also surfaced six live value-bug families —
    see "R3-discovered value-bug families" below.
 
-2. **qu behavior-resizable style-sets (the one remaining multiset row).** The qu
-   reorder renders each inline `if X then set Y to Z end` with the inner set's
-   verb-final tail AFTER the block terminator (`sichus … chayqa … tukuy man churanay`),
-   so the conditional fold consumes up to `tukuy` and strands `man churanay`; the two
-   style sets (`noqaq *width/*height … man churanay`) following the if-run are
-   swallowed — 10 of en's 12 sets parse. Likely an i18n transformer/corpus rendering
-   bug (the `end` belongs after the verb), not parser tolerance. Locked by an
-   `it.fails` in `packages/semantic/test/multilingual-roadmap-fixes.test.ts` that flips
-   when repaired.
+2. ~~**qu behavior-resizable style-sets (the one remaining multiset row).**~~
+   **DONE** (2026-07-10, transformer-rendering arc —
+   `docs-internal/HANDOFF_transformer-rendering.md`, resolved). The diagnosis
+   held: rendering bug, not parser tolerance. The transformer's new
+   trailing-`end` strip (`transformSingle` step 0a) renders each inline-if's
+   inner set verb-final BEFORE the terminator (`… man churanay tukuy`), the
+   conditional fold keeps the tail, and all 12 sets parse (multiset row gone,
+   qu avgMultisetRecall back to 1.0). The `it.fails` flipped to a hard
+   `toBe(12)`; the pre-arc render stays locked as `QU_RESIZABLE_LEGACY`
+   (tolerance input, `>= 10` floor).
 
 3. ~~**bn standalone trigger.**~~ **DONE** (2026-07-10, same arc). The predicted
    one-liner: `bn: ['কে']` added to the trigger schema's event `markerVariants`
@@ -2651,11 +2652,13 @@ value-bug families"), F6 **wontfix** (documented), F7 **re-filed**:
 2. ~~**bn duration-glue**~~ **FIXED — two mechanisms, neither the tokenizer**
    (the handoff's hypothesis was wrong; the bn tokenizer splits fine).
    (a) `repeat-while` only: the reorder renders wait's object phrase as
-   `200ms শেষ কে` (terminator INSIDE the phrase — see the transformer defect
-   note below) and the SOV verb-anchoring's `processGroup` joined the pair
-   whitespace-free into `duration="200msশেষ"`. Fixed by skipping stray
-   terminator-shaped tokens during value accumulation (positional `শেষ
-   <selector>` keeps its `last` reading via selector lookahead).
+   `200ms শেষ কে` (terminator INSIDE the phrase) and the SOV verb-anchoring's
+   `processGroup` joined the pair whitespace-free into `duration="200msশেষ"`.
+   Fixed by skipping stray terminator-shaped tokens during value accumulation
+   (positional `শেষ <selector>` keeps its `last` reading via selector
+   lookahead). The RENDER itself was fixed in the transformer-rendering arc
+   (family 7 below): the trailing-`end` strip now emits `200ms কে অপেক্ষা শেষ`
+   — the parser-side skip stays as the tolerance lock for the pre-arc shape.
    (b) The other five rows were family-1's mechanism: the generated verb-first
    wait's duration slot captured তারপর/শেষ (`duration="then"`/`"end"`) while
    dropping the real `2s/1s/100ms কে` prefix — fixed by the same
@@ -2696,26 +2699,36 @@ value-bug families"), F6 **wontfix** (documented), F7 **re-filed**:
    worth the regression surface for zero runtime effect (decision 2026-07-10).
    The 8 rows stay visible in the R3 report; do NOT special-case the R3 walker.
    If a future arc flips it, regenerate the baseline and watch R1/R2.
-7. **qu/tr behavior trigger-event residue — RE-FILED to the transformer arc**
-   (`behavior-sortable`; handoff: `docs-internal/HANDOFF_transformer-rendering.md`). Probing shows the command-level action multiset
-   matches en in both languages; only VALUES around the loop's wait line
-   corrupt, each adjacent to a malformed render: tr renders the repeat header's
-   from-phrase AFTER the verb (`kadar olay pointerup i tekrarla belge den`) and
-   the wait line verb-FIRST (`bekle pointermove(clientY) veya … belge den` —
-   the middle trigger captures the stranded `belge` as its event; the loop's
-   `son` before `remove` gives the patient a spurious `last` prefix); qu
-   renders the wait verb-MEDIAL (`qillqa manta suyay pointermove(clientY) utaq
-   …` — the middle trigger glues the whole stranded or-run). Same
-   transformer-rendering family as the open qu `behavior-resizable` side-quest
-   (item 2 of the colon-event follow-ups above) and the bn repeat-while
-   terminator placement (family 2a). Locked by two `it.fails` in
-   `multilingual-roadmap-fixes.test.ts` § "R3 value-bug families" F7 (flip when
-   the transformer rendering is repaired). **Transformer-arc worklist:** fix the
-   SOV/agglutinative reorder stranding (a) or-run wait lines rendered
-   verb-first/verb-medial (tr/qu), (b) from-phrases postposed after the verb
-   (tr `belge den`), (c) block terminators rendered inside the following
-   clause's object phrase (bn `200ms শেষ কে অপেক্ষা`, qu resizable's `tukuy man
-   churanay`).
+7. ~~**qu/tr behavior trigger-event residue — RE-FILED to the transformer arc**~~
+   **DONE** (2026-07-10, transformer-rendering arc —
+   `docs-internal/HANDOFF_transformer-rendering.md`, resolved; all four
+   `behavior-sortable` R3 rows gone). Fixed as a scoped render + parser-gap
+   pair, NOT a blanket reorder (a full tr/bn canonicalOrder extension was
+   tried first and re-rendered the whole corpus into shapes the parser can't
+   bind — R3 exploded 12→39 rows; reverted):
+   - (a) or-run wait lines: new i18n `wait-oblique-verb-final` rules (tr/qu
+     profiles, gated to `duration`+`source`, no-event predicate) render
+     `belge den … veya … bekle` / `qillqa manta … utaq … suyay` — the
+     stranded run no longer leaks into the next trigger's event.
+   - (b) tr repeat header: new i18n `repeat-until-event-verb-final` rule
+     (predicate-gated to `repeat until event`) renders `kadar olay pointerup
+     i belge den tekrarla`, matched semantic-side by the new
+     `repeat-tr-until-head-verb-final` pattern (the post-verb variant stays
+     for the legacy shape).
+   - (c) terminator placement: the transformer's trailing-`end` strip
+     (`transformSingle` step 0a) — see colon-event follow-ups item 2.
+   - qu `sortable:start` needed a parser fix regardless of rendering: the qu
+     corpus trigger shape matched NO pattern (only the greedy verb-anchoring
+     fallback, which glued the next line's fronted `hayk_akama`); added
+     `trigger-qu-event-first-verb-final` (position-0 match).
+   - tr `remove.patient="last .{dragClass}"`: the loop's own `son` before a
+     selector took the positional-`last` reading. The curated end-keyword
+     sets (now shared via `parser/end-keywords.ts`) are audited to never be
+     positional (tr last=`sonuncu`, qu last=`qhipa`), so `matchRoleToken` and
+     `isStrayTerminator` now treat curated end words as structural
+     unconditionally (dual-use bn `শেষ` keeps its selector lookahead).
+   F7 locks flipped to hard asserts on the refreshed corpus fixtures; pre-arc
+   shapes stay locked as `QU/TR_SORTABLE_LEGACY` tolerance inputs.
 8. ~~**ms `repeat 3 kali` count swallowed**~~ **FIXED**. The `repeat-ms-times`
    HEAD's count word was left as English `times`, so `ulang 3 kali` fell through
    to the generated positional repeat (`loopType=3`, no quantity). Localized to

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -2510,3 +2510,84 @@ describe('qu fused (no-underscore) empty/null value word (chusaq)', () => {
     expect(out.indexOf('chusaq')).toBeLessThan(out.indexOf('.error'));
   });
 });
+
+// =============================================================================
+// SOV reorder stranding (transformer-rendering arc)
+// =============================================================================
+//
+// Three rendering defects, one family (docs-internal/HANDOFF_transformer-rendering.md):
+// (a) `wait for X or Y from Z` rendered verb-first (tr) / verb-medial (qu) —
+//     reorderRoles' safety-net appended roles missing from canonicalOrder
+//     AFTER the verb, stranding the or-run/from-phrase outside the clause;
+// (b) `repeat until event E from S` postposed the from-phrase after the verb;
+// (c) a trailing block terminator (`… wait 200ms end` fragments from the
+//     then-splitter) was swept into the open role's VALUE and rendered inside
+//     the phrase instead of after the verb.
+// Fixed by extending tr/qu/bn canonicalOrder to full verb-final role orders
+// and stripping/re-appending the stranded terminator in transformSingle.
+
+describe('SOV reorder stranding (transformer-rendering arc)', () => {
+  it('[tr] wait + or-run + from-phrase renders verb-final, from-phrase in-clause', () => {
+    const out = new GrammarTransformer('en', 'tr').transform(
+      'wait for pointermove(clientY) or pointerup(clientY) from document'
+    );
+    expect(out).toContain('veya');
+    expect(out.trim().endsWith('bekle')).toBe(true);
+    expect(out.indexOf('belge den')).toBeGreaterThanOrEqual(0);
+    expect(out.indexOf('belge den')).toBeLessThan(out.indexOf('bekle'));
+  });
+
+  it('[qu] wait + or-run + from-phrase renders verb-final, from-phrase in-clause', () => {
+    const out = new GrammarTransformer('en', 'qu').transform(
+      'wait for pointermove(clientY) or pointerup(clientY) from document'
+    );
+    expect(out).toContain('utaq');
+    expect(out.trim().endsWith('suyay')).toBe(true);
+    expect(out.indexOf('qillqa manta')).toBeGreaterThanOrEqual(0);
+    expect(out.indexOf('qillqa manta')).toBeLessThan(out.indexOf('pointermove'));
+  });
+
+  it('[tr] repeat-until-event keeps the from-phrase before the verb', () => {
+    const out = new GrammarTransformer('en', 'tr').transform(
+      'repeat until event pointerup from document'
+    );
+    expect(out.trim().endsWith('tekrarla')).toBe(true);
+    expect(out.indexOf('belge den')).toBeGreaterThanOrEqual(0);
+    expect(out.indexOf('belge den')).toBeLessThan(out.indexOf('tekrarla'));
+  });
+
+  it('[bn] trailing-end fragment renders the terminator after the verb', () => {
+    // `then`-split fragment of `… then wait 200ms end` (repeat-while body).
+    const out = new GrammarTransformer('en', 'bn').transform('wait 200ms end');
+    expect(out.trim()).toBe('200ms কে অপেক্ষা শেষ');
+    expect(out).not.toContain('শেষ কে'); // terminator no longer inside the object phrase
+  });
+
+  it('[qu] inline-if set keeps its verb-final tail before the terminator', () => {
+    const out = new GrammarTransformer('en', 'qu').transform(
+      'if newWidth < minWidth then set newWidth to minWidth end'
+    );
+    expect(out).toMatch(/man churanay tukuy\s*$/);
+  });
+
+  it('[tr] trailing-end set fragment renders verb-final with trailing terminator', () => {
+    // Previously the set-to rule's end-guard predicate skipped verb-final
+    // reorder for these fragments; with the terminator stripped first, the
+    // rule applies and the terminator follows the verb.
+    const out = new GrammarTransformer('en', 'tr').transform('set dragClass to "sorting" end');
+    expect(out.trim()).toBe('dragClass i "sorting" e ayarla son');
+  });
+
+  const draggableWait =
+    'wait for pointermove(clientX, clientY) or pointerup(clientX, clientY) from document';
+  it('[tr] draggable-shaped wait (clientX, clientY) is verb-final', () => {
+    const out = new GrammarTransformer('en', 'tr').transform(draggableWait);
+    expect(out.trim().endsWith('bekle')).toBe(true);
+    expect(out.indexOf('belge den')).toBeLessThan(out.indexOf('bekle'));
+  });
+  it('[qu] draggable-shaped wait (clientX, clientY) is verb-final', () => {
+    const out = new GrammarTransformer('en', 'qu').transform(draggableWait);
+    expect(out.trim().endsWith('suyay')).toBe(true);
+    expect(out.indexOf('qillqa manta')).toBeLessThan(out.indexOf('pointermove'));
+  });
+});

--- a/packages/i18n/src/grammar/profiles/index.ts
+++ b/packages/i18n/src/grammar/profiles/index.ts
@@ -420,6 +420,12 @@ export const turkishProfile: LanguageProfile = {
   morphology: 'agglutinative',
   direction: 'ltr',
 
+  // NOTE: roles absent from this order are safety-net-appended AFTER the verb
+  // by reorderRoles. That stranding is what the semantic parser's generated
+  // patterns + reclaim tolerances were built around, so extending this order
+  // wholesale re-renders (and breaks) the whole tr corpus — fix individual
+  // defective shapes with per-command `rules` below instead (see the
+  // wait/repeat-until rules from the transformer-rendering arc).
   canonicalOrder: ['patient', 'event', 'action'],
 
   markers: [
@@ -513,6 +519,44 @@ export const turkishProfile: LanguageProfile = {
       transform: {
         // $var i #el e bağla
         roleOrder: ['patient', 'destination', 'action'],
+        insertMarkers: true,
+      },
+    },
+    {
+      name: 'wait-oblique-verb-final',
+      description: "Keep wait's from-phrase and or-run inside the clause, verb-final",
+      priority: 90,
+      match: {
+        commands: ['wait', 'bekle'],
+        // Only the multi-argument form (`wait for X or Y from Z`) strands:
+        // without this rule the safety-net appends duration+source AFTER the
+        // verb (`bekle … belge den`), and the stranded from-phrase is captured
+        // by the NEXT statement as a junk trigger event (behavior-sortable R3).
+        requiredRoles: ['action', 'duration', 'source'],
+        // Never reorder a fused single-line handler — its event must stay put.
+        predicate: parsed => !parsed.roles.has('event'),
+      },
+      transform: {
+        // belge den pointermove(clientY) veya pointerup(clientY) bekle
+        roleOrder: ['patient', 'source', 'duration', 'action'],
+        insertMarkers: true,
+      },
+    },
+    {
+      name: 'repeat-until-event-verb-final',
+      description: "Keep repeat-until-event's from-phrase before the verb",
+      priority: 90,
+      match: {
+        commands: ['repeat', 'tekrarla'],
+        requiredRoles: ['action', 'patient', 'source'],
+        // Gate to the until-event head; `repeat for item in .items` also
+        // carries patient+source and must keep its (parseable) default order.
+        predicate: parsed => /^repeat\s+until\s+event\b/i.test((parsed.original ?? '').trim()),
+      },
+      transform: {
+        // kadar olay pointerup i belge den tekrarla — matched semantic-side by
+        // repeat-tr-until-head-verb-final.
+        roleOrder: ['patient', 'source', 'action'],
         insertMarkers: true,
       },
     },
@@ -692,6 +736,8 @@ export const quechuaProfile: LanguageProfile = {
   morphology: 'agglutinative', // Actually polysynthetic
   direction: 'ltr',
 
+  // NOTE: roles absent from this order are safety-net-appended AFTER the verb
+  // (see the Turkish profile note) — extend via per-command `rules`, not here.
   canonicalOrder: ['patient', 'source', 'destination', 'event', 'action'],
 
   markers: [
@@ -704,6 +750,28 @@ export const quechuaProfile: LanguageProfile = {
     { form: 'pi', role: 'event', position: 'postposition', required: true },
     { form: 'wan', role: 'style', position: 'postposition', required: false },
     { form: 'hina', role: 'method', position: 'postposition', required: false }, // "as/like"
+  ],
+
+  rules: [
+    {
+      name: 'wait-oblique-verb-final',
+      description: "Keep wait's from-phrase and or-run inside the clause, verb-final",
+      priority: 90,
+      match: {
+        commands: ['wait', 'suyay'],
+        // Only `wait for X or Y from Z` strands: duration is missing from
+        // canonicalOrder, so the or-run lands AFTER the verb and the next
+        // trigger glues it into its event (behavior-sortable R3). See the
+        // matching Turkish rule.
+        requiredRoles: ['action', 'duration', 'source'],
+        predicate: parsed => !parsed.roles.has('event'),
+      },
+      transform: {
+        // qillqa manta pointermove(clientY) utaq pointerup(clientY) suyay
+        roleOrder: ['patient', 'source', 'duration', 'action'],
+        insertMarkers: true,
+      },
+    },
   ],
 };
 
@@ -749,6 +817,8 @@ export const bengaliProfile: LanguageProfile = {
 
   // Bengali: Object comes before verb, postpositions follow nouns
   // "on click increment #count" → "#count কে ক্লিক এ বৃদ্ধি"
+  // NOTE: roles absent from this order are safety-net-appended AFTER the verb
+  // (see the Turkish profile note) — extend via per-command `rules`, not here.
   canonicalOrder: ['patient', 'event', 'action'],
 
   markers: [

--- a/packages/i18n/src/grammar/transformer.ts
+++ b/packages/i18n/src/grammar/transformer.ts
@@ -1901,6 +1901,18 @@ export class GrammarTransformer {
       return this.transformBlock(block);
     }
 
+    // 0a. Fragment carrying a stranded trailing block terminator (`wait 200ms
+    //     end`, `set x to y end` — what the `then`-splitter leaves from
+    //     `if … then <cmd> end`). `end` is not a marker, so left in place it is
+    //     swept into the open role's VALUE and rendered inside that phrase
+    //     (bn `200ms শেষ কে অপেক্ষা`). Strip it, transform the clause alone, and
+    //     re-append the translated terminator after the verb — the same tail
+    //     position transformBlockBody emits for event-headed blocks.
+    const strippedEnd = this.transformWithTrailingEnd(input);
+    if (strippedEnd !== null) {
+      return strippedEnd;
+    }
+
     // 0b. `set @attr to V on <scope>` (S1 tabs-aria): strip the trailing
     //     `on <scope>`, transform the scope-less set normally, then re-insert
     //     `on <scope>` where the semantic set patterns expect it.
@@ -1949,6 +1961,36 @@ export class GrammarTransformer {
 
     // 7. Join without markers (still use joinTokens for consistency)
     return joinTokens(reordered.map(e => e.translated || e.value));
+  }
+
+  /**
+   * `<command …> end` fragments: transform the command without its stranded
+   * terminator, then re-append the translated terminator as a standalone
+   * trailing token. Fragments that open a block of their own (`if … end`,
+   * `repeat … end`, `js … end`) bail — their terminator belongs to them and
+   * their dedicated paths handle it.
+   */
+  private transformWithTrailingEnd(input: string): string | null {
+    const src = this.sourceProfile.code;
+    const tokens = input.trim().split(/\s+/);
+    if (tokens.length < 2) {
+      return null;
+    }
+    const sourceEnd = translateWord('end', 'en', src).toLowerCase();
+    if (tokens[tokens.length - 1].toLowerCase() !== sourceEnd) {
+      return null;
+    }
+    const openers = new Set(
+      ['if', 'repeat', 'unless', 'while', 'when', 'live', 'js'].map(k =>
+        translateWord(k, 'en', src).toLowerCase()
+      )
+    );
+    if (tokens.slice(0, -1).some(t => openers.has(t.toLowerCase()))) {
+      return null;
+    }
+    const inner = this.transformSingle(tokens.slice(0, -1).join(' '));
+    const endT = translateWord(tokens[tokens.length - 1], src, this.targetProfile.code);
+    return `${inner} ${endT}`;
   }
 
   /**

--- a/packages/semantic/src/parser/end-keywords.ts
+++ b/packages/semantic/src/parser/end-keywords.ts
@@ -1,0 +1,65 @@
+/**
+ * Curated per-language block-terminator surfaces.
+ *
+ * These sets are AUDITED for two collision classes and deliberately exclude
+ * the colliding words:
+ *  - exit/end homonyms (ja 終了, ko 종료, de beenden are the dicts' `exit`
+ *    emissions — listing them made an `exit` inside a block read as the block
+ *    terminator);
+ *  - positional-`last` homonyms (ar آخر, bn শেষ ARE the positional words —
+ *    listing them chopped clauses at every positional last).
+ * The inverse also holds and is load-bearing: a word IN a curated set is
+ * never the positional `last` (tr emits `sonuncu` for last, `son` stays the
+ * terminator; qu last is `qhipa`, not `tukuy`), so role captures and value
+ * groups can treat it as structural residue unconditionally.
+ *
+ * Shared by the semantic parser's isEndKeyword and the pattern matcher's
+ * role-value guards (pattern-matcher can't import semantic-parser — cycle).
+ */
+const CURATED_END_KEYWORDS: Record<string, Set<string>> = {
+  en: new Set(['end']),
+  // 終了 is deliberately ABSENT: it is the i18n dict's `exit` emission
+  // (`exit: 終了`, ja.ts), and listing it as an `end` alternative made the
+  // body parser count an `exit` inside an `if … exit … end` block as the
+  // block terminator — so the real 終わり closed the whole handler body,
+  // dropping every command after the block (behavior-sortable degenerate).
+  // 終わり is the dict's `end` emission; おわり is the kana variant.
+  ja: new Set(['終わり', 'おわり']),
+  // ar آخر is deliberately ABSENT: it is the positional `last` keyword;
+  // listing it here chopped clauses at every positional last (ar focus-trap
+  // lost its if-branch body). النهاية is what the i18n dict emits for end.
+  ar: new Set(['نهاية', 'انتهى', 'النهاية']),
+  es: new Set(['fin', 'final', 'terminar']),
+  // 종료 is deliberately ABSENT — same exit/end collision as ja above
+  // (`exit: 종료`, ko.ts). 끝 is the dict's `end` emission; 마침 a variant.
+  ko: new Set(['끝', '마침']),
+  zh: new Set(['结束', '终止', '完']),
+  tr: new Set(['son', 'bitiş', 'bitti']),
+  pt: new Set(['fim', 'final', 'término']),
+  fr: new Set(['fin', 'terminer', 'finir']),
+  // beenden is deliberately ABSENT — same exit/end collision as ja above
+  // (`exit: beenden`, de.ts; the de profile's `end` alternatives are only
+  // ['ende', 'fertig'], so this hardcoded set was the lone offender).
+  de: new Set(['ende', 'fertig']),
+  id: new Set(['selesai', 'akhir', 'tamat']),
+  tl: new Set(['wakas', 'tapos']),
+  bn: new Set(['সমাপ্ত']),
+  qu: new Set(['tukukuy', 'tukuy', 'puchukay']),
+  sw: new Set(['mwisho', 'maliza', 'tamati']),
+};
+
+/** The curated set for a language, or undefined for profile-fallback languages. */
+export function curatedEndKeywordSet(language: string): Set<string> | undefined {
+  return CURATED_END_KEYWORDS[language];
+}
+
+/**
+ * True when `value` is one of the language's CURATED terminator surfaces
+ * (audited to never be positional `last` — see the map's doc comment). Does
+ * NOT include the universal English-literal `end` acceptance or the
+ * profile-keyword fallback; callers wanting full terminator detection use the
+ * semantic parser's isEndKeyword.
+ */
+export function isCuratedEndKeyword(value: string, language: string): boolean {
+  return CURATED_END_KEYWORDS[language]?.has(value.toLowerCase()) ?? false;
+}

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -28,6 +28,7 @@ import { getPossessiveReference } from './utils/possessive-keywords';
 import type { LanguageProfile } from '../generators/profiles/types';
 import { tryGetProfile } from '../registry';
 import { isAtEndConnective } from '../patterns/put';
+import { isCuratedEndKeyword } from './end-keywords';
 import type { ConfidenceModel } from './confidence-model';
 import { defaultConfidenceModel } from './confidence-model';
 
@@ -563,6 +564,17 @@ export class PatternMatcher {
     if (token.kind === 'keyword') {
       const connNorm = (token.normalized ?? token.value).toLowerCase();
       if (connNorm === 'then' || (connNorm === 'end' && tokens.peek(1)?.kind !== 'selector')) {
+        return patternToken.optional || false;
+      }
+      // A CURATED end word (by VALUE — tr `son`, qu `tukuy`) is never a role
+      // value, even before a selector and even when the tokenizer normalizes
+      // it to something else (tr son→'last', the positional homonym): the
+      // curated sets are audited so those words are always the terminator
+      // (tr emits `sonuncu` for positional last). Without this, a loop's own
+      // `son` directly before the next command's selector matched
+      // tryMatchPositionalExpression and prefixed that command's role value
+      // (tr behavior-sortable remove.patient="last .{dragClass}").
+      if (isCuratedEndKeyword(token.value, this.currentProfile?.code ?? '')) {
         return patternToken.optional || false;
       }
     }

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -38,6 +38,7 @@ import {
 import { getPatternsForLanguage, tryGetProfile } from '../registry';
 import { getSchema } from '../generators/command-schemas';
 import { patternMatcher } from './pattern-matcher';
+import { curatedEndKeywordSet } from './end-keywords';
 import { tryParseBlock, tryParseFeatureBlock, tryParseProgram } from './block-parser';
 import { eventNameTranslations } from '../patterns/event-handler';
 import { isAtEndPositionNoun } from '../patterns/put';
@@ -2045,7 +2046,18 @@ export class SemanticParserImpl implements ISemanticParser {
       if (isEnd && pendingBlockDepth > 0) {
         pendingBlockDepth--;
         pendingOpenerKinds.pop();
-        currentClauseTokens.push(current);
+        // Annotate: THIS terminator closes a tracked open block. Downstream,
+        // the flat clause run can't tell a block-closing `son`/`শেষ` from a
+        // positional `last` — the selector lookahead in isStrayTerminator
+        // would read `son .{dragClass}` (loop-end + remove's patient) as
+        // `last .{dragClass}` and prefix the next command's role value (the
+        // tr behavior-sortable remove.patient R3 row). The annotation keeps
+        // the positional reading for every terminator-shaped token EXCEPT the
+        // ones this walker itself matched to an opener.
+        currentClauseTokens.push({
+          ...current,
+          metadata: { ...current.metadata, closesTrackedBlock: true },
+        });
         tokens.advance();
         continue;
       }
@@ -2979,10 +2991,26 @@ export class SemanticParserImpl implements ISemanticParser {
     // positional-`last` phrase lives (bn `শেষ <li/>`, tr `son .item`), so any
     // terminator-shaped token followed by a selector keeps its positional
     // reading.
-    const isStrayTerminator = (t: LanguageToken, next: LanguageToken | undefined): boolean =>
-      (this.isEndKeyword(t.value, language) ||
-        (t.kind === 'keyword' && (t.normalized ?? '').toLowerCase() === 'end')) &&
-      !(next && next.kind === 'selector');
+    const isStrayTerminator = (t: LanguageToken, next: LanguageToken | undefined): boolean => {
+      const curatedEnd = this.isEndKeyword(t.value, language);
+      const normalizedEnd = t.kind === 'keyword' && (t.normalized ?? '').toLowerCase() === 'end';
+      if (!curatedEnd && !normalizedEnd) return false;
+      // A terminator the clause walker matched to a tracked block opener is
+      // ALWAYS structural (never positional `last`), even before a selector —
+      // see the annotation in parseBodyWithClauses.
+      if (t.metadata?.closesTrackedBlock === true) return true;
+      // A CURATED end word is never the positional `last`: the curated sets
+      // are audited for exactly that collision (tr emits `sonuncu` for last,
+      // `son` stays the terminator; qu last is `qhipa`, not `tukuy`; ar آخر is
+      // deliberately absent BECAUSE it is positional). Without this, a loop's
+      // own `son` directly before the next command's selector was read as
+      // `last <sel>` and prefixed that command's role value (tr
+      // behavior-sortable remove.patient="last .{dragClass}").
+      if (curatedEnd) return true;
+      // Dual-use words reached via the normalized fallback (bn শেষ = end AND
+      // positional last) keep their positional reading before a selector.
+      return !(next && next.kind === 'selector');
+    };
 
     // Process a group of tokens: collect value tokens until a marker is found
     const processGroup = (tokens: LanguageToken[]) => {
@@ -4246,37 +4274,9 @@ export class SemanticParserImpl implements ISemanticParser {
    */
   private isEndKeyword(value: string, language: string): boolean {
     const v = value.toLowerCase();
-    const endKeywords: Record<string, Set<string>> = {
-      en: new Set(['end']),
-      // 終了 is deliberately ABSENT: it is the i18n dict's `exit` emission
-      // (`exit: 終了`, ja.ts), and listing it as an `end` alternative made the
-      // body parser count an `exit` inside an `if … exit … end` block as the
-      // block terminator — so the real 終わり closed the whole handler body,
-      // dropping every command after the block (behavior-sortable degenerate).
-      // 終わり is the dict's `end` emission; おわり is the kana variant.
-      ja: new Set(['終わり', 'おわり']),
-      // ar آخر is deliberately ABSENT: it is the positional `last` keyword;
-      // listing it here chopped clauses at every positional last (ar focus-trap
-      // lost its if-branch body). النهاية is what the i18n dict emits for end.
-      ar: new Set(['نهاية', 'انتهى', 'النهاية']),
-      es: new Set(['fin', 'final', 'terminar']),
-      // 종료 is deliberately ABSENT — same exit/end collision as ja above
-      // (`exit: 종료`, ko.ts). 끝 is the dict's `end` emission; 마침 a variant.
-      ko: new Set(['끝', '마침']),
-      zh: new Set(['结束', '终止', '完']),
-      tr: new Set(['son', 'bitiş', 'bitti']),
-      pt: new Set(['fim', 'final', 'término']),
-      fr: new Set(['fin', 'terminer', 'finir']),
-      // beenden is deliberately ABSENT — same exit/end collision as ja above
-      // (`exit: beenden`, de.ts; the de profile's `end` alternatives are only
-      // ['ende', 'fertig'], so this hardcoded set was the lone offender).
-      de: new Set(['ende', 'fertig']),
-      id: new Set(['selesai', 'akhir', 'tamat']),
-      tl: new Set(['wakas', 'tapos']),
-      bn: new Set(['সমাপ্ত']),
-      qu: new Set(['tukukuy', 'tukuy', 'puchukay']),
-      sw: new Set(['mwisho', 'maliza', 'tamati']),
-    };
+    // Curated sets live in end-keywords.ts (shared with the pattern matcher's
+    // role-value guards) — see that module for the collision-audit notes.
+    //
     // The English literal `end` is accepted in EVERY language, not just the
     // profile-fallback ones: hyperscript keywords that pass through a translation
     // untouched keep their English form, and crucially a masked `js(…) … end`
@@ -4287,7 +4287,7 @@ export class SemanticParserImpl implements ISemanticParser {
     // over-consumes the rest of the handler body (the removable/sortable
     // command-drop: `trigger`, `remove`, … vanish after the js-bearing `if`).
     // en already works because `end` is in its curated set; this aligns the rest.
-    const curated = endKeywords[language];
+    const curated = curatedEndKeywordSet(language);
     if (curated) return v === 'end' || curated.has(v);
     return v === 'end' || this.profileKeywordMatches(language, 'end', v);
   }

--- a/packages/semantic/src/patterns/repeat.ts
+++ b/packages/semantic/src/patterns/repeat.ts
@@ -397,6 +397,47 @@ function repeatUntilHeadSOV(
 }
 
 /**
+ * Verb-final twin of {@link repeatUntilHeadSOV}: `{until-word} {event-word}
+ * {event} {obj-marker} {source} {from-marker} {repeat-verb}` — the source
+ * phrase INSIDE the clause, before the verb (tr `kadar olay pointerup i belge
+ * den tekrarla`). This is the grammatically-correct SOV order the i18n
+ * transformer emits since the transformer-rendering arc; the post-verb
+ * variant above still matches the pre-arc corpus shape (`… tekrarla belge
+ * den`), kept as a tolerance lock. The source group is REQUIRED here so this
+ * variant never outbids the post-verb one on sourceless heads.
+ */
+function repeatUntilHeadSOVVerbFinal(
+  language: string,
+  spec: { untilWord: string; eventWord: string; objMarker: string; fromWord: string }
+): LanguagePattern {
+  return {
+    id: `repeat-${language}-until-head-verb-final`,
+    language,
+    command: 'repeat',
+    priority: 111, // above the post-verb variant so the correct shape wins
+    template: {
+      format: `${spec.untilWord} ${spec.eventWord} {event} ${spec.objMarker} {source} ${spec.fromWord} repeat`,
+      tokens: [
+        { type: 'literal', value: spec.untilWord },
+        { type: 'literal', value: spec.eventWord },
+        { type: 'role', role: 'event', expectedTypes: ['literal', 'expression'] },
+        { type: 'literal', value: spec.objMarker },
+        {
+          type: 'role',
+          role: 'source',
+          expectedTypes: ['selector', 'reference', 'expression'],
+        },
+        { type: 'literal', value: spec.fromWord },
+        { type: 'literal', value: 'repeat' },
+      ],
+    },
+    extraction: {
+      loopType: { default: { type: 'literal', value: 'until-event' } },
+    },
+  };
+}
+
+/**
  * Mid-clause twin of {@link repeatUntilHeadQu}: anchors at `kama`(→until)
  * WITHOUT the `hayk _ a` junk prefix. Inside a multi-command clause (the
  * sortable behavior body) the PRECEDING command's verb-first pattern greedily
@@ -496,6 +537,12 @@ for (const [lang, spec] of VERB_FIRST_UNTIL_HEADS) {
 }
 for (const [lang, spec] of SOV_UNTIL_HEADS) {
   addPattern(lang, repeatUntilHeadSOV(lang, spec));
+  // tr renders the source phrase pre-verb since the transformer-rendering
+  // arc (the i18n `repeat-until-event-verb-final` rule); hi/bn/ja/ko renders
+  // are unchanged (post-verb) so they don't get the verb-final variant.
+  if (lang === 'tr') {
+    addPattern(lang, repeatUntilHeadSOVVerbFinal(lang, spec));
+  }
 }
 addPattern('qu', repeatUntilHeadQu);
 addPattern('qu', repeatUntilHeadQuMidClause);

--- a/packages/semantic/src/patterns/trigger.ts
+++ b/packages/semantic/src/patterns/trigger.ts
@@ -129,6 +129,49 @@ function getTriggerPatternsHe(): LanguagePattern[] {
   ];
 }
 
+function getTriggerPatternsQu(): LanguagePattern[] {
+  return [
+    {
+      // The i18n corpus shape: `sortable:start ta noqa man kichay` — event
+      // (patient-marked `ta`), optional destination (`man`), verb-final. The
+      // generated qu trigger patterns (`[{destination} man] {event} pi
+      // kuyuchiy`) never match it, so in a multi-command body the line only
+      // survives via the greedy verb-anchoring fallback — which, when the
+      // NEXT statement opens with the fronted until-compound (`hayk_akama …
+      // kutipay`), eats `hayk` as the trigger's event (the behavior-sortable
+      // qu `sortable:start` R3 row). A position-0 match wins before the
+      // fallback can glue. Literals are NORMALIZED forms (kichay→trigger).
+      id: 'trigger-qu-event-first-verb-final',
+      language: 'qu',
+      command: 'trigger',
+      priority: 105,
+      template: {
+        format: '{event} ta [{destination} man] trigger',
+        tokens: [
+          { type: 'role', role: 'event', expectedTypes: ['literal', 'expression'] },
+          { type: 'literal', value: 'ta' },
+          {
+            type: 'group',
+            optional: true,
+            tokens: [
+              {
+                type: 'role',
+                role: 'destination',
+                expectedTypes: ['selector', 'reference', 'expression'],
+              },
+              { type: 'literal', value: 'man' },
+            ],
+          },
+          { type: 'literal', value: 'trigger' },
+        ],
+      },
+      extraction: {
+        destination: { default: { type: 'reference', value: 'me' } },
+      },
+    },
+  ];
+}
+
 export function getTriggerPatternsForLanguage(language: string): LanguagePattern[] {
   switch (language) {
     case 'en':
@@ -137,6 +180,8 @@ export function getTriggerPatternsForLanguage(language: string): LanguagePattern
       return getTriggerPatternsZh();
     case 'he':
       return getTriggerPatternsHe();
+    case 'qu':
+      return getTriggerPatternsQu();
     default:
       return [];
   }

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -12563,33 +12563,47 @@ describe('colon-qualified event names: full behavior bodies capture every trigge
     });
   }
 
-  const QU_RESIZABLE = [
-    'Resizable(minWidth, minHeight, maxWidth, maxHeight) ta behavior',
-    '    noqa manta pointerdown(clientX, clientY) pi',
-    '        the ruway ta sayay',
-    '        resizable:start ta kichay',
-    '        width ta tupuy',
-    '        startWidth ta chay man churanay',
-    '        height ta tupuy',
-    '        startHeight ta chay man churanay',
-    '        startX ta clientX man churanay',
-    '        startY ta clientY man churanay',
-    '        hayk_akama ruway pointerup ta qillqa manta kutipay',
-    '            qillqa manta suyay pointermove(clientX, clientY) utaq pointerup(clientX, clientY)',
-    '            newWidth ta startWidth + clientX - startX man churanay',
-    '            newHeight ta startHeight + clientY - startY man churanay',
-    '            sichus newWidth < minWidth chayqa newWidth ta minWidth tukuy man churanay',
-    '            sichus newWidth > maxWidth chayqa newWidth ta maxWidth tukuy man churanay',
-    '            sichus newHeight < minHeight chayqa newHeight ta minHeight tukuy man churanay',
-    '            sichus newHeight > maxHeight chayqa newHeight ta maxHeight tukuy man churanay',
-    '            noqaq *width ta newWidth + "px" man churanay',
-    '            noqaq *height ta newHeight + "px" man churanay',
-    '            resizable:resize ta kichay',
-    '        tukuy',
-    '        resizable:end ta kichay',
-    '    tukuy',
-    'tukuy',
-  ].join('\n');
+  // `fixedReorder` selects the current corpus render (transformer-rendering
+  // arc: wait verb-final, inline-if terminator AFTER the verb-final tail) vs
+  // the LEGACY pre-arc render (wait verb-medial, `tukuy man churanay`
+  // stranding), which stays locked as a tolerance input.
+  const quResizable = (fixedReorder: boolean): string => {
+    const clamp = (cond: string, assign: string): string =>
+      fixedReorder
+        ? `            sichus ${cond} chayqa ${assign} man churanay tukuy`
+        : `            sichus ${cond} chayqa ${assign} tukuy man churanay`;
+    return [
+      'Resizable(minWidth, minHeight, maxWidth, maxHeight) ta behavior',
+      '    noqa manta pointerdown(clientX, clientY) pi',
+      '        the ruway ta sayay',
+      '        resizable:start ta kichay',
+      '        width ta tupuy',
+      '        startWidth ta chay man churanay',
+      '        height ta tupuy',
+      '        startHeight ta chay man churanay',
+      '        startX ta clientX man churanay',
+      '        startY ta clientY man churanay',
+      '        hayk_akama ruway pointerup ta qillqa manta kutipay',
+      fixedReorder
+        ? '            qillqa manta pointermove(clientX, clientY) utaq pointerup(clientX, clientY) suyay'
+        : '            qillqa manta suyay pointermove(clientX, clientY) utaq pointerup(clientX, clientY)',
+      '            newWidth ta startWidth + clientX - startX man churanay',
+      '            newHeight ta startHeight + clientY - startY man churanay',
+      clamp('newWidth < minWidth', 'newWidth ta minWidth'),
+      clamp('newWidth > maxWidth', 'newWidth ta maxWidth'),
+      clamp('newHeight < minHeight', 'newHeight ta minHeight'),
+      clamp('newHeight > maxHeight', 'newHeight ta maxHeight'),
+      '            noqaq *width ta newWidth + "px" man churanay',
+      '            noqaq *height ta newHeight + "px" man churanay',
+      '            resizable:resize ta kichay',
+      '        tukuy',
+      '        resizable:end ta kichay',
+      '    tukuy',
+      'tukuy',
+    ].join('\n');
+  };
+  const QU_RESIZABLE = quResizable(true);
+  const QU_RESIZABLE_LEGACY = quResizable(false);
 
   it('[qu] behavior-resizable: three triggers by VALUE, no lost measure', () => {
     const nodes = collect(parse(QU_RESIZABLE, 'qu'));
@@ -12597,19 +12611,30 @@ describe('colon-qualified event names: full behavior bodies capture every trigge
       ['resizable:start', 'resizable:resize', 'resizable:end'].sort()
     );
     expect(count(nodes, 'measure')).toBe(2);
-    // The en reference has 12 sets; qu currently recovers 10.
-    expect(count(nodes, 'set')).toBeGreaterThanOrEqual(10);
+    // All 12 of the en reference's sets parse since the transformer-rendering
+    // arc (the trailing-`end` strip renders `man churanay tukuy`, so the
+    // conditional fold no longer strands the verb-final tail).
+    expect(count(nodes, 'set')).toBe(12);
   });
 
-  // KNOWN RESIDUE (split out — see docs-internal/MULTILINGUAL_NEXT_STEPS.md):
-  // the qu i18n reorder renders the inline-if blocks with the inner set's
-  // verb-final `man churanay` AFTER `tukuy` ("end"), so the conditional fold
-  // strands the fragment and the two style sets (`noqaq *width/*height …`)
-  // are swallowed: 10 of the en reference's 12 sets parse. Flips to a hard
-  // failure (fix the count above) when the reorder/fold is repaired.
-  it.fails('[qu] behavior-resizable: the two style sets still drop (reorder residue)', () => {
+  // FIXED (transformer-rendering arc): the i18n trailing-`end` strip now
+  // renders each inline-if's inner set verb-final BEFORE `tukuy`, so the
+  // conditional fold keeps the two style sets (`noqaq *width/*height …`).
+  it('[qu] behavior-resizable: all 12 sets parse (was the reorder residue)', () => {
     const nodes = collect(parse(QU_RESIZABLE, 'qu'));
     expect(count(nodes, 'set')).toBe(12);
+  });
+
+  it('[qu] LEGACY pre-arc render: triggers by VALUE + set floor (tolerance lock)', () => {
+    // The pre-arc corpus shape (verb-medial wait, `tukuy man churanay`
+    // stranding) remains a valid input: triggers and measures stay faithful,
+    // and at least the 10 non-stranded sets parse.
+    const nodes = collect(parse(QU_RESIZABLE_LEGACY, 'qu'));
+    expect(triggerValues(nodes).sort()).toEqual(
+      ['resizable:start', 'resizable:resize', 'resizable:end'].sort()
+    );
+    expect(count(nodes, 'measure')).toBe(2);
+    expect(count(nodes, 'set')).toBeGreaterThanOrEqual(10);
   });
 });
 
@@ -12858,25 +12883,25 @@ describe('R3 value-bug families (docs-internal/HANDOFF_value-bug-families.md)', 
     });
   });
 
-  describe('F7: qu/tr behavior-sortable trigger residue (re-filed to the transformer arc)', () => {
-    // KNOWN RESIDUE — re-filed, not a parser gap (see MULTILINGUAL_NEXT_STEPS
-    // § R3 families, item 7). The command-level action multiset matches en in
-    // BOTH languages; only the VALUES around the loop's wait line corrupt,
-    // and every miss sits adjacent to a malformed i18n render:
-    //   tr line 15: `kadar olay pointerup i tekrarla belge den` — the
-    //     from-phrase strands AFTER the verb (en: repeat until event
-    //     pointerup from document);
-    //   tr line 16: `bekle pointermove(clientY) veya pointerup(clientY)
-    //     belge den` — verb-FIRST in an SOV language, or-run + from-phrase
-    //     stranded post-verb (the middle trigger captures the stranded
-    //     `belge` as its event);
-    //   qu line 16: `qillqa manta suyay pointermove(clientY) utaq
-    //     pointerup(clientY)` — verb-MEDIAL, or-run stranded post-verb (the
-    //     middle trigger glues the whole stranded run into its event).
-    // Same family as the qu behavior-resizable it.fails above (the reorder
-    // renders fragments outside their clause). These flip when the
-    // transformer rendering is repaired.
-    const QU_SORTABLE = [
+  describe('F7: qu/tr behavior-sortable trigger events (fixed in the transformer-rendering arc)', () => {
+    // FIXED (transformer-rendering arc; formerly the re-filed residue of
+    // MULTILINGUAL_NEXT_STEPS § R3 families, item 7). Three coordinated fixes:
+    //  - i18n `wait-oblique-verb-final` rules (tr/qu) render the loop's wait
+    //    line verb-final with the from-phrase + or-run INSIDE the clause, so
+    //    the stranded run no longer leaks into the next trigger's event;
+    //  - the i18n tr `repeat-until-event-verb-final` rule renders the loop
+    //    head's from-phrase before the verb (`kadar olay pointerup i belge
+    //    den tekrarla`), matched by `repeat-tr-until-head-verb-final`;
+    //  - `trigger-qu-event-first-verb-final` matches the qu corpus trigger
+    //    shape at position 0 (previously only the greedy verb-anchoring
+    //    fallback parsed it, and it glued the next line's fronted
+    //    `hayk_akama` as the event), and the curated-end guard in
+    //    matchRoleToken stops tr's loop-closing `son` from prefixing the
+    //    following remove's patient as positional `last`.
+    // The LEGACY fixtures pin the PRE-arc corpus shapes, which remain valid
+    // inputs (tolerance locks); the primary fixtures are the current
+    // patterns.db renders.
+    const quSortable = (waitLine: string): string[] => [
       'Sortable(dragClass) ta behavior',
       '    init',
       '        sichus dragClass kanqa mana_riqsisqa',
@@ -12892,16 +12917,22 @@ describe('R3 value-bug families (docs-internal/HANDOFF_value-bug-families.md)', 
       '        .{dragClass} ta item man yapay',
       '        sortable:start ta noqa man kichay',
       '        hayk_akama ruway pointerup ta qillqa manta kutipay',
-      '            qillqa manta suyay pointermove(clientY) utaq pointerup(clientY)',
+      waitLine,
       '            sortable:move ta noqa man kichay',
       '        tukuy',
       '        .{dragClass} ta item manta qichuy',
       '        sortable:end ta noqa man kichay',
       '    tukuy',
       'tukuy',
-    ].join('\n');
+    ];
+    const QU_SORTABLE = quSortable(
+      '            qillqa manta pointermove(clientY) utaq pointerup(clientY) suyay'
+    ).join('\n');
+    const QU_SORTABLE_LEGACY = quSortable(
+      '            qillqa manta suyay pointermove(clientY) utaq pointerup(clientY)'
+    ).join('\n');
 
-    const TR_SORTABLE = [
+    const trSortable = (headerLine: string, waitLine: string): string[] => [
       'Sortable(dragClass) i behavior',
       '    init',
       '        eğer dragClass dir tanımsız',
@@ -12916,34 +12947,67 @@ describe('R3 value-bug families (docs-internal/HANDOFF_value-bug-families.md)', 
       '        the olay i durdur',
       '        .{dragClass} i ekle item e',
       '        sortable:start i tetikle ben e',
-      '        kadar olay pointerup i tekrarla belge den',
-      '            bekle pointermove(clientY) veya pointerup(clientY) belge den',
+      headerLine,
+      waitLine,
       '            sortable:move i tetikle ben e',
       '        son',
       '        .{dragClass} i kaldır item den',
       '        sortable:end i tetikle ben e',
       '    son',
       'son',
-    ].join('\n');
+    ];
+    const TR_SORTABLE = trSortable(
+      '        kadar olay pointerup i belge den tekrarla',
+      '            belge den pointermove(clientY) veya pointerup(clientY) bekle'
+    ).join('\n');
+    const TR_SORTABLE_LEGACY = trSortable(
+      '        kadar olay pointerup i tekrarla belge den',
+      '            bekle pointermove(clientY) veya pointerup(clientY) belge den'
+    ).join('\n');
 
     const triggerValues = (nodes: Record<string, any>[]): string[] =>
       nodes.filter(n => n.action === 'trigger').map(n => String(role(n, 'event')?.raw ?? role(n, 'event')?.value ?? '?'));
 
-    it.fails('[qu] behavior-sortable: all three trigger events by VALUE (reorder residue)', () => {
+    it('[qu] behavior-sortable: all three trigger events by VALUE', () => {
       const nodes = collect(parse(QU_SORTABLE, 'qu'));
       expect(triggerValues(nodes).sort()).toEqual(
         ['sortable:start', 'sortable:move', 'sortable:end'].sort()
       );
     });
 
-    it.fails('[tr] behavior-sortable: sortable:move + bare remove patient (reorder residue)', () => {
+    it('[qu] LEGACY pre-arc render: all three trigger events by VALUE (tolerance lock)', () => {
+      // The position-0 qu trigger pattern fixes the hayk-glue on the OLD
+      // corpus shape too, and the pre-verb wait strand no longer reaches the
+      // middle trigger — the legacy text now parses fully faithful.
+      const nodes = collect(parse(QU_SORTABLE_LEGACY, 'qu'));
+      expect(triggerValues(nodes).sort()).toEqual(
+        ['sortable:start', 'sortable:move', 'sortable:end'].sort()
+      );
+    });
+
+    it('[tr] behavior-sortable: all three trigger events by VALUE + bare remove patient', () => {
       const nodes = collect(parse(TR_SORTABLE, 'tr'));
-      expect(triggerValues(nodes)).toContain('sortable:move');
+      expect(triggerValues(nodes).sort()).toEqual(
+        ['sortable:start', 'sortable:move', 'sortable:end'].sort()
+      );
       const rm = first(nodes, 'remove');
       expect(role(rm, 'patient')?.value).toBe('.{dragClass}');
     });
 
-    it('[qu/tr] behavior-sortable: command-level actions all survive (only values corrupt)', () => {
+    it('[tr] LEGACY pre-arc render: bare remove patient (curated-end guard lock)', () => {
+      // On the legacy text the wait strand still corrupts the middle
+      // trigger's event (that needed the render fix), but the loop-closing
+      // `son` no longer prefixes remove's patient as positional `last` —
+      // that's the matchRoleToken curated-end guard, which applies to the
+      // old shape as well.
+      const nodes = collect(parse(TR_SORTABLE_LEGACY, 'tr'));
+      const rm = first(nodes, 'remove');
+      expect(role(rm, 'patient')?.value).toBe('.{dragClass}');
+      const acts = collect(parse(TR_SORTABLE_LEGACY, 'tr')).map(n => n.action);
+      expect(acts.filter(a => a === 'trigger').length, 'tr legacy trigger count').toBe(3);
+    });
+
+    it('[qu/tr] behavior-sortable: command-level actions all survive', () => {
       const enActions = collect(parse(TR_SORTABLE, 'tr')).map(n => n.action);
       for (const [lang, src] of [['qu', QU_SORTABLE], ['tr', TR_SORTABLE]] as const) {
         const acts = collect(parse(src, lang)).map(n => n.action);

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-10T20:46:52.059Z",
-  "commit": "3542bc6c",
+  "timestamp": "2026-07-10T22:47:36.999Z",
+  "commit": "4175f0b2",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -16,7 +16,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -644,13 +644,13 @@
       "avgFidelity": 1,
       "avgPrecision": 0.9989716846334493,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9730936819172112,
+      "avgRoleFidelity": 0.9738198983297022,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1284,7 +1284,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1909,7 +1909,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2543,7 +2543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3177,7 +3177,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3811,7 +3811,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4439,13 +4439,13 @@
       "avgFidelity": 1,
       "avgPrecision": 0.9978354978354977,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9698257080610021,
+      "avgRoleFidelity": 0.9705519244734929,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5079,7 +5079,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5713,7 +5713,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6341,13 +6341,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9730936819172112,
+      "avgRoleFidelity": 0.9738198983297022,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6975,13 +6975,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9698257080610021,
+      "avgRoleFidelity": 0.970551924473493,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7615,7 +7615,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8249,7 +8249,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8883,7 +8883,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9510,14 +9510,14 @@
       "avgConfidence": 0.7316532673675531,
       "avgFidelity": 1,
       "avgPrecision": 1,
-      "avgMultisetRecall": 0.9995004995004996,
-      "avgRoleFidelity": 0.953034547152194,
-      "avgValueRecall": 0.9867924528301886,
+      "avgMultisetRecall": 1,
+      "avgRoleFidelity": 0.9522415829076727,
+      "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10151,7 +10151,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10785,7 +10785,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11419,7 +11419,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12053,7 +12053,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12681,13 +12681,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9716198897859796,
-      "avgValueRecall": 0.9867924528301886,
+      "avgRoleFidelity": 0.9719376094664444,
+      "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13321,7 +13321,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13955,7 +13955,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14589,7 +14589,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 496661,
+      "bundleSize": 497541,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15212,7 +15212,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 496661,
+      "size": 497541,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Resolves the transformer-rendering arc (`docs-internal/HANDOFF_transformer-rendering.md`, now marked resolved): the i18n `GrammarTransformer`'s SOV reorder rendered fragments outside their clause — verb-first/verb-medial `wait for X or Y from Z` lines (tr/qu), a postposed from-phrase in tr's `repeat until event … from …` header, and block terminators emitted inside the following phrase (bn/qu/tr). Downstream, the stranded fragments were captured as junk trigger events — the four remaining non-wontfix R3 rows (`behavior-sortable` qu ×2 / tr ×2) and the one sub-1.0 multiset row (qu `behavior-resizable`, 10/12 sets).

## Approach

**Scoped per-command rules, not a blanket reorder.** A wholesale tr/bn `canonicalOrder` extension was tried first and reverted: the semantic parser's generated patterns + the #635 reclaim tolerances co-evolved around the old stranded shapes, so re-rendering the whole corpus exploded R3 from 12 to 39 rows. The landed fix follows the existing `put-into`/`set-to` rule precedent.

### i18n renderer
- `wait-oblique-verb-final` rules (tr/qu, gated to `duration`+`source`, no-event predicate): `belge den pointermove(clientY) veya pointerup(clientY) bekle` / `qillqa manta … utaq … suyay` — the or-run + from-phrase stay in-clause, verb-final.
- `repeat-until-event-verb-final` rule (tr, predicate-gated to `repeat until event`): `kadar olay pointerup i belge den tekrarla`.
- `transformSingle` step 0a: a fragment's stranded trailing `end` (from the `then`-splitter) is stripped, the clause transformed alone, and the translated terminator re-appended after the verb — bn repeat-while renders `200ms কে অপেক্ষা শেষ`, qu resizable's inline-if sets render `man churanay tukuy` (all 12 sets parse).

### semantic parser (gaps rendering alone could not fix)
- `repeat-tr-until-head-verb-final` pattern (required pre-verb source group); the post-verb variant stays for the legacy shape.
- `trigger-qu-event-first-verb-final`: the qu corpus trigger shape matched **no** pattern — only the greedy verb-anchoring fallback parsed it, gluing the next line's fronted `hayk_akama` as the event (the qu `sortable:start` row).
- Curated end-keyword sets extracted to `parser/end-keywords.ts` (shared with pattern-matcher). They are audited never-positional (tr emits `sonuncu` for last, qu last is `qhipa`, ar `آخر` deliberately absent), so `matchRoleToken`/`isStrayTerminator` treat curated end words as structural unconditionally — the loop's own `son` no longer prefixes `remove.patient` as `"last .{dragClass}"`. Dual-use bn `শেষ` keeps its selector lookahead.

### locks + baseline
- F7 and colon-event `it.fails` flipped to hard asserts on refreshed corpus fixtures; pre-arc shapes retained as `*_LEGACY` tolerance locks (resizable set floor `>=10` → `toBe(12)`).
- 8 new rendering locks in `grammar.test.ts` (incl. the draggable `clientX, clientY` variants).
- NEXT_STEPS § R3 item 7 and § colon-event item 2 retired with outcomes; F2 note updated; handoff marked resolved.
- Baseline regenerated + prettier'd + diff audited: tr/qu avgValueRecall 0.9868 → 0.9906, qu avgMultisetRecall → 1.0, R2 execution → 1.0. Only R3 residue left: `swap-content` ×8 (documented F6 wontfix). `patterns.db` not committed (convention).

## Verification

- Full sweep 3696/3696, every moved signal attributed (report read end-to-end, not just exit code).
- `--regression` gate green on a freshly populated db; `--save-baseline` on the same db.
- Suites: core 7199 ✓, semantic 6978 ✓ (incl. 1131 in the lock file), i18n 932 ✓; typecheck clean on both packages.
- behavior-draggable (same wait+or-run shape, masked by a seed line-wrap) verified: parses all three trigger events by value in tr and qu post-fix — no seed unwrap needed; the shape is locked by the new clientX,clientY unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)