### PR TITLE
fix(ci): paths-filter needs predicate-quantifier 'every' for negations to work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,14 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: filter
         with:
+          # REQUIRED for the `code` filter's negations to work. The default
+          # quantifier is 'some' (OR over the pattern list), under which the
+          # leading '**' matches every file and the '!…' lines never subtract —
+          # `code` evaluated true on EVERY diff (observed live: go.mod-only
+          # #664 ran the full npm stack). 'every' = a file counts only when it
+          # matches ALL patterns (inside '**' AND outside each excluded set).
+          # Single-positive-pattern filters (protocol, goclient) are unaffected.
+          predicate-quantifier: 'every'
           # `code` is true when any changed file is OUTSIDE the doc set and
           # outside the non-npm surfaces (protocol/, clients/) that carry their
           # own jobs. `protocol` is true when the LSE spec, fixtures, or any of


### PR DESCRIPTION
## Summary

Follow-up to #660, fixing a **pre-existing** filter bug it inherited: `dorny/paths-filter`'s default `predicate-quantifier` is `'some'` (OR over the pattern list), so the `code` filter's leading `'**'` matched every file and the `'!…'` exclusions never subtracted — **`code` has always evaluated true on every diff**. The original doc-only-skip design therefore never actually skipped anything (fail-open, so nobody noticed).

Observed live: go.mod-only #664 fired `goclient` correctly *and* `code` (`clients/go-client/go.mod [modified]` listed under "Filter code = true" in the Detect changes log), running the full npm stack the #660 gate was meant to skip.

With `predicate-quantifier: 'every'`, a file counts only when it matches ALL patterns (inside `'**'` AND outside each excluded set) — the documented include+exclude idiom. Single-positive-pattern filters (`protocol`, `goclient`) are unaffected.

Validation: YAML parses, `check:ci-order` OK. This PR touches `.github/**` (inside `code`), so its own run exercises the full suite; the next go-only/docs-only PR validates the skip live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)