### PR TITLE
fix(semantic,i18n): R1 deferred-tail arc — en-reference defects + SOV render geometry (E/H/G + qu tail)

### DIFF
--- a/docs-internal/HANDOFF_r1-deferred-tail.md
+++ b/docs-internal/HANDOFF_r1-deferred-tail.md
@@ -1,5 +1,27 @@
 # Handoff: the R1 deferred tail (en-reference defects + render geometry)
 
+> **RESOLVED 2026-07-11** (branch `fix/r1-deferred-tail`). All in-scope
+> families cleared; F deferred per this doc's own reasoning. avgRoleFidelity:
+> ja 0.9938 → **0.9978**, bn 0.9938 / tr 0.9927 → **0.9962**, ko 0.9905 →
+> **0.9946**, qu 0.9792 → **0.9936**, hi 0.9883 → **0.9907**. Sweeps green
+> after every increment (3696/3696, R2 1.0, R3 loss only swap-content F6);
+> baseline regenerated + audited per increment; `--regression` green at arc
+> end. Per-family ledger:
+>
+> | family | outcome | how |
+> | ------ | ------- | --- |
+> | E — event-debounce `${}` URL (×6) | **fixed** (4199a0dd) | extractUrl carries `${…}` spans (balanced braces; unclosed keeps legacy cut). Realignment surfaced two masked co-causes, fixed in-increment: the SOV `debounced at 300ms` head stranded `at 300ms` junk (identifier-preposition skip added), and fused matches captured native event words raw (buildEventHandler canonicalizes exact eventNameTranslations hits; tr got boyutlandırma/kaydırma tokenizer keywords). en + all six capture the full URL as source:literal AND responseType:expression |
+> | H — form-submit-prevent halt/call (×6 + tr call) | **fixed** (19020c54) | sovHaltCallFusedRule (per-SOV-profile custom render) splits the swept patient blob at the call verb; both commands verb-final, joined by the then-connective. halt.patient:reference everywhere, tr call aligned, row confidence 0.5→1.0 |
+> | G — focus-trap condition/operand boundary (ja/ko/qu) | **fixed** (c5c884cc) | option (a) + a tokenizer alignment the probe surfaced: transformBlockBody emits the then-connective at the clause/body seam (razor-gated: SOV + positional-headed branch + no existing then — the fold's isThenKeyword boundary, #636 guards untouched); ja/ko/qu containment words (の中/안에/ukupi) registered as whole `in` keywords (split fragments broke the generated focus pattern; qu's stranded `pi` read as event marker). Bonus: whole ukupi realigned qu last-in-collection scroll |
+> | qu tail — go/scroll/put ×2/toggle/window-resize call | **fixed** (299bb27a; scroll under G) | single-quoted strings classify literal (put ×2 byte-identical to en); toggle-qu-patient-first-dest covers the #636 verb-final order (destination:expression="next .panel", byte-identical); go-qu-url-dest re-types the fronted url pair expression via ExtractionRule.transform (documented-but-unwired field, now honored in applyExtractionRules); interior `_` allowed in the qu keyword extractor's longest-first scan → k_iri/hatun_kay tokenize whole (window-resize: event literal:resize, clean call.patient:expression) |
+> | F — pick-text-range (×6) | **deferred** | per this doc's reasoning: the en reference is degenerate (first word only; pickSchema models no range roles) — the fix raises the en denominator for all 24 languages, the most expensive row for ×6. Recorded in NEXT_STEPS § 2026-07-11b |
+> | qu on.event ×2 (announce, on-custom) | **out of scope** | reactive/event-anchor class, per this doc; G's probe did not explain them (en types the custom event expression, qu literal) |
+> | swap-content | **out of scope** | F6 wontfix, unchanged |
+>
+> Residual per-language misses: ja 1 (pick) · bn/tr 2 (pick, swap) · ko 3
+> (pick, on.event ×2) · qu 4 (pick, swap, on.event ×2) · hi 5 (pick, swap,
+> on.event ×3).
+
 > **For a fresh session.** Read this, then CLAUDE.md ("Multilingual parse rate ≠
 > fidelity" and "Running the multilingual `--regression` gate locally"), then
 > `docs-internal/HANDOFF_r1-role-fidelity.md` (RESOLVED — this arc picks up its

--- a/docs-internal/HANDOFF_r1-deferred-tail.md
+++ b/docs-internal/HANDOFF_r1-deferred-tail.md
@@ -1,0 +1,241 @@
+# Handoff: the R1 deferred tail (en-reference defects + render geometry)
+
+> **For a fresh session.** Read this, then CLAUDE.md ("Multilingual parse rate ≠
+> fidelity" and "Running the multilingual `--regression` gate locally"), then
+> `docs-internal/HANDOFF_r1-role-fidelity.md` (RESOLVED — this arc picks up its
+> "Family D outcomes" deferrals; its method and traps carry over verbatim) and
+> `docs-internal/HANDOFF_transformer-rendering.md` (RESOLVED — the per-command
+> i18n `rules` mechanism Family H below needs). Branch from `main` **after PR
+> #637 merges** (it landed the whole R1 arc: the `--triage-r1` tool, the
+> trailing-reclaim machinery, and the 2026-07-11 baseline this doc's numbers
+> come from).
+>
+> Working-tree note: `docs-internal/HANDOFF_top-level-command-sequences.md`
+> is a SEPARATE arc (top-level program truncation, #632's follow-up) — it may
+> still be untracked; don't fold it into this one. `patterns.db` is a local
+> `populate` artifact — never commit it; re-run `populate` before any probe.
+
+## Why this arc
+
+After the R1 arc (PR #637), the SOV six sit at: bn/ja **0.9938**, tr
+**0.9927**, ko **0.9905**, hi **0.9883**, qu **0.9792** avgRoleFidelity. The
+remaining misses are NOT parse-side pattern gaps — the R1 arc burned those
+down. What's left splits into two sub-arcs with **opposite disciplines**:
+
+- **Sub-arc 1 (en-reference defects, Families E/F):** the en reference parse
+  itself is broken on these rows, so every language "misses" against a junk
+  denominator. Fixing them **moves the denominator for all 24 languages** —
+  the R1/R3 dip-then-realign discipline applies (see Method).
+- **Sub-arc 2 (render geometry, Families G/H):** the i18n transformer
+  scrambles the SOV render so badly no scoped parse-side fix is honest.
+  These are i18n per-command-rule fixes (the #636 mechanism), which
+  re-render corpus rows — the corpus-rewrite discipline applies.
+
+Run `--triage-r1 --languages qu,ko,ja,tr,bn,hi` first (tool:
+`packages/testing-framework/src/multilingual/tools/triage-r1.ts`); the
+2026-07-11 residual is reproduced verbatim below so you can diff.
+
+## The families (2026-07-11 probes, verbatim — all pre-probed, trust these)
+
+### Family E — event-debounce: `${}` splits the URL token (×6, en-side)
+
+- Missing `fetch.source:literal`; captured instead `fetch.source:expression`.
+- **en's own capture is truncated**: `on input debounced at 300ms fetch
+  /api/search?q=${my value} as json …` → `fetch-en-simple
+  source:literal="/api/search?q=${my"` — the URL token ends at the WHITESPACE
+  inside `${my value}`. ja gets `fetch-ja-sov source:expression="}"` (junk).
+- Root: the URL extractor (`packages/semantic/src/tokenizers/extractors/url.ts`)
+  does not carry `${…}` interpolation spans. Fix there: when a `${` opens
+  inside a URL candidate, consume through the matching `}` (whitespace
+  included) before resuming the usual terminator scan.
+- This changes the **en value** → expect the R3 all-language realignment
+  (the "en-firestorm" — here it is the INTENDED signal, not a bug). After the
+  extractor fix, re-probe en + all six: the SOV sides should capture the same
+  full URL through their existing fetch patterns (`fetch-<lang>-sov` /
+  fused); if a language still junks, fix ITS side in the same increment —
+  never land the en-side change alone across a sweep boundary.
+- Check collateral: grep the corpus for other `${…}`-in-URL rows (patterns.db
+  `SELECT code_example_id FROM pattern_translations WHERE language='en' AND
+  hyperscript LIKE '%${%'`) — every hit realigns in the same increment.
+
+### Family F — pick-text-range: pick's roles are unmodeled (×6, en-side)
+
+- Missing `pick.patient:expression`; captured instead `pick.patient:literal`
+  (+ qu extras).
+- **en's own capture is degenerate**: `on click pick characters 0 to 5 of
+  #note` → `pick-en-generated patient:expression="characters"` — the first
+  WORD only. The range (`0 to 5`) and source (`#note`) are dropped because
+  `pickSchema` (`packages/semantic/src/generators/command-schemas.ts`) doesn't
+  model them.
+- Proper fix: extend pickSchema (e.g. patient = the unit word, quantity/
+  endQuantity or a range role, source = `of`-marked) + transformer render
+  check + SOV pattern variants. **This RAISES the en denominator** — all 24
+  languages dip on this row until each captures the new roles; budget the
+  whole 24-language realignment or don't start it. The ja render is already
+  scrambled (`characters 0 を クリック で 選択 5 の #note に` — range split
+  around the verb), so expect i18n rule work too. This is the most expensive
+  row in the tail for ×6 — consider deferring again unless pick matters for
+  a demo; if deferred, say so in NEXT_STEPS with this reasoning.
+
+### Family G — focus-trap: the focus operand leaks into the if-condition (ja/ko/qu)
+
+- Missing `focus.patient:expression`; captured instead `reference`(ja) /
+  `selector`(ko/qu) — the schema default / a fragment.
+- en: `if target matches last <button/> in .modal focus first <button/> in
+  .modal halt end` → `focus patient:expression="first <button/> in .modal"`.
+- ja probe: `conditional-ja-folded condition:expression="対象 一致する last
+  <button/> の 中 .modal first <button/> の"` — the condition consumed the
+  focus operand's HEAD; focus got `patient:reference=me`. ko/qu same shape
+  (`patient:selector=".modal"` — the tail fragment).
+- Root: SOV renders have **no boundary marker** between the if-condition and
+  the branch's first command operand (the verb is clause-final, so operand
+  runs abut). The conditional fold (`conditional-<lang>-folded` machinery)
+  over-consumes. Options, in preferred order: (a) i18n rule to render a
+  boundary the fold already respects; (b) a condition-END heuristic gated to
+  the corpus shape (a positional keyword `first/last` + tag-selector run at
+  the condition tail belongs to the NEXT command when a focus-class verb
+  closes the clause) — this abuts the event-anchor guard machinery (the
+  hottest path; #636 curated-end guards live there — do not weaken), so probe
+  exhaustively and keep the gate razor-thin.
+
+### Family H — form-submit-prevent: fused-clause scramble (×6 + tr/qu call)
+
+- Missing `halt.patient:reference` ×6; tr also `call.patient:expression`
+  (captured instead `call.patient:reference`); qu window-resize
+  `call.patient:expression` is the same root exercised elsewhere.
+- en: `on submit halt the event call validateForm() if result is false log
+  "Invalid form" end` → `halt patient:reference=event` + `call
+  patient:expression=validateForm()`.
+- ja probe: `the イベント 呼び出し validateForm() を 送信 で 停止 もし…` —
+  `the イベント` (halt's operand) is stranded clause-INITIAL, far from 停止;
+  halt captured ZERO roles. tr probe: `the olay çağır validateForm() i gönder
+  de durdur …` — call got `patient:reference=event` and halt got
+  `patient:expression=validateForm()` — **the two commands' operands are
+  swapped**.
+- Root is the TRANSFORMER: two juxtaposed commands (`halt the event` +
+  `call validateForm()`) are interleaved across the fused event clause.
+  Fix render-side with per-command `rules` in the i18n profiles
+  (`packages/i18n/src/grammar/profiles/index.ts` — the tr
+  `wait-oblique-verb-final` / `repeat-until-event-verb-final` rules from #636
+  are the template): keep `halt <patient>` adjacent and verb-final. A corpus
+  re-render follows — the corpus-rewrite discipline (attribute every
+  per-language delta; keep the pre-arc shape parseable with a legacy
+  tolerance if any pattern anchored on it).
+
+### qu-only tail (probe before choosing; some may be one-liners)
+
+- `go.destination:expression` + `scroll.destination:expression` — qu routes
+  go-url/last-in-collection through the verb-anchoring FALLBACK (not the
+  fused `*-sov-simple` patterns the other five match), so the R1-arc's
+  `tryAttachTrailingExpressionRole` reclaim never fires. Probe why the qu
+  fused patterns miss (marker? verb form?) — teaching the reclaim the
+  fallback path is the wrong layer; fixing the qu fused-pattern match is
+  scoped.
+- `put.patient:literal` ×2 (make-toast-element, on-custom-event-receive;
+  captured instead `expression`), `toggle.destination:expression`
+  (toggle-aria-expanded; captured instead `literal`), `call.patient` on
+  window-resize (three junk roles captured — see Family H).
+- `on.event:expression` ×2 (announce-screen-reader, on-custom-event-receive)
+  — reactive-head adjacent; treat as out of scope like ko/hi's unless a
+  Family G probe happens to explain them.
+
+### Explicitly OUT of scope (unchanged decisions)
+
+- **swap-content** (`swap.destination:selector`, bn/hi/qu/tr): F6 wontfix
+  (NEXT_STEPS § R3 families item 6) — do not chase without reopening it.
+- **ko/hi reactive `on.event` rows** (when-value-changes,
+  when-multiple-changes, window-resize): event-anchor guard machinery.
+
+## Residual triage (2026-07-11, the exact starting ledger)
+
+bn 4: E, H, F, swap. ja 4: E, G, H, F. tr 5: E, F, H(halt+call), swap.
+ko 6: E, G, H, F, on.event ×2. hi 7: E, H, F, swap, on.event ×3.
+qu 13: E, G, H(+window-resize call), F, swap, go, scroll, put ×2, toggle,
+on.event ×2.
+
+## Where the code lives
+
+- URL extractor: `packages/semantic/src/tokenizers/extractors/url.ts`
+  (registered via `getHyperscriptExtractors`, `extractor-helpers.ts`).
+- pickSchema: `packages/semantic/src/generators/command-schemas.ts`.
+- i18n per-command rules: `packages/i18n/src/grammar/profiles/index.ts`
+  (tr rules block ~525–562 is the #636 template; each SOV profile has its
+  own `rules` array).
+- Conditional fold: `conditional-<lang>-folded` — grep
+  `packages/semantic/src/patterns/` + the fold site in
+  `semantic-parser.ts`; probe before touching (Family G's warning).
+- The R1 arc's reclaim machinery (reuse, don't duplicate):
+  `tryAttachTrailingStyle`, `tryAttachTrailingExpressionRole`,
+  `tryAttachTrailingRole` in
+  `packages/semantic/src/parser/semantic-parser.ts`; pattern builders
+  `verbFinalOrRunWait` (wait.ts), `sovForBindingHead` (repeat.ts),
+  `set-qu-oblique-source` (set.ts).
+- Locks: `packages/semantic/test/multilingual-roadmap-fixes.test.ts` — the
+  R1 arc's describes ("R1 Family A/B/C/D…") show the current conventions
+  (self-contained describe, `collect`/`role`/`first` helpers, corpus-shaped
+  strings).
+
+## Method
+
+Inherited from the R1 + transformer-rendering arcs (probe full bodies, scoped
+fixes, per-family verification cycle, `--save-baseline` + line-by-line audit
+at the end, never commit patterns.db), PLUS the en-side discipline for
+Families E/F:
+
+1. An en-reference change moves the denominator for all 24 languages at
+   once. Fix en AND every language's capture **in the same increment** —
+   never land the en side alone. Mid-increment R1/R3 drops on the touched
+   rows are expected; the increment is done when the full sweep shows the
+   row realigned everywhere (or the residue is per-language triaged).
+2. The regression gate compares against the COMMITTED baseline — an en
+   enrichment will show as drops until `--save-baseline` at the increment
+   end. Read the sweep, don't trust the gate mid-increment; regenerate the
+   baseline per increment, audit the diff (every changed number must map to
+   the increment), commit baseline only.
+3. Families G/H re-render corpus rows (i18n changes): rebuild i18n + all
+   downstream (`test:multilingual:build-deps`), `populate`, and attribute
+   every per-language delta in the sweep before locking.
+
+Verification cycle (identical to the R1 arc):
+
+```bash
+npm run test:multilingual:build-deps
+npm run populate --prefix packages/patterns-reference
+cd packages/testing-framework
+npx tsx src/multilingual/cli.ts --full --bundle browser-priority --triage-r1 --languages qu,ko,ja,tr,bn,hi
+npx tsx src/multilingual/cli.ts --full --bundle browser-priority   # read EVERY signal
+npm test --prefix packages/semantic -- --run test/multilingual-roadmap-fixes.test.ts
+```
+
+## Traps
+
+- All of the R1 + transformer-rendering arcs' traps: prettier in lint-staged
+  bumps src mtimes AT COMMIT — rebuild before any post-commit sweep or
+  `--save-baseline` (it refuses on stale dists; `--triage-r1` only WARNS);
+  tsx probes need `process.exit(0)`; probes run with cwd inside the package.
+- **Full-body probes, not fragments**: in the R1 arc, the bare qu/bn/hi
+  for-head fragments parsed through a different path than the same head
+  inside the corpus body (locks had to use full rows). R1 scores the in-body
+  shape — probe and lock that.
+- The trailing reclaims (`tryAttachTrailingStyle`/`ExpressionRole`) fire at
+  BOTH the fused-event and parseClause sites — a new pattern that consumes
+  tokens the reclaims used to see changes their behavior; re-run the R1
+  Family A/D locks after any fetch/render/js/go/scroll-adjacent change.
+- ko's 로 doubles as style AND as-marker; ja `で` as style AND event marker;
+  the reclaims' response-word and action gates encode this — extend the
+  gates, don't remove them.
+- Never weaken the #636 curated-end guards (`matchRoleToken` ~564–580,
+  `isStrayTerminator`) — Family G work is adjacent to them.
+
+## Definition of done
+
+- Family E cleared in all six (+ en's URL capture whole; R3 realigned — no
+  row of the touched patterns below 1.0 in any language).
+- Family H cleared for the six (halt.patient:reference everywhere; tr/qu
+  call rows aligned); G cleared for ja/ko/qu or deferred with a probe-backed
+  reason; F fixed-or-deferred with reasoning recorded in NEXT_STEPS.
+- qu-only tail triaged: each row fixed or per-entry deferred (documented).
+- No drops in any other signal at increment ends; `--regression` green
+  against the regenerated baseline; unit locks per family; baseline
+  audited + committed (never patterns.db); this handoff marked resolved;
+  NEXT_STEPS updated.

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -120,13 +120,79 @@ COMPLETE.**
 **Post-launch track (ratchet-protected, not launch-blocking):** wait-payload
 spurious for ×3 (bn draggable/sortable/resizable — the unconsumed or-run
 payload), tr remove.patient block-walk leak, wait-line param leak ja,
-language-grammar.ts drift guard, and the R1-arc deferrals (event-debounce
-`${}` URL tokenization — also truncates the EN reference; pick range-role
-modeling; form-submit-prevent fused-clause scramble — render-side; focus-trap
-condition-boundary leak; see HANDOFF_r1-role-fidelity.md § Family D
-outcomes). The SOV-six role polish and the R1 long tail (fetch/render.style,
-qu set, or-run wait, beep/js/go/scroll/log/for) were cleared by the R1 arc
-(2026-07-11, below). The six-signal gate holds the bar — regressions fail CI.
+language-grammar.ts drift guard, and the two standing R1 deferrals (pick
+range-role modeling — Family F below; the reactive on.event rows). The
+R1-arc Family D deferrals (event-debounce `${}` URL truncation,
+form-submit-prevent fused-clause scramble, focus-trap condition-boundary
+leak) and the qu-only tail were cleared by the R1 deferred-tail arc
+(2026-07-11b, below); the SOV-six role polish and the R1 long tail
+(fetch/render.style, qu set, or-run wait, beep/js/go/scroll/log/for) by the
+R1 arc (2026-07-11, below). The six-signal gate holds the bar — regressions
+fail CI.
+
+> **Update 2026-07-11b (R1 deferred-tail arc, branch `fix/r1-deferred-tail`
+> — HANDOFF_r1-deferred-tail.md RESOLVED):** avgRoleFidelity ja 0.9938 →
+> **0.9978**, bn 0.9938 / tr 0.9927 → **0.9962**, ko 0.9905 → **0.9946**,
+> qu 0.9792 → **0.9936**, hi 0.9883 → **0.9907**. Four increments, sweeps
+> green after each (parse 3696/3696, R2 1.0, R3 loss only swap-content F6),
+> baseline regenerated + audited per increment:
+>
+> - **Family E (en-side, event-debounce ×6):** the URL extractor now carries
+>   `${…}` interpolation spans whole (balanced braces; unclosed `${` keeps
+>   the legacy whitespace cut), un-truncating the en reference. The en
+>   enrichment exposed two masked co-causes, fixed in-increment: the SOV
+>   `debounced at 300ms` head left `at 300ms` junk in the clause
+>   (untranslated `at` tokenizes identifier — extractStandaloneModifiers now
+>   skips one identifier preposition before a duration literal), and fused
+>   matches captured native event words registered only in
+>   eventNameTranslations as raw expressions (buildEventHandler now
+>   canonicalizes an exact table hit to the English literal; tr additionally
+>   registers boyutlandırma/kaydırma tokenizer keywords).
+> - **Family H (render-side, form-submit-prevent ×6 + tr call):**
+>   sovHaltCallFusedRule (shared factory, per-SOV-profile constants) splits
+>   the swept `halt <operand> call <args>` patient blob at the language's
+>   call verb and emits both commands verb-final joined by the
+>   then-connective. halt.patient:reference everywhere; row confidence
+>   0.5 → 1.0.
+> - **Family G (two-sided, focus-trap ja/ko/qu):** transformBlockBody emits
+>   the then-connective at the if-condition/branch seam (gated: SOV target +
+>   positional-headed branch + no existing then), and ja/ko/qu register
+>   their containment word (の中/안에/ukupi) as a whole keyword→`in` token —
+>   split, the fragments broke the generated focus pattern's operand run,
+>   and qu's stranded `pi` mis-read as the event marker. Bonus: the whole
+>   ukupi realigned qu last-in-collection (scroll.destination).
+> - **qu tail (5 rows):** single-quoted strings classify literal
+>   (put.patient ×2, byte-identical to en); toggle-qu-patient-first-dest
+>   covers the #636 verb-final render order (toggle-aria destination
+>   byte-identical to en); go-qu-url-dest re-types the fronted `url "/page"`
+>   pair as expression via ExtractionRule.transform — a documented field
+>   that was never wired, now honored in applyExtractionRules; interior `_`
+>   allowed in the qu keyword extractor's longest-first scan (gated to exact
+>   entries) so the dict's k_iri/hatun_kay compounds tokenize whole —
+>   window-resize now parses on.event:literal=resize + a clean
+>   call.patient:expression (the junk source/destination roles are gone).
+>
+> **Deferred, with reasons (the standing R1 tail):**
+>
+> - **pick-text-range (Family F, all six):** the en reference itself is
+>   degenerate (`pick.patient:expression="characters"` — the first WORD;
+>   pickSchema models no range/source roles), so chasing SOV parity buys
+>   nothing. The proper fix (pickSchema range roles + transformer render +
+>   SOV pattern variants) RAISES the en denominator for all 24 languages —
+>   the most expensive row in the tail for ×6 misses. Take it only if pick
+>   matters for a demo; budget the full 24-language realignment.
+> - **Reactive on.event rows (hi/ko when-value-changes +
+>   when-multiple-changes, hi window-resize, qu announce-screen-reader +
+>   on-custom-event-receive):** event-anchor guard machinery — the hottest
+>   parser path; unchanged out-of-scope decision. (hi window-resize is the
+>   आकार_बदलें `_`-split + बदलें→toggle homonym; the tr boyutlandırma
+>   rename precedent applies if ever taken.)
+> - **swap-content (bn/hi/qu/tr):** F6 wontfix, unchanged (§ R3 families
+>   item 6).
+>
+> Residual per-language misses: ja 1 (pick) · bn/tr 2 (pick, swap) · ko 3
+> (pick, on.event ×2) · qu 4 (pick, swap, on.event ×2) · hi 5 (pick, swap,
+> on.event ×3).
 
 > **Update 2026-07-11 (R1 role-fidelity arc, branch `fix/r1-role-fidelity-sov`
 > — HANDOFF_r1-role-fidelity.md RESOLVED):** avgRoleFidelity qu 0.9522 →

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -2591,3 +2591,40 @@ describe('SOV reorder stranding (transformer-rendering arc)', () => {
     expect(out.indexOf('qillqa manta')).toBeLessThan(out.indexOf('pointermove'));
   });
 });
+
+// The form-submit-prevent head fuses TWO juxtaposed commands (`halt the event
+// call validateForm()`); parseEventHandler sweeps both into one patient blob
+// and the SOV patient-first reorder fronted it whole — halt's operand stranded
+// clause-initial, call's operand riding with it (tr bound validateForm() to
+// halt and the event to call). sovHaltCallFusedRule splits the blob at the
+// language's call verb and emits both commands verb-final, joined by the
+// then-connective (R1 deferred-tail Family H,
+// docs-internal/HANDOFF_r1-deferred-tail.md).
+describe('SOV fused halt+call heads render both commands verb-final (Family H)', () => {
+  const src =
+    'on submit halt the event call validateForm() if result is false log "Invalid form" end';
+  const EXPECT: Array<[string, string]> = [
+    ['ja', 'the イベント を 送信 で 停止 それから validateForm() を 呼び出し'],
+    ['ko', 'the 이벤트 를 제출 할 때 정지 그러면 validateForm() 를 호출'],
+    ['tr', 'the olay i gönder de durdur ardından validateForm() i çağır'],
+    ['bn', 'the ঘটনা কে জমা এ থামুন তারপর validateForm() কে কল'],
+    ['hi', 'the घटना को जमा पर रोकें फिर validateForm() को कॉल'],
+    ['qu', 'the ruway ta kachay pi sayay chayqa validateForm() ta qayay'],
+  ];
+  for (const [lang, head] of EXPECT) {
+    it(`[${lang}] halt keeps its operand adjacent + verb-final; call follows the connective`, () => {
+      const out = new GrammarTransformer('en', lang).transform(src);
+      expect(out.startsWith(head)).toBe(true);
+    });
+  }
+
+  it('[ja] a plain `halt the event` handler keeps its default render (rule stands down)', () => {
+    const out = new GrammarTransformer('en', 'ja').transform('on submit halt the event');
+    expect(out.trim()).toBe('the イベント を 送信 で 停止');
+  });
+
+  it('[tr] a call-only handler keeps its default render (no halt — rule stands down)', () => {
+    const out = new GrammarTransformer('en', 'tr').transform('on click call myFunction()');
+    expect(out.trim()).toBe('myFunction() i tıklama de çağır');
+  });
+});

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -2628,3 +2628,35 @@ describe('SOV fused halt+call heads render both commands verb-final (Family H)',
     expect(out.trim()).toBe('myFunction() i tıklama de çağır');
   });
 });
