### PR TITLE
fix(semantic): R1 role-fidelity arc — SOV six to ≥0.98 (qu ≥0.979)

### DIFF
--- a/docs-internal/HANDOFF_r1-role-fidelity.md
+++ b/docs-internal/HANDOFF_r1-role-fidelity.md
@@ -1,12 +1,22 @@
 # Handoff: the R1 role-fidelity arc (SOV six — qu first, then ja/ko/tr)
 
+> **RESOLVED 2026-07-11** (branch `fix/r1-role-fidelity-sov`). All targets
+> exceeded: qu 0.9522 → **0.9792** (target ≥ 0.97); ja 0.9738 → **0.9938**,
+> tr 0.9719 → **0.9927**, ko 0.9706 → **0.9905** (targets ≥ 0.98); stretch
+> bn 0.9738 → **0.9938**, hi 0.9706 → **0.9883**. Families A/B/C fully
+> cleared; Family D: four increments landed (D1 sigil refs + set marker
+> swap, D2 fused-simple trailing-expression reclaim, D3 optional-chaining
+> possessive fold, D4 verb-final for-binding heads), remainder deferred with
+> per-entry reasons — see "Family D outcomes" at the end of this doc.
+> Regression gate green after every family; baseline regenerated.
+>
 > **For a fresh session.** Read this, then CLAUDE.md ("Multilingual parse rate ≠
 > fidelity" and "Running the multilingual `--regression` gate locally"), then
 > `docs-internal/HANDOFF_transformer-rendering.md` (RESOLVED — its method and
 > traps carry over verbatim, especially the "scoped fixes, not blanket reorder"
 > lesson and the full-body-probe discipline). Branch from `main` **after PR
-> #636** merges (it landed the wait/repeat render fixes, the curated-end
-> guards, and the `--triage-r1` tool this handoff's data comes from).
+> #636** merges (it landed the wait/repeat render fixes and the curated-end
+> guards; the `--triage-r1` tool lands as this arc's preamble commit).
 
 ## Why this arc
 
@@ -205,3 +215,32 @@ the tail — a shared-root fix here pays ×4–×6 (all SOV languages at once).
 - New unit locks per fixed family; baseline regenerated + prettier'd +
   audited + committed (never patterns.db); this handoff marked resolved and
   NEXT_STEPS updated.
+
+## Family D outcomes (arc close-out, 2026-07-11)
+
+Probing overturned the shared-classifier hypothesis for most of the tail: the
+big entries were **fused `*-sov-simple` default-role drops** (the Family A
+geometry — argument stranded after the verb), not `tokensToSemanticValue`
+mistypes. Per-entry ledger:
+
+| entry (vs en)                   | outcome  | how / why |
+| ------------------------------- | -------- | --------- |
+| `set.destination:reference` (beep-debug) | **fixed** (D1) | sigil-ref branch in `tokenToSemanticValue` + unconditional set patient↔destination marker swap in `mapRoleForCommand` (set's surface order is dest-first; put untouched) |
+| `js.patient:expression` (js-inline) | **fixed** (D2) | `tryAttachTrailingExpressionRole` — code run to clause boundary, split verb fragments (ja `実行`) trimmed |
+| `go.destination:expression` (go-url) | **fixed** (D2) | same reclaim — run to the postpositional destination marker (primary surface only); fused default-`me` patient leak dropped |
+| `scroll.destination:expression` (last-in-collection) | **fixed** (D2) | same reclaim as go |
+| `log.patient:property-path` (optional-chaining-possessive) | **fixed** (D3) | possessive chain consumer now folds `?` + `.prop` links; en's TYPE (denominator) unchanged, its property string carries the full chain, byte-identical across all six |
+| `for.patient:expression` + `for.source:reference` (template-literal-list-build) | **fixed** (D4) | verb-final `for-<lang>-sov-basic` heads for the SOV six (action `for`, en's for-en-basic roles); the fallback had shredded the head on the in/object particles |
+| `fetch.source:literal` (event-debounce) | **deferred** | the en reference itself truncates the interpolated URL at the space inside `${my value}` (`source:literal="/api/search?q=${my"`); SOV captures junk `}`. Root is the URL extractor splitting inside `${…}` — a tokenizer fix that would also change the en value (R3-visible in all 24). Follow-up: teach the url extractor `${…}` spans, then realign |
+| `pick.patient:expression` (pick-text-range) | **deferred** | the en reference is degenerate (`patient:expression="characters"` — first word only; pick's range roles aren't modeled). Chasing SOV parity against a junk denominator buys nothing; proper fix models pick's roles in the schema + transformer render |
+| `halt.patient:reference` (form-submit-prevent) | **deferred** | transformer scrambles `halt the event` + `call validateForm()` across the fused event clause (tr binds validateForm() to halt and event to call; ja strands `the イベント` clause-initial). Render-side fix — a transformer-rendering follow-up, not a parse-side patch |
+| `call.patient:expression` (form-submit-prevent tr / window-resize qu) | **deferred** | same root as halt above (fused-clause scramble) |
+| `focus.patient:expression` (focus-trap) | **deferred** | the positional focus operand (`first <button/> in .modal`) leaks into the preceding if-CONDITION — SOV renders have no boundary marker between condition and command. Conditional-fold boundary geometry, adjacent to the event-anchor guard machinery (the "hottest path" warning) |
+| `swap.destination:selector` (swap-content) | **out of scope** | F6 wontfix (NEXT_STEPS § R3 families item 6) — unchanged decision |
+| ko/qu/hi reactive `on.event` rows (when-value-changes etc.) | **out of scope** | per this handoff's scoping — event-anchor guard machinery |
+
+Residual per-language misses after the arc: bn/ja 4, tr 5, ko 6, hi 7, qu 13
+(qu carries the qu-only put/toggle/scroll oddities plus the out-of-scope
+rows). No "extract shared classifier" refactor is warranted — the increments
+did not converge on the assembler logic (most fixes were reclaims/patterns,
+not classifier branches).

--- a/docs-internal/HANDOFF_r1-role-fidelity.md
+++ b/docs-internal/HANDOFF_r1-role-fidelity.md
@@ -1,0 +1,207 @@
+# Handoff: the R1 role-fidelity arc (SOV six — qu first, then ja/ko/tr)
+
+> **For a fresh session.** Read this, then CLAUDE.md ("Multilingual parse rate ≠
+> fidelity" and "Running the multilingual `--regression` gate locally"), then
+> `docs-internal/HANDOFF_transformer-rendering.md` (RESOLVED — its method and
+> traps carry over verbatim, especially the "scoped fixes, not blanket reorder"
+> lesson and the full-body-probe discipline). Branch from `main` **after PR
+> #636** merges (it landed the wait/repeat render fixes, the curated-end
+> guards, and the `--triage-r1` tool this handoff's data comes from).
+
+## Why this arc
+
+R1 (role fidelity: recall of the en reference's `action.role:valueType` set,
+per pattern, averaged per language) is the last broad fidelity signal below
+~0.99. The SOV six lag the corpus; the 2026-07-10 baseline
+(`packages/testing-framework/baselines/multilingual-priority.json`):
+
+| lang | avgRoleFidelity | misses | patterns hit |
+| ---- | --------------- | ------ | ------------ |
+| qu   | **0.9522**      | 33     | 27           |
+| hi   | 0.9706          | 19     | 18           |
+| ko   | 0.9706          | 19     | 18           |
+| tr   | 0.9719          | 20     | 18           |
+| bn   | 0.9738          | 17     | 16           |
+| ja   | 0.9738          | 17     | 16           |
+
+qu sits ~2 points below its own cohort, so the arc is **qu to ≥ 0.97 first**,
+with the shared-family fixes lifting ja/ko/tr toward ~0.98 on the way. bn and
+hi were triaged too (2026-07-10): they share Family A and the Family D tail
+almost line-for-line, so the cohort fixes lift all six.
+
+## The triage tool (new in #636's follow-up — run this first, trust it)
+
+```bash
+npm run test:multilingual:build-deps        # the tool warns on stale dists
+cd packages/testing-framework
+npx tsx src/multilingual/cli.ts --full --bundle browser-priority \
+  --triage-r1 --languages qu,ko,ja,tr
+```
+
+`--triage-r1` (`src/multilingual/tools/triage-r1.ts`) itemizes every missing
+`action.role:type` entry vs the en reference, clustered, with the entries the
+language captured INSTEAD for the same action (the mistype pairing). It uses
+the exact gate pipeline (`ParseValidator` → `fillSchemaDefaults` →
+`collectRoleSignature` → Set recall), so its per-language averages reproduce
+the committed baseline to 4 decimals — a fix that moves the triage moves the
+signal.
+
+## The miss families (2026-07-10 triage, verbatim clusters)
+
+### Family A — `with`-options blob dropped: `fetch.style` / `render.style` (ALL four, 6 misses each)
+
+- `fetch.style:expression` ×4 in every language: `fetch-with-method`,
+  `fetch-with-headers`, `fetch-with-method-body`, `fetch-formdata`.
+- `render.style:expression` ×2 in every language:
+  `render-template-with-data`, `morph-with-template`.
+- **No "captured instead" pairing** — the options blob (`with method:"POST"
+  body:…` / `with {…}`) vanishes from the SOV parse entirely; en captures it
+  as `style:expression`.
+- 24 misses across the four languages — the single largest family, and the
+  best effort-to-lift ratio in the arc (~+0.01 per language by itself).
+- Suspect the SOV fetch/render patterns (see `sovFetch` in
+  `packages/semantic/src/patterns/fetch.ts`, added in the 2026-06-17
+  increment) simply have no trailing/fronted options group. Check where the
+  i18n transformer puts the `with`-phrase in SOV renders first (probe the
+  render, then the parse — pull the actual corpus text from patterns.db).
+
+### Family B — qu `set` possessive/property-path mis-rolling (qu ONLY, 7 misses)
+
+- `set.patient:expression` ×4: `two-way-binding`, `computed-value`,
+  `template-literal-interpolation`, `template-literal-list-build`.
+- `set.destination:property-path` ×3: same patterns minus list-build.
+- Captured instead: `set.destination:literal`, `set.patient:literal`,
+  `set.patient:selector`, `set.source:selector` — the qu parse finds A set
+  but scrambles which side is the property-path destination and which the
+  expression value.
+- This family is most of qu's gap below the cohort. Probe the qu renders of
+  `two-way-binding`/`computed-value` (possessive `noqaq …`/`X ın Y` analogues
+  — qu possessive config in `packages/semantic/src/generators/profiles/quechua.ts`)
+  against the qu set patterns; the transformer-rendering arc's paired
+  render+pattern method applies.
+
+### Family C — tr/qu or-run wait junk (2 misses each; the #636 leftover)
+
+- `wait.event:literal` missing in `behavior-sortable` + `behavior-resizable`;
+  captured instead `wait.duration:expression` (the `duration=")"` junk).
+- The renders are now CORRECT verb-final (`belge den pointermove(clientY)
+  veya pointerup(clientY) bekle` — #636); no tr/qu wait pattern matches the
+  or-run + from-phrase shape, so the verb-anchoring fallback bins the run as
+  a junk duration.
+- **Key scoping fact:** R1 is a Set recall of TYPES. The en reference for the
+  or-run wait captures ONLY `wait.event:literal` (first event; it drops the
+  or-alternatives and the source itself). Parity therefore needs a tr/qu wait
+  pattern that captures ANY event as `event:<literal>` — e.g.
+  `[{source} den] {event} veya <event2> bekle`-shaped. **Do NOT "improve" the
+  en reference parse instead** — en defines the denominator for all 24
+  languages, and raising it (capturing both events + source) would instantly
+  drop R1 everywhere until every language catches up (the R3 en-firestorm
+  note's R1 analogue).
+
+### Family D — the SOV-cohort ×1 type-mistype tail (~10 families, one miss per language each)
+
+Same entries recur across ja/ko/tr/qu (each is ONE fix exercised four ways;
+check bn/hi too):
+
+| missing (vs en)                | captured instead              | pattern                       |
+| ------------------------------ | ----------------------------- | ----------------------------- |
+| `js.patient:expression`        | `js.patient:reference`        | js-inline                     |
+| `go.destination:expression`    | `…:reference` / `…:literal`   | go-url                        |
+| `log.patient:property-path`    | `log.patient:expression`      | optional-chaining-possessive  |
+| `pick.patient:expression`      | `…:literal` (+qu extras)      | pick-text-range               |
+| `scroll.destination:expression`| `…:reference` / `…:selector`  | last-in-collection            |
+| `set.destination:reference`    | `set.destination:literal`     | beep-debug-expression         |
+| `fetch.source:literal`         | `fetch.source:expression`     | event-debounce                |
+| `halt.patient:reference`       | (dropped / `…:expression`)    | form-submit-prevent           |
+| `for.patient` + `for.source`   | `for.*:literal`               | template-literal-list-build   |
+| `focus.patient:expression`     | `…:reference` / `…:selector`  | focus-trap                    |
+
+These are value-TYPE classification drifts (tokenizer/`tokensToSemanticValue`
+typing differs from en's), not structural drops. Cheap individually IF the
+root is a shared classifier; expensive if each is bespoke. Triage the top 3–4
+(js-inline, go-url, optional-chaining, event-debounce) before committing to
+the tail — a shared-root fix here pays ×4–×6 (all SOV languages at once).
+
+### Explicitly OUT of scope
+
+- **swap-content** (`swap.destination:selector` ×1 in tr/qu): the F6 wontfix
+  family (NEXT_STEPS § R3 families item 6, decision 2026-07-10). The tr/qu R1
+  rows are the same root; do not chase without reopening that decision.
+- **ko `on.event` ×2** (`when-value-changes`, `when-multiple-changes`) and
+  **qu `on.event:expression` ×2**: reactive `when (<expr>) changes` heads —
+  they abut the event-anchor guard machinery (hottest path); take them only
+  if Family D's method happens to cover them.
+
+## Where the code lives
+
+- **Triage:** `packages/testing-framework/src/multilingual/tools/triage-r1.ts`
+  (`--triage-r1`); signatures in `src/multilingual/fidelity.ts`
+  (`collectRoleSignature` — `action.role:type`, `STRUCTURAL_ACTIONS` excluded,
+  schema defaults materialized by `fillSchemaDefaults` before collection).
+- **SOV patterns:** `packages/semantic/src/patterns/*.ts` (fetch.ts has the
+  `sovFetch` precedent; wait.ts, set.ts) + generated patterns from
+  `packages/semantic/src/generators/` profiles.
+- **Verb-anchoring fallback + role typing:**
+  `packages/semantic/src/parser/semantic-parser.ts`
+  (`parseSOVClauseByVerbAnchoring`, `extractRolesFromMarkedTokens`,
+  `tokensToSemanticValue`) and `pattern-matcher.ts` (`matchRoleToken`,
+  curated-end guards from #636 — do not undo).
+- **Renders:** probe with `GrammarTransformer` per the transformer-rendering
+  handoff; corpus text via
+  `sqlite3 packages/patterns-reference/data/patterns.db "SELECT hyperscript
+  FROM pattern_translations WHERE code_example_id='…' AND language='…'"`.
+
+## Method (inherited from the transformer-rendering arc — it worked)
+
+1. **Triage first, per family**: re-run `--triage-r1` (add `--languages
+   bn,hi` for the cohort check); pick the family, pull the corpus renders,
+   parse the FULL bodies (fragments parse differently than in-body — probe
+   with `semanticParser.parseStatements` or full-behavior `parse`, dumping
+   `metadata.patternId` to see which pattern actually matched).
+2. **Scoped fixes only**: per-command patterns / i18n rules, never blanket
+   canonicalOrder or global reorder changes (see the resolved handoff's
+   R3-12→39 post-mortem). Keep pre-arc shapes parseable (legacy tolerance
+   locks) when a render changes.
+3. **Never touch the en reference to gain R1** — it moves every language's
+   denominator at once (Family C note).
+4. After each family: ordered build → `populate` → re-run `--triage-r1` (the
+   family's rows must vanish, no new rows in ANY language) → full sweep
+   WITHOUT `--regression`, read every signal (R0/precision/multiset/R2/R3 —
+   a pattern-side fix can change which pattern WINS a match and shift value
+   captures).
+5. Lock each fixed family with unit tests on corpus-shaped inputs (the
+   `multilingual-roadmap-fixes.test.ts` conventions; `it.fails` for known
+   residue).
+6. `--regression` green → `--save-baseline` on a freshly populated db →
+   prettier the baseline → audit the diff line-by-line → commit baseline,
+   **never patterns.db**.
+
+## Traps
+
+- All of the transformer-rendering handoff's traps (stale dists — prettier
+  in lint-staged bumps src mtimes at commit, rebuild before sweeping; tsx
+  probes need `process.exit(0)`; probes run with cwd inside the package).
+- `--triage-r1` warns on stale dists rather than refusing — heed the warning;
+  the numbers describe the BUILT parser.
+- R1 is Set-based: a fix that captures a role the en reference ALSO captures
+  but with a repeated entry gains nothing; and R1-parity ≠ correctness — a
+  captured-but-wrong VALUE moves R3, so watch both.
+- Family A touches fetch — `fetch` patterns interact with the F4 pl/ru/uk
+  mis-role relabel (`normalizeCommandRoles`) and the sovFetch patterns;
+  regression-test those unit locks.
+- The hottest-path warning stands: pattern-priority changes can flip which
+  pattern wins on OTHER corpus rows. The full-sweep read (not exit code) is
+  the guard.
+
+## Definition of done
+
+- qu avgRoleFidelity ≥ 0.97; ja/ko/tr each ≥ 0.98 (stretch: bn/hi lifted by
+  the cohort families too).
+- Families A and B fully cleared (triage rows gone); C cleared for tr/qu;
+  D cleared for whichever entries share roots (documented outcome per entry,
+  fixed or explicitly deferred with reason).
+- No drops in any other signal (parse-rate, R0 fidelity/precision/multiset,
+  R2, R3) in the full sweep; `--regression` green.
+- New unit locks per fixed family; baseline regenerated + prettier'd +
+  audited + committed (never patterns.db); this handoff marked resolved and
+  NEXT_STEPS updated.

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -119,11 +119,35 @@ COMPLETE.**
 
 **Post-launch track (ratchet-protected, not launch-blocking):** wait-payload
 spurious for ×3 (bn draggable/sortable/resizable — the unconsumed or-run
-payload), SOV-six role polish (qu/hi ~0.956 R1), tr remove.patient block-walk
-leak, wait-line param leak ja, SOV halt ×6, the R1 long tail (fetch ×18 two
-sub-arcs, set.patient:literal ×16, bind ×14, render.style ×12,
-add.destination ×4, toggle.destination ×2), language-grammar.ts drift guard.
-The six-signal gate holds the bar — regressions fail CI.
+payload), tr remove.patient block-walk leak, wait-line param leak ja,
+language-grammar.ts drift guard, and the R1-arc deferrals (event-debounce
+`${}` URL tokenization — also truncates the EN reference; pick range-role
+modeling; form-submit-prevent fused-clause scramble — render-side; focus-trap
+condition-boundary leak; see HANDOFF_r1-role-fidelity.md § Family D
+outcomes). The SOV-six role polish and the R1 long tail (fetch/render.style,
+qu set, or-run wait, beep/js/go/scroll/log/for) were cleared by the R1 arc
+(2026-07-11, below). The six-signal gate holds the bar — regressions fail CI.
+
+> **Update 2026-07-11 (R1 role-fidelity arc, branch `fix/r1-role-fidelity-sov`
+> — HANDOFF_r1-role-fidelity.md RESOLVED):** avgRoleFidelity qu 0.9522 →
+> **0.9792**, ja/bn 0.9738 → **0.9938**, tr 0.9719 → **0.9927**, ko 0.9706 →
+> **0.9905**, hi 0.9706 → **0.9883** — all arc targets (qu ≥ 0.97,
+> ja/ko/tr ≥ 0.98) exceeded, stretch bn/hi included. Seven commits, gate
+> green after each: `--triage-r1` preamble; Family A (trailing SOV
+> with-options blob reclaimed as fetch/render style — the fused event
+> patterns stranded it post-verb; + tr `ile` style marker); Family B (qu
+> set oblique-`manta`-source pattern + the missing backtick branch in the qu
+> string extractor — template literals shattered to ~12 fragments); Family C
+> (tr/qu verb-final or-run wait patterns; first event → duration → the
+> known-event relabel emits `event:literal`, en-parity); Family D ×4 (sigil
+> refs + unconditional set patient↔destination marker swap in the fallback;
+> fused `*-sov-simple` trailing-expression reclaim for js/go/scroll;
+> optional-chaining `?`+`.prop` possessive fold — en type unchanged, full
+> chain byte-identical across the six; verb-final `for-<lang>-sov-basic`
+> binding heads). Key insight vs the handoff's hypothesis: most of the D
+> tail was NOT a shared fallback-classifier root but fused-simple-pattern
+> default-role drops (the Family A geometry) — fixed with reclaims/patterns,
+> so no shared-classifier extraction is warranted.
 
 Caveats: each en enrichment can mint honest-dip entries (bounded by the
 census/A-B discipline; historically <1 session total), and this scopes the

--- a/packages/semantic/src/generators/profiles/turkish.ts
+++ b/packages/semantic/src/generators/profiles/turkish.ts
@@ -86,7 +86,10 @@ export const turkishProfile: LanguageProfile = {
       position: 'after',
     }, // Dative/Locative + Genitive (with buffer consonants)
     source: { primary: 'den', alternatives: ['dan', 'ten', 'tan'], position: 'after' }, // Ablative
-    style: { primary: 'le', alternatives: ['la', 'yle', 'yla'], position: 'after' }, // Instrumental
+    // `ile` is the free-standing instrumental the transformer actually emits
+    // for with-phrases (`getir method:"POST" body:form ile`); the suffix
+    // forms cover hand-written agglutinated variants.
+    style: { primary: 'le', alternatives: ['la', 'yle', 'yla', 'ile'], position: 'after' }, // Instrumental
     event: { primary: 'i', alternatives: ['ı', 'u', 'ü'], position: 'after' }, // Event as accusative
   },
   keywords: {

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -1513,15 +1513,41 @@ export class PatternMatcher {
         propertyName = propertyName.substring(1);
       }
 
-      // Consume chained dot-property access (.parentElement.style.display)
+      // Consume chained dot-property access (.parentElement.style.display),
+      // including optional-chaining links: the tokenizer splits `?.prop` into
+      // `?` + `.prop`, and stopping at the `?` left the chain HALF-consumed —
+      // property-path(me, "?.dataset") with `?.customValue` stranded, so the
+      // verb-final SOV patterns could never complete through to their patient
+      // particle and the row fell to a bare `?.customValue` expression
+      // (optional-chaining-possessive, R1 Family D). A `?` is only folded
+      // when a `.prop` selector immediately follows, so a ternary after a
+      // possessive value is untouched.
       let chainedProps = propertyName;
-      while (
-        tokens.peek()?.kind === 'selector' &&
-        tokens.peek()!.value.startsWith('.') &&
-        /^\.[a-zA-Z_]\w*/.test(tokens.peek()!.value)
-      ) {
-        chainedProps += tokens.peek()!.value; // keep the dots for chaining
-        tokens.advance();
+      for (;;) {
+        const nxt = tokens.peek();
+        if (
+          nxt?.kind === 'selector' &&
+          nxt.value.startsWith('.') &&
+          /^\.[a-zA-Z_]\w*/.test(nxt.value)
+        ) {
+          chainedProps += nxt.value; // keep the dots for chaining
+          tokens.advance();
+          continue;
+        }
+        if (nxt?.value === '?') {
+          const after = tokens.peek(1);
+          if (
+            after?.kind === 'selector' &&
+            after.value.startsWith('.') &&
+            /^\.[a-zA-Z_]\w*/.test(after.value)
+          ) {
+            chainedProps += `?${after.value}`;
+            tokens.advance();
+            tokens.advance();
+            continue;
+          }
+        }
+        break;
       }
 
       // Check for a trailing method call: chain + '(' [args...] ')'

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1856,6 +1856,12 @@ export class SemanticParserImpl implements ISemanticParser {
         // absent-or-`me`-default only, destination matched by PRIMARY marker
         // only, strict value shapes.
         this.tryAttachTrailingRole(tokens, commandNode as CommandSemanticNode, language);
+
+        // Trailing STYLE (with-options) reclaim — see tryAttachTrailingStyle.
+        // Placed AFTER the responseType reclaim so fetch-with-headers' post-
+        // marker `JSON` tail stays unconsumed exactly as before (en-symmetric
+        // lossiness: the en reference drops it too).
+        this.tryAttachTrailingStyle(tokens, commandNode as CommandSemanticNode, language);
       }
 
       // Check if pattern has continuation marker (then-chains).
@@ -2547,6 +2553,7 @@ export class SemanticParserImpl implements ISemanticParser {
         commands.push(cmd);
         directHits++;
         this.tryAttachTrailingRole(clauseStream, cmd, language);
+        this.tryAttachTrailingStyle(clauseStream, cmd, language);
       } else {
         // A `for`-binding loop (`repeat for <var> in <coll>`) loses its `for`
         // binder keyword in transit (the i18n transformer emits `repeat <var> in
@@ -2778,6 +2785,100 @@ export class SemanticParserImpl implements ISemanticParser {
         }
       }
     }
+  }
+
+  /**
+   * Reclaim a trailing post-verb `with`-options run as the `style` role. The
+   * SOV canonicalOrders carry no `style` slot, so the transformer's safety net
+   * appends the with-phrase AFTER the verb with its postposition (ja `フェッチ
+   * method:"POST" body:form で`, tr `getir … ile`, qu `apamuy … wan`), where
+   * the fused event pattern (`fetch-event-<lang>-sov-patient-first`) and the
+   * standalone SOV patterns leave it unconsumed — fetch.style/render.style
+   * missing in the whole SOV cohort while en captures `style:expression` (the
+   * R1 Family A cluster). The #530 [verb..boundary] re-parse can't recover it:
+   * the tail is verb-FIRST relative to the slice while every standalone SOV
+   * pattern is verb-final.
+   *
+   * Scans ahead for the profile's postpositional `style` marker and, when a
+   * non-empty run of value tokens ends at it inside the clause, captures the
+   * run as `style:expression` and consumes through the marker. Conservative by
+   * construction: gated to fetch/render (the only commands whose corpus
+   * with-phrase strands — show/hide/transition also declare `style` and stay
+   * untouched), to an ABSENT style role, and to a postpositional marker; the
+   * scan aborts unconsumed at a clause boundary (conjunction / then / curated
+   * end — a run without its marker is never captured) and is capped, so a
+   * marker far past the clause can't pull in foreign tokens. Mid-run particles
+   * that belong to the blob (formdata's `として`/`olarak`/`hina` as-markers)
+   * don't terminate the scan — only the style marker itself does, first match
+   * wins (ko's 로 doubles as the as-marker: the first 로 closes the options
+   * run, the rest stays unconsumed exactly as before).
+   */
+  private tryAttachTrailingStyle(
+    stream: TokenStream,
+    command: CommandSemanticNode,
+    language: string
+  ): void {
+    if (command.action !== 'fetch' && command.action !== 'render') return;
+    const roles = command.roles as Map<SemanticRole, SemanticValue>;
+    if (roles.has('style')) return;
+    const schema = getSchema(command.action as ActionType);
+    if (!schema?.roles.some(r => r.role === 'style')) return;
+    const profile = tryGetProfile(language);
+    const marker = profile?.roleMarkers?.style;
+    if (!marker || marker.position !== 'after') return;
+
+    const surfaces = new Set(
+      [marker.primary, ...(marker.alternatives ?? [])].map(s => s.toLowerCase())
+    );
+    const isBoundary = (t: LanguageToken): boolean =>
+      t.kind === 'conjunction' ||
+      (t.kind === 'keyword' &&
+        (this.isThenKeyword(t.value, language) || this.isEndKeyword(t.value, language)));
+
+    // Cap comfortably above the widest corpus blob (qu fetch-with-headers
+    // splits to 13 tokens) while keeping a runaway scan impossible.
+    const SCAN_CAP = 24;
+    let markerOffset = -1;
+    let depth = 0; // (…)/{…} nesting — ko's 로 doubles as the as-marker and
+    for (let i = 0; i < SCAN_CAP; i++) {
+      // appears INSIDE formdata's parenthesized body; only a depth-0 marker
+      // closes the options run.
+      const t = stream.peek(i);
+      if (!t || isBoundary(t)) break;
+      if (t.value === '(' || t.value === '{') depth++;
+      else if (t.value === ')' || t.value === '}') depth = Math.max(0, depth - 1);
+      if (
+        depth === 0 &&
+        (t.kind === 'particle' || t.kind === 'keyword') &&
+        surfaces.has(t.value.toLowerCase())
+      ) {
+        markerOffset = i;
+        break;
+      }
+    }
+    // No marker in range, or an empty run (`<verb> で …` has no options).
+    if (markerOffset <= 0) return;
+
+    const run: LanguageToken[] = [];
+    for (let i = 0; i < markerOffset; i++) {
+      const t = stream.peek(i);
+      if (t) run.push(t);
+    }
+    // ko's style marker 로 doubles as its AS-marker, so a bare `json 로`
+    // as-phrase (event-debounce) would misread as a with-phrase. A run that is
+    // a single known response-type word is an as-phrase — leave it unconsumed
+    // exactly as before (the en reference drops it too: equal lossiness).
+    if (
+      run.length === 1 &&
+      SemanticParserImpl.RESPONSE_TYPE_WORDS.has(run[0].value.toLowerCase())
+    ) {
+      return;
+    }
+    roles.set('style', {
+      type: 'expression',
+      raw: this.joinTokenText(run),
+    } as SemanticValue);
+    for (let i = 0; i <= markerOffset; i++) stream.advance();
   }
 
   // ==========================================================================

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1862,6 +1862,10 @@ export class SemanticParserImpl implements ISemanticParser {
         // marker `JSON` tail stays unconsumed exactly as before (en-symmetric
         // lossiness: the en reference drops it too).
         this.tryAttachTrailingStyle(tokens, commandNode as CommandSemanticNode, language);
+
+        // Trailing EXPRESSION-run reclaim (js code / go+scroll destination
+        // phrase) — see tryAttachTrailingExpressionRole.
+        this.tryAttachTrailingExpressionRole(tokens, commandNode as CommandSemanticNode, language);
       }
 
       // Check if pattern has continuation marker (then-chains).
@@ -2554,6 +2558,7 @@ export class SemanticParserImpl implements ISemanticParser {
         directHits++;
         this.tryAttachTrailingRole(clauseStream, cmd, language);
         this.tryAttachTrailingStyle(clauseStream, cmd, language);
+        this.tryAttachTrailingExpressionRole(clauseStream, cmd, language);
       } else {
         // A `for`-binding loop (`repeat for <var> in <coll>`) loses its `for`
         // binder keyword in transit (the i18n transformer emits `repeat <var> in
@@ -2879,6 +2884,127 @@ export class SemanticParserImpl implements ISemanticParser {
       raw: this.joinTokenText(run),
     } as SemanticValue);
     for (let i = 0; i <= markerOffset; i++) stream.advance();
+  }
+
+  /**
+   * Reclaim a trailing post-verb EXPRESSION run for the fused `*-sov-simple`
+   * drops — the Family A geometry with per-command terminators. The fused
+   * simple event patterns capture only the verb and DEFAULT the primary role
+   * to `me`, leaving the real argument unconsumed after the verb, where the
+   * #530 [verb..boundary] re-parse can't recover it (the tail is verb-FIRST
+   * while every standalone SOV pattern is verb-final):
+   *   ja `クリック で JS実行 console.log("from js") 終わり`   → js.patient dropped
+   *   ja `クリック で 移動 url "/page" に`                    → go.destination dropped
+   *   tr `tıklama de kaydır sonuncu <.message/> içinde #chat e` → scroll.destination
+   * The en reference types each as `expression` (js-opaque-en / the en
+   * generated patterns), so the SOV default `reference=me` was an R1 miss on
+   * js-inline / go-url / last-in-collection across the cohort (Family D).
+   *
+   * Per-command terminator: js's code run ends at the clause boundary
+   * (then/end/conjunction — mirroring en's js-opaque `js … end` capture);
+   * go/scroll's destination phrase ends at the profile's postpositional
+   * destination marker, PRIMARY surface only (several profiles list
+   * destination alternatives that belong to other roles — the
+   * tryAttachTrailingRole precedent). Only fires on an absent or defaulted-
+   * `me` role, never on a genuine capture; the scan is depth-aware, aborts
+   * unconsumed at a clause boundary, and is capped.
+   */
+  private tryAttachTrailingExpressionRole(
+    stream: TokenStream,
+    command: CommandSemanticNode,
+    language: string
+  ): void {
+    const action = command.action as string;
+    const spec: { role: SemanticRole; terminator: 'boundary' | 'destination-marker' } | null =
+      action === 'js'
+        ? { role: 'patient' as SemanticRole, terminator: 'boundary' }
+        : action === 'go' || action === 'scroll'
+          ? { role: 'destination' as SemanticRole, terminator: 'destination-marker' }
+          : null;
+    if (!spec) return;
+    const roles = command.roles as Map<SemanticRole, SemanticValue>;
+    const existing = roles.get(spec.role);
+    if (existing && !(existing.type === 'reference' && existing.value === 'me')) return;
+
+    const profile = tryGetProfile(language);
+    if (!profile) return;
+    let markerSurface: string | null = null;
+    if (spec.terminator === 'destination-marker') {
+      const marker = profile.roleMarkers?.destination;
+      if (!marker || marker.position !== 'after') return;
+      markerSurface = marker.primary.toLowerCase();
+    }
+
+    const isBoundary = (t: LanguageToken): boolean =>
+      t.kind === 'conjunction' ||
+      (t.kind === 'keyword' &&
+        (this.isThenKeyword(t.value, language) || this.isEndKeyword(t.value, language)));
+
+    const SCAN_CAP = 24;
+    const run: LanguageToken[] = [];
+    let depth = 0;
+    let sawMarker = false;
+    for (let i = 0; i < SCAN_CAP; i++) {
+      const t = stream.peek(i);
+      if (!t || isBoundary(t)) break;
+      if (t.value === '(' || t.value === '{') depth++;
+      else if (t.value === ')' || t.value === '}') depth = Math.max(0, depth - 1);
+      if (
+        markerSurface !== null &&
+        depth === 0 &&
+        (t.kind === 'particle' || t.kind === 'keyword') &&
+        t.value.toLowerCase() === markerSurface
+      ) {
+        sawMarker = true;
+        break;
+      }
+      run.push(t);
+    }
+    // A marker-terminated role must SEE its marker inside the window — a
+    // boundary/EOF-terminated scan means the phrase isn't the corpus shape
+    // and is left untouched. js (boundary-terminated) just needs a run.
+    if (run.length === 0) return;
+    if (markerSurface !== null && !sawMarker) return;
+
+    const consume = run.length + (sawMarker ? 1 : 0);
+
+    // The ja tokenizer splits the compound verb `JS実行` into `JS<keyword>` +
+    // `実行<identifier>`; the fused pattern's verb matched the `JS` head, so
+    // the leftover verb FRAGMENT leads the run. Trim leading tokens that are
+    // substrings of the action's own keyword so they never pollute the code
+    // expression. Consumption still covers them — they belong to the verb.
+    let trimmed = run;
+    if (action === 'js') {
+      const kw = profile.keywords?.js;
+      const isVerbFragment = (t: LanguageToken): boolean =>
+        [kw?.primary, ...(kw?.alternatives ?? [])].some(
+          k => !!k && k.length > t.value.length && k.includes(t.value)
+        );
+      let from = 0;
+      while (from < trimmed.length && isVerbFragment(trimmed[from])) from++;
+      trimmed = trimmed.slice(from);
+      if (trimmed.length === 0) return;
+    }
+
+    roles.set(spec.role, {
+      type: 'expression',
+      raw: this.joinTokenText(trimmed),
+    } as SemanticValue);
+    // Drop the fused default-patient leak (`patient:reference=me`) for
+    // commands whose schema declares no patient (go/scroll) — the
+    // repeat/wait reclaim precedent; a REAL patient capture is never touched.
+    if (spec.role !== 'patient') {
+      const pat = roles.get('patient');
+      if (
+        pat &&
+        pat.type === 'reference' &&
+        pat.value === 'me' &&
+        !getSchema(action as ActionType)?.roles.some(r => r.role === 'patient')
+      ) {
+        roles.delete('patient');
+      }
+    }
+    for (let i = 0; i < consume; i++) stream.advance();
   }
 
   // ==========================================================================

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -3184,9 +3184,21 @@ export class SemanticParserImpl implements ISemanticParser {
    */
   private mapRoleForCommand(
     markerRole: string,
-    _action: string,
+    action: string,
     existingRoles: Record<string, SemanticValue>
   ): string | null {
+    // `set`'s surface order is DESTINATION-first (`set <dest> to <value>`), so
+    // the SOV reorder marks the DESTINATION with the patient particle (`$x を
+    // beep! 私の値 に 設定`) and the VALUE with the destination particle —
+    // systematically, not just on slot collision. The collision-only swap
+    // below left every fallback-parsed set with flipped roles vs the en
+    // reference (beep-debug-expression across the SOV cohort, R1 Family D).
+    // set only: `put <value> into <dest>` is VALUE-first, so put's patient
+    // particle really does mark the patient.
+    if (action === 'set') {
+      if (markerRole === 'patient') markerRole = 'destination';
+      else if (markerRole === 'destination') markerRole = 'patient';
+    }
     // Direct mapping — if the role isn't taken yet, use it
     if (!existingRoles[markerRole]) {
       return markerRole;
@@ -3300,6 +3312,14 @@ export class SemanticParserImpl implements ISemanticParser {
     }
     if (val === 'false' || val === '偽' || val === '거짓' || val === 'yanlış') {
       return createLiteral(false);
+    }
+
+    // Variable references (`:local` / `$global`) — mirrors the pattern-path
+    // single-token classifier; without this branch a fallback-captured `$x`
+    // fell to the literal default while every pattern capture (and the en
+    // reference) types it reference (R1 Family D, beep-debug-expression).
+    if (val.length > 1 && (val.startsWith(':') || val.startsWith('$'))) {
+      return createReference(val as Parameters<typeof createReference>[0]);
     }
 
     // References: me, it, you (check normalized form)

--- a/packages/semantic/src/patterns/repeat.ts
+++ b/packages/semantic/src/patterns/repeat.ts
@@ -514,6 +514,62 @@ const repeatUntilHeadQu: LanguagePattern = {
   },
 };
 
+/**
+ * Verb-FINAL for-binding head — the SOV mirror of `repeatForInHead`, emitted
+ * as action `for` to match the en reference (`for-en-basic`: `for item in
+ * $items` → for.patient:expression + for.source:reference; list-build's loop
+ * head). The transformer renders the SOV head clause-final-verb:
+ *   ja `item の 中 $items を ために`      qu `item uku pi $items ta sapankaq`
+ * No pattern covered the shape, so the verb-anchoring fallback shredded it on
+ * the in/object particles (ja destination:literal="item" patient:literal=
+ * "中$items", qu event:literal="itemuku" — R1 Family D, ×2 rows in all six).
+ * The object particle before the for-verb is optional so a hand-written
+ * marker-less head still parses. Head-only: the loop BODY follows after a
+ * then-connective and parses as sibling commands, exactly like en.
+ */
+function sovForBindingHead(
+  language: string,
+  spec: { inWords: string[]; objMarker: string; forVerb: string }
+): LanguagePattern {
+  return {
+    id: `for-${language}-sov-basic`,
+    language,
+    command: 'for',
+    priority: 105,
+    template: {
+      format: `{patient} ${spec.inWords.join(' ')} {source} [${spec.objMarker}] ${spec.forVerb}`,
+      tokens: [
+        { type: 'role', role: 'patient', expectedTypes: ['expression', 'reference'] },
+        ...spec.inWords.map(w => ({ type: 'literal' as const, value: w })),
+        { type: 'role', role: 'source', expectedTypes: ['selector', 'expression', 'reference'] },
+        {
+          type: 'group',
+          optional: true,
+          tokens: [{ type: 'literal', value: spec.objMarker }],
+        },
+        { type: 'literal', value: spec.forVerb },
+      ],
+    },
+    extraction: {
+      patient: { position: 0 },
+    },
+  };
+}
+
+// Corpus surfaces (token kinds vary — tr için is a particle, bn জন্য carries
+// no normalized 'for' — so literals match by VALUE; in-words reuse the
+// FOR_IN_HEADS table's split forms).
+const SOV_FOR_BINDING_HEADS: Array<
+  [string, { inWords: string[]; objMarker: string; forVerb: string }]
+> = [
+  ['ja', { inWords: ['の', '中'], objMarker: 'を', forVerb: 'ために' }],
+  ['ko', { inWords: ['안', '에'], objMarker: '를', forVerb: '각각' }],
+  ['tr', { inWords: ['içinde'], objMarker: 'i', forVerb: 'için' }],
+  ['qu', { inWords: ['uku', 'pi'], objMarker: 'ta', forVerb: 'sapankaq' }],
+  ['bn', { inWords: ['এ'], objMarker: 'কে', forVerb: 'জন্য' }],
+  ['hi', { inWords: ['में'], objMarker: 'को', forVerb: 'हेतु' }],
+];
+
 const BY_LANG = new Map<string, LanguagePattern[]>();
 const addPattern = (lang: string, p: LanguagePattern) => {
   const list = BY_LANG.get(lang);
@@ -528,6 +584,9 @@ for (const [lang, countWord, marker] of SOV_REPEAT_TIMES) {
 }
 for (const [lang, spec] of FOR_IN_HEADS) {
   addPattern(lang, repeatForInHead(lang, spec));
+}
+for (const [lang, spec] of SOV_FOR_BINDING_HEADS) {
+  addPattern(lang, sovForBindingHead(lang, spec));
 }
 for (const [lang, spec] of WHILE_HEADS) {
   addPattern(lang, repeatWhileHead(lang, spec));

--- a/packages/semantic/src/patterns/set.ts
+++ b/packages/semantic/src/patterns/set.ts
@@ -1057,6 +1057,65 @@ function getSetPatternsZh(): LanguagePattern[] {
  * Get set patterns for a specific language.
  */
 /**
+ * Quechua (SOV) set with an interleaved oblique source phrase.
+ *
+ * The transformer renders `on input from #firstName set <dest> to <value>`
+ * with the handler's from-phrase INSIDE the body clause, between the
+ * ta-marked destination and the man-marked patient:
+ *   `#greeting.innerText ta #firstName manta "Hello, " + noqaq chanin man
+ *    yaykuchiy pi churanay`                (two-way-binding, computed-value)
+ * The generated `set-qu-generated` has no slot for `<source> manta`, so the
+ * whole clause fell to the verb-anchoring fallback, which can type neither
+ * the property-path destination nor the operator-run patient (destination
+ * came back `literal`, patient `selector`/`literal` — the R1 Family B
+ * cluster; en: destination:property-path + patient:expression via
+ * set-en-possessive).
+ *
+ * The manta group is REQUIRED here: the plain `{destination} ta {patient}
+ * man churanay` shape already parses correctly through the generated
+ * pattern, so this one fires only on the oblique-source shape and shadows
+ * nothing. The source lands on the node exactly as the fallback used to
+ * emit it (schema-extra, invisible to every signal). `churay` is
+ * deliberately absent from the verb list — it is qu's PUT verb (the de
+ * setzen-collision precedent).
+ */
+function getSetPatternsQu(): LanguagePattern[] {
+  return [
+    {
+      id: 'set-qu-oblique-source',
+      language: 'qu',
+      command: 'set',
+      priority: 105,
+      template: {
+        format: '{destination} ta {source} manta {patient} man churanay',
+        tokens: [
+          {
+            type: 'role',
+            role: 'destination',
+            expectedTypes: ['property-path', 'selector', 'reference', 'expression'],
+          },
+          { type: 'literal', value: 'ta' },
+          {
+            type: 'role',
+            role: 'source',
+            expectedTypes: ['selector', 'reference', 'expression'],
+          },
+          { type: 'literal', value: 'manta' },
+          { type: 'role', role: 'patient', expectedTypes: ['literal', 'expression', 'reference'] },
+          { type: 'literal', value: 'man' },
+          { type: 'literal', value: 'churanay', alternatives: ['kamaykuy'] },
+        ],
+      },
+      extraction: {
+        destination: { position: 0 },
+        source: { position: 2 },
+        patient: { position: 4 },
+      },
+    },
+  ];
+}
+
+/**
  * Append an optional trailing `[on {scope}]` group to each hand-crafted set
  * pattern (S1 tabs-aria). These patterns tie the generated `set-*-generated`
  * pattern on priority and win on stable-sort order, so without the scope group
@@ -1119,6 +1178,8 @@ export function getSetPatternsForLanguage(language: string): LanguagePattern[] {
       return withTrailingScope(getSetPatternsPl());
     case 'pt':
       return withTrailingScope(getSetPatternsPt());
+    case 'qu':
+      return withTrailingScope(getSetPatternsQu());
     case 'ru':
       return withTrailingScope(getSetPatternsRu());
     case 'sw':

--- a/packages/semantic/src/patterns/wait.ts
+++ b/packages/semantic/src/patterns/wait.ts
@@ -183,6 +183,115 @@ function getWaitPatternsTl(): LanguagePattern[] {
   ];
 }
 
+/**
+ * Turkish / Quechua (SOV, verb-final) or-run wait — the verb-final mirror of
+ * `wait-ar-from-first` / `wait-tl-from-first`.
+ *
+ * The transformer renders the behaviors' `wait for pointermove(clientY) or
+ * pointerup(clientY) from document` verb-final with the from-phrase fronted
+ * (post-#636): tr `belge den pointermove(clientY) veya pointerup(clientY)
+ * bekle`, qu `qillqa manta pointermove(clientY) utaq pointerup(clientY)
+ * suyay`. No wait pattern matched the or-run shape, so the verb-anchoring
+ * fallback binned the run as a junk `duration:expression=")"` and the event
+ * dropped (wait.event:literal missing in tr/qu — R1 Family C).
+ *
+ * Unlike ar/tl (verb-first — the or-tail could stay harmless TRAILING
+ * tokens), the verb-final pattern must consume through to its verb anchor,
+ * so the `veya/utaq <event2>` alternative lands in a deliberately-junk
+ * `patient` slot the schema doesn't declare — the en reference drops the
+ * alternative too (`wait-en-for-event` keeps only the FIRST event), so this
+ * adds nothing en doesn't also lose. The first event lands in `duration`,
+ * and the known-event duration→event relabel in normalizeCommandRoles types
+ * it `event:literal`, matching the en reference (the tl precedent).
+ */
+/**
+ * Builds the verb-final or-run wait pattern for one language. The event
+ * tokenizes as a bare keyword with its `(args)` SPLIT off (`pointermove` `(`
+ * `clientY` `)`), and the bare-call fold rejects keyword heads (widening it
+ * would retype the EN reference's own event slot — off limits), so each
+ * paren run is consumed by an optional `( {junk} )` literal group instead
+ * (the withTrailingScope group idiom); a parenless hand-written form still
+ * matches. The junk `condition` captures are schema-extras, invisible to
+ * every signal, and both runs share one role so they collapse to a single
+ * map entry.
+ */
+function verbFinalOrRunWait(
+  id: string,
+  language: string,
+  verb: string,
+  sourceMarker: string,
+  orWord: string,
+  parenArgCount: number,
+  sourceMarkerAlternatives?: string[]
+): LanguagePattern {
+  // `( arg [, arg] )` — an optional group per event; a group must match
+  // whole-or-not, so the one-arg (behavior-sortable, `(clientY)`) and two-arg
+  // (behavior-resizable, `(clientX, clientY)`) shapes are separate pattern
+  // variants rather than one group. All junk captures share the `condition`
+  // role so they collapse to a single schema-extra map entry.
+  const parenGroup = () => ({
+    type: 'group' as const,
+    optional: true,
+    tokens: [
+      { type: 'literal' as const, value: '(' },
+      ...Array.from({ length: parenArgCount }, (_, i) => [
+        ...(i > 0 ? [{ type: 'literal' as const, value: ',' }] : []),
+        {
+          type: 'role' as const,
+          role: 'condition' as const,
+          expectedTypes: ['expression', 'literal', 'reference'] as const,
+        },
+      ]).flat(),
+      { type: 'literal' as const, value: ')' },
+    ],
+  });
+  return {
+    id,
+    language,
+    command: 'wait',
+    priority: 105,
+    template: {
+      format: `{source} ${sourceMarker} {duration} ${orWord} {patient} ${verb}`,
+      tokens: [
+        { type: 'role', role: 'source', expectedTypes: ['expression', 'reference'] },
+        {
+          type: 'literal',
+          value: sourceMarker,
+          ...(sourceMarkerAlternatives ? { alternatives: sourceMarkerAlternatives } : {}),
+        },
+        { type: 'role', role: 'duration', expectedTypes: ['expression', 'literal'] },
+        parenGroup(),
+        { type: 'literal', value: orWord },
+        { type: 'role', role: 'patient', expectedTypes: ['expression', 'literal'] },
+        parenGroup(),
+        { type: 'literal', value: verb },
+      ],
+    },
+    extraction: {
+      source: { position: 0 },
+      duration: { position: 2 },
+    },
+  } as LanguagePattern;
+}
+
+function getWaitPatternsTr(): LanguagePattern[] {
+  return [
+    verbFinalOrRunWait('wait-tr-or-run', 'tr', 'bekle', 'den', 'veya', 1, ['dan', 'ten', 'tan']),
+    verbFinalOrRunWait('wait-tr-or-run-2arg', 'tr', 'bekle', 'den', 'veya', 2, [
+      'dan',
+      'ten',
+      'tan',
+    ]),
+  ];
+}
+
+function getWaitPatternsQu(): LanguagePattern[] {
+  return [
+    verbFinalOrRunWait('wait-qu-or-run', 'qu', 'suyay', 'manta', 'utaq', 1),
+    verbFinalOrRunWait('wait-qu-or-run-2arg', 'qu', 'suyay', 'manta', 'utaq', 2),
+  ];
+}
+
 export function getWaitPatternsForLanguage(language: string): LanguagePattern[] {
   switch (language) {
     case 'en':
@@ -195,6 +304,10 @@ export function getWaitPatternsForLanguage(language: string): LanguagePattern[] 
       return getWaitPatternsAr();
     case 'tl':
       return getWaitPatternsTl();
+    case 'tr':
+      return getWaitPatternsTr();
+    case 'qu':
+      return getWaitPatternsQu();
     default:
       return [];
   }

--- a/packages/semantic/src/tokenizers/quechua.ts
+++ b/packages/semantic/src/tokenizers/quechua.ts
@@ -26,19 +26,23 @@ import type { ValueExtractor, ExtractionResult } from './value-extractor-types';
 /**
  * Custom string literal extractor for Quechua.
  *
- * Accepts both double (") and single (') quotes. Single quotes are safe here
- * even though Quechua glottalizes with an apostrophe (`ch'usaq`, `ñit'iy`):
- * those apostrophes are always MID-word, and this extractor is only consulted at
- * a token-start position (after whitespace) — no Quechua word *starts* with `'`,
- * and the word/keyword extractor (registered after this one) consumes the whole
- * glottalized word before its apostrophe is ever a token boundary. Without single
- * quotes the corpus `'Saved!'` (make-toast) tokenized as `'Saved` + `!` + `'`.
+ * Accepts double (") and single (') quotes plus backtick templates. Single
+ * quotes are safe here even though Quechua glottalizes with an apostrophe
+ * (`ch'usaq`, `ñit'iy`): those apostrophes are always MID-word, and this
+ * extractor is only consulted at a token-start position (after whitespace) —
+ * no Quechua word *starts* with `'`, and the word/keyword extractor
+ * (registered after this one) consumes the whole glottalized word before its
+ * apostrophe is ever a token boundary. Without single quotes the corpus
+ * `'Saved!'` (make-toast) tokenized as `'Saved` + `!` + `'`. Backticks mirror
+ * the framework StringLiteralExtractor every other language uses — without
+ * them a template literal shattered into ~12 fragments and no set pattern
+ * could match the clause (template-literal-interpolation, R1 Family B).
  */
 class QuechuaStringLiteralExtractor implements ValueExtractor {
   readonly name = 'quechua-string-literal';
 
   canExtract(input: string, position: number): boolean {
-    return input[position] === '"' || input[position] === "'";
+    return input[position] === '"' || input[position] === "'" || input[position] === '`';
   }
 
   extract(input: string, position: number): ExtractionResult | null {

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -13451,4 +13451,39 @@ describe('R1 Family D: SOV fallback value-typing increments (docs-internal/HANDO
       }
     });
   });
+
+  describe('D3: optional-chaining possessive folds the FULL chain (optional-chaining-possessive)', () => {
+    // The tokenizer splits `?.prop` into `?` + `.prop`; the possessive
+    // chain consumer stopped at the second `?`, leaving property-path(me,
+    // "?.dataset") with `?.customValue` stranded — the verb-final SOV
+    // patterns could never complete through to their patient particle and
+    // fell to a bare `?.customValue` expression. Folding `?` + `.prop`
+    // links consumes the whole chain; en's TYPE (and so the R1 denominator)
+    // is unchanged — only its property string now carries the full chain.
+    const ROWS: Array<[string, string]> = [
+      ['en', 'on click log my?.dataset?.customValue'],
+      ['ja', '私の?.dataset?.customValue を クリック で 記録'],
+      ['ko', '내?.dataset?.customValue 를 클릭 할 때 로그'],
+      ['tr', 'benim?.dataset?.customValue i tıklama de kaydet'],
+      ['qu', 'noqaq?.dataset?.customValue ta ñitiy pi qillqakuy'],
+      ['bn', 'আমার?.dataset?.customValue কে ক্লিক এ লগ'],
+      ['hi', 'मेरा?.dataset?.customValue को क्लिक पर लॉग'],
+    ];
+    for (const [lang, src] of ROWS) {
+      it(`[${lang}] log patient is one property-path over the full ?. chain`, () => {
+        const l = first(collect(parse(src, lang)), 'log');
+        const p = role(l, 'patient');
+        expect(p?.type).toBe('property-path');
+        expect(p?.property).toBe('?.dataset?.customValue');
+        expect(p?.object).toMatchObject({ type: 'reference', value: 'me' });
+      });
+    }
+
+    it('[en] a ternary after a possessive value is not swallowed by the ? fold', () => {
+      // `?` folds only when a `.prop` selector immediately follows.
+      const s = first(collect(parse('on click set my innerHTML to "a"', 'en')), 'set');
+      expect(role(s, 'destination')?.type).toBe('property-path');
+      expect(role(s, 'destination')?.property).toBe('innerHTML');
+    });
+  });
 });

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -13267,3 +13267,66 @@ describe('R1 Family B: qu set — oblique manta source + whole backtick template
     expect(role(s, 'source')).toBeUndefined();
   });
 });
+
+describe('R1 Family C: tr/qu verb-final or-run wait captures the first event (docs-internal/HANDOFF_r1-role-fidelity.md)', () => {
+  // The behaviors' `wait for pointermove(...) or pointerup(...) from document`
+  // renders verb-final with a fronted from-phrase (post-#636); no tr/qu wait
+  // pattern matched the or-run shape, so the verb-anchoring fallback binned
+  // the run as junk duration:expression=")" and the event dropped. The
+  // verb-final mirrors of wait-ar-from-first/wait-tl-from-first capture the
+  // first event into `duration`; the known-event duration→event relabel then
+  // emits event:literal, matching the en reference (which also keeps ONLY the
+  // first event). Corpus strings are canonical pattern_translations rows.
+  const roleOf = (node: unknown, role: string): any => {
+    const walk = (n: any): any => {
+      if (!n || typeof n !== 'object') return undefined;
+      if (n.action === 'wait' && n.roles instanceof Map) return n.roles.get(role);
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches', 'eventHandlers', 'initBlock']) {
+        const c = n[f];
+        if (Array.isArray(c)) for (const x of c) { const r = walk(x); if (r !== undefined) return r; }
+        else if (c && typeof c === 'object') { const r = walk(c); if (r !== undefined) return r; }
+      }
+      return undefined;
+    };
+    return walk(node);
+  };
+  const countWaits = (node: unknown): number => {
+    let n = 0;
+    const walk = (x: any): void => {
+      if (!x || typeof x !== 'object') return;
+      if (x.action === 'wait') n++;
+      for (const f of ['body', 'statements', 'thenBranch', 'elseBranch', 'branches', 'eventHandlers', 'initBlock']) {
+        const c = x[f];
+        if (Array.isArray(c)) c.forEach(walk);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return n;
+  };
+
+  const ROWS: Array<[string, string, string]> = [
+    ['tr', 'sortable (1-arg)', 'belge den pointermove(clientY) veya pointerup(clientY) bekle'],
+    ['qu', 'sortable (1-arg)', 'qillqa manta pointermove(clientY) utaq pointerup(clientY) suyay'],
+    ['tr', 'resizable (2-arg)', 'belge den pointermove(clientX, clientY) veya pointerup(clientX, clientY) bekle'],
+    ['qu', 'resizable (2-arg)', 'qillqa manta pointermove(clientX, clientY) utaq pointerup(clientX, clientY) suyay'],
+  ];
+  for (const [lang, label, src] of ROWS) {
+    it(`[${lang}] ${label}: first event captured as event:literal, single wait`, () => {
+      const node = parse(src, lang);
+      expect(roleOf(node, 'event')).toMatchObject({ type: 'literal', value: 'pointermove' });
+      expect(countWaits(node), `${lang} phantom command check`).toBe(1);
+    });
+  }
+
+  it('[tr] parenless hand-written or-run still parses (groups optional)', () => {
+    const node = parse('belge den pointermove veya pointerup bekle', 'tr');
+    expect(roleOf(node, 'event')).toMatchObject({ type: 'literal', value: 'pointermove' });
+  });
+
+  it('[en] reference unchanged: first event only, via wait-en-for-event', () => {
+    const node = parse('wait for pointermove(clientY) or pointerup(clientY) from document', 'en');
+    expect(roleOf(node, 'event')).toMatchObject({ type: 'literal', value: 'pointermove' });
+    expect(countWaits(node)).toBe(1);
+  });
+});

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -13330,3 +13330,70 @@ describe('R1 Family C: tr/qu verb-final or-run wait captures the first event (do
     expect(countWaits(node)).toBe(1);
   });
 });
+
+describe('R1 Family D: SOV fallback value-typing increments (docs-internal/HANDOFF_r1-role-fidelity.md)', () => {
+  // The verb-anchoring fallback's typing (tokensToSemanticValue /
+  // tokenToSemanticValue) diverged from the pattern path the en reference
+  // uses — bare sigil refs fell to literal, multi-token runs glue+first-token
+  // type only. Each increment mirrors one pattern-path behavior, gated so
+  // untouched inputs are byte-identical. Corpus strings are canonical
+  // pattern_translations rows.
+  const CHILD_FIELDS = [
+    'body',
+    'statements',
+    'thenBranch',
+    'elseBranch',
+    'branches',
+    'eventHandlers',
+    'initBlock',
+    'initCommands',
+  ];
+  const collect = (node: unknown): Record<string, any>[] => {
+    const flat: Record<string, any>[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec);
+      for (const f of CHILD_FIELDS) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return flat;
+  };
+  const role = (n: Record<string, any> | undefined, r: string): any =>
+    n && n.roles instanceof Map ? n.roles.get(r) : undefined;
+  const first = (nodes: Record<string, any>[], action: string): Record<string, any> | undefined =>
+    nodes.find(n => n.action === action);
+
+  describe('D1: sigil reference + set marker-role swap (beep-debug-expression)', () => {
+    // The fallback typed `$x` literal (no `:local`/`$global` branch) AND
+    // mapped set's ta/を-marked DESTINATION to patient — set's surface order
+    // is dest-first, so the SOV patient particle systematically marks the
+    // destination. en: destination:reference="$x" + patient:literal.
+    const ROWS: Array<[string, string]> = [
+      ['ja', '$x を beep! 私の 値 に 設定 クリック で'],
+      ['ko', '$x 를 beep! 내 값 에 설정 클릭 할 때'],
+      ['tr', '$x i beep! benim değer e ayarla tıklama de'],
+      ['qu', '$x ta beep! noqaq chanin man ñitiy pi churanay'],
+    ];
+    for (const [lang, src] of ROWS) {
+      it(`[${lang}] fallback set: $x lands as destination:reference, value as patient:literal`, () => {
+        const s = first(collect(parse(src, lang)), 'set');
+        expect(s).toBeDefined();
+        expect(role(s, 'destination')).toMatchObject({ type: 'reference', value: '$x' });
+        expect(role(s, 'patient')?.type).toBe('literal');
+      });
+    }
+
+    it('[ja] put keeps its natural mapping (no swap): patient stays the を-marked value', () => {
+      // put is VALUE-first — its patient particle really marks the patient.
+      const p = first(collect(parse('"hello" を #output に 置く', 'ja')), 'put');
+      expect(p).toBeDefined();
+      expect(role(p, 'patient')?.value).toBe('hello');
+      expect(role(p, 'destination')?.value).toBe('#output');
+    });
+  });
+});

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -13486,4 +13486,36 @@ describe('R1 Family D: SOV fallback value-typing increments (docs-internal/HANDO
       expect(role(s, 'destination')?.property).toBe('innerHTML');
     });
   });
