### PR TITLE
ci(publish-gates): make export validation actually gate; real size limits; publish-time checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,8 +352,17 @@ jobs:
           echo "Verifying package.json exports match actual dist files..." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Run export validation for published packages
-          node scripts/validate-exports.mjs core semantic i18n vite-plugin mcp-server patterns-reference aot-compiler compilation-service language-server --strict 2>&1 | tee /tmp/export-validation.log
+          # Run export validation for published packages. The default job
+          # shell is `bash -e` WITHOUT pipefail, so a bare `cmd | tee` here
+          # reported tee's exit code and the --strict failure never gated
+          # (fixed in the 2026-07-20 pre-release audit). pipefail makes the
+          # pipeline carry the validator's exit; the if-guard keeps the
+          # summary parsing below reachable on failure.
+          set -o pipefail
+          status=0
+          if ! node scripts/validate-exports.mjs core semantic i18n vite-plugin mcp-server patterns-reference aot-compiler compilation-service language-server --strict 2>&1 | tee /tmp/export-validation.log; then
+            status=1
+          fi
 
           # Parse results for summary
           if grep -q "✅" /tmp/export-validation.log; then
@@ -368,6 +377,8 @@ jobs:
             grep -A 10 "Missing exports" /tmp/export-validation.log >> $GITHUB_STEP_SUMMARY || true
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           fi
+
+          exit $status
 
       # Bare-Node import of @hyperfixi/core (+ /commands, /behaviors): guards
       # the dom-globals shim ordering ahead of morphlex's module-scope
@@ -956,33 +967,72 @@ jobs:
 
       - name: Check size limits
         run: |
-          # Size limits (gzipped bytes)
-          MAX_LITE=4000           # 4 KB
-          MAX_HYBRID=15000        # 15 KB
-          MAX_BROWSER=230000      # 230 KB (actual: ~203-208 KB, allow headroom)
+          # Size limits (gzipped bytes), aligned with pre-publish-check.yml.
+          # Until the 2026-07-20 pre-release audit this step initialized
+          # failed=0, emitted ::warning:: on breach, and never set failed=1 —
+          # `exit $failed` could not fail, and the stale 230 KB browser cap
+          # (pre-dedupe "~203-208 KB" era) was being silently exceeded by the
+          # real ~299 KB gz bundle. The browser/hx-v4 ceilings exist to catch
+          # RE-duplication (the #616 double core+semantic class).
+          MAX_LITE=4000           # 4 KB   (actual ~2 KB)
+          MAX_HYBRID=20000        # 20 KB  (hybrid-hx actual ~18.5 KB gz)
+          MAX_BROWSER=340000      # 340 KB (hyperfixi.js actual ~299 KB gz post-dedupe)
+          MAX_HXV4=350000         # 350 KB (hyperfixi-hx-v4.js actual ~311 KB gz post-dedupe)
 
           failed=0
 
           if [[ -f "packages/core/dist/hyperfixi-lite.js" ]]; then
             size=$(gzip -c packages/core/dist/hyperfixi-lite.js | wc -c | tr -d ' ')
             if [[ "$size" -gt "$MAX_LITE" ]]; then
-              echo "::warning::hyperfixi-lite.js ($size bytes gzip) exceeds limit ($MAX_LITE bytes)"
+              echo "::error::hyperfixi-lite.js ($size bytes gzip) exceeds limit ($MAX_LITE bytes)"
+              failed=1
+            else
+              echo "hyperfixi-lite.js: $size bytes gzip (limit $MAX_LITE)"
             fi
           fi
 
-          if [[ -f "packages/core/dist/hyperfixi-hybrid-complete.js" ]]; then
-            size=$(gzip -c packages/core/dist/hyperfixi-hybrid-complete.js | wc -c | tr -d ' ')
-            if [[ "$size" -gt "$MAX_HYBRID" ]]; then
-              echo "::warning::hyperfixi-hybrid-complete.js ($size bytes gzip) exceeds limit ($MAX_HYBRID bytes)"
+          # hyperfixi-hx.js shares the hybrid ceiling; it is listed explicitly
+          # because its filename matches no hyperfixi-hybrid-* glob (the same
+          # naming gap that once left hx-v4 unchecked in pre-publish-check).
+          for bundle in hyperfixi-hybrid-complete.js hyperfixi-hx.js; do
+            if [[ -f "packages/core/dist/$bundle" ]]; then
+              size=$(gzip -c "packages/core/dist/$bundle" | wc -c | tr -d ' ')
+              if [[ "$size" -gt "$MAX_HYBRID" ]]; then
+                echo "::error::$bundle ($size bytes gzip) exceeds limit ($MAX_HYBRID bytes)"
+                failed=1
+              else
+                echo "$bundle: $size bytes gzip (limit $MAX_HYBRID)"
+              fi
             fi
