### PR TITLE
fix(bundle): dedupe core+semantic in full browser bundles — 534→299 / 540→311 KB gz

### DIFF
--- a/.github/workflows/pre-publish-check.yml
+++ b/.github/workflows/pre-publish-check.yml
@@ -323,22 +323,19 @@ jobs:
           echo "## Bundle Size Limit Validation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Size limits (gzipped bytes), set 2026-07-13 from MEASURED reality
-          # (published 2.7.2 artifacts + fresh local builds) the first time
-          # this gate ever ran against real files — the old limits (browser
-          # 290 KB "actual ~273 KB", hybrid 18 KB "actual ~16.6 KB") dated
-          # from a much smaller bundle era and were never enforced: the
-          # bundles they named did not exist in CI runs (realtime missing
-          # from BUILD_ORDER) and the [[ -f ]] guards skipped them silently.
-          # Published 2.7.2 hyperfixi.js is 529 KB gz (minified — reactivity
-          # + realtime pre-installed + multilingual growth); hybrid-hx 16.9 KB
-          # published, 18.5 KB on the current tree. These are ceilings against
-          # regression, not aspirations — ratchet DOWN after the post-release
-          # bundle-diet investigation (see NEXT_STEPS).
+          # Size limits (gzipped bytes). Ratcheted DOWN 2026-07-14 after the
+          # bundle dedupe: 2.6.0→2.7.0 had DOUBLED the full bundles (the #616
+          # plugin pre-install inlined core's prebuilt dist/index.mjs — with an
+          # embedded second @lokascript/semantic — alongside the src graph;
+          # 286→529 KB gz overnight). The rollup alias in
+          # rollup.browser*.config.mjs folds the plugin imports onto the src
+          # graph: hyperfixi.js measured ~299 KB gz, hx-v4 ~311 KB gz. These
+          # ceilings exist specifically to catch RE-duplication (any change
+          # that re-inlines a second core/semantic blows straight past them).
           MAX_LITE=4000           # 4 KB   (actual ~2 KB)
           MAX_HYBRID=20000        # 20 KB  (hybrid-hx actual ~18.5 KB gz)
-          MAX_BROWSER=560000      # 560 KB (hyperfixi.js actual ~538 KB gz)
-          MAX_HXV4=560000         # 560 KB (hyperfixi-hx-v4.js actual ~545 KB gz)
+          MAX_BROWSER=340000      # 340 KB (hyperfixi.js actual ~299 KB gz post-dedupe)
+          MAX_HXV4=350000         # 350 KB (hyperfixi-hx-v4.js actual ~311 KB gz post-dedupe)
 
           failed=0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **HyperFixi** is a complete \_hyperscript ecosystem with server-side compilation, multi-language i18n (24 languages including SOV/VSO grammar transformation), semantic-first multilingual parsing, and comprehensive developer tooling. Engine packages are published under `@hyperfixi/*`, multilingual packages under `@lokascript/*`.
 
 - **14,000+ tests** passing across all suites (core ~7000, semantic ~6500, i18n ~900, plus per-package suites)
-- **~534 KB** full browser bundle (gzipped); slim bundles from **1.9 KB** (lite) to **18 KB** (hybrid-hx) — sizes re-measured 2026-07-13; bundle-diet investigation queued post-release
+- **~299 KB** full browser bundle (gzipped); slim bundles from **1.9 KB** (lite) to **18 KB** (hybrid-hx) — sizes re-measured 2026-07-14 after the bundle dedupe (the 2.7.x ~534 KB figure was a duplicate core+semantic copy, since removed)
 - **\_hyperscript compatible** — tested via gallery examples, bundle compatibility matrix, and command/expression browser tests (Playwright)
 
 ## Monorepo Structure
@@ -501,7 +501,7 @@ The bundle compatibility test suite automatically tests all 7 bundles against ga
 
 - Location: `packages/core/src/compatibility/browser-tests/bundle-compatibility.spec.ts`
 - Tests: Toggle, show/hide, input mirroring, counter, modals, fetch, tabs, blocks, event modifiers