+
+// SOV renders emit nothing between an if-condition's tail and a POSITIONAL-
+// headed branch operand (`… .modal 最初 <button/> …`), and the semantic fold's
+// command-start detection can't see that shape — the condition swallowed the
+// focus operand's head (focus-trap, ja/ko/qu). transformBlockBody now emits
+// the target's then-connective at the clause/body seam, gated to exactly the
+// blind shape (R1 deferred-tail Family G).
+describe('SOV if-blocks get a then-connective before a positional branch head (Family G)', () => {
+  const src =
+    'on keydown[key=="Tab"] from .modal if target matches last <button/> in .modal focus first <button/> in .modal halt end';
+  const SEAM: Array<[string, string]> = [
+    ['ja', '.modal それから 最初'],
+    ['ko', '.modal 그러면 첫번째'],
+    ['qu', '.modal chayqa ñawpaq'],
+    ['tr', '.modal ardından ilk'],
+    ['bn', '.modal তারপর প্রথম'],
+    ['hi', '.modal फिर पहला'],
+  ];
+  for (const [lang, seam] of SEAM) {
+    it(`[${lang}] focus-trap renders the connective at the condition/branch seam`, () => {
+      const out = new GrammarTransformer('en', lang).transform(src);
+      expect(out).toContain(seam);
+    });
+  }
+
+  it('[qu] a non-positional branch head gains no connective (form-submit if unchanged)', () => {
+    const out = new GrammarTransformer('en', 'qu').transform(
+      'on submit halt the event call validateForm() if result is false log "Invalid form" end'
+    );
+    expect(out).toContain('llulla "Invalid form" ta qillqakuy');
+  });
+});

