### PR TITLE
feat(hyperscript-tools-i18n): canonical parse-check on the English side (roadmap §5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,6 +509,11 @@ jobs:
       - name: Test i18n
         run: npm test --prefix packages/i18n
 
+      - name: Test hyperscript-tools-i18n
+        # pretest (ensure-fresh + build) builds this package's dist in-job;
+        # its only workspace dep (@lokascript/i18n) comes from build-artifacts.
+        run: npm test --prefix packages/hyperscript-tools-i18n
+
       - name: Test hyperscript-adapter
         run: npm test --prefix packages/hyperscript-adapter
 

--- a/docs-internal/HANDOFF_foreign-validity-burndown.md
+++ b/docs-internal/HANDOFF_foreign-validity-burndown.md
@@ -337,8 +337,10 @@ For the first time in the arc there is NO mis-filed-tractable tail left to probe
 Phase 11 drained it (its four re-filings — th resize "structural", bn `এ` "dict realign",
 zh `执行` "opaque", bn `অথবা` "?" — were the 11th–14th consecutive mis-filings). The
 realistic Phase 12 menu: (a) swap ar/tl in its own PR (design in § "What Phase 11 left"),
-(b) the pick-text-range family (~3 arcs, spike verdict below), (c) the remaining infra
-follow-up (bake the parse-check into the `@hyperscript-tools/i18n` transpiler), or
+(b) the pick-text-range family (~3 arcs, spike verdict below), ~~(c) the remaining infra
+follow-up (bake the parse-check into the `@hyperscript-tools/i18n` transpiler)~~ —
+**DONE for the English side** (`src/validate.ts`, CLI `--check`, Eleventy `parseCheck`;
+foreign-output gating still awaits the v2 semantic transpiler), or
 (d) slot-aware disambiguation research for the blocked copula/exists families — the only
 thing that would move the 24 blocked pairs, and genuinely hard.
 
@@ -370,8 +372,12 @@ probe also REFUTED the "registration ORDER makes ar `is` structurally impossible
 claim: EXTRAS run LAST and override profile entries (`base-tokenizer.ts` ~L553), so
 order is no barrier — but the pair stays blocked on the genuine it/is ambiguity
 (`إذا هو هو "cancel"` = "if it is cancel" — both senses adjacent on one line).**
-Of the two infra follow-ups, R4 is DONE (#727); the remaining one is baking the
-parse-check into the `@hyperscript-tools/i18n` transpiler (roadmap §5).
+Of the two infra follow-ups, R4 is DONE (#727); the second — baking the parse-check
+into the `@hyperscript-tools/i18n` transpiler (roadmap §5) — is DONE for the ENGLISH
+side (`packages/hyperscript-tools-i18n/src/validate.ts` reuses the `loadCanonicalParser`
+recipe; CLI `--check` exits 3, Eleventy `parseCheck: 'off'|'warn'|'error'`, `./validate`
+API). Faithful foreign-OUTPUT gating there still awaits the v2 semantic transpiler (the
+i18n GrammarTransformer's `toEnglish` is the known-weak 8/30 round-trip path).
 
 **Phase 5 registered `document`/`window`/`detail` in one shared Set + 20 profiles — DO NOT
 re-plan it.** It is drift reconciliation (core's `REFERENCE_KEYWORDS` and the parser's
@@ -692,8 +698,13 @@ sole entry in `baselines/canonical-validity.json`.
   against the committed allowlist as the R4 ratchet (new invalid pair OR stale
   allowlist entry both fail; full mode only). The en-side check remains vitest-only
   (its allowlist holds exactly 1 entry, pick-text-range).
-- **Bake the parse-check into the build-time `@hyperscript-tools/i18n` transpiler**
-  (roadmap §5).
+- ~~**Bake the parse-check into the build-time `@hyperscript-tools/i18n` transpiler**
+  (roadmap §5)~~ — **DONE for the English side**: `packages/hyperscript-tools-i18n/src/validate.ts`
+  reuses the `loadCanonicalParser` recipe (self-contained: node builtins + `hyperscript.org`,
+  extraction-ready) to gate the ENGLISH input (`from === 'en'`) and foreign→English output
+  (`to === 'en'`). Surfaces: CLI `--check` (exit 3), Eleventy `parseCheck: 'off'|'warn'|'error'`
+  (default warn), `@hyperscript-tools/i18n/validate` API. Faithful foreign-OUTPUT gating still
+  awaits the v2 semantic-engine transpiler (the i18n GrammarTransformer is lossy in reverse).
 
 ## Probe recipe
 

--- a/docs-internal/HYPERSCRIPT_TOOLS_NEXT_STEPS.md
+++ b/docs-internal/HYPERSCRIPT_TOOLS_NEXT_STEPS.md
@@ -1,0 +1,155 @@
+# hyperscript-tools — Next Steps / Roadmap
+
+_A forward-looking working roadmap for the fork-free **`@hyperscript-tools/*`** family of tooling for
+**original _hyperscript** (hyperscript.org, Big Sky Software), consolidating the observations from the
+2026-07-15 session. Planning lives in this monorepo because the source packages (semantic, i18n, adapter)
+still live here, even though the product ships from `github.com/codetalcott/hyperscript-tools`._
+
+## Context
+
+We rebuilt `@hyperscript-tools/mcp-server` on the **canonical _hyperscript parser** (no regex, no fork
+dependency) and extracted it to its own public repo, with eventual **contribution to Big Sky Software**
+in view. That work established a repeatable pattern — _fork-free tooling built on the real
+`hyperscript.org` engine, validity enforced by the parser itself_ — and surfaced a larger opportunity:
+a **multilingual (SOV/VSO/SVO) layer for original _hyperscript**. This roadmap captures where things
+stand and the sequenced next steps, including the open decisions that need a call before the multilingual
+work starts.
+
+## 1. Shipped
+
+- **`@hyperscript-tools/mcp-server`** — rebuilt parser-backed; moved to
+  **`github.com/codetalcott/hyperscript-tools`** (public npm-workspaces monorepo, CI green). hyperfixi
+  PR **#686** (removal) and docs PR **#86** merged.
+- Properties worth preserving as the family's design DNA:
+  - Runs the real `hyperscript.org` parser **headlessly** (import the sibling `_hyperscript.esm.js` by
+    resolved path; no DOM shim; `safeParse` catches the `js`-command `new Function` throw).
+  - 10 tools; an **inventory drift test** pins the documented command/feature set to the parser's own
+    registry (`internals.createParser(...).commandStart/featureStart`).
+  - Self-contained: depends only on `hyperscript.org` + MCP SDK. No fork coupling.
+
+## 2. Immediate follow-ups (mcp-server handoff)
+
+- **Trusted npm publisher (OIDC provenance)** → point `@hyperscript-tools/mcp-server` at
+  `codetalcott/hyperscript-tools`.
+- **Version reset** from the inherited `2.7.2` to a fresh line before the first publish from the new repo.
+- **Rebuild/deploy hyperfixi-docs** so `_site/tools/index.html` regenerates (PR #86 updated the source
+  `tools/index.md` to the 10-tool surface).
+
+## 3. The multilingual opportunity (feasibility established)
+
+Making **original _hyperscript** run 24-language source (SOV like ja/ko/tr, VSO like ar, SVO) is
+**feasible and largely already built** — the hard linguistic work exists; what remains is packaging,
+engine choice, and fidelity.
+
+- **A working path already exists:** `@lokascript/hyperscript-adapter` patches the stock engine's
+  `runtime.getScript` and rewrites each `_="..."` attribute into an **English hyperscript string**
+  before the lexer sees it. Targets the original engine (not the fork).
+- **Both translation engines are fork-free at runtime.** Runtime chain: `semantic → framework → intent`
+  (+ `nearley`), no `@hyperfixi/core`. The build-time `@lokascript/i18n`'s `@hyperfixi/core` dependency
+  is a **phantom** (JSDoc `@example` only, marked `external`, absent from dist); its whole `dependencies`
+  block is mis-categorized (semantic is test-only; esbuild/happy-dom/vite are build tooling; real deps
+  `zod` + `node-html-parser` are undeclared).
+- **loka-js is not a grammar source** (fixi-family flat keyword swapping; deliberately refuses the parser
+  path). Its one transferable gem: **per-element language resolution** (`data-loka-lang` → nearest `lang`
+  ancestor → `en`) enabling mixed-language pages.
+
+### The decisive empirical finding — engine choice (2026-07-15 spike)
+
+Round-trip `en → translate(lang) → foreign → translate(en) → en′`, then validate `en′` on the **real
+`hyperscript.org` parser**, 30 cases (5 snippets × ja/ko/tr/ar/es/zh):
+
+| Engine | Canonical-valid | Exact round-trip |
+| --- | --- | --- |
+| **i18n `GrammarTransformer`** _(what today's `@hyperscript-tools/i18n` uses)_ | **8/30** | 8/30 |
+| **semantic** _(what the adapter uses)_ | **24/30** | 18/30 |
+
+The i18n engine is badly broken in reverse (dropped commands, unstripped particles `할`/`把`, `into`→`to`,
+scrambled order). The semantic engine's 6 failures are two **identifiable, known R3 residual bugs**: the
+`add … to me` destination role dropped, and `fetch`'s URL literal quoted/`from`-inserted.
+
+**→ A build-time transpiler must wrap the SEMANTIC engine (`parseSemantic → render`), NOT the i18n
+`GrammarTransformer`.** The current `@hyperscript-tools/i18n` wraps the weak engine.
+
+## 4. Fidelity & validity findings
+
+- **No engine-vs-engine gate exists.** The "fidelity ratchet" measures _semantic-parse-of-i18n-output_
+  vs _semantic-parse-of-English_ — the two engines are never asked to agree on a shared artifact.
+- Direct cross-checks are narrow/enumerated: `testing-framework/src/vocab/batch3-roundtrip.test.ts`
+  (~30 patterns), `i18n/src/positional-keyword-drift.test.ts` (emit→tokenize), plus the **un-gated**
+  `patterns-reference/scripts/validate-role-alignment.ts`. i18n's `toEnglish` correctness is essentially
+  untested (the spike shows why: 8/30).
+- **Validity vs corpus split** (re: "we relied on patterns-reference for validity"): the moved
+  mcp-server never used patterns-reference (its validity is the parser + golden corpus + drift test).
+  patterns-reference is the multilingual **corpus + fidelity net**, and it is **fork-coupled**
+  (`@lokascript/semantic` + sqlite). The **canonical-validity check is portable** (just parse with
+  `hyperscript.org`; `verify-engines.ts` already cross-checks against upstream) — the **corpus is not**.
+
+## 5. Recommended roadmap (sequenced)
+
+### Now — finish the MCP-server handoff
+
+Section 2 items (publish provenance, version reset, docs deploy).
+
+### Next — `@hyperscript-tools/i18n` v2: build-time transpiler on the SEMANTIC engine
+
+- **Extract the semantic engine fork-free** (`semantic` + `framework` + `intent` + `nearley`) using the
+  same headless-spike discipline proven for the mcp-server and re-proven for i18n this session.
+- **package.json hygiene** for the extracted package: drop phantom `@hyperfixi/core`, move
+  esbuild/happy-dom/vite/semantic to devDependencies, declare `zod` + `node-html-parser`.
+- **Wrap `parseSemantic → render`** for build-time English→foreign and foreign→English translation.
+- **Bake a canonical-validity gate into CI** — every emitted output must parse on `hyperscript.org`
+  (productionize the spike, or literally call `@hyperscript-tools/mcp-server`'s `validate_hyperscript`).
+  This is the general gate the fork's ratchet lacks, and it's engine-agnostic.
+  - _Status (2026-07-18): the **English side** shipped in the v1 package_ — `packages/hyperscript-tools-i18n/src/validate.ts`
+    reuses the proven headless loader (self-contained: node builtins + `hyperscript.org`, no fork
+    coupling), gating English input (`--from en`) and foreign→English output. Surfaces: CLI `--check`
+    (exit 3), Eleventy `parseCheck: 'off'|'warn'|'error'`, `@hyperscript-tools/i18n/validate` API; the
+    package's tests now run in CI (`unit-tests` job). The **"every emitted output" (faithful
+    foreign-output) half** lands with the semantic-engine v2 below — the v1 GrammarTransformer's
+    `toEnglish` is the known-weak 8/30 round-trip path, so gating its foreign output would be red noise.
+- **Address the 2 known semantic R3 bugs** (destination `to me`, `fetch` URL literal) or gate them.
+
+### Later — runtime + per-element language (ambitious)
+
+- Repackage `hyperscript-adapter` as a `_hyperscript.use()` plugin over the extracted semantic engine.
+- Add loka-js's per-element `lang`-ancestor resolution for mixed-language pages (the real differentiator).
+- Higher fidelity risk (confidence-gating, SOV fallthrough) — do only after the build-time path proves
+  the fidelity story.
+
+## 6. Open decisions (need a call before multilingual work starts)
+
+1. **Corpus strategy** — generate a fork-free test corpus, or export `patterns.db` **data-only** (no
+   `@lokascript/semantic` code) for the new repo to validate against? (Validity is portable; corpus is
+   the coupled part.)
+2. **Build-time first vs runtime first** — recommend build-time (lower fidelity risk, deterministic,
+   CI-gatable).
+3. **Big Sky framing / timing** — when to approach upstream, and whether to pitch mcp-server alone first
+   or mcp-server + multilingual together.
+4. _(Resolved)_ npm scope `@hyperscript-tools/*` is user-owned; the family lives in
+   `codetalcott/hyperscript-tools`.
+
+## 7. Key references
+
+- New repo: `github.com/codetalcott/hyperscript-tools` (mcp-server).
+- Runtime multilingual path:
+  `packages/hyperscript-adapter/src/{slim-preprocessor,hyperscript-renderer,plugin}.ts`.
+- Semantic engine (the one to wrap): `packages/semantic` — `parseSemantic`, `render`, `translate`;
+  fork-free chain `semantic → framework → intent` (+ `nearley`).
+- i18n `GrammarTransformer` (the weak engine, avoid for execution):
+  `packages/i18n/src/grammar/{transformer,types,profiles}.ts`.
+- Fidelity ratchet: `packages/testing-framework/src/multilingual/fidelity.ts`, `orchestrator.ts`.
+- Validity net (fork-coupled):
+  `packages/patterns-reference/scripts/{verify-translations,verify-engines,validate-role-alignment}.ts`.
+- Narrow cross-checks: `testing-framework/src/vocab/batch3-roundtrip.test.ts`,
+  `i18n/src/positional-keyword-drift.test.ts`.
+
+## 8. Verification (reproduce the observations)
+
+- **Engine comparison spike:** for each `en` snippet × lang, `translate(en,'en',lang)` →
+  `translate(foreign,lang,'en')` → parse the result with the canonical `hyperscript.org` esm build;
+  count `errors.length === 0`. Reproduces the 8/30 (i18n) vs 24/30 (semantic) split.
+- **Fork-free extraction spike:** stage a cleaned `package.json` (real runtime deps only), `npm pack`,
+  install in an isolated dir, assert no `@hyperfixi/*` in `node_modules`, run a translate call. (Proven
+  this session for i18n; repeat for the semantic subtree.)
+- **Validity gate prototype:** pipe any translated corpus through `hyperscript.org` `parse` (or the
+  mcp-server `validate_hyperscript`) and fail on non-empty `errors`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9706,7 +9706,6 @@
       "version": "0.9.93",
       "resolved": "https://registry.npmjs.org/hyperscript.org/-/hyperscript.org-0.9.93.tgz",
       "integrity": "sha512-9Lr9SisBgUW5AjeTekwXErZJLlnFFfq8BiXDzaMGpmX8MA64XdSM3MFYDaWsSFj/ALxeWwtteVgWobKn8DYIkA==",
-      "dev": true,
       "license": "BSD 2-Clause",
       "bin": {
         "hyperscript.org": "dist/platform/node-hyperscript.js"
@@ -19743,7 +19742,8 @@
       "version": "2.7.2",
       "license": "MIT",
       "dependencies": {
-        "@lokascript/i18n": "^2.7.2"
+        "@lokascript/i18n": "^2.7.2",
+        "hyperscript.org": "^0.9.93"
       },
       "bin": {
         "hyperscript-i18n": "dist/cli.js"
@@ -20912,6 +20912,7 @@
         "@lokascript/semantic": "^2.7.2"
       },
       "devDependencies": {
+        "@types/node": "^20.0.0",
         "vite": "^8.1.4"
       }
     },

--- a/packages/hyperscript-tools-i18n/README.md
+++ b/packages/hyperscript-tools-i18n/README.md
@@ -21,15 +21,67 @@ HTML structure is preserved.
 
 ### Flags
 
-| Flag            | Description                                                                        |
-| --------------- | ---------------------------------------------------------------------------------- |
-| `--langs`, `-l` | Comma-separated target language codes (`ja,es,ko`).                                |
-| `--out`, `-o`   | Output directory. Defaults to `.`.                                                 |
-| `--from`, `-f`  | Source locale of the input. Defaults to `en`.                                      |
-| `--strict`      | Fail the run on any single attribute that can't be translated. Default is lenient. |
+| Flag            | Description                                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------------ |
+| `--langs`, `-l` | Comma-separated target language codes (`ja,es,ko`).                                              |
+| `--out`, `-o`   | Output directory. Defaults to `.`.                                                               |
+| `--from`, `-f`  | Source locale of the input. Defaults to `en`.                                                    |
+| `--strict`      | Fail the run on any single attribute that can't be translated. Default is lenient.               |
+| `--check`       | Parse-check the English hyperscript on the real engine and exit 3 if any is invalid (see below). |
 
 Inputs may be individual files or directories — every `.html` in a directory
 is processed.
+
+## Canonical parse-check
+
+Every `_="..."` attribute this tool touches on the **English side** can be
+validated against the real [`hyperscript.org`](https://hyperscript.org) parser —
+the same engine the browser runs. This is checked for:
+
+- **input** when translating _from_ English (`--from en`, the default) — catches
+  an invalid canonical source before it ships in all 24 languages, and
+- **output** when a target language is `en` (foreign → English).
+
+Foreign-language _output_ is deliberately **not** round-trip-checked here: this
+package's grammar transformer is lossy in reverse, so a round-trip gate would be
+noise. Faithful foreign-output gating belongs to the semantic-engine transpiler
+(roadmap §5, "later").
+
+By default, invalid English prints a deduped warning and the run continues:
+
+```text
+sample.html: invalid hyperscript (English input -> ja): _="on click qqqq zzzz"
+  - Unexpected Token : qqqq
+```
+
+Pass `--check` to escalate to a build failure (exit code **3**) after all files
+are processed and written:
+
+```bash
+npx @hyperscript-tools/i18n translate src/page.html --langs ja,es --out dist/ --check
+```
+
+**Exit codes:** `0` success · `1` no inputs matched (or `--check` but the parser
+failed to load) · `2` usage error · `3` `--check` found invalid hyperscript.
+
+In the Eleventy plugin, use the `parseCheck` option (`'off' | 'warn' | 'error'`,
+default `'warn'`):
+
+```js
+eleventyConfig.addPlugin(hyperscriptI18n, { parseCheck: 'error' });
+```
+
+Programmatically:
+
+```ts
+import { validateHyperscript } from '@hyperscript-tools/i18n/validate';
+
+const errors = await validateHyperscript('on click toggle .active'); // [] = valid
+```
+
+> **Caveat:** the attribute scanner is a regex over `_="..."`, so hyperscript
+> inside HTML comments or `<script>` bodies is checked too. Warn-by-default keeps
+> that from breaking builds.
 
 ## Eleventy plugin
 

--- a/packages/hyperscript-tools-i18n/package.json
+++ b/packages/hyperscript-tools-i18n/package.json
@@ -19,11 +19,15 @@
     },
     "./cli": {
       "default": "./dist/cli.js"
+    },
+    "./validate": {
+      "types": "./dist/validate.d.ts",
+      "import": "./dist/validate.js"
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts src/cli.ts src/eleventy.ts --format esm --dts --clean",
-    "dev": "tsup src/index.ts src/cli.ts src/eleventy.ts --format esm --dts --watch",
+    "build": "tsup src/index.ts src/cli.ts src/eleventy.ts src/validate.ts --format esm --dts --clean",
+    "dev": "tsup src/index.ts src/cli.ts src/eleventy.ts src/validate.ts --format esm --dts --watch",
     "typecheck": "tsc --noEmit",
     "pretest": "../../scripts/ensure-fresh.sh ../i18n . && npm run build --silent",
     "test": "node --test test/*.test.mjs",
@@ -44,7 +48,8 @@
   "author": "HyperFixi Contributors",
   "license": "MIT",
   "dependencies": {
-    "@lokascript/i18n": "^2.7.2"
+    "@lokascript/i18n": "^2.7.2",
+    "hyperscript.org": "^0.9.93"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/hyperscript-tools-i18n/src/cli.ts
+++ b/packages/hyperscript-tools-i18n/src/cli.ts
@@ -13,7 +13,9 @@
 
 import { mkdirSync, readFileSync, writeFileSync, existsSync, statSync, readdirSync } from 'node:fs';
 import { dirname, join, basename, extname, resolve } from 'node:path';
-import { translateHtml } from './html.js';
+import { translateHtml, checkHtmlInput } from './html.js';
+import { loadValidator, formatParseCheckReport } from './validate.js';
+import type { CanonicalValidate, ParseCheckReport } from './validate.js';
 
 interface Args {
   command: 'translate' | 'help';
@@ -22,6 +24,7 @@ interface Args {
   from: string;
   out: string;
   strict: boolean;
+  check: boolean;
 }
 
 function parseArgs(argv: string[]): Args {
@@ -32,6 +35,7 @@ function parseArgs(argv: string[]): Args {
     from: 'en',
     out: '.',
     strict: false,
+    check: false,
   };
 
   if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') return args;
@@ -52,6 +56,8 @@ function parseArgs(argv: string[]): Args {
       args.from = argv[++i] ?? 'en';
     } else if (a === '--strict') {
       args.strict = true;
+    } else if (a === '--check') {
+      args.check = true;
     } else if (a.startsWith('-')) {
       throw new Error(`Unknown flag: ${a}`);
     } else {
@@ -85,7 +91,7 @@ function printHelp(): void {
   console.log(`hyperscript-i18n — translate _="..." attributes in HTML
 
 Usage:
-  hyperscript-i18n translate <input> [<input> ...] --langs <codes> --out <dir> [--from <code>] [--strict]
+  hyperscript-i18n translate <input> [<input> ...] --langs <codes> --out <dir> [--from <code>] [--strict] [--check]
 
 Options:
   --langs, -l   Comma-separated target language codes (e.g. ja,es,ko).
@@ -93,9 +99,19 @@ Options:
   --from, -f    Source locale of the input. Defaults to 'en'.
   --strict      Fail the run if any single attribute fails to translate.
                 Default is lenient: untranslatable snippets are left in place.
+  --check       Validate the ENGLISH hyperscript on the real hyperscript.org
+                parser (input when --from en; output when a target is en) and
+                exit 3 if any attribute is invalid. Without --check, invalid
+                attributes only print a warning.
 
 Output:
   For each input file foo.html and each lang, writes <out>/foo.<lang>.html.
+
+Exit codes:
+  0  success
+  1  no HTML inputs matched, or --check requested but the parser failed to load
+  2  usage error (bad flags / missing --langs / no inputs)
+  3  --check found invalid hyperscript
 
 Example:
   hyperscript-i18n translate src/patterns.html --langs ja,es,ko --out dist/
@@ -133,14 +149,51 @@ export async function run(argv: string[]): Promise<number> {
 
   mkdirSync(args.out, { recursive: true });
 
+  // Warn is the default, so the validator is always needed unless it fails to
+  // load. A load failure is fatal only under --check; otherwise checks quietly
+  // disable and the run proceeds.
+  let validate: CanonicalValidate | undefined;
+  try {
+    validate = await loadValidator();
+  } catch (err) {
+    const msg = (err as Error).message;
+    if (args.check) {
+      console.error(`--check requested but the canonical parser failed to load: ${msg}`);
+      return 1;
+    }
+    console.warn(`parse-check disabled (could not load hyperscript.org): ${msg}`);
+  }
+
+  const failures: Array<ParseCheckReport & { file: string }> = [];
+  const printedCodes = new Set<string>(); // suppress identical-code warn spam across files/langs
+  const recorderFor =
+    (file: string) =>
+    (report: ParseCheckReport): void => {
+      failures.push({ file, ...report });
+      if (!printedCodes.has(report.code)) {
+        printedCodes.add(report.code);
+        console.warn(`${file}: ${formatParseCheckReport(report)}`);
+      }
+    };
+
   let written = 0;
   for (const file of files) {
     const html = readFileSync(file, 'utf8');
     const stem = basename(file, extname(file));
+    const onInvalid = recorderFor(file);
+
+    // Input check runs ONCE per file (not per lang).
+    if (validate && args.from === 'en') {
+      for (const report of checkHtmlInput(html, validate)) onInvalid(report);
+    }
+
     for (const lang of args.langs) {
       const translated = translateHtml(html, lang, {
         from: args.from,
         lenient: !args.strict,
+        validate, // still drives the OUTPUT check when lang === 'en'
+        checkInput: false, // input already checked once above
+        onInvalid,
       });
       const outPath = join(args.out, `${stem}.${lang}.html`);
       mkdirSync(dirname(outPath), { recursive: true });
@@ -152,6 +205,19 @@ export async function run(argv: string[]): Promise<number> {
   console.log(
     `Wrote ${written} files (${files.length} input × ${args.langs.length} langs) to ${args.out}`
   );
+
+  if (args.check && failures.length > 0) {
+    const fileCount = new Set(failures.map(f => f.file)).size;
+    console.error(
+      `\nParse-check failed: ${failures.length} invalid hyperscript attribute(s) in ${fileCount} file(s):`
+    );
+    for (const f of failures) {
+      console.error(
+        `  ${f.file} [${f.stage}]: ${formatParseCheckReport(f).split('\n').join('\n  ')}`
+      );
+    }
+    return 3;
+  }
   return 0;
 }
 

--- a/packages/hyperscript-tools-i18n/src/eleventy.ts
+++ b/packages/hyperscript-tools-i18n/src/eleventy.ts
@@ -18,17 +18,34 @@
  *   export default function (eleventyConfig) {
  *     eleventyConfig.addPlugin(hyperscriptI18n);
  *   }
+ *
+ * The plugin is ASYNC: when `parseCheck` is on (the default), it awaits the
+ * canonical `hyperscript.org` parser before returning. Eleventy 3 awaits plugin
+ * callbacks passed to `addPlugin`, so the check is active before any template
+ * renders. All three filters are registered SYNCHRONOUSLY before that await, so
+ * an un-awaited caller (or Eleventy 2) still gets working filters — the check
+ * simply activates once the parser finishes loading.
  */
 
 import { translate } from '@lokascript/i18n';
 import { translateHtml, translateHtmlToManyLangs } from './html.js';
 import type { LangCode, TranslateHtmlOptions } from './html.js';
+import { loadValidator, warnInvalidOnce, formatParseCheckReport } from './validate.js';
+import type { CanonicalValidate, ParseCheckReport } from './validate.js';
 
 export interface EleventyPluginOptions {
   /** Default source locale for filters. Defaults to 'en'. */
   defaultFrom?: LangCode;
   /** Default lenient flag for HTML translation. Defaults to true. */
   lenient?: boolean;
+  /**
+   * Canonical parse-check for the ENGLISH side (input when source is 'en';
+   * output when a target is 'en'):
+   *   'off'   — no check
+   *   'warn'  — print a deduped warning for invalid English (default)
+   *   'error' — throw, failing the build
+   */
+  parseCheck?: 'off' | 'warn' | 'error';
   /** Override filter names (in case of collisions in your config). */
   filterNames?: {
     snippet?: string;
@@ -41,32 +58,51 @@ interface EleventyConfig {
   addFilter(name: string, fn: (...args: unknown[]) => unknown): void;
 }
 
-export default function hyperscriptI18nPlugin(
+export default async function hyperscriptI18nPlugin(
   eleventyConfig: EleventyConfig,
   options: EleventyPluginOptions = {}
-): void {
+): Promise<void> {
   const defaultFrom = options.defaultFrom ?? 'en';
   const lenient = options.lenient ?? true;
+  const parseCheck = options.parseCheck ?? 'warn';
   const names = {
     snippet: options.filterNames?.snippet ?? 'translateHs',
     snippetMany: options.filterNames?.snippetMany ?? 'translateHsAll',
     html: options.filterNames?.html ?? 'translateHsHtml',
   };
 
+  // Assigned once the parser resolves below; the filters close over it.
+  let validate: CanonicalValidate | undefined;
+
+  const check = (code: string, stage: 'input' | 'output', from: string, to: string): void => {
+    if (!validate) return;
+    const errors = validate(code);
+    if (errors.length === 0) return;
+    const report: ParseCheckReport = { stage, code, errors, from, to };
+    if (parseCheck === 'error')
+      throw new Error(`[hyperscript-i18n] ${formatParseCheckReport(report)}`);
+    warnInvalidOnce(report);
+  };
+
   eleventyConfig.addFilter(names.snippet, (input: unknown, to: unknown, from: unknown) => {
     if (typeof input !== 'string' || typeof to !== 'string') return input;
     const source = typeof from === 'string' ? from : defaultFrom;
     if (source === to) return input;
+    if (source === 'en') check(input, 'input', source, to); // before the try — 'error' must escape
+    let out: string;
     try {
-      return translate(input, source, to);
+      out = translate(input, source, to);
     } catch {
       return lenient ? input : '';
     }
+    if (to === 'en') check(out, 'output', source, to); // after the try — same reason
+    return out;
   });
 
   eleventyConfig.addFilter(names.snippetMany, (input: unknown, langs: unknown, from: unknown) => {
     if (typeof input !== 'string' || !Array.isArray(langs)) return {};
     const source = typeof from === 'string' ? from : defaultFrom;
+    if (source === 'en') check(input, 'input', source, '*'); // once, before the lang loop
     const out: Record<string, string> = {};
     for (const lang of langs) {
       if (typeof lang !== 'string') continue;
@@ -78,7 +114,9 @@ export default function hyperscriptI18nPlugin(
         out[lang] = translate(input, source, lang);
       } catch {
         out[lang] = lenient ? input : '';
+        continue;
       }
+      if (lang === 'en') check(out[lang], 'output', source, 'en');
     }
     return out;
   });
@@ -88,9 +126,28 @@ export default function hyperscriptI18nPlugin(
     const opts: TranslateHtmlOptions = {
       from: typeof from === 'string' ? from : defaultFrom,
       lenient,
+      validate: parseCheck === 'off' ? undefined : validate,
+      checkInput: true,
+      onInvalid: parseCheck === 'error' ? 'error' : 'warn',
     };
     return translateHtml(html, to, opts);
   });
+
+  if (parseCheck !== 'off') {
+    try {
+      validate = await loadValidator();
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (parseCheck === 'error') {
+        throw new Error(
+          `[hyperscript-i18n] parseCheck 'error' but the canonical parser failed to load: ${msg}`
+        );
+      }
+      console.warn(
+        `[hyperscript-i18n] parse-check disabled (could not load hyperscript.org): ${msg}`
+      );
+    }
+  }
 }
 
 export { translateHtml, translateHtmlToManyLangs };

--- a/packages/hyperscript-tools-i18n/src/html.ts
+++ b/packages/hyperscript-tools-i18n/src/html.ts
@@ -5,11 +5,21 @@
  * attributes, translates each from a source locale to a target locale, and
  * returns the rewritten HTML. The grammar transformer doesn't know about HTML;
  * this module is the glue.
+ *
+ * Optionally parse-checks the ENGLISH side against the real `hyperscript.org`
+ * engine (see ./validate): the input when `from === 'en'` and the output when
+ * `to === 'en'`. The check only runs when a `validate` function is supplied, so
+ * existing callers see no behaviour change.
  */
 
 import { translate } from '@lokascript/i18n';
+import { formatParseCheckReport, warnInvalidOnce } from './validate.js';
+import type { CanonicalValidate, ParseCheckReport } from './validate.js';
 
 export type LangCode = string;
+
+/** What to do with an invalid-English report. */
+export type OnInvalid = 'warn' | 'error' | ((report: ParseCheckReport) => void);
 
 export interface TranslateHtmlOptions {
   /** Source locale of the input HTML's `_=` attributes. Defaults to 'en'. */
@@ -20,6 +30,18 @@ export interface TranslateHtmlOptions {
    * whole page build.
    */
   lenient?: boolean;
+  /**
+   * Canonical validator (from `loadValidator()`). When absent, no parse-check
+   * runs and behaviour is unchanged.
+   */
+  validate?: CanonicalValidate;
+  /** What to do with an invalid-English report. Default 'warn' (deduped console.warn). */
+  onInvalid?: OnInvalid;
+  /**
+   * Set false when the caller already validated the English input (as
+   * `translateHtmlToManyLangs` and the CLI do). Default true.
+   */
+  checkInput?: boolean;
 }
 
 const ATTR_PATTERNS: ReadonlyArray<RegExp> = [
@@ -28,6 +50,47 @@ const ATTR_PATTERNS: ReadonlyArray<RegExp> = [
   /(_\s*=\s*`)([^`]+)(`)/g,
 ];
 
+/**
+ * Every `_=` attribute body in `html` (double/single/backtick quoted), deduped,
+ * in document order.
+ */
+export function extractHyperscriptAttributes(html: string): string[] {
+  const seen = new Set<string>();
+  for (const pattern of ATTR_PATTERNS) {
+    // matchAll on a /g regex does not mutate lastIndex, so reusing the shared patterns is safe.
+    for (const m of html.matchAll(pattern)) {
+      seen.add(m[2]);
+    }
+  }
+  return [...seen];
+}
+
+/**
+ * Validate every English `_=` attribute body of `html`; returns a report for
+ * each invalid one (stage 'input').
+ */
+export function checkHtmlInput(
+  html: string,
+  validate: CanonicalValidate,
+  to: LangCode = '*'
+): ParseCheckReport[] {
+  const reports: ParseCheckReport[] = [];
+  for (const code of extractHyperscriptAttributes(html)) {
+    const errors = validate(code);
+    if (errors.length > 0) {
+      reports.push({ stage: 'input', code, errors, from: 'en', to });
+    }
+  }
+  return reports;
+}
+
+function dispatch(report: ParseCheckReport, onInvalid: OnInvalid): void {
+  if (typeof onInvalid === 'function') onInvalid(report);
+  else if (onInvalid === 'error')
+    throw new Error(`[hyperscript-i18n] ${formatParseCheckReport(report)}`);
+  else warnInvalidOnce(report);
+}
+
 export function translateHtml(
   html: string,
   to: LangCode,
@@ -35,19 +98,33 @@ export function translateHtml(
 ): string {
   const from = options.from ?? 'en';
   const lenient = options.lenient ?? true;
+  const { validate } = options;
+  const onInvalid = options.onInvalid ?? 'warn';
 
   if (from === to) return html;
+
+  if (validate && options.checkInput !== false && from === 'en') {
+    for (const report of checkHtmlInput(html, validate, to)) dispatch(report, onInvalid);
+  }
 
   let out = html;
   for (const pattern of ATTR_PATTERNS) {
     out = out.replace(pattern, (_match, before: string, body: string, after: string) => {
+      let translated: string;
       try {
-        const translated = translate(body, from, to);
-        return `${before}${translated}${after}`;
+        translated = translate(body, from, to);
       } catch (err) {
         if (lenient) return `${before}${body}${after}`;
         throw err;
       }
+      // Output check sits OUTSIDE the lenient try/catch so 'error' mode escapes.
+      if (validate && to === 'en') {
+        const errors = validate(translated);
+        if (errors.length > 0) {
+          dispatch({ stage: 'output', code: translated, errors, from, to }, onInvalid);
+        }
+      }
+      return `${before}${translated}${after}`;
     });
   }
   return out;
@@ -58,9 +135,20 @@ export function translateHtmlToManyLangs(
   langs: ReadonlyArray<LangCode>,
   options: TranslateHtmlOptions = {}
 ): Map<LangCode, string> {
+  const from = options.from ?? 'en';
+  let perLang = options;
+
+  // Check the (shared) English input once, then suppress the per-lang re-check.
+  if (options.validate && options.checkInput !== false && from === 'en') {
+    for (const report of checkHtmlInput(html, options.validate)) {
+      dispatch(report, options.onInvalid ?? 'warn');
+    }
+    perLang = { ...options, checkInput: false };
+  }
+
   const out = new Map<LangCode, string>();
   for (const lang of langs) {
-    out.set(lang, translateHtml(html, lang, options));
+    out.set(lang, translateHtml(html, lang, perLang));
   }
   return out;
 }

--- a/packages/hyperscript-tools-i18n/src/index.ts
+++ b/packages/hyperscript-tools-i18n/src/index.ts
@@ -8,5 +8,13 @@
 
 export { translate, toLocale, toEnglish, GrammarTransformer } from '@lokascript/i18n';
 
-export { translateHtml, translateHtmlToManyLangs } from './html.js';
-export type { LangCode, TranslateHtmlOptions } from './html.js';
+export {
+  translateHtml,
+  translateHtmlToManyLangs,
+  extractHyperscriptAttributes,
+  checkHtmlInput,
+} from './html.js';
+export type { LangCode, TranslateHtmlOptions, OnInvalid } from './html.js';
+
+export { loadValidator, validateHyperscript, formatParseCheckReport } from './validate.js';
+export type { CanonicalValidate, ParseCheckReport } from './validate.js';

--- a/packages/hyperscript-tools-i18n/src/validate.ts
+++ b/packages/hyperscript-tools-i18n/src/validate.ts
@@ -1,0 +1,103 @@
+/**
+ * Canonical parse-check.
+ *
+ * Loads the REAL `hyperscript.org` engine headlessly (parse-only needs no DOM)
+ * and exposes a validate function that NEVER throws. The engine has two failure
+ * channels: `parse().errors` COLLECTS grammar errors, but the tokenizer THROWS
+ * on an unknown character (e.g. a leaked non-ASCII surface → `Unknown token: เ`)
+ * and the `js` command's `new Function` throws on invalid JavaScript. Both
+ * throws are folded into the returned array so callers have one contract —
+ * check `.length === 0`, never wrap in try/catch expecting invalidity to throw.
+ *
+ * Self-contained on purpose: node builtins + `hyperscript.org` only, no
+ * `@lokascript/*` or `@hyperfixi/*` imports, so the package stays extraction-ready.
+ */
+
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+/** Parse `src` on the canonical engine; returns error messages (empty = valid). Never throws. */
+export type CanonicalValidate = (src: string) => string[];
+
+export interface ParseCheckReport {
+  /** 'input' = English source before translating; 'output' = English produced from a foreign source. */
+  stage: 'input' | 'output';
+  /** The invalid English hyperscript. */
+  code: string;
+  /** Canonical parser error messages (first line each). */
+  errors: string[];
+  /** Source locale of the translate call ('en' for stage 'input'). */
+  from: string;
+  /** Target locale ('en' for stage 'output'; '*' for an aggregated input check). */
+  to: string;
+}
+
+interface HyperscriptApi {
+  version?: string;
+  parse: (src: string) => { errors?: Array<{ message: string }> } | undefined;
+}
+
+let cached: Promise<CanonicalValidate> | undefined;
+
+/**
+ * Load (once, module-cached) the canonical validator. Resolve `hyperscript.org`,
+ * then import the sibling prebuilt `_hyperscript.esm.js` by file URL. Rejects if
+ * the package cannot be loaded or does not expose `parse()`.
+ */
+export function loadValidator(): Promise<CanonicalValidate> {
+  if (!cached) {
+    cached = (async () => {
+      const require = createRequire(import.meta.url);
+      // Package root resolves to the IIFE build; the unexported ESM build sits beside it.
+      const iife = require.resolve('hyperscript.org');
+      const esm = path.join(path.dirname(iife), '_hyperscript.esm.js');
+      const mod = (await import(pathToFileURL(esm).href)) as {
+        default?: HyperscriptApi;
+      } & HyperscriptApi;
+      const hs = mod.default ?? mod;
+      if (typeof hs?.parse !== 'function') {
+        throw new Error(
+          'Loaded hyperscript.org but it did not expose parse(); the package layout may have changed.'
+        );
+      }
+      return (src: string): string[] => {
+        try {
+          return (hs.parse(src)?.errors ?? []).map(e => e.message.split('\n')[0]);
+        } catch (e) {
+          return ['threw: ' + (e as Error).message.split('\n')[0]];
+        }
+      };
+    })();
+  }
+  return cached;
+}
+
+/** Convenience: load (cached) and validate in one call. */
+export async function validateHyperscript(src: string): Promise<string[]> {
+  return (await loadValidator())(src);
+}
+
+/** Multi-line human-readable rendering of a report (head line + one `  - <error>` line each). */
+export function formatParseCheckReport(r: ParseCheckReport): string {
+  const code = r.code.length > 80 ? r.code.slice(0, 77) + '...' : r.code;
+  const where = r.stage === 'input' ? `English input -> ${r.to}` : `English output <- ${r.from}`;
+  return [`invalid hyperscript (${where}): _="${code}"`, ...r.errors.map(e => `  - ${e}`)].join(
+    '\n'
+  );
+}
+
+const warned = new Set<string>();
+
+/** Default warn printer; dedupes by `r.code` per process. Returns true if it printed. */
+export function warnInvalidOnce(r: ParseCheckReport): boolean {
+  if (warned.has(r.code)) return false;
+  warned.add(r.code);
+  console.warn(`[hyperscript-i18n] ${formatParseCheckReport(r)}`);
+  return true;
+}
+
+/** @internal test hook — clears the per-process warn-dedupe set. */
+export function __resetParseCheckWarnings(): void {
+  warned.clear();
+}

--- a/packages/hyperscript-tools-i18n/test/cli.test.mjs
+++ b/packages/hyperscript-tools-i18n/test/cli.test.mjs
@@ -16,6 +16,7 @@ async function withTempDir(fn) {
 }
 
 const SAMPLE_HTML = '<button _="on click toggle .active on me">go</button>';
+const INVALID_HTML = '<button _="on click qqqq zzzz">go</button>';
 
 test('translate command writes one file per lang', async () => {
   await withTempDir(async dir => {
@@ -107,5 +108,57 @@ test('--from changes source locale', async () => {
     const out = readFileSync(join(dir, 'es.en.html'), 'utf8');
     // English keywords expected somewhere in the translated body.
     assert.match(out, /toggle|click|active/i);
+  });
+});
+
+test('invalid English without --check still exits 0 and writes files', async () => {
+  await withTempDir(async dir => {
+    const input = join(dir, 'bad.html');
+    const out = join(dir, 'out');
+    writeFileSync(input, INVALID_HTML);
+    const code = await run(['translate', input, '--langs', 'es,ja', '--out', out]);
+    assert.equal(code, 0);
+    assert.deepEqual(readdirSync(out).sort(), ['bad.es.html', 'bad.ja.html']);
+  });
+});
+
+test('invalid English with --check exits 3 but still writes files', async () => {
+  await withTempDir(async dir => {
+    const input = join(dir, 'bad.html');
+    const out = join(dir, 'out');
+    writeFileSync(input, INVALID_HTML);
+    const code = await run(['translate', input, '--langs', 'es', '--out', out, '--check']);
+    assert.equal(code, 3);
+    assert.deepEqual(readdirSync(out).sort(), ['bad.es.html']);
+  });
+});
+
+test('valid English with --check exits 0', async () => {
+  await withTempDir(async dir => {
+    const input = join(dir, 'good.html');
+    const out = join(dir, 'out');
+    writeFileSync(input, SAMPLE_HTML);
+    const code = await run(['translate', input, '--langs', 'es', '--out', out, '--check']);
+    assert.equal(code, 0);
+  });
+});
+
+test('--check processes all files before failing', async () => {
+  await withTempDir(async dir => {
+    const out = join(dir, 'out');
+    writeFileSync(join(dir, 'a.html'), INVALID_HTML);
+    writeFileSync(join(dir, 'b.html'), INVALID_HTML);
+    const code = await run([
+      'translate',
+      join(dir, 'a.html'),
+      join(dir, 'b.html'),
+      '--langs',
+      'es',
+      '--out',
+      out,
+      '--check',
+    ]);
+    assert.equal(code, 3);
+    assert.deepEqual(readdirSync(out).sort(), ['a.es.html', 'b.es.html']);
   });
 });

--- a/packages/hyperscript-tools-i18n/test/eleventy.test.mjs
+++ b/packages/hyperscript-tools-i18n/test/eleventy.test.mjs
@@ -2,6 +2,7 @@
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import hyperscriptI18nPlugin from '../dist/eleventy.js';
+import { __resetParseCheckWarnings } from '../dist/validate.js';
 
 function fakeConfig() {
   const filters = new Map();
@@ -92,4 +93,60 @@ test('plugin honors defaultFrom override', () => {
   // With defaultFrom='es', translating to 'es' is a no-op
   const out = fn('alternar .active', 'es');
   assert.equal(out, 'alternar .active');
+});
+
+// --- parse-check integration (await the plugin so the validator is loaded) ---
+
+const INVALID = 'on click qqqq zzzz';
+
+test('parseCheck warn: invalid English input warns but still returns a result', async () => {
+  __resetParseCheckWarnings();
+  const cfg = fakeConfig();
+  await hyperscriptI18nPlugin(cfg); // default parseCheck: 'warn'
+  const fn = cfg._filters.get('translateHs');
+  const original = console.warn;
+  let warned = 0;
+  console.warn = () => {
+    warned++;
+  };
+  let out;
+  try {
+    out = fn(INVALID, 'es');
+  } finally {
+    console.warn = original;
+  }
+  assert.equal(warned, 1);
+  assert.notEqual(out, undefined);
+});
+
+test('parseCheck error: filter throws on invalid, not on valid', async () => {
+  const cfg = fakeConfig();
+  await hyperscriptI18nPlugin(cfg, { parseCheck: 'error' });
+  const fn = cfg._filters.get('translateHs');
+  assert.throws(() => fn(INVALID, 'es'), /invalid hyperscript/);
+  assert.doesNotThrow(() => fn('toggle .active', 'es'));
+});
+
+test('parseCheck off: no warning on invalid input', async () => {
+  const cfg = fakeConfig();
+  await hyperscriptI18nPlugin(cfg, { parseCheck: 'off' });
+  const fn = cfg._filters.get('translateHs');
+  const original = console.warn;
+  let warned = 0;
+  console.warn = () => {
+    warned++;
+  };
+  try {
+    fn(INVALID, 'es');
+  } finally {
+    console.warn = original;
+  }
+  assert.equal(warned, 0);
+});
+
+test('translateHsAll with parseCheck error throws on invalid English input', async () => {
+  const cfg = fakeConfig();
+  await hyperscriptI18nPlugin(cfg, { parseCheck: 'error' });
+  const fn = cfg._filters.get('translateHsAll');
+  assert.throws(() => fn(INVALID, ['es', 'ja']), /invalid hyperscript/);
 });

--- a/packages/hyperscript-tools-i18n/test/html.test.mjs
+++ b/packages/hyperscript-tools-i18n/test/html.test.mjs
@@ -2,7 +2,16 @@
 // Runs against the built dist; pretest rebuilds @lokascript/i18n + this package.
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { translateHtml, translateHtmlToManyLangs } from '../dist/index.js';
+import {
+  translateHtml,
+  translateHtmlToManyLangs,
+  extractHyperscriptAttributes,
+} from '../dist/index.js';
+import { __resetParseCheckWarnings } from '../dist/validate.js';
+
+// Stub validator: any body containing 'BAD' is invalid. Keeps these tests
+// deterministic and independent of the real parser.
+const stub = src => (src.includes('BAD') ? ['boom'] : []);
 
 test('translateHtml swaps double-quoted _= attributes', () => {
   const html = '<button _="on click toggle .active on me">x</button>';
@@ -21,7 +30,8 @@ test('translateHtml handles single-quoted attributes', () => {
 });
 
 test('translateHtml preserves surrounding markup and other attributes', () => {
-  const html = '<div class="x" data-id="1"><p>hello world</p><button _="on click toggle .active on me">go</button></div>';
+  const html =
+    '<div class="x" data-id="1"><p>hello world</p><button _="on click toggle .active on me">go</button></div>';
   const out = translateHtml(html, 'es');
   // Non-_= structure is preserved verbatim
   assert.match(out, /<div class="x" data-id="1">/);
@@ -71,4 +81,100 @@ test('translateHtmlToManyLangs preserves order in iteration', () => {
   const result = translateHtmlToManyLangs(html, ['ko', 'ja', 'es']);
   const keys = Array.from(result.keys());
   assert.deepEqual(keys, ['ko', 'ja', 'es']);
+});
+
+// --- parse-check integration ---
+
+test('no validate option → no parse-check runs (guard against default-on)', () => {
+  const original = console.warn;
+  let warned = 0;
+  console.warn = () => {
+    warned++;
+  };
+  try {
+    translateHtml('<button _="BAD input-guard">x</button>', 'es');
+  } finally {
+    console.warn = original;
+  }
+  assert.equal(warned, 0);
+});
+
+test('input warn fires once for an invalid English attribute', () => {
+  __resetParseCheckWarnings();
+  const original = console.warn;
+  let warned = 0;
+  console.warn = () => {
+    warned++;
+  };
+  try {
+    const out = translateHtml('<button _="BAD input-a">x</button>', 'es', { validate: stub });
+    assert.match(out, /<button _="[^"]+">x<\/button>/, 'still returns rewritten HTML');
+  } finally {
+    console.warn = original;
+  }
+  assert.equal(warned, 1);
+});
+
+test('onInvalid callback receives the input report shape', () => {
+  const reports = [];
+  translateHtml('<button _="BAD input-b">x</button>', 'es', {
+    validate: stub,
+    onInvalid: r => reports.push(r),
+  });
+  assert.equal(reports.length, 1);
+  assert.deepEqual(reports[0], {
+    stage: 'input',
+    code: 'BAD input-b',
+    errors: ['boom'],
+    from: 'en',
+    to: 'es',
+  });
+});
+
+test('onInvalid "error" throws on invalid input', () => {
+  assert.throws(
+    () =>
+      translateHtml('<button _="BAD input-c">x</button>', 'es', {
+        validate: stub,
+        onInvalid: 'error',
+      }),
+    /invalid hyperscript/
+  );
+});
+
+test('output-stage check fires when target is en', () => {
+  const reports = [];
+  // from es → en; stub flags everything, so the translated output is reported.
+  translateHtml('<button _="alternar .active">x</button>', 'en', {
+    from: 'es',
+    validate: () => ['boom'],
+    onInvalid: r => reports.push(r),
+  });
+  assert.ok(reports.some(r => r.stage === 'output'));
+});
+
+test('checkInput:false skips the input check', () => {
+  const reports = [];
+  translateHtml('<button _="BAD input-d">x</button>', 'es', {
+    validate: stub,
+    checkInput: false,
+    onInvalid: r => reports.push(r),
+  });
+  assert.equal(reports.length, 0);
+});
+
+test('translateHtmlToManyLangs checks the shared input exactly once', () => {
+  const reports = [];
+  translateHtmlToManyLangs('<button _="BAD input-e">x</button>', ['es', 'ja', 'ko'], {
+    validate: stub,
+    onInvalid: r => reports.push(r),
+  });
+  assert.equal(reports.length, 1, 'input checked once, not once per lang');
+});
+
+test('extractHyperscriptAttributes covers all quote styles and dedupes', () => {
+  const html =
+    '<a _="toggle .a"></a><b _=\'toggle .b\'></b><c _=`toggle .c`></c><d _="toggle .a"></d>';
+  const bodies = extractHyperscriptAttributes(html);
+  assert.deepEqual(bodies, ['toggle .a', 'toggle .b', 'toggle .c']);
 });

--- a/packages/hyperscript-tools-i18n/test/validate.test.mjs
+++ b/packages/hyperscript-tools-i18n/test/validate.test.mjs
@@ -1,0 +1,90 @@
+// Tests for the canonical parse-check (src/validate.ts).
+// Runs against the built dist; pretest rebuilds @lokascript/i18n + this package.
+// Uses the REAL hyperscript.org parser. Assertions match on message SUBSTRINGS
+// only (never full text) so they survive upstream 0.9.x wording drift.
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import {
+  loadValidator,
+  validateHyperscript,
+  formatParseCheckReport,
+  warnInvalidOnce,
+  __resetParseCheckWarnings,
+} from '../dist/validate.js';
+
+test('loadValidator resolves to a function and caches the instance', async () => {
+  const a = await loadValidator();
+  const b = await loadValidator();
+  assert.equal(typeof a, 'function');
+  assert.equal(a, b, 'two awaited loads return the same cached function');
+});
+
+test('valid hyperscript returns an empty error array', async () => {
+  const validate = await loadValidator();
+  assert.deepEqual(validate('on click toggle .active on me'), []);
+  assert.deepEqual(validate('toggle .active'), []);
+});
+
+test('grammar-invalid hyperscript returns collected errors', async () => {
+  const validate = await loadValidator();
+  const errors = validate('on click qqqq zzzz');
+  assert.ok(errors.length >= 1, 'expected at least one error');
+  assert.match(errors[0], /qqqq/);
+});
+
+test('tokenizer throw is folded, never thrown', async () => {
+  const validate = await loadValidator();
+  let errors;
+  assert.doesNotThrow(() => {
+    errors = validate('ถ้า x'); // leaked Thai surface → tokenizer "Unknown token"
+  });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /^threw: /);
+});
+
+test('js-command throw is folded, never thrown', async () => {
+  const validate = await loadValidator();
+  let errors;
+  assert.doesNotThrow(() => {
+    errors = validate('js ] end'); // invalid JS body → new Function throws at parse time
+  });
+  assert.ok(errors.length >= 1);
+});
+
+test('validateHyperscript convenience loads and validates', async () => {
+  assert.deepEqual(await validateHyperscript('on click toggle .active on me'), []);
+});
+
+test('formatParseCheckReport truncates long code and lists errors', () => {
+  const long = 'on click ' + 'toggle .active '.repeat(20);
+  const out = formatParseCheckReport({
+    stage: 'input',
+    code: long,
+    errors: ['boom', 'bang'],
+    from: 'en',
+    to: 'es',
+  });
+  assert.match(out, /\.\.\.$|\.\.\."/, 'long code should be truncated with ...');
+  assert.match(out, /\n {2}- boom/);
+  assert.match(out, /\n {2}- bang/);
+});
+
+test('warnInvalidOnce dedupes by code within a process', () => {
+  __resetParseCheckWarnings();
+  const original = console.warn;
+  let calls = 0;
+  console.warn = () => {
+    calls++;
+  };
+  try {
+    const report = { stage: 'input', code: 'DUP', errors: ['x'], from: 'en', to: 'es' };
+    assert.equal(warnInvalidOnce(report), true);
+    assert.equal(warnInvalidOnce(report), false);
+    assert.equal(calls, 1);
+    __resetParseCheckWarnings();
+    assert.equal(warnInvalidOnce(report), true);
+    assert.equal(calls, 2);
+  } finally {
+    console.warn = original;
+  }
+});

--- a/packages/testing-framework/src/multilingual/canonical-validity.ts
+++ b/packages/testing-framework/src/multilingual/canonical-validity.ts
@@ -16,9 +16,11 @@
  * The FOREIGN-side sibling (foreign-canonical-validity.ts) is folded into
  * `multilingual/cli.ts`'s `--regression` gate as the R4 canonical-validity
  * ratchet. This en-side check remains vitest-only (its allowlist holds exactly
- * one entry, pick-text-range). Remaining follow-up: bake the same parse-check
- * into the build-time `@hyperscript-tools/i18n` transpiler so every emitted
- * output is parser-gated.
+ * one entry, pick-text-range). The same loader recipe now also ships in the
+ * build-time `@hyperscript-tools/i18n` transpiler (`src/validate.ts`, CLI
+ * `--check`, Eleventy `parseCheck`) to gate its ENGLISH side (input + foreign→
+ * English output). Faithful foreign-OUTPUT gating still awaits the v2
+ * semantic-engine transpiler (the i18n GrammarTransformer is lossy in reverse).
  */
 
 import { createRequire } from 'node:module';

--- a/packages/testing-framework/src/multilingual/foreign-canonical-validity.ts
+++ b/packages/testing-framework/src/multilingual/foreign-canonical-validity.ts
@@ -4,9 +4,11 @@
  * The sibling en-render gate (canonical-validity.ts) renders every corpus English
  * reference and parses it on the real `hyperscript.org` engine. But the PRODUCTION
  * path is foreign→English: an authored non-English source is parsed and rendered to
- * English (`preprocessToEnglish` → `render`, and the roadmap's build-time
- * `@hyperscript-tools/i18n` transpiler). A parse can be role-faithful (the fidelity
- * ratchet scores ~1.0) yet still render English the canonical parser rejects.
+ * English (`preprocessToEnglish` → `render`). A parse can be role-faithful (the
+ * fidelity ratchet scores ~1.0) yet still render English the canonical parser rejects.
+ * (The build-time `@hyperscript-tools/i18n` transpiler now parse-gates its ENGLISH
+ * side with the same loader recipe; faithful foreign-output gating there still awaits
+ * the v2 semantic-engine transpiler, since its GrammarTransformer is lossy in reverse.)
  *
  * This gate closes that blind spot for the multilingual path: for every language, it
  * renders each authored `pattern_translation` to English and parses the result on


### PR DESCRIPTION
## What & why

Bakes the **canonical parse-check** into the build-time `@hyperscript-tools/i18n` transpiler — the last infra follow-up of the foreign-validity burndown (roadmap §5 / `HANDOFF_foreign-validity-burndown.md`). Every English hyperscript string the transpiler touches can now be validated against the **real `hyperscript.org` engine** (the same parser the browser runs):

- **input** when translating _from_ English (`--from en`, the default) — catches an invalid canonical source before it ships in all 24 languages, and
- **output** when a target language is `en` (foreign → English).

**Scope is English-only by design.** Foreign-language _output_ is deliberately not round-trip-checked: the v1 GrammarTransformer's `toEnglish` is the known-weak 8/30 round-trip path, so gating it would be red noise. Faithful foreign-output gating belongs to the v2 semantic-engine transpiler.

## Changes

- **New `src/validate.ts`** — self-contained headless loader (`loadValidator`, cached) reusing the proven `loadCanonicalParser` recipe (resolve `hyperscript.org`, import the sibling `_hyperscript.esm.js` by file URL, no DOM shim). Honors the **never-throws contract**: grammar errors _and_ both throw channels (tokenizer unknown-char, `js`-command `new Function`) fold into one `string[]`. Exports `validateHyperscript`, `formatParseCheckReport`, deduped `warnInvalidOnce`; new `./validate` subpath. **No `@hyperfixi/*` or `@lokascript/semantic` imports** — stays extraction-ready for the external `hyperscript-tools` repo.
- **`html.ts`** — optional `validate`/`onInvalid`/`checkInput` on `TranslateHtmlOptions`; the output check sits outside the lenient try/catch so `'error'` escapes. New `extractHyperscriptAttributes`/`checkHtmlInput` helpers. No behavior change when `validate` is absent.
- **`cli.ts`** — `--check` flag, new **exit code 3** (reported after all files are processed and written), per-file input check, deduped warnings, full failure summary.
- **`eleventy.ts`** — now **async** with `parseCheck: 'off' | 'warn' | 'error'` (default `'warn'`). Filters register synchronously before the await, so un-awaited/Eleventy-2 callers keep working (Eleventy 3 awaits `addPlugin`).
- **Dep**: `hyperscript.org@^0.9.93` as a regular dependency. No version bump (uniform 2.7.2).
- **CI**: the `unit-tests` job now runs this package's tests — they were **absent from CI** before.
- **Docs**: testing-framework `canonical-validity` comments, the burndown handoff, and roadmap §5 marked done-for-English.

## Verification

- Build + typecheck clean; emits `validate.js`/`.d.ts`.
- **50/50 tests pass** (new `validate.test.mjs` + additions across html/cli/eleventy).
- CLI smoke: invalid English → one deduped warning + exit 0; `--check` → summary + **exit 3** (files still written); valid + `--check` → exit 0.
- `check-ci-build-order` + `validate-versions` green; prettier clean.

## ⚠️ Reviewer note

The Eleventy plugin's return type changes `void → Promise<void>`. Functionally safe un-awaited (filters register synchronously), but a **type-level change** for any strictly-typed consumer passing the plugin where `() => void` is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)