### PR TITLE
fix(parser): preserve `go` destination in traditional parser + interchange

### DIFF
--- a/docs-internal/HANDOFF_go-interchange-inference.md
+++ b/docs-internal/HANDOFF_go-interchange-inference.md
@@ -1,0 +1,204 @@
+# HANDOFF: `go` URL destination drop (traditional parser + interchange)
+
+> ## ✅ RESOLVED — 2026-07-14 (Strategy A, two-layer fix)
+>
+> Both layers implemented and verified end-to-end. `go`'s destination now
+> survives the traditional parser and binds as an interchange `destination` role
+> (+ `method` for the `url` form). Full standard-hyperscript `go` grammar
+> supported (`go [to] <expr> [in new window]`, `go back`; naked `/paths` and
+> scheme URLs; deprecated `url`/scroll forms kept for back-compat). The runtime
+> [go.ts](../packages/core/src/commands/navigation/go.ts) was **not** touched —
+> it already supported every form.
+>
+> **Files:**
+> - `packages/core/src/parser/command-parsers/navigation-commands.ts` (**new** —
+>   `parseGoCommand`, a flat token-scan; reuses the now-exported
+>   `parseBareURLPath` for naked-URL reassembly).
+> - `packages/core/src/parser/parser-constants.ts` — `'go'` added to
+>   `COMPOUND_COMMANDS`.
+> - `packages/core/src/parser/command-parsers/utility-commands.ts` —
+>   `parseBareURLPath` exported + parameterized with a terminator predicate;
+>   `case 'go'` in `parseCompoundCommand`.
+> - `packages/core/src/ast-utils/interchange/from-core.ts` — `case 'go'` in
+>   `inferRoles` (handles all three producer shapes + `target` fallback).
+> - Tests: `navigation-commands.test.ts` (**new**),
+>   `go-roles.e2e.test.ts` (**new**), fixtures added to `from-core.test.ts`.
+>
+> **Verification:** end-to-end through the exact AOT adapter path
+> (`compileSync(…,{traditional:true})` → `fromCoreAST` → `generateCommand`,
+> fresh dist) — `go to /page` → `location.href="/page"`, `go back` →
+> `history.back()`, `go to url "/dash"` → `location.href="/dash"`,
+> `go to https://x.com` → correct. Suites green: core 7251, aot-compiler 618,
+> intent 80, plus 151 new-test assertions; typecheck clean; browser bundle
+> builds. **The diagnosis below is retained for context.**
+
+> Rewritten 2026-07-14 after verifying against **real** core parses (fresh
+> dists). The **previous version of this doc misdiagnosed the bug** — it claimed
+> a single interchange-inference gap against core args `[{id url},{lit /page}]`,
+> a shape the real core parser never emits. The probe it was based on called
+> `inferRolesFromSchema` with hand-fabricated args and was never checked against
+> an actual `compileSync`. Corrected findings below.
+>
+> Pre-existing bug, NOT a regression from the pre-release arcs (#680–#683). The
+> go-url arc (#680) fixed the SEMANTIC parse path and made this gap visible.
+> Scope: **multi-layer** (traditional parser + interchange), not the small
+> self-contained interchange tweak the old doc described. No fidelity-baseline
+> coupling (the interchange path is not in the multilingual corpus).
+
+## Symptom
+
+`go to url "/page"` loses its destination (`/page`) in the interchange format
+that the AOT compiler and downstream tools consume
+(`packages/aot-compiler/src/compiler/core-parser-adapter.ts` →
+`fromCoreAST`). Sibling forms `go /page` and `go back` are also affected.
+
+## The bug is TWO layers, on TWO different parse paths
+
+The AOT/interchange adapter calls
+`hyperscript.compileSync(code, { traditional: true })`
+([core-parser-adapter.ts:59](../packages/aot-compiler/src/compiler/core-parser-adapter.ts#L59)).
+`traditional: true` **disables semantic parsing**
+([hyperscript-api.ts:843](../packages/core/src/api/hyperscript-api.ts#L843)),
+so `go` runs through the traditional parser — the layer that is broken first.
+
+### Layer 1 — the traditional parser DROPS the URL (blocking layer)
+
+Verified (2026-07-14, fresh dists, `compileSync(src, {traditional:true})`):
+
+| source | core `args` | note |
+| --- | --- | --- |
+| `go to url "/page"` | `[{id to}, {id url}]` | **`"/page"` gone from the AST** |
+| `go url "/page"` | `[{id url}]` | `"/page"` gone |
+| `go /page` | `[{binaryExpression __ERROR__ / page}]` | bare path mis-parses |
+| `go back` | `[{id back}]` | ok |
+| `go to "/page"` | `[{id to}, {lit /page}]` | ok (string kept after `to`) |
+| `send url "/page"` | `[{id url}, {lit /page}]` | **ok — `send` has a dedicated parser** |
+
+Root cause: the generic command-arg loop
+([parser.ts:3483-3538](../packages/core/src/parser/parser.ts#L3483)) only
+continues to the next arg on a comma or a **continuation keyword**
+(`into|from|to|with|by|at|before|after|over`). `url` is not one, so after
+parsing `[to, url]` the loop hits a bare string literal with no continuation
+context and **breaks, discarding `"/page"`**. `send`/`fetch` never reach this
+loop — they are dispatched to dedicated command parsers earlier in
+`parseCommandCore`. `go` has **no** dedicated traditional parser (there is no
+`command-parsers/navigation-commands.ts`).
+
+Because the URL is gone before interchange runs, **no `from-core.ts` change can
+fix Layer 1.** The interchange layer even mis-binds the leftover: with args
+`[{id to},{id url}]` the `to` marker matches and binds `destination: {id url}`
+(the literal word "url"), which is wrong but non-empty.
+
+### Layer 2 — interchange inference drops the destination even when the URL survives
+
+On the SEMANTIC path (`traditional: false`) the URL **does** survive, but in
+modifiers, not args:
+
+```text
+go to url "/page"  (traditional:false)  →
+  { name:'go', args:[], modifiers:{ on:{lit "/page"}, method:{lit "url"} } }
+```
+
+`fromCoreAST` of that node still returns **no `roles`**: `inferRoles` falls to
+its `default:` branch → `inferRolesFromSchema(goSchema, args:[], modifiers, …)`.
+`goSchema`'s `destination` role has `markerOverride { en: 'to' }`, so:
+
+- Pass 1 (marker scan) looks for a `to` key in modifiers/args — the modifier key
+  is `on`, not `to` → no match.
+- Pass 2 (target) — no `target`.
+- Pass 3 (positional) **excludes** `destination` because it has a non-empty
+  marker (`englishMarkers(destination) === ['to']`).
+
+→ `roles = {}` → dropped. This is the real interchange gap (the old doc's
+instinct), but the trigger is `modifiers.on` under-mapping, not the fabricated
+`[{id url},{lit /page}]` arg shape.
+
+Confirmed directly by feeding hand-built "ideal" shapes to `fromCoreAST`:
+`[{id url},{lit /page}]`, `[{lit /page}]`, and `[{id back}]` all yield
+`roles: undefined`; only the `target`-carried form (`go to /page` with a
+trailing target) binds `destination`.
+
+## Reproduce (the CORRECT probe — use this, not the old fabricated one)
+
+```js
+// ABSOLUTE dist paths; rebuild intent/semantic/core dists first
+// (stale-dist pretest hooks do NOT fire for direct node/tsx).
+const core = await import('<abs>/packages/core/dist/index.mjs');
+const { hyperscript, fromCoreAST } = core;
+for (const trad of [true, false]) {
+  const res = hyperscript.compileSync('go to url "/page"', { traditional: trad });
+  // find the { type:'command', name:'go' } node in res.ast, then:
+  // console.log(trad, JSON.stringify(res.ast), JSON.stringify(fromCoreAST(goNode).roles));
+}
+```
+
+Expect: `traditional:true` → args `[to,url]`, URL absent; `traditional:false` →
+`modifiers.on = /page`, but `fromCoreAST(...).roles` empty.
+
+## Fix strategies (choose scope; both real fixes are multi-file)
+
+The 2026-07-14 session (this one) **deferred implementation** on purpose — the
+release runbook (v2.8.0, publish 07-21/22) is active and this is bigger than a
+release-week edit. Options for a focused post-release session:
+
+- **(A) Scoped two-layer fix — tightest blast radius.**
+  1. **Layer 1:** give `go` a dedicated traditional command parser (new
+     `packages/core/src/parser/command-parsers/navigation-commands.ts`, wired
+     into `parseCommandCore` alongside the `fetch`/`add`/`transition`
+     dispatches). Emit the runtime-contract args
+     ([go.ts:72-105](../packages/core/src/commands/navigation/go.ts#L72)):
+     `['back']` → history; `['url', <urlExpr>]` → url nav; `[<bareUrl>]` →
+     `/`-or-scheme nav; else scroll. Mirror `send`'s dedicated parser.
+  2. **Layer 2:** interchange `case 'go'` in `from-core.ts` mapping the emitted
+     args (and `modifiers.on`/`method` for the semantic path) → `destination`
+     (+ `method`, an already-modeled interchange role — `put` emits it).
+  Go-only; does **not** touch the generic arg loop or the AOT flag.
+
+- **(B) AOT-reroute — less code, broader runtime-path change.**
+  Add the Layer-2 interchange `case 'go'` (reads `modifiers.on`/`method` +
+  `target`), AND stop the AOT adapter forcing `traditional: true` so the
+  URL-preserving semantic parse feeds interchange. Risk: the flag change alters
+  the AOT parse path for **every** command, not just `go` — audit before doing
+  this.
+
+Do NOT do interchange-only against `traditional:true`: the URL is already gone
+at Layer 1, so it fixes nothing end-to-end.
+
+## Verification (once implemented)
+
+- End-to-end at the layer(s) you fix: core-parse `go to url "/page"`,
+  `go back`, `go /page` via the SAME path the AOT adapter uses
+  (`compileSync(code, {traditional:true})` for strategy A;
+  `{traditional:false}` for strategy B) → `fromCoreAST(...)` → assert the
+  interchange node carries the destination (and `method:'url'`).
+- Runtime: if Layer 1 changes, assert `go.ts` still receives runtime-contract
+  args (`['url','/page']` etc.) — existing tests in
+  `packages/core/src/commands/navigation/__tests__/go.test.ts`.
+- Interchange unit tests: `packages/core/src/ast-utils/interchange/from-core.test.ts`
+  (hand-built `coreNode('command', {name:'go', …})` fixtures — mirror the `put`
+  roles tests around line 968). **Match fixtures to REAL parser output**, not
+  assumed shapes — that mismatch is what produced the old doc.
+- Suites: `npm run test:check --prefix packages/core`,
+  `npm test --prefix packages/intent -- --run`.
+- No multilingual resweep needed (no semantic/i18n/dict changes) UNLESS you
+  touch `goSchema` (e.g. adding `argSkipTokens`) — then re-run the
+  `--regression` gate to confirm inert.
+
+## Context you'd otherwise re-derive
+
+- Runtime `go` contract ([go.ts:72-105](../packages/core/src/commands/navigation/go.ts#L72)):
+  `args[0]==='back'` → history; args containing `'url'` → next arg is the URL;
+  bare `/`-or-scheme arg → bare-url nav; else scroll. The runtime keys on
+  evaluated STRING args (`'url'`, `'/page'`, `'back'`).
+- #680 fixed the semantic side: generated url-variant patterns
+  (`rolePrefixLiteralVariants` on `goSchema`,
+  [command-schemas.ts:1720](../packages/semantic/src/generators/command-schemas.ts#L1720)),
+  fused-path reclaims in `semantic-parser.ts`, and rewrote `goMapper`
+  ([command-mappers.ts:510](../packages/semantic/src/ast-builder/command-mappers.ts#L510))
+  to the args contract above. That path is `buildAST` (semantic → AST directly),
+  which is NOT the `compileSync` semantic path that emits `modifiers.on` — don't
+  conflate them.
+- Probe hygiene: ABSOLUTE dist paths; rebuild intent/semantic/core dists first
+  (stale-dist pretest hooks do NOT fire for direct `node`/`tsx`); schema-
+  validation warnings on stderr are noise. And — the lesson of this doc — probe
+  the **real** `compileSync` output, never hand-fabricated args.

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -2692,7 +2692,7 @@ Most map to families this file had already named:
 | reactive `when … changes` heads | 48 | when-value-changes ×24, when-multiple-changes ×24 | = named reactive `on.event` deferral |
 | set source-qualifier tails (`from #firstName` on bind rows) | 44 | two-way-binding ×22, computed-value ×22 | NEW — named here |
 | show/hide style-capture (`with *opacity`) | 38 | show-with-transition ×19, hide-with-transition ×19 | = named Batch-3 leftover |
-| go-url destination (`"/page"`) | 18 | go-url ×18 | = named Batch-3 leftover |
+| go-url destination (`"/page"`) | ~~18~~ | go-url ×18 | **RESOLVED — #680** (semantic go-url capture, x24; snapshot predates #680, resweep to zero the count). Traditional/interchange sibling resolved 2026-07-14, `HANDOFF_go-interchange-inference.md` |
 | swap with-phrase | 6 | swap-content ×6 | = named F6 (wontfix) |
 | command-option tails, misc (render/morph `: $data` ×36 — **resolved by Arc E**, the render rows' naked with-pair folds via the same mechanism as fetch — `beep! <expr>` ×18, unless operator tail ×18, tell to-infinitive ×16, do-not-throw leak ×3, fetch-as id ×1+2, sw async vocab gap ×1) | ~~95~~ **59** | ~~render-template-with-data ×18, morph-with-template ×18,~~ beep-debug-expression ×18, unless-condition ×18, tell-command ×16, fetch-do-not-throw ×3, fetch-error-handling ×2, async-block ×1, fetch-json ×1 | NEW — named here; render/morph rows RESOLVED (Arc E) |
 
@@ -3143,12 +3143,19 @@ packages on day one (#615). Lexicon end-state + domain-side history:
 >
 > **Discoveries logged (not fixed in Batch 1):**
 >
-> 1. **go-url destination drop, en included**: `go to url "/page"` parses to
->    `destination=expression:"url"` and DROPS `"/page"` — identically in en and es
->    (P5c/P5d), so fidelity 1.0 masks it corpus-wide (the en-reference-corruption
->    class; R3 silent because the value is a quoted string, not a bare URL token).
->    Candidate for the R3 value-bug families list: teach `go`'s patterns the `url
->    <literal>` idiom, then resweep — en denominator moves ×24.
+> 1. **go-url destination drop, en included** — **✅ RESOLVED (#680, 2026-07-14).**
+>    `go to url "/page"` used to parse to `destination=expression:"url"` and DROP
+>    `"/page"` — identically in en and es (P5c/P5d), so fidelity 1.0 masked it
+>    corpus-wide (the en-reference-corruption class; R3 silent because the value
+>    is a quoted string, not a bare URL token). #680 taught `go`'s patterns the
+>    `url <literal>` idiom (`rolePrefixLiteralVariants` on `goSchema`) exactly as
+>    suggested here; the semantic parse now captures it in all 24 languages —
+>    verified: `go to url "/page"` → `{destination:"/page", method:"url"}`,
+>    `go to /page` → `{destination:"/page"}`, `go back` → `{destination:"back"}`.
+>    The SIBLING traditional-parser + interchange layer (the `compileSync`
+>    `{traditional:true}` path the AOT adapter uses — NOT in this corpus) was a
+>    separate gap, resolved 2026-07-14; see
+>    `docs-internal/HANDOFF_go-interchange-inference.md`.
 > 2. **`show`/`hide` style role is uncaptured in EVERY language including en**
 >    (`on click show #modal with *opacity` captures patient only). Another
 >    en-denominator gap: hi `साथ` / ar render-style registrations are untestable

--- a/packages/core/src/ast-utils/interchange/from-core.test.ts
+++ b/packages/core/src/ast-utils/interchange/from-core.test.ts
@@ -1008,6 +1008,188 @@ describe('fromCoreAST', () => {
       expect(result.roles.destination).toEqual({ type: 'selector', value: '#box' });
     });
 
+    // go — three real producer shapes reach inferRoles:
+    //  1. traditional parser: flat args, keywords as core `string` nodes
+    //     (→ interchange `literal`), naked URLs as core `literal` nodes
+    //  2. semantic compileSync: args:[], modifiers.on/method
+    //  3. buildAST goMapper: positional literal args
+    describe('go roles', () => {
+      // -- shape 1: traditional parser --
+      it('url keyword form → destination + method (traditional)', () => {
+        const result = fromCoreAST(
+          coreNode('command', {
+            name: 'go',
+            args: [
+              coreNode('string', { value: 'to' }),
+              coreNode('string', { value: 'url' }),
+              coreNode('literal', { value: '/page' }),
+            ],
+          })
+        ) as any;
+        expect(result.roles.destination).toEqual({ type: 'literal', value: '/page' });
+        expect(result.roles.method).toEqual({ type: 'literal', value: 'url' });
+      });
+
+      it('url keyword without `to` → destination + method', () => {
+        const result = fromCoreAST(
+          coreNode('command', {
+            name: 'go',
+            args: [coreNode('string', { value: 'url' }), coreNode('literal', { value: '/page' })],
+          })
+        ) as any;
+        expect(result.roles.destination).toEqual({ type: 'literal', value: '/page' });
+        expect(result.roles.method).toEqual({ type: 'literal', value: 'url' });
+      });
+
+      it('naked path → destination, no method', () => {
+        const result = fromCoreAST(
+          coreNode('command', {
+            name: 'go',
+            args: [coreNode('string', { value: 'to' }), coreNode('literal', { value: '/about' })],
+          })
+        ) as any;
+        expect(result.roles.destination).toEqual({ type: 'literal', value: '/about' });
+        expect(result.roles.method).toBeUndefined();
+      });
+
+      it('go back → destination as identifier (AOT history.back)', () => {
+        const result = fromCoreAST(
+          coreNode('command', { name: 'go', args: [coreNode('string', { value: 'back' })] })
+        ) as any;
+        expect(result.roles.destination).toEqual({
+          type: 'identifier',
+          value: 'back',
+          name: 'back',
+        });
+        expect(result.roles.method).toBeUndefined();
+      });
+
+      it('go forward → destination as identifier', () => {
+        const result = fromCoreAST(
+          coreNode('command', { name: 'go', args: [coreNode('string', { value: 'forward' })] })
+        ) as any;
+        expect(result.roles.destination).toEqual({
+          type: 'identifier',
+          value: 'forward',
+          name: 'forward',
+        });
+      });
+
+      it('scroll form → destination is the `of` target', () => {
+        const result = fromCoreAST(
+          coreNode('command', {
+            name: 'go',
+            args: [
+              coreNode('string', { value: 'to' }),
+              coreNode('string', { value: 'top' }),
+              coreNode('string', { value: 'of' }),
+              coreNode('selector', { value: '#header' }),
+            ],
+          })
+        ) as any;
+        expect(result.roles.destination).toEqual({ type: 'selector', value: '#header' });
+      });
+
+      it('scroll form skips a `the` before the target', () => {
+        const result = fromCoreAST(
+          coreNode('command', {
+            name: 'go',
+            args: [
+              coreNode('string', { value: 'to' }),
+              coreNode('string', { value: 'bottom' }),
+              coreNode('string', { value: 'of' }),
+              coreNode('string', { value: 'the' }),
+              coreNode('selector', { value: '#el' }),
+            ],
+          })
+        ) as any;
+        expect(result.roles.destination).toEqual({ type: 'selector', value: '#el' });
+      });
+
+      it('position-only (`go to top`) → no roles', () => {
+        const result = fromCoreAST(
+          coreNode('command', {
+            name: 'go',
+            args: [coreNode('string', { value: 'to' }), coreNode('string', { value: 'top' })],
+          })
+        ) as any;
+        expect(result.roles).toBeUndefined();
+      });
+
+      // -- shape 2: semantic compileSync (modifiers.on/method) --
+      it('semantic modifiers path → destination + method', () => {
+        const result = fromCoreAST(
+          coreNode('command', {
+            name: 'go',
+            args: [],
+            modifiers: {
+              on: coreNode('literal', { value: '/page' }),
+              method: coreNode('literal', { value: 'url' }),
+            },
+          })
+        ) as any;
+        expect(result.roles.destination).toEqual({ type: 'literal', value: '/page' });
+        expect(result.roles.method).toEqual({ type: 'literal', value: 'url' });
+      });
+
+      it('semantic modifiers path normalizes back → identifier', () => {
+        const result = fromCoreAST(
+          coreNode('command', {
+            name: 'go',
+            args: [],
+            modifiers: { on: coreNode('literal', { value: 'back' }) },
+          })
+        ) as any;
+        expect(result.roles.destination).toEqual({
+          type: 'identifier',
+          value: 'back',
+          name: 'back',
+        });
+      });
+
+      // -- shape 3: buildAST goMapper (positional literals) --
+      it('buildAST positional url form → destination + method', () => {
+        const result = fromCoreAST(
+          coreNode('command', {
+            name: 'go',
+            args: [coreNode('literal', { value: 'url' }), coreNode('literal', { value: '/page' })],
+          })
+        ) as any;
+        expect(result.roles.destination).toEqual({ type: 'literal', value: '/page' });
+        expect(result.roles.method).toEqual({ type: 'literal', value: 'url' });
+      });
+
+      it('buildAST positional back → destination identifier', () => {
+        const result = fromCoreAST(
+          coreNode('command', { name: 'go', args: [coreNode('literal', { value: 'back' })] })
+        ) as any;
+        expect(result.roles.destination).toEqual({
+          type: 'identifier',
+          value: 'back',
+          name: 'back',
+        });
+      });
+
+      it('buildAST positional bare path → destination', () => {
+        const result = fromCoreAST(
+          coreNode('command', { name: 'go', args: [coreNode('literal', { value: '/page' })] })
+        ) as any;
+        expect(result.roles.destination).toEqual({ type: 'literal', value: '/page' });
+      });
+
+      // -- target fallback (explicit cases bypass schema Pass-2) --
+      it('binds a trailing target to destination', () => {
+        const result = fromCoreAST(
+          coreNode('command', {
+            name: 'go',
+            args: [],
+            target: coreNode('selector', { value: '#box' }),
+          })
+        ) as any;
+        expect(result.roles.destination).toEqual({ type: 'selector', value: '#box' });
+      });
+    });
+
     it('infers increment roles: patient + quantity', () => {
       const result = fromCoreAST(
         coreNode('command', {

--- a/packages/core/src/ast-utils/interchange/from-core.ts
+++ b/packages/core/src/ast-utils/interchange/from-core.ts
@@ -461,6 +461,99 @@ function inferRoles(
       break;
     }
 
+    // go [to] <url> [in new window] / go back / go to <pos> of <el>
+    //
+    // Three producer shapes reach here (core `string` nodes convert to
+    // interchange `literal`, so the traditional and buildAST shapes coincide):
+    //  1. traditional parser: flat args, keywords + naked URLs as literals —
+    //     [lit to, lit url, lit '/page'] / [lit to, lit '/about'] / [lit back]
+    //  2. semantic compileSync: args:[], modifiers.on = destination,
+    //     modifiers.method = literal 'url'
+    //  3. buildAST goMapper: positional literal args [lit 'url', lit '/page'] …
+    //
+    // Schema inference can't produce these: goSchema.destination is a marker
+    // role (markerOverride 'to') so it's excluded from positional binding, and
+    // `method` lives only in rolePrefixLiteralVariants, which the schema engine
+    // never reads.
+    case 'go': {
+      const kw = (n: unknown): string | undefined => {
+        if (!n || typeof n !== 'object') return undefined;
+        const v = n as { type?: string; name?: unknown; value?: unknown };
+        if (v.type === 'identifier') {
+          if (typeof v.name === 'string' && v.name !== '') return v.name;
+          return typeof v.value === 'string' ? v.value : undefined;
+        }
+        if (v.type === 'literal' && typeof v.value === 'string') return v.value;
+        return undefined;
+      };
+      const asNode = (x: unknown): InterchangeNode | undefined =>
+        x && typeof x === 'object' && 'type' in (x as object) ? (x as InterchangeNode) : undefined;
+
+      let destination: InterchangeNode | undefined;
+      let method: InterchangeNode | undefined;
+
+      const onMod = asNode(modifiers?.on);
+      if (args.length === 0 && onMod) {
+        // Shape 2 — semantic modifiers path.
+        destination = onMod;
+        if (kw(asNode(modifiers?.method)) === 'url') {
+          method = { type: 'literal', value: 'url' };
+        }
+      } else {
+        // Shapes 1 & 3 — flat positional args.
+        const words = args.map(kw);
+        const urlIdx = words.indexOf('url');
+        if (urlIdx !== -1 && args[urlIdx + 1]) {
+          destination = args[urlIdx + 1];
+          method = { type: 'literal', value: 'url' };
+        } else {
+          const SKIP = new Set(['to', 'the']);
+          const POSITION = new Set([
+            'top',
+            'middle',
+            'bottom',
+            'left',
+            'center',
+            'right',
+            'smoothly',
+            'instantly',
+            'in',
+            'new',
+            'window',
+          ]);
+          const headIdx = args.findIndex((_, i) => {
+            const w = words[i];
+            return w === undefined || !SKIP.has(w);
+          });
+          const headWord = headIdx !== -1 ? words[headIdx] : undefined;
+          const ofIdx = words.indexOf('of');
+          if (headWord === 'back' || headWord === 'forward') {
+            destination = { type: 'identifier', value: headWord, name: headWord };
+          } else if (ofIdx !== -1 && args[ofIdx + 1]) {
+            // scroll form: destination is the `of` target, skipping a `the`.
+            destination = kw(args[ofIdx + 1]) === 'the' ? args[ofIdx + 2] : args[ofIdx + 1];
+          } else if (headIdx !== -1 && !POSITION.has(headWord ?? '')) {
+            destination = args[headIdx];
+          }
+          // position-only (`go to top`) → left for the target fallback below.
+        }
+      }
+
+      // AOT GoCodegen emits history.back()/forward() only for an identifier-typed
+      // destination; a literal `back` would codegen `location.href = "back"`.
+      const destWord = kw(destination);
+      if ((destWord === 'back' || destWord === 'forward') && destination?.type !== 'identifier') {
+        destination = { type: 'identifier', value: destWord, name: destWord };
+      }
+
+      // Explicit cases bypass schema Pass-2 target binding — do it here.
+      if (!destination && target) destination = target;
+
+      if (destination) roles.destination = destination;
+      if (method) roles.method = method;
+      break;
+    }
+
     default: {
       // Fall back to schema-driven role inference (Option 4 — scroll, push,
       // replace, process and any future command without an explicit case).

--- a/packages/core/src/ast-utils/interchange/go-roles.e2e.test.ts
+++ b/packages/core/src/ast-utils/interchange/go-roles.e2e.test.ts
@@ -1,0 +1,71 @@
+/**
+ * End-to-end regression for the `go` URL-destination drop.
+ *
+ * Exercises the exact path the AOT interchange adapter uses
+ * (core-parser-adapter.ts): compileSync(code, { traditional: true }) →
+ * fromCoreAST(goNode) → roles. Kept separate from from-core.test.ts so that
+ * file stays parser-free. Fixtures are REAL parser output, not hand-built —
+ * the previous handoff misdiagnosed the bug precisely because its fixtures were
+ * fabricated.
+ */
+import { describe, it, expect } from 'vitest';
+import { hyperscript } from '../../api/hyperscript-api';
+import { fromCoreAST } from './from-core';
+
+function findGoNodes(node: unknown, out: any[] = []): any[] {
+  if (!node || typeof node !== 'object') return out;
+  const n = node as Record<string, unknown>;
+  if (n.type === 'command' && n.name === 'go') out.push(n);
+  for (const key of Object.keys(n)) {
+    const v = n[key];
+    if (Array.isArray(v)) v.forEach(c => findGoNodes(c, out));
+    else if (v && typeof v === 'object') findGoNodes(v, out);
+  }
+  return out;
+}
+
+function rolesFor(src: string, traditional = true): any {
+  const res: any = hyperscript.compileSync(src, { traditional });
+  const go = findGoNodes(res.ast ?? res.node ?? res)[0];
+  expect(go, `no go node for: "${src}"`).toBeDefined();
+  return (fromCoreAST(go) as any).roles;
+}
+
+describe('go interchange roles (traditional parse → fromCoreAST)', () => {
+  it('naked path keeps the destination', () => {
+    const roles = rolesFor('go to /page');
+    expect(roles.destination).toMatchObject({ type: 'literal', value: '/page' });
+    expect(roles.method).toBeUndefined();
+  });
+
+  it('scheme URL keeps the destination', () => {
+    expect(rolesFor('go to https://example.com').destination).toMatchObject({
+      type: 'literal',
+      value: 'https://example.com',
+    });
+  });
+
+  it('deprecated url form → destination + method', () => {
+    const roles = rolesFor('go to url "/page"');
+    expect(roles.destination).toMatchObject({ type: 'literal', value: '/page' });
+    expect(roles.method).toMatchObject({ type: 'literal', value: 'url' });
+  });
+
+  it('go back → destination identifier back', () => {
+    expect(rolesFor('go back').destination).toMatchObject({ type: 'identifier', value: 'back' });
+  });
+
+  it('preserves the destination for a go inside an event handler', () => {
+    // Handler-level conversion (the go lives in the handler body).
+    expect(rolesFor('on click go to /x').destination).toMatchObject({
+      type: 'literal',
+      value: '/x',
+    });
+  });
+
+  it('semantic parse path also binds the destination', () => {
+    const roles = rolesFor('go to url "/page"', false);
+    expect(roles.destination).toMatchObject({ type: 'literal', value: '/page' });
+    expect(roles.method).toMatchObject({ type: 'literal', value: 'url' });
+  });
+});

--- a/packages/core/src/parser/command-parsers/__tests__/navigation-commands.test.ts
+++ b/packages/core/src/parser/command-parsers/__tests__/navigation-commands.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Integration tests for the dedicated `go` command parser.
+ *
+ * These parse real hyperscript source through the full Parser (so they also
+ * exercise the COMPOUND_COMMANDS dispatch wiring) and assert on the flat arg
+ * list `parseGoCommand` emits. The runtime (commands/navigation/go.ts) consumes
+ * that flat list directly, so the arg shapes here ARE the runtime contract.
+ *
+ * Regression: `go` used to fall into the generic command-arg loop, which
+ * dropped trailing URLs (`go to /page` → the URL was discarded) and folded
+ * scroll forms into binary expressions.
+ */
+import { describe, it, expect } from 'vitest';
+import { parse } from '../../parser';
+import { evaluateAST } from '../../runtime';
+import { GoCommand } from '../../../commands/navigation/go';
+
+// Recursively locate every `{ type:'command', name:'go' }` node in an AST.
+function findGoNodes(node: unknown, out: any[] = []): any[] {
+  if (!node || typeof node !== 'object') return out;
+  const n = node as Record<string, unknown>;
+  if (n.type === 'command' && n.name === 'go') out.push(n);
+  for (const key of Object.keys(n)) {
+    const v = n[key];
+    if (Array.isArray(v)) v.forEach(c => findGoNodes(c, out));
+    else if (v && typeof v === 'object') findGoNodes(v, out);
+  }
+  return out;
+}
+
+function firstGo(src: string): any {
+  const result = parse(src);
+  const go = findGoNodes(result.node ?? (result as any).ast ?? result)[0];
+  expect(go, `no go node found for: "${src}"`).toBeDefined();
+  return go;
+}
+
+// Reduce an arg node to a comparable { type, value } shape.
+function shape(arg: any): { type: string; value: unknown } {
+  return { type: arg.type, value: arg.value ?? arg.name };
+}
+function argShapes(src: string): Array<{ type: string; value: unknown }> {
+  return (firstGo(src).args ?? []).map(shape);
+}
+
+describe('parseGoCommand — canonical navigation forms', () => {
+  it('naked absolute path: go to /about', () => {
+    expect(argShapes('go to /about')).toEqual([
+      { type: 'string', value: 'to' },
+      { type: 'literal', value: '/about' },
+    ]);
+  });
+
+  it('naked scheme URL: go to https://example.com', () => {
+    expect(argShapes('go to https://example.com')).toEqual([
+      { type: 'string', value: 'to' },
+      { type: 'literal', value: 'https://example.com' },
+    ]);
+  });
+
+  it('bare path without `to`: go /page', () => {
+    expect(argShapes('go /page')).toEqual([{ type: 'literal', value: '/page' }]);
+  });
+
+  it('multi-segment path: go to /users/42', () => {
+    expect(argShapes('go to /users/42')).toEqual([
+      { type: 'string', value: 'to' },
+      { type: 'literal', value: '/users/42' },
+    ]);
+  });
+
+  it('path segment that is a command word stays intact: go to /get', () => {
+    expect(argShapes('go to /get')).toEqual([
+      { type: 'string', value: 'to' },
+      { type: 'literal', value: '/get' },
+    ]);
+  });
+
+  it('quoted string destination: go to "#section"', () => {
+    expect(argShapes('go to "#section"')).toEqual([
+      { type: 'string', value: 'to' },
+      { type: 'literal', value: '#section' },
+    ]);
+  });
+
+  it('template literal destination: go to `/${p}`', () => {
+    const args = argShapes('go to `/${p}`');
+    expect(args[0]).toEqual({ type: 'string', value: 'to' });
+    expect(args[1].type).toBe('templateLiteral');
+  });
+
+  it('variable destination: go to myUrl', () => {
+    expect(argShapes('go to myUrl')).toEqual([
+      { type: 'string', value: 'to' },
+      { type: 'identifier', value: 'myUrl' },
+    ]);
+  });
+
+  it('in new window: go to /page in new window', () => {
+    expect(argShapes('go to /page in new window')).toEqual([
+      { type: 'string', value: 'to' },
+      { type: 'literal', value: '/page' },
+      { type: 'string', value: 'in' },
+      { type: 'string', value: 'new' },
+      { type: 'string', value: 'window' },
+    ]);
+  });
+
+  it('variable + in new window does not swallow `in`: go to myUrl in new window', () => {
+    expect(argShapes('go to myUrl in new window')).toEqual([
+      { type: 'string', value: 'to' },
+      { type: 'identifier', value: 'myUrl' },
+      { type: 'string', value: 'in' },
+      { type: 'string', value: 'new' },
+      { type: 'string', value: 'window' },
+    ]);
+  });
+
+  it('history: go back', () => {
+    expect(argShapes('go back')).toEqual([{ type: 'string', value: 'back' }]);
+  });
+
+  it('history: go forward', () => {
+    expect(argShapes('go forward')).toEqual([{ type: 'string', value: 'forward' }]);
+  });
+});
+
+describe('parseGoCommand — deprecated forms (back-compat)', () => {
+  it('url keyword: go to url "/page"', () => {
+    expect(argShapes('go to url "/page"')).toEqual([
+      { type: 'string', value: 'to' },
+      { type: 'string', value: 'url' },
+      { type: 'literal', value: '/page' },
+    ]);
+  });
+
+  it('url keyword without `to`: go url "/page"', () => {
+    expect(argShapes('go url "/page"')).toEqual([
+      { type: 'string', value: 'url' },
+      { type: 'literal', value: '/page' },
+    ]);
+  });
+
+  it('scroll: go to top of #header', () => {
+    expect(argShapes('go to top of #header')).toEqual([
+      { type: 'string', value: 'to' },
+      { type: 'string', value: 'top' },
+      { type: 'string', value: 'of' },
+      { type: 'selector', value: '#header' },
+    ]);
+  });
+
+  it('scroll + instantly: go to top of #header instantly', () => {
+    expect(argShapes('go to top of #header instantly')).toEqual([
+      { type: 'string', value: 'to' },
+      { type: 'string', value: 'top' },
+      { type: 'string', value: 'of' },
+      { type: 'selector', value: '#header' },
+      { type: 'string', value: 'instantly' },
+    ]);
+  });
+
+  it('scroll with `the`: go to bottom of the #el', () => {
+    expect(argShapes('go to bottom of the #el')).toEqual([
+      { type: 'string', value: 'to' },
+      { type: 'string', value: 'bottom' },
+      { type: 'string', value: 'of' },
+      { type: 'string', value: 'the' },
+      { type: 'selector', value: '#el' },
+    ]);
+  });
+
+  it('scroll positive offset: go to top of #el + 50', () => {
+    expect(argShapes('go to top of #el + 50')).toEqual([
+      { type: 'string', value: 'to' },
+      { type: 'string', value: 'top' },
+      { type: 'string', value: 'of' },
+      { type: 'selector', value: '#el' },
+      { type: 'string', value: '+' },
+      { type: 'literal', value: 50 },
+    ]);
+  });
+
+  it('scroll px offset: go to bottom of me - 50px', () => {
+    expect(argShapes('go to bottom of me - 50px')).toEqual([
+      { type: 'string', value: 'to' },
+      { type: 'string', value: 'bottom' },
+      { type: 'string', value: 'of' },
+      { type: 'identifier', value: 'me' },
+      { type: 'string', value: '-' },
+      { type: 'string', value: '50px' },
+    ]);
+  });
+});
+
+describe('parseGoCommand — dispatch across command positions', () => {
+  it('preserves the URL inside a `then` sequence', () => {
+    // The sequence path must route go through the dedicated parser too.
+    expect(argShapes('on click go to /x then add .done')).toEqual([
+      { type: 'string', value: 'to' },
+      { type: 'literal', value: '/x' },
+    ]);
+  });
+
+  it('preserves the URL inside an if/then branch', () => {
+    expect(argShapes('if true then go to /page')).toEqual([
+      { type: 'string', value: 'to' },
+      { type: 'literal', value: '/page' },
+    ]);
+  });
+
+  it('stops at the `and` boundary: go back and log "x"', () => {
+    expect(argShapes('go back and log "x"')).toEqual([{ type: 'string', value: 'back' }]);
+  });
+
+  it('bare `go` parses without crashing', () => {
+    expect(argShapes('go')).toEqual([]);
+  });
+});
+
+describe('parseGoCommand — runtime evaluation contract', () => {
+  // The keyword string nodes must evaluate to their own text and naked URLs to
+  // the reassembled path, so go.ts parseInput sees the flat string array it scans.
+  const evaluator = { evaluate: (n: any, c: any) => evaluateAST(n, c) };
+  const ctx: any = { me: null, variables: {}, locals: new Map() };
+
+  it('go to /about → parseInput args ["to","/about"]', async () => {
+    const node = firstGo('go to /about');
+    const input = await new GoCommand().parseInput({ ...node } as any, evaluator as any, ctx);
+    expect(input.args).toEqual(['to', '/about']);
+  });
+
+  it('go back → parseInput args ["back"]', async () => {
+    const node = firstGo('go back');
+    const input = await new GoCommand().parseInput({ ...node } as any, evaluator as any, ctx);
+    expect(input.args).toEqual(['back']);
+  });
+
+  it('go to url "/page" → parseInput args ["to","url","/page"]', async () => {
+    const node = firstGo('go to url "/page"');
+    const input = await new GoCommand().parseInput({ ...node } as any, evaluator as any, ctx);
+    expect(input.args).toEqual(['to', 'url', '/page']);
+  });
+});

--- a/packages/core/src/parser/command-parsers/navigation-commands.ts
+++ b/packages/core/src/parser/command-parsers/navigation-commands.ts
@@ -1,0 +1,182 @@
+/**
+ * Navigation Command Parsers
+ *
+ * Dedicated parser for the `go` command. `go` has no continuation-keyword
+ * context, so the generic command-arg loop drops its trailing destination
+ * (`go to /page` → the URL is discarded) and folds scroll forms
+ * (`go to top of #el`) into binary expressions. This parser instead emits
+ * `go`'s arguments as a flat, ordered token list that the runtime
+ * ([commands/navigation/go.ts]) consumes directly:
+ *
+ *   - structural keywords (`to`, `url`, `of`, `in new window`, scroll positions,
+ *     `back`) as `string` nodes — they must evaluate to their own text, since an
+ *     unbound identifier evaluates to `undefined` at runtime;
+ *   - naked URLs (`/about`, `https://x.com`) reassembled into a single string
+ *     literal (they don't survive expression parsing — a leading `/` is a binary
+ *     operator);
+ *   - everything else (quoted strings, template literals, variables, selectors)
+ *     via `parsePrimary`.
+ *
+ * Supports the standard hyperscript grammar `go [to] <expression> [in new window]`
+ * and `go back` (https://hyperscript.org/commands/go/), plus the deprecated
+ * `go to url <expr>` and scroll-modifier forms (`go to the top of ... smoothly`)
+ * for back-compat.
+ *
+ * @module parser/command-parsers/navigation-commands
+ */
+
+import type { ParserContext, IdentifierNode } from '../parser-types';
+import type { ASTNode, CommandNode, Token } from '../../types/core';
+import { CommandNodeBuilder } from '../command-node-builder';
+import { isCommandBoundary } from '../helpers/parsing-helpers';
+import { parseBareURLPath } from './utility-commands';
+
+/**
+ * Keywords that structure a `go` command. Matched value-first (via
+ * `resolveKeyword` for multilingual input) and emitted as `string` nodes.
+ */
+const GO_KEYWORDS = new Set([
+  'to',
+  'the',
+  'url',
+  'of',
+  'in',
+  'new',
+  'window',
+  'top',
+  'middle',
+  'bottom',
+  'left',
+  'center',
+  'right',
+  'smoothly',
+  'instantly',
+  'back',
+  'forward',
+]);
+
+/**
+ * Tokens that terminate a naked-URL run. Unlike the fetch terminator this does
+ * NOT stop on arbitrary command tokens, so path segments that happen to be
+ * command words (`/get`, `/add`) stay part of the URL; it stops at `in`
+ * (→ `in new window`) and the command-sequence boundaries.
+ */
+const GO_URL_STOP = new Set([
+  'in',
+  'then',
+  'and',
+  'else',
+  'end',
+  'otherwise',
+  'when',
+  'where',
+  'catch',
+  'finally',
+]);
+
+function isGoURLTerminator(ctx: ParserContext): boolean {
+  return ctx.isAtEnd() || GO_URL_STOP.has(ctx.peek().value);
+}
+
+function stringNode(value: string, tok: Pick<Token, 'start' | 'end' | 'line' | 'column'>): ASTNode {
+  return {
+    type: 'string',
+    value,
+    start: tok.start,
+    end: tok.end,
+    line: tok.line,
+    column: tok.column,
+  } as ASTNode;
+}
+
+/** A naked URL begins with `/`, or a scheme (identifier immediately followed by `:`). */
+function isNakedURLStart(ctx: ParserContext): boolean {
+  const tok = ctx.peek();
+  if (tok.value === '/') return true;
+  if (ctx.checkIdentifierLike()) {
+    const next = ctx.peekAt(1);
+    return !!next && next.value === ':' && next.start === tok.end;
+  }
+  return false;
+}
+
+/**
+ * Parse `go` command arguments as a flat token list.
+ *
+ * @param ctx - Parser context providing access to parser state and methods
+ * @param identifierNode - The `go` identifier node
+ * @returns CommandNode representing the go command
+ */
+export function parseGoCommand(
+  ctx: ParserContext,
+  identifierNode: IdentifierNode
+): CommandNode | null {
+  const args: ASTNode[] = [];
+
+  while (!isCommandBoundary(ctx, ['when', 'where', 'catch', 'finally'])) {
+    const tok = ctx.peek();
+    const canonical = ctx.resolveKeyword(tok.value).toLowerCase();
+
+    // 1. Structural go keyword → flat string arg.
+    if (GO_KEYWORDS.has(canonical)) {
+      ctx.advance();
+      args.push(stringNode(canonical, tok));
+      continue;
+    }
+
+    // 2. Naked URL (/path or scheme://…) → one reassembled string literal.
+    if (isNakedURLStart(ctx)) {
+      const url = parseBareURLPath(ctx, isGoURLTerminator);
+      if (url) {
+        args.push(url);
+        continue;
+      }
+      // Pathological lone `/`: consume it so the loop makes progress.
+      ctx.advance();
+      args.push(stringNode(tok.value, tok));
+      continue;
+    }
+
+    // 3. Scroll offset sign (`+ 50`, `- 50px`) → keep the sign as a string.
+    if (tok.value === '+' || tok.value === '-') {
+      ctx.advance();
+      args.push(stringNode(tok.value, tok));
+      continue;
+    }
+
+    // 4. Number, merging an immediately-adjacent `px` unit into "50px".
+    if (tok.kind === 'number') {
+      ctx.advance();
+      const next = ctx.peek();
+      if (!ctx.isAtEnd() && next.value === 'px' && next.start === tok.end) {
+        const px = ctx.advance();
+        args.push(stringNode(`${tok.value}px`, { ...tok, end: px.end }));
+      } else {
+        args.push({
+          type: 'literal',
+          value: Number(tok.value),
+          raw: tok.value,
+          start: tok.start,
+          end: tok.end,
+          line: tok.line,
+          column: tok.column,
+        } as ASTNode);
+      }
+      continue;
+    }
+
+    // 5. Anything else — quoted string, template literal, variable, selector,
+    //    me/it, parenthesized expression — is a single primary atom.
+    const before = ctx.current;
+    args.push(ctx.parsePrimary());
+    if (ctx.current === before) {
+      // parsePrimary didn't consume (e.g. an error token) — stop rather than spin.
+      break;
+    }
+  }
+
+  return CommandNodeBuilder.fromIdentifier(identifierNode)
+    .withArgs(...args)
+    .endingAt(ctx.getPosition())
+    .build();
+}

--- a/packages/core/src/parser/command-parsers/utility-commands.ts
+++ b/packages/core/src/parser/command-parsers/utility-commands.ts
@@ -20,6 +20,7 @@ import * as controlFlowCommands from './control-flow-commands';
 import * as animationCommands from './animation-commands';
 import * as domCommands from './dom-commands';
 import * as variableCommands from './variable-commands';
+import * as navigationCommands from './navigation-commands';
 
 /**
  * Parse compound command
@@ -72,6 +73,8 @@ export function parseCompoundCommand(
       return animationCommands.parseMeasureCommand(ctx, identifierNode);
     case 'js':
       return parseJsCommand(ctx, identifierNode);
+    case 'go':
+      return navigationCommands.parseGoCommand(ctx, identifierNode);
     case 'tell':
       return parseTellCommand(ctx, identifierNode);
     case 'pick':
@@ -243,15 +246,23 @@ function isFetchURLTerminator(ctx: ParserContext): boolean {
 }
 
 /**
- * Parse a bare (unquoted) URL path starting with '/' (e.g. /api/data, /users/123).
+ * Parse a bare (unquoted) URL path (e.g. /api/data, /users/123, https://x.com).
  * Collects `/`, identifier, and other non-terminator tokens into a string literal.
  * Returns null if the path can't be reconstructed.
+ *
+ * @param isTerminator - predicate marking the token that ends the URL run.
+ *   Defaults to the fetch terminator (stops at `as`/`with`/`{`/command boundary);
+ *   the `go` parser passes its own so path segments that are command words
+ *   (`/get`) stay part of the URL.
  */
-function parseBareURLPath(ctx: ParserContext): ASTNode | null {
+export function parseBareURLPath(
+  ctx: ParserContext,
+  isTerminator: (ctx: ParserContext) => boolean = isFetchURLTerminator
+): ASTNode | null {
   const startPos = ctx.savePosition();
   let path = '';
 
-  while (!ctx.isAtEnd() && !isFetchURLTerminator(ctx)) {
+  while (!ctx.isAtEnd() && !isTerminator(ctx)) {
     path += ctx.advance().value;
   }
 

--- a/packages/core/src/parser/parser-constants.ts
+++ b/packages/core/src/parser/parser-constants.ts
@@ -172,6 +172,10 @@ export const COMPOUND_COMMANDS = new Set([
   'halt',
   'measure',
   'js',
+  // go [to] <url> [in new window] / go back / (deprecated) go to url <u>,
+  // go to <pos> of <el> — keyword-driven; the generic arg loop drops the
+  // trailing URL and folds scroll forms into binary expressions.
+  'go',
   'tell', // tell <target> <command> [<command> ...]
   // pick: 5 variants from upstream _hyperscript (first/last/random/range/match)
   // — keyword-driven, can't be parsed by the generic identifier-plus-args path.


### PR DESCRIPTION
## Problem

`go to /page` (and `go to url "/page"`, `go to https://x.com`, `go back`) lost its **destination** when parsed through the traditional parser — the exact path the AOT interchange adapter uses (`compileSync(code, { traditional: true })` → `fromCoreAST`). `go` had no dedicated parser, so it fell into the generic command-arg loop, which drops the trailing URL (no continuation-keyword context) and folds naked paths into error binary-expressions. And even where the URL survived, interchange role inference never bound a `destination` role (`goSchema.destination`'s `to` marker excludes it from schema-driven positional binding).

Pre-existing bug — surfaced by the #680 semantic go-url arc, which fixed the *semantic* path but not this traditional/interchange layer. The runtime (`commands/navigation/go.ts`) already supported every form; only parsing + interchange were broken.

## Fix (two layers, go-only blast radius)

**Layer 1 — dedicated traditional parser** (`command-parsers/navigation-commands.ts`, new): a flat token-scan emitting `go`'s runtime-contract args — keywords as `string` nodes (they must evaluate to their own text), naked URLs reassembled into one string literal, everything else via `parsePrimary`. Reuses the now-exported `parseBareURLPath` (parameterized with a terminator predicate; `fetch` behavior unchanged) for `/paths` **and** scheme URLs. Wired via `COMPOUND_COMMANDS` + a `parseCompoundCommand` case, so it covers bare statements, `then`-sequences, and `if/then` branches through one dispatch point.

**Layer 2 — explicit `case 'go'` in interchange `inferRoles`** (`ast-utils/interchange/from-core.ts`): maps all three producer shapes (traditional flat args, semantic `compileSync` `modifiers.on`/`method`, buildAST positional literals) plus a `target` fallback → `destination` (+ `method` for the deprecated `url` form), normalizing `back`/`forward` to an identifier node so AOT emits `history.back()`/`forward()`.

Supports the standard hyperscript grammar `go [to] <expr> [in new window]` and `go back` (per https://hyperscript.org/commands/go/); the deprecated `go to url ...` and scroll-modifier forms still parse. `go.ts` is untouched.

## Verification

End-to-end through the exact AOT adapter path (`compileSync(…,{traditional:true})` → `fromCoreAST` → `generateCommand`, fresh dist):

| source | generated |
| --- | --- |
| `go to /page` | `window.location.href = "/page"` |
| `go back` | `history.back()` |
| `go to url "/dash"` | `window.location.href = "/dash"` |
| `go to https://x.com` | `window.location.href = "https://x.com"` |

- Suites green: **core 7251**, **aot-compiler 618**, **intent 80**
- **New tests**: `navigation-commands.test.ts` (all forms + runtime `parseInput` contract + sequence/branch dispatch), `from-core.test.ts` fixtures (all three shapes + target fallback), `go-roles.e2e.test.ts` (the full adapter path)
- Full typecheck clean; browser bundle builds

## Not changed / out of scope

- `go.ts` runtime, the generic arg loop, the AOT `traditional:true` flag, `goSchema`, and `packages/semantic`/`packages/i18n` — so **no multilingual fidelity-baseline coupling** (the interchange path isn't in the corpus).
- Pre-existing runtime quirks noted for follow-up: naked `go to "#section"` routes to scroll rather than hash-nav; `go forward` parses/AOT-compiles but has no `go.ts` runtime branch.

Docs: `HANDOFF_go-interchange-inference.md` marked RESOLVED; the go-url references in `MULTILINGUAL_NEXT_STEPS.md` annotated (the semantic facet was #680).

🤖 Generated with [Claude Code](https://claude.com/claude-code)