--- a/packages/i18n/src/grammar/profiles/index.ts
+++ b/packages/i18n/src/grammar/profiles/index.ts
@@ -6,7 +6,7 @@
  * language-specific markers and rules.
  */
 
-import type { LanguageProfile, SemanticRole } from '../types';
+import type { GrammarRule, LanguageProfile, SemanticRole } from '../types';
 import { reorderRoles, insertMarkers } from '../types';
 
 // =============================================================================
@@ -46,6 +46,87 @@ export const englishProfile: LanguageProfile = {
     { form: 'for', role: 'duration', position: 'preposition', required: false },
   ],
 };
+
+// =============================================================================
+// Shared SOV rule factory — fused `halt the event call fn()` heads (Family H,
+// docs-internal/HANDOFF_r1-deferred-tail.md)
+// =============================================================================
+
+/**
+ * The form-submit-prevent head fuses TWO juxtaposed commands (`on submit halt
+ * the event call validateForm()`): parseEventHandler reads `halt` as the
+ * action and sweeps `the event call validateForm()` into ONE patient blob, so
+ * the SOV patient-first reorder fronts the whole blob — halt's operand lands
+ * clause-initial far from its verb, and call's operand rides inside the blob
+ * (tr bound validateForm() to halt and the event to call). No roleOrder can
+ * fix a single-blob patient; this custom render splits the blob at the
+ * language's call verb and emits both commands verb-final, joined by the
+ * then-connective (the boundary the semantic compound-splitter already
+ * respects — the event-debounce geometry):
+ *
+ *   `<halt-operand> <pm> <event> <em> <halt-verb> <conn> <call-args> <pm> <call-verb>`
+ *
+ * The trailing EVENTBLOCKPLACEHOLDER (tryTransformEventWithBlockBody's mask
+ * for an `if … end` tail) is re-emitted clause-final so the caller's
+ * strip-and-append keeps working.
+ */
+function sovHaltCallFusedRule(cfg: {
+  callVerb: string; // the dictionary's call rendering — the blob split point
+  patientMarker: string;
+  eventMarker: string;
+  connective: string;
+}): GrammarRule {
+  return {
+    name: 'halt-call-fused-verb-final',
+    description: 'Split the swept `halt <operand> call <args>` blob; both verbs clause-final',
+    priority: 95,
+    match: {
+      commands: ['halt'],
+      requiredRoles: ['action', 'event', 'patient'],
+      // Only the juxtaposed-call blob: a plain `halt`/`halt the event` handler
+      // keeps its default render. The translated call verb must be present to
+      // split on — if the dictionary emission drifts, the rule stands down
+      // rather than emitting a mangled clause.
+      predicate: parsed => {
+        const p = parsed.roles.get('patient');
+        return (
+          !!p && /\bcall\b/.test(p.value) && !!p.translated && p.translated.includes(cfg.callVerb)
+        );
+      },
+    },
+    transform: {
+      roleOrder: [], // unused — custom takes over
+      custom: parsed => {
+        const p = parsed.roles.get('patient')!;
+        const ev = parsed.roles.get('event')!;
+        const act = parsed.roles.get('action')!;
+        let blob = (p.translated ?? p.value).trim();
+        const PH = 'EVENTBLOCKPLACEHOLDER';
+        let tail = '';
+        if (blob.endsWith(PH)) {
+          blob = blob.slice(0, -PH.length).trim();
+          tail = ` ${PH}`;
+        }
+        const at = blob.indexOf(cfg.callVerb);
+        const haltOperand = blob.slice(0, at).trim();
+        const callArgs = blob.slice(at + cfg.callVerb.length).trim();
+        return (
+          [
+            haltOperand,
+            cfg.patientMarker,
+            ev.translated ?? ev.value,
+            cfg.eventMarker,
+            act.translated ?? act.value,
+            cfg.connective,
+            callArgs,
+            cfg.patientMarker,
+            cfg.callVerb,
+          ].join(' ') + tail
+        );
+      },
+    },
+  };
+}
 
 // =============================================================================
 // Japanese (SOV, Postpositions)
