### PR TITLE
docs: sync multilingual status prose with the 2026-07-11 baseline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,7 +261,7 @@ The four PR-only jobs already ran against the merged-as-PR code, so re-running t
 **Known Issues:**
 
 - Experimental behaviors (Draggable, Sortable, Resizable) still run imperative JS installers; migration to the compiled hyperscript `source` path is in progress. Curated (5) + optional (3) behaviors already run the source-compiled path and are fully tested (behaviors suite green).
-- The SOV six (hi, qu, ko, tr, ja, bn) have lower **role fidelity** (R1 ~0.95 vs corpus ~0.98) than SVO languages — every pattern parses faithfully at the command level in all 24 priority languages, but role-level capture still lags on the hardest reorders. Tracked by the multilingual fidelity ratchet (not `continue-on-error`); remaining arcs in `docs-internal/MULTILINGUAL_NEXT_STEPS.md`.
+- **Role fidelity (R1) headroom is now thin and flat** — the SOV six (hi, qu, ko, tr, ja, bn) were burned down to ≥ 0.9907 by the R1 arcs (#637/#638) and no longer trail the SVO languages (lowest are now th 0.9845 / ms / de / fr; corpus mean ≈ 0.992). Every pattern parses faithfully at the command level in all 24 priority languages. Remaining R1 deferrals are named (pick range-role modeling, the reactive `on.event` rows, swap F6) — tracked by the multilingual fidelity ratchet (not `continue-on-error`); queue in `docs-internal/MULTILINGUAL_NEXT_STEPS.md`.
 
 ### Multilingual parse rate ≠ fidelity
 
@@ -281,10 +281,12 @@ the committed baseline:
   command): `lossyPasses`. **0.** (Both bands were burned down across #492–#506;
   history in `docs-internal/MULTILINGUAL_ROADMAP.md`.)
 - **faithful** (fid = 1.0). **3696 / 3696.** Cross-language `avgFidelity` = 1.000,
-  `avgPrecision` ≈ 0.976, `avgRoleFidelity` ≈ 0.977 (the SOV six sit ~0.95 —
-  the remaining headroom).
+  `avgPrecision` ≈ 0.9997, `avgRoleFidelity` ≈ 0.992, `avgMultisetRecall` = 1.000,
+  `avgValueRecall` ≈ 0.997 (the SOV six sit ≥ 0.991 on R1 after #637/#638; the
+  lowest R1 languages are now th/ms/de/fr ≈ 0.985 — the remaining headroom is
+  thin and flat).
 
-> **Figures snapshot:** as of the **2026-07-05** baseline. They drift as work lands
+> **Figures snapshot:** as of the **2026-07-11** baseline (`c5c884cc`). They drift as work lands
 > — the **authoritative** numbers always live in the committed baseline,
 > `packages/testing-framework/baselines/multilingual-priority.json` (its `timestamp`
 > and `commit` fields stamp each regeneration). Treat the prose here as orientation,
@@ -312,10 +314,11 @@ yields a 0 delta):
    `[bind, bind]` collapses to `{bind}`, which `[bind]` satisfies in full. That is how
    `bind-two-way` recorded fidelity 1.0 in all 24 languages while every one of them
    parsed only the first of its two `bind`s (the top-level command-sequence fix that
-   added this signal). Counting duplicates makes the drop visible. One row sits below
-   1.0 today — qu `behavior-resizable` drops its two style `set`s (`noqaq *width/*height`):
-   the qu reorder renders the inline-if's verb-final `man churanay` after `tukuy`/end, and
-   the conditional fold strands it (tracked in `docs-internal/MULTILINGUAL_NEXT_STEPS.md`).
+   added this signal). Counting duplicates makes the drop visible. All 24 languages
+   sit at 1.0 today — the last sub-1.0 row (qu `behavior-resizable`, whose reorder
+   rendered the inline-if's verb-final `man churanay` after `tukuy`/end and stranded
+   it at the conditional fold) was cleared by the SOV if-seam work in the R1
+   deferred-tail arc (#638).
    The nine other rows this signal originally flagged (colon-qualified event names
    `draggable:start` split at the local-variable sigil by every non-en tokenizer, plus
    two masked co-causes) were fixed in the colon-event-names arc — history in
@@ -357,8 +360,9 @@ baseline generated against a stale/transitional DB will read as drifted.
 degenerate flips, avgFidelity 0.02) are **conservative cross-machine headroom**
 (Mac-generated baseline vs CI Linux float/collation drift), not absorbers of local
 run-to-run jitter — don't read a green gate as "within noise." The remaining
