### PR TITLE
feat(testing): foreign-validity infra — R4 canonical-validity ratchet, single-channel validate, committed triage tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,9 +272,9 @@ As of 2026-01-23, all CI testing has been consolidated into a single `.github/wo
 | ---- | ------------------------- | --- | ----------------- | ------------------------------------------------- |
 | 0    | `changes`                 | ✓   | ✓                 | Path classifier (code / protocol / goclient)      |
 | 1    | `build`                   | ✓   | ✓                 | Build all packages once; gated on `code` paths    |
-| 2    | `export-validation`       | ✓   | ✓                 | Verify package.json exports resolve to dist       |
-| 3    | `lint-typecheck`          | ✓   | ✓                 | ESLint + TypeScript checks                        |
-| 4    | `unit-tests`              | ✓   | ✓                 | Vitest tests on Node 24                           |
+| 2    | `export-validation`       | ✓   | —                 | Verify package.json exports resolve to dist       |
+| 3    | `lint-typecheck`          | ✓   | —                 | ESLint + TypeScript checks                        |
+| 4    | `unit-tests`              | ✓   | —                 | Vitest tests on Node 24                           |
 | 5    | `coverage`                | —   | main only         | Codecov upload (already gated to push+main)       |
 | 6    | `browser-tests`           | ✓   | —                 | Playwright; PR-only (slim post-merge)             |
 | 7    | `multilingual-validation` | ✓   | —                 | 20-language sweep; PR-only (slim post-merge)      |
@@ -284,7 +284,7 @@ As of 2026-01-23, all CI testing has been consolidated into a single `.github/wo
 | 10.5 | `go-client`               | ✓   | —                 | `go build` + `go test`; gated on go-client paths  |
 | 11   | `benchmarks`              | —   | main only         | Perf trend tracking (already gated to push+main)  |
 
-The four PR-only jobs already ran against the merged-as-PR code, so re-running them on the post-merge push to main wastes ~60 min runner-time per merge. Merge-skew is caught by `build` + `lint-typecheck` + `unit-tests` (still run on push). For perfect skew detection without duplication, see the merge-queue note in `.github/workflows/ci.yml`.
+The PR-only jobs already ran against the merged-as-PR code (`strict` branch protection means the PR validated the exact merged tree), so re-running them on the post-merge push would be redundant — the push run keeps only `build` + `coverage` + `benchmarks`. For the reasoning see the job comments in `.github/workflows/ci.yml`.
 
 **Triggers:**
 
@@ -327,7 +327,7 @@ the committed baseline:
 > not truth. Current plan + per-arc history:
 > `docs-internal/MULTILINGUAL_NEXT_STEPS.md`.
 
-The `--regression` gate ratchets on **eight** signals (each fails CI; each guarded so
+The `--regression` gate ratchets on **nine** signals (each fails CI; each guarded so
 an un-regenerated baseline never retro-flags — a baseline lacking a signal's field
 yields a 0 delta):
 
@@ -382,10 +382,28 @@ yields a 0 delta):
    bn duration-glue, SOV `in me` qualifier glue, pl/ru/uk `fetch` URL mis-role,
    hi `transition` duration drop, bn/qu/tr behavior trigger events.
 
+9. **canonical-validity ratchet (R4)** — every authored foreign translation is rendered
+   to English and parsed on the real `hyperscript.org` engine; the invalid
+   (pattern, language) pairs are diffed against the committed allowlist
+   (`packages/testing-framework/baselines/foreign-canonical-validity.json`). Both
+   directions fail at tolerance 0: a NEW invalid pair is a validity regression, and a
+   stale entry (an allowlisted pair that now renders valid) must be pruned via
+   `tools/regen-foreign-baseline.ts` in the same change that cleared it. Catches the
+   class R0–R3 cannot: a parse that is role-faithful yet renders English the canonical
+   parser rejects (signals 1–8 never parse the rendered surface). Full mode only;
+   triage failures with `tools/triage-foreign-residual.ts`. The same allowlist backs the
+   standalone vitest gate (`foreign-canonical-validity.test.ts`), so the two cannot
+   disagree; the en-side twin (`canonical-validity.test.ts`, allowlist of exactly 1:
+   `pick-text-range`) remains vitest-only.
+
 None of the recall-based signals can see a regression in the **English reference
 itself** — en defines the reference, so a parser change that truncates every language
 identically (as the top-level-sequence bug did) moves nothing. Only tests catch that.