@@ -140,6 +221,13 @@ export const japaneseProfile: LanguageProfile = {
         insertMarkers: true,
       },
     },
+    // the イベント を 送信 で 停止 それから validateForm() を 呼び出し
+    sovHaltCallFusedRule({
+      callVerb: '呼び出し',
+      patientMarker: 'を',
+      eventMarker: 'で',
+      connective: 'それから',
+    }),
   ],
 };
 
@@ -248,6 +336,13 @@ export const koreanProfile: LanguageProfile = {
         insertMarkers: true,
       },
     },
+    // the 이벤트 를 제출 할 때 정지 그러면 validateForm() 를 호출
+    sovHaltCallFusedRule({
+      callVerb: '호출',
+      patientMarker: '를',
+      eventMarker: '할 때',
+      connective: '그러면',
+    }),
   ],
 };
 
@@ -560,6 +655,13 @@ export const turkishProfile: LanguageProfile = {
         insertMarkers: true,
       },
     },
+    // the olay i gönder de durdur ardından validateForm() i çağır
+    sovHaltCallFusedRule({
+      callVerb: 'çağır',
+      patientMarker: 'i',
+      eventMarker: 'de',
+      connective: 'ardından',
+    }),
   ],
 };
 
@@ -772,6 +874,13 @@ export const quechuaProfile: LanguageProfile = {
         insertMarkers: true,
       },
     },
+    // the ruway ta kachay pi sayay chayqa validateForm() ta qayay
+    sovHaltCallFusedRule({
+      callVerb: 'qayay',
+      patientMarker: 'ta',
+      eventMarker: 'pi',
+      connective: 'chayqa',
+    }),
   ],
 };
 
@@ -897,6 +1006,13 @@ export const bengaliProfile: LanguageProfile = {
         insertMarkers: true,
       },
     },
+    // the ঘটনা কে জমা এ থামুন তারপর validateForm() কে কল
+    sovHaltCallFusedRule({
+      callVerb: 'কল',
+      patientMarker: 'কে',
+      eventMarker: 'এ',
+      connective: 'তারপর',
+    }),
   ],
 };
 
@@ -1110,6 +1226,13 @@ export const hindiProfile: LanguageProfile = {
         insertMarkers: true,
       },
     },
+    // the घटना को जमा पर रोकें फिर validateForm() को कॉल
+    sovHaltCallFusedRule({
+      callVerb: 'कॉल',
+      patientMarker: 'को',
+      eventMarker: 'पर',
+      connective: 'फिर',
+    }),
   ],
 };
 