+
+  describe('D4: verb-final SOV for-binding heads (template-literal-list-build)', () => {
+    // The transformer renders the for-head clause-final-verb (`item の 中
+    // $items を ために`); only verb-FIRST repeat-for-in heads existed, so the
+    // verb-anchoring fallback shredded the head on the in/object particles.
+    // for-<lang>-sov-basic mirrors en's for-en-basic roles exactly.
+    // FULL corpus bodies — the bare head fragment parses through a different
+    // path in qu/bn/hi (the transformer-rendering arc's full-body-probe
+    // discipline); R1 scores the in-body shape, so that is what locks.
+    const ROWS: Array<[string, string]> = [
+      ['ja', '$html を "" に 設定 クリック で それから item の中 $items を ために それから $html を $html + `<li>${item.name}</li>` に 設定 終わり それから #list.innerHTML を $html に 設定'],
+      ['ko', '$html 를 "" 에 설정 클릭 할 때 그러면 item 안에 $items 를 각각 그러면 $html 를 $html + `<li>${item.name}</li>` 에 설정 끝 그러면 #list.innerHTML 를 $html 에 설정'],
+      ['tr', '$html i "" e ayarla tıklama de ardından item içinde $items i için ardından $html i $html + `<li>${item.name}</li>` e ayarla son ardından #list.innerHTML i $html e ayarla'],
+      ['qu', '$html ta "" man ñitiy pi churanay chayqa item ukupi $items ta sapankaq chayqa $html ta $html + `<li>${item.name}</li>` man churanay tukuy chayqa #list.innerHTML ta $html man churanay'],
+      ['bn', '$html কে "" তে সেট ক্লিক এ তারপর item এ $items কে জন্য তারপর $html কে $html + `<li>${item.name}</li>` তে সেট শেষ তারপর #list.innerHTML কে $html তে সেট'],
+      ['hi', '$html को "" में सेट क्लिक पर फिर item में $items को हेतु फिर $html को $html + `<li>${item.name}</li>` में सेट समाप्त फिर #list.innerHTML को $html में सेट'],
+    ];
+    for (const [lang, src] of ROWS) {
+      it(`[${lang}] for-head: patient:expression + source:reference, like en`, () => {
+        const f = first(collect(parse(src, lang)), 'for');
+        expect(f).toBeDefined();
+        expect(role(f, 'patient')).toMatchObject({ type: 'expression', raw: 'item' });
+        expect(role(f, 'source')).toMatchObject({ type: 'reference', value: '$items' });
+      });
+    }
+
+    it('[ja] marker-less hand-written head still parses (object particle optional)', () => {
+      const f = first(collect(parse('item の中 $items ために', 'ja')), 'for');
+      expect(f).toBeDefined();
+      expect(role(f, 'source')).toMatchObject({ type: 'reference', value: '$items' });
+    });
+  });
 });

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -13396,4 +13396,59 @@ describe('R1 Family D: SOV fallback value-typing increments (docs-internal/HANDO
       expect(role(p, 'destination')?.value).toBe('#output');
     });
   });
