### PR TITLE
fix(parser): end a naked fetch URL at whitespace, not at any command word

### DIFF
--- a/packages/core/docs/EXAMPLES.md
+++ b/packages/core/docs/EXAMPLES.md
@@ -886,9 +886,22 @@ Absolute URLs work unquoted too, matching hyperscript.org's own examples:
 </button>
 ```
 
-Quoting always works and is worth preferring when the URL is built from a variable
-or contains characters the tokenizer would otherwise split — a path segment that
-happens to be a command word (`fetch /api/put/1`) ends the unquoted URL early.
+An unquoted URL runs to the next whitespace, matching hyperscript.org. A path
+segment that happens to be a command word is therefore just part of the path:
+
+```html
+<button _="on click fetch /api/put/1 as json then put it into #output">Load</button>
+```
+
+`${…}` is carried whole — including any spaces inside it — and interpolated:
+
+```html
+<button _="on click fetch /api/${id} as json then put it into #output">Load</button>
+<input _="on input fetch /search?q=${my value} as json then put it into #results" />
+```
+
+Quoting still works and is worth preferring when the URL is built from a variable
+or contains a space outside an interpolation.
 
 ### Fetch with Loading State
 

--- a/packages/core/src/parser/command-parsers/navigation-commands.ts
+++ b/packages/core/src/parser/command-parsers/navigation-commands.ts
@@ -55,29 +55,6 @@ const GO_KEYWORDS = new Set([
   'forward',
 ]);
 
-/**
- * Tokens that terminate a naked-URL run. Unlike the fetch terminator this does
- * NOT stop on arbitrary command tokens, so path segments that happen to be
- * command words (`/get`, `/add`) stay part of the URL; it stops at `in`
- * (→ `in new window`) and the command-sequence boundaries.
- */
-const GO_URL_STOP = new Set([
-  'in',
-  'then',
-  'and',
-  'else',
-  'end',
-  'otherwise',
-  'when',
-  'where',
-  'catch',
-  'finally',
-]);
-
-function isGoURLTerminator(ctx: ParserContext): boolean {
-  return ctx.isAtEnd() || GO_URL_STOP.has(ctx.peek().value);
-}
-
 function stringNode(value: string, tok: Pick<Token, 'start' | 'end' | 'line' | 'column'>): ASTNode {
   return {
     type: 'string',
@@ -114,8 +91,13 @@ export function parseGoCommand(
     }
 
     // 2. Naked URL (/path or scheme://…) → one reassembled string literal.
+    //
+    // The same routine `fetch` uses. `go` used to pass its own GO_URL_STOP set
+    // (`in`, `then`, `and`, …), but every word in it is whitespace-separated in
+    // the grammar, so adjacency subsumes the whole set: in `go to /x in new
+    // window`, `x` ends at 8 and `in` starts at 9, so the URL stops on its own.
     if (isNakedURLStart(ctx)) {
-      const url = parseBareURLPath(ctx, isGoURLTerminator);
+      const url = parseBareURLPath(ctx);
       if (url) {
         args.push(url);
         continue;

--- a/packages/core/src/parser/command-parsers/utility-commands.ts
+++ b/packages/core/src/parser/command-parsers/utility-commands.ts
@@ -233,19 +233,6 @@ export function parseMultiWordCommand(
 }
 
 /**
- * Check if the current token terminates a bare URL path in a fetch command.
- * URL paths end before modifiers (as, with), braces, command boundaries, etc.
- */
-function isFetchURLTerminator(ctx: ParserContext): boolean {
-  if (ctx.isAtEnd()) return true;
-  const val = ctx.peek().value;
-  return (
-    ['as', 'with', '{', 'then', 'end', 'else', 'otherwise', ')'].includes(val) ||
-    isCommandBoundary(ctx)
-  );
-}
-
-/**
  * A naked URL begins with `/`, or with a scheme — an identifier immediately
  * followed by `:` (`https:`, `http:`, `mailto:`). Adjacency matters: the tokens
  * must touch, so `foo : bar` and a `key: value` pair are not mistaken for one.
@@ -266,24 +253,82 @@ export function isNakedURLStart(ctx: ParserContext): boolean {
 }
 
 /**
- * Parse a bare (unquoted) URL path (e.g. /api/data, /users/123, https://x.com).
- * Collects `/`, identifier, and other non-terminator tokens into a string literal.
- * Returns null if the path can't be reconstructed.
+ * Punctuation that ends a naked URL even with no whitespace before it.
  *
- * @param isTerminator - predicate marking the token that ends the URL run.
- *   Defaults to the fetch terminator (stops at `as`/`with`/`{`/command boundary);
- *   the `go` parser passes its own so path segments that are command words
- *   (`/get`) stay part of the URL.
+ * Upstream _hyperscript ends a naked URL at whitespace and nothing else
+ * (`parseURLOrExpression` → `consumeUntilWhitespace` → `NakedString`). We keep
+ * two of the old terminator set's entries:
+ *   `{` — load-bearing: the brace-without-`with` options form,
+ *         `fetch /api/data{method:"POST"}`, which upstream does not have
+ *   `)` — carried over from the old set as a no-regression measure. Nothing
+ *         reaches it today, because a run can only START at `/` or a scheme
+ *         (`isNakedURLStart`), so `fetch (/a/b)` goes to `parsePrimary` and
+ *         fails there exactly as it did before this change.
+ *
+ * `[` and `]` are deliberately NOT stops (`?ids[]=1` and `http://[::1]/x` are
+ * real URLs), and neither is `,` (`?ids=1,2,3` is a real query string).
  */
-export function parseBareURLPath(
-  ctx: ParserContext,
-  isTerminator: (ctx: ParserContext) => boolean = isFetchURLTerminator
-): ASTNode | null {
-  const startPos = ctx.savePosition();
-  let path = '';
+const URL_HARD_STOPS = new Set(['{', ')']);
 
-  while (!ctx.isAtEnd() && !isTerminator(ctx)) {
-    path += ctx.advance().value;
+/**
+ * Parse a naked (unquoted) URL — `/api/data`, `https://host/path`.
+ *
+ * Termination is by ADJACENCY, which is upstream's whitespace rule expressed in
+ * the only terms available here: the tokenizer discards whitespace, but every
+ * token carries character offsets, so `tok.start === prev.end` means "nothing
+ * came between them". That covers spaces and newlines alike.
+ *
+ * The old rule stopped at `isCommandBoundary`, i.e. at any of ~60 command words,
+ * so a URL whose path contained one was truncated:
+ *
+ *     fetch /api/put/1 as json   ->  url "/api/", a bogus `partial` `put`
+ *                                    command in the sequence, `as json` dropped
+ *
+ * and `parse()` still reported success. `go` never had the bug precisely because
+ * it did not use the command-word stop; both now share this one routine, as they
+ * do upstream.
+ *
+ * A `${…}` interpolation span is carried whole — its own `{` is not an options
+ * brace, and the space in `${my value}` is part of the URL — and is reproduced
+ * verbatim from source, because joining token values would collapse it to
+ * `${myvalue}`. When the result contains `${`, the node is a `templateLiteral`
+ * so the evaluator actually interpolates it; adjacency swallows `${id}` into the
+ * URL either way, so emitting a plain literal would guarantee a 404. A bare `$`
+ * (`/api/$filter`) is not interpolation and stays a literal.
+ */
+export function parseBareURLPath(ctx: ParserContext): ASTNode | null {
+  const startPos = ctx.savePosition();
+  const firstTok = ctx.peek();
+  let path = '';
+  let prev: Token | null = null;
+
+  while (!ctx.isAtEnd()) {
+    const tok = ctx.peek();
+
+    // Whitespace (or a newline) ended the URL.
+    if (prev && tok.start !== prev.end) break;
+
+    // `${…}` span — checked before URL_HARD_STOPS so the span's own braces are
+    // not mistaken for the options-brace form.
+    if (tok.value === '$' && ctx.peekAt(1)?.value === '{') {
+      ctx.advance(); // $
+      let last = ctx.advance(); // {
+      let depth = 1;
+      while (!ctx.isAtEnd() && depth > 0) {
+        last = ctx.advance();
+        if (last.value === '{') depth++;
+        else if (last.value === '}') depth--;
+      }
+      // Verbatim from source: token values alone would drop the whitespace.
+      path += ctx.getInputSlice(tok.start, last.end);
+      prev = last;
+      continue;
+    }
+
+    if (URL_HARD_STOPS.has(tok.value)) break;
+
+    prev = ctx.advance();
+    path += prev.value;
   }
 
   if (!path || path === '/') {
@@ -291,13 +336,21 @@ export function parseBareURLPath(
     return null;
   }
 
-  return {
-    type: 'literal',
-    value: path,
-    raw: path,
-    start: startPos,
-    end: ctx.savePosition(),
-  } as ASTNode;
+  // Character offsets, like every other node. This used to write
+  // ctx.savePosition() — a TOKEN INDEX — into start/end, which
+  // ast-utils/interchange/from-core.ts copies straight through and
+  // ctx.getInputSlice() would have sliced garbage from.
+  const span = {
+    start: firstTok.start,
+    end: prev ? prev.end : firstTok.end,
+    line: firstTok.line,
+    column: firstTok.column,
+  };
+
+  if (path.includes('${')) {
+    return { type: 'templateLiteral', value: path, ...span } as ASTNode;
+  }
+  return { type: 'literal', value: path, raw: path, ...span } as ASTNode;
 }
 
 /**

--- a/packages/core/src/parser/fetch-bare-url.test.ts
+++ b/packages/core/src/parser/fetch-bare-url.test.ts
@@ -106,3 +106,159 @@ describe('fetch with a naked URL', () => {
     expect(values).toContain('https://example.com/page');
   });
 });
+
+/**
+ * Where the naked URL ENDS.
+ *
+ * The run used to stop at `isCommandBoundary`, i.e. at any of ~60 command words,
+ * so a path segment that happened to be one truncated the URL:
+ *
+ *     fetch /api/put/1 as json
+ *       -> url "/api/", a bogus `partial` `put` command spliced into the
+ *          sequence, `as json` dropped — and result.success still true.
+ *
+ * Termination is now by ADJACENCY, which is upstream's whitespace rule expressed
+ * in the terms available here (the tokenizer discards whitespace, but tokens
+ * carry character offsets). `go` shares the routine, as it does upstream.
+ */
+describe('naked URL termination (adjacency)', () => {
+  const nodeOf = (
+    cmd: CommandNode
+  ): { type?: string; value?: unknown; start?: number; end?: number } =>
+    cmd.args?.[0] as { type?: string; value?: unknown; start?: number; end?: number };
+
+  const commandsOf = (src: string): CommandNode[] => {
+    const result = parse(src);
+    expect(result.success).toBe(true);
+    const node = result.node as { type?: string; commands?: CommandNode[] };
+    return (node.commands ?? [node as CommandNode]) as CommandNode[];
+  };
+
+  describe('the bug', () => {
+    it('keeps a path segment that is a command word', () => {
+      const cmd = fetchCommand('fetch /api/put/1 as json');
+      expect(urlOf(cmd)).toBe('/api/put/1');
+      expect(asOf(cmd)).toBe('json');
+      // The truncation also spliced a second, `partial` command into the parse.
+      expect(parse('fetch /api/put/1 as json').errors ?? []).toEqual([]);
+    });
+
+    it('keeps a command word in an absolute URL too', () => {
+      const cmd = fetchCommand('fetch https://x.com/put/1 as json');
+      expect(urlOf(cmd)).toBe('https://x.com/put/1');
+      expect(asOf(cmd)).toBe('json');
+    });
+
+    it('keeps six consecutive command words', () => {
+      expect(urlOf(fetchCommand('fetch /api/remove/add/toggle/log/wait/1'))).toBe(
+        '/api/remove/add/toggle/log/wait/1'
+      );
+    });
+  });
+
+  describe('regression guards (all real usages in this repo)', () => {
+    it('still ends the URL before a whitespace-separated command', () => {
+      // packages/mcp-server/src/tools/patterns.ts, resources/content.ts, and
+      // .github/skills/.../patterns.md all ship exactly this.
+      const commands = commandsOf('on click add .loading to me fetch /api remove .loading from me');
+      expect(commands.map(c => c.name)).toEqual(['add', 'fetch', 'remove']);
+      expect(urlOf(commands[1])).toBe('/api');
+    });
+
+    it('still ends the URL at then / and', () => {
+      const withThen = commandsOf('fetch /api/data then put it into #out');
+      expect(withThen.map(c => c.name)).toEqual(['fetch', 'put']);
+      expect(urlOf(withThen[0])).toBe('/api/data');
+
+      const withAnd = commandsOf('fetch /content and put it into #target');
+      expect(urlOf(withAnd[0])).toBe('/content');
+    });
+
+    it('still ends the URL at a newline', () => {
+      const commands = commandsOf('on click\n  fetch /api/put/1 as json\n  put it into #out\nend');
+      expect(commands.map(c => c.name)).toEqual(['fetch', 'put']);
+      expect(urlOf(commands[0])).toBe('/api/put/1');
+      expect(asOf(commands[0])).toBe('json');
+    });
+
+    it('still takes the with-options form, spaced or not', () => {
+      const spaced = fetchCommand('fetch /api/data {method:"POST"}');
+      expect(urlOf(spaced)).toBe('/api/data');
+      expect(modifiersOf(spaced)['with']).toBeDefined();
+
+      // No space: `{` is a hard stop, because adjacency alone would swallow it.
+      const tight = fetchCommand('fetch /api/data{method:"POST"}');
+      expect(urlOf(tight)).toBe('/api/data');
+      expect(modifiersOf(tight)['with']).toBeDefined();
+    });
+
+    it('still parses as JSON do not throw', () => {
+      const commands = commandsOf('fetch /api/users as JSON do not throw then log it');
+      expect(urlOf(commands[0])).toBe('/api/users');
+      expect(asOf(commands[0])).toBe('JSON');
+    });
+
+    it('keeps commas — a query string is not a token boundary', () => {
+      const cmd = fetchCommand('fetch /search?q=hello&ids=1,2,3 as json');
+      expect(urlOf(cmd)).toBe('/search?q=hello&ids=1,2,3');
+      expect(asOf(cmd)).toBe('json');
+    });
+  });
+
+  describe('${…} interpolation', () => {
+    it('emits a templateLiteral so the URL actually interpolates', () => {
+      // Adjacency swallows `${id}` into the URL either way, so a plain literal
+      // here would guarantee a 404.
+      const cmd = fetchCommand('fetch /api/${id} as json');
+      expect(nodeOf(cmd).type).toBe('templateLiteral');
+      expect(nodeOf(cmd).value).toBe('/api/${id}');
+      expect(asOf(cmd)).toBe('json');
+    });
+
+    it('carries a span containing whitespace whole', () => {
+      // Joining token values would collapse this to `${myvalue}`; the span is
+      // reproduced verbatim from source instead.
+      const cmd = fetchCommand('fetch /search?q=${my value} as json');
+      expect(nodeOf(cmd).value).toBe('/search?q=${my value}');
+      expect(asOf(cmd)).toBe('json');
+    });
+
+    it('resumes the URL after the span', () => {
+      const cmd = fetchCommand('fetch /api/${id}/more as json');
+      expect(nodeOf(cmd).value).toBe('/api/${id}/more');
+      expect(asOf(cmd)).toBe('json');
+    });
+
+    it('leaves a bare $ alone', () => {
+      // `/api/$filter` is OData, not interpolation — a templateLiteral here
+      // would let evaluateTemplateLiteralNode's $var pass eat it.
+      const cmd = fetchCommand('fetch /api/$filter as json');
+      expect(nodeOf(cmd).type).toBe('literal');
+      expect(nodeOf(cmd).value).toBe('/api/$filter');
+    });
+
+    it('terminates on an unclosed span', { timeout: 1000 }, () => {
+      expect(() => parse('fetch /api/${a as json')).not.toThrow();
+    });
+  });
+
+  it('reports character offsets, not token indices', () => {
+    // These used to be ctx.savePosition() — token indices — inside a command
+    // node measured in characters. ast-utils/interchange/from-core.ts copies
+    // them through verbatim.
+    const cmd = fetchCommand('fetch /api/put/1');
+    expect(nodeOf(cmd).start).toBe(6);
+    expect(nodeOf(cmd).end).toBe(16);
+  });
+
+  it('lets go keep a command-word path while `in` still ends the URL', () => {
+    // Adjacency subsumes the whole GO_URL_STOP set: `1` ends at 15, `in` starts
+    // at 16, so the URL stops on its own.
+    const result = parse('go to /api/put/1 in new window');
+    expect(result.success).toBe(true);
+    const values = ((result.node as CommandNode).args ?? []).map(
+      (a: unknown) => (a as { value?: unknown }).value
+    );
+    expect(values).toEqual(['to', '/api/put/1', 'in', 'new', 'window']);
+  });
+});

--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -237,6 +237,7 @@ export const commands: Record<string, CommandRef> = {
     examples: [
       'fetch /api/data as json',
       'fetch https://example.com/api as json',
+      'fetch /api/${id} as json',
       'fetch /api/users as html',
       'fetch /api/submit with method:"POST"',
     ],


### PR DESCRIPTION
Item 3 from the 2.9.1 downstream-report follow-ups. **Stacked on #775** (needs its brace offsets for the `${…}` span slicing).

### The bug
```
fetch /api/put/1 as json
  -> url "/api/", a bogus `partial` `put` command spliced into the sequence,
     `as json` dropped — and result.success STILL true (2 unread entries in errors)
```

Any path segment that is one of the ~60 command words did this: `/api/set/1`, `/api/get/x`, `/products/add`. #769 made absolute URLs reach the same scanner, so `fetch https://x.com/put/1` truncated to `https://x.com/` too.

Cause: `isFetchURLTerminator` called `isCommandBoundary`, true for every command word. `go` never had the bug precisely *because* it didn't use that stop — it carried its own fixed `GO_URL_STOP`.

### The fix: adjacency, matching upstream
Upstream `_hyperscript` ends a naked URL at whitespace and nothing else (`parseURLOrExpression` → `consumeUntilWhitespace` → `NakedString`), using **one routine for both `fetch` and `go`**. Our tokenizer discards whitespace, but tokens carry character offsets, so `tok.start === prev.end` expresses the same rule — and covers newlines for free. `isNakedURLStart` (#769) already relied on that trick.

So: terminate by adjacency, and collapse `fetch` and `go` onto one routine. Every word in `GO_URL_STOP` is whitespace-separated, so adjacency subsumes the set — in `go to /x in new window`, `x` ends at 8 and `in` starts at 9.

Two hard stops remain: `{` (load-bearing — `fetch /api/data{method:"POST"}`) and `)` (inherited; nothing reaches it today, noted as such). Deliberately **not** stops: `[`/`]` (`?ids[]=1`, `http://[::1]/x`) and `,` (`?ids=1,2,3`).

### Rejected: newline-termination
The follow-up doc suggested it. It breaks three usages shipping in this repo — `fetch /api remove .loading from me` in mcp-server's `patterns.ts`, `content.ts` and the skills reference — all of which adjacency preserves, because they have a space before the command.

### `${…}` interpolation
Carried whole and reproduced verbatim from source (joining token values would collapse `${my value}` → `${myvalue}`), and the node becomes a `templateLiteral` when the URL contains `${`. That's **forced, not optional**: adjacency swallows `${id}` into the URL either way, so a plain literal would guarantee a 404. Follows the conditional emit `parseCSSObjectLiteral` already does. Guarded on `${`, not a bare `$`, so `/api/$filter` stays literal.

### Also
`parseBareURLPath` wrote `ctx.savePosition()` — a **token index** — into `start`/`end` while every other node uses character offsets (`literal start:1,end:4` inside `command start:0,end:11`). `ast-utils/interchange/from-core.ts` copies those through verbatim.

### Verification
23 tests, **8 fail without this change**: the bug, the repo's real usages as explicit regression guards, the interpolation cases, character offsets, and `go` parity. Full core suite green (7540). Multilingual re-run against a rebuilt core dist is unchanged — R2's `EXECUTION_SUBSET` is DOM/control-flow only, no fetch rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)