--- a/packages/i18n/src/grammar/transformer.ts
+++ b/packages/i18n/src/grammar/transformer.ts
@@ -2369,7 +2369,28 @@ export class GrammarTransformer {
     const clauseT = clause ? translateMultiWordValue(clause, src, dst) : '';
     const bodyT = this.transformConditionalBody(bodyTokens);
 
-    return [headT, clauseT, bodyT, tailT].filter(s => s.length > 0).join(' ');
+    // SOV condition/branch boundary (R1 deferred-tail Family G): the SOV body
+    // renders its first command operand-first (`最初 <button/> の中 .modal を
+    // フォーカス`), so nothing marks where the condition ends and the branch
+    // operand begins — the semantic fold's command-start detection needs a
+    // `{value}{particle}` run followed by a verb, which a POSITIONAL-headed
+    // operand (`first <button/> …`) never forms, and the condition scan
+    // swallows the operand's head (focus-trap: ja focus.patient fell to the
+    // `me` default, ko/qu to the `.modal` tail). Emit the target's
+    // then-connective at the seam — the boundary the fold already respects
+    // (isThenKeyword) — gated to exactly the blind shape: SOV target, a
+    // positional keyword right after the branch's command verb, and no `then`
+    // already ending the condition.
+    const POSITIONAL_BRANCH_HEADS = new Set(['first', 'last', 'next', 'previous', 'closest']);
+    const thenT =
+      this.targetProfile.wordOrder === 'SOV' &&
+      clauseT &&
+      POSITIONAL_BRANCH_HEADS.has(bodyTokens[1]?.toLowerCase()) &&
+      inner[bodyStart - 1]?.toLowerCase() !== 'then'
+        ? translateWord('then', src, dst)
+        : '';
+
+    return [headT, clauseT, thenT, bodyT, tailT].filter(s => s.length > 0).join(' ');
   }
 
   /**

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -2487,20 +2487,31 @@ export class PatternMatcher {
   }
 
   /**
-   * Apply extraction rules to fill in static values and defaults for missing roles.
+   * Apply extraction rules to fill in static values and defaults for missing
+   * roles, and re-shape captured roles that declare a `transform` (the
+   * ExtractionRule field was documented but unwired — go-qu-url-dest is the
+   * first consumer: it re-types the marker-bound capture to the expression
+   * shape the en reference produces).
    */
   private applyExtractionRules(
     pattern: LanguagePattern,
     captured: Map<SemanticRole, SemanticValue>
   ): void {
     for (const [role, rule] of Object.entries(pattern.extraction)) {
-      if (!captured.has(role as SemanticRole)) {
-        if (rule.value !== undefined) {
-          // Static value extraction (e.g., action: { value: "toggle" })
-          captured.set(role as SemanticRole, { type: 'literal', value: rule.value });
-        } else if (rule.default) {
-          captured.set(role as SemanticRole, rule.default);
+      const existing = captured.get(role as SemanticRole);
+      if (existing) {
+        if (rule.transform) {
+          const raw =
+            existing.type === 'literal'
+              ? String(existing.value)
+              : String((existing as { raw?: unknown }).raw ?? '');
+          captured.set(role as SemanticRole, rule.transform(raw));
         }
+      } else if (rule.value !== undefined) {
+        // Static value extraction (e.g., action: { value: "toggle" })
+        captured.set(role as SemanticRole, { type: 'literal', value: rule.value });
+      } else if (rule.default) {
+        captured.set(role as SemanticRole, rule.default);
       }
     }
   }

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -1287,9 +1287,40 @@ export class SemanticParserImpl implements ISemanticParser {
     }
 
     // Extract the event name
-    const eventValue = match.captured.get('event');
+    let eventValue = match.captured.get('event');
     if (!eventValue) {
       throw new Error('Event handler pattern matched but no event captured');
+    }
+
+    // Canonicalize a native-word event capture. The fused *-sov-simple patterns
+    // bind the {event} token AS TOKENIZED, so a native event word registered
+    // only in eventNameTranslations (ja サイズ変更, ko 리사이즈, bn রিসাইজ) —
+    // not as a tokenizer keyword — lands raw and expression-typed, while the
+    // SOV-extraction path resolves it to the English literal. Which path ran
+    // was decided by junk ahead of the clause (the `debounced at 300ms` head),
+    // so the typing was path-incidental (window-resize R1). Gate to an exact
+    // table hit (→ English literal, the handler convention) or a bare
+    // KNOWN_EVENTS word typed expression (→ literal, same word); a genuine
+    // reactive/expression head (`my value`, parenthesized params) matches
+    // neither and is byte-identical.
+    {
+      const word =
+        eventValue.type === 'expression'
+          ? (eventValue as { raw?: unknown }).raw
+          : eventValue.type === 'literal'
+            ? eventValue.value
+            : undefined;
+      if (typeof word === 'string' && /^[^\s()[\]{}:]+$/.test(word)) {
+        const english = eventNameTranslations[language]?.[word];
+        if (english) {
+          eventValue = { type: 'literal', value: english, dataType: 'string' };
+        } else if (
+          eventValue.type === 'expression' &&
+          SemanticParserImpl.KNOWN_EVENTS.has(word.toLowerCase())
+        ) {
+          eventValue = { type: 'literal', value: word.toLowerCase(), dataType: 'string' };
+        }
+      }
     }
 
     // Extract event modifiers (.once, .debounce(), .throttle(), etc.)
@@ -5076,8 +5107,22 @@ export class SemanticParserImpl implements ISemanticParser {
       // Skip preposition tokens (sa, عند, at, etc.)
       if (nextIdx < allTokens.length) {
         const nextToken = allTokens[nextIdx];
-        // Skip keyword/particle tokens that are prepositions (not selectors, literals, etc.)
-        if (nextToken.kind === 'keyword' || nextToken.kind === 'particle') {
+        // Skip keyword/particle tokens that are prepositions (not selectors, literals, etc.).
+        // The SOV renders keep the en preposition untranslated (`debounced at
+        // 300ms …`), where `at` tokenizes as a bare IDENTIFIER — left in place
+        // it strands `at 300ms` junk at the clause head and the fused parse
+        // loses its trailing reclaims (event-debounce responseType). Skip one
+        // identifier only when a duration-shaped literal directly follows.
+        const after = allTokens[nextIdx + 1];
+        const identifierPreposition =
+          nextToken.kind === 'identifier' &&
+          after?.kind === 'literal' &&
+          /^\d+(ms|s|m)?$/.test(after.value);
+        if (
+          nextToken.kind === 'keyword' ||
+          nextToken.kind === 'particle' ||
+          identifierPreposition
+        ) {
           nextIdx++;
           tokensToSkip++;
         }

--- a/packages/semantic/src/patterns/grammar-transformed.ts
+++ b/packages/semantic/src/patterns/grammar-transformed.ts
@@ -1,8 +1,9 @@
 /**
  * Grammar-Transformed Patterns (Consolidated)
  *
- * Patterns for SOV/VSO grammar-transformed output.
- * Currently all languages rely on auto-generation from profiles.
+ * Patterns for SOV/VSO grammar-transformed output that the schema generators
+ * don't cover. Most languages rely on auto-generation from profiles; entries
+ * here are corpus-shaped one-offs.
  *
  * Phase 3.2: Consolidated from 4 files into single file.
  */
@@ -13,7 +14,37 @@ import type { LanguagePattern } from '../types';
  * Get grammar-transformed patterns for a specific language.
  */
 export function getGrammarTransformedPatternsForLanguage(language: string): LanguagePattern[] {
-  // All languages currently rely on auto-generated patterns
-  void language;
+  if (language === 'qu') {
+    return [
+      // go-url: the qu render fronts the whole destination phrase (`url
+      // "/page" man ñitiy pi riy`); the generated `go-qu-generated`
+      // ({destination} man riy) skipped the leading `url` word as noise and
+      // bound only the quoted string — destination:literal vs the en
+      // reference's destination:expression (R1 deferred-tail qu tail).
+      // Anchoring the `url` head keeps the pair together and re-types the
+      // capture as the expression the en side produces.
+      {
+        id: 'go-qu-url-dest',
+        language: 'qu',
+        command: 'go',
+        priority: 105,
+        template: {
+          format: 'url {destination} man riy',
+          tokens: [
+            { type: 'literal', value: 'url' },
+            { type: 'role', role: 'destination', expectedTypes: ['literal', 'expression'] },
+            { type: 'literal', value: 'man', alternatives: ['pa'] },
+            { type: 'literal', value: 'riy', alternatives: ['puriy'] },
+          ],
+        },
+        extraction: {
+          destination: {
+            position: 1,
+            transform: raw => ({ type: 'expression', raw: `url ${raw}` }),
+          },
+        },
+      },
+    ];
+  }
   return [];
 }

--- a/packages/semantic/src/patterns/repeat.ts
+++ b/packages/semantic/src/patterns/repeat.ts
@@ -207,8 +207,11 @@ const FOR_IN_HEADS: Array<[string, { forWords?: string[]; inWords: string[] }]> 
   ['he', { forWords: ['עבור', 'את'], inWords: ['in'] }],
   ['hi', { inWords: ['में'] }],
   ['bn', { inWords: ['এ'] }],
-  ['ja', { inWords: ['の', '中'] }],
-  ['ko', { inWords: ['안', '에'] }],
+  // ja/ko/qu containment words tokenize WHOLE (keyword→in entries added for
+  // the focus-trap Family G operand run) — the old split forms (の+中, 안+에,
+  // uku+pi) no longer appear in the stream.
+  ['ja', { inWords: ['の中'] }],
+  ['ko', { inWords: ['안에'] }],
   ['zh', { forWords: ['为', '把'], inWords: ['在'] }],
   ['tr', { inWords: ['içinde'] }],
   ['id', { forWords: ['untuk'], inWords: ['dalam'] }],
@@ -217,7 +220,7 @@ const FOR_IN_HEADS: Array<[string, { forWords?: string[]; inWords: string[] }]> 
   ['th', { forWords: ['สำหรับ'], inWords: ['ใน'] }],
   ['vi', { forWords: ['với mỗi'], inWords: ['trong'] }],
   ['tl', { forWords: ['para_sa'], inWords: ['sa_loob'] }],
-  ['qu', { inWords: ['uku', 'pi'] }],
+  ['qu', { inWords: ['ukupi'] }],
 ];
 
 /**
@@ -562,10 +565,12 @@ function sovForBindingHead(
 const SOV_FOR_BINDING_HEADS: Array<
   [string, { inWords: string[]; objMarker: string; forVerb: string }]
 > = [
-  ['ja', { inWords: ['の', '中'], objMarker: 'を', forVerb: 'ために' }],
-  ['ko', { inWords: ['안', '에'], objMarker: '를', forVerb: '각각' }],
+  // ja/ko/qu in-words are single whole tokens now (keyword→in entries — see
+  // the FOR_IN_HEADS note); the split forms are gone from the stream.
+  ['ja', { inWords: ['の中'], objMarker: 'を', forVerb: 'ために' }],
+  ['ko', { inWords: ['안에'], objMarker: '를', forVerb: '각각' }],
   ['tr', { inWords: ['içinde'], objMarker: 'i', forVerb: 'için' }],
-  ['qu', { inWords: ['uku', 'pi'], objMarker: 'ta', forVerb: 'sapankaq' }],
+  ['qu', { inWords: ['ukupi'], objMarker: 'ta', forVerb: 'sapankaq' }],
   ['bn', { inWords: ['এ'], objMarker: 'কে', forVerb: 'জন্য' }],
   ['hi', { inWords: ['में'], objMarker: 'को', forVerb: 'हेतु' }],
 ];

--- a/packages/semantic/src/patterns/toggle.ts
+++ b/packages/semantic/src/patterns/toggle.ts
@@ -435,6 +435,33 @@ function getTogglePatternsQu(): LanguagePattern[] {
         patient: { position: 2 },
       },
     },
+    // Patient-first with trailing destination: .open ta qhipantin .panel man
+    // t'ikray — the i18n full verb-final order (#636 qu canonicalOrder) puts
+    // the destination AFTER the patient, but every dest-bearing variant above
+    // is destination-first, so the shape fell to the verb-anchoring fallback,
+    // which glued the positional run (destination:literal="qhipantin.panel"
+    // vs en destination:expression="next .panel") — toggle-aria-expanded,
+    // R1 deferred-tail qu tail.
+    {
+      id: 'toggle-qu-patient-first-dest',
+      language: 'qu',
+      command: 'toggle',
+      priority: 102,
+      template: {
+        format: "{patient} ta {destination} man t'ikray",
+        tokens: [
+          { type: 'role', role: 'patient' },
+          { type: 'literal', value: 'ta' },
+          { type: 'role', role: 'destination' },
+          { type: 'literal', value: 'man', alternatives: ['pa'] },
+          { type: 'literal', value: "t'ikray", alternatives: ['tikray', 'kutichiy'] },
+        ],
+      },
+      extraction: {
+        patient: { position: 0 },
+        destination: { position: 2 },
+      },
+    },
   ];
 }
 

--- a/packages/semantic/src/tokenizers/extractors/quechua-keyword.ts
+++ b/packages/semantic/src/tokenizers/extractors/quechua-keyword.ts
@@ -157,10 +157,15 @@ export class QuechuaKeywordExtractor implements ContextAwareExtractor {
       const after = input[startPos + len];
       if (after !== undefined && isQuechuaLetter(after)) continue;
 
-      // Check all chars are Quechua
+      // Check all chars are Quechua. An interior `_` is allowed so the dict's
+      // underscore compounds (k_iri, hatun_kay — exact keyword entries) can
+      // match whole; a compound with no entry fails the lookup below and falls
+      // through to the word-walk, splitting at `_` exactly as before.
       let allQuechua = true;
       for (let i = 0; i < candidate.length; i++) {
-        if (!isQuechuaLetter(candidate[i])) {
+        const ch = candidate[i];
+        if (ch === '_' && i > 0 && i < candidate.length - 1) continue;
+        if (!isQuechuaLetter(ch)) {
           allQuechua = false;
           break;
         }

--- a/packages/semantic/src/tokenizers/extractors/url.ts
+++ b/packages/semantic/src/tokenizers/extractors/url.ts
@@ -7,38 +7,49 @@
 
 import type { ValueExtractor, ExtractionResult } from '../value-extractor-types';
 
+const URL_PREFIXES = ['http://', 'https://', '//', './', '../', '/'];
+
+/**
+ * Find the index just past the `}` that closes a `${` whose `{` sits at
+ * `start - 1`. Inner braces are balanced; returns -1 if it never closes.
+ */
+function findInterpolationEnd(input: string, start: number): number {
+  let depth = 1;
+  for (let i = start; i < input.length; i++) {
+    const ch = input[i];
+    if (ch === '{') depth++;
+    else if (ch === '}' && --depth === 0) return i + 1;
+  }
+  return -1;
+}
+
 /**
  * Extract a URL from input at position.
  * Handles: /path, ./path, ../path, //domain.com, http://, https://
  */
 export function extractUrl(input: string, position: number): string | null {
   const remaining = input.slice(position);
+  const prefix = URL_PREFIXES.find(p => remaining.startsWith(p));
+  if (!prefix) return null;
 
-  // Absolute URL: http:// or https://
-  if (remaining.startsWith('http://') || remaining.startsWith('https://')) {
-    const match = remaining.match(/^https?:\/\/[^\s]*/);
-    return match ? match[0] : null;
+  // Consume to the first whitespace, except that a `${…}` interpolation span
+  // is carried whole — the space inside `/api/search?q=${my value}` is part
+  // of the URL, not a token boundary.
+  let i = prefix.length;
+  while (i < remaining.length) {
+    const ch = remaining[i];
+    if (ch === '$' && remaining[i + 1] === '{') {
+      const end = findInterpolationEnd(remaining, i + 2);
+      if (end !== -1) {
+        i = end;
+        continue;
+      }
+      // Unclosed `${` — no span to carry; the plain scan below applies.
+    }
+    if (/\s/.test(ch)) break;
+    i++;
   }
-
-  // Protocol-relative URL: //domain.com
-  if (remaining.startsWith('//')) {
-    const match = remaining.match(/^\/\/[^\s]*/);
-    return match ? match[0] : null;
-  }
-
-  // Relative paths: ./path or ../path
-  if (remaining.startsWith('./') || remaining.startsWith('../')) {
-    const match = remaining.match(/^\.\.?\/[^\s]*/);
-    return match ? match[0] : null;
-  }
-
-  // Absolute path: /path
-  if (remaining.startsWith('/')) {
-    const match = remaining.match(/^\/[^\s]*/);
-    return match ? match[0] : null;
-  }
-
-  return null;
+  return remaining.slice(0, i);
 }
 
 /**

--- a/packages/semantic/src/tokenizers/japanese.ts
+++ b/packages/semantic/src/tokenizers/japanese.ts
@@ -84,6 +84,12 @@ const JAPANESE_EXTRAS: KeywordEntry[] = [
   { native: '前', normalized: 'previous' },
   { native: '最も近い', normalized: 'closest' },
   { native: '親', normalized: 'parent' },
+  // Containment (`first <button/> in .modal`): the i18n dict emits の中, which
+  // otherwise splits の(particle) + 中(identifier) — the stray identifier broke
+  // the generated focus pattern's operand run (focus-trap Family G; tr/bn/hi
+  // work because their in-word is one token). Whole-token entry mirrors en's
+  // keyword `in` mid-run geometry.
+  { native: 'の中', normalized: 'in' },
 
   // Events
   { native: 'クリック', normalized: 'click' },

--- a/packages/semantic/src/tokenizers/korean.ts
+++ b/packages/semantic/src/tokenizers/korean.ts
@@ -95,6 +95,11 @@ const KOREAN_EXTRAS: KeywordEntry[] = [
   { native: '이전', normalized: 'previous' },
   { native: '가장가까운', normalized: 'closest' },
   { native: '부모', normalized: 'parent' },
+  // Containment (`first <button/> in .modal`): the i18n dict emits 안에, which
+  // otherwise splits 안(identifier) + 에(particle) — the stray identifier broke
+  // the generated focus pattern's operand run (focus-trap Family G). Whole-token
+  // entry mirrors en's keyword `in` mid-run geometry.
+  { native: '안에', normalized: 'in' },
 
   // Events
   { native: '클릭', normalized: 'click' },

--- a/packages/semantic/src/tokenizers/quechua.ts
+++ b/packages/semantic/src/tokenizers/quechua.ts
@@ -154,6 +154,13 @@ const QUECHUA_EXTRAS: KeywordEntry[] = [
   // longest-first cure). Whole-token entry mirrors en's keyword `in` mid-run
   // geometry (focus-trap Family G).
   { native: 'ukupi', normalized: 'in' },
+  // window-resize compounds: the dict emits underscore-joined k_iri (window)
+  // and hatun_kay (resize), which the `_` split shattered into junk role
+  // fragments (call.source:literal="k_iri" destination:literal="hatun_" —
+  // the qu window-resize R1 row; hatun_kay sits in eventNameTranslations but
+  // never arrived whole). The ñawpaq_kaq entry above is the precedent.
+  { native: 'k_iri', normalized: 'window' },
+  { native: 'hatun_kay', normalized: 'resize' },
   { native: 'qaylla', normalized: 'closest' },
   { native: 'tayta', normalized: 'parent' },
 
@@ -280,7 +287,13 @@ export class QuechuaTokenizer extends BaseTokenizer {
       token.startsWith('<')
     )
       return 'selector';
-    if (token.startsWith('"')) return 'literal';
+    // Both ASCII quote forms: the corpus renders single-quoted strings
+    // (`'Saved!' ta chay man churay`, make-toast) and the string extractor
+    // already carries them whole — but only `"` classified as literal, so the
+    // single-quoted value fell to identifier → put.patient:expression with the
+    // quotes kept, vs en literal:"Saved!" (R1 deferred-tail qu tail). Safe for
+    // glottalized words (t'ikray): their apostrophe is never token-INITIAL.
+    if (token.startsWith('"') || token.startsWith("'")) return 'literal';
     if (/^\d/.test(token)) return 'literal';
     if (['==', '!=', '<=', '>=', '<', '>', '&&', '||', '!'].includes(token)) return 'operator';
 

--- a/packages/semantic/src/tokenizers/quechua.ts
+++ b/packages/semantic/src/tokenizers/quechua.ts
@@ -148,6 +148,12 @@ const QUECHUA_EXTRAS: KeywordEntry[] = [
   // aswan-prefixed compound splits (the suffix extractor strips -wan from
   // 'aswan'). The i18n dict emits bare 'kaylla' (near/close).
   { native: 'kaylla', normalized: 'closest' },
+  // Containment (`first <button/> in .modal`): the i18n dict emits ukupi,
+  // which otherwise splits uku(identifier) + pi — and the stranded `pi`
+  // mis-reads as the EVENT marker (the ñawpaqpi/qhepapi class above; same
+  // longest-first cure). Whole-token entry mirrors en's keyword `in` mid-run
+  // geometry (focus-trap Family G).
+  { native: 'ukupi', normalized: 'in' },
   { native: 'qaylla', normalized: 'closest' },
   { native: 'tayta', normalized: 'parent' },
 

--- a/packages/semantic/src/tokenizers/turkish.ts
+++ b/packages/semantic/src/tokenizers/turkish.ts
@@ -136,6 +136,19 @@ const TURKISH_EXTRAS: KeywordEntry[] = [
   { native: 'farebirak', normalized: 'mouseup' },
   { native: 'kaydır', normalized: 'scroll' },
   { native: 'kaydir', normalized: 'scroll' },
+  // resize/scroll nominal forms: listed in eventNameTranslations (which only
+  // the SOV-extraction path consults) but not registered as keywords — so a
+  // fused *-sov-simple match captured them RAW (`boyutlandırma de çağır` →
+  // event:expression:boyutlandırma, the window-resize R1 flip once the
+  // debounced-head junk no longer forced the SOV-extraction path). Keyword
+  // entries normalize them at the token, the same route the healthy natives
+  // (tıklama→click) take.
+  { native: 'boyutlandırma', normalized: 'resize' },
+  { native: 'boyutlandirma', normalized: 'resize' },
+  { native: 'boyutlandır', normalized: 'resize' },
+  { native: 'boyutlandir', normalized: 'resize' },
+  { native: 'kaydırma', normalized: 'scroll' },
+  { native: 'kaydirma', normalized: 'scroll' },
   { native: 'tuş_bas', normalized: 'keydown' },
   { native: 'tus_bas', normalized: 'keydown' },
   { native: 'tuş_bırak', normalized: 'keyup' },

--- a/packages/semantic/test/extractors/url.test.ts
+++ b/packages/semantic/test/extractors/url.test.ts
@@ -1,0 +1,64 @@
+/**
+ * UrlExtractor Tests
+ *
+ * Covers `${…}` interpolation spans inside URLs: the whitespace-terminator
+ * scan used to cut `/api/search?q=${my value}` at the space inside the
+ * interpolation, truncating the en reference for event-debounce and junking
+ * every SOV parse of the same row (R1 deferred-tail Family E,
+ * docs-internal/HANDOFF_r1-deferred-tail.md). A `${` that opens inside a URL
+ * candidate is consumed through its matching `}` — whitespace and balanced
+ * inner braces included — before the plain scan resumes. An UNCLOSED `${`
+ * carries no span and keeps the legacy stop-at-whitespace behavior.
+ */
+import { describe, it, expect } from 'vitest';
+import { extractUrl, UrlExtractor } from '../../src/tokenizers/extractors/url';
+
+describe('extractUrl — plain URLs (legacy behavior unchanged)', () => {
+  it('extracts each prefix form to the first whitespace', () => {
+    expect(extractUrl('/api/data then log it', 0)).toBe('/api/data');
+    expect(extractUrl('./rel/path x', 0)).toBe('./rel/path');
+    expect(extractUrl('../up/path x', 0)).toBe('../up/path');
+    expect(extractUrl('//cdn.example.com/lib.js x', 0)).toBe('//cdn.example.com/lib.js');
+    expect(extractUrl('http://x.com/a b', 0)).toBe('http://x.com/a');
+    expect(extractUrl('https://x.com/a b', 0)).toBe('https://x.com/a');
+  });
+
+  it('returns the bare prefix when nothing follows', () => {
+    expect(extractUrl('/ alone', 0)).toBe('/');
+  });
+
+  it('returns null off a URL prefix', () => {
+    expect(extractUrl('.active on me', 0)).toBeNull();
+  });
+});
+
+describe('extractUrl — ${…} interpolation spans (Family E)', () => {
+  it('carries a whitespace-bearing interpolation whole (the event-debounce shape)', () => {
+    expect(extractUrl('/api/search?q=${my value} as json', 0)).toBe('/api/search?q=${my value}');
+  });
+
+  it('carries spans in absolute and relative forms, resuming the plain scan after', () => {
+    expect(extractUrl('https://x.com/a?b=${c d}&e=1 rest', 0)).toBe('https://x.com/a?b=${c d}&e=1');
+    expect(extractUrl('./rel/${a b}/tail x', 0)).toBe('./rel/${a b}/tail');
+  });
+
+  it('balances inner braces inside the span', () => {
+    expect(extractUrl('/api?q=${fn({a:1}) ok}z w', 0)).toBe('/api?q=${fn({a:1}) ok}z');
+  });
+
+  it('an unclosed ${ keeps the legacy whitespace cut', () => {
+    expect(extractUrl('/api?q=${unclosed rest', 0)).toBe('/api?q=${unclosed');
+  });
+
+  it('a bare $ without { is an ordinary URL character', () => {
+    expect(extractUrl('/api?price=$5 x', 0)).toBe('/api?price=$5');
+  });
+});
+
+describe('UrlExtractor — extract() length spans the interpolation', () => {
+  it('reports the full span length so the tokenizer consumes past the inner space', () => {
+    const r = new UrlExtractor().extract('/api/search?q=${my value} as json', 0);
+    expect(r?.value).toBe('/api/search?q=${my value}');
+    expect(r?.length).toBe('/api/search?q=${my value}'.length);
+  });
+});

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -13638,3 +13638,59 @@ describe('R1 deferred-tail Family H: fused halt+call renders verb-final and pars
     expect(role(call, 'patient')).toMatchObject({ type: 'expression', raw: 'validateForm()' });
   });
 });
+
+describe('R1 deferred-tail Family G: SOV focus-trap branch operand survives the fold (docs-internal/HANDOFF_r1-deferred-tail.md)', () => {
+  // focus-trap: en `if target matches last <button/> in .modal focus first
+  // <button/> in .modal halt end` → focus.patient:expression. SOV renders had
+  // no boundary between the condition tail and the positional-headed branch
+  // operand, so the fold's condition scan swallowed the operand head (ja fell
+  // to the `me` default, ko/qu to the `.modal` tail). Two-sided fix: the
+  // transformer emits the then-connective at the seam (the fold's
+  // isThenKeyword boundary), and ja/ko/qu register their containment word
+  // (の中/안에/ukupi) as a whole `in` keyword — split, its fragments broke the
+  // generated focus pattern's operand run (qu's stranded `pi` even read as
+  // the event marker). Corpus strings are the re-rendered rows.
+  const CHILD_FIELDS = ['body', 'statements', 'thenBranch', 'elseBranch', 'branches'];
+  const collect = (node: unknown): Record<string, any>[] => {
+    const flat: Record<string, any>[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec);
+      for (const f of CHILD_FIELDS) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return flat;
+  };
+  const role = (n: Record<string, any> | undefined, r: string): any =>
+    n && n.roles instanceof Map ? n.roles.get(r) : undefined;
+
+  const ROWS: Array<[string, string]> = [
+    ['ja', 'keydown[key=="Tab"] で .modal から もし 対象 一致する 最後 <button/> の中 .modal それから 最初 <button/> の中 .modal を フォーカス それから 停止 終わり'],
+    ['ko', 'keydown[key=="Tab"] 할 때 .modal 에서 만약 대상 일치 마지막 <button/> 안에 .modal 그러면 첫번째 <button/> 안에 .modal 를 포커스 그러면 정지 끝'],
+    ['qu', '.modal manta keydown[key=="Tab"] pi sichus punta tupan qhipa <button/> ukupi .modal chayqa ñawpaq <button/> ukupi .modal ta qhaway chayqa sayay tukuy'],
+    ['tr', 'keydown[key=="Tab"] de .modal den eğer hedef eşleşir sonuncu <button/> içinde .modal ardından ilk <button/> içinde .modal i odak ardından durdur son'],
+    ['bn', 'keydown[key=="Tab"] এ .modal থেকে যদি লক্ষ্য matches শেষ <button/> এ .modal তারপর প্রথম <button/> এ .modal কে ফোকাস তারপর থামুন শেষ'],
+    ['hi', 'keydown[key=="Tab"] पर .modal से अगर लक्ष्य मेल खाता अंतिम <button/> में .modal फिर पहला <button/> में .modal को फोकस फिर रोकें समाप्त'],
+  ];
+  for (const [lang, src] of ROWS) {
+    it(`[${lang}] focus-trap: focus.patient:expression captured, if/halt intact`, () => {
+      const cmds = collect(parse(src, lang));
+      const actions = new Set(cmds.map(c => c.action));
+      for (const a of ['on', 'if', 'focus', 'halt']) expect(actions.has(a)).toBe(true);
+      const focus = cmds.find(c => c.action === 'focus');
+      expect(role(focus, 'patient')?.type).toBe('expression');
+      expect(String(role(focus, 'patient')?.raw)).toContain('<button/>');
+    });
+  }
+
+  it('[ja] the branch fragment parses standalone (の中 is one `in` token)', () => {
+    const cmds = collect(parse('最初 <button/> の中 .modal を フォーカス', 'ja'));
+    const focus = cmds.find(c => c.action === 'focus');
+    expect(role(focus, 'patient')).toMatchObject({ type: 'expression' });
+  });
+});

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -13578,3 +13578,63 @@ describe('R1 deferred-tail Family E: URL extractor carries ${…} spans (docs-in
     expect(node?.eventModifiers?.debounce).toBe(300);
   });
 });
