### PR TITLE
ci(publish): add @lokascript/htmx-adapter to publish + pre-publish lists

### DIFF
--- a/.github/workflows/pre-publish-check.yml
+++ b/.github/workflows/pre-publish-check.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           PACKAGES="${{ github.event.inputs.packages }}"
           if [ "$PACKAGES" = "all" ]; then
-            PACKAGES="intent,framework,semantic,core,i18n,hyperscript-adapter,patterns-reference,server-bridge,types-browser,domain-sql,domain-bdd,domain-llm,domain-todo,domain-behaviorspec,domain-jsx,domain-flow,domain-voice,domain-learn,domain-config,aot-compiler,compilation-service,planner,mcp-server,vite-plugin,behaviors,reactivity,components,speech,intent-element,testing-framework,language-server,language-server-hyperscript,multilingual-hyperscript"
+            PACKAGES="intent,framework,semantic,core,i18n,hyperscript-adapter,patterns-reference,server-bridge,types-browser,domain-sql,domain-bdd,domain-llm,domain-todo,domain-behaviorspec,domain-jsx,domain-flow,domain-voice,domain-learn,domain-config,aot-compiler,compilation-service,planner,mcp-server,vite-plugin,behaviors,reactivity,components,speech,intent-element,testing-framework,language-server,language-server-hyperscript,multilingual-hyperscript,htmx-adapter"
           fi
           echo "Checking packages: $PACKAGES"
           echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
@@ -115,7 +115,7 @@ jobs:
           # developer-tools' dist ships the prism-hyperscript-i18n asset the
           # bundle-compatibility harness pages load (validation v5: every
           # bundle "failed" on that one missing asset).
-          BUILD_ORDER="intent framework semantic domain-bdd domain-sql domain-jsx domain-todo domain-behaviorspec domain-llm domain-flow domain-voice domain-learn domain-toolkit domain-config behaviors core patterns-reference i18n hyperscript-adapter aot-compiler compilation-service planner mcp-server mcp-multilingual-intent developer-tools server-bridge types-browser vite-plugin language-server reactivity realtime components speech intent-element"
+          BUILD_ORDER="intent framework semantic domain-bdd domain-sql domain-jsx domain-todo domain-behaviorspec domain-llm domain-flow domain-voice domain-learn domain-toolkit domain-config behaviors core patterns-reference i18n hyperscript-adapter aot-compiler compilation-service planner mcp-server mcp-multilingual-intent developer-tools server-bridge types-browser vite-plugin language-server reactivity realtime components speech intent-element htmx-adapter"
 
           for pkg in $BUILD_ORDER; do
             if [ -d "packages/$pkg" ]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,6 +133,12 @@ jobs:
           npm run build --prefix packages/language-server-hyperscript
           npm run build --prefix packages/multilingual-hyperscript
           npm run build --prefix packages/hyperscript-tools-i18n
+          # htmx-adapter is dependency-free (adapter for upstream htmx v4);
+          # added 2026-07-21 — it shipped in #735 as a PUBLIC package but was
+          # missing from this list AND from ALL_PACKAGES, so v2.8.0's dry run
+          # silently skipped it (the audit's "dropped from the build-order
+          # list" class, caught during the release itself).
+          npm run build --prefix packages/htmx-adapter
           # Core browser bundles depend on i18n/dist/browser.js + reactivity/dist
           # and realtime/dist (browser-bundle.ts inlines both plugins)
           npm run build:browser --prefix packages/core
@@ -218,7 +224,7 @@ jobs:
                         compilation-service planner mcp-server vite-plugin \
                         behaviors reactivity realtime components speech intent-element testing-framework language-server \
                         language-server-hyperscript multilingual-hyperscript \
-                        hyperscript-tools-i18n"
+                        hyperscript-tools-i18n htmx-adapter"
 
           for pkg in $ALL_PACKAGES; do
             [ ! -f "packages/$pkg/package.json" ] && continue
@@ -355,7 +361,7 @@ jobs:
                        compilation-service mcp-server vite-plugin \
                        behaviors testing-framework language-server \
                        language-server-hyperscript multilingual-hyperscript \
-                       hyperscript-tools-i18n; do
+                       hyperscript-tools-i18n htmx-adapter; do
               [ -f "packages/$pkg/package.json" ] || continue
               IS_PRIVATE=$(node -p "require('./packages/$pkg/package.json').private || false")
               [ "$IS_PRIVATE" = "true" ] && continue

