### PR TITLE
fix(protocol/typescript): moduleResolution node → bundler (unblocks TS 6/7)

### DIFF
--- a/protocol/typescript/tsconfig.json
+++ b/protocol/typescript/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["ES2020"],
     "strict": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
## Why

The `/protocol/typescript` conformance job fails under a TypeScript major bump (Dependabot #667):

```
tsconfig.json(5,25): error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

`"moduleResolution": "node"` is the `node10` alias — **deprecated in TS 6, removed in TS 7**. This is the same `node10` deprecation flagged in the TS 7 trajectory work (`docs-internal/SPIKE_vite-plus-toolchain.md`), here in the standalone `protocol/typescript` workspace (which has its own dependabot majors group with no TS deferral).

## Fix

Migrate `moduleResolution` to **`"bundler"`** — modern, extensionless-import-compatible, pairs with `module: "ESNext"`. Removes a `node10` blocker on the path to the native compiler.

## Verification (probed locally)

- Typecheck: **0 errors** under both the current TypeScript **and** TS 6.0.3 (the deprecation is gone).
- **140 conformance tests pass.**

Unblocks #667 on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)