+
+describe('R1 deferred-tail Family H: fused halt+call renders verb-final and parses like en (docs-internal/HANDOFF_r1-deferred-tail.md)', () => {
+  // form-submit-prevent: en `on submit halt the event call validateForm() if
+  // result is false log "Invalid form" end` → halt.patient:reference=event +
+  // call.patient:expression=validateForm(). The old SOV renders interleaved
+  // the two commands across the fused clause (halt captured ZERO roles; tr
+  // swapped the operands). Corpus strings below are the sovHaltCallFusedRule
+  // renders (canonical pattern_translations rows after re-populate).
+  const CHILD_FIELDS = ['body', 'statements', 'thenBranch', 'elseBranch', 'branches'];
+  const collect = (node: unknown): Record<string, any>[] => {
+    const flat: Record<string, any>[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec);
+      for (const f of CHILD_FIELDS) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return flat;
+  };
+  const role = (n: Record<string, any> | undefined, r: string): any =>
+    n && n.roles instanceof Map ? n.roles.get(r) : undefined;
+
+  const ROWS: Array<[string, string]> = [
+    ['ja', 'the イベント を 送信 で 停止 それから validateForm() を 呼び出し もし 結果 である 偽 "Invalid form" を 記録 終わり'],
+    ['ko', 'the 이벤트 를 제출 할 때 정지 그러면 validateForm() 를 호출 만약 결과 이다 거짓 "Invalid form" 를 로그 끝'],
+    ['tr', 'the olay i gönder de durdur ardından validateForm() i çağır eğer sonuç dir yanlış "Invalid form" i kaydet son'],
+    ['bn', 'the ঘটনা কে জমা এ থামুন তারপর validateForm() কে কল যদি ফলাফল হয় মিথ্যা "Invalid form" কে লগ শেষ'],
+    ['hi', 'the घटना को जमा पर रोकें फिर validateForm() को कॉल अगर परिणाम है झूठ "Invalid form" को लॉग समाप्त'],
+    ['qu', 'the ruway ta kachay pi sayay chayqa validateForm() ta qayay sichus lluqsiy kanqa llulla "Invalid form" ta qillqakuy tukuy'],
+  ];
+  for (const [lang, src] of ROWS) {
+    it(`[${lang}] form-submit-prevent: halt.patient:reference + call.patient:expression, if/log intact`, () => {
+      const cmds = collect(parse(src, lang));
+      const actions = new Set(cmds.map(c => c.action));
+      for (const a of ['on', 'halt', 'call', 'if', 'log']) expect(actions.has(a)).toBe(true);
+      const halt = cmds.find(c => c.action === 'halt');
+      expect(role(halt, 'patient')).toMatchObject({ type: 'reference', value: 'event' });
+      const call = cmds.find(c => c.action === 'call');
+      expect(role(call, 'patient')).toMatchObject({ type: 'expression', raw: 'validateForm()' });
+    });
+  }
+
+  it('[en] the en reference parse is unchanged', () => {
+    const cmds = collect(
+      parse(
+        'on submit halt the event call validateForm() if result is false log "Invalid form" end',
+        'en'
+      )
+    );
+    const halt = cmds.find(c => c.action === 'halt');
+    expect(role(halt, 'patient')).toMatchObject({ type: 'reference', value: 'event' });
+    const call = cmds.find(c => c.action === 'call');
+    expect(role(call, 'patient')).toMatchObject({ type: 'expression', raw: 'validateForm()' });
+  });
+});

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -13519,3 +13519,62 @@ describe('R1 Family D: SOV fallback value-typing increments (docs-internal/HANDO
     });
   });
 });