-- Bundles: lite (1.9 KB), lite-plus (2.6 KB), hybrid-complete (7.7 KB), hybrid-hx (18 KB), hybrid-hx-v4 (~540 KB), minimal (76 KB), standard (82 KB), browser (~534 KB)
+- Bundles: lite (1.9 KB), lite-plus (2.6 KB), hybrid-complete (7.7 KB), hybrid-hx (18 KB), hybrid-hx-v4 (~311 KB), minimal (76 KB), standard (82 KB), browser (~299 KB)
 - Prints ASCII compatibility matrix showing feature support across all bundles
 
 ### Using Behaviors (Browser)
@@ -725,8 +725,8 @@ Quick selection (sizes gzipped):
 | `hyperfixi-lite.js`            | 1.9 KB    | Tiny static page (8 commands, regex parser)                                                |
 | `hyperfixi-hybrid-complete.js` | 7.7 KB    | Pure hyperscript, ~85% coverage (AST parser, blocks, modifiers)                            |
 | `hyperfixi-hx.js`              | 18 KB     | + htmx v1/v2 attributes (`hx-get` etc.); no reactivity/streaming                           |
-| `hyperfixi-hx-v4.js`           | ~540 KB   | `hx-live`, `bind`, `when`, SSE, WebSocket — full runtime + reactivity                      |
-| `hyperfixi.js`                 | ~534 KB   | Full bundle with parser (`window.hyperfixi`); reactivity + realtime plugins pre-installed  |
+| `hyperfixi-hx-v4.js`           | ~311 KB   | `hx-live`, `bind`, `when`, SSE, WebSocket — full runtime + reactivity                      |
+| `hyperfixi.js`                 | ~299 KB   | Full bundle with parser (`window.hyperfixi`); reactivity + realtime plugins pre-installed  |
 | `hyperfixi-multilingual.js`    | 97 KB     | Multilingual, parser-free (pair with a semantic bundle)                                    |
 | semantic bundles               | 56–195 KB | `LokaScriptSemantic*` globals; regional subsets (en/es/western/east-asian/priority/all-24) |
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The plugin scans your files for `_="..."` attributes and generates a minimal bun
 
 - **43 commands** -- toggle, add, remove, set, put, fetch, repeat, if/else, and more
 - **\_hyperscript compatible** -- existing hyperscript code works as-is
