### PR TITLE
fix(semantic): render conditionals, object-literal with, bind features (validity 11→3)

### DIFF
--- a/packages/semantic/src/explicit/renderer.ts
+++ b/packages/semantic/src/explicit/renderer.ts
@@ -8,8 +8,10 @@
 import type {
   ActionType,
   SemanticNode,
+  SemanticRole,
   EventHandlerSemanticNode,
   CompoundSemanticNode,
+  ConditionalSemanticNode,
   BehaviorSemanticNode,
   DefSemanticNode,
   SemanticValue,
@@ -18,6 +20,15 @@ import type {
   ReferenceValue,
   PropertyPathValue,
 } from '../types';
+
+/**
+ * Loop/tell block-header commands: their body follows the header directly, with no
+ * chain word between the header and its first body command. The explicit loop/tell
+ * subset of the schema `hasBody` flag — `hasBody` also covers if/on/async/js/
+ * behavior/… which render through their own node kinds/paths and keep their chain
+ * word. Shared by renderCompound and joinStatements.
+ */
+const BLOCK_HEADER_ACTIONS = new Set<ActionType>(['repeat', 'for', 'while', 'tell']);
 // Import from registry for tree-shaking (registry uses directly-registered patterns first)
 import { getPatternsForLanguageAndCommand, tryGetProfile } from '../registry';
 import { getSupportedLanguages as getTokenizerLanguages } from '../tokenizers';
@@ -44,6 +55,12 @@ export class SemanticRendererImpl implements ISemanticRenderer {
     }
     if (node.kind === 'def') {
       return this.renderDef(node as DefSemanticNode, language);
+    }
+    // A conditional carries its branches in thenBranch/elseBranch, never in roles.
+    // Without this the pattern path renders the head only (`if <cond>`) and drops
+    // the body + `end` — the canonical parser then rejects the dangling condition.
+    if (node.kind === 'conditional') {
+      return this.renderConditional(node as ConditionalSemanticNode, language);
     }
 
     const patterns = getPatternsForLanguageAndCommand(language, node.action);
@@ -88,17 +105,63 @@ export class SemanticRendererImpl implements ISemanticRenderer {
     // …`, not `repeat 3 times then add …`; `tell #panel add …`, not `tell #panel
     // then add …`). The parser flattens the block into this compound (no
     // LoopSemanticNode with an attached body reaches the renderer), so suppress the
-    // chain word immediately after any block-header command. A `then` BETWEEN body
-    // commands stays valid, so every other join keeps the chain word. This is the
-    // explicit loop/tell subset of the schema `hasBody` flag — `hasBody` also covers
-    // if/on/async/js/behavior/… which render through other node kinds/paths and must
-    // keep their chain word.
-    const BLOCK_HEADER_ACTIONS = new Set<ActionType>(['repeat', 'for', 'while', 'tell']);
+    // chain word immediately after any block-header command (BLOCK_HEADER_ACTIONS).
+    // A `then` BETWEEN body commands stays valid, so every other join keeps the
+    // chain word.
     let out = renderedStatements[0] ?? '';
     for (let i = 1; i < renderedStatements.length; i++) {
       const prev = node.statements[i - 1];
+      const cur = node.statements[i];
       const afterBlockHeader = prev.kind === 'command' && BLOCK_HEADER_ACTIONS.has(prev.action);
-      out += (afterBlockHeader ? ' ' : ` ${chainWord} `) + renderedStatements[i];
+      // Consecutive top-level `bind` features are separate reactive features, not a
+      // then-chain — `bind $x to #a then bind $x to #b` is rejected (`Unexpected
+      // Token : then` between features). Space-join them (a bind clause is
+      // self-delimiting; canonical accepts both space and newline separation).
+      const betweenBindFeatures =
+        prev.kind === 'command' &&
+        prev.action === 'bind' &&
+        cur.kind === 'command' &&
+        cur.action === 'bind';
+      const sep = afterBlockHeader || betweenBindFeatures ? ' ' : ` ${chainWord} `;
+      out += sep + renderedStatements[i];
+    }
+    return out;
+  }
+
+  /**
+   * Render a conditional (`if <cond> <then-body> [else <else-body>] end`). The
+   * branches carry the block structure, so they close with an explicit `end` (the
+   * canonical block delimiter) — mirrors renderCompound's block awareness. Branch
+   * bodies join like a statement list (a `then` between siblings, none after a
+   * loop/tell header).
+   */
+  private renderConditional(node: ConditionalSemanticNode, language: string): string {
+    const cond = node.roles.get('condition' as SemanticRole);
+    const condStr = cond ? this.valueToNaturalString(cond, language) : '';
+    const parts = [`${this.keyword(language, 'if')} ${condStr}`.trim()];
+    const thenBody = this.joinStatements(node.thenBranch, language);
+    if (thenBody) parts.push(thenBody);
+    if (node.elseBranch && node.elseBranch.length > 0) {
+      parts.push(this.keyword(language, 'else'), this.joinStatements(node.elseBranch, language));
+    }
+    parts.push(this.keyword(language, 'end'));
+    return parts.join(' ');
+  }
+
+  /**
+   * Join a statement list the way a block body reads: ` then ` between siblings,
+   * but a single space immediately after a loop/tell block header (whose body
+   * follows directly). Shared by renderConditional's branches; renderCompound
+   * keeps its own copy because it also handles the multi-handler and bind-feature
+   * cases.
+   */
+  private joinStatements(statements: readonly SemanticNode[], language: string): string {
+    const rendered = statements.map(s => this.render(s, language));
+    let out = rendered[0] ?? '';
+    for (let i = 1; i < rendered.length; i++) {
+      const prev = statements[i - 1];
+      const afterBlockHeader = prev.kind === 'command' && BLOCK_HEADER_ACTIONS.has(prev.action);
+      out += (afterBlockHeader ? ' ' : ' then ') + rendered[i];
     }
     return out;
   }
@@ -337,6 +400,18 @@ export class SemanticRendererImpl implements ISemanticRenderer {
           value.value === 'event'
         ) {
           return `the ${this.valueToNaturalString(value, language)}`;
+        }
+        // `render <tmpl> with <named-args>` takes a bare `key: value` list, not a
+        // braced object literal — `render #row with {row:$data}` is rejected but
+        // `render #row with row: $data` is valid. The parser captures the args as
+        // an object-literal expression; strip the outer braces for render's `with`
+        // (style) role. NOT applied to fetch's `with {…}`, whose braced options
+        // object IS canonical (different command, so scoped by action).
+        if (node.action === 'render' && token.role === 'style' && value.type === 'expression') {
+          const raw = value.raw.trim();
+          if (raw.startsWith('{') && raw.endsWith('}')) {
+            return raw.slice(1, -1).trim();
+          }
         }
         return this.valueToNaturalString(value, language);
       }

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -5655,12 +5655,29 @@ export class SemanticParserImpl implements ISemanticParser {
    * literals) keep their surface value; for en the two are identical.
    */
   private joinTokenText(toks: readonly LanguageToken[]): string {
-    return toks
-      .map(t =>
-        t.kind === 'keyword' ? ((t as { normalized?: string }).normalized ?? t.value) : t.value
-      )
-      .join(' ')
-      .trim();
+    const textOf = (t: LanguageToken): string =>
+      t.kind === 'keyword' ? ((t as { normalized?: string }).normalized ?? t.value) : t.value;
+    let out = '';
+    for (let i = 0; i < toks.length; i++) {
+      const text = textOf(toks[i]);
+      if (i === 0) {
+        out = text;
+        continue;
+      }
+      // A member access glues to its object with no space (`event.shiftKey`,
+      // `window.scrollY`), but a class selector in a comparison keeps it (`I match
+      // .active`). Both surface as a `.`-prefixed token, so disambiguate by SOURCE
+      // adjacency: glue only when this `.`-token immediately abuts the previous
+      // token in the source (no gap). Without this the condition expression renders
+      // `event .shiftKey`, which the canonical parser reads as two tokens and rejects.
+      const prev = toks[i - 1];
+      const adjacent =
+        prev.position?.end !== undefined &&
+        toks[i].position?.start !== undefined &&
+        prev.position.end === toks[i].position.start;
+      out += (adjacent && text.startsWith('.') ? '' : ' ') + text;
+    }
+    return out.trim();
   }
 
   /** Whether a command pattern matches at the head of the given token slice. */

