### PR TITLE
fix(core): compound-adapter kind gate + size-truth docs pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **HyperFixi** is a complete \_hyperscript ecosystem with server-side compilation, multi-language i18n (24 languages including SOV/VSO grammar transformation), semantic-first multilingual parsing, and comprehensive developer tooling. Engine packages are published under `@hyperfixi/*`, multilingual packages under `@lokascript/*`.
 
 - **14,000+ tests** passing across all suites (core ~7000, semantic ~6500, i18n ~900, plus per-package suites)
-- **203 KB** browser bundle (gzipped, 39% reduction from original)
+- **~534 KB** full browser bundle (gzipped); slim bundles from **1.9 KB** (lite) to **18 KB** (hybrid-hx) — sizes re-measured 2026-07-13; bundle-diet investigation queued post-release
 - **\_hyperscript compatible** — tested via gallery examples, bundle compatibility matrix, and command/expression browser tests (Playwright)
 
 ## Monorepo Structure
@@ -501,7 +501,7 @@ The bundle compatibility test suite automatically tests all 7 bundles against ga
 
 - Location: `packages/core/src/compatibility/browser-tests/bundle-compatibility.spec.ts`
 - Tests: Toggle, show/hide, input mirroring, counter, modals, fetch, tabs, blocks, event modifiers
-- Bundles: lite (1.9 KB), lite-plus (2.6 KB), hybrid-complete (7.3 KB), hybrid-hx (9.5 KB), hybrid-hx-v4 (~257 KB), minimal (58 KB), standard (63 KB), browser (203 KB)
+- Bundles: lite (1.9 KB), lite-plus (2.6 KB), hybrid-complete (7.7 KB), hybrid-hx (18 KB), hybrid-hx-v4 (~540 KB), minimal (76 KB), standard (82 KB), browser (~534 KB)
 - Prints ASCII compatibility matrix showing feature support across all bundles
 
 ### Using Behaviors (Browser)