+
+describe('R1 deferred-tail Family E: URL extractor carries ${…} spans (docs-internal/HANDOFF_r1-deferred-tail.md)', () => {
+  // event-debounce: the en REFERENCE itself truncated the interpolated URL at
+  // the space inside `${my value}` (source:literal="/api/search?q=${my"), so
+  // every language "missed" against a junk denominator — ja captured
+  // source:expression="}". The extractor now carries `${…}` spans whole; the
+  // en value changed, so this is the R3 all-language realignment row.
+  // Corpus strings are canonical pattern_translations rows (full bodies).
+  const CHILD_FIELDS = ['body', 'statements', 'thenBranch', 'elseBranch', 'branches'];
+  const collect = (node: unknown): Record<string, any>[] => {
+    const flat: Record<string, any>[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec);
+      for (const f of CHILD_FIELDS) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return flat;
+  };
+  const role = (n: Record<string, any> | undefined, r: string): any =>
+    n && n.roles instanceof Map ? n.roles.get(r) : undefined;
+
+  const URL = '/api/search?q=${my value}';
+  const ROWS: Array<[string, string]> = [
+    ['en', 'on input debounced at 300ms fetch /api/search?q=${my value} as json then put it into #results'],
+    ['ja', 'debounced at 300ms /api/search?q=${my value} を 入力 で フェッチ json それから それ を #results に 置く'],
+    ['ko', 'debounced at 300ms /api/search?q=${my value} 를 입력 할 때 가져오기 json 로 그러면 그것 를 #results 에 넣다'],
+    ['tr', 'debounced at 300ms /api/search?q=${my value} i giriş de getir json olarak ardından o i #results e koy'],
+    ['bn', 'debounced at 300ms /api/search?q=${my value} কে ইনপুট এ আনুন json তারপর এটি কে #results তে রাখুন'],
+    ['hi', 'debounced at 300ms /api/search?q=${my value} को इनपुट पर लाएं json के रूप में फिर यह को #results में रखें'],
+    ['qu', 'debounced at 300ms /api/search?q=${my value} ta yaykuchiy pi apamuy json hina chayqa chay ta #results man churay'],
+  ];
+  for (const [lang, src] of ROWS) {
+    it(`[${lang}] event-debounce captures the WHOLE interpolated URL as source:literal`, () => {
+      const cmds = collect(parse(src, lang));
+      expect(cmds.map(c => c.action)).toContain('fetch');
+      const f = cmds.find(c => c.action === 'fetch');
+      expect(role(f, 'source')).toMatchObject({ type: 'literal', value: URL });
+      // The un-truncated en parse matches fetch-en-with-response-type, so the
+      // denominator gained responseType — the six reach it through the cluster-B
+      // reclaim, which needs the `debounced at 300ms` head consumed WHOLE (the
+      // untranslated `at` tokenizes as an identifier; extractStandaloneModifiers
+      // skips it only when a duration literal follows).
+      expect(role(f, 'responseType')).toMatchObject({ type: 'expression', raw: 'json' });
+    });
+  }
+
+  it('[ja] the standalone-modifier head consumes its duration (no `at 300ms` junk)', () => {
+    const node = parse('debounced at 300ms /api/x を クリック で フェッチ', 'ja') as {
+      eventModifiers?: { debounce?: number };
+    };
+    expect(node?.eventModifiers?.debounce).toBe(300);
+  });
+});

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -13694,3 +13694,89 @@ describe('R1 deferred-tail Family G: SOV focus-trap branch operand survives the 
     expect(role(focus, 'patient')).toMatchObject({ type: 'expression' });
   });
 });