-fidelity headroom is R1 role-fidelity (SOV six) and R0-precision spurious-action
-families, tracked in `docs-internal/MULTILINGUAL_NEXT_STEPS.md`.
+fidelity headroom is the thin R1 tail (named deferrals: pick range-roles, reactive
+`on.event` rows, swap F6) and the R3 residual rows — current queue in
+`docs-internal/MULTILINGUAL_NEXT_STEPS.md`.
 
 #### Running the multilingual `--regression` gate locally
 

--- a/docs-internal/HANDOFF_vocab-consistency.md
+++ b/docs-internal/HANDOFF_vocab-consistency.md
@@ -1,0 +1,132 @@
+# Handoff: vocab consistency — `validate` + `dump` (Arc A of the v2.8 bar)
+
+## Context
+
+Per-language vocabulary is hand-authored in **five uncoordinated surfaces**
+(~7,000+ entries), and the drift between them is the single most common recent
+bug class: fused/split event keywords (#533–#535, #540, #633), marker collisions
+(#558, #560, #569, #586), render/parse symmetry (#565, #636, #638). Every one of
+those cost a probe → fix → resweep → baseline arc. This arc builds the
+authoring-time check that turns that class into a CI warning.
+
+This is **v2.8 release-bar item 1** (NEXT_STEPS § "v2.8 release bar", target
+≈ 2026-07-22). It is Arc A of the session plan; its output ledger is the
+required input to Arc B (the `derive.ts` dictionary flip), which is
+**post-release and NOT part of this arc** — do not flip any surface to
+generated here.
+
+Assessment + surface map: 2026-07-12 session. Lexicon end-state and the
+domain-side precedent: `docs-internal/FRAMEWORK_SEMANTIC_BRIDGE_PLAN.md`
+("a single lexicon"; `buildMarkerLookup` foothold; lint R5).
+
+## The surfaces
+
+| # | Surface | Where | Entries |
+| - | ------- | ----- | ------- |
+| S1 | Semantic language profiles (keywords, `roleMarkers`, `possessive`, `references`) | `packages/semantic/src/generators/profiles/*.ts` (24 files) | ~2,330 keywords + ~6 markers/lang. **Documented source of truth.** |
+| S2 | Command-schema marker tables (`markerOverride`, `markerVariants`) | `packages/semantic/src/generators/command-schemas.ts` (36 tables) | ~350 |
+| S3 | i18n dictionaries | `packages/i18n/src/dictionaries/*.ts` (24 files) | ~4,000. Hand-authored; `derive.ts::deriveFromProfile` exists but `index.ts` imports the hand files (derive utils only re-exported, `index.ts:158`). |
+| S4 | i18n grammar profiles (role-marker `markers[]` forms, connectives, render rules) | `packages/i18n/src/grammar/profiles/index.ts` (single 1,435-line file) | ~203 marker forms |
+| S5 | Tokenizer EXTRAS + event names | `packages/semantic/src/tokenizers/*.ts` (`initializeKeywordsFromProfile` + hand EXTRAS, ~1,056) · `packages/semantic/src/patterns/event-handler.ts:20` `eventNameTranslations` (13 langs, 239) | ~1,300 |
+
+Already-generated links (do not re-check, but don't break):
+profiles → vite-plugin (`packages/vite-plugin/scripts/sync-keywords.ts`),
+profiles + grammar → corpus DB (`packages/patterns-reference/scripts/sync-translations.ts`),
+profiles → domain patterns (framework bridge, `packages/framework/src/multilingual/builders.ts`).
+
+## The check matrix (`validate`)
+
+| Check | Pair | Finding condition | Tier |
+| ----- | ---- | ----------------- | ---- |
+| V1 keywords | S1 ↔ S3 | same concept key, **different translation** (normalized) | error |
+| V1b coverage | S1 ↔ S3 | concept in S1 missing from S3 (or vice-versa where S3 category maps to a profile concept) | warn |
+| V2 role markers | S1 `roleMarkers` ↔ S2 `markerOverride`/`markerVariants` ↔ S4 `markers[]` | a marker word present in one copy and absent from the others' **form sets** (containment, not 1:1 — see traps) | error |
+| V3 event names | S5 `eventNameTranslations` ↔ S3 `events` category ↔ tokenizer EXTRAS event nominals | same English event, different native word | error |
+| V3b coverage | S5 | language absent from `eventNameTranslations` (11 of 24 today) | info |
+| V4 tokenizer classification | S1/S2/S4 words → that language's tokenizer | any keyword/marker that does not classify as `keyword` (lint R5 generalized from the nine domains to the core stack) | error |
+
+R5 precedent: `packages/domain-toolkit/src/rules/keyword-classification.ts` —
+on day one it found **220 real** profile↔tokenizer drift findings in the domain
+packages (#615), zero waivers needed after fixes. Expect a comparable first
+sweep here; that ledger is the deliverable, not a failure.
+
+Also in scope: **retire the dead script** — `packages/i18n/package.json`
+`validate-dictionaries` points at `scripts/validate-dictionaries.js`, which
+does not exist. Point it (or a new script name) at the new tool;
+`derive.ts` already exports a `validateDictionary` worth absorbing.
+
+## The right lever
+
+Host the CLI in **`packages/testing-framework`** (suggested:
+`src/vocab/cli.ts`), beside the multilingual CLI — it already depends on both
+`@lokascript/semantic` and `@lokascript/i18n`, has the tsx/CI wiring, and the
+ensure-fresh stale-dist guard pattern to copy. Alternative considered and
+rejected: extending `domain-toolkit` (its rules operate on `DomainVocabulary`,
+not the core stack's profile shape) — reuse its R5 *logic*, not its host.
+
+- `validate [--language xx] [--check V1..V4] [--json]` — prints per-language ×
+  per-check counts + the disagreement ledger; exits non-zero only on
+  `error`-tier findings **not** covered by the waiver file.
+- Waivers: a committed `vocab-waivers.json` (finding key + one-line reason).
+  Bar item 1 is "0 unwaived, every waiver named" — honesty over totality.
+- `dump [--concept toggle] [--language xx] [--format md|tsv|json]` — the
+  concept × language table over the same loaded model. Stretch within the arc;
+  the `packages/semantic/editor/` profile-editor GUI is a candidate future
+  front-end, not part of this arc.
+- CI: add to the PR job set **warn-only** first (report in the job log); flip
+  to gating in a follow-up PR once the first ledger is triaged. Do not gate
+  red on day one.
+
+## Traps
+
+- **Comparison semantics, not string equality.** Markers have allomorphs
+  (tr `markerVariants` exists because the transformer emits `ya` where the
+  schema said `e`), multiword forms, and per-slot variants; S4 stores arrays of
+  forms. Compare as normalized **form sets with containment**, and report the
+  raw strings. Naive 1:1 equality will drown the ledger in false positives.
+- **Direction of authority differs per pair.** S1 is the documented source of
+  truth, but S3 legitimately holds render vocabulary S1 never needs — an
+  S3-only entry is warn/info, an S1↔S3 *conflict* is an error. Encode the tier
+  in the matrix, don't let "missing" and "wrong" share a severity.
+- **Classify whole surface forms (V4).** The fused/compound lessons (qu `_`
+  compounds #638, ja/ko/qu containment words, tr `enyakın`) mean V4 must run
+  the tokenizer's real longest-match path on the whole marker/keyword string,
+  not per-word — a split result IS the finding.
+- **Fresh dists or src imports.** A CLI run against a stale `dist/` scores code
+  that differs from the checkout (the qu unreproducible-baseline incident).
+  Copy the multilingual CLI's refusal guard, or import src via tsx explicitly.
+- **First sweep ≠ regression.** The initial ledger will be large (R5's was
+  220). Triage into fix-now / waive-with-reason / Arc-B-input. Only V4 errors
+  are usually fix-now (they mean a word cannot tokenize at all).
+- **If goldens are added:** the pre-commit prettier hook reformats them —
+  regenerate **then prettier** before any `git diff --quiet` byte-identity
+  check (batch-4 lesson).
+- **Never commit `patterns.db`**; this arc shouldn't touch it at all (no
+  corpus resweep needed — validate is static analysis; the eight-signal gate
+  is unaffected unless a fix-now finding changes a profile, in which case the
+  standard resweep discipline applies).
+
+## Measure
+
+```bash
+cd packages/testing-framework
+npx tsx src/vocab/cli.ts validate --json > /tmp/vocab-ledger.json; echo "exit=$?"
+npx tsx src/vocab/cli.ts dump --concept toggle
+```
+
+Before: no cross-surface check exists; `validate-dictionaries` is dead.
+Deliverable numbers: findings per check per language, waiver count, and the
+fix-now subset (expect V4 to dominate it).
+
+## Definition of done
+
+- `validate` implements V1–V4 with the tiering above; per-language and
+  per-check filters; JSON ledger output.
+- The dead `validate-dictionaries` script is replaced or removed.
+- CI runs validate warn-only on PRs; the gating flip is a named follow-up.
+- The first disagreement ledger is triaged: fix-now findings fixed (with the
+  standard resweep if any profile changed), the rest waived with reasons or
+  recorded as Arc B input in NEXT_STEPS.
+- `dump` renders the concept × language table for at least keywords + role
+  markers (stretch: events).
+- NEXT_STEPS § "v2.8 release bar" item 1 checked off or its residual named.

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -2915,28 +2915,91 @@ value-bug families"), F6 **wontfix** (documented), F7 **re-filed**:
 >   verb-anchoring) is a separate matter; the `fetch`→`source` verb-anchoring remap tried earlier
 >   proved **inert** on the corpus and was dropped.
 
-### Current queue (2026-07-12, post #639)
+### Current queue (2026-07-12, post #639) — session plan toward v2.8
 
-The sequence above is fully resolved; the open work now lives in the sections above.
-Ranked by leverage:
+The sequence above is fully resolved. Fidelity is at a high-water mark (all eight
+ratchets green). v2.7.2 was published 2026-07-08 but **not publicized**; the target
+is a solid, publicized release within ~10 days (**≈ 2026-07-22**). One arc ≈ one
+session ≈ one PR. Arcs A/C/E fit the window; Arcs B/D are explicitly post-release
+(both move the baseline or the confidence model — wrong risk profile days before a
+publicized cut).
 
-1. **Extend `unconsumed-input` to the remaining parse stages** — the deferred sub-task
-   from the top-level command-sequences arc (§ "Input coverage" above). The Stage-2-only
-   diagnostic surfaced 158 firings and every one was a real silent drop at confidence 1.0;
-   the uninstrumented stages (event-handler bodies, compound, SOV/VSO) are where most
-   translated rows route, so 0 is a floor. All four stages funnel through
-   `parseBodyWithClauses` / `buildEventHandler`, so a per-segment coverage check there may
-   cover them at once. Prerequisite for item 2.
-2. **The `unconsumed-input` → confidence-penalty scoring change** — both preconditions
-   then met (`SCHEMA_NO_REQUIRED_ROLES` fixed #628/#629; all stages measured). Five-step
-   plan in § "Input coverage". Payoff: re-evaluate whether `parseInternal` Stages 0 / 0.5
-   can be simplified.
-3. **Part 2b — `fetch … with { }` ×23 + naked named-arg capture** (§ deferral above).
-   All-or-nothing across 24 languages (R1 en-reference constraint) + baseline regen; a
-   self-contained user-facing alternative to 1–2.
-4. **Standing R1/R3 deferrals** (post-launch track, top of doc): pick range-role modeling
-   (Family F — only if `pick` matters for a demo; raises the en denominator ×24), the
-   reactive `on.event` rows (event-anchor guard machinery), swap-content F6 (wontfix).
+**Arc A — vocab `validate` + `dump` (new 2026-07-12; do first).** Per-language vocab
+is hand-authored in five uncoordinated surfaces (~7,000+ entries): semantic profiles
+(~2.3k), i18n dictionaries (~4k — `derive.ts::deriveFromProfile` exists but is unused),
+command-schema `markerOverride` tables (~350), i18n grammar-profile markers (~200),
+tokenizer EXTRAS + `eventNameTranslations` (~1.3k). Keywords are authored 2–5×, role
+markers 3–4×, event names 3× — and the drift between them is the single most common
+recent bug class (fused/split event keywords in PRs #533–#535, #540, #633; marker
+collisions in #558, #560, #569, #586; render/parse symmetry in #565, #636, #638). Build:
+
+- `validate` — cross-surface consistency check: profiles ↔ i18n dicts (keywords),
+  profiles ↔ command-schemas ↔ grammar profiles (role markers), `eventNameTranslations`
+  ↔ i18n `events` category, and every marker/keyword must classify as `keyword` in that
+  language's tokenizer (lint R5 generalized from the nine domains to the core stack).
+  Replace the dead `validate-dictionaries` npm script (target file missing). Wire into
+  CI warn-first, then gate. Its disagreement ledger is the required input to Arc B.
+- `dump` — one concept × language table view over the same data model (the
+  `packages/semantic/editor/` profile-editor GUI is a candidate front-end).
+
+Prior art: lint R5 caught 220 real profile↔tokenizer drift findings in the domain
+packages on day one (#615). Lexicon end-state + domain-side history:
+`docs-internal/FRAMEWORK_SEMANTIC_BRIDGE_PLAN.md` ("a single lexicon", the
+`buildMarkerLookup` foothold).
+
+**Arc B — `derive.ts` dictionary flip (own arc; baseline-coupled).** Reconcile Arc A's
+profile↔dictionary disagreement ledger, then switch `i18n/src/dictionaries/index.ts`
+to the generated path — killing the single largest duplication (~4k entries). Hand
+edits that diverged from profiles will change rendered corpus translations, so this
+moves the fidelity baseline: full resweep + old-vs-new attribution against the same
+DB, same discipline as a parser arc. Do NOT start before Arc A's validator exists.
+
+**Arc C — extend `unconsumed-input` to the remaining parse stages** — the deferred
+sub-task from the top-level command-sequences arc (§ "Input coverage" above). The
+Stage-2-only diagnostic surfaced 158 firings and every one was a real silent drop at
+confidence 1.0; the uninstrumented stages (event-handler bodies, compound, SOV/VSO)
+are where most translated rows route, so 0 is a floor. All four stages funnel through
+`parseBodyWithClauses` / `buildEventHandler`, so a per-segment coverage check there
+may cover them at once. Prerequisite for Arc D. Expect new firings → its own burn-down.
+
+**Arc D — the `unconsumed-input` → confidence-penalty scoring change** — both
+preconditions then met (`SCHEMA_NO_REQUIRED_ROLES` fixed #628/#629; all stages
+measured by Arc C). Five-step plan in § "Input coverage". Payoff: re-evaluate whether
+`parseInternal` Stages 0 / 0.5 can be simplified.
+
+**Arc E — Part 2b: `fetch … with { }` ×23 + naked named-arg capture** (§ deferral
+above). All-or-nothing across 24 languages (R1 en-reference constraint) + baseline
+regen; the user-facing feature arc of the release. Cheaper after Arc A's `dump`.
+
+**Standing deferrals (unchanged):** pick range-role modeling (Family F — only if
+`pick` matters for a demo; raises the en denominator ×24), the reactive `on.event`
+rows (event-anchor guard machinery), swap-content F6 (wontfix).
+
+### v2.8 release bar (proposed 2026-07-12 · target ≈ 2026-07-22)
+
+Modeled on the launch bar: few items, each measurable, each gate-held once reached.
+The bar is the release definition; the arcs are the route. Split for the 10-day
+window: items 1–4 are **must-have**, item 5 is the **stretch headline**.
+
+1. **Vocab consistency green in CI** (Arc A `validate`) — 0 unwaived cross-surface
+   disagreements (or every waiver named), replacing today's state where the only
+   dictionary validator is a dead script. `dump` ships if time allows; Arc B's
+   generated dictionaries are the durable fix but are post-release by design.
+2. **Input coverage is total** (Arc C) — every `parseInternal` stage instrumented;
+   `--diagnose-coverage` reports 0 firings corpus-wide or each residual is named.
+   If new firings exceed what the window can burn down, naming them all still
+   clears the bar (the launch-bar precedent: honesty over totality).
+3. **Fidelity floors held, not raised** — the eight-signal ratchet holds the
+   2026-07-11 high-water marks (R1 ≥ 0.99, R3 ≥ 0.995, others saturated). No new
+   fidelity bar item — the remaining tail is the named deferrals. This item is
+   free unless Arcs A–C break something; it exists so the release notes can claim it.
+4. **Release hygiene** — 0 critical Dependabot alerts on **shipped** packages
+   (7 critical repo-wide today, shipped-path subset unknown → triage first; alerts
+   confined to `experiments/`/`clients/` are waivable with a note);
+   `pre-publish-check` workflow green; publish dry-run of the monorepo version bump.
+5. **Stretch — `fetch … with { }` captured in all 24 languages** (Arc E) — the
+   user-visible feature claim for the release notes. Take it only after 1–4 are
+   locked; it needs a baseline regen, so it must not land in the final two days.
 
 Re-baseline (`--save-baseline`) after each intentional fidelity change, regenerate against a
 freshly `populate`d DB, and commit only the dicts/profiles + baseline (not `patterns.db`).

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -9,7 +9,7 @@
 > [BEHAVIORS_CONSOLIDATION_PLAN.md](BEHAVIORS_CONSOLIDATION_PLAN.md). Read this first,
 > then dive into those for the per-arc detail.
 
-## Where we are (2026-07-06 baseline · post session-14 / L7 · `browser-priority`)
+## Where we are (2026-07-11 baseline `c5c884cc` · post R1-deferred-tail #638 · `browser-priority`)
 
 > ## 🎉 THE LAUNCH BAR IS COMPLETE (session 14 / L7)
 >
@@ -17,24 +17,27 @@
 > take-class spurious `for` ×6 — fell in the L7 drill; the residual `for` ×3
 > (wait-payload behaviors) is below the ×5 bar threshold and stays on the
 > post-launch track. Fidelity work from here is post-launch polish; the
-> six-signal ratchet holds the bar in CI.
+> eight-signal ratchet holds the bar in CI.
 
 Authoritative source: `packages/testing-framework/baselines/multilingual-priority.json`
 (its `timestamp` + `commit` fields stamp each regen). 24 langs × 154 patterns = 3696.
 
-| Signal                         | Value                  | Notes                                                     |
-| ------------------------------ | ---------------------- | --------------------------------------------------------- |
-| parse rate                     | **3696 / 3696 (100%)** | zero hard fails, holding                                  |
-| degenerate passes (fid < 0.5)  | **0**                  | band cleared (#492/#493), holding                         |
-| lossy passes (0.5 ≤ fid < 1.0) | **0**                  | band cleared (#495–#506), holding                         |
-| faithful (fid = 1.0)           | **3696**               | every parsing pattern is faithful                         |
-| avgFidelity (R0-recall)        | **1.000**              | saturated                                                 |
-| avgPrecision (R0 trust floor)  | **0.996**              | bar 3 reached L4 (0.9953); L6 → 0.9957; L7 → 0.9963       |
-| avgRoleFidelity (R1)           | **0.986**              | session-13 / L5: 0.9838 → 0.9862 — **bar 4 reached**      |
-| avgExecutionFidelity (R2)      | **1.000**              | 47-pattern curated subset fully reproduces en DOM effects |
+| Signal                         | Value                  | Notes                                                                                                                          |
+| ------------------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| parse rate                     | **3696 / 3696 (100%)** | zero hard fails, holding                                                                                                       |
+| degenerate passes (fid < 0.5)  | **0**                  | band cleared (#492/#493), holding                                                                                              |
+| lossy passes (0.5 ≤ fid < 1.0) | **0**                  | band cleared (#495–#506), holding                                                                                              |
+| faithful (fid = 1.0)           | **3696**               | every parsing pattern is faithful                                                                                              |
+| avgFidelity (R0-recall)        | **1.000**              | saturated                                                                                                                      |
+| avgPrecision (R0 trust floor)  | **0.9997**             | bar 3 reached L4 (0.9953); L7 → 0.9963; R3/R1 arcs → 0.9997 (min 0.9978)                                                       |
+| avgMultisetRecall (R0 dupes)   | **1.000**              | signal added #632; last sub-1.0 row (qu behavior-resizable) cleared by #638's SOV if-seam work                                 |
+| avgRoleFidelity (R1)           | **0.9919**             | bar 4 reached session 13 (0.9862); #637/#638 → 0.9919. SOV six now ≥ 0.9907 — lowest langs are th 0.9845 / ms / de / fr        |
+| avgValueRecall (R3)            | **0.9967**             | signal added #634; F1–F8 burned down #635; residual = swap F6 wontfix + triaged rows (min 0.9906)                              |
+| avgExecutionFidelity (R2)      | **1.000**              | 47-pattern curated subset fully reproduces en DOM effects                                                                      |
 
-The six-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recall ·
-R0-precision · R1 · R2) — see CLAUDE.md "Multilingual parse rate ≠ fidelity".
+The eight-signal ratchet gate is fully wired (parse-rate · degenerate · R0-recall ·
+R0-precision · R0-multiset-recall · R1 · R2 · R3) — see CLAUDE.md "Multilingual
+parse rate ≠ fidelity".
 **The launch bar is complete (all four items) — remaining fidelity work is the
 post-launch track below.**
 
@@ -127,7 +130,7 @@ form-submit-prevent fused-clause scramble, focus-trap condition-boundary
 leak) and the qu-only tail were cleared by the R1 deferred-tail arc
 (2026-07-11b, below); the SOV-six role polish and the R1 long tail
 (fetch/render.style, qu set, or-run wait, beep/js/go/scroll/log/for) by the
-R1 arc (2026-07-11, below). The six-signal gate holds the bar — regressions
+R1 arc (2026-07-11, below). The eight-signal gate holds the bar — regressions
 fail CI.
 
 > **Update 2026-07-11b (R1 deferred-tail arc, branch `fix/r1-deferred-tail`
@@ -2846,15 +2849,14 @@ value-bug families"), F6 **wontfix** (documented), F7 **re-filed**:
    (PRs #446 ms `bind`×4 + hi keywords, #447 sw `input` event). Parse rate **3688 → 3695/3696**.
    Only `tr window-resize` remains — deferred as **structural SOV** (see Track 2 increment notes).
    The hi `live`/`intercept` bareKeyword block-shape work is the remaining genuine block-parser arc.
-5. **Track 3 — R1 role-fidelity** triaged (2026-06-17): the laggard (hi 0.683 / qu 0.770 / bn 0.780)
-   is **dominated by structural SOV mis-anchoring**, not dict-alignment (see the Track 3 triage
-   note) — `on.event:literal` + `fetch.source:literal` are the top drops and both trace to "fronted
-   literal/expression mistaken for the event / bare SOV command not matched."
-6. **The convergent next arc — SOV bare-command / event-anchor disambiguation.** `tr window-resize`,
-   the hi/qu/bn R1 laggard, and the SOV `fetch` NULLs are **one structural problem**. A focused arc
-   here is now the highest-leverage remaining parser work — but it's regression-sensitive (hottest
-   SOV path), so guard R0/precision/parse-rate carefully. Alternative if smaller wins are preferred:
-   **Track 4** lossy long-tail (94 lossy ≫ the 1 remaining hard-fail).
+5. ~~**Track 3 — R1 role-fidelity** triaged (2026-06-17)~~ **DONE** — the structural-SOV
+   triage (hi 0.683 / qu 0.770 / bn 0.780) was burned down across the increment below, the
+   launch-bar drills, and the dedicated R1 arcs (#637 + #638). The SOV six now sit at
+   **≥ 0.9907** — they no longer trail the SVO languages (lowest are th 0.9845 / ms / de / fr).
+6. ~~**The convergent next arc — SOV bare-command / event-anchor disambiguation.**~~ **DONE**
+   (increment note below, 2026-06-17). The follow-on R1 work continued through #637/#638;
+   standing R1 deferrals are pick range-role modeling (Family F) and the reactive `on.event`
+   rows (see the post-launch track at the top of this doc).
 
 > **Increment DONE (2026-06-17 — SOV event-anchor / bare-command).** The structural root cause
 > (a fronted **literal / expression / URL** mis-anchored as the handler event in SOV reorders) is
@@ -2894,7 +2896,8 @@ value-bug families"), F6 **wontfix** (documented), F7 **re-filed**:
 >
 > **Still open (out of this increment):**
 >
-> - **`tr window-resize`** — the lone remaining hard-fail (still 3695/3696). Compounded: (1) the i18n
+> - **`tr window-resize`** — _(since resolved — tr parses 154/154 and the corpus holds 3696/3696
+>   in the current baseline; kept for history)_ — was the lone remaining hard-fail (3695/3696). Compounded: (1) the i18n
 >   transformer emits `boyut_değiştir` for `resize`, which the tr tokenizer splits on `_` →
 >   `değiştir`(→`toggle` collision); (2) the `debounced at 200ms` modifier is left untranslated and
 >   fronted. Deferred — it needs an i18n single-token-resize emission + tr tokenizer fused-token entry
@@ -2911,6 +2914,29 @@ value-bug families"), F6 **wontfix** (documented), F7 **re-filed**:
 >   Any remaining qu/bn `fetch.source` **role-typing** slice (R1 — mis-typed `fetch.patient` via
 >   verb-anchoring) is a separate matter; the `fetch`→`source` verb-anchoring remap tried earlier
 >   proved **inert** on the corpus and was dropped.
+
+### Current queue (2026-07-12, post #639)
+
+The sequence above is fully resolved; the open work now lives in the sections above.
+Ranked by leverage:
+
+1. **Extend `unconsumed-input` to the remaining parse stages** — the deferred sub-task
+   from the top-level command-sequences arc (§ "Input coverage" above). The Stage-2-only
+   diagnostic surfaced 158 firings and every one was a real silent drop at confidence 1.0;
+   the uninstrumented stages (event-handler bodies, compound, SOV/VSO) are where most
+   translated rows route, so 0 is a floor. All four stages funnel through
+   `parseBodyWithClauses` / `buildEventHandler`, so a per-segment coverage check there may
+   cover them at once. Prerequisite for item 2.
+2. **The `unconsumed-input` → confidence-penalty scoring change** — both preconditions
+   then met (`SCHEMA_NO_REQUIRED_ROLES` fixed #628/#629; all stages measured). Five-step
+   plan in § "Input coverage". Payoff: re-evaluate whether `parseInternal` Stages 0 / 0.5
+   can be simplified.
+3. **Part 2b — `fetch … with { }` ×23 + naked named-arg capture** (§ deferral above).
+   All-or-nothing across 24 languages (R1 en-reference constraint) + baseline regen; a
+   self-contained user-facing alternative to 1–2.
+4. **Standing R1/R3 deferrals** (post-launch track, top of doc): pick range-role modeling
+   (Family F — only if `pick` matters for a demo; raises the en denominator ×24), the
+   reactive `on.event` rows (event-anchor guard machinery), swap-content F6 (wontfix).
 
 Re-baseline (`--save-baseline`) after each intentional fidelity change, regenerate against a
 freshly `populate`d DB, and commit only the dicts/profiles + baseline (not `patterns.db`).


### PR DESCRIPTION
## What

Docs-only sync of the two status-bearing documents with the committed baseline (`timestamp` 2026-07-11, `commit c5c884cc`), following the #639 closeout — plus (second commit) the session plan and v2.8 release bar for the ~2026-07-22 target.

## Stale → current (commit 1)

**`docs-internal/MULTILINGUAL_NEXT_STEPS.md`**
- "Where we are" header: 2026-07-06 → 2026-07-11 (`c5c884cc`); avgPrecision 0.996 → **0.9997**; avgRoleFidelity 0.986 → **0.9919**; added the two missing signal rows (avgMultisetRecall **1.000**, avgValueRecall **0.9967**)
- "six-signal ratchet" → **eight-signal** in live prose (3 spots; dated session logs left as history)
- §Recommended sequence: items 5/6 (SOV event-anchor arc, completed 2026-06-17) marked DONE; the "lone hard-fail tr window-resize (3695/3696)" note annotated as since-resolved (tr parses 154/154)

**`CLAUDE.md`**
- Signal 5: "one row sits below 1.0 (qu behavior-resizable)" → all 24 languages at 1.0 (cleared by #638's SOV if-seam work)
- Figures snapshot: 2026-07-05 → 2026-07-11 figures
- Known Issues: the "SOV six lag SVO on R1" bullet inverted by #637/#638 — SOV six ≥ 0.9907, lowest languages now th/ms/de/fr ≈ 0.985

## Session plan + release bar (commit 2)

- **Current queue** restructured into five PR-sized arcs: **A** vocab `validate`+`dump` CLI (new — five hand-authored vocab surfaces, ~7k entries, drift = dominant recent bug class), **B** `derive.ts` dictionary flip (post-release; baseline-coupled), **C** unconsumed-input stage extension, **D** scoring penalty (post-release), **E** fetch-with Part 2b (stretch)
- **v2.8 release bar** (target ≈ 2026-07-22): vocab validator green in CI · input coverage total or residuals named · fidelity floors held by the eight-signal ratchet · shipped-path Dependabot criticals zeroed + pre-publish green · stretch: `fetch … with {}` ×24

All figures verified directly against `packages/testing-framework/baselines/multilingual-priority.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)