### PR TITLE
fix(semantic): beep!-prefix value fold — 18/24 languages silently truncated `set $x to beep! my value`

### DIFF
--- a/docs-internal/HANDOFF_foreign-validity-burndown.md
+++ b/docs-internal/HANDOFF_foreign-validity-burndown.md
@@ -642,13 +642,18 @@ The handoff's premise was doubly wrong:
   GAIN a rule — a source-adjacent leading `!` glues like the `.`-member rule
   (`expression-lexicon.ts`). "The join loses its spaces" was only half the story; it also had
   to STOP adding one.
-- **en is separately, pre-existingly broken and DEFERRED.** `set $x to beep! my value` →
-  `set $x to beep` (the `matchRoleToken` single-token slot capture drops `! my value`;
-  `beep` alone is a valid canonical identifier, so en is not in the en-render allowlist).
-  Fixing it means folding `beep! <expr>` as an expression prefix in
-  `pattern-matcher.ts` value-slot capture — a different root cause on the primary parse path
-  for all languages. Named follow-up; clears **0** foreign gate pairs (the foreign gate never
-  renders en→en).
+- ~~**en is separately, pre-existingly broken and DEFERRED.**~~ **DONE (2026-07-19,
+  the beep!-prefix value fold).** The probe showed the deferral note undersold it:
+  **18 of 24 languages truncated** (`set $x to beep`), not just en — every SVO/VSO
+  language shared en's single-token capture, gate-invisibly (the truncated render is
+  valid English, and the en REFERENCE truncated identically so no recall signal
+  moved). Fix = `tryMatchBeepPrefixExpression` in `pattern-matcher.ts`, the prefix
+  sibling of the operator-run fold: `beep` + SOURCE-ADJACENT `!` + operand →
+  one expression value joined through `joinExpressionTokens` (which supplies the
+  Phase-6 `!`-glue). All 24 languages now render the full `beep! my value`;
+  R1 rose in 15 languages (7 to 1.0000) — the truncating reference had been
+  masking a role-fidelity gap. Guards in `beep-debug-expression.test.ts`; the R1
+  Family-D locks updated to the better type (patient:expression, mirror intact).
 
 ### 4. ~~Deliberately blocked (24 after Phase 11)~~ — CLEARED (Phase 12, ambiguous-sense anchor)
 

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -673,6 +673,15 @@ export class PatternMatcher {
       patternToken.role !== 'event' &&
       (!patternToken.expectedTypes || patternToken.expectedTypes.includes('expression'))
     ) {
+      // `beep! <expr>` first: its head (`beep`) is a plain value token, so the
+      // single-token capture below would otherwise take it and strand the
+      // `! <expr>` tail as unconsumed — the same silent truncation the operator
+      // run fixes for `"Hello, " + my value`, in prefix form.
+      const beepValue = this.tryMatchBeepPrefixExpression(tokens);
+      if (beepValue) {
+        captured.set(patternToken.role, beepValue);
+        return true;
+      }
       const runValue = this.tryMatchOperatorRunExpression(tokens);
       if (runValue) {
         captured.set(patternToken.role, runValue);
@@ -1130,6 +1139,58 @@ export class PatternMatcher {
    * Returns null — leaving the stream untouched — unless an operator DIRECTLY
    * follows the first operand, so ordinary single-token captures never change.
    */
+  /**
+   * Try to match canonical hyperscript's `beep! <expr>` debug prefix as ONE
+   * expression value (`set $x to beep! my value`). Without this fold the value
+   * slot captures the bare `beep` (a valid identifier on its own) and the
+   * `! <expr>` tail drops as unconsumed — silently WRONG, and invisible to
+   * every recall signal because the en REFERENCE truncates identically (the
+   * probe measured 18 of 24 languages truncating; only the SOV six, which take
+   * the verb-anchoring fall-through into `joinExpressionTokens`, rendered the
+   * full value). See HANDOFF_foreign-validity-burndown § "beep!".
+   *
+   * Gates: the literal `beep` head, a SOURCE-ADJACENT `!` (the same adjacency
+   * voucher the join seam's `!`-glue uses — canonical rejects the spaced
+   * `beep !`, so adjacency is definitive), and a real operand following (a
+   * dangling `beep!` stays a plain single-token capture). A following operator
+   * run composes (`beep! my value + 1`) via the same operand consumer.
+   */
+  private tryMatchBeepPrefixExpression(tokens: TokenStream): SemanticValue | null {
+    const head = tokens.peek();
+    const bang = tokens.peek(1);
+    if (!head || !bang || bang.value !== '!') return null;
+    if ((head.normalized ?? head.value).toLowerCase() !== 'beep') return null;
+    const adjacent =
+      head.position?.end !== undefined &&
+      bang.position?.start !== undefined &&
+      head.position.end === bang.position.start;
+    if (!adjacent) return null;
+
+    const mark = tokens.mark();
+    const startIdx = tokens.position();
+    tokens.advance(); // beep
+    tokens.advance(); // !
+    if (!this.tryConsumeRunOperand(tokens)) {
+      tokens.reset(mark);
+      return null;
+    }
+    for (;;) {
+      const op = tokens.peek();
+      if (!op || !PatternMatcher.RUN_OPERATORS.has(op.value)) break;
+      const beforeOp = tokens.mark();
+      tokens.advance();
+      if (!this.tryConsumeRunOperand(tokens)) {
+        tokens.reset(beforeOp);
+        break;
+      }
+    }
+    const raw = joinExpressionTokens(
+      tokens.tokens.slice(startIdx, tokens.position()),
+      this.currentProfile
+    );
+    return { type: 'expression', raw, value: raw } as SemanticValue;
+  }
+
   private tryMatchOperatorRunExpression(tokens: TokenStream): SemanticValue | null {
     const mark = tokens.mark();
     const startIdx = tokens.position();

--- a/packages/semantic/test/beep-debug-expression.test.ts
+++ b/packages/semantic/test/beep-debug-expression.test.ts
@@ -38,3 +38,41 @@ describe('beep! debug-expression renders canonical English (no glue, no leak)', 
     expect(hasNonAscii(rendered)).toBe(false);
   });
 });
+
+/**
+ * The value-slot prefix fold (tryMatchBeepPrefixExpression) — the en/SVO/VSO
+ * half of the story. Before the fold, the value slot captured the bare `beep`
+ * (a valid identifier) and dropped `! <expr>` as unconsumed — silently WRONG
+ * in en and 17 more languages, invisible to every recall signal because the en
+ * REFERENCE truncated identically (probe 2026-07-19: 18/24 truncated; only
+ * the SOV five above rendered the full value, via the fall-through join).
+ */
+describe('beep! value-slot prefix fold (en + SVO/VSO)', () => {
+  it('en: the set value captures the whole `beep! my value`, not the bare `beep`', () => {
+    const rendered = render(parse('on click set $x to beep! my value', 'en'), 'en');
+    expect(rendered).toBe('on click set $x to beep! my value');
+  });
+
+  it('en: composes with the operator run (`beep! my value + 1`)', () => {
+    const rendered = render(parse('on click set $x to beep! my value + 1', 'en'), 'en');
+    expect(rendered).toContain('beep! my value + 1');
+  });
+
+  it('en: the fold is bounded — a following role marker stays with its own role', () => {
+    const rendered = render(parse('on click put beep! my value into #log', 'en'), 'en');
+    expect(rendered).toContain('put beep! my value into #log');
+  });
+
+  it('en: a SPACED `beep !` never folds (adjacency is the voucher)', () => {
+    // Canonical rejects the spaced form, so folding it would invent validity;
+    // the pre-existing single-token capture (and its truncation) is preserved.
+    const rendered = render(parse('on click set $x to beep ! my value', 'en'), 'en');
+    expect(rendered).toContain('set $x to beep');
+    expect(rendered).not.toContain('beep!');
+  });
+
+  it('en: a dangling `beep!` with no operand declines the fold', () => {
+    const rendered = render(parse('on click set $x to beep!', 'en'), 'en');
+    expect(rendered).toContain('set $x to beep');
+  });
+});

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -13401,7 +13401,11 @@ describe('R1 Family D: SOV fallback value-typing increments (docs-internal/HANDO
     // The fallback typed `$x` literal (no `:local`/`$global` branch) AND
     // mapped set's ta/を-marked DESTINATION to patient — set's surface order
     // is dest-first, so the SOV patient particle systematically marks the
-    // destination. en: destination:reference="$x" + patient:literal.
+    // destination. en: destination:reference="$x" + patient:expression.
+    // (patient was `literal` until the beep!-prefix value fold landed — the en
+    // reference itself truncated to `beep`; both sides now capture the full
+    // `beep! my value` as ONE expression, so the mirror holds at the better
+    // type. See tryMatchBeepPrefixExpression in pattern-matcher.ts.)
     const ROWS: Array<[string, string]> = [
       ['ja', '$x を beep! 私の 値 に 設定 クリック で'],
       ['ko', '$x 를 beep! 내 값 에 설정 클릭 할 때'],
@@ -13409,11 +13413,12 @@ describe('R1 Family D: SOV fallback value-typing increments (docs-internal/HANDO
       ['qu', '$x ta beep! noqaq chanin man ñitiy pi churanay'],
     ];
     for (const [lang, src] of ROWS) {
-      it(`[${lang}] fallback set: $x lands as destination:reference, value as patient:literal`, () => {
+      it(`[${lang}] fallback set: $x lands as destination:reference, value as patient:expression (beep! fold)`, () => {
         const s = first(collect(parse(src, lang)), 'set');
         expect(s).toBeDefined();
         expect(role(s, 'destination')).toMatchObject({ type: 'reference', value: '$x' });
-        expect(role(s, 'patient')?.type).toBe('literal');
+        expect(role(s, 'patient')?.type).toBe('expression');
+        expect(role(s, 'patient')?.value).toContain('beep! my value');
       });
     }
 

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,22 +1,22 @@
 {
-  "timestamp": "2026-07-19T14:43:24.018Z",
-  "commit": "f7131aff",
+  "timestamp": "2026-07-19T15:16:23.515Z",
+  "commit": "2ba96f78",
   "languages": {
     "ar": {
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8404303667240408,
+      "avgConfidence": 0.840918600294981,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9983660130718954,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 0.9906542056074766,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -434,6 +434,10 @@
           "success": true,
           "confidence": 0.7894736842105263
         },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
         "caret-var-write": {
           "success": true,
           "confidence": 0.7894736842105263
@@ -519,10 +523,6 @@
           "confidence": 0.7142857142857143
         },
         "keydown-key-is-syntax": {
-          "success": true,
-          "confidence": 0.7142857142857143
-        },
-        "beep-debug-expression": {
           "success": true,
           "confidence": 0.7142857142857143
         },
@@ -640,7 +640,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8662494982043849,
+      "avgConfidence": 0.8681291974525052,
       "avgFidelity": 1,
       "avgPrecision": 0.997835497835498,
       "avgMultisetRecall": 1,
@@ -650,7 +650,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1120,6 +1120,10 @@
           "success": true,
           "confidence": 0.7894736842105263
         },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
         "caret-var-write": {
           "success": true,
           "confidence": 0.7894736842105263
@@ -1240,10 +1244,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 0.5
-        },
         "pick-text-range": {
           "success": true,
           "confidence": 0.5
@@ -1278,13 +1278,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9961873638344227,
+      "avgRoleFidelity": 0.9978213507625273,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1909,7 +1909,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2537,13 +2537,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9983660130718954,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3171,13 +3171,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9961873638344227,
+      "avgRoleFidelity": 0.9978213507625273,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3805,13 +3805,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9967320261437909,
+      "avgRoleFidelity": 0.9983660130718954,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4435,7 +4435,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.9128584448133308,
+      "avgConfidence": 0.9114913908146978,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
@@ -4445,7 +4445,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -4823,10 +4823,6 @@
           "success": true,
           "confidence": 1
         },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 1
-        },
         "pick-text-range": {
           "success": true,
           "confidence": 1
@@ -4971,6 +4967,10 @@
           "success": true,
           "confidence": 0.7894736842105263
         },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
         "caret-var-write": {
           "success": true,
           "confidence": 0.7894736842105263
@@ -5073,13 +5073,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9954092748210397,
+      "avgRoleFidelity": 0.9970432617491443,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5713,7 +5713,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6337,7 +6337,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8565092384641251,
+      "avgConfidence": 0.8583889377122453,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
@@ -6347,7 +6347,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6805,6 +6805,10 @@
           "success": true,
           "confidence": 0.7894736842105263
         },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
         "caret-var-write": {
           "success": true,
           "confidence": 0.7894736842105263
@@ -6937,10 +6941,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 0.5
-        },
         "pick-text-range": {
           "success": true,
           "confidence": 0.5
@@ -6971,7 +6971,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8514587334136199,
+      "avgConfidence": 0.8533384326617401,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
@@ -6981,7 +6981,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7428,6 +7428,10 @@
           "confidence": 0.7894736842105263
         },
         "template-literal-list-build": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "beep-debug-expression": {
           "success": true,
           "confidence": 0.7894736842105263
         },
@@ -7563,10 +7567,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 0.5
-        },
         "pick-text-range": {
           "success": true,
           "confidence": 0.5
@@ -7609,13 +7609,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.99400871459695,
+      "avgRoleFidelity": 0.9956427015250545,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8243,13 +8243,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9970588235294119,
+      "avgRoleFidelity": 0.9986928104575165,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8877,13 +8877,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9983660130718954,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9517,7 +9517,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10145,13 +10145,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9983660130718954,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10779,13 +10779,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9983660130718954,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11413,13 +11413,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.994880174291939,
+      "avgRoleFidelity": 0.9965141612200435,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12043,17 +12043,17 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8239183073548376,
+      "avgConfidence": 0.8244065409257779,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9983660130718954,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 0.9906542056074766,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12376,6 +12376,10 @@
           "confidence": 0.7894736842105263
         },
         "template-literal-list-build": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "beep-debug-expression": {
           "success": true,
           "confidence": 0.7894736842105263
         },
@@ -12567,10 +12571,6 @@
           "success": true,
           "confidence": 0.7142857142857143
         },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 0.7142857142857143
-        },
         "caret-var-increment": {
           "success": true,
           "confidence": 0.7142857142857143
@@ -12677,7 +12677,7 @@
       "parseSuccess": 154,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8572513534919545,
+      "avgConfidence": 0.8591310527400748,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
@@ -12687,7 +12687,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13145,6 +13145,10 @@
           "success": true,
           "confidence": 0.7894736842105263
         },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
         "caret-var-write": {
           "success": true,
           "confidence": 0.7894736842105263
@@ -13277,10 +13281,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "beep-debug-expression": {
-          "success": true,
-          "confidence": 0.5
-        },
         "pick-text-range": {
           "success": true,
           "confidence": 0.5
@@ -13315,13 +13315,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9983660130718954,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13955,7 +13955,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14583,13 +14583,13 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9963429816370993,
+      "avgRoleFidelity": 0.9979769685652039,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 537015,
+      "bundleSize": 537681,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15212,7 +15212,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 537015,
+      "size": 537681,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## What

Fixes the last named en-side parse bug from the foreign-validity arc — and the probe showed the handoff's filing **undersold it 18×**: not just en, but **18 of 24 languages** silently truncated `set $x to beep! my value` to `set $x to beep`. The value slot's single-token capture took the bare `beep` (a valid identifier) and dropped `! <expr>` as unconsumed. Gate-invisible twice over: the truncated render is valid English, and the en *reference* truncated identically, so no recall signal could move. Only the SOV six rendered the full value (Phase 6's fall-through path).

## Fix

`tryMatchBeepPrefixExpression` in `pattern-matcher.ts` — the prefix-form sibling of the existing `tryMatchOperatorRunExpression` (which fixed the same truncation class for `"Hello, " + my value`). Gates:

- literal `beep` head with a **source-adjacent** `!` (canonical rejects the spaced `beep !`, so adjacency is definitive — same voucher as the Phase-6 `!`-glue)
- a real operand following (dangling `beep!` stays a plain capture)
- composes with the operator run (`beep! my value + 1`), bounded by role markers (`put beep! my value into #log`)

The consumed slice joins through `joinExpressionTokens`, reusing the Phase-6 glue and possessive anchors.

## Measured

- All 24 languages now render `on click set $x to beep! my value` byte-identically; the previously-correct SOV six unchanged.
- **avgRoleFidelity rose in 15 languages — seven (ar/es/pt/ru/sw/tl/uk) to 1.0000.** The truncating en reference had been masking a real role-fidelity gap.
- Edge probes: spaced `beep !` declines, dangling `beep!` declines, `put`-bounded fold verified.

## Gates (all green)

- Semantic suite 7416 (R1 Family-D locks updated to the better type — patient:expression, en mirror intact, value assertion added)
- Both canonical gates green; allowlist unchanged (truncated renders were already "valid" — this is the silent-correction class, like Phase 5's 51)
- Fidelity ratchet green on all 9 signals; baseline regenerated for the R1 improvements
- `test:affected` green (domain-toolkit 0-test artifact only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)