### PR TITLE
ci(deps): split vitest + prettier out of the minor-and-patch Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,14 @@ updates:
       minor-and-patch:
         patterns:
           - '*'
+        # Known group-breakers get individual PRs for deliberate handling:
+        # vitest 4.1.x mass-breaks the core test transform; prettier 3.9.5
+        # reflows enough files to add lint errors. Excluded 2026-07-14 so the
+        # rest of the group can go green + auto-merge (#668 was the red PR).
+        exclude-patterns:
+          - 'vitest'
+          - '@vitest/*'
+          - 'prettier'
         update-types:
           - 'minor'
           - 'patch'


### PR DESCRIPTION
Task 2 of the v2.8.0 publish-day runbook (safe-early item).

#668 (weekly minor-and-patch group) is red while auto-merge-armed: vitest 4.1.x mass-breaks the core test transform, and prettier 3.9.5 adds 8 lint errors. Per the group's own policy comment ("if this group PR goes red, add the offender to exclude-patterns"), this excludes `vitest`, `@vitest/*`, and `prettier` from the root npm `minor-and-patch` group so they fall back to individual PRs for deliberate handling and the rest of the group can go green.

`eslint-plugin-prettier` stays in the group — its 5.5.5→5.5.6 patch doesn't change formatting rules; the lint failures come from prettier itself.

After merge: comment `@dependabot recreate` on #668 to regenerate it under the new config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)