+
+  describe('D2: fused *-sov-simple trailing expression runs (js-inline, go-url, last-in-collection)', () => {
+    // The fused simple event patterns capture only the verb and DEFAULT the
+    // primary role to me, stranding the real argument after the verb where
+    // the #530 re-parse cannot recover it (verb-first tail vs verb-final
+    // standalone patterns). tryAttachTrailingExpressionRole reclaims the run
+    // — js to the clause boundary, go/scroll to the postpositional
+    // destination marker — typed expression like the en reference.
+    it('[ja] js-inline: code run reclaimed, verb fragment 実行 trimmed', () => {
+      const j = first(collect(parse('クリック で JS実行 console.log("from js") 終わり', 'ja')), 'js');
+      expect(role(j, 'patient')?.type).toBe('expression');
+      expect(role(j, 'patient')?.raw).toContain('console');
+      expect(role(j, 'patient')?.raw).not.toContain('実行');
+    });
+
+    it('[tr] js-inline: code run reclaimed', () => {
+      const j = first(collect(parse('tıklama de js console.log("from js") son', 'tr')), 'js');
+      expect(role(j, 'patient')?.type).toBe('expression');
+      expect(role(j, 'patient')?.raw).toContain('console');
+    });
+
+    const GO_ROWS: Array<[string, string]> = [
+      ['ja', 'クリック で 移動 url "/page" に'],
+      ['tr', 'tıklama de git url "/page" e'],
+    ];
+    for (const [lang, src] of GO_ROWS) {
+      it(`[${lang}] go-url: destination phrase reclaimed as expression, default-me patient leak dropped`, () => {
+        const g = first(collect(parse(src, lang)), 'go');
+        expect(role(g, 'destination')?.type).toBe('expression');
+        expect(role(g, 'destination')?.raw).toContain('url');
+        expect(role(g, 'patient')).toBeUndefined();
+      });
+    }
+
+    const SCROLL_ROWS: Array<[string, string]> = [
+      ['ja', 'クリック で スクロール 最後 <.message/> の中 #chat に'],
+      ['tr', 'tıklama de kaydır sonuncu <.message/> içinde #chat e'],
+    ];
+    for (const [lang, src] of SCROLL_ROWS) {
+      it(`[${lang}] last-in-collection: scroll destination reclaimed as expression`, () => {
+        const s = first(collect(parse(src, lang)), 'scroll');
+        expect(role(s, 'destination')?.type).toBe('expression');
+        expect(role(s, 'destination')?.raw).toContain('#chat');
+      });
+    }
+
+    it('[ja] a bare go with a REAL destination capture is never overwritten', () => {
+      // The reclaim only fires on an absent or defaulted-me role.
+      const g = first(collect(parse('#top に 移動 クリック で', 'ja')), 'go');
+      expect(g).toBeDefined();
+      if (role(g, 'destination') !== undefined) {
+        expect(role(g, 'destination')?.type).not.toBe('undefined');
+      }
+    });
+  });
 });

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -13035,3 +13035,112 @@ describe('R3 value-bug families (docs-internal/HANDOFF_value-bug-families.md)', 
     });
   });
 });
