### PR TITLE
fix(semantic): render loop/tell body directly, not as a then-chain (canonical-validity 22→17)

### DIFF
--- a/packages/semantic/src/explicit/renderer.ts
+++ b/packages/semantic/src/explicit/renderer.ts
@@ -6,6 +6,7 @@
  */
 
 import type {
+  ActionType,
   SemanticNode,
   EventHandlerSemanticNode,
   CompoundSemanticNode,
@@ -82,7 +83,24 @@ export class SemanticRendererImpl implements ISemanticRenderer {
     }
     const renderedStatements = node.statements.map(stmt => this.render(stmt, language));
     const chainWord = this.getChainWord(node.chainType, language);
-    return renderedStatements.join(` ${chainWord} `);
+    // A loop/tell HEADER takes its body directly — canonical hyperscript rejects a
+    // chain word between the header and its first body command (`repeat 3 times add
+    // …`, not `repeat 3 times then add …`; `tell #panel add …`, not `tell #panel
+    // then add …`). The parser flattens the block into this compound (no
+    // LoopSemanticNode with an attached body reaches the renderer), so suppress the
+    // chain word immediately after any block-header command. A `then` BETWEEN body
+    // commands stays valid, so every other join keeps the chain word. This is the
+    // explicit loop/tell subset of the schema `hasBody` flag — `hasBody` also covers
+    // if/on/async/js/behavior/… which render through other node kinds/paths and must
+    // keep their chain word.
+    const BLOCK_HEADER_ACTIONS = new Set<ActionType>(['repeat', 'for', 'while', 'tell']);
+    let out = renderedStatements[0] ?? '';
+    for (let i = 1; i < renderedStatements.length; i++) {
+      const prev = node.statements[i - 1];
+      const afterBlockHeader = prev.kind === 'command' && BLOCK_HEADER_ACTIONS.has(prev.action);
+      out += (afterBlockHeader ? ' ' : ` ${chainWord} `) + renderedStatements[i];
+    }
+    return out;
   }
 
   /**

--- a/packages/testing-framework/baselines/canonical-validity.json
+++ b/packages/testing-framework/baselines/canonical-validity.json
@@ -2,7 +2,7 @@
   "description": "Allowlist for the canonical-validity gate (packages/testing-framework/src/multilingual/canonical-validity.test.ts). Each id renders to English that the real hyperscript.org parser rejects. A NEW invalid render outside this list, or an allowlisted id that becomes valid, both fail the gate. Shrink this list as renderer fixes land.",
   "note": "These are the ranked worklist for the deferred full renderer sweep; the fetch `from`+quote family was fixed (renderSuppress) and is intentionally NOT here. See docs-internal/HANDOFF_semantic-roundtrip-validity.md § FINDINGS.",
   "corpusCheckedAtGeneration": 133,
-  "validAtGeneration": 111,
+  "validAtGeneration": 116,
   "allowedInvalid": [
     {
       "id": "behavior-draggable",
@@ -85,50 +85,20 @@
     {
       "id": "repeat-for-each",
       "command": "repeat",
-      "error": "Expected 'times' but found 'then'",
-      "reason": "loop/block body rendered with a spurious `then` between header and first command"
-    },
-    {
-      "id": "repeat-forever",
-      "command": "repeat",
-      "error": "Expected 'end' but found 'then'",
-      "reason": "loop/block body rendered with a spurious `then` between header and first command"
+      "error": "Expected 'times' but found 'add'",
+      "reason": "repeat `for`-variant renders `repeat item in .items` — the `for` binder is an optional literal-only group render suppresses (patterns/repeat.ts repeatForInHead); canonical needs `repeat for item in …` / `for item in …` (block-header `then` fixed in renderCompound)"
     },
     {
       "id": "repeat-times",
       "command": "repeat",
-      "error": "Expected 'end' but found 'then'",
-      "reason": "loop/block body rendered with a spurious `then` between header and first command"
-    },
-    {
-      "id": "repeat-until-event",
-      "command": "repeat",
-      "error": "Expected 'end' but found 'then'",
-      "reason": "loop/block body rendered with a spurious `then` between header and first command"
-    },
-    {
-      "id": "repeat-while",
-      "command": "repeat",
-      "error": "Expected 'end' but found 'then'",
-      "reason": "loop/block body rendered with a spurious `then` between header and first command"
+      "error": "Expected either a class reference or attribute expression",
+      "reason": "`add \"<p>Line</p>\" to me` renders `add \"<p>Line</p>\"` — default-`me` destination suppression (renderer.ts) drops the `to me` canonical requires for an `add` of a string literal (block-header `then` fixed in renderCompound)"
     },
     {
       "id": "send-with-detail",
       "command": "send",
       "error": "Expected ':' but found ','",
       "reason": "call-style argument list mangled (`update(value, :, 42)`)"
-    },
-    {
-      "id": "template-literal-list-build",
-      "command": "set",
-      "error": "Expected 'end' but found 'then'",
-      "reason": "compound set/for body rendered with a spurious `then`"
-    },
-    {
-      "id": "tell-other-element",
-      "command": "tell",
-      "error": "Expected 'end' but found 'then'",
-      "reason": "tell block body rendered with a spurious `then`"
     },
     {
       "id": "wait-for-event",


### PR DESCRIPTION
## What

First PR of the **canonical-validity allowlist burndown** (net for the roadmap's build-time `@hyperscript-tools/i18n` transpiler; gate added in #689). Clears **cluster #1** — loop/tell block bodies rendered as `then`-chains.

`renderCompound` (`packages/semantic/src/explicit/renderer.ts`) joined every flattened compound statement with ` then `. When a loop/tell **header** (`repeat`/`for`/`while`/`tell`) is the first statement in the compound, this emits a `then` between the header and its first body command:

- `repeat 3 times then add …` — `Expected 'times'/'end' but found 'then'`
- `tell #panel then add …` — `Expected 'end' but found 'then'`

The real `hyperscript.org` parser rejects these. A loop/tell header takes its body **directly** — no chain word between the header and its first body command (a `then` *between* body commands stays valid; a trailing `end` is optional). The fix suppresses the chain word immediately after any block-header command; every other join is unchanged.

Uses the explicit `{repeat, for, while, tell}` set rather than the schema `hasBody` flag — `hasBody` also covers `if`/`on`/`async`/`js`/`behavior`/… which render through other node kinds/paths and must keep their chain word.

## Result

Allowlist **22 → 17**. Deletes 5 now-valid entries (`repeat-until-event`, `repeat-forever`, `repeat-while`, `template-literal-list-build`, `tell-other-element`).

Two repeat rows stay allowlisted with **updated reasons** — dropping the header-`then` exposes *secondary* render bugs underneath (deferred to the next PR):
- `repeat-times`: `add "<p>Line</p>" to me` → `add "<p>Line</p>"` (default-`me` destination suppression drops a `to me` canonical requires for an `add` of a string literal)
- `repeat-for-each`: `repeat for item in .items` → `repeat item in .items` (the `for` binder is an optional literal-only group render suppresses)

## Verification

- ✅ `canonical-validity` gate green (stale-check demanded the 5 deletions)
- ✅ Semantic suite green (7302 passed)
- ✅ Fidelity ratchet no-regression — `--full --bundle browser-priority --regression` green (renderer-only change; parse-based ratchet doesn't move)
- ✅ Foreign→English production path (`preprocessToEnglish → render`) now round-trips these to canonical-valid English — es/ja `tell` and ja `repeat forever` were invalid before this fix
- ✅ No test updates needed (no test asserted the buggy loop/tell render surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)