### PR TITLE
fix(htmx-adapter): add repository field — npm provenance requires it

### DIFF
--- a/packages/htmx-adapter/package.json
+++ b/packages/htmx-adapter/package.json
@@ -48,5 +48,10 @@
     "dist",
     "src",
     "README.md"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/codetalcott/hyperfixi.git",
+    "directory": "packages/htmx-adapter"
+  }
 }


### PR DESCRIPTION
## Summary

The v2.8.0 publish (run 29836121238) published **34/35** packages; only `@lokascript/htmx-adapter` failed — npm **E422**: sigstore provenance validation requires `repository.url` to match `https://github.com/codetalcott/hyperfixi`, and this package had no `repository` field at all (swept: it was the only public package in the workspace missing it). `npm publish --dry-run` generates no provenance bundle, which is why two green dry runs couldn't catch it.

Adds the standard field (url + directory), same shape as every other package.

## Recovery

After merge, re-dispatch `publish.yml` with the same inputs (`minor`/`latest`/`dry-run=false`): the publish loop skips the 34 already-published versions ("already published, skipping"), publishes htmx-adapter, then runs the previously-skipped bump-commit / tag / GitHub-release steps — completing v2.8.0 as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)