### PR TITLE
fix(semantic): go-url destination capture — URL no longer dropped, ×24 languages

### DIFF
--- a/packages/semantic/src/ast-builder/command-mappers.ts
+++ b/packages/semantic/src/ast-builder/command-mappers.ts
@@ -498,23 +498,38 @@ const sendMapper: CommandMapper = {
 /**
  * Go command mapper (navigation).
  *
- * Semantic: go source:/page destination:url
- * AST: { name: 'go', args: [/page], modifiers: { to: url } }
+ * The runtime's GoCommand reads ONLY positional args (never modifiers):
+ *   args[0] === 'back'          → history back
+ *   args includes 'url'         → next arg is the URL (go [to] url "/page")
+ *   arg starts with '/'/scheme  → bare-URL navigation
+ *   otherwise                   → scroll (go to top of #header)
+ *
+ * Semantic: go destination:/page [method:url]
+ * AST: { name: 'go', args: ['url', '/page'] } | { args: ['back'] } | { args: [<dest>] }
  */
 const goMapper: CommandMapper = {
   action: 'go',
   toAST(node, _builder) {
-    const source = convertRoleValue(node, 'source');
-    const destination = convertRoleValue(node, 'destination');
+    const dest = node.roles.get('destination');
+    const method = node.roles.get('method');
 
     const args: ExpressionNode[] = [];
-    const modifiers: Record<string, ExpressionNode> = {};
 
-    // Source is the URL/location to navigate to
-    if (source) args.push(source);
-    if (destination) modifiers['to'] = destination;
+    const rawDest =
+      dest && 'value' in dest ? dest.value : (dest as { raw?: unknown } | undefined)?.raw;
+    if (dest && String(rawDest) === 'back') {
+      // The runtime keys on the literal string 'back'; an expression-typed
+      // capture would evaluate as a variable lookup instead.
+      args.push({ type: 'literal', value: 'back' } as ExpressionNode);
+    } else if (dest) {
+      if (method && String('value' in method ? method.value : undefined) === 'url') {
+        args.push({ type: 'literal', value: 'url' } as ExpressionNode);
+      }
+      const destExpr = convertRoleValue(node, 'destination');
+      if (destExpr) args.push(destExpr);
+    }
 
-    return createCommandNode('go', args, modifiers);
+    return createCommandNode('go', args, {});
   },
 };
 

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -84,6 +84,15 @@ export interface RoleSpec {
    * Used by `put` to expose `into|before|after` as the `method` role.
    */
   readonly methodCarrier?: SemanticRole;
+  /**
+   * Literal keyword required IMMEDIATELY before this role's VALUE, independent
+   * of the role marker's side (a preposition stays before it, a postposed
+   * particle stays after the value): `a url "/page"`, `url "/page" তে`. Set
+   * only on schema clones built by the pattern generator's
+   * `rolePrefixLiteralVariants` expansion — never on a base schema, so base
+   * patterns stay byte-identical.
+   */
+  readonly valuePrefixLiteral?: Record<string, string>;
 }
 
 /**
@@ -134,6 +143,26 @@ export interface CommandSchema {
    * transition goal NOTE); a separate variant has no skippable group at all.
    */
   readonly omitRoleVariants?: ReadonlyArray<SemanticRole>;
+  /**
+   * Generate an EXTRA, higher-priority pattern variant per entry, with a
+   * REQUIRED literal keyword inserted immediately before the named role's
+   * value token (`go [to] url {destination}` beside `go [to] {destination}`).
+   * Because the literal is required, the variant is inert unless the keyword
+   * is present — the base patterns are untouched, so forms that ride on them
+   * (`go back`) cannot regress. The matched keyword is recorded as a
+   * fixed-value literal in `methodCarrier` (mirroring {@link RoleSpec.methodCarrier}).
+   */
+  readonly rolePrefixLiteralVariants?: ReadonlyArray<{
+    readonly role: SemanticRole;
+    /** Per-language keyword (e.g. URL_MARKER_ALL_LANGS). Languages absent from the map get no variant. */
+    readonly literal: Record<string, string>;
+    /** Pattern id suffix, e.g. 'url' → `<action>-<lang>-generated-url`. */
+    readonly idSuffix: string;
+    /** Priority delta over the counterpart pattern (default +5). */
+    readonly priorityDelta?: number;
+    /** Record the matched keyword as this role (fixed-value extraction). */
+    readonly methodCarrier?: SemanticRole;
+  }>;
   /** Notes about special handling */
   readonly notes?: string;
   /**
@@ -1625,6 +1654,39 @@ export const continueSchema: CommandSchema = {
 // =============================================================================
 
 /**
+ * `url` is a globally-recognized tech acronym; we use it as the marker
+ * keyword across all 24 supported languages to keep the parser surface
+ * consistent with the core hyperscript grammar (`push url <X>`).
+ * (Defined here, above its first schema reference — `goSchema` — to avoid TDZ.)
+ */
+const URL_MARKER_ALL_LANGS: Record<string, string> = {
+  en: 'url',
+  es: 'url',
+  pt: 'url',
+  fr: 'url',
+  de: 'url',
+  it: 'url',
+  ja: 'url',
+  ko: 'url',
+  zh: 'url',
+  ar: 'url',
+  he: 'url',
+  hi: 'url',
+  bn: 'url',
+  tr: 'url',
+  ru: 'url',
+  uk: 'url',
+  pl: 'url',
+  id: 'url',
+  vi: 'url',
+  th: 'url',
+  ms: 'url',
+  tl: 'url',
+  sw: 'url',
+  qu: 'url',
+};
+
+/**
  * Go command: navigates to a URL.
  */
 export const goSchema: CommandSchema = {
@@ -1649,6 +1711,19 @@ export const goSchema: CommandSchema = {
       // the patient particle as a destination-marker alternative, scoped to go.
       markerOptional: { en: true },
       markerVariants: { he: ['את'], zh: ['把'] },
+    },
+  ],
+  // `go to url "/page"` — without this variant the destination captures the
+  // bare word `url` and the actual URL is dropped as tolerated-trailing text,
+  // in en and therefore in every render (the go-url corpus row). The required
+  // `url` literal keeps the variant inert for `go back` / scroll forms.
+  rolePrefixLiteralVariants: [
+    {
+      role: 'destination',
+      literal: URL_MARKER_ALL_LANGS,
+      idSuffix: 'url',
+      priorityDelta: 5,
+      methodCarrier: 'method',
     },
   ],
 };
