### PR TITLE
fix(semantic): suppress implicit me source, not just destination (remove/take/measure)

### DIFF
--- a/packages/semantic/src/explicit/renderer.ts
+++ b/packages/semantic/src/explicit/renderer.ts
@@ -445,28 +445,29 @@ export class SemanticRendererImpl implements ISemanticRenderer {
           return null;
         }
 
-        // For optional groups with destination role, skip if destination is "me" (the default)
-        // This avoids rendering "on me" / "en yo" when it's implicit
+        // Skip an optional group whose destination/source role is the implicit
+        // `me` default (the parser injects it when unspecified). This avoids the
+        // redundant `on me` / `to me` / `from me` / `of me` — `add .active`, not
+        // `add .active to me`; `remove me`, not `remove me from me`; `measure my x`,
+        // not `measure my x of me`. The `on` event-source renders via its own path,
+        // so it is untouched here.
         if (token.optional) {
-          const destToken = token.tokens.find(
-            (t: any) => t.type === 'role' && t.role === 'destination'
-          );
-          if (destToken) {
-            const destValue = node.roles.get('destination');
+          for (const roleName of ['destination', 'source'] as const) {
+            const roleToken = token.tokens.find(
+              (t: any) => t.type === 'role' && t.role === roleName
+            );
+            if (!roleToken) continue;
+            const roleValue = node.roles.get(roleName);
+            if (roleValue?.type !== 'reference' || roleValue.value !== 'me') continue;
             // Keep an explicit destination when the patient is string content —
             // canonical `add "<p>Line</p>" to me` requires it (`add "<p>Line</p>"`
             // alone is rejected: `add` expects a class/attribute reference). A
             // class/attribute patient defaults to `me` fine, so it stays suppressed.
-            const patient = node.roles.get('patient');
-            const patientIsStringLiteral =
-              patient?.type === 'literal' && patient.dataType === 'string';
-            if (
-              destValue?.type === 'reference' &&
-              destValue.value === 'me' &&
-              !patientIsStringLiteral
-            ) {
-              return null; // Skip rendering default "me" destination
+            if (roleName === 'destination') {
+              const patient = node.roles.get('patient');
+              if (patient?.type === 'literal' && patient.dataType === 'string') continue;
             }
+            return null; // Skip rendering the implicit "me" destination/source
           }
         }
 


### PR DESCRIPTION
## What

A render-quality fix (stacked on #703). The renderer suppressed an implicit `me` **destination** (`add .active`, not `add .active to me`) but not an implicit `me` **source**, so commands whose default target is a `source` role emitted a redundant clause:

| Input | Before | After |
|-------|--------|-------|
| `remove me` | `remove me from me` | `remove me` |
| `remove .active` | `remove .active from me` | `remove .active` |
| `measure my x` | `measure my x of me` | `measure my x` |
| `take .active` | `take .active from me` | `take .active` |

`remove me from me` is also semantically off — it reads as "remove element `me` from within `me`", not "remove `me` from the DOM".

Generalizes the implicit-`me` suppression to cover the `source` role too. Explicit sources (`remove .active from #x`, `take .active from .tabs`) are unchanged; the `add "<str>" to me` string-patient exception still keeps its destination; the `on` event-source renders via its own path so it's untouched. All shortened forms are valid canonical hyperscript.

> These renders were already valid (redundant, not rejected), so the allowlist is unchanged — this is quality, not a burndown step.

## Verification

- ✅ canonical-validity gate green (still 1: `pick`)
- ✅ Semantic suite green (7302 passed) — no test asserted the old `from/of me` renders
- ✅ Fidelity ratchet `--full --regression` green (render-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)