### PR TITLE
fix(hybrid): reject catch/finally instead of running the catch body on success

### DIFF
--- a/docs/BROWSER_BUNDLES.md
+++ b/docs/BROWSER_BUNDLES.md
@@ -53,10 +53,17 @@ For projects prioritizing bundle size over features:
 
 > **`catch` / `finally` on event handlers need the full AST parser.** `on click … catch e … end`
 > is supported by `hyperfixi.js`, `hyperfixi-hx-v4.js`, `hyperfixi-minimal.js` and
-> `hyperfixi-standard.js`. The lite and hybrid bundles use a different parser that does not
-> recognise the keywords — it absorbs them into the handler body, so the catch commands run in
-> sequence on the success path instead of on error. Use one of the full bundles if you rely on
-> handler-level error handling.
+> `hyperfixi-standard.js`.
+>
+> The **hybrid** bundles (`hyperfixi-hybrid-complete.js`, `hyperfixi-hx.js`) **reject** them:
+> the attribute fails to parse and the error is logged to the console naming the keyword and
+> the remedy. They used to absorb the keywords into the handler body, which put the catch
+> commands on the **success** path — a failure message overwriting a successful render.
+>
+> The **lite** bundles' regex parser does not recognise the keywords at all and silently
+> ignores the attribute.
+>
+> Use one of the full bundles if you rely on handler-level error handling.
 
 ```html
 <!-- Example: Hybrid Complete with expressions and blocks -->

--- a/packages/core/src/bundle-generator/parser-template-drift.test.ts
+++ b/packages/core/src/bundle-generator/parser-template-drift.test.ts
@@ -1,0 +1,68 @@
+/**
+ * `HYBRID_PARSER_TEMPLATE` is a hand-maintained COPY of
+ * parser/hybrid/parser-core.ts, emitted as source text for generated bundles and
+ * re-exported publicly from bundle-generator/index.ts. Nothing in the build
+ * compares the two, so they drift silently — and a behavioural difference
+ * between the parser we test and the parser a consumer embeds is exactly the
+ * kind of gap that ships.
+ *
+ * This asserts the template BEHAVES like the source on the invariants that
+ * matter, rather than diffing text (the copies are legitimately different:
+ * TypeScript vs JavaScript, and different command sets).
+ *
+ * Note the template is not what `generateBundle()` emits — generator.ts writes
+ * an `import { HybridParser } from '<path>/parser-core'` instead — so a
+ * divergence here costs no bundle bytes. It still misleads whoever embeds the
+ * exported template.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { HYBRID_PARSER_TEMPLATE } from './parser-templates';
+import { HybridParser } from '../parser/hybrid/parser-core';
+
+interface TemplateParser {
+  parse(): unknown;
+}
+
+/** Evaluate the template and hand back its HybridParser class. */
+const loadTemplateParser = (): (new (code: string) => TemplateParser) | null => {
+  try {
+    return new Function(`${HYBRID_PARSER_TEMPLATE}\nreturn HybridParser;`)() as new (
+      code: string
+    ) => TemplateParser;
+  } catch {
+    return null;
+  }
+};
+
+describe('HYBRID_PARSER_TEMPLATE stays in step with parser-core', () => {
+  const TemplateParser = loadTemplateParser();
+
+  it('is self-contained enough to evaluate', () => {
+    // If this fails the behavioural assertions below degrade to the source-text
+    // check at the bottom, which is weaker but still catches this drift.
+    expect(TemplateParser).not.toBeNull();
+  });
+
+  it.runIf(TemplateParser)('rejects catch, like the source parser', () => {
+    const src = "on click log 'a' catch e log e end";
+    expect(() => new HybridParser(src).parse()).toThrow(/needs the full parser/);
+    expect(() => new TemplateParser!(src).parse()).toThrow(/needs the full parser/);
+  });
+
+  it.runIf(TemplateParser)('rejects finally, like the source parser', () => {
+    const src = "on click log 'a' finally log 'b' end";
+    expect(() => new HybridParser(src).parse()).toThrow(/needs the full parser/);
+    expect(() => new TemplateParser!(src).parse()).toThrow(/needs the full parser/);
+  });
+
+  it.runIf(TemplateParser)('still parses an ordinary handler', () => {
+    expect(() => new TemplateParser!('on click toggle .active').parse()).not.toThrow();
+  });
+
+  it('carries the guard in its source text', () => {
+    // Independent of evaluation, so this keeps working if the template ever
+    // gains a dependency that `new Function` cannot resolve.
+    expect(HYBRID_PARSER_TEMPLATE).toMatch(/match\('catch',\s*'finally'\)/);
+  });
+});

--- a/packages/core/src/bundle-generator/parser-templates.ts
+++ b/packages/core/src/bundle-generator/parser-templates.ts
@@ -561,6 +561,12 @@ class HybridParser {
     const normalized = normalizeCommand(this.peek().value);
     if (cmdMap[normalized]) return cmdMap[normalized]();
 
+    // Mirrors parser/hybrid/parser-core.ts: absorbing catch/finally into the
+    // body ran the error path on every success. Reject loudly instead.
+    if (this.match('catch', 'finally')) {
+      throw new Error("'" + this.peek().value + "' needs the full parser (use hyperfixi.js)");
+    }
+
     if (!this.isAtEnd() && !this.match('then', 'and', 'end', 'else')) this.advance();
     return null;
   }

--- a/packages/core/src/parser/hybrid/parser-core.test.ts
+++ b/packages/core/src/parser/hybrid/parser-core.test.ts
@@ -793,4 +793,67 @@ describe('HybridParser', () => {
       expect(value.property).toBe('values');
     });
   });
+
+  /**
+   * `catch`/`finally` are full-parser-only. This parser used to swallow them in
+   * parseCommand's skip fallback, one token at a time, which put the CATCH BODY
+   * on the success path:
+   *
+   *   on click put 'a' into #r catch e put 'b' into #r end
+   *     -> body: [put 'a' into #r, put 'b' into #r]   // both run on success
+   *
+   * so a failure message overwrote a successful render. It now throws, which the
+   * bundle entry points already catch and console.error with the offending code.
+   */
+  describe('catch/finally rejection', () => {
+    const attempt = (code: string) => (): unknown => parse(code);
+
+    it('rejects a catch block on an event handler', () => {
+      expect(
+        attempt(`on click
+          put 'a' into #r
+        catch e
+          put 'b' into #r
+        end`)
+      ).toThrow(/'catch' needs the full parser/);
+    });
+
+    it('rejects finally with no catch', () => {
+      expect(
+        attempt(`on click
+          log 'a'
+        finally
+          log 'b'
+        end`)
+      ).toThrow(/'finally' needs the full parser/);
+    });
+
+    it('rejects catch nested inside an if body', () => {
+      // Every block routes through parseCommandSequence -> parseCommand, so the
+      // one guard covers if/repeat/for/while/fetch as well as the top level.
+      expect(attempt("on click if true log 'a' catch e log e end end")).toThrow(
+        /'catch' needs the full parser/
+      );
+    });
+
+    it('no longer appends the catch body to the success path', () => {
+      // Pre-fix this returned a body of length 2, both puts on the success path.
+      expect(attempt("on click put 'a' into #r catch e put 'b' into #r end")).toThrow();
+    });
+
+    it('names the remedy, not just the problem', () => {
+      expect(attempt("on click log 'a' catch e log e end")).toThrow(/hyperfixi\.js/);
+    });
+
+    it('leaves a .catch class selector alone', () => {
+      // `.catch` lexes as a selector token, so it never reaches the guard.
+      expect(attempt('on click toggle .catch')).not.toThrow();
+      expect(parse('on click toggle .catch').body[0].name).toBe('toggle');
+    });
+
+    it('leaves catch as a variable name alone', () => {
+      // `set` consumes its own operands before the fallback is reached.
+      expect(attempt('set catch to 1')).not.toThrow();
+    });
+  });
 });

--- a/packages/core/src/parser/hybrid/parser-core.ts
+++ b/packages/core/src/parser/hybrid/parser-core.ts
@@ -157,6 +157,24 @@ export class HybridParser {
       return cmdMap[normalized]();
     }
 
+    // `catch`/`finally` open error blocks only the full AST parser understands.
+    // The skip fallback below used to swallow them one token at a time, so the
+    // CATCH BODY joined the success-path sequence and ran on every success —
+    // `put 'Request failed' into #out` overwriting a successful render. Silent
+    // and destructive.
+    //
+    // Reject loudly instead. Every consumer of this parser has an error boundary
+    // that logs the offending code (browser-bundle-hybrid-complete.ts and the
+    // other bundle entries console.error it), so the cost is an inert element
+    // and an actionable message — a strictly better failure than running the
+    // error path on success.
+    // The message is deliberately terse — it costs bundle bytes in the smallest
+    // bundles we ship, and the error boundary already logs the offending code,
+    // so it only needs the keyword and the remedy.
+    if (this.match('catch', 'finally')) {
+      throw new Error(`'${this.peek().value}' needs the full parser (use hyperfixi.js)`);
+    }
+
     if (!this.isAtEnd() && !this.match('then', 'and', 'end', 'else')) {
       this.advance();
     }