@@ -515,7 +515,7 @@ Include the resolver bundle after core — all standard behaviors resolve on dem
 <button _="install Toggleable(cls: 'highlighted')">Toggle</button>
 ```
 
-Behaviors are hyperscript source strings compiled on first use. The resolver bundle is 3.8 KB gzipped.
+Behaviors are hyperscript source strings compiled on first use. The resolver bundle is 5.5 KB gzipped.
 
 ### Dynamic Class Selectors
 
@@ -719,16 +719,16 @@ generator, and semantic regional bundles — lives in
 
 Quick selection (sizes gzipped):
 
-| Bundle                         | Size     | Use case                                                                                   |
-| ------------------------------ | -------- | ------------------------------------------------------------------------------------------ |
-| via `@hyperfixi/vite-plugin`   | minimal  | **Default for Vite projects** — scans usage, emits the right bundle                        |
-| `hyperfixi-lite.js`            | 1.9 KB   | Tiny static page (8 commands, regex parser)                                                |
-| `hyperfixi-hybrid-complete.js` | 7.3 KB   | Pure hyperscript, ~85% coverage (AST parser, blocks, modifiers)                            |
-| `hyperfixi-hx.js`              | 9.7 KB   | + htmx v1/v2 attributes (`hx-get` etc.); no reactivity/streaming                           |
-| `hyperfixi-hx-v4.js`           | ~257 KB  | `hx-live`, `bind`, `when`, SSE, WebSocket — full runtime + reactivity                      |
-| `hyperfixi.js`                 | ~286 KB  | Full bundle with parser (`window.hyperfixi`); reactivity + realtime plugins pre-installed  |
-| `hyperfixi-multilingual.js`    | 64.3 KB  | Multilingual, parser-free (pair with a semantic bundle)                                    |
-| semantic bundles               | 16–90 KB | `LokaScriptSemantic*` globals; regional subsets (en/es/western/east-asian/priority/all-24) |
+| Bundle                         | Size      | Use case                                                                                   |
+| ------------------------------ | --------- | ------------------------------------------------------------------------------------------ |
+| via `@hyperfixi/vite-plugin`   | minimal   | **Default for Vite projects** — scans usage, emits the right bundle                        |
+| `hyperfixi-lite.js`            | 1.9 KB    | Tiny static page (8 commands, regex parser)                                                |
+| `hyperfixi-hybrid-complete.js` | 7.7 KB    | Pure hyperscript, ~85% coverage (AST parser, blocks, modifiers)                            |
+| `hyperfixi-hx.js`              | 18 KB     | + htmx v1/v2 attributes (`hx-get` etc.); no reactivity/streaming                           |
+| `hyperfixi-hx-v4.js`           | ~540 KB   | `hx-live`, `bind`, `when`, SSE, WebSocket — full runtime + reactivity                      |
+| `hyperfixi.js`                 | ~534 KB   | Full bundle with parser (`window.hyperfixi`); reactivity + realtime plugins pre-installed  |
+| `hyperfixi-multilingual.js`    | 97 KB     | Multilingual, parser-free (pair with a semantic bundle)                                    |
+| semantic bundles               | 56–195 KB | `LokaScriptSemantic*` globals; regional subsets (en/es/western/east-asian/priority/all-24) |
 
 Rule of thumb: start as small as you can; upgrade when you hit a missing feature.
 The vite plugin removes this decision entirely.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm version](https://img.shields.io/npm/v/@hyperfixi/core.svg)](https://www.npmjs.com/package/@hyperfixi/core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A tree-shakeable [\_hyperscript](https://hyperscript.org) runtime. Human-readable UI behaviors from 7 KB.
+A tree-shakeable [\_hyperscript](https://hyperscript.org) runtime. Human-readable UI behaviors from 1.9 KB.
 
 ## Try It
 
@@ -71,7 +71,7 @@ The plugin scans your files for `_="..."` attributes and generates a minimal bun
 
 - **43 commands** -- toggle, add, remove, set, put, fetch, repeat, if/else, and more
 - **\_hyperscript compatible** -- existing hyperscript code works as-is
-- **Tree-shakeable** -- ship only the commands you use (1.9 KB to 200 KB)
+- **Tree-shakeable** -- ship only the commands you use (1.9 KB lite to ~534 KB full)
 - **TypeScript types** -- full type safety with comprehensive definitions
 - **Optional multilingual** -- write hyperscript in 24 languages ([lokascript.org](https://lokascript.org))
 - **Optional htmx compat** -- htmx-like attributes via the `hyperfixi-hx.js` bundle
@@ -101,7 +101,7 @@ translation preserved meaning rather than merely "parsed". Two writeups go deep:
 
 ## Learn More
 
-- [Choosing a bundle](https://hyperfixi.org/guide/bundles/) -- 6 bundles from 1.9 KB to 200 KB
+- [Choosing a bundle](https://hyperfixi.org/guide/bundles/) -- bundles from 1.9 KB (lite) to ~534 KB (full)
 - [Examples gallery](https://hyperfixi.org/examples/) -- 35+ interactive demos
 - [Playground](https://hyperfixi.org/playground/) -- live REPL
 - [Vite plugin guide](https://hyperfixi.org/guide/vite-plugin/) -- automatic tree-shaking

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -3479,6 +3479,16 @@ window: items 1–4 are **must-have**, item 5 is the **stretch headline**.
    candidate** (user-visible on the shipped full bundle); marked as a
    knownIssue in bundle-compatibility.spec.ts (printed, not asserted) until
    fixed — remove the knownIssue field with the fix.
+   _✓ FIXED (2026-07-13):_ `createSemanticAdapter` now exposes `command` only
+   when the semantic node's `kind` is `'command'` (or absent, preserving
+   behavior for parse fns that don't report kind); any other kind
+   (`compound`, `event-handler`, …) omits `command`, fails the inlined
+   confidence gate, and the traditional parser takes the segment. Core-only
+   change (the `SemanticParseFn` minimal interface gained optional `kind` —
+   structural, no packages/semantic edit → baseline untouched). Repro
+   (fetch-data multi-line body via `compileSync`) went from
+   `command:compound` in the AST to `[add, log, remove]`; knownIssue field
+   removed; 6 adapter unit tests added in semantic-integration.test.ts.
 5. **Stretch — `fetch … with { }` captured in all 24 languages** (Arc E) — the
    user-visible feature claim for the release notes. Take it only after 1–4 are
    locked; it needs a baseline regen, so it must not land in the final two days.

--- a/docs/BROWSER_BUNDLES.md
+++ b/docs/BROWSER_BUNDLES.md
@@ -10,11 +10,11 @@
 Decision tree for the most common cases:
 
 1. **Using `@hyperfixi/vite-plugin`?** Don't pick a bundle by hand — the plugin scans your project and emits the right one (minimal handcrafted when possible, falls back to `hx-v4` when it spots htmx v4 features). See [vite plugin README](../packages/vite-plugin/README.md).
-2. **Need `hx-live`, `bind`, `when`, SSE, or WebSocket?** Use `hyperfixi-hx-v4.js` (~257 KB gz). Single script tag, everything auto-installed. The size cost buys correctness — the slim runtime can't satisfy these features (its `set` doesn't fire `notifyGlobalWrite`, the slim parser doesn't know reactive features, and SSE/WS modules aren't wired).
-3. **Need only htmx v1/v2 attributes (`hx-get`/`hx-post`/etc.)?** Use `hyperfixi-hx.js` (~13 KB gz). Includes htmx-compat + the slim hybrid runtime for `_=` attributes. No reactivity, no streaming.
-4. **Pure hyperscript (`_=` attributes), ~85% feature coverage, smallest realistic size?** Use `hyperfixi-hybrid-complete.js` (~7.3 KB gz). Full AST parser, expressions, event modifiers, block commands (`if`, `for`, `repeat`, `while`, `fetch`).
+2. **Need `hx-live`, `bind`, `when`, SSE, or WebSocket?** Use `hyperfixi-hx-v4.js` (~540 KB gz). Single script tag, everything auto-installed. The size cost buys correctness — the slim runtime can't satisfy these features (its `set` doesn't fire `notifyGlobalWrite`, the slim parser doesn't know reactive features, and SSE/WS modules aren't wired).
+3. **Need only htmx v1/v2 attributes (`hx-get`/`hx-post`/etc.)?** Use `hyperfixi-hx.js` (~18 KB gz). Includes htmx-compat + the slim hybrid runtime for `_=` attributes. No reactivity, no streaming.
+4. **Pure hyperscript (`_=` attributes), ~85% feature coverage, smallest realistic size?** Use `hyperfixi-hybrid-complete.js` (~7.7 KB gz). Full AST parser, expressions, event modifiers, block commands (`if`, `for`, `repeat`, `while`, `fetch`).
 5. **Tiny static page (toggle / show / hide / put / set)?** Use `hyperfixi-lite.js` (~1.9 KB gz). Regex parser, 8 commands. Drops to `hyperfixi-lite-plus.js` (~2.6 KB gz) if you need a few more commands + i18n aliases.
-6. **Authoring in multiple languages (Japanese, Korean, Arabic, etc.) or need the full semantic parser at runtime?** Use `hyperfixi.js` (full bundle, ~203 KB gz) or `hyperfixi-multilingual.js` (~64 KB, parser-free i18n via the semantic bundle loaded separately).
+6. **Authoring in multiple languages (Japanese, Korean, Arabic, etc.) or need the full semantic parser at runtime?** Use `hyperfixi.js` (full bundle, ~534 KB gz) or `hyperfixi-multilingual.js` (~97 KB, parser-free i18n via the semantic bundle loaded separately).
 
 Rule of thumb: start as small as you can; upgrade when you hit a missing feature. The vite plugin removes this decision entirely for projects that use it.
 
@@ -22,10 +22,10 @@ Rule of thumb: start as small as you can; upgrade when you hit a missing feature
 
 | Bundle                                               | Global                  | Size (gzip) | Use Case                             |
 | ---------------------------------------------------- | ----------------------- | ----------- | ------------------------------------ |
-| `packages/core/dist/hyperfixi.js`                    | `window.hyperfixi`      | 203.5 KB    | Full bundle with parser              |
-| `packages/behaviors/dist/resolver.browser.global.js` | `HyperFixiBehaviors`    | 3.8 KB      | Lazy behavior resolver (8 behaviors) |
-| `packages/core/dist/hyperfixi-multilingual.js`       | `window.hyperfixi`      | 64.3 KB     | Multilingual (no parser)             |
-| `packages/i18n/dist/lokascript-i18n.min.js`          | `window.LokaScriptI18n` | 35.0 KB     | Grammar transformation               |
+| `packages/core/dist/hyperfixi.js`                    | `window.hyperfixi`      | ~534 KB     | Full bundle with parser              |
+| `packages/behaviors/dist/resolver.browser.global.js` | `HyperFixiBehaviors`    | 5.5 KB      | Lazy behavior resolver (8 behaviors) |
+| `packages/core/dist/hyperfixi-multilingual.js`       | `window.hyperfixi`      | 96.8 KB     | Multilingual (no parser)             |
+| `packages/i18n/dist/lokascript-i18n.min.js`          | `window.LokaScriptI18n` | 43.3 KB     | Grammar transformation               |
 
 > **Note**: As of v2.0.0, the primary bundles are `hyperfixi-*.js`. Backward-compatible aliases (`lokascript-*.js`) are provided but will be removed in v3.0.0. See [MIGRATION.md](../MIGRATION.md).
 
@@ -37,9 +37,9 @@ For projects prioritizing bundle size over features:
 | ------------------------------ | ----------- | --------- | ------------------------------------------------------------- |
 | `hyperfixi-lite.js`            | 1.9 KB      | 8         | Regex parser, basic commands                                  |
 | `hyperfixi-lite-plus.js`       | 2.6 KB      | 14        | Regex parser, more commands, i18n aliases                     |
-| `hyperfixi-hybrid-complete.js` | 7.3 KB      | 21+blocks | Full AST parser, expressions, event modifiers                 |
-| `hyperfixi-hx.js`              | 9.7 KB      | 21+blocks | hybrid-complete + htmx/fixi attribute support                 |
-| `hyperfixi-hx-v4.js`           | ~257 KB     | 40+blocks | Full runtime + htmx-compat + reactivity (hx-live, bind, when) |
+| `hyperfixi-hybrid-complete.js` | 7.7 KB      | 21+blocks | Full AST parser, expressions, event modifiers                 |
+| `hyperfixi-hx.js`              | 18 KB       | 21+blocks | hybrid-complete + htmx/fixi attribute support                 |
+| `hyperfixi-hx-v4.js`           | ~540 KB     | 40+blocks | Full runtime + htmx-compat + reactivity (hx-live, bind, when) |
 
 **Hybrid Complete** (~85% hyperscript coverage) is recommended - it supports:
 
@@ -103,7 +103,7 @@ When `@hyperfixi/reactivity` is installed, the htmx-compat layer recognizes the 
 
 The expression re-runs only when its tracked dependencies actually change (not on every DOM mutation, which is the upstream htmx v4 approach). If reactivity isn't installed, the element is skipped with a clear console error pointing to the install command.
 
-**Easiest path: use the `hyperfixi-hx-v4.js` bundle.** It ships the full runtime + `@hyperfixi/reactivity` auto-installed + the htmx-compat layer in a single script tag. Larger than `hyperfixi-hx.js` (~257 KB vs 13 KB gzipped) but no manual plugin wiring required. For size-tuned production builds, use `@hyperfixi/vite-plugin` instead.
+**Easiest path: use the `hyperfixi-hx-v4.js` bundle.** It ships the full runtime + `@hyperfixi/reactivity` auto-installed + the htmx-compat layer in a single script tag. Larger than `hyperfixi-hx.js` (~540 KB vs 18 KB gzipped) but no manual plugin wiring required. For size-tuned production builds, use `@hyperfixi/vite-plugin` instead.
 
 ```html
 <script src="hyperfixi-hx-v4.js"></script>
