### PR TITLE
fix(vocab): Batch 1 — V4 probe verdict, es hacia registration, 78 class-waivers

### DIFF
--- a/docs-internal/HANDOFF_vocab-batch1-v4-probe.md
+++ b/docs-internal/HANDOFF_vocab-batch1-v4-probe.md
@@ -1,5 +1,16 @@
 # Handoff: vocab Batch 1 — the V4 probe, then one semantic-side marker PR
 
+> **RESOLVED 2026-07-12** — probe verdict: Outcome A (matchLiteralToken matches
+> pattern literals by raw `token.value` before kind) for every pattern-literal
+> word; Outcome B (live) only for render-only grammar alternatives — es `hacia`
+> confirmed live (destination silently defaulted to `me`) and fixed via
+> `roleMarkers.destination.alternatives`. 78 remaining V4s class-waived with
+> per-family probe citations. V4 unwaived 79 → 0; es V2 `hacia` cleared; ledger
+> 242 → 162 unwaived. `--regression` exit 0 (no ratchet fired),
+> `--diagnose-coverage` 0/3696. Full conclusion + discoveries (go-url
+> destination drop in en, uncaptured show/hide style role, dead send.destination
+> overrides): `MULTILINGUAL_NEXT_STEPS.md` § "V4 probe conclusion (Batch 1)".
+
 ## Context
 
 Arc A (#642) landed the vocab-consistency CLI (`packages/testing-framework/src/vocab/`)

--- a/docs-internal/HANDOFF_vocab-batch1-v4-probe.md
+++ b/docs-internal/HANDOFF_vocab-batch1-v4-probe.md
@@ -1,0 +1,83 @@
+# Handoff: vocab Batch 1 — the V4 probe, then one semantic-side marker PR
+
+## Context
+
+Arc A (#642) landed the vocab-consistency CLI (`packages/testing-framework/src/vocab/`)
+warn-only in CI. Current ledger: **242 errors** (V1 ×94 · V4 ×79 · V3 ×60 · V2 ×9).
+The batch plan lives in `MULTILINGUAL_NEXT_STEPS.md` § "Arc A first ledger". This is
+**Batch 1**: classify all 79 V4 errors with ONE probe, then clear them in ONE
+semantic-side PR (fix or class-waive) — never per-finding.
+
+Measure:
+
+```bash
+npm run test:multilingual:build-deps        # vocab CLI refuses on stale dist
+cd packages/testing-framework
+npx tsx src/vocab/cli.ts validate --check V4 --json /tmp/v4.json; echo "exit=$?"
+```
+
+## The probe (do FIRST — its answer classifies all 79 at once)
+
+**Question: when a pattern's marker word classifies as `identifier` in the
+tokenizer, does the pattern matcher still consume it as the marker (matching by
+value/normalized), or does matching fail or degrade?**
+
+Read the marker-consumption path in
+`packages/semantic/src/parser/pattern-matcher.ts` (`matchTokenSequence` /
+role-marker handling): what is compared — `token.value`, `token.normalized`,
+`token.kind`? Note anywhere `kind` gates behavior (event anchoring, morphology,
+normalization only applying to keyword-kind tokens).
+
+Then probe empirically, one representative per family — **assert on captured
+roles, never "it parses"**:
+
+| family | probe | V4-flagged word |
+| ------ | ----- | --------------- |
+| schema quantity marker | fr `incrémenter #compteur par 2` → `increment.quantity` = 2? | fr `par` (also de `um`) |
+| render destination marker | round-trip the es transformer output containing `hacia` | es `hacia` (also V2) |
+| en duration marker | `transition opacity to 0 over 300ms` → `duration` captured? | en `over` |
+| untranslated scope | which corpus rows exercise `set.scope` at all? then probe one non-en | `on` ×22 langs |
+| untranslated patient | en `push url /x` + one translation | `url` ×24 langs |
+| as/method render markers | round-trip an es/fr/pl render using `como`/`comme`/`jako` | ~20 words |
+
+Prior evidence that kind DOES matter at least sometimes (cite in the analysis):
+\#638 Family G had to register ja/ko/qu containment words as whole `in` keywords
+because identifier-kind fragments broke generated patterns; sw `kama`/`kuwa`
+(#569) was a keyword-collision fix.
+
+**Outcome A (matcher matches by value; kind irrelevant on this path):** the V4
+class is *latent*, not live. Decide per family: register anyway (normalization +
+consistency) or class-waive (`V4|*|on`, `V4|*|url` — wildcard waivers landed in
+Batch 0) with the probe's finding as the reason. Consider splitting V4's tier:
+marker-words-in-patterns (warn) vs profile keywords (error).
+
+**Outcome B (kind gates anything):** live parse gaps — fix by registration, with
+a parse-level test per family proving the role captures (and fails without).
+
+## The fix PR (same branch, after the probe)
+
+- **Where to register matters:** prefer `profile.roleMarkers[role].alternatives`
+  when the word IS a role marker (es `hacia` → destination alternatives — this
+  also clears its V2 error); use tokenizer `EXTRAS` only for non-marker
+  vocabulary. Registering in profiles changes pattern GENERATION — watch
+  R0-precision (phantom captures) in the resweep.
+- **`on`/`url` (46 of 79):** if the corpus never exercises those roles non-en
+  AND the probe says latent → class-waive with reason; if exercised → translate
+  via per-language `markerOverride`, possibly as its own increment.
+- tr vowel-harmony allomorphs already live in `markerVariants` — don't
+  double-register.
+- Resweep discipline (semantic src changes): ordered build → fresh populate →
+  `--diagnose-coverage` + `--regression`, real exit codes (no `| tail`), plus
+  before/after vocab ledger. Baseline regen only if fidelity legitimately moves —
+  attribute old-vs-new against the same DB, prettier the baseline.
+- Never commit `patterns.db`.
+
+## Definition of done
+
+- The probe's answer (matcher marker semantics) written into NEXT_STEPS —
+  it also governs Batches 2–3.
+- V4 unwaived errors → **0** (registered or class-waived with the probe cited).
+- es `hacia` V2 error cleared via the roleMarkers route, or explicitly deferred.
+- Each registration family has a test proven to fail without the fix.
+- `--regression` exit 0 (or delta attributed); vocab ledger before/after in the
+  PR body.

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -2993,6 +2993,68 @@ packages on day one (#615). Lexicon end-state + domain-side history:
 >
 > Until then the CI step is warn-only by design.
 
+> **V4 probe conclusion (Batch 1, 2026-07-12) — matcher marker semantics; governs
+> Batches 2–3.** The pattern matcher consumes a pattern-literal (marker) token via
+> `matchLiteralToken` → `getMatchType` (`pattern-matcher.ts`), which compares **raw
+> `token.value` first** (exact, case-sensitive), then `token.normalized`, then stem
+> (confidence ≥ 0.7); `token.kind` gates ONLY the last-resort case-insensitive branch
+> (keyword-kind) and auxiliary consumption paths (event source-clause windows
+> `pattern-matcher.ts:264/:915`, connective/curated-end guards `:564/:577`, the
+> trailing-verb guard `:614`). Generated patterns carry the **native surface word**
+> (schema `markerOverride[lang]` / `profile.roleMarkers` primary+alternatives) and
+> handcrafted patterns carry it verbatim — so a marker word that classifies as
+> `identifier` is still consumed as the marker wherever it appears as a pattern
+> literal. **V4 is therefore Outcome A (latent) for every pattern-literal word, and
+> Outcome B (live) only for render-only grammar alternatives with no parse-side
+> literal.** Empirical probes (asserting on captured roles, one per family):
+>
+> - fr `par` / de `um` → `increment.quantity=10` captured ✓ (P1); en `over` →
+>   `transition.duration=500ms` ✓ (P3); `on` → `set.scope=.tab`/`me` captured, es
+>   tabs-aria row ✓ (P4); `url` → `push.patient` captured en+es ✓ (P5); es `como` →
+>   `fetch.responseType=json`, role-identical to the en reference, via the
+>   handcrafted fetch pattern's literal ✓ (P6); zh `时` → `event=click` via the
+>   hardcoded `sovEventMarkers` path ✓ (P7); fr `en` → `repeat source=.items` ✓ (P9).
+> - **es `hacia` (render-only destination alternative) was LIVE**: `agregar
+>   .selected hacia #item` captured `destination=me` (schema default — silent drop);
+>   `poner … hacia #output` returned null. **Fixed** by registering `hacia` in the es
+>   semantic profile `roleMarkers.destination.alternatives` (the tokenizer derives
+>   keywords from roleMarkers, so V4 cleared too; V2 es error cleared; red→green
+>   test in `packages/semantic/test/multilingual-roadmap-fixes.test.ts`).
+> - The other 78 V4s waived with per-family probe citations
+>   (`packages/testing-framework/vocab-waivers.json`, 31 entries). Notables: the
+>   send.destination overrides (de `an`, ko `에게`, tr `-e`) are **dead vocab** — the
+>   transformer renders `zu`/`에` and tr `-e` shatters (live allomorphs already in
+>   `markerVariants`); ar `بـ-`/`كـ-` are attach-notation artifacts (split to the
+>   registered bare prefix); hi `साथ` is blocked on style-capture (below).
+>
+> **Discoveries logged (not fixed in Batch 1):**
+>
+> 1. **go-url destination drop, en included**: `go to url "/page"` parses to
+>    `destination=expression:"url"` and DROPS `"/page"` — identically in en and es
+>    (P5c/P5d), so fidelity 1.0 masks it corpus-wide (the en-reference-corruption
+>    class; R3 silent because the value is a quoted string, not a bare URL token).
+>    Candidate for the R3 value-bug families list: teach `go`'s patterns the `url
+>    <literal>` idiom, then resweep — en denominator moves ×24.
+> 2. **`show`/`hide` style role is uncaptured in EVERY language including en**
+>    (`on click show #modal with *opacity` captures patient only). Another
+>    en-denominator gap: hi `साथ` / ar render-style registrations are untestable
+>    until style capture exists.
+> 3. de `senden` tokenizes normalized→`submit` (last-wins keyword collision with
+>    the send verb). Harmless today ONLY because literal matching is value-based;
+>    a latent footgun if any path starts trusting `normalized` for verbs.
+> 4. `set.scope` `on` / push-replace `url` stay English by design
+>    (passthrough-alignment, CORRECTNESS §7bb). If a native-marker increment is ever
+>    wanted, it must change render + schema override together (co-evolution) — its
+>    own increment, not vocab hygiene.
+>
+> **Governance for Batches 2–3:** classification-only mismatches (word consumed as a
+> pattern literal) are latent — waive or downgrade, don't register into profiles
+> "for hygiene" (profile registration changes pattern GENERATION). Register into
+> `roleMarkers[role].alternatives` only when the render side can emit a form the
+> parse side has no literal for (the hacia class), and only as an alternative to an
+> EXISTING marker entry. Optional structural follow-up: split V4's tier —
+> marker-words-appearing-in-patterns → warn, profile keywords → error.
+
 **Arc B — `derive.ts` dictionary flip (own arc; baseline-coupled).** Reconcile Arc A's
 profile↔dictionary disagreement ledger, then switch `i18n/src/dictionaries/index.ts`
 to the generated path — killing the single largest duplication (~4k entries). Hand

--- a/packages/domain-bdd/src/tokenizers/index.ts
+++ b/packages/domain-bdd/src/tokenizers/index.ts
@@ -139,6 +139,7 @@ const ES_KEYWORDS = new Set([
   'de',
   'desde',
   'sobre',
+  'hacia', // destination alternative (vocab Batch 1 — semantic es roleMarkers)
 ]);
 
 export class SpanishBDDTokenizer extends BaseTokenizer {

--- a/packages/semantic/src/generators/profiles/spanish.ts
+++ b/packages/semantic/src/generators/profiles/spanish.ts
@@ -49,7 +49,10 @@ export const spanishProfile: LanguageProfile = {
     },
   },
   roleMarkers: {
-    destination: { primary: 'en', alternatives: ['sobre', 'a'], position: 'before' },
+    // `hacia` is the i18n grammar's optional destination render form ("towards");
+    // without it here a rendered/user `hacia` clause silently dropped the
+    // destination (add → default `me`, put → null parse). Vocab Batch 1 (V2+V4).
+    destination: { primary: 'en', alternatives: ['sobre', 'a', 'hacia'], position: 'before' },
     source: { primary: 'de', alternatives: ['desde'], position: 'before' },
     patient: { primary: '', position: 'before' },
     style: { primary: 'con', position: 'before' },

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -13780,3 +13780,54 @@ describe('R1 deferred-tail qu tail: per-row alignments (docs-internal/HANDOFF_r1
     expect(cmds.find(c => c.action === 'toggle')).toBeTruthy();
   });
 });
+
+describe('Spanish hacia destination alignment (vocab Batch 1, V2+V4)', () => {
+  // The es i18n grammar declares `hacia` as a destination render alternative
+  // (i18n profiles: { form: 'hacia', role: 'destination' }), but the semantic
+  // es profile's roleMarkers.destination did not list it — so a `hacia` clause
+  // silently dropped the destination: `agregar .selected hacia #item` captured
+  // destination=me (the schema default) instead of #item. Registering it as a
+  // destination alternative fixes the capture AND its V4 classification (the
+  // tokenizer derives keywords from roleMarkers). Probe evidence:
+  // docs-internal/HANDOFF_vocab-batch1-v4-probe.md → MULTILINGUAL_NEXT_STEPS.md
+  // § "V4 probe conclusion".
+  function findAction(node: unknown, action: string): Record<string, any> | null {
+    if (!node || typeof node !== 'object') return null;
+    const n = node as Record<string, any>;
+    if (n.action === action) return n;
+    for (const f of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      const c = n[f];
+      if (Array.isArray(c)) {
+        for (const x of c) {
+          const hit = findAction(x, action);
+          if (hit) return hit;
+        }
+      }
+    }
+    return null;
+  }
+
+  it('[es] `agregar .selected hacia #item` captures destination=#item (was: me)', () => {
+    const node = parse('en clic agregar .selected hacia #item', 'es');
+    const add = findAction(node, 'add');
+    expect(add).not.toBeNull();
+    const roles = add!.roles as Map<string, { value?: unknown }>;
+    expect(roles.get('destination')?.value).toBe('#item');
+  });
+
+  it('[es] control: `agregar .selected a #item` still captures destination=#item', () => {
+    const node = parse('en clic agregar .selected a #item', 'es');
+    const add = findAction(node, 'add');
+    expect(add).not.toBeNull();
+    const roles = add!.roles as Map<string, { value?: unknown }>;
+    expect(roles.get('destination')?.value).toBe('#item');
+  });
+
+  it('[es] `poner "hola" hacia #output` captures destination=#output', () => {
+    const node = parse('poner "hola" hacia #output', 'es');
+    const put = findAction(node, 'put');
+    expect(put).not.toBeNull();
+    const roles = put!.roles as Map<string, { value?: unknown }>;
+    expect(roles.get('destination')?.value).toBe('#output');
+  });
+});

--- a/packages/testing-framework/vocab-waivers.json
+++ b/packages/testing-framework/vocab-waivers.json
@@ -1,1 +1,126 @@
-[]
+[
+  {
+    "key": "V4|*|url",
+    "reason": "Batch 1 probe P5/P5b: push/replace's `url` is a deliberate all-language passthrough marker (URL_MARKER_ALL_LANGS); matchLiteralToken consumes pattern literals by raw token.value before kind, so patient captures correctly (en+es probed) despite identifier classification. push/replace are not corpus-exercised. See MULTILINGUAL_NEXT_STEPS.md § 'V4 probe conclusion (Batch 1)'."
+  },
+  {
+    "key": "V4|*|on",
+    "reason": "Batch 1 probe P4: set.scope's `on` is passthrough-alignment by design (command-schemas set.scope comment; CORRECTNESS §7bb); pattern literals match by raw token.value, so scope captures (.tab / me) — tabs-aria faithful in all 24 languages. Per-language translate-via-markerOverride queued as its own increment in MULTILINGUAL_NEXT_STEPS.md."
+  },
+  {
+    "key": "V4|fr|par",
+    "reason": "Batch 1 probe P1: `incrémenter #score par 10` captures quantity=10 — the increment/decrement markerOverride word is a generated-pattern literal, matched by raw token.value (kind-independent)."
+  },
+  {
+    "key": "V4|de|um",
+    "reason": "Batch 1 probe P1b: `erhöhen #score um 10` captures quantity=10 — same schema-markerOverride literal mechanism as fr `par`."
+  },
+  {
+    "key": "V4|en|over",
+    "reason": "Batch 1 probe P3: `transition opacity to 0 over 500ms` captures duration=500ms — `over` is the en transition markerOverride literal, matched by raw token.value."
+  },
+  {
+    "key": "V4|fr|en",
+    "reason": "Batch 1 probe P9: repeat-for-each `répéter item en .items` captures source=.items — for.source markerOverride literal, matched by raw token.value."
+  },
+  {
+    "key": "V4|he|in",
+    "reason": "Batch 1 probe P9 mechanism class (for.source markerOverride literal, matched by raw token.value; fr `en` probed as the representative)."
+  },
+  {
+    "key": "V4|ms|dalam",
+    "reason": "Batch 1 probe P9 mechanism class (for.source markerOverride literal, matched by raw token.value; fr `en` probed as the representative)."
+  },
+  {
+    "key": "V4|tl|sa_loob",
+    "reason": "Batch 1 probe P9 mechanism class (for.source markerOverride literal, matched by raw token.value); aux probe: sa_loob tokenizes as a single token, so no shatter risk."
+  },
+  {
+    "key": "V4|vi|trong",
+    "reason": "Batch 1 probe P9 mechanism class (for.source markerOverride literal, matched by raw token.value; fr `en` probed as the representative)."
+  },
+  {
+    "key": "V4|de|an",
+    "reason": "Batch 1: dead vocab — the transformer renders send.destination as `zu` (corpus send-event/send-with-detail rows), never this override word; no parse path needs it. Schema-override↔render alignment queued in MULTILINGUAL_NEXT_STEPS.md."
+  },
+  {
+    "key": "V4|ko|에게",
+    "reason": "Batch 1: dead vocab — the transformer renders send.destination as `에` (corpus send-event row), never `에게`. Schema-override↔render alignment queued in MULTILINGUAL_NEXT_STEPS.md."
+  },
+  {
+    "key": "V4|tr|-e",
+    "reason": "Batch 1: dead vocab — aux probe shows `-e` shatters to `-` + `e(particle)`; the live tr dative allomorphs already parse via markerVariants (e/a/ye/ya). Schema-override↔render alignment queued in MULTILINGUAL_NEXT_STEPS.md."
+  },
+  {
+    "key": "V4|*|como",
+    "reason": "Batch 1 probe P6: es `buscar /api/user como json` captures responseType=json via the handcrafted fetch pattern's `como` literal, identical role shape to the en reference — pattern literals match by raw token.value. Corpus fetch rows faithful. (es + pt.)"
+  },
+  {
+    "key": "V4|*|sebagai",
+    "reason": "Batch 1 probe P6 mechanism class (grammar.method render word consumed as a handcrafted/pattern literal by raw token.value; es `como` probed as the representative). (id + ms.)"
+  },
+  {
+    "key": "V4|fr|comme",
+    "reason": "Batch 1 probe P6 mechanism class (grammar.method word consumed as a pattern literal by raw token.value; corpus fetch rows faithful)."
+  },
+  {
+    "key": "V4|pl|jako",
+    "reason": "Batch 1 probe P6 mechanism class (grammar.method word consumed as a pattern literal by raw token.value; corpus fetch rows faithful)."
+  },
+  {
+    "key": "V4|de|als",
+    "reason": "Batch 1 probe P6 mechanism class (grammar.method word consumed as a pattern literal by raw token.value; corpus fetch rows faithful)."
+  },
+  {
+    "key": "V4|it|come",
+    "reason": "Batch 1 probe P6 mechanism class (grammar.method word consumed as a pattern literal by raw token.value; corpus fetch rows faithful)."
+  },
+  {
+    "key": "V4|ru|как",
+    "reason": "Batch 1 probe P6 mechanism class (grammar.method word consumed as a pattern literal by raw token.value; corpus fetch rows faithful)."
+  },
+  {
+    "key": "V4|uk|як",
+    "reason": "Batch 1 probe P6 mechanism class (grammar.method word consumed as a pattern literal by raw token.value; corpus fetch rows faithful)."
+  },
+  {
+    "key": "V4|sw|kuwa",
+    "reason": "Batch 1 probe P6 mechanism class (grammar.method word consumed as a pattern literal by raw token.value; sw kama/kuwa keyword-collision history in #569)."
+  },
+  {
+    "key": "V4|th|เป็น",
+    "reason": "Batch 1 probe P6 mechanism class (grammar.method word consumed as a pattern literal by raw token.value; corpus fetch rows faithful)."
+  },
+  {
+    "key": "V4|tl|bilang",
+    "reason": "Batch 1 probe P6 mechanism class (grammar.method word consumed as a pattern literal by raw token.value; corpus fetch rows faithful)."
+  },
+  {
+    "key": "V4|tr|olarak",
+    "reason": "Batch 1 probe P6 mechanism class (grammar.method word consumed as a pattern literal by raw token.value; corpus fetch rows faithful)."
+  },
+  {
+    "key": "V4|vi|như",
+    "reason": "Batch 1 probe P6 mechanism class (grammar.method word consumed as a pattern literal by raw token.value; corpus fetch rows faithful)."
+  },
+  {
+    "key": "V4|he|כ",
+    "reason": "Batch 1 probe P6 mechanism class (grammar.method word consumed as a pattern literal by raw token.value; corpus fetch rows faithful)."
+  },
+  {
+    "key": "V4|ar|كـ-",
+    "reason": "Batch 1: notation artifact — the grammar lists the attached-prefix form with a trailing hyphen; the tokenizer splits it and the bare prefix is what appears in token streams. Never a standalone token, so word-level classification cannot apply."
+  },
+  {
+    "key": "V4|ar|بـ-",
+    "reason": "Batch 1: notation artifact — aux probe shows `بـ-` splits to `بـ` (already keyword→style) + `-`. The hyphen suffix is the grammar's attach-notation, never a standalone token."
+  },
+  {
+    "key": "V4|hi|साथ",
+    "reason": "Batch 1: render-only style alternative, and the style role is not captured on this path in ANY language including en (probe: `show #modal with *opacity` captures patient only) — registration is untestable until style capture lands. Queued in MULTILINGUAL_NEXT_STEPS.md."
+  },
+  {
+    "key": "V4|zh|时",
+    "reason": "Batch 1 probe P7: `当 点击 时 切换 把 .active` captures event=click — SOV event markers are consumed by semantic-parser's hardcoded sovEventMarkers path, matched by value."
+  }
+]


### PR DESCRIPTION
## Vocab Batch 1 (per `docs-internal/HANDOFF_vocab-batch1-v4-probe.md`)

### The probe (classifies all 79 V4 errors at once)

**Question:** when a pattern's marker word classifies as `identifier` in the tokenizer, does the matcher still consume it as the marker?

**Answer (code + empirical):** `matchLiteralToken → getMatchType` (`packages/semantic/src/parser/pattern-matcher.ts`) compares **raw `token.value` first** (exact, case-sensitive), then `token.normalized`, then stem (≥ 0.7); `token.kind` gates only the case-insensitive fallback and auxiliary paths (event source-clause windows, connective/curated-end/trailing-verb guards). Generated patterns carry the **native surface word** (schema `markerOverride[lang]` / profile roleMarkers), handcrafted patterns carry it verbatim — so identifier classification is **latent (Outcome A)** for every word that appears as a pattern literal, and **live (Outcome B)** only for render-only grammar alternatives with no parse-side literal.

Probes asserted on **captured roles**, never "it parses":

| family | probe | verdict |
| --- | --- | --- |
| schema quantity marker | fr `incrémenter #score par 10` / de `um 10` | `quantity=10` captured — latent |
| en duration marker | `transition opacity to 0 over 500ms` | `duration=500ms` captured — latent |
| untranslated scope `on` ×23 | es tabs-aria row (corpus-exercised ×24) | `scope=.tab`/`me` captured — latent (passthrough by design, CORRECTNESS §7bb) |
| untranslated patient `url` ×24 | en+es `push url "/new-page"` | `patient` captured — latent (push/replace not corpus-exercised) |
| as/method render markers ×17 | es fetch-json row `… como json …` | `responseType=json`, role-identical to en reference (handcrafted fetch literal) — latent |
| render destination marker | es `agregar .selected hacia #item` | **LIVE: destination silently defaulted to `me`; `poner … hacia` → null** |
| zh event `时` / fr for.source `en` | corpus rows | captured — latent |

### The fix

- **es `hacia`** → registered in `profile.roleMarkers.destination.alternatives` (the tokenizer derives keywords from roleMarkers, so this clears **V4 + the es V2 error** in one move). Red→green tests in `packages/semantic/test/multilingual-roadmap-fixes.test.ts` — both hacia cases proven failing before the fix (destination=`me` / SemanticParseError), control `a` case passing throughout.
- **78 latent findings class-waived** in `packages/testing-framework/vocab-waivers.json` (31 entries: `V4|*|url`, `V4|*|on` wildcards + per-word entries), each citing the probe family. Notables: de `an`/ko `에게`/tr `-e` send.destination overrides are **dead vocab** (transformer renders `zu`/`에`; tr `-e` shatters — live allomorphs already in `markerVariants`); ar `بـ-`/`كـ-` are attach-notation artifacts; hi `साथ` blocked on style-capture (see discoveries).
- Probe conclusion + governance for Batches 2–3 written into `MULTILINGUAL_NEXT_STEPS.md` § "V4 probe conclusion (Batch 1)"; handoff stamped RESOLVED.

### Discoveries logged (not fixed here)

1. **go-url destination drop, en included**: `go to url "/page"` → `destination=expression:"url"`, `"/page"` dropped — identically in en+es, so fidelity 1.0 masks it corpus-wide (en-reference-corruption class; R3 silent because the value is a quoted string).
2. **`show`/`hide` style role uncaptured in every language incl. en** (`with *opacity` → patient only) — blocks hi/ar style-marker registrations.
3. de `senden` tokenizes normalized→`submit` (last-wins collision) — harmless only because literal matching is value-based.

### Vocab ledger

| | before | after |
| --- | --- | --- |
| errors | 242 | 240 (V4 79→78, V2 9→8 — hacia fixed on both surfaces) |
| **unwaived errors** | **242** | **162** (V1 ×94 + V2 ×8 + V3 ×60 — Batches 2–3) |
| **V4 unwaived** | **79** | **0** |
| waived | 0 | 78 (31 entries, 0 stale) |
| warns / infos | 305 / 2410 | 305 / 2410 (unchanged) |

### Gates (real exit codes, ordered build + fresh populate first)

- multilingual `--regression`: **exit 0** — no ratchet fired (parse-rate, degenerate, R0-recall, R0-precision, multiset-recall, R1, R2, R3); no baseline regen needed since fidelity didn't move
- `--diagnose-coverage`: **0/3696** unconsumed input
- semantic suite: **7069 passed** (93 files); typecheck clean; vocab CLI tests 21 passed
- `vocab validate --check V4`: exit 0, "no unwaived errors"; full validate exits 1 on the remaining V1/V2/V3 as expected (CI step stays warn-only until Batch 4)
- `patterns.db` not committed (local repopulations only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)