### PR TITLE
fix(semantic): reconstruct call args verbatim, not comma-rejoined (send detail; validity 3→2)

### DIFF
--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -1886,9 +1886,18 @@ export class PatternMatcher {
 
     const mark = tokens.mark();
     tokens.advance(); // function name
-    tokens.advance(); // (
+    const openParen = tokens.advance(); // (
 
-    const args: string[] = [];
+    // Reconstruct the parenthesized content VERBATIM by source adjacency rather
+    // than collecting tokens and re-joining with `, `. The tokenizer splits the
+    // call into separate tokens (`value` `:` `42`), and the old comma-rejoin
+    // assumed a positional arg list — so a named-argument / detail call
+    // `update(value: 42)` came out as `update(value, :, 42)` (the `:` became a
+    // phantom arg). Adjacency-joining preserves every shape: `a, b` stays `a, b`,
+    // `value: 42` stays `value: 42` (a token glues to the previous when it abuts
+    // it in the source, else a single space separates them).
+    let content = '';
+    let prevEnd = openParen.position?.end;
     let closed = false;
     let guard = 0;
     while (!tokens.isAtEnd() && guard++ < PatternMatcher.MAX_METHOD_ARGS + 2) {
@@ -1899,11 +1908,9 @@ export class PatternMatcher {
         closed = true;
         break;
       }
-      if (argToken.value === ',') {
-        tokens.advance();
-        continue;
-      }
-      args.push(argToken.value);
+      const adjacent = prevEnd !== undefined && argToken.position?.start === prevEnd;
+      content += (content === '' || adjacent ? '' : ' ') + argToken.value;
+      prevEnd = argToken.position?.end;
       tokens.advance();
     }
 
@@ -1912,7 +1919,7 @@ export class PatternMatcher {
       return null;
     }
 
-    return { type: 'expression', raw: `${token.value}(${args.join(', ')})` } as SemanticValue;
+    return { type: 'expression', raw: `${token.value}(${content})` } as SemanticValue;
   }
 
   /**

--- a/packages/testing-framework/baselines/canonical-validity.json
+++ b/packages/testing-framework/baselines/canonical-validity.json
@@ -2,7 +2,7 @@
   "description": "Allowlist for the canonical-validity gate (packages/testing-framework/src/multilingual/canonical-validity.test.ts). Each id renders to English that the real hyperscript.org parser rejects. A NEW invalid render outside this list, or an allowlisted id that becomes valid, both fail the gate. Shrink this list as renderer fixes land.",
   "note": "These are the ranked worklist for the deferred full renderer sweep; the fetch `from`+quote family was fixed (renderSuppress) and is intentionally NOT here. See docs-internal/HANDOFF_semantic-roundtrip-validity.md § FINDINGS.",
   "corpusCheckedAtGeneration": 133,
-  "validAtGeneration": 130,
+  "validAtGeneration": 131,
   "allowedInvalid": [
     {
       "id": "behavior-removable",
@@ -15,12 +15,6 @@
       "command": "pick",
       "error": "Unexpected value: <<<EOF>>>",
       "reason": "pick range-roles dropped (named R1 deferral: pick range-role modeling)"
-    },
-    {
-      "id": "send-with-detail",
-      "command": "send",
-      "error": "Expected ':' but found ','",
-      "reason": "parse-side value corruption: `send update(value: 42)` captured as `update(value, :, 42)` (not a render bug)"
     }
   ]
 }


### PR DESCRIPTION
## What

Fourth PR of the **canonical-validity allowlist burndown** (stacked on #701). A parse-side fix for `send-with-detail`.

> **Base is #701's branch** — review #699 → #700 → #701 → this in order.

`tryMatchBareCallExpression` (`packages/semantic/src/parser/pattern-matcher.ts`) collected the tokens inside a bare `name(…)` call and re-joined them with `', '`, assuming a **positional comma-separated arg list**. A named-argument / detail call tokenizes as `name` `(` `value` `:` `42` `)`, so the `:` became a phantom argument:

```
send update(value: 42) to #target  →  send update(value, :, 42) to #target   ✗ (Expected ':' but found ',')
```

Now the parenthesized content is reconstructed **verbatim by source adjacency** — the same principle as the `joinTokenText` member-access fix in #701: a token glues to the previous when it abuts it in the source, else a single space separates them. Every shape is preserved:

| Source | Before | After |
|--------|--------|-------|
| `update(value: 42)` | `update(value, :, 42)` ✗ | `update(value: 42)` ✓ |
| `adjustLayout(a, b)` | `adjustLayout(a, b)` | `adjustLayout(a, b)` (unchanged) |
| `validateForm()` | `validateForm()` | `validateForm()` (unchanged) |

## Result

Allowlist **3 → 2**. Only the two deliberate deferrals remain:
- `pick-text-range` — named R1 deferral (pick range-role modeling)
- `behavior-removable` — behavior block with an inline `js(me) … end` block (see note below)

Full burndown across #699 → #700 → #701 → this: **22 → 2**.

## Verification

- ✅ canonical-validity gate green (2 entries left)
- ✅ Semantic suite green (7302 passed) — positional-arg calls unaffected
- ✅ Fidelity ratchet `--full --bundle browser-priority --regression` green
- ✅ Foreign→English: the detail now round-trips **es / ja / zh** → `send update(value: 42) to #target` (not just the en gate) — a real production improvement, since the value was corrupted for every language

🤖 Generated with [Claude Code](https://claude.com/claude-code)