### PR TITLE
fix(publish): accept either package-name form, fail on a zero-match filter, gate tag/release to full runs

### DIFF
--- a/.github/workflows/pre-publish-check.yml
+++ b/.github/workflows/pre-publish-check.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       packages:
-        description: 'Packages to check (comma-separated, e.g., core,semantic,i18n or "all")'
+        description: 'Packages: "all", or a comma-separated subset by DIRECTORY name (e.g. core,semantic,i18n). Note publish.yml accepts either directory or npm names; this one takes directory names only.'
         required: true
         type: string
         default: 'all'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ on:
         type: boolean
         default: false
       packages:
-        description: 'Packages to publish (comma-separated subset, or "all")'
+        description: 'Packages: "all", or a comma-separated subset by directory name (domain-learn) or npm name (@lokascript/domain-learn). A filter matching nothing fails the run.'
         required: false
         type: string
         default: 'all'
@@ -206,6 +206,7 @@ jobs:
           node scripts/sync-changelogs.cjs
 
       - name: Publish packages
+        id: publish
         env:
           # NPM_TOKEN required for initial publish of new packages
           # (OIDC trusted publishing only works for packages already on npm)
@@ -235,14 +236,28 @@ jobs:
                         language-server-hyperscript multilingual-hyperscript \
                         hyperscript-tools-i18n htmx-adapter"
 
+          # A filter entry may be either the DIRECTORY name (`domain-learn`) or the
+          # npm name (`@lokascript/domain-learn`). It used to match the npm name
+          # only, while the sibling pre-publish-check workflow takes directory
+          # names for an identically-described input — so passing directory names
+          # here silently matched NOTHING, published zero packages, and still
+          # reported success. That happened for real on the 2.9.0 release and cost
+          # a full cycle. MATCHED counts what survives the filter; the guard after
+          # the loop turns "matched nothing" into a hard failure.
+          MATCHED=0
+
           for pkg in $ALL_PACKAGES; do
             [ ! -f "packages/$pkg/package.json" ] && continue
 
             # Skip if not in filter (unless filter is "all")
             if [ "$FILTER" != "all" ]; then
               PKG_NAME=$(node -p "require('./packages/$pkg/package.json').name")
-              echo "$FILTER" | grep -qF "$PKG_NAME" || continue
+              # Exact match on either form, comma-delimited so `domain-learn`
+              # cannot also match `domain-learn-extras`.
+              echo ",$FILTER," | grep -qF ",$pkg," || \
+                echo ",$FILTER," | grep -qF ",$PKG_NAME," || continue
             fi
+            MATCHED=$((MATCHED + 1))
 
             PKG_NAME=$(node -p "require('./packages/$pkg/package.json').name")
             PKG_VER=$(node -p "require('./packages/$pkg/package.json').version")
@@ -273,6 +288,16 @@ jobs:
             echo "::error::Failed:$FAILED"
             exit 1
           fi
+
+          # A filter that matches nothing is always a mistake — a typo, or the
+          # wrong naming convention — and used to pass as a green no-op that
+          # still cut a tag and a GitHub Release. Fail loudly instead.
+          if [ "$MATCHED" -eq 0 ]; then
+            echo "::error::packages filter '$FILTER' matched none of ALL_PACKAGES — nothing was published. Use directory names (domain-learn) or npm names (@lokascript/domain-learn), comma-separated."
+            exit 1
+          fi
+          echo "published=$MATCHED" >> $GITHUB_OUTPUT
+          echo "✓ $MATCHED package(s) processed"
 
       - name: Commit version changes
         # When version-type=current, the bump was already committed by hand
@@ -338,14 +363,22 @@ jobs:
           fi
 
       - name: Create Git tags
-        if: ${{ github.event.inputs.dry-run == 'false' }}
+        # Only a FULL run cuts release artifacts. A subset dispatch is a repair
+        # (finishing a partial publish, re-pushing one package), and tagging from
+        # one would overwrite the real release's tag with a partial one. On the
+        # 2.9.0 release a subset run that published ZERO packages still cut the
+        # tag and a Release marked Latest — a tag is not evidence a release
+        # happened, and this is half of why. The other half is the zero-match
+        # guard in the publish step.
+        if: ${{ github.event.inputs.dry-run == 'false' && github.event.inputs.packages == 'all' }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           git tag -f "v$VERSION"
           git push origin "v$VERSION" --force
 
       - name: Create GitHub Release
-        if: ${{ github.event.inputs.dry-run == 'false' }}
+        # Same gate as the tag above — a repair run must not re-cut the Release.
+        if: ${{ github.event.inputs.dry-run == 'false' && github.event.inputs.packages == 'all' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Fixes the two release-tooling faults that turned a recoverable partial publish
into a longer incident during 2.9.0.

## 1. The `packages` filter matched only the npm name

```bash
echo "$FILTER" | grep -qF "$PKG_NAME" || continue
```

`pre-publish-check.yml` takes **directory** names for an input described the same
way. Dispatching the 2.9.0 repair run with directory names matched nothing,
published **zero** packages, exited **0**, and still cut a `v2.9.0` tag and a
GitHub Release marked Latest. A green run, a tag, and nothing on npm.

Now accepts either form, matched **exactly** — the needle and the filter are both
comma-wrapped, so `domain-learn` can't also match `domain-learn-extras`, which the
old substring grep would have.

## 2. Silence on a zero-match filter

A filter matching nothing is always a mistake — a typo, or the wrong convention.
It now fails with a message naming both accepted forms.

## 3. Tag and Release were ungated

They ran on `dry-run == 'false'` alone, regardless of what the publish loop did.
Now they also require `packages == 'all'`. A subset dispatch is a **repair**, not
a release: it shouldn't mint the artifacts, and it certainly shouldn't
force-overwrite a real release's tag (`git tag -f` + `--force` push).

Both input descriptions now state which forms they accept — the mismatch between
the two workflows is what made the wrong guess look right.

## Not fixed here

The per-package loop deliberately tolerates failures so one bad package can't
abort the rest, failing at the end instead. That's why 2.9.0 published 19 of 35
and left `@hyperfixi/core` depending on a `@lokascript/intent@^2.9.0` that didn't
exist — `npm install @hyperfixi/core` was broken until the remaining 16 landed.

The tolerance is right. The gap is that **nothing verifies the published set is
internally resolvable** before the run is called done. A cheap check — after
publishing, resolve every published package's internal deps against the registry
— would have caught it within the same run instead of after. Left out to keep
this PR to the two faults it names; happy to add it if you want it here.

## Testing

Workflow-only; both files parse as YAML. The filter logic is exercised by the
next release dispatch — worth a `dry-run: true` with a subset filter to confirm
both name forms match before relying on it.