+
+describe('R1 deferred-tail qu tail: per-row alignments (docs-internal/HANDOFF_r1-deferred-tail.md)', () => {
+  // Four scoped qu fixes, each locked with the full canonical
+  // pattern_translations row and the en-matching capture:
+  // - single-quoted strings classify literal (put ×2: make-toast-element,
+  //   on-custom-event-receive — was patient:expression with quotes kept);
+  // - patient-first trailing-destination toggle pattern (toggle-aria-expanded
+  //   — the fallback glued destination:literal="qhipantin.panel");
+  // - go-qu-url-dest re-types the url pair as expression via the (newly
+  //   wired) extraction transform (go-url — was destination:literal="/page");
+  // - underscore compounds k_iri/hatun_kay tokenize whole (window-resize —
+  //   call carried three junk roles and the event fragmented to `kay`).
+  const CHILD_FIELDS = ['body', 'statements', 'thenBranch', 'elseBranch', 'branches'];
+  const collect = (node: unknown): Record<string, any>[] => {
+    const flat: Record<string, any>[] = [];
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return;
+      const rec = n as Record<string, any>;
+      if (typeof rec.action === 'string') flat.push(rec);
+      for (const f of CHILD_FIELDS) {
+        const c = rec[f];
+        if (Array.isArray(c)) for (const x of c) walk(x);
+        else if (c && typeof c === 'object') walk(c);
+      }
+    };
+    walk(node);
+    return flat;
+  };
+  const role = (n: Record<string, any> | undefined, r: string): any =>
+    n && n.roles instanceof Map ? n.roles.get(r) : undefined;
+
+  it('[qu] make-toast-element: both puts capture literal patients like en', () => {
+    const cmds = collect(
+      parse(
+        "a <div.toast/> ta ñitiy pi ruray chayqa 'Saved!' ta chay man churay chayqa chay pi tukuy pa kurku ta churay",
+        'qu'
+      )
+    );
+    const puts = cmds.filter(c => c.action === 'put');
+    expect(role(puts[0], 'patient')).toMatchObject({ type: 'literal', value: 'Saved!' });
+  });
+
+  it('[qu] on-custom-event-receive: put patient literal, unquoted', () => {
+    const cmds = collect(parse("'Got it!' ta noqa man hello pi churay", 'qu'));
+    const put = cmds.find(c => c.action === 'put');
+    expect(role(put, 'patient')).toMatchObject({ type: 'literal', value: 'Got it!' });
+  });
+
+  it('[qu] toggle-aria-expanded: second toggle keeps the positional destination as expression', () => {
+    const cmds = collect(
+      parse(
+        '@aria-expanded ta noqa man ñitiy pi tikray chayqa .open ta qhipantin .panel man tikray',
+        'qu'
+      )
+    );
+    const toggles = cmds.filter(c => c.action === 'toggle');
+    expect(toggles.length).toBe(2);
+    expect(role(toggles[1], 'destination')).toMatchObject({
+      type: 'expression',
+      raw: 'next .panel',
+    });
+  });
+
+  it('[qu] go-url: destination typed expression (the en reference type)', () => {
+    const cmds = collect(parse('url "/page" man ñitiy pi riy', 'qu'));
+    const go = cmds.find(c => c.action === 'go');
+    expect(role(go, 'destination')?.type).toBe('expression');
+  });
+
+  it('[qu] window-resize: event resolves to resize, call keeps ONLY its expression patient', () => {
+    const node = parse(
+      'debounced at 200ms adjustLayout() ta k_iri manta hatun_kay pi qayay',
+      'qu'
+    ) as Record<string, any>;
+    expect(node.roles?.get('event')).toMatchObject({ type: 'literal', value: 'resize' });
+    const call = collect(node).find(c => c.action === 'call');
+    expect(role(call, 'patient')).toMatchObject({ type: 'expression', raw: 'adjustLayout()' });
+    expect(call?.roles?.has('source')).toBe(false);
+    expect(call?.roles?.has('destination')).toBe(false);
+  });
+
+  it("[qu] glottalized words are untouched by the single-quote literal (t'ikray still the verb)", () => {
+    const cmds = collect(parse(".active ta t'ikray", 'qu'));
+    expect(cmds.find(c => c.action === 'toggle')).toBeTruthy();
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-11T04:50:11.740Z",
-  "commit": "3e86d4e1",
+  "timestamp": "2026-07-11T14:20:59.958Z",
+  "commit": "a0a3abea",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -16,7 +16,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -644,13 +644,13 @@
       "avgFidelity": 1,
       "avgPrecision": 0.9989716846334493,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9937908496732026,
+      "avgRoleFidelity": 0.9950980392156863,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1284,7 +1284,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1909,7 +1909,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2543,7 +2543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3177,7 +3177,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3811,7 +3811,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4439,13 +4439,13 @@
       "avgFidelity": 1,
       "avgPrecision": 0.9978354978354977,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9883442265795207,
+      "avgRoleFidelity": 0.9896514161220045,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5079,7 +5079,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5713,7 +5713,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6341,13 +6341,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9937908496732026,
+      "avgRoleFidelity": 0.9950980392156863,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6975,13 +6975,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9905228758169935,
+      "avgRoleFidelity": 0.9918300653594772,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7615,7 +7615,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8249,7 +8249,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8883,7 +8883,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9511,13 +9511,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9791783380018673,
+      "avgRoleFidelity": 0.980485527544351,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10151,7 +10151,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10785,7 +10785,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11419,7 +11419,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12053,7 +12053,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12681,13 +12681,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9927015250544662,
+      "avgRoleFidelity": 0.9940087145969497,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13321,7 +13321,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13955,7 +13955,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14589,7 +14589,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 502444,
+      "bundleSize": 503134,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15212,7 +15212,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 502444,
+      "size": 503134,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-11T14:44:36.452Z",
-  "commit": "19020c54",
+  "timestamp": "2026-07-11T15:02:35.962Z",
+  "commit": "c5c884cc",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -16,7 +16,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -650,7 +650,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1284,7 +1284,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1909,7 +1909,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2543,7 +2543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3177,7 +3177,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3811,7 +3811,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4445,7 +4445,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5079,7 +5079,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5713,7 +5713,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6347,7 +6347,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6981,7 +6981,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7615,7 +7615,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8249,7 +8249,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8883,7 +8883,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9511,13 +9511,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9853874883286647,
+      "avgRoleFidelity": 0.9936196700902583,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10151,7 +10151,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10785,7 +10785,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11419,7 +11419,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12053,7 +12053,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12687,7 +12687,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13321,7 +13321,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13955,7 +13955,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14589,7 +14589,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503196,
+      "bundleSize": 503726,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15212,7 +15212,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 503196,
+      "size": 503726,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-11T14:20:59.958Z",
-  "commit": "a0a3abea",
+  "timestamp": "2026-07-11T14:30:15.580Z",
+  "commit": "4199a0dd",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -640,11 +640,11 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8611474573880582,
+      "avgConfidence": 0.8643942106348115,
       "avgFidelity": 1,
       "avgPrecision": 0.9989716846334493,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9950980392156863,
+      "avgRoleFidelity": 0.9961873638344226,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -833,6 +833,10 @@
           "confidence": 1
         },
         "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-submit-prevent": {
           "success": true,
           "confidence": 1
         },
@@ -1201,10 +1205,6 @@
           "confidence": 0.5
         },
         "async-block": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "form-submit-prevent": {
           "success": true,
           "confidence": 0.5
         },
@@ -4439,7 +4439,7 @@
       "avgFidelity": 1,
       "avgPrecision": 0.9978354978354977,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9896514161220045,
+      "avgRoleFidelity": 0.9907407407407406,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -6337,11 +6337,11 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8532624852173719,
+      "avgConfidence": 0.8565092384641251,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9950980392156863,
+      "avgRoleFidelity": 0.9961873638344226,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -6534,6 +6534,10 @@
           "confidence": 1
         },
         "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-submit-prevent": {
           "success": true,
           "confidence": 1
         },
@@ -6889,10 +6893,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "form-submit-prevent": {
-          "success": true,
-          "confidence": 0.5
-        },
         "window-keydown": {
           "success": true,
           "confidence": 0.5
@@ -6971,11 +6971,11 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8482119801668667,
+      "avgConfidence": 0.8514587334136199,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9918300653594772,
+      "avgRoleFidelity": 0.9929193899782135,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -7168,6 +7168,10 @@
           "confidence": 1
         },
         "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-submit-prevent": {
           "success": true,
           "confidence": 1
         },
@@ -7512,10 +7516,6 @@
           "confidence": 0.5
         },
         "async-block": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "form-submit-prevent": {
           "success": true,
           "confidence": 0.5
         },
@@ -9507,11 +9507,11 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7349000206143064,
+      "avgConfidence": 0.7381467738610596,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.980485527544351,
+      "avgRoleFidelity": 0.9815748521630874,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -9644,6 +9644,10 @@
           "confidence": 1
         },
         "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-submit-prevent": {
           "success": true,
           "confidence": 1
         },
@@ -9960,10 +9964,6 @@
           "confidence": 0.5
         },
         "input-clear": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "form-submit-prevent": {
           "success": true,
           "confidence": 0.5
         },
@@ -12677,11 +12677,11 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8521493126756279,
+      "avgConfidence": 0.8553960659223812,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9940087145969497,
+      "avgRoleFidelity": 0.9961873638344226,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -12870,6 +12870,10 @@
           "confidence": 1
         },
         "input-validation": {
+          "success": true,
+          "confidence": 1
+        },
+        "form-submit-prevent": {
           "success": true,
           "confidence": 1
         },
@@ -13226,10 +13230,6 @@
           "confidence": 0.5
         },
         "async-block": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "form-submit-prevent": {
           "success": true,
           "confidence": 0.5
         },

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-11T14:30:15.580Z",
-  "commit": "4199a0dd",
+  "timestamp": "2026-07-11T14:44:36.452Z",
+  "commit": "19020c54",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -16,7 +16,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -650,7 +650,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1284,7 +1284,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1909,7 +1909,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2543,7 +2543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3177,7 +3177,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3811,7 +3811,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4445,7 +4445,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5079,7 +5079,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5713,7 +5713,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6341,13 +6341,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9961873638344226,
+      "avgRoleFidelity": 0.9978213507625272,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6975,13 +6975,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9929193899782135,
+      "avgRoleFidelity": 0.9945533769063181,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7615,7 +7615,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8249,7 +8249,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8883,7 +8883,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9511,13 +9511,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9815748521630874,
+      "avgRoleFidelity": 0.9853874883286647,
       "avgValueRecall": 0.9905660377358491,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10151,7 +10151,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10785,7 +10785,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11419,7 +11419,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12053,7 +12053,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12687,7 +12687,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13321,7 +13321,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13955,7 +13955,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14589,7 +14589,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 503134,
+      "bundleSize": 503196,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15212,7 +15212,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 503134,
+      "size": 503196,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Summary

Picks up the R1 arc's (#637) Family D deferrals per `docs-internal/HANDOFF_r1-deferred-tail.md` (now RESOLVED). The residual split into **en-reference defects** (the en parse itself was junk, so all 24 languages scored against a bad denominator) and **SOV render geometry** (the i18n transformer scrambled operand order beyond honest parse-side repair).

**avgRoleFidelity:** ja 0.9938 → **0.9978** · bn 0.9938 / tr 0.9927 → **0.9962** · ko 0.9905 → **0.9946** · qu 0.9792 → **0.9936** · hi 0.9883 → **0.9907**

## Increments (baseline regenerated + audited after each)

- **Family E (`4199a0dd`, en-side):** the URL extractor carries `${…}` interpolation spans whole — `/api/search?q=${my value}` no longer truncates at the inner space, un-junking the en reference (event-debounce) and realigning all 24 languages. The en enrichment exposed two masked co-causes, fixed in-increment: the SOV `debounced at 300ms` head left `at 300ms` junk in every clause (identifier-preposition skip), and fused matches captured native event words raw (`buildEventHandler` now canonicalizes exact `eventNameTranslations` hits; tr gains boyutlandırma/kaydırma tokenizer keywords).
- **Family H (`19020c54`, render-side):** `sovHaltCallFusedRule` splits the swept `halt the event call validateForm()` patient blob at each language's call verb and renders both commands verb-final, joined by the then-connective — `halt.patient:reference` in all six, tr's swapped operands fixed, row confidence 0.5 → 1.0.
- **Family G (`c5c884cc`, two-sided):** `transformBlockBody` emits the then-connective at the SOV if-condition/branch seam (razor-gated to positional-headed branches; #636 curated-end guards untouched), and ja/ko/qu register their containment word (の中/안에/ukupi) as a whole `in` keyword — the split fragments had broken the generated focus pattern's operand run (focus-trap). Bonus: whole `ukupi` realigned qu last-in-collection.
- **qu tail (`299bb27a`):** single-quoted strings classify literal (put ×2 byte-identical to en); patient-first trailing-destination toggle pattern (toggle-aria byte-identical); `go-qu-url-dest` types the fronted url pair expression via `ExtractionRule.transform` (documented-but-unwired field, now honored); interior `_` in the qu keyword extractor's longest-first scan lets the dict's `k_iri`/`hatun_kay` compounds tokenize whole (window-resize fully clean).

## Deferred (recorded in NEXT_STEPS § 2026-07-11b)

- **pick-text-range (Family F):** the en reference is degenerate (first word only; pickSchema has no range roles) — fixing it raises the denominator for all 24 languages; take only if pick matters for a demo.
- **Reactive on.event rows** (hi/ko/qu): event-anchor guard machinery, unchanged out-of-scope decision.
- **swap-content:** F6 wontfix, unchanged.

Residual misses: ja 1 · bn/tr 2 · ko 3 · qu 4 · hi 5 — all in the three deferred classes.

## Verification

- Sweeps green after every increment: parse 3696/3696, R0/precision/multiset unchanged, R2 = 1.0, R3 loss only the pre-existing swap-content wontfix.
- `--regression` gate green (all eight ratchets) against the regenerated baseline at arc end.
- Locks: `test/extractors/url.test.ts` (new) + four corpus-shaped describes in `multilingual-roadmap-fixes.test.ts` (semantic 7066 green); render locks in `grammar.test.ts` (i18n 947 green).
- patterns.db not committed (local populate artifact); baseline diffs audited line-by-line per increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)