### PR DESCRIPTION
Item 2 from the 2.9.1 downstream-report follow-ups. **Stacked on #776.**

### The bug
The hybrid parser had no notion of `catch`/`finally`. `parseCommandSequence` stops only at `end`/`else`, and `parseCommand`'s tail fallback advances past any unrecognised token and returns null — so `catch` and its error symbol were swallowed one token at a time and the **catch body was appended to the same sequence as the try body**:

```
on click put 'a' into #r catch e put 'b' into #r end
  -> body: [put 'a' into #r, put 'b' into #r]     // BOTH run on success
```

i.e. `put 'Request failed' into #out` overwriting a successful render. Silent, and *destructive* rather than merely absent. This is the bundle-level half of what #768 fixed for the full parser.

### Reject, don't warn
A `console.warn` leaves the harmful behaviour in place, and the harm is the point: a dead attribute is recoverable, a handler that runs its error path on success is not. Every consumer already has an error boundary that logs the offending code, so the cost is an inert element plus an actionable message.

### Why the guard goes in `parseCommand`'s fallback
- Not `parseCommandSequence`: adding a stop-set entry only makes the sequence return early, and since `parse()` never checks for leftover tokens the catch body would be silently **dropped** instead of silently mis-run — still silent.
- Not the tokenizer: `match()` compares `token.value` and never `token.type`, so promoting `catch` to a keyword changes nothing.
- The fallback is reached from every body (top level, if/else, repeat, for, while, fetch), so one guard covers all.

