### PR TITLE
fix(deps): patch transitive js-yaml and brace-expansion DoS advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6312,9 +6312,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -10189,9 +10189,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "tmp": "^0.2.7",
     "qs": "^6.15.2",
     "yaml": "^2.9.0",
-    "brace-expansion": "^5.0.6"
+    "brace-expansion": "^5.0.7",
+    "js-yaml": "^4.3.0"
   },
   "lint-staged": {
     "packages/*/src/**/*.ts": [


### PR DESCRIPTION
## Summary
- Resolves Dependabot alerts #368, #369, #350 (js-yaml + brace-expansion DoS advisories)
- Both packages are transitive dev-only deps pulled in via `lerna` → `cosmiconfig`/`nx`/`minimatch` — never reachable from any published `@hyperfixi`/`@lokascript` package or runtime bundle
- Bumps the existing root `overrides` block (same pattern already used there for `minimatch`, `tar`, `esbuild`, etc.) to pull in patched versions: `js-yaml` → 4.3.0, `brace-expansion` → 5.0.7
- Both patched versions satisfy lerna's own dependency ranges (`^4.1.0`, `^10.2.3`) — no breaking change, no lerna major bump needed
- `npm audit` now reports 0 vulnerabilities (was 2 high + 1 moderate)

## Test plan
- [x] `npm audit` → 0 vulnerabilities
- [x] `npm ls js-yaml brace-expansion --all` → confirms 4.3.0 / 5.0.7 resolved throughout the tree
- [x] Verified lerna is a devDependency only, not wired into any npm script — no build/test impact
- [ ] CI required checks (Build All Packages, Lint & Typecheck, Unit Tests, Export Validation, Multilingual Validation, Browser Tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)