+
+describe('R1 Family A: trailing SOV with-options blob reclaimed as fetch/render style (docs-internal/HANDOFF_r1-role-fidelity.md)', () => {
+  // The SOV canonicalOrders carry no `style` slot, so the transformer's
+  // safety net strands the with-options blob AFTER the verb with its
+  // postposition, where the fused event patterns left it unconsumed —
+  // fetch.style/render.style:expression missing across the SOV cohort while
+  // the en reference captures it (R1 Family A, the largest miss cluster).
+  // tryAttachTrailingStyle reclaims the depth-0 marker-terminated run.
+  // Corpus strings are canonical patterns.db pattern_translations rows.
+  const CHILD_FIELDS = [
+    'body',
+    'statements',
+    'thenBranch',
+    'elseBranch',
+    'branches',
+    'eventHandlers',
+    'initBlock',
+    'initCommands',
+  ];
+
+  const collect = (node: unknown): Record<string, any>[] => {
+    const flat: Record<string, any>[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec);
+      for (const f of CHILD_FIELDS) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return flat;
+  };
+
+  const role = (n: Record<string, any> | undefined, r: string): any =>
+    n && n.roles instanceof Map ? n.roles.get(r) : undefined;
+
+  const first = (nodes: Record<string, any>[], action: string): Record<string, any> | undefined =>
+    nodes.find(n => n.action === action);
+
+  describe('fetch-with-method: style:expression captured, source untouched', () => {
+    const ROWS: Array<[string, string]> = [
+      ['ja', '/api/form を 送信 で フェッチ method:"POST" body:form で'],
+      ['ko', '/api/form 를 제출 할 때 가져오기 method:"POST" body:form 로'],
+      ['tr', '/api/form i gönder de getir method:"POST" body:form ile'],
+      ['qu', '/api/form ta kachay pi apamuy method:"POST" body:form wan'],
+    ];
+    for (const [lang, src] of ROWS) {
+      it(`[${lang}] captures style as expression and keeps source`, () => {
+        const nodes = collect(parse(src, lang));
+        const f = first(nodes, 'fetch');
+        expect(f, `${lang} fetch survives`).toBeDefined();
+        expect(role(f, 'source')?.value, `${lang} source`).toBe('/api/form');
+        expect(role(f, 'style')?.type, `${lang} style type`).toBe('expression');
+        expect(role(f, 'style')?.raw, `${lang} style content`).toContain('method');
+      });
+    }
+  });
+
+  describe('render-template-with-data: style:expression captured, then-chain survives', () => {
+    const ROWS: Array<[string, string]> = [
+      ['ja', '#user-list を クリック で 描画 users: $data で それから それ を #container に 置く'],
+      ['ko', '#user-list 를 클릭 할 때 렌더링 users: $data 로 그러면 그것 를 #container 에 넣다'],
+      ['tr', '#user-list i tıklama de render users: $data ile ardından o i #container e koy'],
+      ['qu', '#user-list ta ñitiy pi rikurichiy users: $data wan chayqa chay ta #container man churay'],
+    ];
+    for (const [lang, src] of ROWS) {
+      it(`[${lang}] captures style as expression; patient + trailing put intact`, () => {
+        const nodes = collect(parse(src, lang));
+        const r = first(nodes, 'render');
+        expect(r, `${lang} render survives`).toBeDefined();
+        expect(role(r, 'patient')?.value, `${lang} patient`).toBe('#user-list');
+        expect(role(r, 'style')?.type, `${lang} style type`).toBe('expression');
+        expect(role(r, 'style')?.raw, `${lang} style content`).toContain('users');
+        const p = first(nodes, 'put');
+        expect(p, `${lang} then-chained put survives`).toBeDefined();
+        expect(role(p, 'destination')?.value, `${lang} put destination`).toBe('#container');
+      });
+    }
+  });
+
+  it('[ko] fetch-formdata: an as-marker 로 INSIDE the parenthesized body does not close the run (depth tracking)', () => {
+    const nodes = collect(
+      parse('/api/submit 를 제출 할 때 가져오기 method:"POST", body:(closest <form/> 로 FormData) 로', 'ko')
+    );
+    const f = first(nodes, 'fetch');
+    expect(role(f, 'style')?.type).toBe('expression');
+    expect(role(f, 'style')?.raw).toContain('FormData');
+  });
+
+  it('[ja] a fetch WITHOUT a with-phrase gains no phantom style', () => {
+    // fetch-loading-state shape: nothing between the verb and the then-chain.
+    const nodes = collect(parse('/api/data を クリック で フェッチ それから それ を 私 に 置く', 'ja'));
+    const f = first(nodes, 'fetch');
+    expect(f).toBeDefined();
+    expect(role(f, 'style')).toBeUndefined();
+  });
+
+  it('[en] reference capture unchanged: style via the en with-options pattern', () => {
+    // en never takes the reclaim path (prepositional style marker); this
+    // locks the R1 denominator the SOV cohort is scored against.
+    const nodes = collect(parse('on submit fetch /api/form with method:"POST" body:form', 'en'));
+    const f = first(nodes, 'fetch');
+    expect(role(f, 'style')?.type).toBe('expression');
+    expect(role(f, 'source')?.value).toBe('/api/form');
+  });
+});

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -13144,3 +13144,126 @@ describe('R1 Family A: trailing SOV with-options blob reclaimed as fetch/render 
     expect(role(f, 'source')?.value).toBe('/api/form');
   });
 });
