### PR TITLE
fix(semantic): canonical-valid render for wait/halt/repeat-for/add-string (validity 17→11)

### DIFF
--- a/packages/semantic/src/explicit/renderer.ts
+++ b/packages/semantic/src/explicit/renderer.ts
@@ -313,11 +313,30 @@ export class SemanticRendererImpl implements ISemanticRenderer {
           // Use default if available
           return null;
         }
-        // The event role of an event handler is the one literal we localize to
-        // the target language (Phase 1b) — scoped here so other role literals
-        // (selectors, string literals) are never touched.
-        if (token.role === 'event' && node.kind === 'event-handler') {
+        // An `event` role names a DOM event — always a bare identifier, never a
+        // quoted string. Render it via renderEventName (localizes for the target
+        // language; identity for en) so `wait for transitionend` / `send click`
+        // stay unquoted. A known DOM event name arrives as a string `literal`
+        // (renderEventName strips the quotes); expression/namespaced events fall
+        // through unchanged. Previously scoped to event-handler nodes only, which
+        // left `wait for {event}` rendering the quoted `wait for "transitionend"`
+        // the canonical parser rejects.
+        if (token.role === 'event') {
           return this.renderEventName(value, language);
+        }
+        // `halt` takes an idiomatic article in canonical hyperscript — `halt the
+        // event` (`halt event` is rejected). The parser strips the leaked article
+        // (skipNoiseWords) so the value is the bare `event` reference; re-add `the`
+        // at render. Scoped to en (the article is English syntax); other languages
+        // render the reference alone.
+        if (
+          language === 'en' &&
+          node.action === 'halt' &&
+          token.role === 'patient' &&
+          value.type === 'reference' &&
+          value.value === 'event'
+        ) {
+          return `the ${this.valueToNaturalString(value, language)}`;
         }
         return this.valueToNaturalString(value, language);
       }
