### PR TITLE
fix(parser): stop losing recovered parse errors, and fix the two bugs that hid

### DIFF
--- a/packages/core/src/api/hyperscript-api.ts
+++ b/packages/core/src/api/hyperscript-api.ts
@@ -324,7 +324,18 @@ export interface CompileResult {
   /** Compiled AST (present if ok=true) */
   ast?: ASTNode;
 
-  /** Compilation errors (present if ok=false) */
+  /**
+   * Compilation errors.
+   *
+   * Usually accompanies `ok: false`, but NOT always: the parser is resilient and
+   * recovers from some malformed input, producing a usable (if degraded) AST
+   * alongside diagnostics. Those cases are `ok: true` WITH a non-empty `errors`
+   * — the AST still executes, and the diagnostics say what was lost.
+   *
+   * They used to be dropped here entirely, so `validate()` called genuinely
+   * malformed code valid while the language server — which reads the parser's
+   * accumulated errors directly — flagged the very same source.
+   */
   errors?: CompileError[];
 
   /** LSE SemanticNode representation (when available) */
@@ -848,9 +859,15 @@ function compileSync(code: string, options?: NewCompileOptions): CompileResult {
     const timeMs = performance.now() - startTime;
 
     if (parseResult.success && parseResult.node) {
+      // A resilient parse can recover and still accumulate diagnostics. Carry
+      // them through rather than dropping them: `ok` stays true so execution is
+      // unaffected (the degraded AST is still what the runtime has always run),
+      // but the information is no longer lost between here and validate().
+      const recovered = parseResult.errors ?? [];
       const result: CompileResult = {
         ok: true,
         ast: parseResult.node,
+        ...(recovered.length > 0 ? { errors: recovered.map(toCompileError) } : {}),
         meta: {
           parser: usesSemanticParser ? 'semantic' : 'traditional',
           language: lang,
@@ -1096,9 +1113,15 @@ async function evalCode(
  */
 async function validate(code: string, options?: NewCompileOptions): Promise<ValidateResult> {
   const result = await compileAsync(code, options);
+  // `valid` is not the same question as `ok`. A resilient parse can succeed
+  // (ok: true — the degraded AST runs) while still reporting what it could not
+  // make sense of. validate()'s entire contract is "is this code correct?", so
+  // recovered diagnostics make it invalid; this is what the language server has
+  // always reported for the same source.
+  const errors = result.errors ?? [];
   return {
-    valid: result.ok,
-    errors: result.errors,
+    valid: result.ok && errors.length === 0,
+    errors: errors.length > 0 ? errors : undefined,
   };
 }
 

--- a/packages/core/src/api/validate-surfaces-recovered-errors.test.ts
+++ b/packages/core/src/api/validate-surfaces-recovered-errors.test.ts
@@ -1,0 +1,74 @@
+/**
+ * `validate()` used to call genuinely malformed code valid.
+ *
+ * The parser is deliberately resilient: it recovers from some malformed input
+ * and returns `success: true` with a usable-but-degraded AST *and* a non-empty
+ * `errors` array. compileSync's success branch never read that array, so the
+ * diagnostics died there — and validate(), which derives `valid` from
+ * compile's `ok`, reported clean.
+ *
+ * Meanwhile the language server reads the parser's accumulated errors directly
+ * (server.ts) and flagged the very same source. Two public surfaces, opposite
+ * answers, for input the real hyperscript.org engine also rejects.
+ *
+ * The fix keeps the two questions separate:
+ *   - `ok`    — "did we produce something runnable?" Unchanged, so resilient
+ *               execution behaves exactly as before.
+ *   - `valid` — "is this code correct?" Now false when anything was recovered.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { hyperscript } from './hyperscript-api';
+
+/** Malformed, recovered by the parser, and rejected by upstream _hyperscript. */
+const RECOVERED = 'put 1 2 3 into';
+/** Malformed beyond recovery — no AST at all. */
+const FATAL = 'set';
+
+describe('validate() surfaces recovered parse errors', () => {
+  it('reports recovered-but-malformed code as invalid', async () => {
+    const result = await hyperscript.validate(RECOVERED);
+    expect(result.valid).toBe(false);
+    expect(result.errors?.length).toBeGreaterThan(0);
+  });
+
+  it('still reports well-formed code as valid, with no errors key', async () => {
+    const result = await hyperscript.validate('toggle .active');
+    expect(result.valid).toBe(true);
+    expect(result.errors).toBeUndefined();
+  });
+
+  it('still reports unrecoverable code as invalid', async () => {
+    const result = await hyperscript.validate(FATAL);
+    expect(result.valid).toBe(false);
+    expect(result.errors?.length).toBeGreaterThan(0);
+  });
+});
+
+describe('compile() keeps executing what it always executed', () => {
+  it('stays ok with an AST when the parser recovered', () => {
+    // The load-bearing half: making validate stricter must NOT stop the runtime
+    // installing a handler it has always installed. `ok` is a different
+    // question from `valid`.
+    const result = hyperscript.compileSync(RECOVERED);
+    expect(result.ok).toBe(true);
+    expect(result.ast).toBeDefined();
+  });
+
+  it('exposes the diagnostics alongside the AST', () => {
+    const result = hyperscript.compileSync(RECOVERED);
+    expect(result.errors?.length).toBeGreaterThan(0);
+  });
+
+  it('omits errors entirely for a clean parse', () => {
+    const result = hyperscript.compileSync('toggle .active');
+    expect(result.ok).toBe(true);
+    expect(result.errors).toBeUndefined();
+  });
+
+  it('is still not-ok with no AST when the parse truly fails', () => {
+    const result = hyperscript.compileSync(FATAL);
+    expect(result.ok).toBe(false);
+    expect(result.ast).toBeUndefined();
+  });
+});

--- a/packages/core/src/parser/command-parsers/event-commands.ts
+++ b/packages/core/src/parser/command-parsers/event-commands.ts
@@ -142,7 +142,21 @@ export function parseTriggerCommand(
       finalArgs.push(ctx.createIdentifier(keyword));
       continue;
     }
-    finalArgs.push(ctx.parsePrimary());
+
+    const before = ctx.savePosition();
+    const expr = ctx.parsePrimary();
+    if (expr) finalArgs.push(expr);
+
+    // parsePrimary() can return WITHOUT consuming a token when it cannot start
+    // an expression there — e.g. the `&` in an HTML-escaped `&lt;form /&gt;`,
+    // which is what a `<form/>` selector becomes when a doc example is copied
+    // through markdown. With no progress check this loop spun forever appending
+    // nodes until the process died of heap exhaustion. A hang is strictly worse
+    // than a bad parse: it takes the page (or the build) with it, and no
+    // `success:false` ever gets returned to say why.
+    if (ctx.savePosition() === before) {
+      ctx.advance();
+    }
   }
 
   // Use CommandNodeBuilder for consistent node construction

--- a/packages/core/src/parser/helpers/parsing-helpers.ts
+++ b/packages/core/src/parser/helpers/parsing-helpers.ts
@@ -37,7 +37,15 @@ export const MULTI_WORD_PATTERNS: MultiWordPattern[] = [
     keywords: ['a', 'an', 'from', 'called'],
     syntax: 'make (a|an) <type> [from <args>] [called <name>]',
   },
-  { command: 'send', keywords: ['to'], syntax: 'send <event> to <target>' },
+  // NOTE: `send` deliberately has NO entry. It is trigger's alias, and
+  // COMPOUND_COMMANDS routes both to parseTriggerCommand — which already
+  // understands `to <target>`, colon-qualified event names (`draggable:start`)
+  // and named event detail. But parseMultiWordCommand runs BEFORE the compound
+  // dispatch, so an entry here shadowed that: `send` reached the generic
+  // arg loop, whose parsePrimary() choked on the `:` in `send evt(id: 1)` with
+  // "Expected closing parenthesis" — on syntax upstream accepts, and which the
+  // identical `trigger evt(id: 1)` parsed correctly because `trigger` was never
+  // listed here.
   { command: 'throw', keywords: [], syntax: 'throw <error>' },
 ];
 

--- a/packages/core/src/parser/send-trigger-parity.test.ts
+++ b/packages/core/src/parser/send-trigger-parity.test.ts
@@ -1,0 +1,110 @@
+/**
+ * `send` is `trigger`'s alias. COMPOUND_COMMANDS routes both to
+ * parseTriggerCommand, which understands `to <target>`, colon-qualified event
+ * names (`draggable:start`) and named event detail.
+ *
+ * But `send` also had an entry in MULTI_WORD_PATTERNS, and parseMultiWordCommand
+ * runs BEFORE the compound dispatch — so `send` never reached the shared parser.
+ * It fell into the generic arg loop, whose parsePrimary() choked on the `:` in
+ * `send evt(id: 1)`:
+ *
+ *     send    evt(id: 1) to #x   ->  "Expected closing parenthesis" + flat
+ *                                    identifier run, event detail LOST
+ *     trigger evt(id: 1) to #x   ->  functionCall node, detail intact
+ *
+ * on syntax the real hyperscript.org engine accepts. Found by diffing our
+ * accumulated parse errors against the upstream engine across the example and
+ * pattern corpora — it was the only false-positive class in 572 sources, and it
+ * appears in this repo's own documented examples.
+ *
+ * These assert the two commands agree. Any divergence is a bug in one of them.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse } from './parser';
+import type { CommandNode } from '../types/base-types';
+
+const cmd = (src: string): CommandNode => {
+  const result = parse(src);
+  expect(result.success).toBe(true);
+  return result.node as CommandNode;
+};
+
+/** Shape of the args, comparable across the two spellings. */
+const shape = (c: CommandNode): Array<{ type?: string; value?: unknown }> =>
+  (c.args ?? []).map(a => {
+    const n = a as { type?: string; value?: unknown; name?: unknown };
+    return { type: n.type, value: n.value ?? n.name };
+  });
+
+describe('send / trigger parity', () => {
+  it.each([
+    'EVENT(id: 1) to #modal',
+    'EVENT(id: 1, name: 2) to #modal',
+    'EVENT(1) to #modal',
+    'EVENT() to #modal',
+    'EVENT to #modal',
+    'EVENT',
+    'draggable:start to #x',
+  ])('parses `%s` identically either way', tail => {
+    const asSend = cmd(`send ${tail.replace('EVENT', 'showProduct')}`);
+    const asTrigger = cmd(`trigger ${tail.replace('EVENT', 'showProduct')}`);
+
+    expect(asSend.name).toBe('send');
+    expect(asTrigger.name).toBe('trigger');
+    expect(shape(asSend)).toEqual(shape(asTrigger));
+    expect(parse(`send ${tail.replace('EVENT', 'showProduct')}`).errors ?? []).toEqual([]);
+  });
+
+  it('keeps named event detail as a functionCall, not a flat identifier run', () => {
+    const c = cmd('send showProduct(id: 1) to #modal');
+    const first = c.args?.[0] as { type?: string; name?: unknown };
+    expect(first.type).toBe('functionCall');
+    expect(first.name).toBe('showProduct');
+  });
+
+  it('still routes the to-target', () => {
+    // The MULTI_WORD_PATTERNS entry existed to capture `to <target>`;
+    // parseTriggerCommand already does it, as a positional arg.
+    expect(shape(cmd('send showProduct(id: 1) to #modal'))).toEqual([
+      { type: 'functionCall', value: 'showProduct' },
+      { type: 'identifier', value: 'to' },
+      { type: 'selector', value: '#modal' },
+    ]);
+  });
+});
+
+/**
+ * parseTriggerCommand's trailing-argument loop called parsePrimary() and
+ * assumed it always consumed. It does not: on a token it cannot start an
+ * expression with, it returns without advancing, and the loop appended nodes
+ * forever until the process died of heap exhaustion.
+ *
+ * The trigger was an HTML-escaped selector — what `<form/>` becomes when a doc
+ * example is copied through markdown — reached from this repo's own docs. A
+ * hang is strictly worse than a bad parse: it takes the page or the build with
+ * it and never returns a `success: false` to explain why.
+ */
+describe('parseTriggerCommand terminates on unparseable trailing tokens', () => {
+  it.each([
+    'trigger hello to &lt;form /&gt;',
+    'send hello to &lt;form /&gt;',
+    'on click send hello to &lt;form /&gt;',
+    'trigger a &amp;&amp; b',
+  ])('terminates on %j', src => {
+    // The bug was unbounded memory growth, so a plain call is the assertion:
+    // pre-fix this never returned.
+    expect(() => parse(src)).not.toThrow();
+  });
+
+  it('reports the malformed input rather than silently succeeding', () => {
+    const result = parse('trigger hello to &lt;form /&gt;');
+    expect((result.errors ?? []).length).toBeGreaterThan(0);
+  });
+
+  it('leaves the well-formed selector form alone', () => {
+    const result = parse('send hello to <form />');
+    expect(result.success).toBe(true);
+    expect(result.errors ?? []).toEqual([]);
+  });
+});


### PR DESCRIPTION
**Stacked on #779.** The accumulated-errors arc, plus the two real bugs the audit turned up.

### The inconsistency
`hyperscript.validate('put 1 2 3 into')` returned `valid: true, errors: []` while the language server flagged the same source — two public surfaces, opposite answers, on input the real `hyperscript.org` engine rejects.

The parser is deliberately resilient: it recovers from some malformed input and returns `success: true` with a degraded AST **and** a non-empty `errors` array. `compileSync`'s success branch never read it (it only mapped the *singular* `parseResult.error`, on the failure branch), so the diagnostics died there. `validate()` derives `valid` from `ok`, so it reported clean. The LSP reads the parser's errors directly, so it didn't.

Because the channel was invisible from the public API, **nothing had ever audited it**. Diffing our accumulated errors against the upstream engine across 572 sources (`examples/`, `docs/`, pattern corpus) found 9 in the silent class — one clean false-positive class, and a latent hang.

### 1. `send` never reached its own parser
`send` is `trigger`'s alias and `COMPOUND_COMMANDS` routes both to `parseTriggerCommand` — but `send` also had an entry in `MULTI_WORD_PATTERNS`, and `parseMultiWordCommand` runs **before** the compound dispatch. So `send` fell into the generic arg loop, whose `parsePrimary()` choked on the `:` in named event detail:

```
send    evt(id: 1) to #x  ->  "Expected closing parenthesis", detail LOST
trigger evt(id: 1) to #x  ->  functionCall node, detail intact
```

Upstream accepts both, and this appears in our own documented examples — so the LSP has been showing a **bogus squiggle on valid code**. Removing the entry lets `send` reach the shared parser, which already handles `to <target>`, colon-qualified event names and named detail. The to-target still lands identically (it was the only thing that entry bought).

### 2. `parseTriggerCommand` could hang
Its trailing-argument loop called `parsePrimary()` and assumed it always consumed. It doesn't — on a token it can't start an expression with it returns without advancing, and the loop appended nodes forever until the process **died of heap exhaustion**.

Reached from an HTML-escaped selector — `send hello to &lt;form /&gt;`, what `<form/>` becomes copied through markdown — which is in this repo's own docs. **Pre-existing on main for `trigger`**; fix #1 would have newly exposed `send` to it, so both belong in one change. A hang is strictly worse than a bad parse: it takes the page or the build with it and never returns a `success: false` to say why. Fixed with a position-progress guard.

### 3. The channel is now visible
Two questions, kept deliberately separate:

| | question | change |
|---|---|---|
| `ok` | "did we produce something runnable?" | **unchanged** — resilient execution behaves exactly as before, no page that works today stops working |
| `valid` | "is this code correct?" | now false when anything was recovered, matching what the LSP has always said |

### Result
After the fixes the corpus has **zero false positives**: all 6 remaining silent-error sources are genuinely malformed and upstream rejects every one. They're in our own docs/examples — worth a follow-up, but they're bugs in the examples, not the parser.

22 new tests (send/trigger parity, loop termination, the validate-vs-compile split); 7 and 2 respectively fail without the fixes. Hang cases assert termination, since pre-fix they never returned. Repo-wide gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)