-(Exception: R3, whose en-corruption failure mode is the all-languages firestorm above.)
+(Exception: R3, whose en-corruption failure mode is the all-languages firestorm above.
+R4 has a related inversion for the RENDERER: a renderer change that corrupts the emitted
+English across languages floods R4 with new invalid pairs at once. A corrupted en
+_reference_ is different — R4's fair denominator silently EXCLUDES pairs whose en raw
+code the canonical parser rejects, so that class still needs the en-side vitest gate.)
 
 After an _intentional_ fidelity change, regenerate the baseline (`--save-baseline`).
 **The baseline must be regenerated against a freshly `populate`d patterns.db** — a

--- a/docs-internal/HANDOFF_foreign-validity-burndown.md
+++ b/docs-internal/HANDOFF_foreign-validity-burndown.md
@@ -45,10 +45,14 @@ Companion scope doc: `docs-internal/EXPRESSION_INTERNAL_TRANSLATION_SCOPE.md`. M
 > All three: exact-2/exact-1 corpus occurrence verified, phantom-safe. Gates: foreign
 > (CLEARED=5, ADDED=0) + en green; fidelity ratchet clean on all 8 signals; semantic
 > suite 7366; test:affected green (domain-toolkit 0-test artifact only).
-> **HARNESS FOOTGUN the recipe below does not state: `loadCanonicalParser`'s validate
-> RETURNS an error array (empty = valid) — it also throws on tokenizer-level unknown
-> tokens, so a try/catch alone misclassifies the error-array failures as VALID (38 of
-> 64 on first run). Check `validate(rendered).length === 0`, and keep the catch.**
+> **HARNESS FOOTGUN (fixed post-Phase-10 by the validity-infra PR): `loadCanonicalParser`'s
+> validate used to have TWO failure channels — it RETURNED an error array (empty = valid)
+> AND threw on tokenizer-level unknown tokens — so a try/catch-only harness misclassified
+> 38/64 pairs as VALID. The contract is now single-channel: validate NEVER throws; the
+> tokenizer throw folds into the returned array as a `threw: …` entry. Check
+> `.length === 0`. The triage harness is also now COMMITTED
+> (`packages/testing-framework/tools/triage-foreign-residual.ts`) — do not rebuild it
+> from a recipe.**
 
 > **PHASE 9 SHIPPED (1 commit `fix/foreign-validity-phase9`, 4 pairs, 2991→2995). It took
 > a path THIS DOC DID NOT LIST — 4 clean value-literal data wins the doc mis-filed as
@@ -528,24 +532,19 @@ change, plausibly the last mechanical win).
 
 ### Reproduce the triage
 
-The gate hides exactly what you need: `checkForeignRenderValidity` assigns
-`rendered = '(threw)'` in its catch, so when `validate()` throws — ~46 of the residual —
-**the render that caused it is discarded**. Render and validate SEPARATELY:
+**The harness is now COMMITTED — do not rebuild it from a recipe:**
 