@@ -2591,38 +2666,6 @@ export const scrollSchema: CommandSchema = {
       markerOverride: { en: 'to' },
     },
   ],
-};
-
-/**
- * `url` is a globally-recognized tech acronym; we use it as the marker
- * keyword across all 24 supported languages to keep the parser surface
- * consistent with the core hyperscript grammar (`push url <X>`).
- */
-const URL_MARKER_ALL_LANGS: Record<string, string> = {
-  en: 'url',
-  es: 'url',
-  pt: 'url',
-  fr: 'url',
-  de: 'url',
-  it: 'url',
-  ja: 'url',
-  ko: 'url',
-  zh: 'url',
-  ar: 'url',
-  he: 'url',
-  hi: 'url',
-  bn: 'url',
-  tr: 'url',
-  ru: 'url',
-  uk: 'url',
-  pl: 'url',
-  id: 'url',
-  vi: 'url',
-  th: 'url',
-  ms: 'url',
-  tl: 'url',
-  sw: 'url',
-  qu: 'url',
 };
 
 /**

--- a/packages/semantic/src/generators/pattern-generator.ts
+++ b/packages/semantic/src/generators/pattern-generator.ts
@@ -187,12 +187,19 @@ export function generateVerbFirstPattern(
 
   // Verb first, then the required role(s) with NO marker (the marker is what
   // disambiguates roles in canonical SOV; verb-first input typically omits it).
-  const roleTokens: PatternToken[] = requiredRoles.map(r => ({
-    type: 'role',
-    role: r.role,
-    optional: false,
-    expectedTypes: r.expectedTypes,
-  }));
+  // A valuePrefixLiteral (rolePrefixLiteralVariants clones only) still precedes
+  // its role's value — the SOV transformer renders `移動 url "/page" に`
+  // verb-first, which is exactly this shape (trailing particle tolerated).
+  const roleTokens: PatternToken[] = requiredRoles.flatMap(r => {
+    const prefix = r.valuePrefixLiteral?.[profile.code];
+    const roleToken: PatternToken = {
+      type: 'role',
+      role: r.role,
+      optional: false,
+      expectedTypes: r.expectedTypes,
+    };
+    return prefix ? [{ type: 'literal', value: prefix } as PatternToken, roleToken] : [roleToken];
+  });
 
   return {
     id: `${schema.action}-${profile.code}-generated-verb-first`,
@@ -256,6 +263,46 @@ export function generatePatternVariants(
     const verbFirst = generateVerbFirstPattern(schema, profile, config);
     if (verbFirst) {
       patterns.push(verbFirst);
+    }
+  }
+
+  // Value-prefix-literal variants: an EXTRA pattern per entry with a REQUIRED
+  // literal keyword immediately before the named role's value (`go [to] url
+  // {destination}`). Higher priority than the counterpart pattern, but inert
+  // unless the keyword is present — base patterns above stay byte-identical,
+  // so forms riding on them (`go back`) cannot regress. The matched keyword is
+  // recorded as a fixed-value literal in the variant's methodCarrier role.
+  for (const v of schema.rolePrefixLiteralVariants ?? []) {
+    const literal = v.literal[profile.code];
+    if (!literal) continue;
+    const { rolePrefixLiteralVariants: _omitted, ...baseSchema } = schema;
+    const cloneSchema: CommandSchema = {
+      ...baseSchema,
+      roles: schema.roles.map(r =>
+        r.role === v.role ? { ...r, valuePrefixLiteral: { [profile.code]: literal } } : r
+      ),
+    };
+    const delta = v.priorityDelta ?? 5;
+    const carrier: Record<string, ExtractionRule> = v.methodCarrier
+      ? { [v.methodCarrier]: { value: literal } }
+      : {};
+    const main = generatePattern(cloneSchema, profile, config);
+    patterns.push({
+      ...main,
+      id: `${schema.action}-${profile.code}-generated-${v.idSuffix}`,
+      priority: (config.basePriority ?? 100) + delta,
+      extraction: { ...main.extraction, ...carrier },
+    });
+    if (config.generateVerbFirstVariants !== false) {
+      const verbFirstUrl = generateVerbFirstPattern(cloneSchema, profile, config);
+      if (verbFirstUrl) {
+        patterns.push({
+          ...verbFirstUrl,
+          id: `${schema.action}-${profile.code}-generated-verb-first-${v.idSuffix}`,
+          priority: (config.basePriority ?? 100) - 20 + delta,
+          extraction: { ...verbFirstUrl.extraction, ...carrier },
+        });
+      }
     }
   }
 
@@ -700,6 +747,16 @@ function buildRoleToken(roleSpec: RoleSpec, profile: LanguageProfile): PatternTo
     expectedTypes: roleSpec.expectedTypes,
   };
 
+  // Required literal immediately before the role VALUE (rolePrefixLiteralVariants
+  // clones only): `[to] url {destination}`, `url {destination} に`. Deliberately
+  // NOT an optional group — the variant must only match when the keyword is
+  // present, so base patterns keep winning everywhere else.
+  const prefixLiteral = roleSpec.valuePrefixLiteral?.[profile.code];
+  const pushPrefixed = (): void => {
+    if (prefixLiteral) tokens.push({ type: 'literal', value: prefixLiteral });
+    tokens.push(roleValueToken);
+  };
+
   // Use override marker if available, otherwise use default
   if (overrideMarker !== undefined) {
     // Command-specific marker override. Multi-word markers (e.g. "partials in",
@@ -716,9 +773,9 @@ function buildRoleToken(roleSpec: RoleSpec, profile: LanguageProfile): PatternTo
     };
     if (position === 'before') {
       for (const word of markerWords) pushWord(word);
-      tokens.push(roleValueToken);
+      pushPrefixed();
     } else {
-      tokens.push(roleValueToken);
+      pushPrefixed();
       for (const word of markerWords) pushWord(word);
     }
   } else if (defaultMarker) {
@@ -751,15 +808,15 @@ function buildRoleToken(roleSpec: RoleSpec, profile: LanguageProfile): PatternTo
       if (defaultMarker.primary) {
         pushMarker(asMarker());
       }
-      tokens.push(roleValueToken);
+      pushPrefixed();
     } else {
       // Postposition/particle: "#button に"
-      tokens.push(roleValueToken);
+      pushPrefixed();
       pushMarker(asMarker());
     }
   } else {
     // No marker, just the role value
-    tokens.push(roleValueToken);
+    pushPrefixed();
   }
 
   return tokens;
@@ -783,7 +840,12 @@ function buildExtractionRules(
     const overrideMarker = roleSpec.markerOverride?.[profile.code];
     const defaultMarker = profile.roleMarkers[roleSpec.role];
 
-    if (overrideMarker !== undefined) {
+    if (roleSpec.valuePrefixLiteral?.[profile.code]) {
+      // The prefix literal sits immediately before the value on every surface,
+      // so it is the extraction anchor (push/replace's proven `url` shape) —
+      // it wins over the role's own marker (`to`), which may be optional/absent.
+      rules[roleSpec.role] = { marker: roleSpec.valuePrefixLiteral[profile.code] };
+    } else if (overrideMarker !== undefined) {
       // Use the override marker
       rules[roleSpec.role] = overrideMarker ? { marker: overrideMarker } : {};
     } else if (defaultMarker && defaultMarker.primary) {

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -3522,6 +3522,80 @@ export class SemanticParserImpl implements ISemanticParser {
     if (!spec) return;
     const roles = command.roles as Map<SemanticRole, SemanticValue>;
     const existing = roles.get(spec.role);
+    // go-url REBIND: a fused event pattern (go-event-*-vso and kin) can bind
+    // the invariant `url` keyword itself as the destination and leave the real
+    // URL unconsumed right behind it (`en clic ir a url "/page"` →
+    // destination=expression:"url", "/page" dropped). Mirror the command-path
+    // url variant: destination = the value, keyword carried as `method`.
+    // (The en reference captures exactly this shape via the generated
+    // go-en-generated-url pattern.)
+    if (
+      action === 'go' &&
+      existing &&
+      existing.type === 'expression' &&
+      String((existing as { raw?: unknown }).raw).toLowerCase() === 'url'
+    ) {
+      const next = stream.peek();
+      if (next && !NON_VALUE_KEYWORDS.has((next.normalized ?? next.value).toLowerCase())) {
+        const v = this.tokenToSemanticValue(next);
+        if (v.type === 'literal' || v.type === 'selector') {
+          roles.set(spec.role, v);
+          roles.set('method', { type: 'literal', value: 'url' } as SemanticValue);
+          stream.advance();
+          return;
+        }
+      }
+      // The fused pattern may have swallowed the URL into a schema-invalid
+      // `patient` slot instead of leaving it in the stream (go declares no
+      // patient) — relabel it (the responseType-relabel precedent).
+      const pat = roles.get('patient');
+      if (pat && (pat.type === 'literal' || pat.type === 'selector')) {
+        roles.set(spec.role, pat);
+        roles.set('method', { type: 'literal', value: 'url' } as SemanticValue);
+        roles.delete('patient');
+        return;
+      }
+    }
+
+    // Same idiom, already-glued shape: an upstream fold captured the whole
+    // phrase as one expression (`url /page`, qu whole-handler fold) with
+    // nothing left in the stream. Split it in place.
+    if (action === 'go' && existing && existing.type === 'expression') {
+      const m = /^url\s+(\S+)$/i.exec(String((existing as { raw?: unknown }).raw ?? ''));
+      if (m) {
+        const value = m[1].replace(/^["']|["']$/g, '');
+        roles.set(spec.role, { type: 'literal', value, dataType: 'string' } as SemanticValue);
+        roles.set('method', { type: 'literal', value: 'url' } as SemanticValue);
+        return;
+      }
+    }
+
+    // Same idiom, patient-slot shape: the fused es-vso class binds the `url`
+    // keyword under PATIENT (destination still absent here — the patient→
+    // primaryRole relabel runs later, in normalizeCommandRoles) with the URL
+    // token next in the stream. Capture it now, before the relabel turns the
+    // keyword itself into the destination and the URL drops.
+    if (action === 'go' && !existing) {
+      const pat = roles.get('patient');
+      if (
+        pat &&
+        pat.type === 'expression' &&
+        String((pat as { raw?: unknown }).raw).toLowerCase() === 'url'
+      ) {
+        const next = stream.peek();
+        if (next && !NON_VALUE_KEYWORDS.has((next.normalized ?? next.value).toLowerCase())) {
+          const v = this.tokenToSemanticValue(next);
+          if (v.type === 'literal' || v.type === 'selector') {
+            roles.set(spec.role, v);
+            roles.set('method', { type: 'literal', value: 'url' } as SemanticValue);
+            roles.delete('patient');
+            stream.advance();
+            return;
+          }
+        }
+      }
+    }
+
     if (existing && !(existing.type === 'reference' && existing.value === 'me')) return;
 
     const profile = tryGetProfile(language);
@@ -3565,6 +3639,31 @@ export class SemanticParserImpl implements ISemanticParser {
     if (markerSurface !== null && !sawMarker) return;
 
     const consume = run.length + (sawMarker ? 1 : 0);
+
+    // go-url IDIOM: a two-token run `url <value>` is the navigation idiom, not
+    // an opaque expression — capture destination = the value and carry the
+    // invariant keyword as `method`, matching the en reference (which parses
+    // this via the generated go-en-generated-url pattern). Gluing it
+    // (`expression:"url \"/page\""`) was faithful only while the en reference
+    // itself was corrupted the same way.
+    if (action === 'go' && run.length === 2 && run[0].value.toLowerCase() === 'url') {
+      const v = this.tokenToSemanticValue(run[1]);
+      if (v.type === 'literal' || v.type === 'selector') {
+        roles.set(spec.role, v);
+        roles.set('method', { type: 'literal', value: 'url' } as SemanticValue);
+        const pat = roles.get('patient');
+        if (
+          pat &&
+          pat.type === 'reference' &&
+          pat.value === 'me' &&
+          !getSchema(action as ActionType)?.roles.some(r => r.role === 'patient')
+        ) {
+          roles.delete('patient');
+        }
+        for (let i = 0; i < consume; i++) stream.advance();
+        return;
+      }
+    }
 
     // The ja tokenizer splits the compound verb `JS実行` into `JS<keyword>` +
     // `実行<identifier>`; the fused pattern's verb matched the `JS` head, so

--- a/packages/semantic/test/command-mappers.test.ts
+++ b/packages/semantic/test/command-mappers.test.ts
@@ -453,9 +453,14 @@ describe('Send Command Mapper', () => {
 // =============================================================================
 
 describe('Go Command Mapper', () => {
-  it('should map go with source (URL)', () => {
+  // The runtime's GoCommand reads ONLY positional args: 'back' → history,
+  // 'url' + next arg → URL navigation, bare value → bare-url/scroll branches.
+  // (The old mapper read a `source` role the schema never produces and emitted
+  // `modifiers.to`, which the runtime ignores — go's semantic path was dead.)
+  it('should map the url idiom to args ["url", <destination>]', () => {
     const node = createCommandNode('go', {
-      source: literal('/path/to/page', 'string'),
+      destination: literal('/page', 'string'),
+      method: literal('url', 'string'),
     });
 
     const mapper = getCommandMapper('go')!;
@@ -463,12 +468,14 @@ describe('Go Command Mapper', () => {
     const result = mapper.toAST(node, builder);
 
     expect(result.name).toBe('go');
-    expect(result.args[0]).toMatchObject({ type: 'literal', value: '/path/to/page' });
+    expect(result.args[0]).toMatchObject({ type: 'literal', value: 'url' });
+    expect(result.args[1]).toMatchObject({ type: 'literal', value: '/page' });
+    expect(result.modifiers ?? {}).toEqual({});
   });
 
-  it('should map go with destination modifier', () => {
+  it('should map go back to args ["back"]', () => {
     const node = createCommandNode('go', {
-      destination: literal('top', 'string'),
+      destination: literal('back', 'string'),
     });
 
     const mapper = getCommandMapper('go')!;
@@ -476,7 +483,22 @@ describe('Go Command Mapper', () => {
     const result = mapper.toAST(node, builder);
 
     expect(result.name).toBe('go');
-    expect(result.modifiers!['to']).toMatchObject({ type: 'literal', value: 'top' });
+    expect(result.args).toHaveLength(1);
+    expect(result.args[0]).toMatchObject({ type: 'literal', value: 'back' });
+  });
+
+  it('should map a plain destination to a single positional arg', () => {
+    const node = createCommandNode('go', {
+      destination: literal('/path/to/page', 'string'),
+    });
+
+    const mapper = getCommandMapper('go')!;
+    const builder = new ASTBuilder();
+    const result = mapper.toAST(node, builder);
+
+    expect(result.name).toBe('go');
+    expect(result.args).toHaveLength(1);
+    expect(result.args[0]).toMatchObject({ type: 'literal', value: '/path/to/page' });
   });
 });
 

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -11316,11 +11316,14 @@ describe('go destination marker: en bare form + he/zh patient-particle variants'
   });
 
   it('[en] `go to url "/page"` still parses with the marker (marked form locked)', () => {
+    // Originally locked destination CONTAINING 'url' — that was the go-url
+    // destination-drop bug (the URL itself was tolerated-trailing and lost).
+    // The url-keyword variant now anchors extraction on the `url` literal:
+    // destination is the actual URL, the keyword is carried as `method`.
     const node = parse('go to url "/page"', 'en') as unknown as Record<string, any>;
     expect(node.action).toBe('go');
-    expect(String(role(node, 'destination')?.raw ?? role(node, 'destination')?.value)).toContain(
-      'url'
-    );
+    expect(String(role(node, 'destination')?.value)).toBe('/page');
+    expect(String(role(node, 'method')?.value)).toBe('url');
   });
 
   for (const [lang, line] of [
@@ -11344,11 +11347,11 @@ describe('go destination marker: en bare form + he/zh patient-particle variants'
     ['zh', '前往 到 url "/page"'],
   ] as const) {
     it(`[${lang}] \`${line}\`: the primary destination marker still parses (go-url locked)`, () => {
+      // Was locked to destination CONTAINING 'url' (the destination-drop bug);
+      // now locked to the corrected capture — destination = the actual URL.
       const node = parse(line, lang) as unknown as Record<string, any>;
       expect(node.action).toBe('go');
-      expect(String(role(node, 'destination')?.raw ?? role(node, 'destination')?.value)).toContain(
-        'url'
-      );
+      expect(String(role(node, 'destination')?.value)).toBe('/page');
     });
   }
 });
@@ -13427,10 +13430,15 @@ describe('R1 Family D: SOV fallback value-typing increments (docs-internal/HANDO
       ['tr', 'tıklama de git url "/page" e'],
     ];
     for (const [lang, src] of GO_ROWS) {
-      it(`[${lang}] go-url: destination phrase reclaimed as expression, default-me patient leak dropped`, () => {
+      it(`[${lang}] go-url: url idiom captured (destination=/page, method=url), default-me patient leak dropped`, () => {
+        // Originally locked the GLUED expression capture (`url "/page"`) —
+        // faithful only while the en reference was corrupted the same way.
+        // The reclaim now recognizes the two-token `url <value>` idiom and
+        // captures it like the en go-en-generated-url pattern does.
         const g = first(collect(parse(src, lang)), 'go');
-        expect(role(g, 'destination')?.type).toBe('expression');
-        expect(role(g, 'destination')?.raw).toContain('url');
+        expect(role(g, 'destination')?.type).toBe('literal');
+        expect(String(role(g, 'destination')?.value)).toBe('/page');
+        expect(String(role(g, 'method')?.value)).toBe('url');
         expect(role(g, 'patient')).toBeUndefined();
       });
     }
@@ -13762,10 +13770,15 @@ describe('R1 deferred-tail qu tail: per-row alignments (docs-internal/HANDOFF_r1
     });
   });
 
-  it('[qu] go-url: destination typed expression (the en reference type)', () => {
+  it('[qu] go-url: url idiom captured (destination=/page literal, method=url)', () => {
+    // Originally locked destination typed `expression` — the en reference's
+    // type at the time, which was itself the go-url destination-drop bug.
+    // The glued `url /page` fold is now split by the go-url idiom reclaim.
     const cmds = collect(parse('url "/page" man ñitiy pi riy', 'qu'));
     const go = cmds.find(c => c.action === 'go');
-    expect(role(go, 'destination')?.type).toBe('expression');
+    expect(role(go, 'destination')?.type).toBe('literal');
+    expect(String(role(go, 'destination')?.value)).toBe('/page');
+    expect(String(role(go, 'method')?.value)).toBe('url');
   });
 
   it('[qu] window-resize: event resolves to resize, call keeps ONLY its expression patient', () => {
@@ -13835,4 +13848,90 @@ describe('Spanish hacia destination alignment (vocab Batch 1, V2+V4)', () => {
     const roles = put!.roles as Map<string, { value?: unknown }>;
     expect(roles.get('destination')?.value).toBe('#output');
   });
+});
+
+describe('go-url destination capture (docs-internal/MULTILINGUAL_NEXT_STEPS.md "go-url destination drop")', () => {
+  // `go to url "/page"` used to capture destination=expression:"url" and DROP
+  // the URL — in en and therefore in every render (the en reference itself was
+  // corrupted, so fidelity 1.0 masked it ×24). The generated url-keyword
+  // variant (rolePrefixLiteralVariants on goSchema) anchors extraction on the
+  // `url` literal that every language's render keeps immediately before the
+  // value.
+  function roleValue(node: unknown, role: string): unknown {
+    const rec = node as { roles?: Map<string, { value?: unknown; raw?: unknown }> } | null;
+    const v = rec?.roles?.get(role);
+    if (!v) return undefined;
+    return v.value !== undefined ? v.value : v.raw;
+  }
+  function findGo(node: unknown): { action?: string; roles?: Map<string, unknown> } | null {
+    if (!node || typeof node !== 'object') return null;
+    const rec = node as Record<string, unknown>;
+    if (rec.action === 'go') return rec as { action: string; roles: Map<string, unknown> };
+    for (const f of ['body', 'commands', 'statements', 'thenBranch', 'elseBranch']) {
+      const c = rec[f];
+      if (Array.isArray(c)) {
+        for (const x of c) {
+          const hit = findGo(x);
+          if (hit) return hit;
+        }
+      } else if (c && typeof c === 'object') {
+        const hit = findGo(c);
+        if (hit) return hit;
+      }
+    }
+    return null;
+  }
+
+  it('[en] `go to url "/page"` captures destination=/page + method=url', () => {
+    const node = parse('go to url "/page"', 'en');
+    expect(node?.action).toBe('go');
+    expect(roleValue(node, 'destination')).toBe('/page');
+    expect(roleValue(node, 'method')).toBe('url');
+  });
+
+  it('[en] marker-less `go url "/page"` also captures destination=/page', () => {
+    const node = parse('go url "/page"', 'en');
+    expect(node?.action).toBe('go');
+    expect(roleValue(node, 'destination')).toBe('/page');
+  });
+
+  // Corpus-shaped bare go-url commands (the exact body the transformer renders).
+  const bareCases: Array<[string, string]> = [
+    ['es', 'ir a url "/page"'],
+    ['he', 'לך על url "/page"'],
+    ['zh', '前往 到 url "/page"'],
+    ['ja', '移動 url "/page" に'],
+    ['tr', 'git url "/page" e'],
+  ];
+  for (const [lang, input] of bareCases) {
+    it(`[${lang}] \`${input}\` captures destination=/page`, () => {
+      const node = parse(input, lang);
+      const go = node?.action === 'go' ? node : findGo(node);
+      expect(go).not.toBeNull();
+      expect(roleValue(go, 'destination')).toBe('/page');
+    });
+  }
+
+  it('[en] full corpus handler `on click go to url "/page"` keeps the URL in the body', () => {
+    const node = parse('on click go to url "/page"', 'en');
+    expect(node).not.toBeNull();
+    const go = findGo(node);
+    expect(go).not.toBeNull();
+    expect(roleValue(go, 'destination')).toBe('/page');
+  });
+
+  // go-back guards: the base patterns are byte-identical, so these must not move.
+  const backCases: Array<[string, string]> = [
+    ['en', 'go back'],
+    ['he', 'לך את back'],
+    ['zh', '前往 把 back'],
+  ];
+  for (const [lang, input] of backCases) {
+    it(`[${lang}] go-back guard: \`${input}\` still captures destination=back, no method`, () => {
+      const node = parse(input, lang);
+      expect(node?.action).toBe('go');
+      expect(String(roleValue(node, 'destination'))).toBe('back');
+      expect(roleValue(node, 'method')).toBeUndefined();
+    });
+  }
 });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-13T18:19:50.260Z",
-  "commit": "e9e87c5b",
+  "timestamp": "2026-07-14T05:18:04.558Z",
+  "commit": "6d7688bf",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -11,12 +11,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9967320261437909,
-      "avgValueRecall": 0.9905660377358491,
+      "avgValueRecall": 0.9906542056074766,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -645,12 +645,12 @@
       "avgPrecision": 0.9989716846334493,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9961873638344226,
-      "avgValueRecall": 0.9905660377358491,
+      "avgValueRecall": 0.9906542056074766,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1278,13 +1278,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9930750077808902,
+      "avgRoleFidelity": 0.9952536570183631,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1909,7 +1909,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2543,7 +2543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3171,13 +3171,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9930750077808902,
+      "avgRoleFidelity": 0.9952536570183631,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3811,7 +3811,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4440,12 +4440,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9929193899782136,
-      "avgValueRecall": 0.9905660377358491,
+      "avgValueRecall": 0.9906542056074766,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5079,7 +5079,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5713,7 +5713,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6342,12 +6342,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9978213507625272,
-      "avgValueRecall": 0.9905660377358491,
+      "avgValueRecall": 0.9906542056074766,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6976,12 +6976,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9945533769063181,
-      "avgValueRecall": 0.9905660377358491,
+      "avgValueRecall": 0.9906542056074766,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7609,13 +7609,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9918300653594772,
+      "avgRoleFidelity": 0.99400871459695,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8249,7 +8249,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8883,7 +8883,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9512,12 +9512,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9936196700902583,
-      "avgValueRecall": 0.9905660377358491,
+      "avgValueRecall": 0.9906542056074766,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10151,7 +10151,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10785,7 +10785,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11413,13 +11413,13 @@
       "avgFidelity": 1,
       "avgPrecision": 0.9978354978354977,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9905228758169934,
+      "avgRoleFidelity": 0.9927015250544662,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12048,12 +12048,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9967320261437909,
-      "avgValueRecall": 0.9905660377358491,
+      "avgValueRecall": 0.9906542056074766,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12682,12 +12682,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9961873638344226,
-      "avgValueRecall": 0.9905660377358491,
+      "avgValueRecall": 0.9906542056074766,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13321,7 +13321,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13949,13 +13949,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.994335511982571,
+      "avgRoleFidelity": 0.9965141612200438,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14589,7 +14589,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 518711,
+      "bundleSize": 521341,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15212,7 +15212,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 518711,
+      "size": 521341,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
P1 of the pre-release 48-hour plan (approved runbook).

## The bug
`go to url "/page"` parsed to `destination=expression:"url"` and **dropped the URL** — in English and therefore in every language: the en reference itself was corrupted, so fidelity 1.0 masked it ×24 (logged in MULTILINGUAL_NEXT_STEPS as the go-url destination drop / en-reference-corruption class). A second latent bug surfaced during planning: `goMapper` read a `source` role the schema never produces and emitted `modifiers.to`, which the runtime ignores — go's semantic path built empty args even for `go back`.

## The fix
- **`goSchema` + generator**: new `rolePrefixLiteralVariants` affordance — an EXTRA generated pattern per language with a REQUIRED `url` literal immediately before the destination value (reuses `URL_MARKER_ALL_LANGS`, the push/replace precedent), priority +5, verb-first twin for SOV. Base patterns stay **byte-identical**, so `go back` (incl. he/zh markerVariants) cannot regress.
- **Fused event paths** (`tryAttachTrailingExpressionRole`): the url idiom is recognized in the three shapes the fused patterns produce — two-token `url <value>` runs (SOV five), a fused-bound `url` destination/patient rebound from the stream (de/fr/ms/th/vi/es), and an already-glued `url /page` expression split in place (qu fold).
- **`goMapper`** rewritten to the runtime's actual args contract: `['back']` | `['url', <url>]` | `[<dest>]`.
- Family D / go-url lock tests updated — they pinned the glued-expression shape, which was faithful only while the en reference had the same bug.

## Verification
- Pre/post probe of all 48 corpus rows (go-url + go-back ×24): **destination=literal:/page + method=url in all 24 go-url rows; all 24 go-back rows byte-identical.**
- Semantic suite: 7302 passed (exit 0, unpiped).
- `--regression` gate: green, all eight ratchets.
- Baseline regenerated: avgRoleFidelity **rises** ~+0.002/language, avgValueRecall ticks up, zero signal decreases (checked programmatically). patterns.db regeneration NOT committed per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)