### PR TITLE
fix(vocab): Batch 3+4 — V1 reconciliation (90→0, probe-first) + CI vocab gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -772,12 +772,13 @@ jobs:
         run: npm run populate --prefix packages/patterns-reference
 
       # Vocab cross-surface consistency (Arc A — docs-internal/HANDOFF_vocab-consistency.md).
-      # WARN-ONLY while the first ledger is burned down; the gating flip is a
-      # named follow-up (NEXT_STEPS § v2.8 release bar, item 1).
-      - name: Vocab consistency (warn-only)
+      # GATING since Batch 4 (release bar item 1): exits 1 on any unwaived
+      # error-tier finding. Waivers (probe-cited) live in
+      # packages/testing-framework/vocab-waivers.json.
+      - name: Vocab consistency (gate)
         run: |
           cd packages/testing-framework
-          npx tsx src/vocab/cli.ts validate --warn-only
+          npx tsx src/vocab/cli.ts validate
 
       # Quick mode (10 core patterns/lang) is genuinely expected at 100% — a real
       # gate, no continue-on-error. A drop here is a real regression in core

--- a/docs-internal/HANDOFF_vocab-batch3-v1-reconciliation.md
+++ b/docs-internal/HANDOFF_vocab-batch3-v1-reconciliation.md
@@ -1,0 +1,158 @@
+# Handoff: vocab Batch 3 — V1 reconciliation (S1 profiles ↔ S3 dictionaries) + Batch 4 gating flip
+
+## Context
+
+Batch 2 (#644) cleared all 60 V3s (probe verdict + 37 dict fixes + 31 S5b
+aliases, zero waivers) — verdict and mechanism in `MULTILINGUAL_NEXT_STEPS.md`
+§ "V3 probe conclusion (Batch 2)". Ledger now: **98 unwaived** (V1 ×90 ·
+V2 ×8). This is **Batch 3**: reconcile the **90 V1 keyword conflicts** in one
+PR, then **Batch 4** in the same arc: flip the CI vocab step to gating once
+unwaived hits 0.
+
+**Scope guard — the `derive.ts` flip is NOT this arc.** The release bar
+(NEXT_STEPS § "v2.8 release bar", item 1) puts Arc B's generated dictionaries
+post-release by design. Batch 3's deliverable is the **per-concept
+reconciliation ledger** (which side won and why — recorded in NEXT_STEPS as
+Arc B's input) plus V1 → 0 unwaived. Do not touch
+`i18n/src/dictionaries/index.ts` wiring.
+
+The two surfaces:
+
+- **S1 (parse)**: `packages/semantic/src/generators/profiles/{lang}.ts` →
+  `keywords` — feeds tokenizer keyword derivation
+  (`initializeKeywordsFromProfile`) AND pattern generation.
+- **S3 (render)**: `packages/i18n/src/dictionaries/{lang}.ts` — what the
+  transformer emits. V1 fires when the profile formSet (primary +
+  alternatives, normed) does NOT contain the **first-category** dict hit
+  (`findInDictionary` iterates categories in insertion order — commands
+  first; the V1 message names the category that hit).
+
+Breakdown: by concept `select` ×15, `reset` ×10, `into`/`submit`/`break` ×7,
+`when` ×6, `clone` ×5, `until` ×4, `while`/`empty` ×3, `and`/`change`/`then`/
+`async` ×2, `close` ×1; by language qu ×18 (heaviest), id/tl/vi ×6, sw/th ×5.
+Two shapes visible in the messages: verb-synonym pairs (ar select `ظلل` vs
+`اختر`, de `markieren` vs `auswählen`) and connective/particle pairs (bn into
+`ভিতরে` vs `তে`, ar and `وأيضاً` vs `و`).
+
+Measure:
+
+```bash
+npm run test:multilingual:build-deps        # vocab CLI refuses on stale dist
+cd packages/testing-framework
+npx tsx src/vocab/cli.ts validate --check V1 --json /tmp/v1.json; echo "exit=$?"
+npx tsx src/vocab/cli.ts dump keywords --concept select   # concept × language table
+```
+
+## The probe (do FIRST — classifies the failure mode per family)
+
+Neither prior verdict transfers wholesale: V4 was about pattern LITERALS
+(latent — matched by raw token.value), V3 about event role VALUES (normalized
+by tokenizer keyword tables). V1 keywords are **verbs and connectives**: the
+dict word is what the transformer RENDERS; whether it parses back depends on
+the tokenizer + generated patterns. Key prior evidence: the corpus is 100%
+faithful today, and the corpus-hot connectives (`into`/`when`/`until`/`and`/
+`then` renders) are everywhere in it — so their dict forms demonstrably parse.
+That predicts a large **latent** class. Verify, don't assume:
+
+1. Corpus exercise: which `pattern_translations` rows contain each flagged
+   dict form (fresh `npm run populate` first)? Expect: connectives corpus-hot,
+   `select`/`reset`/`clone`/`async`/`close` corpus-cold or absent.
+2. Parse one corpus-shaped line per family via `parseSemantic(text, lang)`,
+   asserting on the captured ACTION and roles vs the en reference — never "it
+   parses" (Batch 2's `expression:undefined` and wrong-verb shapes are the
+   failure modes to look for). E.g. does ar `اختر …` parse as action=select?
+   Does de `auswählen` (also the dict's `pick` word — check homonyms) resolve
+   to the right action?
+3. Category-shadowing check per row: the V1 message names the dict category
+   that matched (e.g. ar reset hits `dictionary.events` — the reset EVENT, not
+   the command). Both `findInDictionary` and the transformer resolve
+   first-category-wins (Batch 2's de blur evidence), so a V1 against a
+   shadowed/dead entry is the dead-vocab class (Batch 1 de `an` precedent).
+4. Note for the verdict: can any ratchet see a live V1 break? (A wrong-verb
+   parse flips the ACTION → R0/fidelity WOULD see it if corpus-exercised —
+   unlike V3. So corpus-hot rows being green is strong latency evidence.)
+
+## The fix fork (per row, mirroring Batch 2 + Batch 1 governance)
+
+- **Dict form parses correctly already** (expected majority) → latent table
+  misalignment. Governance (Batch 1, standing): do NOT register into profiles
+  "for hygiene" — profile keyword additions change tokenizer keyword sets AND
+  pattern generation. Prefer **waive with probe citation** (wildcard
+  `V1|lang|key` keys, `packages/testing-framework/vocab-waivers.json`), OR add
+  the dict word to profile `alternatives` only where it is a genuine synonym
+  worth parse coverage AND the probe shows the parse side currently lacks it.
+- **Dict form does NOT parse / parses as the wrong action** → live
+  render→parse break (the V3-broken analog) → fix the DICTIONARY to a
+  probe-verified parseable form (corpus-coupled → resweep; baseline may
+  legitimately move) — or, where the dict form is the linguistically right
+  render and the tokenizer should know it, profile-alternatives route
+  (semantic src → R5 domain ripple: bdd/behaviorspec/learn lint learned
+  Batch 1's es `hacia`; expect the same for any profile keyword edit).
+- **Dead/shadowed dict entry** (V1 hit in a category the transformer never
+  uses for that concept) → align it to the profile form or waive as dead
+  vocab, per Batch 1 precedent.
+
+Record every decision in a per-concept reconciliation table (concept × lang ×
+winner × why) appended to NEXT_STEPS § Arc A ledger (Batch 3 entry) — this
+table IS Arc B's post-release input.
+
+## Batch 4 (same arc, after V1 → 0)
+
+1. Waive the 8 remaining V2s with named reasons (all triaged): the style-role
+   family ar `بـ-`/`مع`, hi `साथ`, ja `と`, ko `와`/`과` — blocked on the
+   show/hide style-capture gap (NEXT_STEPS § "V4 probe conclusion" discovery
+   2); en `method:as` + `duration:for` — schema-override↔render alignment
+   queued. Wildcard waiver keys are `check|lang|key`.
+2. Flip `.github/workflows/ci.yml` "Vocab consistency (warn-only)" → drop
+   `--warn-only` (and rename the step). The PR's own CI run proves the gate.
+   Release bar item 1 closes here.
+
+## Traps (Batch 1+2 lessons + standing)
+
+- **Profile keyword edits are semantic-side behavior changes** (tokenizer +
+  pattern generation) — probe before/after, run domain lint suites (bdd,
+  behaviorspec, learn — R5 collects profile keywords), full resweep.
+- **Dict edits move rendered corpus translations** — one full resweep at the
+  end: ordered build → fresh `populate` → `--diagnose-coverage` +
+  `--regression`, real exit codes (no `| tail`; capture `$?`). If fidelity
+  legitimately moves, `--save-baseline` against the SAME freshly-populated DB,
+  attribute old-vs-new per language in the PR body, prettier the baseline,
+  commit dicts/profiles + baseline — **never `patterns.db`**.
+- i18n has dictionary-coupled test expectations (Batch 2 hit
+  `new-languages.test.ts` on sw focus) — expect a few for `select`/`reset`
+  renames; update them with a one-line reason, don't loosen them.
+- Homonym/collision check before ANY rename (Batch 2's sw `badilisha`
+  event=toggle and zh `按键`=keypress lessons): grep the target word across
+  the same dict's other categories and the tokenizer's keyword entries first.
+- Rebuild before the vocab CLI or any dist-reading step — it refuses stale
+  dist; `npx tsx` probes read src but the CLI + sweep read dist.
+- V1's check is containment of the dict value in the profile formSet — either
+  side can move to satisfy it; pick by the probe, not by hygiene.
+- Prove at least one fix red→green per class at the parse level (captured
+  action/roles), per-class not per-row; archive the before/after probe logs.
+- lint-staged runs prettier on commit — diffs may reflow.
+
+## Definition of done
+
+- Probe verdict (latent-vs-live classification + ratchet-visibility note)
+  appended to `MULTILINGUAL_NEXT_STEPS.md` § Arc A ledger (Batch 3 entry),
+  with the per-concept reconciliation table (Arc B's input).
+- V1 unwaived → **0** (fixed or waived with probe cited); V2 ×8 waived with
+  named reasons.
+- CI vocab step flipped to gating (Batch 4) and green on the PR.
+- `--regression` exit 0, or delta attributed + baseline regenerated with
+  old-vs-new per-language attribution in the PR body.
+- Before/after vocab ledger in the PR body (start: **98 unwaived — V1 ×90 ·
+  V2 ×8**; end: 0 unwaived, waiver count named).
+- i18n / semantic / testing-framework suites + domain lint (bdd,
+  behaviorspec, learn) green; CI green.
+
+## Adjacent queue (NOT Batch 3/4 scope — don't drift)
+
+Logged in NEXT_STEPS: id `tekan_mouse`/`lepas_mouse` shatter family (needs an
+S5b-coverage check "V3c" to even surface), zh mouseenter `鼠标进入` dead
+entry, R2 curated-subset admission of one bare non-click event pattern (e.g.
+input-validation `on blur`), go-url destination drop (en-corruption class),
+show/hide style-capture (unblocks the 6 style V2 waivers), V4 tier-split
+(marker-words-in-patterns → warn), the `derive.ts` flip itself (post-release
+Arc B).

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -2987,11 +2987,12 @@ packages on day one (#615). Lexicon end-state + domain-side history:
 > PR (as/method tokenizer keywords per the #638 containment-words precedent;
 > translate-or-waive the untranslated `on`/`url` schema markers); Batch 2 =
 > V3 event-word alignment in the i18n dictionaries (semantic side is
-> authoritative post-#533–#540; corpus-coupled → one resweep); Batch 3 =
-> V1 via Arc B (the 94 are the review diff for the `derive.ts` flip — the
-> class dies structurally); Batch 4 = flip the CI step to gating.
+> authoritative post-#533–#540; corpus-coupled → one resweep); Batch 3 ✓ =
+> V1 reconciled directly (probe-first, NOT deferred to Arc B — the per-concept
+> table below is Arc B's input); Batch 4 ✓ = CI step flipped to gating.
 >
-> Until then the CI step is warn-only by design.
+> All four batches landed — the CI step is a GATE as of Batch 4 (see § "V1
+> probe conclusion (Batch 3)" below).
 
 > **V4 probe conclusion (Batch 1, 2026-07-12) — matcher marker semantics; governs
 > Batches 2–3.** The pattern matcher consumes a pattern-literal (marker) token via
@@ -3124,6 +3125,111 @@ packages on day one (#615). Lexicon end-state + domain-side history:
 >   pattern (e.g. input-validation, `on blur`) to close the structural blind
 >   spot this probe exposed.
 
+> **V1 probe conclusion (Batch 3, 2026-07-12) — verb/connective reconciliation;
+> ledger 90 → 0 unwaived (38 dict fixes + 2 profile-alternatives + 50 waived) +
+> Batch 4 gating flip.** All 90 rows probed with captured-ACTION and
+> captured-VALUE assertions (never "it parses"): corpus-hot rows against the
+> real corpus line vs the en reference of the same pattern; corpus-cold rows by
+> rendering a concept-exercising en line through `GrammarTransformer` (the
+> populate path) and parsing the render, with the profile form swapped into the
+> same slot as the discriminator. Probe logs archived (before/after).
+>
+> - **Latent class confirmed but SMALLER than predicted (49 of 90).** The
+>   corpus-hot connectives (`when` ×146 rows/lang, `into`, `then` ×53,
+>   `until`, `while`, pl `click` ×106, tl `from` ×24 …) all parse identical to
+>   the en reference — the dict side is the parse-authoritative form and the
+>   PROFILE keyword is the misaligned copy (the exact inverse of V3's verdict).
+>   For Arc B: **in the connective/particle families the dictionary should
+>   win** the reconciliation.
+> - **Live wrong-verb class (24 rows, all corpus-cold in the broken slot) —
+>   Batch 2's wrong-verb shape, systemic:** the dict word doubled as a
+>   DIFFERENT command's keyword. select ×15 (dict word = the pick keyword —
+>   `pick-text-range` renders faithfully via the separate `pick` dict key, but
+>   a bare select render parsed **null** in all 15); clone ×5 (dict word = the
+>   copy verb → parsed action=copy); id close (tutup = hide), sw copy (nakili =
+>   clone — the inverse!), vi prepend (thêm đầu shatters at thêm=add), qu open
+>   (kichay = trigger). All dict-fixed to the profile primaries (probe-verified
+>   red→green, `packages/testing-framework/src/vocab/batch3-roundtrip.test.ts`);
+>   the pick/copy/hide/trigger keys keep their words, so no corpus render moved.
+> - **Live wrong-EVENT class — the headline: es/pl/tr/vi `on submit` corpus
+>   rows were broken in production while every ratchet stayed green.** The dict
+>   events.submit word doubled as the send VERB, and the tokenizer keyword
+>   table (the parse authority, per Batch 2) captured `on.event="send"` in the
+>   live form-disable-on-submit / form-submit-prevent rows — a listener bound
+>   to the wrong event. Invisible to R0/R1 (action set + role TYPE unchanged),
+>   R3 (plain event names are not whitelist-invariant), and R2 (curated subset
+>   has no submit trigger — third confirmation of that structural blind spot).
+>   Dict-fixed to the profile primaries (envío/wysłaniu/gönderme/nộp/apaykachay
+>   — each probe-verified to capture `"submit"` in the exact corpus slots; qu
+>   kachay was context-flaky, capturing submit in one row and send in the
+>   other). Same class corpus-cold: reset ×7 dict-fixed (it/ko/pl/pt/ru/uk/qu —
+>   dict forms captured `on.event` as expression (broken listener) or a wrong
+>   event (qu qallariy→"default"); profile verbs capture literal `"reset"`), qu
+>   change (tikray→"toggle" → kambiay). S5b has **no reset key for any
+>   language** (why V3 never saw the family); qu kambiay/apaykachay added as
+>   appended S5b aliases per Batch 2 discipline.
+> - **Ratchet-visibility verdict:** R0 WOULD flip on a corpus-exercised
+>   wrong-verb parse — and that is precisely why none existed: every
+>   corpus-exercised V1 row parsed faithfully, and every live break sat in a
+>   corpus-cold slot (bare select/clone/close/copy/prepend/open commands,
+>   reset events) or at the VALUE level (submit "send"), where no ratchet
+>   looks. Corpus-green ≠ vocabulary-correct, verdict confirmed for verbs.
+> - **Latent-by-absence class (10 rows):** `break` ×7 + qu `continue` + `and`
+>   ×2 — **en itself** silently drops these (`repeat 3 times break end` parses
+>   break-less in en and in every render; `if #a and #b …` drops the second
+>   conjunct in en). No parse authority exists to reconcile against; Arc C
+>   (unconsumed-input) territory. Dead-vocab subclass: qu on/async, id/tl into
+>   underscore forms — the transformer never emits them in any corpus slot.
+> - **Blocked rows (4):** ar/sw/tl reset — NO candidate round-trips (sw:
+>   dict weka_upya→"put", profile anzisha-upya→"init", en passthrough→
+>   expression; ar/tl: every form → expression). ja empty — dict-fix
+>   unavailable (expressions.empty=空 feeds the corpus-hot `is empty` renders;
+>   a commands-category addition would shadow it on render), and the
+>   profile-alternative was probed and **reverted**: registering bare 空
+>   injected a phantom `empty` action into the hot input-validation rows (an
+>   R0-precision regression caught by the after-probe). ko/qu took the same
+>   profile-alternative safely (비어있는/chusaq — hot rows clean, command slot
+>   now parses).
+> - **Batch 4 (same PR):** the 8 V2 survivors waived with named reasons (6
+>   style-role rows blocked on show/hide style-capture; en method:as +
+>   duration:for consumed as pattern literals, V4-probe mechanism —
+>   schema-override↔render alignment queued), and the CI step flipped
+>   **warn-only → gating** (release bar item 1 closes).
+> - **Logged, out of scope:** (1) fr repeat-until-event corpus row captures
+>   `on.event` mousedown as expression — fr dict mousedown `sourisappuyée` is
+>   the fused class Batch 2 fixed elsewhere, invisible because S5b fr lacks
+>   mousedown (the V3c coverage-gap family, more evidence). (2) The pick
+>   literal-vs-expression HOT-ROLE-DIFFs (hi/ja/ko/tr/qu) are the standing pick
+>   range-role deferral, untouched.
+>
+> **Per-concept reconciliation table (Arc B's input — which side won and why):**
+>
+> | Concept | Languages | Winner | Why |
+> | --- | --- | --- | --- |
+> | select | ar de hi id ja ko ms pl qu ru sw th tr uk vi | profile (dict-fixed) | dict word = pick keyword; bare select parsed null; profile verb parses; `pick` key separate so pick rows unmoved |
+> | clone | bn hi th tl vi | profile (dict-fixed) | dict word = copy verb → action=copy |
+> | close / copy / prepend / open | id / sw / vi / qu | profile (dict-fixed) | wrong-verb: tutup=hide, nakili=clone, thêm đầu→add, kichay=trigger |
+> | reset | it ko pl pt ru uk qu | profile (dict-fixed) | dict form broke the listener (expression / wrong event); profile verb captures `"reset"` |
+> | reset | ar sw tl | none (waived, blocked) | NO form round-trips (incl. en passthrough); tokenizer event coverage gap, V3c-adjacent |
+> | submit | es pl tr vi qu | profile (dict-fixed) | dict word = send verb → event `"send"` captured LIVE in corpus form rows |
+> | submit | id th | dict (waived) | kirim/ส่ง capture `"submit"` — profile envío-class words are the misaligned side |
+> | change | qu | profile (dict-fixed) | tikray = toggle verb → event `"toggle"` |
+> | change | id | dict (waived) | ubah captures `"change"` |
+> | blur | it | profile (dict-fixed) | noun sfuocatura dropped command patient; verb round-trips both slots |
+> | empty | ko qu | dict (profile-alternative added) | dict adjective renders the empty COMMAND; hacia-class registration; hot `is empty` rows unaffected (probed) |
+> | empty | ja | none (waived, blocked) | bare 空 phantoms the hot expression rows if registered (probed + reverted); dict-fix shadowed |
+> | when | ja ms th tl vi zh | dict (waived) | corpus-hot handler-opener ×146 rows/lang, parses identical to en |
+> | while / until / then | fr sw zh / fr qu ru uk / ko qu | dict (waived) | corpus-hot, loopType/event/sequence captured identical to en |
+> | into | bn de es id pt qu tl | dict-or-dead (waived) | put-destination renders via grammar role markers; dict word round-trips where it appears (bn তে) or never renders (id/tl underscore forms) |
+> | click / input / from / event / before / after / throw / async / scroll | pl / th / tl / qu / qu / qu / qu / sw / it | dict (waived) | corpus-hot, value-verified where applicable (click R2-covered; อินพุต→"input") |
+> | async / on | qu | dead (waived) | render keeps English `async` / uses the `pi` marker — dict word never emitted |
+> | break / continue / and | fr hi id ms tl vi qu / qu / ar qu | none (waived) | no parse path in ANY language incl. en — Arc C unconsumed-input class |
+>
+> Ledger after Batch 3+4: **0 unwaived** (was 98 = V1 ×90 · V2 ×8). Waivers:
+> 78 Batch-1 V4 class-waivers + 26 V1 + 8 V2 (all probe-cited,
+> `packages/testing-framework/vocab-waivers.json`). CI vocab step is now a
+> GATE.
+
 **Arc B — `derive.ts` dictionary flip (own arc; baseline-coupled).** Reconcile Arc A's
 profile↔dictionary disagreement ledger, then switch `i18n/src/dictionaries/index.ts`
 to the generated path — killing the single largest duplication (~4k entries). Hand
@@ -3162,6 +3268,8 @@ window: items 1–4 are **must-have**, item 5 is the **stretch headline**.
    disagreements (or every waiver named), replacing today's state where the only
    dictionary validator is a dead script. `dump` ships if time allows; Arc B's
    generated dictionaries are the durable fix but are post-release by design.
+   **✓ MET (Batch 3+4, 2026-07-12): 0 unwaived, every waiver probe-cited, CI
+   step gating.**
 2. **Input coverage is total** (Arc C) — every `parseInternal` stage instrumented;
    `--diagnose-coverage` reports 0 firings corpus-wide or each residual is named.
    If new firings exceed what the window can burn down, naming them all still

--- a/packages/i18n/src/dictionaries/ar.ts
+++ b/packages/i18n/src/dictionaries/ar.ts
@@ -62,7 +62,7 @@ export const ar: Dictionary = {
     clear: 'نظّف', // امسح is a remove alternative in the profile
     close: 'أغلق',
     open: 'افتح',
-    select: 'اختر',
+    select: 'ظلل', // Batch 3: اختر is the pick keyword — bare select rendered with it parses null
     clone: 'استنسخ',
     prepend: 'سبق',
     socket: 'مقبس',

--- a/packages/i18n/src/dictionaries/bn.ts
+++ b/packages/i18n/src/dictionaries/bn.ts
@@ -47,7 +47,7 @@ export const bengaliDictionary: Dictionary = {
     init: 'শুরু',
     behavior: 'আচরণ',
     install: 'ইনস্টল',
-    clone: 'কপি',
+    clone: 'ক্লোন', // Batch 3: কপি is the copy verb — rendered clone parsed as action=copy
     swap: 'বদল',
     morph: 'রূপান্তর',
     beep: 'বীপ',

--- a/packages/i18n/src/dictionaries/de.ts
+++ b/packages/i18n/src/dictionaries/de.ts
@@ -67,7 +67,7 @@ export const de: Dictionary = {
     clear: 'bereinigen', // löschen is a remove alternative in the profile
     close: 'schließen',
     open: 'öffnen',
-    select: 'auswählen',
+    select: 'markieren', // Batch 3: auswählen is the pick keyword — bare select rendered with it parses null
     clone: 'klonen',
     prepend: 'voranstellen',
     focus: 'fokussieren',

--- a/packages/i18n/src/dictionaries/es.ts
+++ b/packages/i18n/src/dictionaries/es.ts
@@ -102,7 +102,7 @@ export const es: Dictionary = {
     blur: 'desenfocar',
     change: 'cambiar',
     input: 'entrada',
-    submit: 'enviar',
+    submit: 'envío', // Batch 3: enviar is the send verb — on-submit listener captured event "send"
     reset: 'reiniciar',
     load: 'cargar',
     unload: 'descargar',

--- a/packages/i18n/src/dictionaries/hi.ts
+++ b/packages/i18n/src/dictionaries/hi.ts
@@ -60,13 +60,13 @@ export const hindiDictionary: Dictionary = {
     behavior: 'व्यवहार',
     focus: 'फोकस',
     blur: 'धुंधला',
-    clone: 'कॉपी',
+    clone: 'क्लोन', // Batch 3: कॉपी is the copy verb — rendered clone parsed as action=copy
     prepend: 'जोड़ें_शुरू',
     breakpoint: 'ब्रेकप्वाइंट',
     clear: 'साफ़-करें',
     close: 'बंद-करें',
     open: 'खोलें',
-    select: 'चुनें',
+    select: 'चिह्नित-करें', // Batch 3: चुनें is the pick keyword — bare select rendered with it parses null
     socket: 'सॉकेट',
   },
 

--- a/packages/i18n/src/dictionaries/id.ts
+++ b/packages/i18n/src/dictionaries/id.ts
@@ -64,9 +64,9 @@ export const id: Dictionary = {
     install: 'pasang',
     breakpoint: 'titik-henti',
     clear: 'bersihkan', // hapus is the remove PRIMARY in the profile
-    close: 'tutup',
+    close: 'tutupkan', // Batch 3: tutup is the hide keyword — rendered close parsed as action=hide
     open: 'buka',
-    select: 'pilih',
+    select: 'tandai', // Batch 3: pilih is the pick keyword — bare select rendered with it parses null
     clone: 'klon',
     prepend: 'awali',
   },

--- a/packages/i18n/src/dictionaries/it.ts
+++ b/packages/i18n/src/dictionaries/it.ts
@@ -100,11 +100,11 @@ export const it: Dictionary = {
     keyup: 'tastosu',
     keypress: 'tastopremi',
     focus: 'fuoco',
-    blur: 'sfuocatura',
+    blur: 'sfuocare', // Batch 3: the noun form parsed the blur command with no patient; the verb round-trips both event and command slots
     change: 'cambio',
     input: 'input',
     submit: 'invio',
-    reset: 'reset',
+    reset: 'reimpostare', // Batch 3: English passthrough captured on.event as expression — profile verb round-trips
     load: 'carica',
     unload: 'scarica',
     resize: 'ridimensiona',

--- a/packages/i18n/src/dictionaries/ja.ts
+++ b/packages/i18n/src/dictionaries/ja.ts
@@ -63,7 +63,7 @@ export const ja: Dictionary = {
     clear: 'クリア',
     close: '閉じる',
     open: '開く',
-    select: '選択',
+    select: '選ぶ', // Batch 3: 選択 is the pick keyword — bare select rendered with it parses null
     clone: '複製',
     prepend: '先頭追加',
     socket: 'ソケット',

--- a/packages/i18n/src/dictionaries/ko.ts
+++ b/packages/i18n/src/dictionaries/ko.ts
@@ -62,7 +62,7 @@ export const ko: Dictionary = {
     clear: '지우기',
     close: '닫기',
     open: '열기',
-    select: '선택',
+    select: '고르기', // Batch 3: 선택 is the pick keyword — bare select rendered with it parses null
     clone: '복제',
     prepend: '앞에추가',
     socket: '소켓',
@@ -105,7 +105,7 @@ export const ko: Dictionary = {
     change: '변경',
     input: '입력',
     submit: '제출',
-    reset: '리셋',
+    reset: '재설정', // Batch 3: 리셋 captured on.event as expression (broken listener) — profile word round-trips
     load: '로드',
     unload: '언로드',
     resize: '리사이즈',

--- a/packages/i18n/src/dictionaries/ms.ts
+++ b/packages/i18n/src/dictionaries/ms.ts
@@ -66,7 +66,7 @@ export const malayDictionary: Dictionary = {
     clear: 'bersihkan', // padam is a remove alternative in the profile
     close: 'tutup',
     open: 'buka',
-    select: 'pilih',
+    select: 'tandai', // Batch 3: pilih is the pick keyword — bare select rendered with it parses null
     socket: 'soket', // derived from the ms profile (socket.primary); see generate-i18n-dictionaries
   },
 

--- a/packages/i18n/src/dictionaries/pl.ts
+++ b/packages/i18n/src/dictionaries/pl.ts
@@ -66,7 +66,7 @@ export const pl: Dictionary = {
     clear: 'zeruj', // wyczyść is a remove alternative in the profile
     close: 'zamknij',
     open: 'otwórz',
-    select: 'wybierz',
+    select: 'zaznacz', // Batch 3: wybierz is the pick keyword — bare select rendered with it parses null
     clone: 'sklonuj',
     prepend: 'poprzedź',
     focus: 'skup',
@@ -108,8 +108,8 @@ export const pl: Dictionary = {
     blur: 'rozmycie',
     change: 'zmiana',
     input: 'wejście',
-    submit: 'wyślij',
-    reset: 'resetuj',
+    submit: 'wysłaniu', // Batch 3: wyślij is the send verb — on-submit listener captured event "send"
+    reset: 'zresetuj', // Batch 3: resetuj captured on.event as expression (broken listener) — profile word round-trips
     load: 'załaduj',
     unload: 'wyładuj',
     resize: 'zmieńrozmiar',

--- a/packages/i18n/src/dictionaries/pt.ts
+++ b/packages/i18n/src/dictionaries/pt.ts
@@ -109,7 +109,7 @@ export const pt: Dictionary = {
     change: 'mudança',
     input: 'entrada',
     submit: 'envio',
-    reset: 'reiniciar',
+    reset: 'redefinir', // Batch 3: reiniciar captured on.event as expression (broken listener) — profile word round-trips
     load: 'carregar',
     unload: 'descarregar',
     resize: 'redimensionar',

--- a/packages/i18n/src/dictionaries/qu.ts
+++ b/packages/i18n/src/dictionaries/qu.ts
@@ -75,8 +75,8 @@ export const qu: Dictionary = {
     breakpoint: 'sayachinay',
     clear: 'pichay',
     close: 'wichqay',
-    open: 'kichay',
-    select: 'akllay',
+    open: 'paskay', // Batch 3: kichay is the trigger keyword — rendered open parsed null
+    select: 'marcay', // Batch 3: akllay is the pick keyword — bare select rendered with it parses null
     clone: 'kikinchay',
     prepend: 'ñawpachiy',
     socket: 'tinkina',
@@ -122,10 +122,10 @@ export const qu: Dictionary = {
     keypress: 'yupana_ñitana',
     focus: 'qhaway',
     blur: 'paqariy',
-    change: 'tikray',
+    change: 'kambiay', // Batch 3: tikray is the toggle verb — on-change listener captured event "toggle"
     input: 'yaykuchiy',
-    submit: 'kachay',
-    reset: 'qallariy',
+    submit: 'apaykachay', // Batch 3: kachay is the send verb — on-submit captured "send" in one corpus slot
+    reset: 'musuqchay', // Batch 3: qallariy is the init/start word — on-reset listener captured event "default"
     load: 'apakuy',
     unload: 'urmay',
     resize: 'hatun_kay',

--- a/packages/i18n/src/dictionaries/ru.ts
+++ b/packages/i18n/src/dictionaries/ru.ts
@@ -70,7 +70,7 @@ export const russianDictionary: Dictionary = {
     clear: 'очистить',
     close: 'закрыть',
     open: 'открыть',
-    select: 'выбрать',
+    select: 'выделить', // Batch 3: выбрать is the pick keyword — bare select rendered with it parses null
   },
 
   modifiers: {
@@ -114,7 +114,7 @@ export const russianDictionary: Dictionary = {
     change: 'изменение',
     input: 'ввод',
     submit: 'отправка',
-    reset: 'сброс',
+    reset: 'сбросить', // Batch 3: сброс captured on.event as expression (broken listener) — profile verb round-trips
     load: 'загрузка',
     unload: 'выгрузка',
     resize: 'изменениеразмера', // fused (no `_`) — see mousedown note above

--- a/packages/i18n/src/dictionaries/sw.ts
+++ b/packages/i18n/src/dictionaries/sw.ts
@@ -52,7 +52,7 @@ export const sw: Dictionary = {
     go: 'nenda',
     pushUrl: 'sukumaUrl',
     replaceUrl: 'badilishaUrl',
-    copy: 'nakili',
+    copy: 'nakala', // Batch 3: nakili is the clone keyword — rendered copy parsed as action=clone
     pick: 'chagua',
     beep: 'lia',
     js: 'js',
@@ -68,7 +68,7 @@ export const sw: Dictionary = {
     clear: 'safisha', // futa is a remove alternative in the profile
     close: 'funga',
     open: 'fungua',
-    select: 'chagua',
+    select: 'alama', // Batch 3: chagua is the pick keyword — bare select rendered with it parses null
     clone: 'nakili',
     prepend: 'tanguliza',
     focus: 'lenga',

--- a/packages/i18n/src/dictionaries/th.ts
+++ b/packages/i18n/src/dictionaries/th.ts
@@ -49,7 +49,7 @@ export const thaiDictionary: Dictionary = {
     init: 'เริ่มต้น',
     behavior: 'พฤติกรรม',
     install: 'ติดตั้ง',
-    clone: 'คัดลอก',
+    clone: 'โคลน', // Batch 3: คัดลอก is the copy verb — rendered clone parsed as action=copy
     swap: 'สลับที่',
     morph: 'แปลงร่าง',
     beep: 'บี๊บ',
@@ -64,7 +64,7 @@ export const thaiDictionary: Dictionary = {
     clear: 'เคลียร์',
     close: 'ปิด',
     open: 'เปิด',
-    select: 'เลือก',
+    select: 'ทำเครื่องหมาย', // Batch 3: เลือก is the pick keyword — bare select rendered with it parses null
   },
 
   modifiers: {

--- a/packages/i18n/src/dictionaries/tl.ts
+++ b/packages/i18n/src/dictionaries/tl.ts
@@ -64,7 +64,7 @@ export const tagalogDictionary: Dictionary = {
     install: 'ikabit',
     behavior: 'ugali',
     init: 'simulan',
-    clone: 'kopyahin',
+    clone: 'i-clone', // Batch 3: kopyahin is the copy verb — rendered clone parsed as action=copy
     breakpoint: 'breakpoint',
     clear: 'burahin',
     close: 'isara',

--- a/packages/i18n/src/dictionaries/tr.ts
+++ b/packages/i18n/src/dictionaries/tr.ts
@@ -63,7 +63,7 @@ export const tr: Dictionary = {
     clear: 'temizle',
     close: 'kapat',
     open: 'aç',
-    select: 'seç',
+    select: 'vurgula', // Batch 3: seç is the pick keyword — bare select rendered with it parses null
     clone: 'klonla',
     prepend: 'başınaekle',
     socket: 'soket',
@@ -111,7 +111,7 @@ export const tr: Dictionary = {
     blur: 'bulanık',
     change: 'değişim',
     input: 'giriş',
-    submit: 'gönder',
+    submit: 'gönderme', // Batch 3: gönder is the send verb — on-submit listener captured event "send"
     reset: 'sıfırla',
     load: 'yükle',
     unload: 'yükle_kaldır',

--- a/packages/i18n/src/dictionaries/uk.ts
+++ b/packages/i18n/src/dictionaries/uk.ts
@@ -70,7 +70,7 @@ export const ukrainianDictionary: Dictionary = {
     clear: 'очистити',
     close: 'закрити',
     open: 'відкрити',
-    select: 'вибрати',
+    select: 'виділити', // Batch 3: вибрати is the pick keyword — bare select rendered with it parses null
   },
 
   modifiers: {
@@ -113,7 +113,7 @@ export const ukrainianDictionary: Dictionary = {
     change: 'зміна',
     input: 'введення',
     submit: 'надсилання',
-    reset: 'скидання',
+    reset: 'скинути', // Batch 3: скидання captured on.event as expression (broken listener) — profile verb round-trips
     load: 'завантаження',
     unload: 'вивантаження',
     resize: 'змінарозміру', // fused (no `_`) — see mousedown note above

--- a/packages/i18n/src/dictionaries/vi.ts
+++ b/packages/i18n/src/dictionaries/vi.ts
@@ -59,14 +59,14 @@ export const vi: Dictionary = {
     init: 'khởi tạo',
     behavior: 'hành vi',
     install: 'cài đặt',
-    clone: 'sao chép',
-    prepend: 'thêm đầu',
+    clone: 'nhân bản', // Batch 3: 'sao chép' is the copy verb — rendered clone parsed as action=copy
+    prepend: 'thêm vào đầu', // Batch 3: 'thêm đầu' shatters at 'thêm' (add) — parsed as action=add
     else: 'không thì',
     breakpoint: 'điểm-dừng',
     clear: 'tẩy', // xóa is the remove PRIMARY in the profile
     close: 'đóng',
     open: 'mở',
-    select: 'chọn',
+    select: 'đánh-dấu', // Batch 3: 'chọn' is the pick keyword — bare select rendered with it parses null
   },
 
   modifiers: {
@@ -94,7 +94,7 @@ export const vi: Dictionary = {
     dblclick: 'nhấp đúp',
     input: 'nhập',
     change: 'thay đổi',
-    submit: 'gửi',
+    submit: 'nộp', // Batch 3: 'gửi' is the send verb — on-submit listener captured event "send"
     keydown: 'phím xuống',
     keyup: 'phím lên',
     keypress: 'nhấn phím',

--- a/packages/i18n/src/grammar/grammar.test.ts
+++ b/packages/i18n/src/grammar/grammar.test.ts
@@ -2606,10 +2606,12 @@ describe('SOV fused halt+call heads render both commands verb-final (Family H)',
   const EXPECT: Array<[string, string]> = [
     ['ja', 'the イベント を 送信 で 停止 それから validateForm() を 呼び出し'],
     ['ko', 'the 이벤트 를 제출 할 때 정지 그러면 validateForm() 를 호출'],
-    ['tr', 'the olay i gönder de durdur ardından validateForm() i çağır'],
+    // Batch 3: tr submit event word gönder→gönderme (gönder is the send verb — captured event "send")
+    ['tr', 'the olay i gönderme de durdur ardından validateForm() i çağır'],
     ['bn', 'the ঘটনা কে জমা এ থামুন তারপর validateForm() কে কল'],
     ['hi', 'the घटना को जमा पर रोकें फिर validateForm() को कॉल'],
-    ['qu', 'the ruway ta kachay pi sayay chayqa validateForm() ta qayay'],
+    // Batch 3: qu submit event word kachay→apaykachay (kachay is the send verb — captured "send" in this slot)
+    ['qu', 'the ruway ta apaykachay pi sayay chayqa validateForm() ta qayay'],
   ];
   for (const [lang, head] of EXPECT) {
     it(`[${lang}] halt keeps its operand adjacent + verb-final; call follows the connective`, () => {

--- a/packages/semantic/src/generators/profiles/japanese.ts
+++ b/packages/semantic/src/generators/profiles/japanese.ts
@@ -105,6 +105,10 @@ export const japaneseProfile: LanguageProfile = {
     focus: { primary: 'フォーカス', alternatives: ['集中'], normalized: 'focus' },
     blur: { primary: 'ぼかし', alternatives: ['フォーカス解除', 'ブラー'], normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
+    // Batch 3: do NOT add bare 空 here — probed: registering it as an empty
+    // keyword injects a phantom `empty` command into the corpus-hot `is empty`
+    // expression rows (である 空), an R0-precision regression. The empty-COMMAND
+    // render gap (dict renders 空, parses null) is waived instead.
     empty: { primary: '空に', alternatives: ['空にする'], normalized: 'empty' },
     open: { primary: '開く', alternatives: ['オープン'], normalized: 'open' },
     close: { primary: '閉じる', alternatives: ['クローズ'], normalized: 'close' },

--- a/packages/semantic/src/generators/profiles/korean.ts
+++ b/packages/semantic/src/generators/profiles/korean.ts
@@ -93,7 +93,9 @@ export const koreanProfile: LanguageProfile = {
     focus: { primary: '포커스', normalized: 'focus' },
     blur: { primary: '블러', normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: '비우기', normalized: 'empty' },
+    // Batch 3: 비어있는 added — the i18n dict renders the empty COMMAND with its
+    // `is empty` adjective (category-shadowed), which parsed null.
+    empty: { primary: '비우기', alternatives: ['비어있는'], normalized: 'empty' },
     open: { primary: '열기', normalized: 'open' },
     close: { primary: '닫기', normalized: 'close' },
     select: { primary: '고르기', normalized: 'select' },

--- a/packages/semantic/src/generators/profiles/quechua.ts
+++ b/packages/semantic/src/generators/profiles/quechua.ts
@@ -102,7 +102,10 @@ export const quechuaProfile: LanguageProfile = {
     focus: { primary: 'qhawachiy', alternatives: ['qhaway'], normalized: 'focus' },
     blur: { primary: 'paqariy', alternatives: ['mana qhawachiy'], normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
-    empty: { primary: "ch'usaq", normalized: 'empty' },
+    // Batch 3: apostrophe-less chusaq added — the i18n dict renders the empty
+    // COMMAND with it (its `is empty` expression word), which parsed null against
+    // the ch'usaq-only command patterns.
+    empty: { primary: "ch'usaq", alternatives: ['chusaq'], normalized: 'empty' },
     open: { primary: 'paskay', normalized: 'open' },
     close: { primary: 'wichqay', normalized: 'close' },
     select: { primary: 'marcay', normalized: 'select' },

--- a/packages/semantic/src/patterns/event-handler.ts
+++ b/packages/semantic/src/patterns/event-handler.ts
@@ -311,8 +311,14 @@ export const eventNameTranslations: Record<string, Record<string, string>> = {
     yaykuy: 'input',
     tikray: 'change',
     "t'ikray": 'change',
+    // Batch 3 aliases (appended so first-wins localization canonicals are
+    // unchanged): the dict now renders kambiay/apaykachay — probe-verified to
+    // capture the canonical event via the tokenizer keyword table, unlike
+    // tikray (captures 'toggle') and kachay ('send' in one corpus slot).
+    kambiay: 'change',
     apachiy: 'submit',
     kachay: 'submit',
+    apaykachay: 'submit',
     'llave uray': 'keydown',
     'llave hawa': 'keyup',
     "q'away": 'focus',

--- a/packages/semantic/test/lexicon-emit-mismatch.test.ts
+++ b/packages/semantic/test/lexicon-emit-mismatch.test.ts
@@ -64,15 +64,17 @@ const LANGS = [
 ];
 
 const KNOWN_MISMATCHES = new Set([
+  // Batch 3 (vocab V1 reconciliation, HANDOFF_vocab-batch3-v1-reconciliation.md)
+  // pruned 24 entries — dicts realigned to the profile primaries: the select
+  // class (dict word doubled as the pick keyword; 15 languages), the wrong-verb
+  // class (bn/hi/th/tl/vi clone→copy, sw copy→clone, id close→hide,
+  // vi prepend→add), and qu open (kichay doubled as trigger).
   'ar:catch:التقط',
   'ar:pushUrl:ادفع رابط',
   'ar:replaceUrl:استبدل رابط',
-  'ar:select:اختر',
-  'bn:clone:কপি',
   'de:catch:fangen',
   'de:pushUrl:urlHinzufügen',
   'de:replaceUrl:urlErsetzen',
-  'de:select:auswählen',
   'es:catch:atrapar',
   'es:pushUrl:pushUrl',
   'es:replaceUrl:reemplazarUrl',
@@ -84,36 +86,28 @@ const KNOWN_MISMATCHES = new Set([
   'fr:while:tantque',
   'hi:break:रोकें',
   'hi:catch:पकड़ें',
-  'hi:clone:कॉपी',
   'hi:pushUrl:url_जोड़ें',
   'hi:replaceUrl:url_बदलें',
-  'hi:select:चुनें',
   'id:break:hentikan',
   'id:catch:tangkap',
-  'id:close:tutup',
   'id:pushUrl:tambahUrl',
   'id:replaceUrl:gantiUrl',
-  'id:select:pilih',
   'it:catch:catturare',
   'it:pushUrl:pushUrl',
   'it:replaceUrl:sostituireUrl',
   'ja:catch:捕まえる',
   'ja:pushUrl:URLプッシュ',
   'ja:replaceUrl:URL置換',
-  'ja:select:選択',
   'ko:catch:잡다',
   'ko:pushUrl:URL푸시',
   'ko:replaceUrl:URL교체',
-  'ko:select:선택',
   'ms:break:henti',
   'ms:catch:tangkap',
   'ms:pushUrl:tolak_url',
   'ms:replaceUrl:ganti_url',
-  'ms:select:pilih',
   'pl:catch:złap',
   'pl:pushUrl:dodajUrl',
   'pl:replaceUrl:zamieńUrl',
-  'pl:select:wybierz',
   'pt:catch:capturar',
   'pt:pushUrl:pushUrl',
   'pt:replaceUrl:substituirUrl',
@@ -125,10 +119,8 @@ const KNOWN_MISMATCHES = new Set([
   // the dict render ñawpaq_kaq + the underscore-compound fold forms it from the
   // shattered ñawpaq/_/kaq run.
   'qu:on:kaqpi',
-  'qu:open:kichay',
   'qu:pushUrl:url_tanqay',
   'qu:replaceUrl:url_tikray',
-  'qu:select:akllay',
   'qu:throw:wikchuy',
   // qu:transition resolved (transition precision drill): dict realigned to the
   // profile primary `pasay` (was `tikray`, which collided with toggle).
@@ -141,11 +133,9 @@ const KNOWN_MISMATCHES = new Set([
   'ru:catch:поймать',
   'ru:pushUrl:добавить_url',
   'ru:replaceUrl:заменить_url',
-  'ru:select:выбрать',
   'ru:until:до',
   'sw:async:sainkroni',
   'sw:catch:shika',
-  'sw:copy:nakili',
   // sw:default resolved (default-value drill, L4): `msingi` (the dict render)
   // added as a profile alternative alongside chaguo-msingi.
   'sw:pushUrl:sukumaUrl',
@@ -154,39 +144,30 @@ const KNOWN_MISMATCHES = new Set([
   // which the profile reads as nothing — sw could not parse its own `return`. The
   // dict now emits `rudisha`, the profile's primary. Surfaced once `worker`'s body
   // stopped being dropped and `return` finally had to parse.
-  'sw:select:chagua',
   // sw:transition resolved (transition precision drill): `mpito` added as a
   // profile alternative — the rendered verb now anchors.
-  'th:clone:คัดลอก',
-  'th:select:เลือก',
   // th:transition resolved (transition precision drill): dict realigned to the
   // profile primary `เปลี่ยนผ่าน` (was `เปลี่ยน`, the profile's `change` keyword).
   'tl:break:itigil',
   'tl:catch:hulihin',
-  'tl:clone:kopyahin',
   'tl:pushUrl:itulak_url',
   'tl:replaceUrl:palitan_url',
   'tr:catch:yakala',
   'tr:pushUrl:urlEkle',
   'tr:replaceUrl:urlDeğiştir',
-  'tr:select:seç',
   // tr:while resolved (HANDOFF-r1-post-cluster-residue item 2): dict realigned to
   // the profile primary `süresince` (was `iken`, the tr WHEN primary).
   'uk:catch:зловити',
   'uk:pushUrl:додати_url',
   'uk:replaceUrl:замінити_url',
-  'uk:select:вибрати',
   'uk:until:до',
   'vi:break:dừng',
   'vi:catch:bắt',
-  'vi:clone:sao chép',
-  'vi:prepend:thêm đầu',
   'vi:pushUrl:pushUrl',
   // vi:render resolved (HANDOFF-lossy-tail render cluster): dict realigned
   // `hiển thị`→`kết xuất` (the profile's render primary); `hiển thị` collided with
   // `show`, so render-template/morph-template parsed render as `show`.
   'vi:replaceUrl:thayThếUrl',
-  'vi:select:chọn',
   // vi:unless resolved (HANDOFF-lossy-tail unless-condition): vietnamese profile
   // primary realigned `trừ_khi`→`trừ khi` so the spaced dict form reads as `unless`
   // (the bare `khi` was previously mistaken for a second `on` handler).

--- a/packages/testing-framework/src/vocab/batch3-roundtrip.test.ts
+++ b/packages/testing-framework/src/vocab/batch3-roundtrip.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Batch 3 red→green proofs — one representative render→parse round-trip per
+ * V1 dict-fix class (docs-internal/MULTILINGUAL_NEXT_STEPS.md § "V1 probe
+ * conclusion (Batch 3)"). Each of these was a live render→parse break before
+ * the Batch 3 dictionary fixes:
+ *
+ * - select class: the dict word doubled as the pick keyword — the bare select
+ *   render parsed null (de `auswählen #note`).
+ * - wrong-verb class: the dict word was another command's verb — the render
+ *   parsed as THAT action (bn clone → copy, id close → hide, sw copy → clone,
+ *   vi prepend → add, qu change-event → toggle).
+ * - reset class: the dict event word captured on.event as an expression (a
+ *   broken listener) or a wrong event; the profile verb round-trips.
+ * - submit class: the dict event word doubled as the send verb — corpus
+ *   on-submit rows captured event "send" (es/pl/tr/vi live).
+ * - blur class (it): the noun form dropped blur.patient in command position.
+ * - empty class (ko/qu profile-alternatives): the dict adjective renders the
+ *   empty COMMAND but only the profile verb parsed. (ja is waived: bare 空
+ *   phantoms the hot `is empty` rows if registered.)
+ *
+ * Assertions are on captured ACTION and role VALUES, never "it parses".
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseSemantic } from '@lokascript/semantic';
+import { GrammarTransformer } from '@lokascript/i18n';
+
+/** Verbatim (action, role, value) triples from a parse tree. */
+function triples(node: unknown, acc: string[] = [], depth = 0): string[] {
+  if (depth > 64 || node === null || typeof node !== 'object') return acc;
+  const rec = node as Record<string, unknown>;
+  if (typeof rec.action === 'string') {
+    const roles = rec.roles;
+    const entries: Array<[unknown, unknown]> =
+      roles instanceof Map
+        ? [...roles.entries()]
+        : roles && typeof roles === 'object'
+          ? Object.entries(roles)
+          : [];
+    for (const [role, v] of entries) {
+      if (v === null || v === undefined) continue;
+      const val = (v as { value?: unknown }).value ?? (v as { raw?: unknown }).raw;
+      acc.push(`${rec.action}.${String(role)}=${String(val)}`);
+    }
+  }
+  for (const f of ['body', 'commands', 'children', 'thenBranch', 'elseBranch']) {
+    const c = rec[f];
+    if (Array.isArray(c)) for (const x of c) triples(x, acc, depth + 1);
+    else if (c && typeof c === 'object') triples(c, acc, depth + 1);
+  }
+  return acc;
+}
+
+function renderAndParse(en: string, lang: string): { render: string; triples: string[] } {
+  const render = new GrammarTransformer('en', lang).transform(en);
+  const result = parseSemantic(render, lang);
+  return { render, triples: result.node ? triples(result.node) : [] };
+}
+
+describe('Batch 3 — select class (dict word was the pick keyword)', () => {
+  it('de: `select #note` renders markieren and parses back as select', () => {
+    const { render, triples: t } = renderAndParse('select #note', 'de');
+    expect(render).toContain('markieren');
+    expect(t).toContain('select.patient=#note');
+  });
+
+  it('ar: `select #note` renders ظلل and parses back as select', () => {
+    const { render, triples: t } = renderAndParse('select #note', 'ar');
+    expect(render).toContain('ظلل');
+    expect(t).toContain('select.patient=#note');
+  });
+});
+
+describe('Batch 3 — wrong-verb class (dict word was another command)', () => {
+  it('bn: `clone #card` no longer parses as copy', () => {
+    const { render, triples: t } = renderAndParse('clone #card', 'bn');
+    expect(render).toContain('ক্লোন');
+    expect(t).toContain('clone.patient=#card');
+  });
+
+  it('id: `close #modal` no longer parses as hide', () => {
+    const { render, triples: t } = renderAndParse('close #modal', 'id');
+    expect(render).toContain('tutupkan');
+    expect(t).toContain('close.patient=#modal');
+  });
+
+  it('sw: `copy #text` no longer parses as clone', () => {
+    const { render, triples: t } = renderAndParse('copy #text', 'sw');
+    expect(render).toContain('nakala');
+    expect(t).toContain('copy.patient=#text');
+  });
+
+  it('vi: `prepend "x" to #list` no longer parses as add', () => {
+    const { render, triples: t } = renderAndParse('prepend "x" to #list', 'vi');
+    expect(render).toContain('thêm vào đầu');
+    expect(t.some(x => x.startsWith('prepend.'))).toBe(true);
+  });
+});
+
+describe('Batch 3 — reset class (broken/wrong-event listener)', () => {
+  it.each([
+    ['it', 'reimpostare'],
+    ['ko', '재설정'],
+    ['pl', 'zresetuj'],
+    ['pt', 'redefinir'],
+    ['ru', 'сбросить'],
+    ['uk', 'скинути'],
+    ['qu', 'musuqchay'],
+  ])('%s: on-reset render captures on.event="reset" (canonical)', (langCode, word) => {
+    const { render, triples: t } = renderAndParse('on reset log "done"', langCode);
+    expect(render).toContain(word);
+    expect(t).toContain('on.event=reset');
+  });
+});
+
+describe('Batch 3 — submit class (dict word was the send verb)', () => {
+  it.each([
+    ['es', 'envío'],
+    ['pl', 'wysłaniu'],
+    ['tr', 'gönderme'],
+    ['vi', 'nộp'],
+    ['qu', 'apaykachay'],
+  ])(
+    '%s: corpus-shaped on-submit render captures on.event="submit", not "send"',
+    (langCode, word) => {
+      const { render, triples: t } = renderAndParse(
+        'on submit add @disabled to <button/> in me put "Submitting..." into <button/> in me',
+        langCode
+      );
+      expect(render).toContain(word);
+      expect(t).toContain('on.event=submit');
+      expect(t).not.toContain('on.event=send');
+    }
+  );
+});
+
+describe('Batch 3 — qu change (dict word was the toggle verb)', () => {
+  it('qu: on-change render captures on.event="change", not "toggle"', () => {
+    const { render, triples: t } = renderAndParse('on change log "x"', 'qu');
+    expect(render).toContain('kambiay');
+    expect(t).toContain('on.event=change');
+  });
+});
+
+describe('Batch 3 — it blur (noun form dropped the command patient)', () => {
+  it('it: blur command render captures blur.patient', () => {
+    const { render, triples: t } = renderAndParse('on keydown[key=="Escape"] blur me', 'it');
+    expect(render).toContain('sfuocare');
+    expect(t).toContain('blur.patient=me');
+  });
+
+  it('it: blur event position still captures on.event="blur"', () => {
+    const { triples: t } = renderAndParse('on blur log "x"', 'it');
+    expect(t).toContain('on.event=blur');
+  });
+});
+
+describe('Batch 3 — empty class (ko/qu profile alternatives)', () => {
+  it('ko: the dict adjective now parses the empty command', () => {
+    const t = triples(parseSemantic('#list 를 비어있는', 'ko').node);
+    expect(t).toContain('empty.patient=#list');
+  });
+
+  it('qu: apostrophe-less chusaq now parses the empty command', () => {
+    const t = triples(parseSemantic('#list ta chusaq', 'qu').node);
+    expect(t).toContain('empty.patient=#list');
+  });
+
+  it('ko/qu: the hot `is empty` expression rows keep parsing without a phantom empty action', () => {
+    for (const [text, langCode] of [
+      [
+        '블러 할 때 만약 내 값 이다 비어있는 .error 를 추가 나 에 아니면 .error 를 제거 나 에서 끝',
+        'ko',
+      ],
+      [
+        'paqariy pi sichus noqaq chanin kanqa chusaq .error ta noqa man yapay manachus .error ta noqa manta qichuy tukuy',
+        'qu',
+      ],
+    ] as const) {
+      const t = triples(parseSemantic(text, langCode).node);
+      expect(t.some(x => x.startsWith('empty.'))).toBe(false);
+    }
+  });
+});

--- a/packages/testing-framework/vocab-waivers.json
+++ b/packages/testing-framework/vocab-waivers.json
@@ -122,5 +122,141 @@
   {
     "key": "V4|zh|时",
     "reason": "Batch 1 probe P7: `当 点击 时 切换 把 .active` captures event=click — SOV event markers are consumed by semantic-parser's hardcoded sovEventMarkers path, matched by value."
+  },
+  {
+    "key": "V1|*|when",
+    "reason": "Batch 3 probe: the dict word is the corpus-hot handler-opener connective (146 rows/lang — ja 時, ms apabila, th เมื่อ, tl kapag, vi khi, zh 当), every probed row parses identical to the en reference (actions+roles; click values R2-covered). The profile `when` keyword is a secondary connective the transformer never renders here. Latent table misalignment — Arc B reconciliation input. See MULTILINGUAL_NEXT_STEPS.md § 'V1 probe conclusion (Batch 3)'."
+  },
+  {
+    "key": "V1|*|while",
+    "reason": "Batch 3 probe: corpus-hot repeat-while renders (fr tantque, sw wakati, zh 当) parse with repeat.loopType=while captured, value-identical to en (zh row value-verified). Latent — Arc B input."
+  },
+  {
+    "key": "V1|*|until",
+    "reason": "Batch 3 probe: corpus-hot repeat-until-event renders (fr jusquà, qu hayk_akama, ru/uk до) capture repeat.event + loopType identical to en (HOT-OK; qu underscore form tokenizes whole). The fr row's on.event mousedown fused-form diff is a pre-existing S5b-coverage gap, unrelated to `until` — logged in the ledger. Latent — Arc B input."
+  },
+  {
+    "key": "V1|*|into",
+    "reason": "Batch 3 probe: put-destination renders come from grammar role markers, not dict modifiers.into — the dict word either round-trips where it does appear (bn তে corpus-hot ×94 HOT-OK; de/es/pt/qu forms hot in for/containment slots) or never renders at all (id ke_dalam, tl papasok_sa — probe COLD dict-ABSENT, transformer emits ke/sa). Dead-or-latent vocabulary — Arc B input."
+  },
+  {
+    "key": "V1|*|break",
+    "reason": "Batch 3 probe: `break` has no parse representation in ANY language including en — `repeat 3 times break end` parses to the same break-less repeat in en and in every rendered translation (Arc C unconsumed-input class). The dict words double as halt verbs and are corpus-hot, faithful, as halt (hi/ms/vi HOT-OK). Word choice is moot until break parses at all."
+  },
+  {
+    "key": "V1|*|and",
+    "reason": "Batch 3 probe: en itself never consumes logical `and` — `if #a and #b log ..` captures condition=#a and silently drops the second conjunct in en (same input-coverage class as break). No parse authority exists to reconcile against; ar و is corpus-absent as a standalone token (clitic prefix). Arc C/E adjacent."
+  },
+  {
+    "key": "V1|*|then",
+    "reason": "Batch 3 probe: corpus-hot sequential connective (ko 그러면, qu chayqa — 53 rows/lang), probed rows (make-element, wait-then) parse identical to en. Latent — Arc B input."
+  },
+  {
+    "key": "V1|qu|continue",
+    "reason": "Batch 3 probe: bare `continue` parses null in en, qu dict purichiy AND qu profile qatipay — no parse path exists anywhere (break/and class). Corpus-cold."
+  },
+  {
+    "key": "V1|pl|click",
+    "reason": "Batch 3 probe: kliknięcie is corpus-hot ×106 and every probed row parses identical to en; click event VALUE is R2-covered (curated exec subset dispatches canonical `click` against the pl listener — baseline green). Profile kliknięciu is the locative variant. Latent."
+  },
+  {
+    "key": "V1|th|input",
+    "reason": "Batch 3 probe: อินพุต corpus rows capture on.event VALUE 'input' verbatim-identical to en (input-mirror probed). Latent."
+  },
+  {
+    "key": "V1|id|submit",
+    "reason": "Batch 3 probe: kirim captures on.event VALUE 'submit' in both corpus on-submit rows (unlike es/pl/tr/vi whose send-verb dict words captured 'send' and were dict-fixed). Latent."
+  },
+  {
+    "key": "V1|th|submit",
+    "reason": "Batch 3 probe: ส่ง captures on.event VALUE 'submit' in both corpus on-submit rows. Latent."
+  },
+  {
+    "key": "V1|id|change",
+    "reason": "Batch 3 probe: `pada ubah ...` captures on.event VALUE 'change' (tokenizer-known); corpus has no on-change rows so the slot is otherwise cold. Latent."
+  },
+  {
+    "key": "V1|it|scroll",
+    "reason": "Batch 3 probe: scorrimento round-trips both slots — window-scroll (event VALUE 'scroll') and scroll-command corpus rows parse value-identical to en. Latent."
+  },
+  {
+    "key": "V1|qu|throw",
+    "reason": "Batch 3 probe: wikchuy is corpus-hot in fetch-do-not-throw and the row parses identical to en (`mana wikchuy` no-throw modifier consumed). Latent."
+  },
+  {
+    "key": "V1|sw|async",
+    "reason": "Batch 3 probe: sainkroni corpus-hot in async-block, HOT-OK, and the re-rendered probe parses identical to en. Latent."
+  },
+  {
+    "key": "V1|qu|async",
+    "reason": "Batch 3 probe: dead vocab — the qu transformer keeps English `async` in the async-block render (probe COLD dict-ABSENT); mana_suyaspa never renders. Arc B input."
+  },
+  {
+    "key": "V1|qu|on",
+    "reason": "Batch 3 probe: dead vocab — qu event handlers render via the `pi` marker (`.active ta ñitiy pi tikray`), never dict commands.on=kaqpi. Arc B input."
+  },
+  {
+    "key": "V1|qu|event",
+    "reason": "Batch 3 probe: ruway is corpus-hot as the event reference (`the ruway ta kachay pi sayay` = on submit halt the event) and parses identical to en (form-submit-prevent HOT-OK). Latent."
+  },
+  {
+    "key": "V1|qu|before",
+    "reason": "Batch 3 probe: ñawpaqpi corpus-hot in put-before, HOT-OK. The profile ñawpaq is the bare stem; the rendered locative form parses. Latent."
+  },
+  {
+    "key": "V1|qu|after",
+    "reason": "Batch 3 probe: qhepapi corpus-hot in put-after, HOT-OK (same locative-form shape as before/ñawpaqpi). Latent."
+  },
+  {
+    "key": "V1|tl|from",
+    "reason": "Batch 3 probe: mula_sa corpus-hot ×24 in remove-from rows, HOT-OK — the underscore form tokenizes whole (sa_loob precedent). Latent."
+  },
+  {
+    "key": "V1|ja|empty",
+    "reason": "Batch 3 probe: BLOCKED both ways — dict-fix is unavailable (expressions.empty=空 also feeds the corpus-hot `is empty` renders and commands-category additions shadow it on render), and the profile-alternatives route was probed and REVERTED: registering bare 空 as an empty keyword injects a phantom `empty` action into the hot input-validation/if-empty rows (R0-precision regression). ko/qu took the profile-alt safely (their adjectives don't phantom); ja's empty-COMMAND render slot (corpus-cold) stays a known gap."
+  },
+  {
+    "key": "V1|ar|reset",
+    "reason": "Batch 3 probe: BLOCKED — no round-trip-safe ar reset form exists: dict 'إعادة تعيين', profile 'إعادة-ضبط'/'أعد-تعيين' AND the en passthrough all capture on.event as expression (broken listener shape). S5b has no reset key for any language; ar tokenizer event coverage gap, V3c-adjacent. Corpus-cold."
+  },
+  {
+    "key": "V1|sw|reset",
+    "reason": "Batch 3 probe: BLOCKED — every candidate captures a WRONG event: dict weka_upya→'put', profile anzisha-upya→'init', en passthrough→expression. sw handler grammar + event table gap (sw is the largest eventLocalizationDenylist set). Corpus-cold."
+  },
+  {
+    "key": "V1|tl|reset",
+    "reason": "Batch 3 probe: BLOCKED — dict 'reset' (en passthrough) and profile 'i-reset' both capture on.event as expression in the kapag handler. tl tokenizer event coverage gap, V3c-adjacent. Corpus-cold."
+  },
+  {
+    "key": "V2|ar|style:بـ-",
+    "reason": "Batch 4: style-role family — the style role is captured on NO path in any language including en (`show #modal with *opacity` captures patient only; Batch 1 discovery 2). Registration is untestable until show/hide style-capture lands (queued in MULTILINGUAL_NEXT_STEPS.md). Also attach-notation artifact (splits to bare بـ)."
+  },
+  {
+    "key": "V2|ar|style:مع",
+    "reason": "Batch 4: style-role family — blocked on show/hide style-capture (no language captures the style role, en included). Queued in MULTILINGUAL_NEXT_STEPS.md."
+  },
+  {
+    "key": "V2|hi|style:साथ",
+    "reason": "Batch 4: style-role family — blocked on show/hide style-capture (see V4|hi|साथ, same word). Queued in MULTILINGUAL_NEXT_STEPS.md."
+  },
+  {
+    "key": "V2|ja|style:と",
+    "reason": "Batch 4: style-role family — blocked on show/hide style-capture (no language captures the style role, en included). Queued in MULTILINGUAL_NEXT_STEPS.md."
+  },
+  {
+    "key": "V2|ko|style:와",
+    "reason": "Batch 4: style-role family — blocked on show/hide style-capture (no language captures the style role, en included). Queued in MULTILINGUAL_NEXT_STEPS.md."
+  },
+  {
+    "key": "V2|ko|style:과",
+    "reason": "Batch 4: style-role family — blocked on show/hide style-capture (no language captures the style role, en included). Queued in MULTILINGUAL_NEXT_STEPS.md."
+  },
+  {
+    "key": "V2|en|method:as",
+    "reason": "Batch 4: schema-override↔render alignment queued (NEXT_STEPS) — `fetch .. as json` consumes `as` as a handcrafted/generated pattern literal (matched by raw token.value, Batch 1 V4 probe mechanism), so parsing works; V2's parse-side union only sees roleMarkers/schema markers, not pattern literals."
+  },
+  {
+    "key": "V2|en|duration:for",
+    "reason": "Batch 4: schema-override↔render alignment queued (NEXT_STEPS) — duration `for` is consumed as a pattern literal (same mechanism as method:as); V2 cannot see pattern literals."
   }
 ]


### PR DESCRIPTION
Batches 3+4 of the Arc A vocab-ledger burn-down (handoff: `docs-internal/HANDOFF_vocab-batch3-v1-reconciliation.md`): reconcile the 90 V1 profile↔dictionary keyword conflicts probe-first, waive the 8 triaged V2s, and flip the CI vocab step from warn-only to a gate.

## Before / after ledger

| | unwaived | waived |
| --- | --- | --- |
| start | **98** (V1 ×90 · V2 ×8) | 78 (Batch 1 V4 class waivers) |
| end | **0** | **136** (78 V4 + 50 V1 + 8 V2 — every waiver probe-cited in `packages/testing-framework/vocab-waivers.json`) |

V1 resolution: **38 dict fixes** (i18n dictionaries realigned to profile primaries) + **2 profile-alternatives** (ko/qu empty) + **50 waived across 26 entries** (class wildcards only where the whole concept-class is waived). Full probe verdict + per-concept reconciliation table (Arc B's input) appended to `MULTILINGUAL_NEXT_STEPS.md` § "V1 probe conclusion (Batch 3)".

## Probe verdict (all 90 rows, captured-ACTION/VALUE assertions — never "it parses")

- **Latent class (50)** — the corpus-hot connectives/particles (`when` ×146 rows/lang, `into`, `then`, `until`, `while`, pl `click` ×106, tl `from`, …) parse identical to the en reference: there the **dictionary is the parse-authoritative side** and the profile copy is the misaligned one (inverse of V3's verdict) — recorded per-concept for Arc B.
- **Live wrong-verb class (24, corpus-cold slots)** — the dict word doubled as a different command's keyword: select ×15 (= the pick keyword; bare select rendered → parsed **null**), clone ×5 (= copy verb → parsed `copy`), id close (= hide), sw copy (= clone), vi prepend (shatters at `thêm` = add), qu open (= trigger). Dict-fixed; the pick/copy/hide/trigger keys keep their words, so **no corpus render moved**.
- **Live wrong-EVENT class — the headline:** es/pl/tr/vi `on submit` corpus rows were binding listeners to **`"send"`** in production (dict submit word = the send verb) while every ratchet stayed green: invisible to R0/R1 (action set + role type unchanged), R3 (plain event names aren't whitelist-invariant), R2 (no submit trigger in the curated subset — third confirmation of that blind spot). Fixed with probe-verified forms (`envío`/`wysłaniu`/`gönderme`/`nộp`/`apaykachay`, each captures `"submit"` in the exact corpus slots). Same class corpus-cold: reset ×7 (broken/wrong-event listeners → profile verbs capture literal `"reset"`), qu change (`tikray`→`"toggle"` → `kambiay`), it blur (noun dropped the command patient → `sfuocare` round-trips both slots).
- **Latent-by-absence (10)** — `break` ×7, qu `continue`, `and` ×2: **en itself silently drops these** (Arc C unconsumed-input class); no parse authority exists to reconcile against.
- **Blocked (4)** — ar/sw/tl reset: no candidate round-trips (sw candidates capture `"put"`/`"init"`; en passthrough → expression); ja empty: the profile-alternative was probed and **reverted** — registering bare 空 injected a phantom `empty` action into the corpus-hot `is empty` rows (R0-precision regression caught by the after-probe). ko/qu took the same alternative safely.

Red→green per class: `packages/testing-framework/src/vocab/batch3-roundtrip.test.ts` (24 render→parse round-trips asserting captured actions/values); the semantic `lexicon-emit-mismatch` ratchet itself flagged the 24 fixed entries as stale — pruned. Before/after probe logs archived (probe-v1.log / probe-v1-after2.log, session scratchpad).

## Batch 4

- 8 V2 waivers with named reasons: 6 style-role rows (ar `بـ-`/`مع`, hi `साथ`, ja `と`, ko `와`/`과`) blocked on the show/hide style-capture gap; en `method:as` + `duration:for` consumed as pattern literals (V4-probe mechanism), schema-override↔render alignment queued.
- `.github/workflows/ci.yml`: "Vocab consistency (warn-only)" → **"Vocab consistency (gate)"** (dropped `--warn-only`). This PR's own CI run proves the gate. Release bar item 1 closed.

## Verification

- vocab CLI `validate`: **exit 0, 0 unwaived, no stale waivers** (135→136 waived findings across 65 entries).
- Suites: i18n 947/947 (2 Family-H expectations updated to the new tr/qu submit renders — same head shape, word swap only), semantic 7069/7069 (lexicon ledger pruned), testing-framework 252+24, domain bdd 153 / behaviorspec 195 / learn 186; typecheck semantic+i18n+testing-framework clean.
- Ordered build → fresh `populate` → `--regression` **exit 0** (`✓ No regression vs baseline` across all eight signals) and `--diagnose-coverage` **exit 0** (`No unconsumed input anywhere in the corpus`) — real captured exit codes, no `| tail` masking.
- Baseline: `--save-baseline` was run against the same freshly-populated DB as an attribution check — per-language metrics came back **byte-identical** (the it blur R1 gain is masked by schema-default `patient=me` injection on both sides; the submit fixes are value-level, invisible to every recall metric — consistent with the probe verdict), so the committed baseline is deliberately untouched.
- `patterns.db` NOT committed (repopulated locally per policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