--- a/packages/testing-framework/baselines/canonical-validity.json
+++ b/packages/testing-framework/baselines/canonical-validity.json
@@ -2,67 +2,19 @@
   "description": "Allowlist for the canonical-validity gate (packages/testing-framework/src/multilingual/canonical-validity.test.ts). Each id renders to English that the real hyperscript.org parser rejects. A NEW invalid render outside this list, or an allowlisted id that becomes valid, both fail the gate. Shrink this list as renderer fixes land.",
   "note": "These are the ranked worklist for the deferred full renderer sweep; the fetch `from`+quote family was fixed (renderSuppress) and is intentionally NOT here. See docs-internal/HANDOFF_semantic-roundtrip-validity.md § FINDINGS.",
   "corpusCheckedAtGeneration": 133,
-  "validAtGeneration": 122,
+  "validAtGeneration": 130,
   "allowedInvalid": [
     {
       "id": "behavior-removable",
       "command": "behavior",
       "error": "Expected 'end' but found 'init'",
-      "reason": "behavior block renders handler/init structure the canonical parser rejects (block-rendering family)"
-    },
-    {
-      "id": "behavior-sortable",
-      "command": "behavior",
-      "error": "Expected 'end' but found 'event'",
-      "reason": "behavior block renders handler/init structure the canonical parser rejects (block-rendering family)"
-    },
-    {
-      "id": "bind-two-way",
-      "command": "bind",
-      "error": "Unexpected Token : then",
-      "reason": "two top-level `bind` features joined with `then` (invalid between features)"
-    },
-    {
-      "id": "fetch-error-handling",
-      "command": "fetch",
-      "error": "Expected 'end' but found '.error'",
-      "reason": "fetch `do not throw` / conditional tail not modeled"
-    },
-    {
-      "id": "window-keydown",
-      "command": "from",
-      "error": "Expected 'end' but found '.ctrlKey'",
-      "reason": "event-source handler if-body drops member access / truncates block"
-    },
-    {
-      "id": "window-scroll",
-      "command": "from",
-      "error": "Expected 'end' but found '.scrollY'",
-      "reason": "event-source handler if-body drops member access / truncates block"
-    },
-    {
-      "id": "event-key-combo",
-      "command": "if",
-      "error": "Expected 'end' but found '.shiftKey'",
-      "reason": "if-condition member access rendered with a space (`event .shiftKey`) + block truncation"
+      "reason": "behavior block with an inline `js(me) … end` block renders handler/init structure the canonical parser rejects (the last behavior-block-structure row; behavior-draggable/sortable cleared via the block-header/halt/conditional fixes)"
     },
     {
       "id": "pick-text-range",
       "command": "pick",
       "error": "Unexpected value: <<<EOF>>>",
       "reason": "pick range-roles dropped (named R1 deferral: pick range-role modeling)"
-    },
-    {
-      "id": "morph-with-template",
-      "command": "render",
-      "error": "Unexpected Token : {",
-      "reason": "object-literal role rendered with braces `with {obj}` that `with` rejects"
-    },
-    {
-      "id": "render-template-with-data",
-      "command": "render",
-      "error": "Unexpected Token : {",
-      "reason": "object-literal role rendered with braces `with {obj}` that `with` rejects"
     },
     {
       "id": "send-with-detail",


### PR DESCRIPTION
## What

Third PR of the **canonical-validity allowlist burndown** (stacked on #700). The structural render cluster — clears **8** entries.

> **Base is #700's branch** — review #699 → #700 → this in order; GitHub retargets to `main` as each lands.

| Fix | Was | Now |
|-----|-----|-----|
| **conditionals** | `if <cond>` (body/branches/`end` dropped) | `if <cond> <then> [else <else>] end` |
| **member access** | `event .shiftKey` (two tokens → rejected) | `event.shiftKey` |
| **render object-literal** | `with {row:$data}` (rejected) | `with row:$data` |
| **bind features** | `bind … then bind …` (rejected) | `bind … bind …` |

- **conditionals**: `render()` had no `conditional` branch, so an `if` rendered head-only and dropped its body, branches, and `end`. Added `renderConditional` emitting the full block (branches join via a shared `joinStatements` helper; `BLOCK_HEADER_ACTIONS` hoisted to module scope).
- **member access**: `joinTokenText` spaced every token. Now a `.`-prefixed token glues to its object only when they're **adjacent in the source** (`position.end === next.start`) — a class selector in a comparison (`I match .active`, a real gap) keeps its space. Verified against the `match .active` regression.
- **render object-literal**: strip the outer braces for `render`'s `with` (style) role. Scoped by action, so fetch's canonical braced `with {…}` options object is untouched.
- **bind**: space-join consecutive top-level `bind` features (a bind clause is self-delimiting).

## Result

Allowlist **11 → 3**. Clears `event-key-combo`, `window-keydown`, `window-scroll`, `fetch-error-handling`, `morph-with-template`, `render-template-with-data`, `bind-two-way`, plus **behavior-sortable** (its handler-block structure was only invalid because the inner `if`s dropped their `end`; `renderConditional` supplies it).

**Remaining 3 are the deliberate residual:**
- `pick-text-range` — named R1 deferral (pick range-role modeling)
- `send-with-detail` — parse-side value corruption (`send update(value: 42)` → `update(value, :, 42)`), not a render bug
- `behavior-removable` — behavior block with an inline `js(me) … end` block (distinct block-structure root cause)

Full burndown across #699 → #700 → this: **22 → 3**.

## Verification

- ✅ canonical-validity gate green (3 entries left)
- ✅ Semantic suite green (7302 passed) — includes the `match .active` selector-spacing case
- ✅ Fidelity ratchet `--full --bundle browser-priority --regression` green (member-access glue is language-invariant + position-driven; render changes are parse-neutral)
- ✅ Foreign→English: conditionals + bind round-trip to valid English in es/ja. (render's ja round-trip hits a **pre-existing** en→foreign translation gap that drops the named-arg key — orthogonal to this render fix; es works.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)