### PR TITLE
fix(semantic): close a js block with end before a following command (validity 2→1)

### DIFF
--- a/packages/semantic/src/explicit/renderer.ts
+++ b/packages/semantic/src/explicit/renderer.ts
@@ -29,6 +29,17 @@ import type {
  * word. Shared by renderCompound and joinStatements.
  */
 const BLOCK_HEADER_ACTIONS = new Set<ActionType>(['repeat', 'for', 'while', 'tell']);
+
+/**
+ * Commands whose captured body is an open-ended block that must be closed by an
+ * explicit `end` when a sibling command follows it. `js` captures its raw
+ * JavaScript body as an expression; without a closing `end` the following
+ * hyperscript (`js foo() then add …`) bleeds into the JS body and the canonical
+ * `js` command's `new Function(...)` throws. A `js` that ends a sequence needs no
+ * `end` (its body runs to the end of the enclosing block). Shared by renderCompound
+ * and joinStatements.
+ */
+const BLOCK_NEEDS_TRAILING_END = new Set<ActionType>(['js']);
 // Import from registry for tree-shaking (registry uses directly-registered patterns first)
 import { getPatternsForLanguageAndCommand, tryGetProfile } from '../registry';
 import { getSupportedLanguages as getTokenizerLanguages } from '../tokenizers';
@@ -122,6 +133,11 @@ export class SemanticRendererImpl implements ISemanticRenderer {
         prev.action === 'bind' &&
         cur.kind === 'command' &&
         cur.action === 'bind';
+      // A `js` (or other open-body) block that is FOLLOWED by a command must close
+      // with `end` first, so its body doesn't swallow the sibling.
+      if (prev.kind === 'command' && BLOCK_NEEDS_TRAILING_END.has(prev.action)) {
+        out += ` ${this.keyword(language, 'end')}`;
+      }
       const sep = afterBlockHeader || betweenBindFeatures ? ' ' : ` ${chainWord} `;
       out += sep + renderedStatements[i];
     }
@@ -161,6 +177,9 @@ export class SemanticRendererImpl implements ISemanticRenderer {
     for (let i = 1; i < rendered.length; i++) {
       const prev = statements[i - 1];
       const afterBlockHeader = prev.kind === 'command' && BLOCK_HEADER_ACTIONS.has(prev.action);
+      if (prev.kind === 'command' && BLOCK_NEEDS_TRAILING_END.has(prev.action)) {
+        out += ` ${this.keyword(language, 'end')}`;
+      }
       out += (afterBlockHeader ? ' ' : ' then ') + rendered[i];
     }
     return out;

--- a/packages/testing-framework/baselines/canonical-validity.json
+++ b/packages/testing-framework/baselines/canonical-validity.json
@@ -2,14 +2,8 @@
   "description": "Allowlist for the canonical-validity gate (packages/testing-framework/src/multilingual/canonical-validity.test.ts). Each id renders to English that the real hyperscript.org parser rejects. A NEW invalid render outside this list, or an allowlisted id that becomes valid, both fail the gate. Shrink this list as renderer fixes land.",
   "note": "These are the ranked worklist for the deferred full renderer sweep; the fetch `from`+quote family was fixed (renderSuppress) and is intentionally NOT here. See docs-internal/HANDOFF_semantic-roundtrip-validity.md § FINDINGS.",
   "corpusCheckedAtGeneration": 133,
-  "validAtGeneration": 131,
+  "validAtGeneration": 132,
   "allowedInvalid": [
-    {
-      "id": "behavior-removable",
-      "command": "behavior",
-      "error": "Expected 'end' but found 'init'",
-      "reason": "behavior block with an inline `js(me) … end` block renders handler/init structure the canonical parser rejects (the last behavior-block-structure row; behavior-draggable/sortable cleared via the block-header/halt/conditional fixes)"
-    },
     {
       "id": "pick-text-range",
       "command": "pick",


### PR DESCRIPTION
## What

Fifth PR of the **canonical-validity allowlist burndown** (stacked on #702). A real bug in native `js … end` rendering, surfaced by the last allowlisted row.

> **Base is #702's branch** — review #699 → #700 → #701 → #702 → this in order.

A `js` command captures its raw JavaScript body as an expression and renders `js <body>`. When another command follows it, canonical hyperscript needs an explicit `end` to close the JS block — without it, the trailing hyperscript bleeds into the JS body and the `js` command's `new Function(...)` throws:

```
on click js doThing() end then add .active to me   (valid input)
  →  on click js doThing() then add .active          ✗ (Unexpected identifier 'then' — invalid JS)
```

Now `end` is emitted after a `js` block whenever a sibling command follows it (in `renderCompound` and the shared `joinStatements` branch-body join). A `js` that ends its sequence needs no `end` (its body runs to the end of the enclosing block), so simple `on click js alert("hi") end` is unaffected.

## Why this one (not the `removable` behavior itself)

Per review guidance, I only took this on because it's a genuine bug in **our** rendering of native `js … end` — not something specific to the questionable, non-native `removable` behavior. The behavior was just the corpus row that exposed it. Confirmed general via `js doThing() end then add .active to me` (a plain two-command handler).

## Result

Allowlist **2 → 1**. `behavior-removable` now renders canonical-valid. Only **`pick-text-range`** remains — the named R1 deferral (pick range-role modeling), intentionally left.

**The burndown is complete: 22 → 1 (the deliberate `pick` deferral).**

## Verification

- ✅ canonical-validity gate green (1 entry: pick)
- ✅ Semantic suite green (7302 passed) — simple/last `js` blocks unaffected
- ✅ Fidelity ratchet `--full --bundle browser-priority --regression` green (render-only)
- ✅ Foreign→English js round-trips valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)