+
+describe('R1 Family B: qu set — oblique manta source + whole backtick templates (docs-internal/HANDOFF_r1-role-fidelity.md)', () => {
+  // Two independent qu-only defects flattened every hard set row to the
+  // verb-anchoring fallback (destination:literal / patient:selector, vs en's
+  // destination:property-path / patient:expression):
+  //  (1) the transformer renders the handler's from-phrase INSIDE the body
+  //      clause (`<dest> ta <src> manta <value> man … churanay`) and no set
+  //      pattern had a source slot — set-qu-oblique-source adds the shape;
+  //  (2) the qu string extractor lacked the backtick branch every other
+  //      language has, so template literals shattered into ~12 fragments and
+  //      no pattern could match the clause at all.
+  // Corpus strings are canonical patterns.db pattern_translations rows.
+  const CHILD_FIELDS = [
+    'body',
+    'statements',
+    'thenBranch',
+    'elseBranch',
+    'branches',
+    'eventHandlers',
+    'initBlock',
+    'initCommands',
+  ];
+
+  const collect = (node: unknown): Record<string, any>[] => {
+    const flat: Record<string, any>[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec);
+      for (const f of CHILD_FIELDS) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return flat;
+  };
+
+  const role = (n: Record<string, any> | undefined, r: string): any =>
+    n && n.roles instanceof Map ? n.roles.get(r) : undefined;
+
+  const first = (nodes: Record<string, any>[], action: string): Record<string, any> | undefined =>
+    nodes.find(n => n.action === action);
+
+  it('[qu] two-way-binding: property-path destination + expression patient through the oblique source', () => {
+    const nodes = collect(
+      parse(
+        '#greeting.innerText ta #firstName manta "Hello, " + noqaq chanin man yaykuchiy pi churanay',
+        'qu'
+      )
+    );
+    const s = first(nodes, 'set');
+    expect(s).toBeDefined();
+    expect(role(s, 'destination')?.type).toBe('property-path');
+    expect(role(s, 'patient')?.type).toBe('expression');
+    expect(role(s, 'patient')?.raw).toContain('noqaq chanin');
+    expect(role(s, 'source')?.value).toBe('#firstName');
+  });
+
+  it('[qu] computed-value: parenthesized operator-run patient stays one expression', () => {
+    const nodes = collect(
+      parse(
+        '#total.innerText ta .quantity manta (the chanin pa #price hina Number) * (noqaq chanin hina Number) man yaykuchiy pi churanay',
+        'qu'
+      )
+    );
+    const s = first(nodes, 'set');
+    expect(role(s, 'destination')?.type).toBe('property-path');
+    expect(role(s, 'patient')?.type).toBe('expression');
+    expect(role(s, 'patient')?.raw).toContain('#price');
+  });
+
+  it('[qu] template-literal-interpolation: backtick template survives as one token', () => {
+    const nodes = collect(parse('noqaq innerHTML ta `<li>${$item.name}</li>` man ñitiy pi churanay', 'qu'));
+    const s = first(nodes, 'set');
+    expect(role(s, 'destination')?.type).toBe('property-path');
+    expect(role(s, 'patient')?.type).toBe('expression');
+    expect(role(s, 'patient')?.raw).toBe('`<li>${$item.name}</li>`');
+  });
+
+  it('[qu] template-literal-list-build: the middle set keeps its operator-run expression patient', () => {
+    const nodes = collect(
+      parse(
+        '$html ta "" man ñitiy pi churanay chayqa item ukupi $items ta sapankaq chayqa $html ta $html + `<li>${item.name}</li>` man churanay tukuy chayqa #list.innerHTML ta $html man churanay',
+        'qu'
+      )
+    );
+    const sets = nodes.filter(n => n.action === 'set');
+    expect(sets.length).toBe(3);
+    expect(role(sets[1], 'destination')?.type).toBe('reference');
+    expect(role(sets[1], 'patient')?.type).toBe('expression');
+    expect(role(sets[1], 'patient')?.raw).toContain('`<li>${item.name}</li>`');
+    // Final set: property-path destination, unchanged by the new pattern.
+    expect(role(sets[2], 'destination')?.type).toBe('property-path');
+  });
+
+  it('[qu] backtick template tokenizes as a single token (framework-extractor parity)', () => {
+    const res: any = getTokenizer('qu').tokenize('$html + `<li>${item.name}</li>` man');
+    const toks = (Array.isArray(res) ? res : (res.tokens ?? [])).filter(
+      (t: any) => t.kind !== 'whitespace'
+    );
+    expect(toks.map((t: any) => t.value)).toContain('`<li>${item.name}</li>`');
+  });
+
+  it("[qu] glottalized words still tokenize whole (ch'usaq apostrophe unaffected by the backtick branch)", () => {
+    const res: any = getTokenizer('qu').tokenize("chayqa ch'usaq man churanay");
+    const toks = (Array.isArray(res) ? res : (res.tokens ?? [])).filter(
+      (t: any) => t.kind !== 'whitespace'
+    );
+    expect(toks.map((t: any) => t.value)).toContain("ch'usaq");
+  });
+
+  it('[qu] plain set (no manta phrase) still parses via the generated pattern', () => {
+    // The oblique-source pattern's manta group is REQUIRED, so it must not
+    // shadow the simple shape.
+    const nodes = collect(parse('$html ta "" man ñitiy pi churanay', 'qu'));
+    const s = first(nodes, 'set');
+    expect(role(s, 'destination')?.value).toBe('$html');
+    expect(role(s, 'patient')?.value).toBe('');
+    expect(role(s, 'source')).toBeUndefined();
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,12 +1,12 @@
 {
-  "timestamp": "2026-07-10T22:47:36.999Z",
-  "commit": "4175f0b2",
+  "timestamp": "2026-07-11T04:50:11.740Z",
+  "commit": "3e86d4e1",
   "languages": {
     "ar": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8394563407500147,
+      "avgConfidence": 0.8385750791544675,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
@@ -16,7 +16,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -194,10 +194,6 @@
           "success": true,
           "confidence": 1
         },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 1
-        },
         "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 1
@@ -363,6 +359,10 @@
           "confidence": 0.8642857142857143
         },
         "modal-close-button": {
+          "success": true,
+          "confidence": 0.8642857142857143
+        },
+        "optional-chaining-possessive": {
           "success": true,
           "confidence": 0.8642857142857143
         },
@@ -640,17 +640,17 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8579007041413049,
+      "avgConfidence": 0.8611474573880582,
       "avgFidelity": 1,
       "avgPrecision": 0.9989716846334493,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9738198983297022,
+      "avgRoleFidelity": 0.9937908496732026,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -944,6 +944,10 @@
           "success": true,
           "confidence": 1
         },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 1
+        },
         "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 1
@@ -1224,10 +1228,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.5
-        },
         "eventsource-basic": {
           "success": true,
           "confidence": 0.5
@@ -1284,7 +1284,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1909,7 +1909,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2543,7 +2543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3177,7 +3177,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3811,7 +3811,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4435,17 +4435,17 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.9077564039970039,
+      "avgConfidence": 0.9110031572437574,
       "avgFidelity": 1,
       "avgPrecision": 0.9978354978354977,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9705519244734929,
+      "avgRoleFidelity": 0.9883442265795207,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -4767,6 +4767,10 @@
           "success": true,
           "confidence": 1
         },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 1
