### PR TITLE
chore(tsconfig): remove TS-7-removed compiler options (node10 / downlevelIteration / baseUrl)

### DIFF
--- a/experiments/ssr-support/tsconfig.json
+++ b/experiments/ssr-support/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "module": "ESNext",
     "lib": ["ES2020", "DOM"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "allowJs": true,

--- a/packages/behaviors/tsconfig.json
+++ b/packages/behaviors/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "incremental": false
   },

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
 
     // Output configuration
@@ -28,16 +28,17 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
 
-    // Path mapping for clean imports
-    "baseUrl": "./src",
+    // Path mapping for clean imports. `paths` is resolved relative to this
+    // tsconfig (baseUrl was dropped — deprecated in TS 6.0, removed in TS 7.0),
+    // so each mapping is prefixed with ./src to preserve the previous resolution.
     "paths": {
-      "@/*": ["*"],
-      "@test/*": ["test/*"],
-      "@core/*": ["core/*"],
-      "@commands/*": ["commands/*"],
-      "@expressions/*": ["expressions/*"],
-      "@features/*": ["features/*"],
-      "@types/*": ["types/*"]
+      "@/*": ["./src/*"],
+      "@test/*": ["./src/test/*"],
+      "@core/*": ["./src/core/*"],
+      "@commands/*": ["./src/commands/*"],
+      "@expressions/*": ["./src/expressions/*"],
+      "@features/*": ["./src/features/*"],
+      "@types/*": ["./src/types/*"]
     },
 
     // Advanced options

--- a/packages/framework/tsconfig.json
+++ b/packages/framework/tsconfig.json
@@ -5,10 +5,10 @@
     "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "incremental": false,
-    "downlevelIteration": true
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": [

--- a/packages/planner/tsconfig.json
+++ b/packages/planner/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "incremental": false
   },

--- a/packages/semantic/tsconfig.json
+++ b/packages/semantic/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "incremental": false
   },

--- a/packages/types-browser/tsconfig.json
+++ b/packages/types-browser/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ES2020",
+    "module": "ESNext",
     "lib": ["ES2020", "DOM"],
     "declaration": true,
     "declarationMap": true,
@@ -10,7 +10,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "emitDeclarationOnly": true
   },
   "include": ["src/**/*"],

--- a/packages/vscode-extension/tsconfig.json
+++ b/packages/vscode-extension/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "node16",
+    "moduleResolution": "node16",
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,15 +2,15 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    
+
     // Output configuration
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "removeComments": false,
-    
+
     // Type checking
     "strict": true,
     "noUnusedLocals": true,
@@ -19,19 +19,19 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
-    
+
     // Module resolution
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    
+
     // Advanced options
     "incremental": true,
     "composite": false
   },
-  
+
   "exclude": [
     "node_modules",
     "dist",


### PR DESCRIPTION
## What & why

Prep for the TypeScript 6→7 line (and the move toward Vite+). TS 6.0 promotes three tsconfig deprecations to **build errors** — silenceable only with the temporary `ignoreDeprecations: "6.0"`, which 7.0 removes; 7.0 drops the options entirely. This **migrates off them** rather than silencing, so the configs are TS-7-ready.

This is the root cause of the failing Dependabot **typescript 5.9.3→6.0.3** (#698) and **majors group** (#693) builds:

```
tsconfig.json: error TS5107: Option 'moduleResolution=node10' is deprecated …
tsconfig.json: error TS5101: Option 'downlevelIteration' is deprecated …
```

## Changes

- **`moduleResolution: "node"` (node10) → `"bundler"`** on the 6 stragglers still on it (`tsconfig.base`, `core`, `framework`, `semantic`, `behaviors`, `planner`, plus the `ssr-support` experiment). **30+ packages already use `bundler`** — this aligns the rest. `bundler` matches how the repo actually resolves (tsup/esbuild/rollup, extensionless imports) and is the Vite-native resolver — unlike `node16`/`nodenext`, which would demand `.js` on every relative import (thousands of breakages).
- **`downlevelIteration` dropped** from `framework` — a no-op at its ES2020 target.
- **`baseUrl` removed** from `core`; `paths` rewritten relative to the tsconfig (`./src/*`), preserving the same resolution with **zero code changes** (vitest resolves `@`/`@test` via its own `resolve.alias`).
- **`vscode-extension`** (genuinely CommonJS) → `module`/`moduleResolution: node16` (the TS-7 CJS path); **`types-browser`** (declaration-only) → `module: esnext` so it can pair with `bundler`.
- **`framework`: add `types: ["node"]`** — TS 6.0 stopped auto-including `@types/node`'s globals, surfacing `process` (TS2591) in `logger.ts` once the deprecation errors cleared. framework already depends on `@types/node`; this makes it explicit.

## Should we migrate node→bundler + drop downlevelIteration? — yes

That's exactly this PR. `bundler` is the correct target because `module: "ESNext"` needs a modern resolver, the repo bundles with bundler-style tooling, and it's what Vite uses. `downlevelIteration` is dead weight at ES2020.

## Validation

- ✅ Clean under the current **TypeScript 5.9.3**: typecheck + build + unit tests on every touched package — **framework 798, core 7251, semantic 7302** tests pass.
- ✅ Under **typescript@6.0.3**, the deprecation errors (TS5107/TS5101) are **gone** across framework/core/types-browser/vscode-extension.
- ✅ No deprecated options remain repo-wide (`node10` 0, `downlevelIteration` 0, `baseUrl` 0).

## Not in this PR (follow-up for a full TS-6/7 upgrade)

TS 6.0 also **tightens type-checking** and surfaces ~85 code/config errors unrelated to deprecated options — missing `process`/DOM-lib globals in **semantic (2)**, **compilation-service (10)**, **server-bridge (~70)**, plus **intent-element (3)**. Those need a separate TS-6 type-compat pass before the `vitest`/TS majors Dependabot bumps can go green. (The failing **vitest 4.1.10** PRs #694/#695/#696 are unrelated — a vitest-internal `SyntaxError` regression in test collection.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)