### PR TITLE
test(core): pin what `def` actually does today (spike, no behavior change)

### DIFF
--- a/docs-internal/HANDOFF-def-execution.md
+++ b/docs-internal/HANDOFF-def-execution.md
@@ -1,0 +1,136 @@
+# `def` is parsed and then throws — spike findings
+
+**Status:** investigation complete, decision pending. No behavior changed by this spike;
+it adds `packages/core/src/runtime/def-execution.test.ts`, which pins current behavior.
+
+Follow-up to the 2.9.1 downstream-report arc. The report listed `def … catch … end` as
+"parsed and silently dropped" and expected the fix to mirror #768's `on`-handler work.
+That framing turned out to be wrong in a way that changes the shape of the job.
+
+---
+
+## What actually happens
+
+`def` is not silently dropped. It **throws**.
+
+```
+parse('def greet(n) return n end')  ->  success, DefNode with params/body
+runtime.execute(defNode, ctx)       ->  rejects: "Unknown AST node type: def"
+ctx.globals.has('greet')            ->  false
+```
+
+`RuntimeBase.execute()`'s switch handles `command`, `eventHandler`, `event`, `behavior`,
+`Program`, `initBlock`, `block`, `sequence`, `CommandSequence`, `objectLiteral`,
+`templateLiteral` and `memberExpression`. There is no `def` case, and `Runtime` does not
+override `execute()`. A `DefNode` falls to `default:` → `evaluateExpression` →
+`evaluateAST`, which throws on the unknown type.
+
+On a page, `attribute-processor` catches that into a `console.error` naming an internal
+node type — which tells an author nothing about `def` being unimplemented.
+
+Consequence worth noting: in a `Program`, `executeProgram` buckets event handlers first
+and runs them before other statements, so a handler alongside a `def` **does** register —
+and then the `def` throws, aborting every statement after it.
+
+So the parser half of #768's shared `parseErrorAndFinallyBlocks()` is real and `DefNode`
+does carry `errorSymbol` / `errorHandler` / `finallyHandler`, with passing tests for that
+shape in `hyperscript-parser.test.ts`. The syntax looks supported. Nothing executes it.
+
+**The task is not "wire catch/finally onto def". It is "make `def` execute at all."**
+
+---
+
+## No other path installs a top-level def
+
+| Probe | Result |
+| ----- | ------ |
+| `case 'def'` across `packages/` | only `ast-utils/generator.ts` and `semantic/src/ast-builder` — both codegen/rendering, neither executes |
+| `'def'` in `compatibility/`, `api/`, `dom/`, `core/` | none (one unrelated `"abc" < "def"` string comparison) |
+| `features/def` / `DefFeature` / `TypedDefFeature` consumers | only `src/index.ts` re-exports, plus its own 3 test files |
+| `def` in `parser/hybrid/` | none — the hybrid parser cannot parse `def` at all |
+| `registerNodeEvaluator` | only the extension mechanism; nothing registers `'def'` |
+
+**One place `def` does work:** inside a `worker` feature. `packages/realtime/src/worker.ts`
+hand-rolls its own def parsing into a `workerFeature` node's `defs[]` and never touches
+`DefNode` (its comment says so explicitly: "core's parseDefFeature is not exposed on
+ParserContext"). That confirms the gap is specifically top-level `def` reaching
+`RuntimeBase.execute`, and is a second, unrelated implementation of the same syntax.
+
+---
+
+## `features/def.ts` — verdict: **bypass**
+
+1574 lines, two parallel implementations, zero production callers. It cannot be adapted
+cheaply, and the evidence is not marginal:
+
+- **`DefFeature.executeFunction`** is a hand-rolled mini-interpreter branching on **string**
+  args — `const toIndex = args.indexOf('to')`, `if (args[0] === 'global')` — not the
+  `CommandNode`s the real parser emits. It cannot execute a real `DefNode.body`.
+- **`TypedDefFeatureImplementation.executeCatchBlock`** builds a `_catchContext`, marks it
+  unused with an eslint-disable, and `return 'handled';` — the literal string.
+  `executeFinallyBlock` is `if (!func.finallyBlock) return; return;`. Both are stubs.
+- Its catch shape is `{parameter, body}`, not the parser's
+  `{errorSymbol, errorHandler, finallyHandler}`, so even the data model needs translating.
+
+Confirmed no consumer outside `packages/core` imports `TypedDefFeatureImplementation`,
+`createDefFeature` or `enhancedDefImplementation`.
+
+**Do not delete it in the same PR** — `src/index.ts` re-exports it publicly, so removal is
+semver-visible. File it as its own cleanup: drop the module and the `index.ts` exports in a
+breaking-change batch.
+
+---
+
+## Options
+
+### A — thin `case 'def'` in `RuntimeBase.execute` (recommended)
+
+Install an async closure into `context.globals` that copies `context.locals`, binds
+`params[i] = args[i]`, delegates the body to the existing `executeCommandSequenceWithResult`
+(which already converts the `return` signal to `ok(returnValue)`), and wraps it in the exact
+try/catch/finally shape #768 put in `createEventHandler` — including
+`if (!errorHandler || isControlFlowError(e)) throw e;` and
+`fnContext.locals.set(errorSymbol, e)`.
+
+`context.globals` works because `createEventHandler` snapshots `locals` but passes `globals`
+by reference, and `evaluateIdentifier` resolves locals → globals → context props →
+`globalThis`. So a `def` registered in `executeProgram`'s later bucket is still visible to a
+handler bound in the earlier one.
+
+~1 day, medium risk. Also widen `DefNode`'s three error fields from `CommandNode[]` to
+`ASTNode[]` to match `EventHandlerNode`.
+
+**Open questions it must answer first** (these are the real risk, not the plumbing):
+namespaced `def utils.foo()` (the parser emits the dotted name as one string), what `me`
+binds to inside the body, `def` nested in a `behavior`, and whether functions are
+per-document or per-element.
+
+### A′ — same, but onto `globalThis` (upstream semantics)
+
+Same size, higher risk: global collisions, no teardown, and it breaks the jsdom test
+isolation the rest of the suite relies on. Only if interop with a real `_hyperscript` page
+is a requirement.
+
+### B — adapt `TypedDefFeatureImplementation`
+
+2–3 days, high risk, and the end state is A wearing a 1574-line coat. Rejected — see above.
+
+### C — loud rejection stopgap
+
+```ts
+case 'def':
+  throw new Error("'def' functions are parsed but not yet executable — see #NNN");
+```
+
+~10 lines, near-zero risk. This is the same trade just made for `catch`/`finally` in the
+hybrid bundles: it converts an opaque internal error into a statement about what the engine
+supports. **Ship this if the answer is "not now"** — it costs almost nothing and stops the
+current message from misleading.
+
+---
+
+## Recommendation
+
+Answer the four open questions under A, then implement A. If they can't be answered soon,
+land C in the meantime — the status quo error message is actively misleading, and C is
+cheap enough that it doesn't compete with A for effort.

--- a/packages/core/src/runtime/def-execution.test.ts
+++ b/packages/core/src/runtime/def-execution.test.ts
@@ -1,0 +1,147 @@
+/**
+ * SPIKE — characterizing, not aspirational. These assert what `def` does TODAY.
+ *
+ * `def … end` parses fine: parser.ts:parseDefFeature produces a DefNode carrying
+ * `errorSymbol` / `errorHandler` / `finallyHandler`, and hyperscript-parser.test.ts
+ * has passing tests for that shape. So the syntax LOOKS supported.
+ *
+ * Nothing executes it. RuntimeBase.execute()'s switch dispatches command,
+ * eventHandler, event, behavior, Program, initBlock, block, sequence,
+ * CommandSequence, objectLiteral, templateLiteral and memberExpression — there
+ * is no `def` case, and `Runtime` does not override execute(). A DefNode falls
+ * to `default:` -> evaluateExpression -> evaluateAST, which throws
+ * `Unknown AST node type: def`.
+ *
+ * So the downstream report's framing ("parsed and silently dropped") is too
+ * generous: it is parsed and then THROWS. On a page the attribute processor
+ * catches that into a console.error naming an internal node type, which tells
+ * an author nothing about `def` being unimplemented.
+ *
+ * A separate implementation sits in src/features/def.ts (TypedDefFeatureImplementation
+ * and DefFeature, ~1574 lines) with ZERO production callers — only src/index.ts
+ * re-exports and its own tests. It cannot execute a real DefNode.body: its
+ * mini-interpreter branches on string args (`args.indexOf('to')`) rather than
+ * the CommandNodes the parser emits, its executeCatchBlock returns the string
+ * 'handled', and its executeFinallyBlock is a bare `return`. Its catch shape is
+ * `{parameter, body}`, not the parser's `{errorSymbol, errorHandler, finallyHandler}`.
+ *
+ * One place `def` DOES work: inside a `worker` feature, which hand-rolls its own
+ * def parsing (packages/realtime/src/worker.ts) into a `workerFeature` node and
+ * never touches DefNode. That confirms the gap is specifically top-level `def`
+ * reaching RuntimeBase.execute.
+ *
+ * INVERT these when a `case 'def'` lands.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Runtime } from './runtime';
+import { parse } from '../parser/parser';
+import { createContext } from '../core/context';
+import type { ExecutionContext } from '../types/core';
+import type { DefNode } from '../types/base-types';
+
+describe('def — current runtime behavior (spike)', () => {
+  let runtime: Runtime;
+  let context: ExecutionContext;
+
+  beforeEach(() => {
+    runtime = new Runtime();
+    // A fresh globals Map: createContext() otherwise defaults to the
+    // module-level sharedGlobals, which would leak between tests.
+    context = createContext(document.createElement('div'), new Map());
+  });
+
+  it('parses to a DefNode with the error blocks populated', () => {
+    const result = parse(`def risky()
+      throw 'boom'
+    catch e
+      log e
+    finally
+      log 'done'
+    end`);
+
+    expect(result.success).toBe(true);
+    const def = result.node as DefNode;
+    expect(def.type).toBe('def');
+    expect(def.errorSymbol).toBe('e');
+    expect(def.errorHandler?.length).toBeGreaterThan(0);
+    expect(def.finallyHandler?.length).toBeGreaterThan(0);
+  });
+
+  it('CURRENT: executing a def throws "Unknown AST node type: def"', async () => {
+    const result = parse('def greet(n)\n  return n\nend');
+    await expect(runtime.execute(result.node!, context)).rejects.toThrow(
+      'Unknown AST node type: def'
+    );
+  });
+
+  it('CURRENT: installs the function nowhere', async () => {
+    const result = parse('def greet(n)\n  return n\nend');
+    await runtime.execute(result.node!, context).catch(() => {});
+
+    expect(context.globals.has('greet')).toBe(false);
+    expect(context.locals.has('greet')).toBe(false);
+    expect((globalThis as Record<string, unknown>).greet).toBeUndefined();
+  });
+
+  it('CURRENT: the def BODY never runs', async () => {
+    const probe = document.createElement('div');
+    probe.id = 'def-probe';
+    document.body.appendChild(probe);
+
+    const result = parse("def sideEffect()\n  put 'ran' into #def-probe\nend");
+    await runtime.execute(result.node!, context).catch(() => {});
+
+    expect(probe.textContent).toBe('');
+    probe.remove();
+  });
+
+  it('CURRENT: in a Program the handler binds, then the def aborts the rest', async () => {
+    // executeProgram buckets eventHandlers first and runs them before
+    // otherStatements, so the handler DOES register — and then the def throws,
+    // taking every statement after it with it.
+    const result = parse(`def greet(n)
+  return n
+end
+on click
+  call greet('x')
+end`);
+    expect(result.success).toBe(true);
+
+    const added: Array<(e: Event) => unknown> = [];
+    const el = context.me as HTMLElement;
+    el.addEventListener = ((_type: string, fn: unknown) => {
+      added.push(fn as (e: Event) => unknown);
+    }) as unknown as typeof el.addEventListener;
+
+    await expect(runtime.execute(result.node!, context)).rejects.toThrow(
+      'Unknown AST node type: def'
+    );
+    expect(added).toHaveLength(1);
+  });
+
+  it('CURRENT: calling the never-installed name fails at call time', async () => {
+    const result = parse("call greet('x')");
+    await expect(runtime.execute(result.node!, context)).rejects.toThrow(
+      /Cannot call non-function|greet/
+    );
+  });
+
+  it('CURRENT: catch never runs, because the body never runs', async () => {
+    // The whole point of the reported defect: `def … catch … end` looks
+    // supported and does nothing. Not even the error path.
+    const probe = document.createElement('div');
+    probe.id = 'def-catch-probe';
+    document.body.appendChild(probe);
+
+    const result = parse(`def risky()
+  throw 'boom'
+catch e
+  put 'caught' into #def-catch-probe
+end`);
+    await runtime.execute(result.node!, context).catch(() => {});
+
+    expect(probe.textContent).toBe('');
+    probe.remove();
+  });
+});


### PR DESCRIPTION
Item 1 from the 2.9.1 downstream-report follow-ups, scoped as a **spike** — the deliverable is a decision, not an implementation. **Stacked on #778.**

### The report's framing was wrong
It listed `def … catch … end` as "parsed and silently dropped", expecting a mirror of #768's on-handler work. `def` is not silently dropped — it **throws**:

```
parse('def greet(n) return n end')  -> success, DefNode with params/body
runtime.execute(defNode, ctx)       -> rejects "Unknown AST node type: def"
ctx.globals.has('greet')            -> false
```

`RuntimeBase.execute()`'s switch has no `def` case and `Runtime` doesn't override it, so a `DefNode` falls to `default:` → `evaluateExpression` → `evaluateAST`, which throws. The attribute processor catches that into a `console.error` naming an internal node type — telling an author nothing about `def` being unimplemented.

The parser half of #768's shared `parseErrorAndFinallyBlocks()` is real and `DefNode` does carry `errorSymbol`/`errorHandler`/`finallyHandler` with passing tests. **The syntax looks supported and nothing executes it.** So the task is not "wire catch/finally onto def" — it's "make `def` execute at all."

### This PR
Seven characterizing tests asserting *today's* behavior, so the follow-up inverts a red test rather than inventing one: the parse shape, the throw, that nothing lands in globals/locals/globalThis, that the body never runs, that catch never runs either, that `call` on the name fails, and that in a `Program` the event handler **does** bind (`executeProgram` buckets handlers first) before the def aborts everything after it.

### Findings — full writeup in `docs-internal/HANDOFF-def-execution.md`
- **No other path installs a top-level def.** Verified across `case 'def'` (only codegen), the bundle/api/dom/core layers (none), `features/def` consumers (only `src/index.ts` re-exports plus its own tests), the hybrid parser (cannot parse `def` at all), and `registerNodeEvaluator`.
- **One place `def` *does* work**, which the plan didn't anticipate: inside a `worker` feature. `packages/realtime/src/worker.ts` hand-rolls its own def parsing into a `workerFeature` node and never touches `DefNode` — a second implementation of the same syntax, and confirmation the gap is specifically top-level `def`.
- **`features/def.ts` (1574 lines, two parallel implementations, zero production callers): bypass, not reuse.** Its mini-interpreter branches on string args (`args.indexOf('to')`) rather than the `CommandNode`s the parser emits; `executeCatchBlock` literally `return 'handled'` after building a context it marks unused; `executeFinallyBlock` is a bare `return`. Not deleted here — `src/index.ts` re-exports it publicly, so that's a separate semver-visible cleanup.

### Recommendation
A thin `case 'def'` installing a closure into `context.globals`, reusing #768's try/catch/finally shape. But it needs four questions answered first — namespaced `def utils.foo()`, what `me` binds to, `def` inside a `behavior`, per-document vs per-element scope. **Those are the real risk, not the plumbing.** A ~10-line loud-rejection stopgap is available if that has to wait; the status quo message is actively misleading.

Core suite green (7559).

🤖 Generated with [Claude Code](https://claude.com/claude-code)