### PR TITLE
fix(core): stop lexing a single-quoted string starting with `s` as possessive

### DIFF
--- a/packages/core/src/parser/possessive-vs-string.test.ts
+++ b/packages/core/src/parser/possessive-vs-string.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Possessive `'s` vs a single-quoted string starting with `s`.
+ *
+ * The possessive check only asked whether the PREVIOUS token was an identifier —
+ * and a command name is an identifier. So `log 'saved'` matched: the tokenizer
+ * emitted the possessive operator and shredded the string into
+ * `log` · `'s` · `aved` · `'`. Every single-quoted literal whose first character
+ * is a lowercase `s` was affected — `'saved'`, `'success'`, `'sent'`, `'stop'` —
+ * while `'ok'`, `'Saved'` and `"saved"` were fine, which is what made it so
+ * quiet. Downstream it surfaced as a phantom trailing command in a handler body.
+ *
+ * The missing condition is adjacency: a real possessive touches the token it
+ * belongs to (`me's`, `#el's`, `(expr)'s`), whereas a string argument is
+ * separated by whitespace.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { tokenize } from './tokenizer';
+import type { Token } from '../types/core';
+import { parse } from './parser';
+import type { CommandNode } from '../types/base-types';
+
+const values = (src: string): string[] => tokenize(src).map((t: Token) => t.value);
+const kinds = (src: string): string[] => tokenize(src).map((t: Token) => `${t.value}:${t.kind}`);
+
+describe('single-quoted strings beginning with `s`', () => {
+  it.each([
+    ["log 'saved'", 'saved'],
+    ["log 'success'", 'success'],
+    ["put 'sent' into me", 'sent'],
+    ["set x to 'stop'", 'stop'],
+    ["log 'should not get here'", 'should not get here'],
+  ])('%s tokenizes as one string', (src, expected) => {
+    const strings = tokenize(src).filter((t: Token) => t.kind === 'string');
+    expect(strings).toHaveLength(1);
+    expect(strings[0].value).toBe(`'${expected}'`);
+    // No possessive operator should appear anywhere in the stream.
+    expect(values(src)).not.toContain("'s");
+  });
+
+  it('leaves the already-working cases alone', () => {
+    expect(kinds("log 'ok'")).toContain("'ok':string");
+    expect(kinds('log "saved"')).toContain('"saved":string');
+    expect(kinds("log 'Saved'")).toContain("'Saved':string");
+  });
+
+  it('parses to the intended command rather than a mangled one', () => {
+    const result = parse("put 'saved' into #status");
+    expect(result.success).toBe(true);
+    const node = result.node as CommandNode;
+    expect(node.name).toBe('put');
+    expect((node.args?.[0] as { value?: unknown }).value).toBe('saved');
+  });
+});
+
+describe('possessive still works when adjacent', () => {
+  it.each([
+    ["log my's"],
+    ["set x to #el's value"],
+    ["log me's innerHTML"],
+    ["log (a)'s b"],
+    // Adjacency is tested against the source character rather than the previous
+    // token's `end`, because bracket/operator tokens do not track offsets
+    // reliably — the `]` here reports end=8 for an apostrophe at index 9.
+    ["[1, 2, 3]'s length"],
+    ["arr's length + obj's count"],
+  ])('%s keeps the possessive operator', src => {
+    expect(values(src)).toContain("'s");
+  });
+
+  it('parses a possessive property access', () => {
+    const result = parse("put me's innerHTML into #out");
+    expect(result.success).toBe(true);
+    expect((result.node as CommandNode).name).toBe('put');
+  });
+});

--- a/packages/core/src/parser/tokenizer.ts
+++ b/packages/core/src/parser/tokenizer.ts
@@ -112,6 +112,18 @@ export function tokenize(input: string): Token[] {
       const isPossessive =
         nextChar === 's' &&
         prevToken &&
+        // The apostrophe must TOUCH what precedes it. Without this, any
+        // single-quoted string whose first character is a lowercase `s` was
+        // lexed as the possessive operator — `log 'saved'` became
+        // log · 's · aved · "'", so `'saved'`, `'success'`, `'sent'`, `'stop'`
+        // silently mis-parsed while `'ok'` and `"saved"` were fine. A real
+        // possessive is always adjacent (`me's`, `#el's`, `[1,2]'s`).
+        //
+        // Tested against the source character, not `prevToken.end`: bracket and
+        // operator tokens do not track their offsets reliably (the `]` in
+        // `[1, 2, 3]'s length` reports end=8 for an apostrophe at 9), so an
+        // offset comparison would reject valid possessives.
+        !/\s/.test(tokenizer.input[tokenizer.position - 1] ?? ' ') &&
         (prevToken.kind === TokenKind.IDENTIFIER ||
           prevToken.kind === TokenKind.SELECTOR ||
           // Support possessive after array/object literals and parenthesized expressions


### PR DESCRIPTION
Found while writing tests for #768 — not part of the original downstream report, and more broadly damaging than any of the three issues it came from.

## The bug

```
log 'saved'          →  log · 's · aved · "'"
log 'success'        →  log · 's · uccess · "'"
put 'sent' into me   →  put · 's · ent · "' into me"
set x to 'stop'      →  set · x · to · 's · top · "'"
```

Any single-quoted string literal whose **first character is a lowercase `s`** was lexed as the possessive `'s` operator followed by debris. The check only asked whether the previous token was an identifier — and a command name *is* an identifier:

```ts
const isPossessive =
  nextChar === 's' &&
  prevToken &&
  (prevToken.kind === TokenKind.IDENTIFIER || ...);
```

`'ok'`, `'Saved'` and `"saved"` are all fine, which is what kept this quiet — you only hit it on a common-but-not-universal subset of string contents (`'saved'`, `'success'`, `'sent'`, `'stop'`, `'submitted'`…). It surfaced as a *phantom command*: a handler body containing `put 'should not get here' into #out` parsed with an extra trailing `get` command spliced out of the shredded string.

## The fix

Adjacency. A real possessive touches what it belongs to (`me's`, `#el's`, `(expr)'s`, `[1,2]'s`); a string argument is separated by whitespace.

Tested against the **source character**, not `prevToken.end` — and that distinction matters. My first attempt compared token offsets and broke three existing expression tests, because bracket and operator tokens don't track offsets reliably: the `]` in `[1, 2, 3]'s length` reports `end=8` for an apostrophe at index 9. The character check has no such dependency.

## Tests

14 new: the five mis-lexed forms, the already-working `'ok'`/`"saved"`/`'Saved'` cases, possessives after identifier / selector / context reference / parenthesized expression / array literal, and parse-level assertions that `put 'saved' into #status` produces the intended command.

Full core suite: **7480 passed / 128 skipped**, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)