### PR TITLE
chore(core): mark features/def.ts deprecated (no behavior change)

### DIFF
--- a/packages/core/src/features/def.ts
+++ b/packages/core/src/features/def.ts
@@ -1,6 +1,30 @@
 /**
  * Enhanced Def Feature Implementation
  * Type-safe function definition feature with enhanced validation and LLM integration
+ *
+ * @deprecated This module is dead scaffolding. It has ZERO production callers —
+ * only `src/index.ts` re-exports and this module's own tests reference it — and
+ * it cannot execute a real `DefNode` produced by the parser:
+ *
+ *   - `DefFeature.executeFunction` is a hand-rolled mini-interpreter branching
+ *     on STRING args (`args.indexOf('to')`, `args[0] === 'global'`), not the
+ *     `CommandNode`s `parseDefFeature` emits.
+ *   - `TypedDefFeatureImplementation.executeCatchBlock` builds a context, marks
+ *     it unused, and returns the literal string `'handled'`.
+ *     `executeFinallyBlock` is a bare `return`.
+ *   - Its catch shape is `{parameter, body}`, not the parser's
+ *     `{errorSymbol, errorHandler, finallyHandler}`.
+ *
+ * Top-level `def` does not execute at all today — `RuntimeBase.execute()` has no
+ * `def` case, so a `DefNode` reaches `evaluateAST` and throws
+ * `Unknown AST node type: def`. Do NOT reach for this module when implementing
+ * that; bypass it. The analysis, the options and the four open design questions
+ * are in `docs-internal/HANDOFF-def-execution.md`, and
+ * `src/runtime/def-execution.test.ts` pins the current behavior.
+ *
+ * Slated for removal together with its `src/index.ts` exports in the next
+ * breaking-change batch — deleting it is semver-visible, which is the only
+ * reason it is still here.
  */
 
 import { v, z } from '../validation/lightweight-validators';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,13 @@ export {
 export { Lexer, Tokens } from './tokenizer';
 
 // Export enhanced feature implementations
+/**
+ * @deprecated These four are dead scaffolding with no production callers, and
+ * they cannot execute a `DefNode` from the parser (see the module docblock in
+ * `./features/def`). Top-level `def` does not execute at all today. Slated for
+ * removal in the next breaking-change batch; they remain only because dropping
+ * a public export is semver-visible.
+ */
 export {
   TypedDefFeatureImplementation,
   createDefFeature,


### PR DESCRIPTION
**Stacked on #780.** Doc-comment only — no behavior change.

`src/features/def.ts` is dead scaffolding: 1574 lines, **zero production callers** (only `src/index.ts` re-exports and its own three test files). The spike in #779 had to explicitly rule it out before recommending how to implement `def` — which is the harm worth fixing now. It *looks* like the place to start, and it isn't.

It cannot execute a real `DefNode`:
- `DefFeature.executeFunction` is a hand-rolled mini-interpreter branching on **string** args (`args.indexOf('to')`, `args[0] === 'global'`), not the `CommandNode`s `parseDefFeature` emits.
- `TypedDefFeatureImplementation.executeCatchBlock` builds a context, marks it unused with an eslint-disable, and returns the literal string `'handled'`. `executeFinallyBlock` is a bare `return`.
- Its catch shape is `{parameter, body}`, not the parser's `{errorSymbol, errorHandler, finallyHandler}`.

### Why deprecate rather than delete
The four symbols are public exports, so removal is semver-visible and belongs in a breaking-change batch — most naturally alongside the `def` implementation, where you'd want it gone anyway. Folding it in there spends the breaking change on something users get value from. A `@deprecated` tag reaches the next reader at zero cost and zero breakage, which is the entire point.

The docblock points at `docs-internal/HANDOFF-def-execution.md` (options + the four open design questions) and `src/runtime/def-execution.test.ts` (which pins what `def` does today: throws `Unknown AST node type: def`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)