### PR TITLE
fix(vocab): Batch 2 — V3 event-word alignment (60→0, probe-verified, zero waivers)

### DIFF
--- a/docs-internal/HANDOFF_vocab-batch2-v3-events.md
+++ b/docs-internal/HANDOFF_vocab-batch2-v3-events.md
@@ -1,0 +1,127 @@
+# Handoff: vocab Batch 2 — V3 event-word alignment (i18n dictionaries ↔ eventNameTranslations)
+
+## Context
+
+Batch 1 (#643) resolved all 79 V4s (probe verdict + es `hacia` registration + 78
+class-waivers) — verdict and governance in `MULTILINGUAL_NEXT_STEPS.md` § "V4
+probe conclusion (Batch 1)". Ledger now: **162 unwaived** (V1 ×94 · V3 ×60 ·
+V2 ×8). This is **Batch 2**: clear the **60 V3 errors** in ONE i18n-side PR.
+(Batch 3 = V1 ×94 via Arc B `derive.ts` flip; Batch 4 = flip CI vocab step to
+gating.)
+
+The two surfaces:
+
+- **S3 (render)**: `packages/i18n/src/dictionaries/{lang}.ts` → `events`
+  category — what the transformer EMITS for event names in translations.
+- **S5b (parse)**: `packages/semantic/src/patterns/event-handler.ts` →
+  `eventNameTranslations` — the native→English mapping the parse side uses to
+  normalize an event word back to the canonical DOM event.
+
+V3 fires when S5b covers an event but does NOT recognize the dict's rendered
+form (es dict `cambiar` vs S5b `cambio`). Breakdown: by language sw ×10, es ×9,
+tr ×8, ja ×6, de ×5, fr ×5, ar ×4, id ×4, pt ×4, zh ×3, qu ×2; by event
+keydown ×11, keyup ×11, mouseover ×10, mouseout ×8, blur ×6, focus ×3, rest ≤2.
+Dominated by the fused/split class (de `mausüber` vs `maus über`) — the
+#533–#535/#540 arcs standardized the SEMANTIC side; the dictionaries were never
+reconciled. **Semantic (S5b) is authoritative.**
+
+Measure:
+
+```bash
+npm run test:multilingual:build-deps        # vocab CLI refuses on stale dist
+cd packages/testing-framework
+npx tsx src/vocab/cli.ts validate --check V3 --json /tmp/v3.json; echo "exit=$?"
+```
+
+## The probe (do FIRST — classifies the failure mode for all 60)
+
+Batch 1's verdict does NOT cover V3: that verdict was about pattern LITERALS
+(matched by raw `token.value`, kind-irrelevant). Event names are **role
+VALUES** — a different mechanism: the captured event value is normalized via
+tokenizer keyword tables / `eventNameTranslations`, and an unrecognized form is
+captured VERBATIM. Expected failure mode (verify, don't assume): the transformer
+renders es `cambiar`, the parse captures `event=literal:"cambiar"`, the built
+listener waits for a DOM event named `cambiar` that never fires — a REAL broken
+listener that **no ratchet sees** (R1 compares role TYPES only; R3's invariant
+whitelist has colon-qualified event names, not plain ones; R0 sees the action).
+
+Probe one row per class, asserting on the captured event VALUE (en reference
+captures `literal:"change"`):
+
+1. Corpus exercise: which `pattern_translations` rows actually contain the
+   flagged dict forms? (`sqlite3 packages/patterns-reference/data/patterns.db`,
+   after a fresh `npm run populate`.) The fused keydown/keyup/mouseover forms
+   very likely DO appear in corpus event handlers.
+2. Parse a corpus-shaped handler with the dict form (de
+   `bei mausüber …`, es `en cambiar …`) via `parseSemantic(text, lang)` — what
+   event value is captured? Compare against the S5b-known form (de `maus über`,
+   es `cambio`).
+3. If the captured value is the raw native word → live-broken-listener class
+   confirmed; also note whether R2 (execution, curated subset) covers any such
+   row — if yes, why didn't it fire? (Curated subset may simply not include
+   these events.)
+
+## The fix PR (same branch, after the probe)
+
+Per-row fork — decide by which form is the linguistically right RENDER:
+
+- **Dict form is wrong/fused** (the `mausüber` class): fix the DICTIONARY to
+  the S5b-known form. This changes rendered corpus translations → parse
+  rate/fidelity CAN move (probably UP if the old form parsed degenerately) —
+  corpus-coupled, hence the one-resweep discipline.
+- **Dict form is a legit synonym** (ar `تركيز` vs `التركيز`): add it as an S5b
+  ALIAS (additive parse-side entry in `eventNameTranslations`; render
+  unchanged; baseline stable). V3's containment check clears either way.
+- Genuinely unfixable rows (if any): waive with reason + probe citation —
+  wildcard waiver keys are `check|lang|key` (see Batch 1 precedent in
+  `packages/testing-framework/vocab-waivers.json`).
+
+Traps (Batch 1 lessons + standing):
+
+- **Dict edits move the baseline** — that is expected here, unlike Batch 1.
+  Full resweep: ordered build → fresh `populate` → `--diagnose-coverage` +
+  `--regression`. If fidelity legitimately improves, regenerate
+  (`--save-baseline`) against the SAME freshly-populated DB, attribute
+  old-vs-new per language in the PR body, prettier the baseline, commit
+  dicts + baseline — **never `patterns.db`**.
+- Real exit codes — no `| tail` on gate commands (use `pipestatus`/redirects).
+- Rebuild i18n (and anything else touched) before the vocab CLI or any probe —
+  it refuses on stale dist; `npx tsx` probes read src but the CLI + sweep read
+  dist.
+- Multi-word event forms (`maus über`, `tecla abajo`) are kept in the
+  tokenizers' `multiWordKeywords` (marker concepts are excluded, event names
+  kept) — verify the split form actually tokenizes as ONE keyword in that
+  language before assuming the S5b form round-trips.
+- **Domain ripple (new, from Batch 1's CI failure)**: semantic-side edits can
+  trip lint R5 in domain packages with hand-authored tokenizers (bdd es
+  `ES_KEYWORDS` had to learn `hacia`). S5b alias additions shouldn't surface
+  there (R5 collects profile keywords/roleMarkers/schema markers, not
+  eventNameTranslations), but if you touch semantic src at all, run the domain
+  lint tests locally: bdd, behaviorspec, learn.
+- i18n has its own ~900-test suite (`npm test --prefix packages/i18n`) with
+  dictionary-coupled expectations — run it; also semantic + testing-framework
+  suites.
+- Prove at least one dict fix red→green at the parse level (captured event
+  value flips from raw native word to the canonical form), per-class not
+  per-row.
+
+## Definition of done
+
+- Probe verdict (captured-event failure mode + whether ratchets can see it)
+  appended to `MULTILINGUAL_NEXT_STEPS.md` § Arc A ledger (Batch 2 entry).
+- V3 unwaived errors → **0** (dict-fixed, S5b-aliased, or waived with probe
+  cited).
+- `--regression` exit 0, or delta attributed + baseline regenerated with
+  old-vs-new per-language attribution in the PR body.
+- Before/after vocab ledger in the PR body (start: 162 unwaived — V1 ×94 ·
+  V3 ×60 · V2 ×8).
+- i18n / semantic / testing-framework suites + domain lint green; CI green.
+
+## Adjacent queue (NOT Batch 2 scope — don't drift)
+
+Logged in NEXT_STEPS § "V4 probe conclusion": go-url destination drop (en
+included — en-corruption class), uncaptured `show`/`hide` style role (blocks
+hi/ar style registrations), dead send.destination overrides (de `an`, ko
+`에게`, tr `-e`), the `on`/`url` translate-increment option, V4 tier-split
+(marker-words-in-patterns → warn). V2 ×8 residue rides with the style-capture
+work, not this batch.

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -3055,6 +3055,75 @@ packages on day one (#615). Lexicon end-state + domain-side history:
 > EXISTING marker entry. Optional structural follow-up: split V4's tier —
 > marker-words-appearing-in-patterns → warn, profile keywords → error.
 
+> **V3 probe conclusion (Batch 2, 2026-07-12) — captured-event failure mode; the
+> broken-listener class is REAL but corpus-cold.** Batch 1's latency verdict does
+> NOT extend to V3: event names are role VALUES, normalized (or not) by the
+> **tokenizer's `{native, normalized}` keyword table** — `eventNameTranslations`
+> (S5b) is the V3 reference and the render-path localization source, but it is
+> partially **aspirational** (16 of the 60 rows' S5b-listed forms do not
+> themselves round-trip: de `taste runter`/`maus über`, id `mouse masuk`, zh
+> `鼠标进入`, sw `bonyeza chini` captures `click`, ar `تمرير الماوس` captures
+> `scroll`, tr's own `fare_bas` shatters). "Semantic side is authoritative"
+> therefore means **the tokenizer keyword table**, not the S5b list per se.
+> Probed all 60 rows (corpus-shaped `toggle-class-basic` handler per language,
+> asserting on the captured event value vs the en reference's `literal:"click"`
+> / `literal:"change"` canonical):
+>
+> - **23 rows OK-NORMALIZED** — the dict form already captures the canonical
+>   event (tokenizer knows it; e.g. sw `bonyeza`→`click` — corpus-hot in 106
+>   rows — es `cambiar`→`change`, tr `farebas`→`mousedown`). V3 here is pure
+>   reference-table misalignment → S5b alias, baseline-stable.
+> - **37 rows BROKEN**, three failure shapes: (a) event role captured as
+>   `expression:undefined` (garbage listener — de/fr/pt/ja fused forms, es
+>   `teclaabajo`…), (b) **wrong event entirely** — sw `badilisha`→`toggle`
+>   (change-event homonym with the toggle verb), sw `panya_juu`→`mouseup`
+>   (dict shares one form for mouseup+mouseover; tokenizer deliberately maps it
+>   to mouseup for the corpus row), zh `按键抬起`→`keydown` (prefix-shatter), qu
+>   `yupana_ñitiy`→`click`, (c) verbatim/tail capture — tr `tuş_bas`→`bas`,
+>   the literal broken-DOM-listener class (`addEventListener("bas")`).
+> - **Ratchet visibility — confirmed blind spot:** parse rate non-null → blind;
+>   R0 sees the action set → blind; R1 compares role TYPES (wrong-value rows
+>   still `event:literal` → blind; the `expression:undefined` shape WOULD flip
+>   the role type, but no such row is corpus-exercised in event position); R3's
+>   invariant whitelist has colon-qualified event names only → plain names
+>   blind. **R2 dispatches the EN reference's canonical event name against the
+>   translated listener, so it catches every shape in this class** — it stayed
+>   silent because its curated subset is `on click` + one `success`
+>   CustomEvent: no blur/key*/mouse*/change trigger exists in the subset.
+>   Queue candidate: admit one non-click bare-event pattern (e.g.
+>   input-validation, `on blur`) to the R2 subset per language-facing arc.
+> - **Why the live corpus never broke:** every bare-event corpus row renders
+>   through a tokenizer-known form — de blur renders `defokussieren` because
+>   `commands.blur` SHADOWS `events.blur` in the transformer's category order
+>   (the dict `events` word `unscharf` was dead vocab), sw renders `kwenye
+>   blur` (English passthrough), and the corpus's only mouseup row rides the
+>   deliberate `panya_juu`→mouseup tokenizer mapping. The 37 broken forms are
+>   all corpus-cold in event position; corpus keydown/keyup usage is
+>   exclusively the filtered English form (`keydown[key=="Escape"]`).
+> - **Resolution (zero waivers):** 23 alias-only rows (dict form works; add it
+>   to `eventNameTranslations` — additive, render untouched, appended after
+>   existing entries so first-wins localization canonicals are unchanged;
+>   includes the two prefix-shatter-but-correct rows zh `按键按下` and id
+>   `tekan_tombol`, kept in the dict because the "clean" alternatives collide —
+>   bare `按键` is zh's keypress entry) + 37 dict fixes to probe-verified
+>   round-tripping forms (S5b-listed where one round-trips: ja katakana,
+>   es/fr/pt split forms, tr fused forms, qu `llave uray/hawa`, zh
+>   `松键`/`鼠标移入`, sw `kubadilisha`/`lenga`/`blur`; tokenizer-registered
+>   where S5b's own form is aspirational: de `taste unten`/`taste oben`/`maus
+>   weg`/`maus drüber`, id `arahkan`/`tinggalkan`, sw `sogeza juu`; English
+>   passthrough where no native exists: id keyup). 31 aliases total (23 + 8
+>   companions for dict-fix forms not in S5b). Expected baseline movement:
+>   ~none (no corpus render changes among the 37).
+> - **Logged, out of scope (candidate next increments):** (1) id
+>   `tekan_mouse`/`lepas_mouse` (dict mousedown/mouseup, corpus-live in
+>   repeat-until-event) likely shatter to `tekan`→keydown — same class, not
+>   V3-visible because S5b id lacks mousedown/mouseup keys (V3 only compares
+>   covered events); an S5b-coverage check (V3c?) would surface it. (2) zh dict
+>   mouseenter `鼠标进入` captures nothing (S5b lists it under mouseover) —
+>   same gap. (3) R2 curated subset should admit one bare non-click event
+>   pattern (e.g. input-validation, `on blur`) to close the structural blind
+>   spot this probe exposed.
+
 **Arc B — `derive.ts` dictionary flip (own arc; baseline-coupled).** Reconcile Arc A's
 profile↔dictionary disagreement ledger, then switch `i18n/src/dictionaries/index.ts`
 to the generated path — killing the single largest duplication (~4k entries). Hand

--- a/packages/i18n/src/dictionaries/de.ts
+++ b/packages/i18n/src/dictionaries/de.ts
@@ -99,14 +99,19 @@ export const de: Dictionary = {
     mouseup: 'mausoben',
     mouseenter: 'mauseintreten',
     mouseleave: 'mausverlassen',
-    mouseover: 'mausüber',
-    mouseout: 'maushinaus',
+    // V3 Batch 2: fused/dead event words realigned to the de tokenizer's
+    // registered forms (S5b's `maus über`/`taste runter` are aspirational — they
+    // do not tokenize; `mausüber` etc. captured event=expression:undefined).
+    mouseover: 'maus drüber',
+    mouseout: 'maus weg',
     mousemove: 'mausbewegen',
-    keydown: 'tasteunten',
-    keyup: 'tasteoben',
+    keydown: 'taste unten',
+    keyup: 'taste oben',
     keypress: 'tastedrücken',
     focus: 'fokus',
-    blur: 'unscharf',
+    // matches commands.blur (which shadows this at render time) and the live
+    // corpus render; `unscharf` was dead vocab that captured no event
+    blur: 'defokussieren',
     change: 'ändern',
     input: 'eingabe',
     submit: 'absenden',

--- a/packages/i18n/src/dictionaries/es.ts
+++ b/packages/i18n/src/dictionaries/es.ts
@@ -90,11 +90,13 @@ export const es: Dictionary = {
     mouseup: 'ratónarriba',
     mouseenter: 'ratónentrar',
     mouseleave: 'ratónsalir',
-    mouseover: 'ratónencima',
-    mouseout: 'ratónfuera',
+    // V3 Batch 2: fused forms split to the S5b/tokenizer-known forms (the fused
+    // spellings captured event=expression:undefined — broken listeners)
+    mouseover: 'ratón encima',
+    mouseout: 'ratón fuera',
     mousemove: 'ratónmover',
-    keydown: 'teclaabajo',
-    keyup: 'teclaarriba',
+    keydown: 'tecla abajo',
+    keyup: 'tecla arriba',
     keypress: 'teclapresar',
     focus: 'enfocar',
     blur: 'desenfocar',

--- a/packages/i18n/src/dictionaries/fr.ts
+++ b/packages/i18n/src/dictionaries/fr.ts
@@ -94,11 +94,13 @@ export const fr: Dictionary = {
     mouseup: 'sourisrelâchée',
     mouseenter: 'sourisentrer',
     mouseleave: 'sourissortir',
-    mouseover: 'sourissur',
-    mouseout: 'sourisdehors',
+    // V3 Batch 2: fused forms split to the S5b/tokenizer-known forms (the fused
+    // spellings captured event=expression:undefined — broken listeners)
+    mouseover: 'souris dessus',
+    mouseout: 'souris dehors',
     mousemove: 'sourisbouger',
-    keydown: 'toucheappuyée',
-    keyup: 'toucherelâchée',
+    keydown: 'touche bas',
+    keyup: 'touche haut',
     keypress: 'touchepressée',
     focus: 'focus',
     blur: 'flou',

--- a/packages/i18n/src/dictionaries/id.ts
+++ b/packages/i18n/src/dictionaries/id.ts
@@ -97,11 +97,17 @@ export const id: Dictionary = {
     mouseup: 'lepas_mouse',
     mouseenter: 'mouse_masuk',
     mouseleave: 'mouse_keluar',
-    mouseover: 'mouse_atas',
-    mouseout: 'mouse_luar',
+    // V3 Batch 2: mouse_atas/mouse_luar captured no event (the S5b forms
+    // `mouse masuk`/`mouse keluar` are aspirational — they don't tokenize
+    // either) — realigned to the tokenizer-registered natives. keydown keeps
+    // tekan_tombol (captures keydown via the registered `tekan`; S5b-aliased).
+    // keyup has NO parseable native (lepas is unregistered) → English
+    // passthrough, matching the blur/reset precedent below.
+    mouseover: 'arahkan',
+    mouseout: 'tinggalkan',
     mousemove: 'gerak_mouse',
     keydown: 'tekan_tombol',
-    keyup: 'lepas_tombol',
+    keyup: 'keyup',
     keypress: 'pencet_tombol',
     focus: 'fokus',
     blur: 'blur',

--- a/packages/i18n/src/dictionaries/ja.ts
+++ b/packages/i18n/src/dictionaries/ja.ts
@@ -95,12 +95,15 @@ export const ja: Dictionary = {
     mouseup: 'マウス解放',
     mouseenter: 'マウス入る',
     mouseleave: 'マウス離れる',
-    mouseover: 'マウス上',
-    mouseout: 'マウス外',
+    // V3 Batch 2: kanji compounds realigned to the S5b/tokenizer katakana
+    // loanwords (the standard JS event terms; the compounds captured
+    // event=expression:undefined — broken listeners)
+    mouseover: 'マウスオーバー',
+    mouseout: 'マウスアウト',
     mousemove: 'マウス移動',
-    keydown: 'キー押下',
-    keyup: 'キー解放',
-    keypress: 'キー押す',
+    keydown: 'キーダウン',
+    keyup: 'キーアップ',
+    keypress: 'キープレス',
     focus: 'フォーカス',
     blur: 'ぼかし',
     change: '変更',

--- a/packages/i18n/src/dictionaries/pt.ts
+++ b/packages/i18n/src/dictionaries/pt.ts
@@ -96,11 +96,13 @@ export const pt: Dictionary = {
     mouseup: 'mouseCima',
     mouseenter: 'mouseEntrar',
     mouseleave: 'mouseSair',
-    mouseover: 'mouseSobre',
-    mouseout: 'mouseFora',
+    // V3 Batch 2: camelCase forms split to the S5b/tokenizer-known forms (the
+    // fused spellings captured event=expression:undefined — broken listeners)
+    mouseover: 'mouse sobre',
+    mouseout: 'mouse fora',
     mousemove: 'mouseMover',
-    keydown: 'teclaBaixo',
-    keyup: 'teclaCima',
+    keydown: 'tecla baixo',
+    keyup: 'tecla cima',
     keypress: 'teclaPressionar',
     focus: 'foco',
     blur: 'desfoque',

--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -113,8 +113,12 @@ export const qu: Dictionary = {
     mouseover: 'rat_hawapi',
     mouseout: 'rat_hawamanta',
     mousemove: 'rat_kuyuy',
-    keydown: 'yupana_ñitiy',
-    keyup: 'yupana_huqariy',
+    // V3 Batch 2: `yupana_ñitiy` split at `_` and mis-captured as the `click`
+    // event (ñitiy→click, the same mechanism as the mousedown fuse above);
+    // `yupana_huqariy` captured verbatim `huqariy`. Realigned to the
+    // S5b/tokenizer forms.
+    keydown: 'llave uray',
+    keyup: 'llave hawa',
     keypress: 'yupana_ñitana',
     focus: 'qhaway',
     blur: 'paqariy',

--- a/packages/i18n/src/dictionaries/sw.ts
+++ b/packages/i18n/src/dictionaries/sw.ts
@@ -108,15 +108,24 @@ export const sw: Dictionary = {
     mouseup: 'panya_juu',
     mouseenter: 'panya_ingia',
     mouseleave: 'panya_toka',
-    mouseover: 'panya_juu',
+    // V3 Batch 2: panya_juu is mouseup's form (shared here by mistake — the
+    // tokenizer deliberately maps it to mouseup for the corpus row, so a
+    // mouseover handler captured `mouseup`) — realigned to the
+    // tokenizer-registered `sogeza juu`.
+    mouseover: 'sogeza juu',
     mouseout: 'panya_nje',
     mousemove: 'panya_sogea',
     keydown: 'kitufe_shuka',
     keyup: 'kitufe_juu',
     keypress: 'kitufe_bonyeza',
-    focus: 'zingatia',
-    blur: 'poteza_macho',
-    change: 'badilisha',
+    // V3 Batch 2: zingatia captured no event → lenga (S5b/tokenizer form);
+    // poteza_macho was a null parse → `blur` (the S5b identity form — matches
+    // the live corpus render `kwenye blur`); badilisha is the toggle VERB
+    // homonym (a change handler captured event=`toggle` — a listener for a DOM
+    // event named "toggle") → kubadilisha (S5b/tokenizer form).
+    focus: 'lenga',
+    blur: 'blur',
+    change: 'kubadilisha',
     input: 'ingizo',
     submit: 'wasilisha',
     reset: 'weka_upya',

--- a/packages/i18n/src/dictionaries/tr.ts
+++ b/packages/i18n/src/dictionaries/tr.ts
@@ -98,11 +98,14 @@ export const tr: Dictionary = {
     mouseup: 'farebırak',
     mouseenter: 'fare_gir',
     mouseleave: 'fare_çık',
-    mouseover: 'fare_üstü',
-    mouseout: 'fare_dışı',
+    // V3 Batch 2: same `_`-split class (tuş_bas captured verbatim `bas` — a
+    // listener for a DOM event named "bas") — realigned to the S5b/tokenizer
+    // fused forms.
+    mouseover: 'fareiçinde',
+    mouseout: 'faredışında',
     mousemove: 'fare_hareket',
-    keydown: 'tuş_bas',
-    keyup: 'tuş_bırak',
+    keydown: 'tuşbasma',
+    keyup: 'tuşbırakma',
     keypress: 'tuş_basım',
     focus: 'odak',
     blur: 'bulanık',

--- a/packages/i18n/src/dictionaries/zh.ts
+++ b/packages/i18n/src/dictionaries/zh.ts
@@ -97,11 +97,17 @@ export const zh: Dictionary = {
     mouseup: '鼠标抬起',
     mouseenter: '鼠标进入',
     mouseleave: '鼠标离开',
-    mouseover: '鼠标悬停',
+    // V3 Batch 2: 鼠标悬停 captured no event (expression:undefined) — realigned
+    // to the tokenizer-registered 鼠标移入 (also S5b-listed). 按键抬起
+    // prefix-shattered to 按键 and captured `keydown` (a keyup handler firing
+    // on keydown) → 松键, the S5b/tokenizer form. keydown keeps 按键按下
+    // (captures keydown via the registered 按键 prefix; S5b-aliased) — fixing
+    // it to bare 按键 would collide with keypress below.
+    mouseover: '鼠标移入',
     mouseout: '鼠标移出',
     mousemove: '鼠标移动',
     keydown: '按键按下',
-    keyup: '按键抬起',
+    keyup: '松键',
     keypress: '按键',
     focus: '聚焦',
     blur: '失焦',

--- a/packages/i18n/src/new-languages.test.ts
+++ b/packages/i18n/src/new-languages.test.ts
@@ -199,7 +199,9 @@ describe('New Language Support', () => {
     it('should handle double-click events', () => {
       const result = translator.translate('on dblclick focus on me', { from: 'en', to: 'sw' });
       expect(result).toContain('bonyeza_mara_mbili'); // dblclick → bonyeza_mara_mbili
-      expect(result).toContain('zingatia'); // focus → zingatia
+      // V3 Batch 2: events.focus realigned zingatia → lenga (zingatia never
+      // tokenized as an event — matches commands.focus and the S5b table)
+      expect(result).toContain('lenga'); // focus → lenga
     });
 
     it('should translate navigation commands', () => {

--- a/packages/semantic/src/patterns/event-handler.ts
+++ b/packages/semantic/src/patterns/event-handler.ts
@@ -55,6 +55,9 @@ export const eventNameTranslations: Record<string, Record<string, string>> = {
     読み込み: 'load',
     サイズ変更: 'resize',
     スクロール: 'scroll',
+    // V3 Batch 2 alias: i18n dictionary form the ja tokenizer already
+    // normalizes (probe-verified).
+    ぼかし: 'blur',
   },
   // Arabic event names → English
   ar: {
@@ -72,6 +75,13 @@ export const eventNameTranslations: Record<string, Record<string, string>> = {
     التركيز: 'focus',
     تحميل: 'load',
     تمرير: 'scroll',
+    // V3 Batch 2 aliases: i18n dictionary forms the ar tokenizer already
+    // normalizes (probe-verified captured values). Appended so first-wins
+    // localization canonicals above are unchanged.
+    تركيز: 'focus',
+    'مفتاح أسفل': 'keydown',
+    'مفتاح أعلى': 'keyup',
+    'فأرة فوق': 'mouseover',
   },
   // Spanish event names → English
   es: {
@@ -89,6 +99,13 @@ export const eventNameTranslations: Record<string, Record<string, string>> = {
     desenfoque: 'blur',
     carga: 'load',
     desplazamiento: 'scroll',
+    // V3 Batch 2 aliases: i18n dictionary verb forms the es tokenizer already
+    // normalizes (probe-verified). Appended — localization canonicals unchanged.
+    cambiar: 'change',
+    enfocar: 'focus',
+    desenfocar: 'blur',
+    cargar: 'load',
+    desplazar: 'scroll',
   },
   // Turkish event names → English
   tr: {
@@ -121,6 +138,13 @@ export const eventNameTranslations: Record<string, Record<string, string>> = {
     boyutlandırma: 'resize',
     boyutlandır: 'resize',
     kaydırma: 'scroll',
+    // V3 Batch 2 aliases: i18n dictionary forms the tr tokenizer already
+    // normalizes (probe-verified; farebas/farebırak are the deliberately fused
+    // dict forms — the table's own fare_bas/fare_bırak `_` entries shatter).
+    bulanık: 'blur',
+    farebas: 'mousedown',
+    farebırak: 'mouseup',
+    kaydır: 'scroll',
   },
   // Portuguese event names → English
   pt: {
@@ -174,6 +198,10 @@ export const eventNameTranslations: Record<string, Record<string, string>> = {
     加载: 'load',
     载入: 'load',
     滚动: 'scroll',
+    // V3 Batch 2 alias: the i18n dictionary keydown form (captures keydown via
+    // the registered 按键 prefix; probe-verified — kept over bare 按键 to avoid
+    // colliding with the dict's keypress entry).
+    按键按下: 'keydown',
   },
   // French event names → English
   fr: {
@@ -199,6 +227,9 @@ export const eventNameTranslations: Record<string, Record<string, string>> = {
     charger: 'load',
     défilement: 'scroll',
     défiler: 'scroll',
+    // V3 Batch 2 alias: i18n dictionary form the fr tokenizer already
+    // normalizes (probe-verified).
+    flou: 'blur',
   },
   // German event names → English
   de: {
@@ -223,6 +254,13 @@ export const eventNameTranslations: Record<string, Record<string, string>> = {
     ladung: 'load',
     scrollen: 'scroll',
     blättern: 'scroll',
+    // V3 Batch 2 aliases: the de tokenizer's registered multi-word event forms
+    // (probe-verified; the table's older `taste runter`/`taste hoch`/`maus
+    // über`/`maus raus` entries are aspirational — they do not tokenize).
+    'taste unten': 'keydown',
+    'taste oben': 'keyup',
+    'maus drüber': 'mouseover',
+    'maus weg': 'mouseout',
   },
   // Indonesian event names → English
   id: {
@@ -243,6 +281,14 @@ export const eventNameTranslations: Record<string, Record<string, string>> = {
     memuat: 'load',
     gulir: 'scroll',
     menggulir: 'scroll',
+    // V3 Batch 2 aliases: tekan_tombol captures keydown via the registered
+    // `tekan`; arahkan/tinggalkan are the tokenizer's registered natives;
+    // keyup is English passthrough (no parseable id native — `lepas` is
+    // unregistered). All probe-verified.
+    tekan_tombol: 'keydown',
+    keyup: 'keyup',
+    arahkan: 'mouseover',
+    tinggalkan: 'mouseout',
   },
   // Bengali event names → English
   bn: {
@@ -301,6 +347,17 @@ export const eventNameTranslations: Record<string, Record<string, string>> = {
     kupakia: 'load',
     sogeza: 'scroll',
     kusogeza: 'scroll',
+    // V3 Batch 2 aliases: i18n dictionary forms the sw tokenizer already
+    // normalizes (probe-verified; bonyeza is corpus-hot — 106 rows), plus the
+    // tokenizer's registered `sogeza juu` for mouseover (the table's `panya
+    // juu` is mouseup's dict form and maps there).
+    bonyeza: 'click',
+    ingizo: 'input',
+    kitufe_shuka: 'keydown',
+    kitufe_juu: 'keyup',
+    panya_nje: 'mouseout',
+    wasilisha: 'submit',
+    'sogeza juu': 'mouseover',
   },
 };
 


### PR DESCRIPTION
## Vocab ledger (before → after)

| Check | Before | After |
| --- | --- | --- |
| **Total unwaived** | **162** | **98** |
| V1 (profile ↔ dict keywords) | 94 | 90 |
| V3 (dict events ↔ eventNameTranslations) | **60** | **0** |
| V2 (render marker unknown to parse side) | 8 | 8 |

Zero new waivers. The four cleared V1s (`es keydown/keyup/mouseover/mouseout`) are a side effect of the dict fixes — the es profile already carried the split forms, so realigning S3 cleared S1↔S3 too (verified by re-running the checks with the old values patched back: 94→90, nothing introduced).

## Probe verdict (ran FIRST — appended to NEXT_STEPS § Arc A ledger, "V3 probe conclusion (Batch 2)")

Batch 1's pattern-literal latency verdict does **not** apply to V3: event names are role VALUES, normalized by each **tokenizer's `{native, normalized}` keyword table** — `eventNameTranslations` (S5b) is the V3 reference and render-localization source but is partially **aspirational** (16/60 rows' S5b-listed forms don't themselves round-trip: de `taste runter`/`maus über`, id `mouse masuk`, zh `鼠标进入`, ar `تمرير الماوس`→scroll…). All 60 rows probed with corpus-shaped handlers, asserting on the captured event value vs the en reference (`literal:"click"`/`literal:"change"`):

- **23 OK-NORMALIZED** — dict form already captures the canonical event (sw `bonyeza`→click is corpus-hot in 106 rows). Pure table misalignment → S5b alias, baseline-stable.
- **37 BROKEN**, three shapes: (a) `expression:undefined` (garbage listener — de/fr/pt/ja fused forms), (b) **wrong event** — sw `badilisha`→`toggle` (change handler listening for a DOM event named "toggle"), sw `panya_juu`→`mouseup`, zh `按键抬起`→`keydown` (keyup handler firing on keydown), qu `yupana_ñitiy`→`click`, (c) shattered tails — tr `tuş_bas`→`bas` (`addEventListener("bas")`).
- **Ratchet visibility (confirmed blind spot):** parse-rate/R0 blind (non-null parse), R1 blind to wrong-value rows (role type still `event:literal`), R3 whitelists only colon-qualified event names. **R2 dispatches the en canonical event name and would catch every shape** — it stayed silent because the curated subset is `on click` + one `success` CustomEvent. Queue candidate: admit one bare non-click event pattern (e.g. `input-validation`, `on blur`).
- **Why the corpus never broke:** every bare-event corpus row renders through a tokenizer-known form (de blur renders `defokussieren` because `commands.blur` shadows `events.blur`; sw renders English `blur`; the one `panya_juu` corpus row is the deliberate mouseup mapping). All 37 broken forms are corpus-cold in event position.

## Fixes

- **37 dictionary events entries** (10 dicts: de/es/fr/id/ja/pt/qu/sw/tr/zh) realigned to probe-verified round-tripping forms: ja katakana loanwords, es/fr/pt split forms, tr fused + qu de-underscored forms, de/id/sw tokenizer-registered natives (`taste unten`, `arahkan`, `sogeza juu`…), id keyup → English passthrough (no parseable native; matches id's blur/reset precedent). zh keydown deliberately kept `按键按下` (fixing to bare `按键` would collide with keypress) — S5b-aliased instead; same for id `tekan_tombol`.
- **31 additive `eventNameTranslations` aliases** — appended after existing entries so first-wins render localization canonicals are unchanged (semantic render path untouched; the denylist's test-locked failure set is unchanged — semantic suite green).
- **1 dictionary-coupled i18n expectation** updated (sw focus `zingatia`→`lenga`).
- No tokenizer changes, no waiver changes, no baseline changes.

## Red→green proof (per class)

Before (probe-v3, old dict forms): 37/60 broken — e.g. de `mausüber`→`expression:undefined`, sw `badilisha`→`literal:"toggle"`, tr `tuş_bas`→`literal:"bas"`, zh `按键抬起`→`literal:"keydown"`, qu `yupana_ñitiy`→`literal:"click"`.
After (same handler templates, new dict forms read from the edited dicts): **60/60 GREEN** — every row captures the canonical event.

## Gates & suites (real exit codes)

| Gate | Result |
| --- | --- |
| vocab `validate --check V3` | **0 errors** (was 60) |
| multilingual `--regression` (8 ratchets) | **exit 0** — 3696/3696, zero baseline movement → no regen needed |
| `--diagnose-coverage` | exit 0 — 0 unconsumed input corpus-wide |
| i18n suite | 947/947 |
| semantic suite (incl. event-name round-trip/denylist test) | 93/93 files |
| testing-framework suite | 8/8 files |
| domain lint: bdd / behaviorspec / learn | all green |
| typecheck semantic + i18n | clean |

`patterns.db` not committed (local regen only, per policy).

## Logged, out of scope (NEXT_STEPS)

1. id `tekan_mouse`/`lepas_mouse` (corpus-live mousedown/mouseup) likely shatter to `tekan`→keydown — invisible to V3 because S5b id lacks those keys; an S5b-coverage check (V3c) would surface the family.
2. zh dict mouseenter `鼠标进入` captures nothing (S5b lists it under mouseover).
3. R2 curated-subset expansion to one bare non-click event pattern.

Batch 3 = V1 ×90 via Arc B `derive.ts` flip; Batch 4 = flip CI vocab step to gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)