### PR TITLE
chore(deps): bundle vitest family and vscode-lsp majors into single groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,19 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+      # vitest + @vitest/* excluded above move as one unit: @vitest/ui
+      # exact-pins its peer `vitest` version, so they are coupled by design
+      # and the fix (docs-internal/HANDOFF_vitest-oxc-decorators.md) has to
+      # touch all three together anyway. Bundled 2026-07-20 so the three
+      # individual PRs (#694/695/696, identical failure) collapse into one
+      # PR/one CI run per rebase instead of three.
+      vitest-family:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
+        update-types:
+          - 'minor'
+          - 'patch'
       # One weekly PR for all majors instead of one PR per dependency. CI is
       # the reviewer: if this group PR goes red, add the offender to
       # exclude-patterns so it falls back to an individual PR for bisection.
@@ -62,6 +75,17 @@ updates:
         # versions), so exclude both or neither.
         exclude-patterns:
           - 'typescript'
+          - 'vscode-languageserver'
+          - 'vscode-languageclient'
+        update-types:
+          - 'major'
+      # vscode-languageserver + vscode-languageclient excluded above move as
+      # one unit (shared upstream, matched versions — see the comment on the
+      # exclusion). Bundled 2026-07-20 so the two individual PRs (#716/#717)
+      # collapse into one PR/one CI run per rebase instead of two. typescript
+      # stays solo — it needs individual bisection, not a partner.
+      vscode-lsp:
+        patterns:
           - 'vscode-languageserver'
           - 'vscode-languageclient'
         update-types:


### PR DESCRIPTION
## Summary
- `vitest` + `@vitest/ui` + `@vitest/coverage-v8` are coupled by design (`@vitest/ui` exact-pins its peer `vitest` version) and share one root cause (`docs-internal/HANDOFF_vitest-oxc-decorators.md`). They were landing as 3 separate individually-excluded PRs (#694/#695/#696) — every rebase re-ran full CI 3x for one bug.
- `vscode-languageserver` + `vscode-languageclient` share an upstream and matched versions; the existing config comment already says "exclude both or neither" but they were still opening as 2 separate PRs (#716/#717).
- Adds a `vitest-family` group and a `vscode-lsp` group so each cluster becomes one PR / one CI run per rebase.
- `typescript` stays excluded and solo — deliberate, for bisection given real build risk (unrelated to this change).
- This only affects *future* Dependabot runs. The 5 existing individual PRs it supersedes are being closed in a follow-up so next week's scheduled run opens the 2 consolidated PRs instead.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` — valid YAML
- [x] Reviewed diff — exclude-patterns on the existing `minor-and-patch`/`majors` catch-all groups are untouched, so nothing currently grouped changes; only the previously-individual packages move into their new dedicated groups
- [ ] CI required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)