### PR TITLE
fix(release): reproducible installs in publish workflow (npm ci + lockfile sync)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,10 +71,16 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # Delete stale lockfile — workspace package versions may differ from lockfile
-          # after a version bump. Regenerate fresh so workspace symlinks resolve correctly.
-          rm -f package-lock.json
-          npm install
+          # npm ci reproduces the committed lockfile tree exactly — the same tree
+          # CI validates on every push. This step previously deleted the lockfile
+          # and ran an unpinned `npm install`, which resolved a fresh tree from
+          # the registry and broke whenever upstream releases shifted hoisting
+          # (the 2026-07-13 i18n vite-types DTS failure: the fresh tree stopped
+          # nesting vite 8 under packages/i18n while the lockfile tree, green on
+          # every CI push, keeps it). The lockfile stays valid here because the
+          # commit step below now regenerates and commits it alongside version
+          # bumps.
+          npm ci
 
       - name: Build all packages
         run: |
@@ -252,17 +258,15 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           BRANCH="${{ github.ref_name }}"
 
-          # The "Install dependencies" step earlier in this job did
-          # `rm -f package-lock.json && npm install`, which leaves an
-          # unstaged lockfile change in the worktree. We intentionally do
-          # NOT commit it (would break the next run's `npm install` because
-          # it would reference workspace-package versions that are now
-          # higher-than-published-at-the-time). Restore it from HEAD so the
-          # subsequent `git pull` doesn't refuse with "your local changes
-          # would be overwritten by merge".
-          git checkout -- package-lock.json 2>/dev/null || true
+          # Regenerate the lockfile so its workspace version stamps match the
+          # bumped package.jsons, and commit it WITH the bump — that is what
+          # keeps `npm ci` (install step above) valid for every subsequent
+          # run. --package-lock-only rewrites the lockfile from the current
+          # package.jsons without touching node_modules; registry resolutions
+          # already satisfied by the existing lockfile are kept.
+          npm install --package-lock-only
 
-          git add packages/*/package.json package.json lerna.json 2>/dev/null || true
+          git add packages/*/package.json package.json lerna.json package-lock.json 2>/dev/null || true
           git commit -m "chore: release v$VERSION" || echo "No changes to commit"
 
           # Pull from the SAME branch the workflow ran on, not hardcoded
@@ -355,7 +359,10 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install --no-audit --no-fund
+        # npm ci for the same reproducibility reason as the publish job: the
+        # checkout is self-consistent (lockfile committed with version bumps),
+        # so install exactly that tree rather than re-resolving from the registry.
+        run: npm ci --no-audit --no-fund
 
       - name: Install Playwright chromium
         run: npx playwright install --with-deps chromium

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -3381,8 +3381,37 @@ window: items 1–4 are **must-have**, item 5 is the **stretch headline**.
    and **Browser Tests joined the required checks on main** so a runtime dep bump
    can't self-merge past a Playwright regression. No merge queue — Dependabot
    auto-rebases its own stale PRs, so ci.yml's "no merge queue" design note stands.
-   Expected steady state ~2–3 Dependabot PRs/week, mostly self-merging. Still open
-   for the ✓: a green `pre-publish-check` run + the publish dry-run.
+   Expected steady state ~2–3 Dependabot PRs/week, mostly self-merging.
+   **✓ MET (2026-07-13): both runs green.** `pre-publish-check` run 29270242303
+   (summary read, not just the conclusion: the export-validation ❌s are a
+   step-ORDERING artifact — that step runs before "Build browser bundles", and
+   the later bundle-size gate passed against the very files it flagged; the
+   domain-* `build:types` warnings are the known-benign DTS class). Publish
+   dry-run run 29270948266: full build + tests + `set-version.cjs` sync to
+   2.8.0 + `npm publish --dry-run` across the monorepo. The FIRST dry-run
+   (29270244008) failed in i18n's DTS (`TS2307: vite`) because publish.yml
+   deleted the lockfile and ran an unpinned `npm install` — fresh-resolve
+   drift the lockfile tree never had. Fixed in this PR: `npm ci` + the
+   version-bump commit now regenerates and commits the lockfile
+   (`npm install --package-lock-only`), which is what keeps `npm ci` valid.
+   _Item-4 crumbs closed:_ **#133** = stale typescript themed-group PR, closed
+   unmerged 2026-07-13 by the #663 sweep (superseded by majors group #670).
+   **js-yaml**: the only open Dependabot alert repo-wide (#350, medium,
+   merge-key quadratic DoS) — dev-only transitive of eslint 8 + lerna 9
+   (`npm ls js-yaml`), never in a shipped package; waived until the eslint 9 /
+   lerna major bumps. **python-client CI job** (mirror of #660's go-client
+   job): deferred post-release.
+   _Monday reconciliation verified (2026-07-13):_ superseded individual PRs
+   all closed (#206, #201, #216/#659, #220/#658, #657 jsdom, #133); jsdom
+   re-landed inside majors group **#670** (16 updates, auto-merge correctly
+   NOT armed, red on Build — CI-as-reviewer working as designed); Browser
+   Tests confirmed among the SIX required checks (strict). One deviation:
+   minor-and-patch group **#668** armed auto-merge but sits safely blocked on
+   two red required checks — vitest 4.1.6→4.1.10 mass-breaks the core test
+   transform (~100 files `SyntaxError: Invalid or unexpected token`) and
+   prettier 3.9.5 introduces 8 ESLint errors. Deliberately NOT remediated in
+   this pass (release focus); options: split vitest+prettier out of the group,
+   or let next Monday's run supersede.
 5. **Stretch — `fetch … with { }` captured in all 24 languages** (Arc E) — the
    user-visible feature claim for the release notes. Take it only after 1–4 are
    locked; it needs a baseline regen, so it must not land in the final two days.


### PR DESCRIPTION
## Problem

The publish job deleted `package-lock.json` and ran an unpinned `npm install`, so every run resolved a fresh dependency tree from the registry. Today's registry state stopped nesting vite 8 under `packages/i18n` on the runner, and the i18n DTS build failed with `TS2307: Cannot find module 'vite'` — while the lockfile tree stays green on every CI push. Failed dry-run: [29270244008](https://github.com/codetalcott/hyperfixi/actions/runs/29270244008).

The unpinned install existed because the version-bump commit deliberately did NOT commit the lockfile, which desynced it — the two hacks propped each other up.

## Fix

- Install with **`npm ci`** (the lockfile always matches the checkout at that point in the job; version bumps happen later in the same run).
- The version-bump commit now regenerates the lockfile with `npm install --package-lock-only` and commits it alongside the bumped package.jsons — which is what keeps `npm ci` valid for every subsequent run.
- `release-smoke` installs with `npm ci` for the same reason.

## Validation

Full publish **dry-run from this branch is green**: [29270948266](https://github.com/codetalcott/hyperfixi/actions/runs/29270948266) — build of all packages, tests, `set-version.cjs` sync to 2.8.0, and `npm publish --dry-run` across the monorepo. Closes the release-bar item 4 tail together with the green `pre-publish-check` run [29270242303](https://github.com/codetalcott/hyperfixi/actions/runs/29270242303).

🤖 Generated with [Claude Code](https://claude.com/claude-code)