### PR TITLE
docs: v2.8.0 release-notes draft + R2 event-modifier probe notes

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -3496,5 +3496,26 @@ window: items 1–4 are **must-have**, item 5 is the **stretch headline**.
    fetch-family firings 78 → 0, ~100 locked tests, baseline regenerated + attributed
    — nine days before target.**
 
+_Release-prep notes (2026-07-13):_ the item-4 compound-adapter fix and the
+size-truth docs pass landed together as **#675** (kind gate in
+`createSemanticAdapter`; knownIssue removed; local `[full]` Fetch Data 8/8 with
+real assertions; all doc size figures at measured reality). **v2.8.0 release
+notes are drafted** at `docs-internal/RELEASE_NOTES_v2.8.0-draft.md` — on
+release day, publish.yml auto-creates the release with `--generate-notes`;
+replace its body with the draft via `gh release edit v2.8.0 --notes-file …`.
+_R2 curated-subset expansion (event modifiers) probed and DEFERRED:_ the idea
+was to add event-once/event-debounce/event-throttle to `EXECUTION_SUBSET`
+(R2 is the only signal watching the modifier→runtime layer Arc F opened), but
+a validator probe shows all three are ineligible under the current jsdom
+harness — event-once's en reference errors (`Cannot call non-function: setup`;
+needs a PATTERN_SETUP stub), event-debounce yields an empty effect signature
+(300ms debounce + network fetch vs the 20ms settle window), event-throttle
+yields an empty signature by construction (call-only body, no DOM mutation).
+Adding the IDs would be a silent no-op (auto-excluded references). Making them
+eligible is a small harness slice (PATTERN_SETUP DOM-mutating stubs,
+PATTERN_TRIGGER input/scroll entries, settle/fake-timer handling for debounce)
+plus a baseline regen — fold into **Arc G**, which already owns the
+handler-head family.
+
 Re-baseline (`--save-baseline`) after each intentional fidelity change, regenerate against a
 freshly `populate`d DB, and commit only the dicts/profiles + baseline (not `patterns.db`).

