### PR TITLE
chore(ci): extend Dependabot coverage to protocol/typescript + Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 
 updates:
+  # Root npm workspace (packages/*, apps/*) — covered by the root package-lock.json
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
@@ -29,6 +30,54 @@ updates:
           - 'eslint'
           - 'eslint-*'
           - 'prettier'
+      # Catch-all: batch remaining minor/patch bumps into one weekly PR
+      # instead of one PR per dependency. Majors stay individual PRs.
+      minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+    labels:
+      - 'dependencies'
+    reviewers:
+      - 'codetalcott'
+
+  # Standalone npm root (own package-lock.json, not part of the workspaces)
+  - package-ecosystem: 'npm'
+    directory: '/protocol/typescript'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+    labels:
+      - 'dependencies'
+    reviewers:
+      - 'codetalcott'
+
+  # Go modules (the go-client currently carries the x/crypto critical alerts)
+  - package-ecosystem: 'gomod'
+    directories:
+      - '/clients/go-client'
+      - '/protocol/go'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 5
+    groups:
+      go-deps:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
     labels:
       - 'dependencies'
     reviewers:


### PR DESCRIPTION
## What

Evaluation of the existing `.github/dependabot.yml` against the actual repo layout found three gaps. Dependabot **security** PRs already fire repo-wide regardless of config (e.g. #604, #626), but **scheduled version updates** only run for configured directories — so uncovered roots drift until an advisory forces a security PR.

Package roots in the repo vs. config before this PR:

| Root | Ecosystem | Covered before |
|---|---|---|
| `/` (npm workspaces `packages/*`, `apps/*`) | npm | yes |
| `/protocol/typescript` (own package-lock.json) | npm | **no** |
| `/clients/go-client` | gomod | **no** — this is where the 7 critical `golang.org/x/crypto` alerts live |
| `/protocol/go` | gomod | **no** |
| GitHub Actions | github-actions | yes |
| `experiments/*` (manifests only, no lockfiles) | npm | no — deliberately left out (sandboxes; security updates still cover them, scheduled updates would be noise) |

## Changes

- New npm entry for `/protocol/typescript` (weekly, grouped minor/patch)
- New gomod entry for `/clients/go-client` + `/protocol/go` via `directories:` (weekly, grouped minor/patch)
- Added a catch-all `minor-and-patch` group to the root npm entry so ungrouped deps batch into one weekly PR instead of one PR each; the existing tool-family groups (typescript/testing/build-tools/linting) match first and majors remain individual PRs
- Existing entries untouched otherwise

YAML validated with a `yaml.safe_load` round-trip (4 update entries parse as expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)