### PR TITLE
fix(exports): make three export maps match build reality (first honest strict-gate run)

### DIFF
--- a/packages/behaviors/package.json
+++ b/packages/behaviors/package.json
@@ -4,7 +4,7 @@
   "description": "Reusable hyperscript behaviors for LokaScript",
   "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/testing-framework/package.json
+++ b/packages/testing-framework/package.json
@@ -24,21 +24,6 @@
       "import": "./dist/assertions.mjs",
       "require": "./dist/assertions.js",
       "types": "./dist/assertions.d.ts"
-    },
-    "./browser": {
-      "import": "./dist/browser.mjs",
-      "require": "./dist/browser.js",
-      "types": "./dist/browser.d.ts"
-    },
-    "./e2e": {
-      "import": "./dist/e2e.mjs",
-      "require": "./dist/e2e.js",
-      "types": "./dist/e2e.d.ts"
-    },
-    "./multilingual": {
-      "import": "./dist/multilingual/index.mjs",
-      "require": "./dist/multilingual/index.js",
-      "types": "./dist/multilingual/index.d.ts"
     }
   },
   "scripts": {

--- a/packages/testing-framework/tsup.config.ts
+++ b/packages/testing-framework/tsup.config.ts
@@ -4,6 +4,11 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
     assertions: 'src/assertions.ts',
+    // runner backs the package.json "./runner" export — it existed in src but
+    // was never built, so the export dangled (caught by the strict export
+    // gate the 2026-07-20 audit armed; ./browser, ./e2e and ./multilingual
+    // had no buildable source at all and were removed from exports instead).
+    runner: 'src/runner.ts',
   },
   format: ['cjs', 'esm'],
   dts: true,

--- a/packages/types-browser/package.json
+++ b/packages/types-browser/package.json
@@ -3,7 +3,6 @@
   "version": "2.7.2",
   "description": "TypeScript type definitions for LokaScript browser globals",
   "type": "module",
-  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

The fresh pre-publish-check dispatch (run 29799165929) — the **first run where the #745 strict export gate could actually fail** — went red on exactly three packages. All three are real shipping defects the old vacuous validation had passed on every historical run:

| Package | Defect | Fix |
| --- | --- | --- |
| `types-browser` | types-only package claimed `main: dist/index.js`; no JS is ever built | dropped `main` (exports map already types-only) |
| `behaviors` | `module: ./dist/index.mjs`; tsup emits ESM as `.js` / CJS as `.cjs` | `module` → `./dist/index.js` |
| `testing-framework` | `./browser` + `./e2e` exports with **no source files**; `./multilingual` is tsx-run tooling never built; `./runner` has real source missing from tsup entries | removed the three fictional exports (zero consumers, grep-verified); added `runner` to tsup entries so `./runner` resolves |

## Verification

- `node scripts/validate-exports.mjs types-browser behaviors testing-framework --strict` → exit 0, all pass.
- testing-framework suite: 262 passed. Multilingual CLI unaffected (invoked from src via tsx).
- After merge: re-dispatch `pre-publish-check.yml -f packages=all` → expected fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)