@@ -340,7 +359,18 @@ export class SemanticRendererImpl implements ISemanticRenderer {
           );
           if (destToken) {
             const destValue = node.roles.get('destination');
-            if (destValue?.type === 'reference' && destValue.value === 'me') {
+            // Keep an explicit destination when the patient is string content —
+            // canonical `add "<p>Line</p>" to me` requires it (`add "<p>Line</p>"`
+            // alone is rejected: `add` expects a class/attribute reference). A
+            // class/attribute patient defaults to `me` fine, so it stays suppressed.
+            const patient = node.roles.get('patient');
+            const patientIsStringLiteral =
+              patient?.type === 'literal' && patient.dataType === 'string';
+            if (
+              destValue?.type === 'reference' &&
+              destValue.value === 'me' &&
+              !patientIsStringLiteral
+            ) {
               return null; // Skip rendering default "me" destination
             }
           }

--- a/packages/semantic/src/patterns/repeat.ts
+++ b/packages/semantic/src/patterns/repeat.ts
@@ -156,17 +156,26 @@ const SOV_REPEAT_TIMES: Array<[string, string, string]> = [
  */
 function repeatForInHead(
   language: string,
-  spec: { forWords?: string[]; inWords: string[] }
+  spec: { forWords?: string[]; inWords: string[]; requireForWords?: boolean }
 ): LanguagePattern {
   const tokens: LanguagePattern['template']['tokens'] = [
     { type: 'literal', value: 'repeat' }, // matches the verb's normalized form
   ];
   if (spec.forWords && spec.forWords.length > 0) {
-    tokens.push({
-      type: 'group',
-      optional: true,
-      tokens: spec.forWords.map(w => ({ type: 'literal' as const, value: w })),
-    });
+    if (spec.requireForWords) {
+      // Required (not an optional group) so the binder RENDERS — render suppresses
+      // an optional literal-only group, which dropped the `for` from the en
+      // `repeat for item in …` (invalid canonical `repeat item in …`). Set only
+      // where the source always carries the binder (en); languages whose
+      // transformer drops it in transit keep the optional group below.
+      for (const w of spec.forWords) tokens.push({ type: 'literal', value: w });
+    } else {
+      tokens.push({
+        type: 'group',
+        optional: true,
+        tokens: spec.forWords.map(w => ({ type: 'literal' as const, value: w })),
+      });
+    }
   }
   tokens.push({ type: 'role', role: 'patient', expectedTypes: ['expression', 'reference'] });
   for (const w of spec.inWords) tokens.push({ type: 'literal', value: w });
@@ -192,8 +201,10 @@ function repeatForInHead(
 
 // in-word/for-word surfaces per language (corpus forms; several langs tokenize
 // the in-word as TWO tokens — ja `の 中`, ko `안 에`, qu `uku pi`).
-const FOR_IN_HEADS: Array<[string, { forWords?: string[]; inWords: string[] }]> = [
-  ['en', { forWords: ['for'], inWords: ['in'] }],
+const FOR_IN_HEADS: Array<
+  [string, { forWords?: string[]; inWords: string[]; requireForWords?: boolean }]
+> = [
+  ['en', { forWords: ['for'], inWords: ['in'], requireForWords: true }],
   ['es', { forWords: ['para'], inWords: ['en'] }],
   ['pt', { forWords: ['para'], inWords: ['dentro'] }],
   ['fr', { forWords: ['pour'], inWords: ['en'] }],

--- a/packages/testing-framework/baselines/canonical-validity.json
+++ b/packages/testing-framework/baselines/canonical-validity.json
@@ -2,14 +2,8 @@
   "description": "Allowlist for the canonical-validity gate (packages/testing-framework/src/multilingual/canonical-validity.test.ts). Each id renders to English that the real hyperscript.org parser rejects. A NEW invalid render outside this list, or an allowlisted id that becomes valid, both fail the gate. Shrink this list as renderer fixes land.",
   "note": "These are the ranked worklist for the deferred full renderer sweep; the fetch `from`+quote family was fixed (renderSuppress) and is intentionally NOT here. See docs-internal/HANDOFF_semantic-roundtrip-validity.md § FINDINGS.",
   "corpusCheckedAtGeneration": 133,
-  "validAtGeneration": 116,
+  "validAtGeneration": 122,
   "allowedInvalid": [
-    {
-      "id": "behavior-draggable",
-      "command": "behavior",
-      "error": "Expected 'end' but found 'event'",
-      "reason": "behavior block renders handler/init structure the canonical parser rejects (block-rendering family)"
-    },
     {
       "id": "behavior-removable",
       "command": "behavior",
@@ -47,18 +41,6 @@
       "reason": "event-source handler if-body drops member access / truncates block"
     },
     {
-      "id": "form-submit-prevent",
-      "command": "halt",
-      "error": "Unexpected Token : event",
-      "reason": "`halt the event` renders as `halt event` (article dropped; `halt event` is invalid)"
-    },
-    {
-      "id": "halt-propagation",
-      "command": "halt",
-      "error": "Unexpected Token : event",
-      "reason": "`halt the event` renders as `halt event` (article dropped; `halt event` is invalid)"
-    },
-    {
       "id": "event-key-combo",
       "command": "if",
       "error": "Expected 'end' but found '.shiftKey'",
@@ -83,28 +65,10 @@
       "reason": "object-literal role rendered with braces `with {obj}` that `with` rejects"
     },
     {
-      "id": "repeat-for-each",
-      "command": "repeat",
-      "error": "Expected 'times' but found 'add'",
-      "reason": "repeat `for`-variant renders `repeat item in .items` — the `for` binder is an optional literal-only group render suppresses (patterns/repeat.ts repeatForInHead); canonical needs `repeat for item in …` / `for item in …` (block-header `then` fixed in renderCompound)"
-    },
-    {
-      "id": "repeat-times",
-      "command": "repeat",
-      "error": "Expected either a class reference or attribute expression",
-      "reason": "`add \"<p>Line</p>\" to me` renders `add \"<p>Line</p>\"` — default-`me` destination suppression (renderer.ts) drops the `to me` canonical requires for an `add` of a string literal (block-header `then` fixed in renderCompound)"
-    },
-    {
       "id": "send-with-detail",
       "command": "send",
       "error": "Expected ':' but found ','",
-      "reason": "call-style argument list mangled (`update(value, :, 42)`)"
-    },
-    {
-      "id": "wait-for-event",
-      "command": "wait",
-      "error": "Expected event name",
-      "reason": "`wait for <event>` renders the event name quoted"
+      "reason": "parse-side value corruption: `send update(value: 42)` captured as `update(value, :, 42)` (not a render bug)"
     }
   ]
 }


### PR DESCRIPTION
## What

Second PR of the **canonical-validity allowlist burndown** (stacked on #699). Four render-surface fixes so more corpus English references parse on the real `hyperscript.org` engine.

> **Base is #699's branch** (`fix/render-validity-block-header-then`) — review/merge that first; GitHub retargets this to `main` once #699 lands.

| Fix | Was | Now |
|-----|-----|-----|
| **wait** event role | `wait for "transitionend"` (quoted → rejected) | `wait for transitionend` |
| **halt** article | `halt event` (rejected) | `halt the event` |
| **repeat `for`-binder** | `repeat item in .items` (rejected) | `repeat for item in .items` |
| **add string content** | `add "<p>Line</p>"` (rejected) | `add "<p>Line</p>" to me` |

- **wait**: an `event` role names a DOM event — a bare identifier, never a quoted string. Render every `event` role via `renderEventName` (was scoped to event-handler nodes only); also unquotes `send`/`trigger` event literals.
- **halt**: the parser strips the leaked article (`skipNoiseWords`), so re-add `the` at render for halt's `event` reference (en-scoped — the article is English syntax). *(First tried a schema `markerOverride`, but that collided with the existing article-skip parse logic — reverted to render-only.)*
- **repeat `for`-binder**: the en `repeat for …` head kept `for` in an optional literal-only group render suppresses; emit it as a required literal for en (the source always carries it). Other languages keep the optional group for transformer-dropped binders. Roles captured are identical → ratchet-neutral.
- **add string content**: keep the implicit `to me` when the patient is a string literal (`add` of string content requires a destination). Class/attribute patients still suppress `me`.

## Result

Allowlist **17 → 11**. Clears `wait-for-event`, `halt-propagation`, `repeat-for-each`, `repeat-times`, plus two bonus clears: `form-submit-prevent` and `behavior-draggable` — their halt/wait lines were the last invalid piece, so both now render canonical-valid (if lossy; the gate is validity-only, fidelity is the ratchet's job).

`send-with-detail` stays allowlisted with a corrected reason: it's a **parse-side** value corruption (`send update(value: 42)` → `update(value, :, 42)`), not a render bug — deferred.

## Verification

- ✅ canonical-validity gate green (11 entries left)
- ✅ Semantic suite green (7302 passed) — includes the dedicated halt article-skip tests
- ✅ Fidelity ratchet `--full --bundle browser-priority --regression` green
- ✅ Foreign→English: halt + repeat-for round-trip to valid English. (wait's foreign round-trip is limited by a **pre-existing** en→foreign *translation* gap that drops the event name — `al clic esperar` — orthogonal to this render fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)