-- **Tree-shakeable** -- ship only the commands you use (1.9 KB lite to ~534 KB full)
+- **Tree-shakeable** -- ship only the commands you use (1.9 KB lite to ~299 KB full)
 - **TypeScript types** -- full type safety with comprehensive definitions
 - **Optional multilingual** -- write hyperscript in 24 languages ([lokascript.org](https://lokascript.org))
 - **Optional htmx compat** -- htmx-like attributes via the `hyperfixi-hx.js` bundle
@@ -101,7 +101,7 @@ translation preserved meaning rather than merely "parsed". Two writeups go deep:
 
 ## Learn More
 
-- [Choosing a bundle](https://hyperfixi.org/guide/bundles/) -- bundles from 1.9 KB (lite) to ~534 KB (full)
+- [Choosing a bundle](https://hyperfixi.org/guide/bundles/) -- bundles from 1.9 KB (lite) to ~299 KB (full)
 - [Examples gallery](https://hyperfixi.org/examples/) -- 35+ interactive demos
 - [Playground](https://hyperfixi.org/playground/) -- live REPL
 - [Vite plugin guide](https://hyperfixi.org/guide/vite-plugin/) -- automatic tree-shaking

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -3496,14 +3496,17 @@ window: items 1–4 are **must-have**, item 5 is the **stretch headline**.
    1,608 KB; distinctive strings DOUBLE 2.6.0→2.7.2 (`sov-simple` 1→2,
    `tıklama` 2→4, `CommandSequence` 15→29); reactivity/dist imports
    `@hyperfixi/core`. hx-v4 imports browser-bundle.js and inherits it.
-   _Remediation (post-release):_ dedupe by aliasing `@hyperfixi/core` to the
-   in-build src graph in rollup.browser.config.mjs (or externalize core in the
-   plugin builds) — est. **−240 KB gz, back to ~290**; then re-verify [full]
-   compat + plugin install, refresh `scripts/bundle-snapshots/baseline.json`
-   (still at 2026-05-19's 252 KB), and re-do the size-truth docs pass. The
-   reactivity/realtime code itself is tiny (24 + 14 KB src). Secondary,
-   only after dedupe: main-bundle terser is weaker than hx-v4's (passes:1,
-   no property mangling). Tooling note: source-map-explorer chokes on
+   _Remediation LANDED (2026-07-14, pulled forward pre-release):_
+   `@rollup/plugin-alias` maps `@hyperfixi/core` → the src barrel in BOTH
+   browser configs (rollup.browser.config.mjs + rollup.browser-hybrid-hx-v4);
+   hyperfixi.js **546 → 306 KB gz (~299 KB)**, hx-v4 **553 → 318 KB (~311)**.
+   Duplication proof: `sov-simple` 2→1, `tıklama` 4→2, index.mjs gone from the
+   sourcemap. Verified: bundled-plugins guard (now incl. `when`), hx-v4
+   reactive suite 12/12, bundle-compatibility 92/92, core 7205.
+   `bundle-snapshots/baseline.json` refreshed; pre-publish ceilings ratcheted
+   560→340/350 KB specifically to catch RE-duplication. Secondary lever still
+   post-release: main-bundle terser is weaker than hx-v4's (passes:1, no
+   property mangling). Tooling note: source-map-explorer chokes on
    @rollup/plugin-terser maps ("column Infinity") — attribute via the map's
    sources/sourcesContent directly.
    _Second discovery (first real run of the [full] compat suite — it runs

--- a/docs-internal/RELEASE_NOTES_v2.8.0-draft.md
+++ b/docs-internal/RELEASE_NOTES_v2.8.0-draft.md
@@ -9,6 +9,21 @@
 
 ## Highlights
 
+### Full bundles cut nearly in half (~534 → ~299 KB gz)
+
+Since 2.7.0 the full bundles had been shipping **two copies of the core runtime
+and multilingual parser**: the bundled reactivity/realtime plugins resolved
+`@hyperfixi/core` to its prebuilt library dist (which embeds a second copy of
+`@lokascript/semantic`) alongside the bundle's own source graph. A rollup alias
+now folds everything onto one graph:
+
+- `hyperfixi.js`: ~534 → **~299 KB gz**
+- `hyperfixi-hx-v4.js`: ~540 → **~311 KB gz**
+
+Same features, same pre-installed plugins (verified by the plugin-install,
+reactive-features, and full bundle-compatibility suites). CI size ceilings are
+ratcheted down to catch any re-duplication.
+
 ### `fetch … with { … }` options in all 24 languages (#662)
 
 `fetch` request options — braced bodies and naked named-arg forms (`method:`,
@@ -62,22 +77,32 @@ assertions.
 
 ## Documented bundle sizes now match reality
 
-The published size figures dated from an earlier, smaller-bundle era and are
-now corrected everywhere (README, CLAUDE.md, docs/BROWSER_BUNDLES.md):
+Every size figure is re-measured on the release artifacts (README, CLAUDE.md,
+docs/BROWSER_BUNDLES.md); the full-bundle numbers reflect the dedupe above:
 
-| Bundle                         | Actual (gzip) | Previously documented |
-| ------------------------------ | ------------- | --------------------- |
-| `hyperfixi-lite.js`            | 1.9 KB        | 1.9 KB                |
-| `hyperfixi-hybrid-complete.js` | 7.7 KB        | 7.3 KB                |
-| `hyperfixi-hx.js`              | 18 KB         | 9.7–13 KB             |
-| `hyperfixi-multilingual.js`    | 97 KB         | 64 KB                 |
-| `hyperfixi-hx-v4.js`           | ~540 KB       | ~257 KB               |
-| `hyperfixi.js` (full)          | ~534 KB       | 203–286 KB            |
+| Bundle                         | Actual (gzip) | 2.7.x         |
+| ------------------------------ | ------------- | ------------- |
+| `hyperfixi-lite.js`            | 1.9 KB        | 1.9 KB        |
+| `hyperfixi-hybrid-complete.js` | 7.7 KB        | 7.7 KB        |
+| `hyperfixi-hx.js`              | 18 KB         | 18 KB         |
+| `hyperfixi-multilingual.js`    | 97 KB         | 97 KB         |
+| `hyperfixi-hx-v4.js`           | **~311 KB**   | ~540 KB       |
+| `hyperfixi.js` (full)          | **~299 KB**   | ~534 KB       |
 
 The slim bundles (lite / lite-plus / hybrid-complete / hybrid-hx) remain the
 recommended starting point, and `@hyperfixi/vite-plugin` still emits the
-minimal bundle automatically. An investigation into the full-bundle growth is
-queued.
+minimal bundle automatically.
+
+## Multilingual correctness fixes
+
+- **`go to url "/page"` no longer drops the URL** (#680) — the destination was
+  silently lost in every language (the English reference itself was affected,
+  which masked it); navigation now receives the real URL in all 24 languages.
+- **Broken event listeners fixed in six languages** (#681) — the de/fr/id/it/
+  pl/zh dictionaries rendered `mousedown`/`mouseup` as words the parser could
+  not resolve (a listener that never fires — id even bound `keydown`). A new
+  V3c vocabulary check now verifies every dictionary event word round-trips on
+  the parse side.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,10 +68,10 @@ packages/
 | ---------------------------- | ----------- | ------------------------------------------- |
 | hyperfixi-lite.js            | 1.9 KB      | Minimal (8 commands, regex parser)          |
 | hyperfixi-lite-plus.js       | 2.6 KB      | More commands + i18n aliases                |
-| hyperfixi-hybrid-complete.js | 7.2 KB      | **Recommended** (~85% hyperscript coverage) |
-| hyperfixi-hx.js              | 9.7 KB      | hybrid-complete + htmx/fixi support         |
-| hyperfixi-minimal.js         | 63 KB       | Full parser + 30 commands                   |
-| hyperfixi.js                 | 200 KB      | Everything (all 43 commands)                |
+| hyperfixi-hybrid-complete.js | 7.7 KB      | **Recommended** (~85% hyperscript coverage) |
+| hyperfixi-hx.js              | 18 KB       | hybrid-complete + htmx/fixi support         |
+| hyperfixi-minimal.js         | 76 KB       | Full parser + 30 commands                   |
+| hyperfixi.js                 | ~299 KB     | Everything + reactivity/realtime plugins    |
 
 **Semantic bundles** (optional, for multilingual support):
 

--- a/docs/BROWSER_BUNDLES.md
+++ b/docs/BROWSER_BUNDLES.md
@@ -10,11 +10,11 @@
 Decision tree for the most common cases:
 
 1. **Using `@hyperfixi/vite-plugin`?** Don't pick a bundle by hand — the plugin scans your project and emits the right one (minimal handcrafted when possible, falls back to `hx-v4` when it spots htmx v4 features). See [vite plugin README](../packages/vite-plugin/README.md).
-2. **Need `hx-live`, `bind`, `when`, SSE, or WebSocket?** Use `hyperfixi-hx-v4.js` (~540 KB gz). Single script tag, everything auto-installed. The size cost buys correctness — the slim runtime can't satisfy these features (its `set` doesn't fire `notifyGlobalWrite`, the slim parser doesn't know reactive features, and SSE/WS modules aren't wired).
+2. **Need `hx-live`, `bind`, `when`, SSE, or WebSocket?** Use `hyperfixi-hx-v4.js` (~311 KB gz). Single script tag, everything auto-installed. The size cost buys correctness — the slim runtime can't satisfy these features (its `set` doesn't fire `notifyGlobalWrite`, the slim parser doesn't know reactive features, and SSE/WS modules aren't wired).
 3. **Need only htmx v1/v2 attributes (`hx-get`/`hx-post`/etc.)?** Use `hyperfixi-hx.js` (~18 KB gz). Includes htmx-compat + the slim hybrid runtime for `_=` attributes. No reactivity, no streaming.
 4. **Pure hyperscript (`_=` attributes), ~85% feature coverage, smallest realistic size?** Use `hyperfixi-hybrid-complete.js` (~7.7 KB gz). Full AST parser, expressions, event modifiers, block commands (`if`, `for`, `repeat`, `while`, `fetch`).
 5. **Tiny static page (toggle / show / hide / put / set)?** Use `hyperfixi-lite.js` (~1.9 KB gz). Regex parser, 8 commands. Drops to `hyperfixi-lite-plus.js` (~2.6 KB gz) if you need a few more commands + i18n aliases.
-6. **Authoring in multiple languages (Japanese, Korean, Arabic, etc.) or need the full semantic parser at runtime?** Use `hyperfixi.js` (full bundle, ~534 KB gz) or `hyperfixi-multilingual.js` (~97 KB, parser-free i18n via the semantic bundle loaded separately).
+6. **Authoring in multiple languages (Japanese, Korean, Arabic, etc.) or need the full semantic parser at runtime?** Use `hyperfixi.js` (full bundle, ~299 KB gz) or `hyperfixi-multilingual.js` (~97 KB, parser-free i18n via the semantic bundle loaded separately).
 
 Rule of thumb: start as small as you can; upgrade when you hit a missing feature. The vite plugin removes this decision entirely for projects that use it.
 
@@ -22,7 +22,7 @@ Rule of thumb: start as small as you can; upgrade when you hit a missing feature
 
 | Bundle                                               | Global                  | Size (gzip) | Use Case                             |
 | ---------------------------------------------------- | ----------------------- | ----------- | ------------------------------------ |
-| `packages/core/dist/hyperfixi.js`                    | `window.hyperfixi`      | ~534 KB     | Full bundle with parser              |
+| `packages/core/dist/hyperfixi.js`                    | `window.hyperfixi`      | ~299 KB     | Full bundle with parser              |
 | `packages/behaviors/dist/resolver.browser.global.js` | `HyperFixiBehaviors`    | 5.5 KB      | Lazy behavior resolver (8 behaviors) |
 | `packages/core/dist/hyperfixi-multilingual.js`       | `window.hyperfixi`      | 96.8 KB     | Multilingual (no parser)             |
 | `packages/i18n/dist/lokascript-i18n.min.js`          | `window.LokaScriptI18n` | 43.3 KB     | Grammar transformation               |
@@ -39,7 +39,7 @@ For projects prioritizing bundle size over features:
 | `hyperfixi-lite-plus.js`       | 2.6 KB      | 14        | Regex parser, more commands, i18n aliases                     |
 | `hyperfixi-hybrid-complete.js` | 7.7 KB      | 21+blocks | Full AST parser, expressions, event modifiers                 |
 | `hyperfixi-hx.js`              | 18 KB       | 21+blocks | hybrid-complete + htmx/fixi attribute support                 |
-| `hyperfixi-hx-v4.js`           | ~540 KB     | 40+blocks | Full runtime + htmx-compat + reactivity (hx-live, bind, when) |
+| `hyperfixi-hx-v4.js`           | ~311 KB     | 40+blocks | Full runtime + htmx-compat + reactivity (hx-live, bind, when) |
 
 **Hybrid Complete** (~85% hyperscript coverage) is recommended - it supports:
 
@@ -103,7 +103,7 @@ When `@hyperfixi/reactivity` is installed, the htmx-compat layer recognizes the 
 
 The expression re-runs only when its tracked dependencies actually change (not on every DOM mutation, which is the upstream htmx v4 approach). If reactivity isn't installed, the element is skipped with a clear console error pointing to the install command.
 
-**Easiest path: use the `hyperfixi-hx-v4.js` bundle.** It ships the full runtime + `@hyperfixi/reactivity` auto-installed + the htmx-compat layer in a single script tag. Larger than `hyperfixi-hx.js` (~540 KB vs 18 KB gzipped) but no manual plugin wiring required. For size-tuned production builds, use `@hyperfixi/vite-plugin` instead.
+**Easiest path: use the `hyperfixi-hx-v4.js` bundle.** It ships the full runtime + `@hyperfixi/reactivity` auto-installed + the htmx-compat layer in a single script tag. Larger than `hyperfixi-hx.js` (~311 KB vs 18 KB gzipped) but no manual plugin wiring required. For size-tuned production builds, use `@hyperfixi/vite-plugin` instead.
 
 ```html
 <script src="hyperfixi-hx-v4.js"></script>
@@ -287,7 +287,7 @@ For developers writing hyperscript in their native language:
 </script>
 ```
 
-**Total size:** ~292 KB gz (97 KB multilingual + 195 KB all-24 semantic) vs ~534 KB gz full bundle
+**Total size:** ~292 KB gz (97 KB multilingual + 195 KB all-24 semantic) vs ~299 KB gz full bundle
 
 ## Full Bundle Usage
 

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -134,8 +134,8 @@ See [docs/API.md](docs/API.md) for complete documentation.
 | `hyperfixi-lite.js`            | 1.9 KB      | Minimal (8 commands, regex parser)                |
 | `hyperfixi-hybrid-complete.js` | 7.7 KB      | Recommended (~85% coverage)                       |
 | `hyperfixi-hx.js`              | 18 KB       | hybrid-complete + htmx/fixi v1/v2 attributes      |
-| `hyperfixi-hx-v4.js`           | ~540 KB     | Full runtime + htmx-compat + reactivity (hx-live) |
-| `hyperfixi.js`                 | ~534 KB     | Everything + bundled reactivity/realtime plugins  |
+| `hyperfixi-hx-v4.js`           | ~311 KB     | Full runtime + htmx-compat + reactivity (hx-live) |
+| `hyperfixi.js`                 | ~299 KB     | Everything + bundled reactivity/realtime plugins  |
 
 ## Custom Bundle Generation
 

--- a/packages/core/rollup.browser-hybrid-hx-v4.config.mjs
+++ b/packages/core/rollup.browser-hybrid-hx-v4.config.mjs
@@ -1,8 +1,16 @@
 import typescript from '@rollup/plugin-typescript';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
+import alias from '@rollup/plugin-alias';
+import { fileURLToPath } from 'node:url';
 
 const noTerser = process.env.NO_TERSER === '1';
+
+// Dedupe (same as rollup.browser.config.mjs — separate rollup invocation, so
+// the alias must be repeated here): fold the plugin dists' `@hyperfixi/core`
+// imports onto the src graph instead of inlining core's prebuilt dist/index.mjs
+// (which embeds a second @lokascript/semantic) as a duplicate copy.
+const coreSrcBarrel = fileURLToPath(new URL('src/index.ts', import.meta.url));
 
 /**
  * HyperFixi Hybrid-HX v4 Bundle
@@ -39,6 +47,9 @@ export default {
     exports: 'named',
   },
   plugins: [
+    alias({
+      entries: [{ find: '@hyperfixi/core', replacement: coreSrcBarrel }],
+    }),
     nodeResolve({
       browser: true,
       preferBuiltins: false,

--- a/packages/core/rollup.browser.config.mjs
+++ b/packages/core/rollup.browser.config.mjs
@@ -2,8 +2,21 @@ import typescript from '@rollup/plugin-typescript';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import terser from '@rollup/plugin-terser';
+import alias from '@rollup/plugin-alias';
+import { fileURLToPath } from 'node:url';
 
 const useTerser = process.env.NO_TERSER !== '1';
+
+// Dedupe: the bundled plugins' dists (reactivity/realtime, added by #616)
+// externalize `@hyperfixi/core`, so without this alias nodeResolve inlines
+// core's prebuilt dist/index.mjs (3.2 MB, with an EMBEDDED second copy of
+// @lokascript/semantic) alongside the src tree this entry already compiles —
+// the bundle shipped core+semantic twice (~534 KB gz instead of ~290).
+// Aliasing onto the src barrel folds the plugins' imports (including
+// reactivity's dynamic `await import('@hyperfixi/core')`, inlined via
+// inlineDynamicImports) onto the one src graph. installPlugin is duck-typed,
+// so the dist-built plugin objects work against src-built core unchanged.
+const coreSrcBarrel = fileURLToPath(new URL('src/index.ts', import.meta.url));
 
 export default {
   input: 'src/compatibility/browser-bundle.ts',
@@ -15,6 +28,9 @@ export default {
     inlineDynamicImports: true,
   },
   plugins: [
+    alias({
+      entries: [{ find: '@hyperfixi/core', replacement: coreSrcBarrel }],
+    }),
     nodeResolve({
       browser: true,
       preferBuiltins: false,

--- a/packages/core/scripts/bundle-snapshots/baseline.json
+++ b/packages/core/scripts/bundle-snapshots/baseline.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./baseline.schema.json",
   "purpose": "Tree-shaking + bundle-size baseline for the evaluator consolidation arc (parser/runtime.ts canonical + ExpressionRegistry).",
-  "generated": "2026-05-19",
-  "commit": "9bc8f4c8",
+  "generated": "2026-07-14",
+  "commit": "ba39dce4",
   "tolerance_percent": 5,
   "notes": "Updated 2026-05-19 to add `hyperfixi-hx-v4.js` (item 15 in htmx-v4-reactive-streaming.md follow-ups). hyperfixi.js refreshed to current size — drift since 2026-05-18 is in the user-visible improvement direction (-8.4% gzip), driven by the SSE template-cache refactor (commit b7182753, item 8) replacing a nested ternary with a switch + closure form that compresses better. Run `node scripts/bundle-size-snapshot.mjs --check` after any future change; failures (±5% drift) point to tree-shaking regressions.",
   "bundles": {
@@ -10,43 +10,43 @@
       "config": "rollup.browser-minimal.config.mjs",
       "entry": "src/compatibility/browser-bundle-minimal-v2.ts",
       "evaluator_strategy": "createCoreRegistry (3 of 7 categories: references, logical, special) + parser/runtime.ts canonical evaluator",
-      "raw_bytes": 298504,
-      "gzip_bytes": 71818
+      "raw_bytes": 319676,
+      "gzip_bytes": 77671
     },
     "hyperfixi-standard.js": {
       "config": "rollup.browser-standard.config.mjs",
       "entry": "src/compatibility/browser-bundle-standard-v2.ts",
       "evaluator_strategy": "createCommonRegistry (5 of 7 categories) + parser/runtime.ts canonical evaluator",
-      "raw_bytes": 326008,
-      "gzip_bytes": 78025
+      "raw_bytes": 348032,
+      "gzip_bytes": 84308
     },
     "hyperfixi-classic.js": {
       "config": "rollup.browser-classic.config.mjs",
       "entry": "src/compatibility/browser-bundle-classic.ts",
       "evaluator_strategy": "createExpressionRegistry (6 of 7 categories: caller-selected) + parser/runtime.ts canonical evaluator",
-      "raw_bytes": 390726,
-      "gzip_bytes": 93272
+      "raw_bytes": 410111,
+      "gzip_bytes": 98945
     },
     "hyperfixi-classic-i18n.js": {
       "config": "rollup.browser-classic-i18n.config.mjs",
       "entry": "src/compatibility/browser-bundle-classic-i18n.ts",
       "evaluator_strategy": "createExpressionRegistry (6 of 7 categories) + i18n keyword mapping + parser/runtime.ts canonical evaluator",
-      "raw_bytes": 500589,
-      "gzip_bytes": 127747
+      "raw_bytes": 549289,
+      "gzip_bytes": 142988
     },
     "hyperfixi.js": {
       "config": "rollup.browser.config.mjs",
       "entry": "src/compatibility/browser-bundle.ts",
       "evaluator_strategy": "kitchen-sink Runtime → constructs full ExpressionRegistry (7 categories) + parser/runtime.ts canonical evaluator",
-      "raw_bytes": 1167489,
-      "gzip_bytes": 252336
+      "raw_bytes": 1391944,
+      "gzip_bytes": 307845
     },
     "hyperfixi-hx-v4.js": {
       "config": "rollup.browser-hybrid-hx-v4.config.mjs",
       "entry": "src/compatibility/browser-bundle-hybrid-hx-v4.ts",
       "evaluator_strategy": "full Runtime + @hyperfixi/reactivity auto-install + htmx-compat (hx-* / fx-* / hx-live / sse-* / ws-*); canonical evaluator",
-      "raw_bytes": 1210765,
-      "gzip_bytes": 265601
+      "raw_bytes": 1429409,
+      "gzip_bytes": 320035
     }
   }
 }

--- a/packages/core/src/compatibility/browser-tests/bundle-compatibility.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/bundle-compatibility.spec.ts
@@ -91,7 +91,7 @@ const BUNDLES = {
   // htmx v4 reactive/streaming surface without manual plugin wiring.
   'hybrid-hx-v4': {
     file: 'hyperfixi-hx-v4.js',
-    size: '~540 KB',
+    size: '~311 KB',
     features: {
       toggle: true,
       addClass: true,
@@ -142,7 +142,7 @@ const BUNDLES = {
   },
   browser: {
     file: 'hyperfixi.js',
-    size: '~534 KB',
+    size: '~299 KB',
     features: {
       toggle: true,
       addClass: true,

--- a/packages/core/src/compatibility/browser-tests/bundled-plugins.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/bundled-plugins.spec.ts
@@ -21,6 +21,7 @@ const PLUGIN_PATTERNS = [
   ['worker', 'worker Calculator def add(a, b) return a + b end end'],
   ['bind', 'bind $name to #input-a'],
   ['live', 'live put `Count: ${$count}` into me end'],
+  ['when', 'when $count changes put $count into #out end'],
 ] as const;
 
 test.describe('Shipped bundle auto-installs plugins @quick', () => {


### PR DESCRIPTION
Task 1 of the approved pre-release plan 2 (bundle dedupe + V3c burn-down).

## Root cause
Since #616 (2.7.0), the full bundles shipped **two copies of core+semantic**: the bundled reactivity/realtime plugin dists externalize `@hyperfixi/core`, so at bundle time nodeResolve inlined core's prebuilt `dist/index.mjs` (3.2 MB, with an embedded second `@lokascript/semantic`) alongside the src graph the entry already compiles. Published-tarball curve: 286 KB gz at 2.6.0 → 529 KB at 2.7.0, overnight; distinctive strings doubled (`sov-simple` 1→2, `tıklama` 2→4).

## Fix
`@rollup/plugin-alias` maps `@hyperfixi/core` → the src barrel in **both** browser configs. Safety analysis (explored before implementing): the plugins' entire runtime import surface from core is one symbol (`getElementScopeMap`); `installPlugin` is duck-typed (no instanceof); the parser-extension registry is globalThis-hoisted, so one copy is strictly safer than the two-copy reconciliation. Library build / Node import surface untouched.

## Results
| | before | after |
|---|---|---|
| `hyperfixi.js` | 546,368 B gz (~534 KB) | **306,053 B gz (~299 KB)** |
| `hyperfixi-hx-v4.js` | 553,403 B gz (~540 KB) | **318,438 B gz (~311 KB)** |

Duplication proof: `sov-simple` 2→1, `tıklama` 4→2, `index.mjs` gone from the sourcemap.

## Verification (all local, real exit codes)
- `bundled-plugins.spec.ts` 4/4 — plugin auto-install guard, **extended with `when`** (previously untested); socket executes end-to-end
- `hx-v4-features.spec.ts` 12/12 — hx-live, bind, sse-stream, ws-send
- `bundle-compatibility.spec.ts` 92/92 (the exact pre-publish invocation) + `i18n-orchestrator-api.spec.ts` 4/4
- core `test:check` 7205 green
- `bundle-size-snapshot.mjs --check` green after baseline refresh

## Also in this PR
- Pre-publish size ceilings ratcheted 560→**340/350 KB** — they now exist specifically to catch re-duplication (the #616 class blows straight past them).
- Size-truth docs pass (README, CLAUDE.md ×2, BROWSER_BUNDLES, ARCHITECTURE, spec labels).
- Release-notes draft: dedupe Highlights entry + entries for #680 (go-url) and #681 (six-language broken listeners).

After merge: dispatch `pre-publish-check.yml` for a fresh honest [full] + size-gate run against main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)