--- a/docs-internal/RELEASE_NOTES_v2.8.0-draft.md
+++ b/docs-internal/RELEASE_NOTES_v2.8.0-draft.md
@@ -54,6 +54,29 @@ parser. Surfaced by the first honest run of the bundle-compatibility suite;
 the gallery fetch-data example now passes on all 8 bundles with real
 assertions.
 
+### Foreign→English canonical validity: 3059/3059 (#697–#736)
+
+Every authored foreign translation now renders English that the canonical
+hyperscript.org parser accepts — both canonical-validity allowlists are empty.
+The burndown (90.7% → 100%) closed dozens of per-language rendering bugs
+(possessive glue, event-source leaks, value-literal bindings, ambiguous-sense
+vocabulary) and finished with full `pick <text-range>` support in all 24
+languages (#733/#734/#736). A new R4 canonical-validity ratchet (#727) makes
+this a ninth `--regression` gate signal so it cannot silently regress.
+
+### New package: `@lokascript/htmx-adapter` (#735)
+
+Multilingual adapter for upstream htmx v4 — a canonicalizing extension that
+lets localized attribute vocabularies drive an unmodified htmx build.
+
+### `trigger` / `fire` fixed in the hybrid bundles (#748)
+
+`trigger` (and its alias `fire`) silently did nothing in the shipped
+`hyperfixi-hybrid-complete.js` and `hyperfixi-hx.js` bundles — advertised in
+the bundle manifest but missing from the inline runtime. Both now dispatch
+exactly like `send`, and a manifest↔runtime consistency test pins every
+advertised command to a real implementation.
+
 ## Correctness & validation
 
 - **Vocab consistency gate in CI** — cross-surface dictionary/profile/renderer
@@ -62,11 +85,12 @@ assertions.
   instrumented (`--diagnose-coverage`); all residual firings are attributed to
   named families. A pattern can no longer score confidence 1.0 while silently
   dropping a trailing clause without that being measured.
-- **Fidelity floors held** — the eight-signal multilingual ratchet
+- **Fidelity floors held** — the nine-signal multilingual ratchet
   (parse-rate, degenerate, R0-recall, R0-precision, multiset-recall, R1 roles,
-  R2 execution, R3 values) holds the 2026-07-11 high-water marks: fidelity
-  1.000 on all 3,696 corpus rows across 24 languages, avgRoleFidelity ≈ 0.992,
-  avgValueRecall ≈ 0.997.
+  R2 execution, R3 values, R4 canonical validity) holds the high-water marks:
+  fidelity 1.000 on all 3,696 corpus rows across 24 languages,
+  avgRoleFidelity ≈ 0.992, avgValueRecall ≈ 0.997, canonical validity
+  3059/3059.
 
 ## Publish-pipeline hardening
 
@@ -78,6 +102,11 @@ assertions.
   step that always runs. Size limits reset to measured reality as
   anti-regression ceilings.
 - Version bumps land on `main` via a release token with PR fallback (#674).
+- Pre-release audit (#745–#750): export validation is strict end-to-end and
+  runs inside the publish workflow itself alongside a bare-Node core import
+  check; CI size limits actually fail (with hx-v4 and hybrid-hx covered);
+  three export maps that claimed never-built files (types-browser, behaviors,
+  testing-framework) were fixed the first time the honest gate ran.
 
 ## Documented bundle sizes now match reality
 


### PR DESCRIPTION
## Summary

The v2.8.0 **dry run** (29832273927) listed 34 packages at 2.8.0 — but not `@lokascript/htmx-adapter`, which #735 shipped as a **public** package (advertised in the release notes as new) yet never entered publish.yml's build list / `ALL_PACKAGES` / summary list, nor pre-publish-check's package + `BUILD_ORDER` lists. Without this, `set-version.cjs` bumps it to 2.8.0 in-repo with no npm release behind it — exactly the "dropped from the build-order list" class the audit documented, caught live by the runbook's dry-run fan-out verification.

The package is dependency-free, builds clean, and passes `validate-exports --strict`; appended to the end of each list (nothing depends on it, so ordering is trivial). Also includes the finalized release-notes draft used by the notes-swap step.

## Verification

- Both workflows YAML-parse.
- After merge: fresh dry run must list **35** packages at 2.8.0 including `@lokascript/htmx-adapter` before the real publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)