### PR TITLE
chore(scripts): drop the extracted mcp-server-hyperscript from test:check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,8 +198,6 @@ packages/*/html/
 !**/test-multilingual-e2e.html
 
 # MCP server files
-mcp-server-hyperscript/dist/
-mcp-server-hyperscript/node_modules/
 packages/mcp-server/com.lokascript.mcp-server.plist
 
 # Lock files (keep package-lock.json)

--- a/scripts/test-check-all.sh
+++ b/scripts/test-check-all.sh
@@ -60,7 +60,6 @@ PACKAGES=(
 
   # MCP & Language Servers
   "mcp-server:MCP Server"
-  "mcp-server-hyperscript:MCP Server (HS)"
   "language-server:Language Server"
 
   # Plugin & bundling


### PR DESCRIPTION
## Problem

`chore: extract mcp-server-hyperscript to its own repo` (#686) deleted `packages/mcp-server-hyperscript/`, but left the package listed in `scripts/test-check-all.sh`. Every `npm run test:check` since then dies on:

```
=== MCP Server (HS) ===
npm error enoent Could not read package.json: .../packages/mcp-server-hyperscript/package.json
```

`failed=1` is set, so the script prints `SOME PACKAGES FAILED` and exits 1 — on a fully green tree. The whole-monorepo gate has been reporting red for a package that no longer exists.

## Fix

- Remove the `"mcp-server-hyperscript:MCP Server (HS)"` entry from the `PACKAGES` list.
- Remove the two now-dead `.gitignore` rules for that directory's `dist/` and `node_modules/`.

## Verification

`npm run test:check` on this branch: **29 packages, ~22,100 tests passing, 142 skipped, exit 0.** No failure markers anywhere in the log. (Before: same test results, exit 1.)

Also confirmed every remaining entry in both the `PACKAGES` list and the `ensure-fresh.sh` argument list resolves to a real `packages/<name>/package.json`, and `bash -n` passes.

## The extraction itself was clean

Checked, since a stale reference can be a sign of a bad move:

- The package's only tests (`src/__tests__/tools.test.ts`) were self-contained and went with it in #686 — nothing orphaned.
- No workspace `package.json` depends on `@hyperscript-tools/mcp-server`; no relative imports or path references survive in any `.ts`/`.js`/`.yml`.
- #686 already updated `publish.yml`, `pre-publish-check.yml`, `CLAUDE.md`, `docs/ARCHITECTURE.md`, and `package-lock.json`. This script was the single miss.
- The `@hyperscript-tools/*` packages still in the monorepo (`i18n`, `language-server`, `multilingual`) share the npm scope, not a dependency — all three pass.

Remaining mentions in `docs-internal/` are historical (the proposal that planned the split, and the roadmap that already records the package as moved), so they're left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)