### PR TITLE
test(testing-framework): tolerate setTimeout clamping in duration assertions

### DIFF
--- a/packages/testing-framework/src/runner.test.ts
+++ b/packages/testing-framework/src/runner.test.ts
@@ -438,7 +438,11 @@ describe('CoreTestRunner', () => {
 
       const result = await runner.runTest(test, context);
 
-      expect(result.duration).toBeGreaterThanOrEqual(50);
+      // Tolerance below the 50ms sleep: setTimeout clamping can fire the
+      // timer ~1-2ms early on CI runners (observed: 49ms in pre-publish run
+      // 29800757714), and the assertion is about duration RECORDING, not
+      // timer precision.
+      expect(result.duration).toBeGreaterThanOrEqual(45);
     });
   });
 });
@@ -686,7 +690,8 @@ describe('measurePerformance', () => {
 
     const metrics = await measurePerformance(mockPage, testFn);
 
-    expect(metrics.loadTime).toBeGreaterThanOrEqual(50);
+    // Same timer-clamping tolerance as the duration test above.
+    expect(metrics.loadTime).toBeGreaterThanOrEqual(45);
   });
 });
 


### PR DESCRIPTION
## Summary

Pre-publish run 29800757714 (the re-dispatch after #749) failed on a single flaky assertion: `runner.test.ts > should record test duration` measured **49ms** for a 50ms sleep — the well-known setTimeout clamping undershoot on CI runners. The same suite passed in the prior run and locally; nothing in the audit PRs touches this path.

Both 50ms duration floors (`result.duration`, `metrics.loadTime`) relaxed to 45ms with a comment — the assertions verify duration *recording*, not timer precision.

## Verification

- testing-framework suite green locally (262 passed).
- After merge: re-dispatch `pre-publish-check.yml -f packages=all` for the final pre-freeze verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)