-          fi
+          done
 
+          # Full bundles are NOT [[ -f ]]-skipped: the build job runs
+          # build:browser, so a missing file means the bundle build silently
+          # failed upstream — that must fail here, not skip.
           if [[ -f "packages/core/dist/hyperfixi.js" ]]; then
             size=$(gzip -c packages/core/dist/hyperfixi.js | wc -c | tr -d ' ')
-            echo "hyperfixi.js gzipped: $size bytes (limit: $MAX_BROWSER bytes)"
             if [[ "$size" -gt "$MAX_BROWSER" ]]; then
-              echo "::warning::hyperfixi.js ($size bytes gzip) exceeds limit ($MAX_BROWSER bytes)"
+              echo "::error::hyperfixi.js ($size bytes gzip) exceeds limit ($MAX_BROWSER bytes)"
+              failed=1
+            else
+              echo "hyperfixi.js: $size bytes gzip (limit $MAX_BROWSER)"
             fi
+          else
+            echo "::error::hyperfixi.js MISSING from dist — bundle build failed upstream"
+            failed=1
+          fi
+
+          if [[ -f "packages/core/dist/hyperfixi-hx-v4.js" ]]; then
+            size=$(gzip -c packages/core/dist/hyperfixi-hx-v4.js | wc -c | tr -d ' ')
+            if [[ "$size" -gt "$MAX_HXV4" ]]; then
+              echo "::error::hyperfixi-hx-v4.js ($size bytes gzip) exceeds limit ($MAX_HXV4 bytes)"
+              failed=1
+            else
+              echo "hyperfixi-hx-v4.js: $size bytes gzip (limit $MAX_HXV4)"
+            fi
+          else
+            echo "::error::hyperfixi-hx-v4.js MISSING from dist — bundle build failed upstream"
+            failed=1
           fi
 
           exit $failed

--- a/.github/workflows/pre-publish-check.yml
+++ b/.github/workflows/pre-publish-check.yml
@@ -289,17 +289,20 @@ jobs:
           IFS=',' read -ra PKG_ARRAY <<< "${{ steps.packages.outputs.packages }}"
           FAILED_PKGS=""
 
-          # Detection is the validator's EXIT CODE (it exits 1 on missing
-          # exports). The previous shape — `if cmd | tee log` plus a
-          # `grep -c … || echo "0"` fallback — tested tee's exit (always 0)
-          # and compared against a two-line "0\n0" string (never equal), so
-          # EVERY package was marked ❌ in the summary of every historical
-          # run; the honest-verdict validation run exposed it.
+          # Detection is the validator's EXIT CODE — which it only raises
+          # under --strict (without the flag the script prints ❌ but still
+          # exits 0, so this loop was vacuously green until --strict was
+          # added in the 2026-07-20 pre-release audit). The previous shape —
+          # `if cmd | tee log` plus a `grep -c … || echo "0"` fallback —
+          # tested tee's exit (always 0) and compared against a two-line
+          # "0\n0" string (never equal), so EVERY package was marked ❌ in
+          # the summary of every historical run; the honest-verdict
+          # validation run exposed it.
           for pkg in "${PKG_ARRAY[@]}"; do
             pkg=$(echo "$pkg" | xargs)
             if [ -d "packages/$pkg" ] && [ -f "packages/$pkg/package.json" ]; then
               echo "Validating $(node -p "require('./packages/$pkg/package.json').name") exports..."
-              if node scripts/validate-exports.mjs "$pkg" > /tmp/${pkg}-exports.log 2>&1; then
+              if node scripts/validate-exports.mjs "$pkg" --strict > /tmp/${pkg}-exports.log 2>&1; then
                 echo "✅ $(node -p "require('./packages/$pkg/package.json').name" 2>/dev/null || echo "$pkg") - All exports valid" >> $GITHUB_STEP_SUMMARY
               else
                 cat /tmp/${pkg}-exports.log