-```ts
-// packages/testing-framework/triage.ts — delete after
-import Database from 'better-sqlite3';
-import { parseSemantic, render } from '@lokascript/semantic';
-import { loadCanonicalParser } from './src/multilingual/canonical-validity';
-const validate = await loadCanonicalParser();
-const db = new Database('../../packages/patterns-reference/data/patterns.db', { readonly: true });
-const src = (db.prepare(
-  'SELECT hyperscript FROM pattern_translations WHERE code_example_id=? AND language=?'
-).get('behavior-draggable', 'ja') as any).hyperscript;
-const rendered = render(parseSemantic(src, 'ja').node!, 'en');
-console.log(rendered);                       // ← keep this OUT of the try that validates
-try { console.log(validate(rendered)); } catch (e) { console.log('LEAK:', e.message); }
+```bash
+npm run populate --prefix packages/patterns-reference   # fresh DB first
+npx tsx packages/testing-framework/tools/triage-foreign-residual.ts [--detail out.json]
 ```
+
+It renders and validates every allowlisted pair SEPARATELY and clusters by the
+canonical parser's actual complaint (~2 s, no gate). `--detail` dumps
+source/rendered/errors per pair. Since the validity-infra PR, `validate` never
+throws (tokenizer-level `Unknown token` throws fold into the returned error array
+as `threw: …` entries) and the gate reports the render WITH the failure instead
+of discarding it as `(threw)`.
 
 Grep the render for non-ASCII to find the leak — in a 20-line behavior body the bad token
 is one word on one line, and the parser only reports a single CHARACTER.
@@ -597,8 +596,11 @@ sole entry in `baselines/canonical-validity.json`.
 
 ## Preserved follow-ups (from the now-deleted render-validity handoff)
 
-- **Fold validity in as an R4 signal** on the ratchet CLI (`--regression`), so validity
-  is first-class alongside R0–R3.
+- ~~**Fold validity in as an R4 signal** on the ratchet CLI (`--regression`)~~ — **DONE**
+  (validity-infra PR): the CLI's `--regression` now runs the foreign validity check
+  against the committed allowlist as the R4 ratchet (new invalid pair OR stale
+  allowlist entry both fail; full mode only). The en-side check remains vitest-only
+  (its allowlist holds exactly 1 entry, pick-text-range).
 - **Bake the parse-check into the build-time `@hyperscript-tools/i18n` transpiler**
   (roadmap §5).
 
@@ -654,8 +656,8 @@ scratchpad outside the workspace cannot resolve `node_modules`. Delete it after.
   **But `git checkout --` on it reverts to the STALE committed copy**, so the next gate run
   fails for a reason that is not your change. Re-`populate` before any further gate/probe
   work. (Bit Phase 4: a green gate went red purely from the cleanup step.)
-- **`regen-foreign-baseline.ts` reformats the JSON** (explodes single-line arrays), which
-  buries your real diff in churn. Run `npx prettier --write` on the baseline afterwards.
+- ~~**`regen-foreign-baseline.ts` reformats the JSON**~~ — fixed (validity-infra PR): the
+  tool now writes through prettier itself, so a no-change regen produces a zero diff.
 - **Exit-code masking is real.** `cmd > log; echo $?; grep …` reports the GREP's status.
   Read the explicit `EXIT=` line, not the harness's summary.
 - The foreign gate throwing `Unknown token: <char>` IS the signal, not a harness bug.

--- a/packages/testing-framework/src/multilingual/canonical-validity.ts
+++ b/packages/testing-framework/src/multilingual/canonical-validity.ts
@@ -13,10 +13,12 @@
  * renderer. Denominator = inputs the canonical parser already accepts, so a few
  * inherently non-canonical corpus rows never distort the signal.
  *
- * Follow-up (see HANDOFF_semantic-roundtrip-validity.md § Recommendation):
- * fold this as an R4 canonical-validity signal into `multilingual/cli.ts`'s
- * `--regression` gate, and bake the same parse-check into the build-time
- * `@hyperscript-tools/i18n` transpiler so every emitted output is parser-gated.
+ * The FOREIGN-side sibling (foreign-canonical-validity.ts) is folded into
+ * `multilingual/cli.ts`'s `--regression` gate as the R4 canonical-validity
+ * ratchet. This en-side check remains vitest-only (its allowlist holds exactly
+ * one entry, pick-text-range). Remaining follow-up: bake the same parse-check
+ * into the build-time `@hyperscript-tools/i18n` transpiler so every emitted
+ * output is parser-gated.
  */
 
 import { createRequire } from 'node:module';
@@ -25,7 +27,16 @@ import path from 'node:path';
 import { getAllPatterns } from '@hyperfixi/patterns-reference';
 import { parseSemantic, render } from '@lokascript/semantic';
 
-/** Parse `src` on the canonical engine; returns the list of error messages (empty = valid). */
+/**
+ * Parse `src` on the canonical engine; returns the list of error messages
+ * (empty = valid). NEVER throws — this is the whole contract. The canonical
+ * engine has two failure channels (`parse().errors` collects grammar errors,
+ * but the TOKENIZER throws on an unknown character, e.g. a leaked Thai
+ * surface → `Unknown token: เ`), and the split channel misclassified 38/64
+ * residual pairs as valid in a try/catch-only harness before it was folded
+ * into this single array here. Check `.length === 0`; do not wrap in try/catch
+ * expecting invalidity to throw.
+ */
 export type CanonicalValidate = (src: string) => string[];
 
 export interface CanonicalValidityFailure {
@@ -47,15 +58,24 @@ export interface CanonicalValidityResult {
 /**
  * Load the real `hyperscript.org` parser headlessly — resolve the package, then
  * import the sibling prebuilt `_hyperscript.esm.js` by file URL (no DOM shim
- * needed for parsing). `hs.parse(src).errors` COLLECTS errors, it does not throw
- * (except the `js` command's `new Function`, which we don't exercise here).
+ * needed for parsing). `hs.parse(src).errors` collects GRAMMAR errors without
+ * throwing, but the engine still THROWS from the tokenizer on an unknown
+ * character (`Unknown token: <char>` — how a leaked non-ASCII surface presents)
+ * and from the `js` command's `new Function`. Both channels are folded into the
+ * one returned array so callers have a single contract (see CanonicalValidate).
  */
 export async function loadCanonicalParser(): Promise<CanonicalValidate> {
   const require = createRequire(import.meta.url);
   const dir = path.dirname(require.resolve('hyperscript.org')); // …/hyperscript.org/dist
   const esm = path.join(dir, '_hyperscript.esm.js');
   const hs = (await import(pathToFileURL(esm).href)).default;
-  return (src: string) => (hs.parse(src)?.errors ?? []).map((e: { message: string }) => e.message);
+  return (src: string) => {
+    try {
+      return (hs.parse(src)?.errors ?? []).map((e: { message: string }) => e.message);
+    } catch (e) {
+      return ['threw: ' + (e as Error).message.split('\n')[0]];
+    }
+  };
 }
 
 function firstCommand(src: string): string {

--- a/packages/testing-framework/src/multilingual/cli.ts
+++ b/packages/testing-framework/src/multilingual/cli.ts
@@ -490,6 +490,55 @@ async function main(): Promise<void> {
           r.newExecutionFailures.map(id => `${r.language}/${id}`)
         );
 
+        // R4 — canonical-validity ratchet: render every authored foreign
+        // translation to English and parse the result on the real
+        // hyperscript.org engine, diffing the invalid (pattern, language)
+        // pairs against the committed allowlist
+        // (baselines/foreign-canonical-validity.json). Both directions fail:
+        // a NEW invalid pair is a validity regression; a stale entry (an
+        // allowlisted pair that now renders valid) must be pruned in the same
+        // change that cleared it (tools/regen-foreign-baseline.ts). Tolerance
+        // 0 — the render+parse is deterministic against a fresh DB, and the
+        // DB/dist freshness guards above already refused stale inputs. Reuses
+        // checkForeignRenderValidity + the allowlist VERBATIM, so this and the
+        // vitest gate (foreign-canonical-validity.test.ts) cannot disagree.
+        // Full-mode only (quick mode keeps its speed contract) and skipped
+        // with a warning when the allowlist is absent, so a checkout without
+        // the baseline never retro-flags.
+        let validityNewInvalid: string[] = [];
+        let validityStale: string[] = [];
+        let validityChecked = false;
+        if (config.mode !== 'quick') {
+          const validityBaselinePath = path.resolve(
+            path.dirname(fileURLToPath(import.meta.url)),
+            '../../baselines/foreign-canonical-validity.json'
+          );
+          if (!fs.existsSync(validityBaselinePath)) {
+            console.warn(`⚠ R4 validity ratchet skipped: no allowlist at ${validityBaselinePath}.`);
+          } else {
+            const { checkForeignRenderValidity, groupFailuresByPattern } =
+              await import('./foreign-canonical-validity');
+            const allowlist = JSON.parse(fs.readFileSync(validityBaselinePath, 'utf8')) as {
+              allowedInvalid: Record<string, string[]>;
+            };
+            const pairKey = (id: string, lang: string) => `${id}/${lang}`;
+            const allowed = new Set(
+              Object.entries(allowlist.allowedInvalid).flatMap(([id, langs]) =>
+                langs.map(l => pairKey(id, l))
+              )
+            );
+            const validity = await checkForeignRenderValidity();
+            const current = new Set(
+              Object.entries(groupFailuresByPattern(validity.failures)).flatMap(([id, langs]) =>
+                langs.map(l => pairKey(id, l))
+              )
+            );
+            validityNewInvalid = [...current].filter(p => !allowed.has(p)).sort();
+            validityStale = [...allowed].filter(p => !current.has(p)).sort();
+            validityChecked = true;
+          }
+        }
+
         let failed = false;
 
         if (regressed.length > 0) {
@@ -622,13 +671,37 @@ async function main(): Promise<void> {
           failed = true;
         }
 
+        if (validityNewInvalid.length > 0) {
+          console.error(
+            `\n✗ Canonical-validity regression (R4): ${validityNewInvalid.length} foreign ` +
+              `translation(s) now render English the hyperscript.org parser rejects:`
+          );
+          for (const p of validityNewInvalid) console.error(`   ${p}`);
+          console.error(
+            `   (triage with tools/triage-foreign-residual.ts; if the invalidity is ` +
+              `expected, allowlist it via tools/regen-foreign-baseline.ts)`
+          );
+          failed = true;
+        }
+
+        if (validityStale.length > 0) {
+          console.error(
+            `\n✗ Stale validity allowlist (R4): ${validityStale.length} allowlisted ` +
+              `pair(s) now render VALID — prune with tools/regen-foreign-baseline.ts:`
+          );
+          for (const p of validityStale) console.error(`   ${p}`);
+          failed = true;
+        }
+
         if (failed) {
           exitCode = 1;
         } else {
           console.log(
             `\n✓ No regression vs baseline ` +
               `(parse-rate ${REGRESSION_TOLERANCE_PTS}pts, fidelity + correctness + ` +
-              `precision + multiset-recall + role + value + execution ratchets).`
+              `precision + multiset-recall + role + value + execution ratchets` +
+              (validityChecked ? ` + canonical validity (R4)` : '') +
+              `).`
           );
           exitCode = 0;
         }

--- a/packages/testing-framework/src/multilingual/foreign-canonical-validity.ts
+++ b/packages/testing-framework/src/multilingual/foreign-canonical-validity.ts
@@ -111,6 +111,9 @@ export async function checkForeignRenderValidity(opts?: {
         rendered = node ? render(node, 'en') : '(no node)';
         errors = validate(rendered);
       } catch (e) {
+        // parseSemantic/render only — validate never throws (its tokenizer-level
+        // throws fold into the returned array), so an invalid render is reported
+        // WITH the render that caused it, not discarded as '(threw)'.
         rendered = '(threw)';
         errors = ['threw: ' + (e as Error).message.split('\n')[0]];
       }

--- a/packages/testing-framework/tools/regen-foreign-baseline.ts
+++ b/packages/testing-framework/tools/regen-foreign-baseline.ts
@@ -57,8 +57,14 @@ async function main() {
   doc.checkedAtGeneration = result.checked;
   doc.validAtGeneration = result.valid;
   doc.allowedInvalid = grouped;
-  writeFileSync(baselinePath, JSON.stringify(doc, null, 2) + '\n', 'utf8');
-  console.log(`\nWrote ${baselinePath}`);
+  // Write through prettier so the diff shows only the real pair changes —
+  // raw JSON.stringify explodes the single-line language arrays, burying them.
+  const prettier = await import('prettier');
+  const raw = JSON.stringify(doc, null, 2) + '\n';
+  const config = await prettier.resolveConfig(baselinePath);
+  const formatted = await prettier.format(raw, { ...config, filepath: baselinePath });
+  writeFileSync(baselinePath, formatted, 'utf8');
+  console.log(`\nWrote ${baselinePath} (prettier-formatted)`);
 }
 
 main().catch(e => {

--- a/packages/testing-framework/tools/triage-foreign-residual.ts
+++ b/packages/testing-framework/tools/triage-foreign-residual.ts
@@ -1,0 +1,130 @@
+/**
+ * Batch triage of the foreign→English validity residual
+ * -----------------------------------------------------
+ * Renders AND validates every allowlisted (pattern, language) pair SEPARATELY,
+ * then clusters by the canonical parser's actual complaint. This is the fast
+ * inner loop of the validity burndown (HANDOFF_foreign-validity-burndown.md,
+ * § "EFFICIENT ITERATION"): run it (~2 s, no gate), attack the largest true
+ * cluster, re-run for an instant all-pairs delta — it is what refuted the
+ * residual's prose triage in Phases 7, 9, and 10. Previously recreated from a
+ * recipe each phase (and once rebuilt WRONG — see the note on `validate` below);
+ * committed so the correct usage is encoded exactly once.
+ *
+ *   npm run populate --prefix packages/patterns-reference   # fresh DB first
+ *   npx tsx packages/testing-framework/tools/triage-foreign-residual.ts [--detail out.json]
+ *
+ * `validate()` returns an ERROR ARRAY (empty = valid) and never throws — do not
+ * wrap it in try/catch expecting invalidity to throw; a harness that did
+ * misclassified 38/64 residual pairs as VALID (Phase 10). A pair reported VALID
+ * here is a STALE allowlist entry: run tools/regen-foreign-baseline.ts to prune
+ * it, and expect ADDED=0.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { getTranslationsByLanguage, type Translation } from '@hyperfixi/patterns-reference';
+import { parseSemantic, render } from '@lokascript/semantic';
+import { loadCanonicalParser } from '../src/multilingual/canonical-validity';
+
+const baselinePath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../baselines/foreign-canonical-validity.json'
+);
+
+type Status = 'VALID' | 'INVALID' | 'PARSE_NULL' | 'RENDER_THREW' | 'NO_ROW';
+
+interface TriageRow {
+  pattern: string;
+  lang: string;
+  status: Status;
+  /** First canonical-parser complaint (or the render-throw message). */
+  complaint: string;
+  source: string;
+  rendered: string;
+  errors: string[];
+}
+
+async function main() {
+  const detailIdx = process.argv.indexOf('--detail');
+  const detailPath = detailIdx !== -1 ? process.argv[detailIdx + 1] : undefined;
+
+  const allowlist = JSON.parse(readFileSync(baselinePath, 'utf8')) as {
+    allowedInvalid: Record<string, string[]>;
+  };
+  const validate = await loadCanonicalParser();
+
+  // One fetch per language (the allowlist is keyed pattern→langs).
+  const languages = [...new Set(Object.values(allowlist.allowedInvalid).flat())];
+  const byLanguage = new Map<string, Map<string, Translation>>();
+  for (const lang of languages) {
+    const translations = await getTranslationsByLanguage(lang, 500);
+    byLanguage.set(lang, new Map(translations.map(t => [t.codeExampleId, t])));
+  }
+
+  const rows: TriageRow[] = [];
+  for (const [pattern, langs] of Object.entries(allowlist.allowedInvalid)) {
+    for (const lang of langs) {
+      const t = byLanguage.get(lang)?.get(pattern);
+      if (!t) {
+        rows.push({ pattern, lang, status: 'NO_ROW', complaint: '', source: '', rendered: '', errors: [] });
+        continue;
+      }
+      const row: TriageRow = {
+        pattern,
+        lang,
+        status: 'INVALID',
+        complaint: '',
+        source: t.hyperscript,
+        rendered: '',
+        errors: [],
+      };
+      try {
+        const node = parseSemantic(t.hyperscript, lang).node;
+        if (!node) {
+          row.status = 'PARSE_NULL';
+        } else {
+          row.rendered = render(node, 'en');
+          row.errors = validate(row.rendered);
+          row.status = row.errors.length === 0 ? 'VALID' : 'INVALID';
+          row.complaint = row.errors[0] ?? '';
+        }
+      } catch (e) {
+        row.status = 'RENDER_THREW';
+        row.complaint = String((e as Error).message ?? e).split('\n')[0];
+      }
+      rows.push(row);
+    }
+  }
+
+  const byStatus: Record<string, number> = {};
+  for (const r of rows) byStatus[r.status] = (byStatus[r.status] ?? 0) + 1;
+  console.log('=== STATUS SUMMARY ===', JSON.stringify(byStatus));
+  if (byStatus['VALID']) {
+    console.log(
+      `!!! ${byStatus['VALID']} STALE allowlist entries (render valid) — run tools/regen-foreign-baseline.ts`
+    );
+  }
+
+  const clusters = new Map<string, TriageRow[]>();
+  for (const r of rows) {
+    const clusterKey =
+      r.status === 'INVALID' ? r.complaint.slice(0, 120) : `[${r.status}]${r.complaint ? ' ' + r.complaint.slice(0, 100) : ''}`;
+    if (!clusters.has(clusterKey)) clusters.set(clusterKey, []);
+    clusters.get(clusterKey)!.push(r);
+  }
+  console.log('\n=== CLUSTERS (by canonical complaint, largest first) ===');
+  for (const [complaint, group] of [...clusters.entries()].sort((a, b) => b[1].length - a[1].length)) {
+    console.log(`\n--- ${group.length} × ${complaint}`);
+    for (const g of group) console.log(`    ${g.pattern}/${g.lang}`);
+  }
+
+  if (detailPath) {
+    writeFileSync(detailPath, JSON.stringify(rows, null, 2) + '\n', 'utf8');
+    console.log(`\nFull detail (source/rendered/errors per pair) → ${detailPath}`);
+  }
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Infra hardening from the Phase 9/10 validity-burndown retro (follow-up to #726) — one theme: make the foreign→English validity signal first-class and its tooling unmistakable. No parser/renderer behavior changes; no baseline changes (verified byte-identical).

**1. R4 canonical-validity ratchet in the multilingual CLI.** `--regression` now renders every authored foreign translation to English, parses it on the real hyperscript.org engine, and diffs the invalid (pattern, language) pairs against the committed allowlist — a ninth signal beside R0–R3. Both directions fail at tolerance 0: a new invalid pair is a validity regression; a stale allowlist entry must be pruned in the same change that cleared it. Reuses `checkForeignRenderValidity` + the allowlist verbatim, so the CLI and the standalone vitest gate cannot disagree. Full mode only; skipped with a warning if the allowlist is absent.

**2. Single-channel `validate`.** `loadCanonicalParser`'s validate had two failure channels — `parse().errors` collects grammar errors, but the tokenizer *throws* on unknown characters (how a leaked foreign surface presents). A try/catch-only harness misclassified 38/64 residual pairs as VALID during Phase 10. validate now never throws; tokenizer throws fold into the returned array as `threw: …` entries. Side effect: the foreign gate reports an invalid render *with* the render that caused it, instead of discarding it as `(threw)`.

**3. Committed triage harness** (`tools/triage-foreign-residual.ts`): the burndown's fast inner loop (render + validate every allowlisted pair separately, cluster by the canonical parser's actual complaint), previously recreated from a handoff recipe each phase — and once rebuilt wrong (see 2). `--detail out.json` dumps per-pair source/rendered/errors.

**4. `regen-foreign-baseline.ts` writes through prettier** — a no-change regen is now a zero diff instead of exploding the single-line language arrays.

**Docs:** CLAUDE.md ratchet section 8→9 signals (R4 entry incl. its fair-denominator blind spot for corrupted en references); CI job table corrected (export-validation / lint-typecheck / unit-tests are PR-only under strict protection); handoff triage recipe replaced with the committed tool, both fixed footguns struck through.

## Verification

- Full `--regression` run green, success line now reads `… + canonical validity (R4)`.
- Triage tool reproduces the 59-pair residual clustering exactly; zero stale entries.
- No-change `regen-foreign-baseline.ts` run → byte-identical baseline (zero git diff).
- Canonical vitest gates 7/7; testing-framework suite 262 passed; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)