+        },
         "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 1
@@ -5055,10 +5059,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.5
-        },
         "intercept-cache-strategies": {
           "success": true,
           "confidence": 0.5
@@ -5079,7 +5079,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5713,7 +5713,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6337,17 +6337,17 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8500157319706186,
+      "avgConfidence": 0.8532624852173719,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9738198983297022,
+      "avgRoleFidelity": 0.9937908496732026,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6637,6 +6637,10 @@
           "success": true,
           "confidence": 1
         },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 1
+        },
         "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 1
@@ -6917,10 +6921,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.5
-        },
         "eventsource-basic": {
           "success": true,
           "confidence": 0.5
@@ -6971,17 +6971,17 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8449652269201134,
+      "avgConfidence": 0.8482119801668667,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.970551924473493,
+      "avgRoleFidelity": 0.9905228758169935,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7268,6 +7268,10 @@
           "confidence": 1
         },
         "method-call-possessive-dot": {
+          "success": true,
+          "confidence": 1
+        },
+        "optional-chaining-possessive": {
           "success": true,
           "confidence": 1
         },
@@ -7543,10 +7547,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.5
-        },
         "eventsource-basic": {
           "success": true,
           "confidence": 0.5
@@ -7615,7 +7615,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8249,7 +8249,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8883,7 +8883,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9507,17 +9507,17 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7316532673675531,
+      "avgConfidence": 0.7349000206143064,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9522415829076727,
+      "avgRoleFidelity": 0.9791783380018673,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9708,6 +9708,10 @@
           "confidence": 1
         },
         "toggle-aria-expanded": {
+          "success": true,
+          "confidence": 1
+        },
+        "optional-chaining-possessive": {
           "success": true,
           "confidence": 1
         },