--- a/docs-internal/RELEASE_NOTES_v2.8.0-draft.md
+++ b/docs-internal/RELEASE_NOTES_v2.8.0-draft.md
@@ -1,0 +1,85 @@
+# v2.8.0 release notes — DRAFT
+
+> Prepared 2026-07-13 for the ≈ 2026-07-22 release. On release day, publish.yml
+> creates the GitHub release with `--generate-notes`; replace its body with this
+> draft via `gh release edit v2.8.0 --notes-file docs-internal/RELEASE_NOTES_v2.8.0-draft.md`
+> (drop this header block first), or paste it above the auto-generated PR list.
+
+---
+
+## Highlights
+
+### `fetch … with { … }` options in all 24 languages (#662)
+
+`fetch` request options — braced bodies and naked named-arg forms (`method:`,
+`headers:`, `body:`, …) — are now captured by the semantic parser in every
+supported language. Previously the options clause was silently dropped in most
+non-English languages (78 residual coverage firings, now 0), so a translated
+`fetch` compiled but issued a bare GET. ~100 new locked tests.
+
+### Event modifiers in all 24 languages (#673)
+
+Event-modifier phrases — `once`, `debounce(N)`, `throttle(N)` and their
+translated forms — now flow from every language's event-handler head to the
+runtime (69 residual firings → 0). Handler heads like
+`on click debounced at 500ms` (and the SOV/VSO equivalents) behave identically
+in all 24 languages.
+
+### "Unknown command: compound" fixed on semantic-path bundles (#675)
+
+Multi-command handler bodies could throw `Unknown command: compound` at runtime
+on the full bundle (`hyperfixi.js`, `hyperfixi-hx-v4.js`) — core's per-segment
+semantic adapter surfaced a compound parse as a single command literally named
+`compound`. The adapter now defers non-command parses to the traditional
+parser. Surfaced by the first honest run of the bundle-compatibility suite;
+the gallery fetch-data example now passes on all 8 bundles with real
+assertions.
+
+## Correctness & validation
+
+- **Vocab consistency gate in CI** — cross-surface dictionary/profile/renderer
+  disagreements are now validated in CI: 0 unwaived, every waiver probe-cited.
+- **Input coverage is total** — every semantic `parseInternal` stage is
+  instrumented (`--diagnose-coverage`); all residual firings are attributed to
+  named families. A pattern can no longer score confidence 1.0 while silently
+  dropping a trailing clause without that being measured.
+- **Fidelity floors held** — the eight-signal multilingual ratchet
+  (parse-rate, degenerate, R0-recall, R0-precision, multiset-recall, R1 roles,
+  R2 execution, R3 values) holds the 2026-07-11 high-water marks: fidelity
+  1.000 on all 3,696 corpus rows across 24 languages, avgRoleFidelity ≈ 0.992,
+  avgValueRecall ≈ 0.997.
+
+## Publish-pipeline hardening
+
+- Reproducible installs in the publish workflow (`npm ci` + lockfile sync,
+  #672).
+- `pre-publish-check` is now an honest gate (#674): `set -o pipefail` on
+  tee-masked steps, real exit codes end-to-end, export validation after bundle
+  builds, complete BUILD_ORDER (including private deps), and a final verdict
+  step that always runs. Size limits reset to measured reality as
+  anti-regression ceilings.
+- Version bumps land on `main` via a release token with PR fallback (#674).
+
+## Documented bundle sizes now match reality
+
+The published size figures dated from an earlier, smaller-bundle era and are
+now corrected everywhere (README, CLAUDE.md, docs/BROWSER_BUNDLES.md):
+
+| Bundle                         | Actual (gzip) | Previously documented |
+| ------------------------------ | ------------- | --------------------- |
+| `hyperfixi-lite.js`            | 1.9 KB        | 1.9 KB                |
+| `hyperfixi-hybrid-complete.js` | 7.7 KB        | 7.3 KB                |
+| `hyperfixi-hx.js`              | 18 KB         | 9.7–13 KB             |
+| `hyperfixi-multilingual.js`    | 97 KB         | 64 KB                 |
+| `hyperfixi-hx-v4.js`           | ~540 KB       | ~257 KB               |
+| `hyperfixi.js` (full)          | ~534 KB       | 203–286 KB            |
+
+The slim bundles (lite / lite-plus / hybrid-complete / hybrid-hx) remain the
+recommended starting point, and `@hyperfixi/vite-plugin` still emits the
+minimal bundle automatically. An investigation into the full-bundle growth is
+queued.
+
+---
+
+_Full changelog: auto-generated PR list below (or
+`https://github.com/codetalcott/hyperfixi/compare/v2.7.2...v2.8.0`)._


### PR DESCRIPTION
## Summary

Doc-only follow-up to #675 (path gate skips the npm stack):

- **`docs-internal/RELEASE_NOTES_v2.8.0-draft.md`** — crafted release notes for the ≈ 07-22 publish. Headlines: fetch with-options ×24 (Arc E #662), event modifiers ×24 (Arc F #673), compound-adapter fix (#675); plus vocab gate, input-coverage totality, fidelity floors held, publish-pipeline hardening (#672/#674), and true bundle sizes. On release day publish.yml auto-creates the release with `--generate-notes`; swap in this body via `gh release edit v2.8.0 --notes-file …`.
- **NEXT_STEPS release-prep notes (dated 2026-07-13)** — #675 landed; the optional R2 curated-subset expansion (event-once/debounce/throttle) was probed against the real `ExecutionValidator` and **deferred to Arc G**: all three are ineligible under the current jsdom harness (en-reference error / empty effect signatures), so adding the IDs would be a silent no-op — contrary to the queue entry's assumption, it needs a small harness slice + baseline regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)