False positives pinned by two tests: `.catch` lexes as a selector, `set catch to 1` is consumed by `parseSet` first.

### Message length is deliberate
The first draft cost **+111 gzip bytes (1.4%)** on `hyperfixi-hybrid-complete.js`, whose entire selling point is size. Dropping the clause that restated "needs the full parser" brings it to **+74 (0.94%)** while keeping what a reader needs: which keyword, and what to use instead. Snapshot gate +0.6% vs ±5%; metadata drift 1.3%, non-blocking as of #774 — under the old exact-equality gate this PR would have failed CI purely on rounding.

### Left alone deliberately
**The lite parser.** Measured, it fails *silently* rather than mis-executing (multi-line doesn't match its `^on\s+…(.+)$` regex — no `/s` flag; single-line yields a garbage selector that no-ops). Lite ships 8 commands and no blocks, so nobody writes `catch` for it, and a guard would cost the 1.9 KB headline across 9 files and 3 duplicated parser copies.

**`metadata.ts`.** Numbers above are macOS-local; per the documented footgun they come from the CI log.

### Drift guard
`HYBRID_PARSER_TEMPLATE` is a hand-maintained copy of `parser-core.ts`, exported publicly for consumers to embed, and **nothing in the build compared the two**. `parser-template-drift.test.ts` now evaluates the template and asserts it rejects identically, with a source-text assertion as fallback. Costs no bundle bytes — `generator.ts` emits an import of `parser-core`, not the template.

`BROWSER_BUNDLES.md`'s note from #768 said lite *and* hybrid absorb the keywords; that's now true only of lite.

Core suite green (7552).

🤖 Generated with [Claude Code](https://claude.com/claude-code)