@@ -10063,10 +10067,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.5
-        },
         "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 0.5
@@ -10151,7 +10151,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10785,7 +10785,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11419,7 +11419,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12043,7 +12043,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8239183073548376,
+      "avgConfidence": 0.8220630197852643,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
@@ -12053,7 +12053,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12216,10 +12216,6 @@
           "confidence": 1
         },
         "method-call-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "optional-chaining-possessive": {
           "success": true,
           "confidence": 1
         },
@@ -12547,6 +12543,10 @@
           "success": true,
           "confidence": 0.7142857142857143
         },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 0.7142857142857143
+        },
         "render-template-with-data": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -12677,17 +12677,17 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8489025594288746,
+      "avgConfidence": 0.8521493126756279,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9719376094664444,
+      "avgRoleFidelity": 0.9927015250544662,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12977,6 +12977,10 @@
           "success": true,
           "confidence": 1
         },
+        "optional-chaining-possessive": {
+          "success": true,
+          "confidence": 1
+        },
         "get-attribute-possessive-dot": {
           "success": true,
           "confidence": 1
@@ -13257,10 +13261,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "optional-chaining-possessive": {
-          "success": true,
-          "confidence": 0.5
-        },
         "eventsource-basic": {
           "success": true,
           "confidence": 0.5
@@ -13321,7 +13321,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13955,7 +13955,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14589,7 +14589,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 497541,
+      "bundleSize": 502444,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15212,7 +15212,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 497541,
+      "size": 502444,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/src/multilingual/cli.ts
+++ b/packages/testing-framework/src/multilingual/cli.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 import { checkDbStamp, getDefaultDbPath } from '@hyperfixi/patterns-reference';
 import { TestOrchestrator } from './orchestrator';
 import { diagnoseCoverage } from './tools/diagnose-coverage';
+import { triageR1 } from './tools/triage-r1';
 import type { TestConfig, LanguageCode } from './types';
 
 /**
@@ -178,6 +179,12 @@ function parseArgs(): TestConfig {
         config.diagnoseCoverage = true;
         break;
 
+      case '--triage-r1':
+        // Read-only measurement pass; short-circuits main() before any gate.
+        // Combine with --languages to scope (en is force-loaded as reference).
+        config.triageR1 = true;
+        break;
+
       default:
         if (arg && arg.startsWith('-')) {
           console.error(`Unknown option: ${arg}`);
@@ -233,6 +240,9 @@ OPTIONS:
       --categories <cats>      Filter by categories (comma-separated)
       --limit <n>              Patterns per language in quick mode (default: 10)
       --save-baseline          Save current results as new baseline
+      --triage-r1              Itemize R1 role-fidelity misses per language
+                               (missing action.role:type entries vs the en
+                               reference, clustered; scope with --languages)
       --diagnose-coverage      Report how often the semantic parser matched a
                                pattern that ignored part of its input, per
                                language, with sample dropped spans. Read-only:
@@ -284,6 +294,21 @@ async function main(): Promise<void> {
         );
       }
       await diagnoseCoverage(config);
+      process.exit(0);
+    }
+
+    // --triage-r1 is the same kind of measurement pass for R1 role fidelity:
+    // itemizes each language's missing `action.role:type` entries vs the en
+    // reference, clustered by entry (with the mistype pairing). Read-only.
+    if (config.triageR1) {
+      const staleDists = findStaleDists();
+      if (staleDists.length > 0) {
+        console.warn(
+          `⚠ Stale dist/ in: ${staleDists.join(', ')} — these numbers describe the built\n` +
+            '  output, not your checkout. Rebuild first: npm run test:multilingual:build-deps\n'
+        );
+      }
+      await triageR1(config);
       process.exit(0);
     }
 

--- a/packages/testing-framework/src/multilingual/tools/triage-r1.ts
+++ b/packages/testing-framework/src/multilingual/tools/triage-r1.ts
@@ -1,0 +1,149 @@
+/**
+ * triage-r1.ts
+ *
+ * Read-only sweep that itemizes R1 role-fidelity misses per language: for every
+ * corpus pattern whose roleFidelity < 1, the `action.role:type` entries present
+ * in the en reference parse but absent from the translation's parse — clustered
+ * by entry so the dominant failure families are visible, with the entries the
+ * translation captured INSTEAD for the same action (the mistype pairing).
+ *
+ * Why this exists: avgRoleFidelity summarizes the SOV-six gap (qu ~0.95, the
+ * rest ~0.97) to one number per language, and the regression gate only reports
+ * DROPS. Planning an improvement arc needs the misses themselves — which roles,
+ * on which actions, in which patterns — measured with exactly the pipeline the
+ * gate scores (ParseValidator → fillSchemaDefaults → collectRoleSignature →
+ * Set recall vs the en reference), so a "fix" that moves the probe also moves
+ * the signal.
+ *
+ * This tool never writes a baseline and never gates. It only reads.
+ */
+import { computeFidelity } from '../fidelity';
+import { loadPatterns } from '../pattern-loader';
+import { ParseValidator } from '../validators/parse-validator';
+import type { ParseResult, TestConfig } from '../types';
+
+interface MissCluster {
+  /** The en-reference `action.role:type` entry the language failed to recall. */
+  entry: string;
+  /** Pattern ids where this entry was missed. */
+  patterns: string[];
+  /**
+   * What the language's parse captured for the SAME action in those patterns
+   * (entries absent from the en reference) — usually the mistype the miss
+   * paired with (`trigger.patient:literal` opposite a missing
+   * `trigger.event:literal`). Empty when the whole command dropped.
+   */
+  haveInstead: Set<string>;
+}
+
+const MAX_PATTERN_IDS_SHOWN = 6;
+
+/**
+ * Sweep the corpus and itemize R1 misses for the requested languages
+ * (default: every non-en language in the run).
+ */
+export async function triageR1(config: TestConfig): Promise<void> {
+  // The en rows ARE the reference — force-load them even when the caller
+  // filtered --languages to the triage targets.
+  const requested = config.languages?.filter(l => l !== 'en');
+  const loadConfig: TestConfig =
+    requested && requested.length > 0
+      ? { ...config, languages: [...requested, 'en' as const] }
+      : config;
+
+  const patterns = await loadPatterns(loadConfig);
+  const validator = new ParseValidator();
+  const results = await validator.validate(patterns);
+
+  const reference = new Map<string, string[]>();
+  for (const r of results) {
+    if (r.pattern.language !== 'en') continue;
+    if (r.success && r.roleSignature && r.roleSignature.length > 0) {
+      reference.set(r.pattern.codeExampleId, r.roleSignature);
+    }
+  }
+
+  const byLanguage = new Map<string, ParseResult[]>();
+  for (const r of results) {
+    if (r.pattern.language === 'en') continue;
+    if (requested && requested.length > 0 && !requested.includes(r.pattern.language)) continue;
+    const list = byLanguage.get(r.pattern.language) ?? [];
+    list.push(r);
+    byLanguage.set(r.pattern.language, list);
+  }
+
+  console.log('\nR1 role-fidelity triage (action.role:type recall vs the en reference)');
+  console.log('━'.repeat(72));
+
+  for (const [language, langResults] of [...byLanguage.entries()].sort()) {
+    const clusters = new Map<string, MissCluster>();
+    const scores: number[] = [];
+    let patternsWithMisses = 0;
+
+    for (const result of langResults) {
+      if (!result.success || !result.roleSignature) continue;
+      const ref = reference.get(result.pattern.codeExampleId);
+      if (!ref) continue;
+
+      const fidelity = computeFidelity(ref, result.roleSignature);
+      if (fidelity === undefined) continue;
+      scores.push(fidelity);
+      if (fidelity >= 1) continue;
+
+      patternsWithMisses++;
+      const candidate = new Set(result.roleSignature);
+      const refSet = new Set(ref);
+      const missing = ref.filter(e => !candidate.has(e));
+      // Entries this parse has that the reference doesn't — candidates for the
+      // "captured instead" pairing, keyed by action.
+      const extrasByAction = new Map<string, string[]>();
+      for (const e of result.roleSignature) {
+        if (refSet.has(e)) continue;
+        const action = e.slice(0, e.indexOf('.'));
+        const list = extrasByAction.get(action) ?? [];
+        list.push(e);
+        extrasByAction.set(action, list);
+      }
+
+      for (const entry of missing) {
+        const cluster = clusters.get(entry) ?? {
+          entry,
+          patterns: [],
+          haveInstead: new Set<string>(),
+        };
+        cluster.patterns.push(result.pattern.codeExampleId);
+        const action = entry.slice(0, entry.indexOf('.'));
+        for (const e of extrasByAction.get(action) ?? []) cluster.haveInstead.add(e);
+        clusters.set(entry, cluster);
+      }
+    }
+
+    const avg = scores.length > 0 ? scores.reduce((a, b) => a + b, 0) / scores.length : undefined;
+    const totalMisses = [...clusters.values()].reduce((a, c) => a + c.patterns.length, 0);
+
+    console.log(
+      `\n[${language}] avgRoleFidelity ${avg?.toFixed(4) ?? 'n/a'} — ` +
+        `${totalMisses} miss(es) across ${patternsWithMisses} pattern(s), ` +
+        `${clusters.size} distinct entry(ies)`
+    );
+
+    const sorted = [...clusters.values()].sort(
+      (a, b) => b.patterns.length - a.patterns.length || a.entry.localeCompare(b.entry)
+    );
+    for (const cluster of sorted) {
+      const ids =
+        cluster.patterns.length > MAX_PATTERN_IDS_SHOWN
+          ? `${cluster.patterns.slice(0, MAX_PATTERN_IDS_SHOWN).join(', ')}, +${
+              cluster.patterns.length - MAX_PATTERN_IDS_SHOWN
+            } more`
+          : cluster.patterns.join(', ');
+      console.log(`  ×${cluster.patterns.length}  missing ${cluster.entry}`);
+      console.log(`        in: ${ids}`);
+      if (cluster.haveInstead.size > 0) {
+        console.log(`        captured instead: ${[...cluster.haveInstead].sort().join(', ')}`);
+      }
+    }
+  }
+
+  console.log();
+}

--- a/packages/testing-framework/src/multilingual/types.ts
+++ b/packages/testing-framework/src/multilingual/types.ts
@@ -106,6 +106,13 @@ export interface TestConfig {
    * then exit. Read-only: never gates, never writes a baseline.
    */
   diagnoseCoverage?: boolean;
+
+  /**
+   * Itemize R1 role-fidelity misses (missing `action.role:type` entries vs the
+   * en reference, clustered) per language, then exit. Read-only: never gates,
+   * never writes a baseline. Scope with `languages`.
+   */
+  triageR1?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Executes `docs-internal/HANDOFF_r1-role-fidelity.md` (now marked RESOLVED): burns down the R1 role-fidelity miss families for the SOV six. All arc targets exceeded:

| lang | before | after | target |
| ---- | ------ | ----- | ------ |
| qu   | 0.9522 | **0.9792** | ≥ 0.97 |
| ja   | 0.9738 | **0.9938** | ≥ 0.98 |
| bn   | 0.9738 | **0.9938** | (stretch) |
| tr   | 0.9719 | **0.9927** | ≥ 0.98 |
| ko   | 0.9706 | **0.9905** | ≥ 0.98 |
| hi   | 0.9706 | **0.9883** | (stretch) |

Every other ratcheted signal held exactly (parse-rate 100%, R0 fidelity/precision/multiset, R2 = 1.0, R3 = 0.9967 with only the F6 wontfix rows). `--regression` gate green after **every** family commit; unit locks per family in `multilingual-roadmap-fixes.test.ts` (40 new tests).

## Per-family commits

1. **Preamble** — lands the `--triage-r1` tool (itemizes missing `action.role:type` entries vs the en reference; reproduces the baseline averages to 4 decimals) + the arc handoff.
2. **Family A** (24 misses, all six languages) — the fused SOV event patterns stranded the `with`-options blob after the verb; `tryAttachTrailingStyle` reclaims the depth-0 marker-terminated run as `style:expression` (fetch/render only, absent-role gated); tr gains the free-standing `ile` style marker.
3. **Family B** (qu, 7 misses) — `set-qu-oblique-source` handles the interleaved `manta` from-phrase; the qu string extractor gains the backtick branch every other language already had (template literals shattered to ~12 fragments).
4. **Family C** (tr/qu or-run wait) — verb-final mirrors of `wait-ar-from-first`/`wait-tl-from-first`; the first event flows through the existing known-event relabel to `event:literal`, matching en.
5. **Family D1** — fallback `:local`/`$global` sigil references + unconditional set patient↔destination marker swap (set's surface order is destination-first; put untouched).
6. **Family D2** — `tryAttachTrailingExpressionRole` reclaims the fused `*-sov-simple` default-role drops (js code runs, go/scroll destination phrases).
7. **Family D3** — the possessive chain consumer folds `?` + `.prop` optional-chaining links; en's type (the R1 denominator) unchanged, property strings byte-identical across the cohort.
8. **Family D4** — verb-final `for-<lang>-sov-basic` binding heads for the SOV six (en's `for-en-basic` roles exactly).
9. **Baseline regeneration** — audited line-by-line; every delta maps to a family.

## Key finding vs the handoff's hypothesis

Most of the Family D tail was **not** a shared fallback-classifier root but fused-simple-pattern default-role drops (the Family A geometry) — fixed with scoped reclaims/patterns, so no shared-classifier extraction is warranted. Remaining entries are deferred with per-entry reasons (event-debounce `${}` URL tokenization — the en reference itself truncates; pick range-role modeling; form-submit-prevent fused-clause scramble; focus-trap condition-boundary leak) — ledger in the handoff's "Family D outcomes" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)