@@ -258,13 +258,13 @@ See [bundle-configs/README.md](../packages/core/bundle-configs/README.md) for fu
 
 | Bundle                                    | Global                        | Size (gzip) | Languages          |
 | ----------------------------------------- | ----------------------------- | ----------- | ------------------ |
-| `browser.global.js`                       | `LokaScriptSemantic`          | 90 KB       | All 24             |
-| `browser-priority.priority.global.js`     | `LokaScriptSemanticPriority`  | 48 KB       | 11 priority        |
-| `browser-western.western.global.js`       | `LokaScriptSemanticWestern`   | 30 KB       | en, es, pt, fr, de |
-| `browser-east-asian.east-asian.global.js` | `LokaScriptSemanticEastAsian` | 24 KB       | ja, zh, ko         |
-| `browser-es-en.es-en.global.js`           | `LokaScriptSemanticEsEn`      | 25 KB       | en, es             |
-| `browser-en.en.global.js`                 | `LokaScriptSemanticEn`        | 20 KB       | en only            |
-| `browser-es.es.global.js`                 | `LokaScriptSemanticEs`        | 16 KB       | es only            |
+| `browser.global.js`                       | `LokaScriptSemantic`          | 195 KB      | All 24             |
+| `browser-priority.priority.global.js`     | `LokaScriptSemanticPriority`  | 107 KB      | 11 priority        |
+| `browser-western.western.global.js`       | `LokaScriptSemanticWestern`   | 89 KB       | en, es, pt, fr, de |
+| `browser-east-asian.east-asian.global.js` | `LokaScriptSemanticEastAsian` | 70 KB       | ja, zh, ko         |
+| `browser-es-en.es-en.global.js`           | `LokaScriptSemanticEsEn`      | 79 KB       | en, es             |
+| `browser-en.en.global.js`                 | `LokaScriptSemanticEn`        | 75 KB       | en only            |
+| `browser-es.es.global.js`                 | `LokaScriptSemanticEs`        | 62 KB       | es only            |
 
 Choose the smallest bundle that covers your target languages. See `packages/semantic/README.md` for details.
 