@@ -350,8 +353,10 @@ jobs:
             fi
           fi
 
-          # Check hybrid bundles
-          for bundle in packages/core/dist/hyperfixi-hybrid-*.js; do
+          # Check hybrid bundles. hyperfixi-hx.js is listed explicitly: it
+          # shares the hybrid ceiling but matches no hyperfixi-hybrid-* glob
+          # (the same naming gap that once left hx-v4 unchecked below).
+          for bundle in packages/core/dist/hyperfixi-hybrid-*.js packages/core/dist/hyperfixi-hx.js; do
             if [[ -f "$bundle" ]]; then
               size=$(gzip -c "$bundle" | wc -c | tr -d ' ')
               filename=$(basename "$bundle")

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,6 +147,20 @@ jobs:
           npm test --prefix packages/compilation-service -- --run
           npm test --prefix packages/mcp-server -- --run
 
+      # Publish-time gates (added 2026-07-20 pre-release audit). Both checks
+      # previously ran only on PRs (ci.yml export-validation job) and in the
+      # manual pre-publish-check dispatch — nothing in THIS workflow's path
+      # stopped a dispatch from shipping a broken exports map or a
+      # Node-unsafe core (dom-globals-shim ordering ahead of morphlex's
+      # module-scope Element.prototype access). Runs after build:browser on
+      # purpose: core's exports map includes dist/hyperfixi*.js bundles that
+      # only exist once the browser bundles are built. Both commands are
+      # unpiped so their exit codes gate directly.
+      - name: Validate exports + bare-Node import
+        run: |
+          node scripts/validate-exports.mjs core semantic i18n vite-plugin mcp-server patterns-reference aot-compiler compilation-service language-server --strict
+          node scripts/check-node-import.mjs
+
       - name: Calculate new version
         id: version
         run: |


### PR DESCRIPTION
## Summary

Part 1 of the v2.8.0 pre-release audit (gates first, so the later audit PRs and publish day run against gates that can actually fail). Three "green" gates could not fail:

- **pre-publish-check "Validate exports" was vacuously green.** It called `validate-exports.mjs` without `--strict`, but the script only exits 1 under `--strict` (`scripts/validate-exports.mjs:332-339`) — so the `if node …` failure branch (summary ❌ + `prepublish-failures.txt` verdict) was unreachable. Verified locally: with a dist file hidden, non-strict exits **0**, strict exits **1**. Now passes `--strict`; the step comment no longer claims an exit-code contract the script didn't have.
- **ci.yml export-validation was advisory.** The `--strict` run was piped through `tee` and the default job shell is `bash -e` **without** pipefail, so the step reported tee's exit. Now `set -o pipefail` + an if-guard, so the failure gates while the step-summary parsing still runs on failure.
- **ci.yml size limits could never fail.** `failed=0` was never set to 1, so `exit $failed` was always 0 — and the stale 230 KB cap ("actual ~203-208 KB" comment, pre-dedupe era) was already being silently exceeded by the real ~299 KB gz bundle. Now `::error::` + `failed=1`, ceilings aligned with pre-publish-check's post-dedupe values (340 KB browser / 350 KB hx-v4 / 20 KB hybrid), and two bundles that matched **no** existing check are covered: `hyperfixi-hx-v4.js` and `hyperfixi-hx.js` (neither matches the `hyperfixi-hybrid-*` glob — the same naming gap in both workflows). Missing full bundles now fail instead of being skipped.
- **publish.yml had no export/Node-import gate in its own path.** Both checks ran only on PRs (ci.yml) and in the manual pre-publish dispatch; a publish dispatch could ship a broken exports map or a Node-unsafe core (the dom-globals-shim/morphlex ordering) ungated. Added `validate-exports --strict` + `check-node-import.mjs` after `build:browser` (core's exports include the browser bundles), before version calc, unpiped.

## Verification

- `validate-exports.mjs` exit-code matrix demonstrated locally (broken: strict=1, non-strict=0; restored: strict=0 against built tree, private aot-compiler skipped by design).
- All three workflows YAML-parse cleanly; `check:ci-order` pre-commit hook passed.
- After merge: dispatch `gh workflow run pre-publish-check.yml -f packages=all` for a fresh honest run (wanted by the release runbook anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)