@@ -287,7 +287,7 @@ For developers writing hyperscript in their native language:
 </script>
 ```
 
-**Total size:** ~511 KB (250 KB + 261 KB) vs 924 KB with full bundle
+**Total size:** ~292 KB gz (97 KB multilingual + 195 KB all-24 semantic) vs ~534 KB gz full bundle
 
 ## Full Bundle Usage
 

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -132,10 +132,10 @@ See [docs/API.md](docs/API.md) for complete documentation.
 | Bundle                         | Size (gzip) | Use Case                                          |
 | ------------------------------ | ----------- | ------------------------------------------------- |
 | `hyperfixi-lite.js`            | 1.9 KB      | Minimal (8 commands, regex parser)                |
-| `hyperfixi-hybrid-complete.js` | 7.2 KB      | Recommended (~85% coverage)                       |
-| `hyperfixi-hx.js`              | 13 KB       | hybrid-complete + htmx/fixi v1/v2 attributes      |
-| `hyperfixi-hx-v4.js`           | ~257 KB     | Full runtime + htmx-compat + reactivity (hx-live) |
-| `hyperfixi.js`                 | ~286 KB     | Everything + bundled reactivity/realtime plugins  |
+| `hyperfixi-hybrid-complete.js` | 7.7 KB      | Recommended (~85% coverage)                       |
+| `hyperfixi-hx.js`              | 18 KB       | hybrid-complete + htmx/fixi v1/v2 attributes      |
+| `hyperfixi-hx-v4.js`           | ~540 KB     | Full runtime + htmx-compat + reactivity (hx-live) |
+| `hyperfixi.js`                 | ~534 KB     | Everything + bundled reactivity/realtime plugins  |
 
 ## Custom Bundle Generation
 

--- a/packages/core/src/compatibility/browser-tests/bundle-compatibility.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/bundle-compatibility.spec.ts
@@ -53,7 +53,7 @@ const BUNDLES = {
   },
   'hybrid-complete': {
     file: 'hyperfixi-hybrid-complete.js',
-    size: '7.3 KB',
+    size: '7.7 KB',
     features: {
       toggle: true,
       addClass: true,
@@ -70,7 +70,7 @@ const BUNDLES = {
   },
   'hybrid-hx': {
     file: 'hyperfixi-hybrid-hx.js',
-    size: '9.5 KB',
+    size: '18 KB',
     features: {
       toggle: true,
       addClass: true,
@@ -91,7 +91,7 @@ const BUNDLES = {
   // htmx v4 reactive/streaming surface without manual plugin wiring.
   'hybrid-hx-v4': {
     file: 'hyperfixi-hx-v4.js',
-    size: '~257 KB',
+    size: '~540 KB',
     features: {
       toggle: true,
       addClass: true,
@@ -108,7 +108,7 @@ const BUNDLES = {
   },
   minimal: {
     file: 'hyperfixi-browser-minimal.js',
-    size: '58 KB',
+    size: '76 KB',
     features: {
       toggle: true,
       addClass: true,
@@ -125,7 +125,7 @@ const BUNDLES = {
   },
   standard: {
     file: 'hyperfixi-browser-standard.js',
-    size: '63 KB',
+    size: '82 KB',
     features: {
       toggle: true,
       addClass: true,
@@ -142,7 +142,7 @@ const BUNDLES = {
   },
   browser: {
     file: 'hyperfixi.js',
-    size: '203 KB',
+    size: '~534 KB',
     features: {
       toggle: true,
       addClass: true,
@@ -273,14 +273,6 @@ const GALLERY_EXAMPLES = [
     name: 'Fetch Data',
     path: '/examples/fetch-and-async/fetch-data.html',
     requiredFeatures: ['fetch', 'blocks'],
-    // Pre-existing (verified on pre-Arc-F dist): core's per-segment semantic
-    // adapter surfaces a compound analysis result as a command literally
-    // named `compound` (semantic-integration.ts createSemanticAdapter maps
-    // `name: node.action` unconditionally), so this page's multi-line body
-    // throws "Unknown command: compound" at runtime while the rest of the
-    // handler works. Surfaced by the first real run of this suite
-    // (pre-publish-check 2026-07-13). Tracked in NEXT_STEPS § v2.8 pre-release.
-    knownIssue: 'semantic adapter emits compound command node (NEXT_STEPS v2.8 pre-release)',
     test: async (page: Page) => {
       const fetchBtn = page
         .locator('button')

--- a/packages/core/src/parser/semantic-integration.test.ts
+++ b/packages/core/src/parser/semantic-integration.test.ts
@@ -15,6 +15,7 @@ import {
   shouldUseSemanticResult,
   languageBenefitsFromSemantic,
   createSemanticIntegration,
+  createSemanticAdapter,
 } from './semantic-integration';
 
 // =============================================================================
@@ -516,5 +517,84 @@ describe('parseExpressionString (via expression type values)', () => {
     const expr = result.node?.args?.[0] as any;
     expect(expr.type).toBe('identifier');
     expect(expr.name).toBe('');
+  });
+});
+
+// =============================================================================
+// createSemanticAdapter Tests
+// =============================================================================
+
+describe('createSemanticAdapter', () => {
+  function makeAdapter(
+    node: { action: string; kind?: string; roles: ReadonlyMap<string, unknown> } | null
+  ) {
+    return createSemanticAdapter({
+      parse: () => ({ node, confidence: 0.95 }),
+      isRegistered: (lang: string) => lang === 'en',
+      registered: () => ['en'],
+    });
+  }
+
+  it('exposes command for a kind:"command" node', () => {
+    const adapter = makeAdapter({
+      action: 'toggle',
+      kind: 'command',
+      roles: new Map([['patient', { type: 'selector', value: '.active' }]]),
+    });
+
+    const result = adapter.analyze('toggle .active', 'en');
+
+    expect(result.command?.name).toBe('toggle');
+    expect(shouldUseSemanticResult(result)).toBe(true);
+  });
+
+  it('exposes command for a kind-less node (parse fns that do not report kind)', () => {
+    const adapter = makeAdapter({ action: 'toggle', roles: new Map() });
+
+    const result = adapter.analyze('toggle .active', 'en');
+
+    expect(result.command?.name).toBe('toggle');
+    expect(shouldUseSemanticResult(result)).toBe(true);
+  });
+
+  it('omits command for a kind:"compound" node so the traditional parser takes the segment', () => {
+    const adapter = makeAdapter({ action: 'compound', kind: 'compound', roles: new Map() });
+
+    const result = adapter.analyze("log 'x', it\nremove .a from me", 'en');
+
+    expect(result.command).toBeUndefined();
+    expect(shouldUseSemanticResult(result)).toBe(false);
+  });
+
+  it('omits command for a kind:"event-handler" node', () => {
+    const adapter = makeAdapter({ action: 'toggle', kind: 'event-handler', roles: new Map() });
+
+    const result = adapter.analyze('on click toggle .active', 'en');
+
+    expect(result.command).toBeUndefined();
+    expect(shouldUseSemanticResult(result)).toBe(false);
+  });
+
+  it('returns no command for a null node', () => {
+    const adapter = makeAdapter(null);
+
+    const result = adapter.analyze('gibberish', 'en');
+
+    expect(result.command).toBeUndefined();
+  });
+
+  it('reports unsupported languages without calling parse', () => {
+    const parse = vi.fn();
+    const adapter = createSemanticAdapter({
+      parse,
+      isRegistered: () => false,
+      registered: () => [],
+    });
+
+    const result = adapter.analyze('toggle .active', 'xx');
+
+    expect(result.confidence).toBe(0);
+    expect(result.errors?.[0]).toContain('not supported');
+    expect(parse).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/parser/semantic-integration.ts
+++ b/packages/core/src/parser/semantic-integration.ts
@@ -919,7 +919,7 @@ interface SemanticParseFn {
     input: string,
     language: string
   ): {
-    node: { action: string; roles: ReadonlyMap<string, unknown> } | null;
+    node: { action: string; kind?: string; roles: ReadonlyMap<string, unknown> } | null;
     confidence: number;
     error?: string;
     tokensConsumed?: number;
@@ -961,10 +961,19 @@ export function createSemanticAdapter(deps: {
         };
       }
       const result = deps.parse(input, language);
+      // Only a `kind: 'command'` node (or a kind-less node, for parse fns that
+      // don't report kind) maps to a single command. Any other kind
+      // ('compound', 'event-handler', …) spans more than one command — exposing
+      // it here would surface a CommandNode literally named after the kind
+      // (e.g. "compound" → "Unknown command: compound" at runtime). Omitting
+      // `command` fails the caller's confidence gate, so the traditional
+      // parser takes the segment instead.
+      const isSingleCommand =
+        result.node !== null && (result.node.kind === undefined || result.node.kind === 'command');
       const out: SemanticAnalysisResult = {
         confidence: result.confidence,
         ...(result.tokensConsumed !== undefined ? { tokensConsumed: result.tokensConsumed } : {}),
-        ...(result.node
+        ...(result.node && isSingleCommand
           ? {
               command: {
                 name: result.node.action,


### PR DESCRIPTION
## Summary

Two v2.8 pre-release items (NEXT_STEPS § v2.8 pre-release, item-4 discoveries):

### 1. Compound-adapter bug — "Unknown command: compound" (pre-release fix)

`createSemanticAdapter` in `packages/core/src/parser/semantic-integration.ts` mapped `command: { name: result.node.action }` **unconditionally**, so a multi-line body segment that the semantic side parses as a COMPOUND surfaced as a CommandNode literally named `compound` → "Unknown command: compound" at runtime on every semantic-path bundle (gallery `fetch-and-async/fetch-data.html`, shipped full bundle). Pre-existing (verified on pre-Arc-F dist); surfaced by the first honest `[full]` compat run in pre-publish-check.

**Fix**: the adapter's minimal `SemanticParseFn` interface gains optional `kind`; `command` is exposed only when `kind === 'command'` (or absent — preserves behavior for parse fns that don't report kind). Any other kind (`compound`, `event-handler`, …) omits `command`, fails the inlined confidence gate in `SemanticIntegrationAdapter.trySemanticParse`, and the traditional parser takes the segment — the per-segment fallback that already exists.

- The top-level converters (framework `to-runtime-ast.ts`, semantic `buildCompound`) already mapped compound → CommandSequence and are **untouched**.
- **No `packages/semantic` changes → multilingual baseline untouched.**
- `repeat`/`for`/`set`/`if`/`unless` are on the parser's `skipSemanticParsing` list, so the kind gate cannot regress those special-cased paths.

**Verification**
- Repro (`compileSync` of the fetch-data handler body): AST went from a `command:compound` node to `[add, log, remove]`.
- 6 new unit tests for `createSemanticAdapter` (kind gating, null node, unsupported language) — file now 39/39.
- `knownIssue` removed from the Fetch Data compat entry; local `[full]` run: **8/8 bundles pass Fetch Data with real assertions** (browser + hx-v4 included).
- Core suite: `test:check` → **7205 passed | 149 skipped, 270 files**.
- After merge: re-dispatch `pre-publish-check.yml -f packages=all` — expect green with the `[full]` compat suite actually passing Fetch Data.

### 2. Size-truth docs pass

All written bundle sizes dated from the smaller-bundle era. Re-measured from fresh 2026-07-13 builds (gzip): `hyperfixi.js` **~534 KB** (docs said 203–286 KB), `hyperfixi-hx-v4.js` **~540 KB** (said ~257 KB), `hybrid-hx` **18 KB**, `hybrid-complete` 7.7 KB, `multilingual` 97 KB, minimal 76 KB, standard 82 KB, resolver 5.5 KB, i18n 43 KB, semantic regional bundles 62–195 KB. Corrected: root `CLAUDE.md`, `packages/core/CLAUDE.md`, `docs/BROWSER_BUNDLES.md`, `README.md`, and the compat-spec display labels. The WHY of the growth stays post-release (bundle-diet investigation, queued in NEXT_STEPS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)