### PR TITLE
feat(core): make `def` execute, with catch/finally

### DIFF
--- a/docs-internal/HANDOFF-def-execution.md
+++ b/docs-internal/HANDOFF-def-execution.md
@@ -1,17 +1,18 @@
-# `def` is parsed and then throws — spike findings
+# `def` execution — findings and what shipped
 
-**Status:** investigation complete, decision pending. No behavior changed by this spike;
-it adds `packages/core/src/runtime/def-execution.test.ts`, which pins current behavior.
+**Status:** implemented. `RuntimeBase.installFunction`, covered by
+`packages/core/src/runtime/def-execution.test.ts`.
 
-Follow-up to the 2.9.1 downstream-report arc. The report listed `def … catch … end` as
-"parsed and silently dropped" and expected the fix to mirror #768's `on`-handler work.
-That framing turned out to be wrong in a way that changes the shape of the job.
+Follow-up to the 2.9.1 downstream-report arc. The report listed
+`def … catch … end` as "parsed and silently dropped" and expected the fix to
+mirror #768's `on`-handler work. Both halves of that framing were wrong, which is
+why this was scoped as a spike first.
 
 ---
 
-## What actually happens
+## What was actually broken
 
-`def` is not silently dropped. It **throws**.
+`def` was not silently dropped. It **threw**.
 
 ```
 parse('def greet(n) return n end')  ->  success, DefNode with params/body
@@ -19,118 +20,120 @@ runtime.execute(defNode, ctx)       ->  rejects: "Unknown AST node type: def"
 ctx.globals.has('greet')            ->  false
 ```
 
-`RuntimeBase.execute()`'s switch handles `command`, `eventHandler`, `event`, `behavior`,
-`Program`, `initBlock`, `block`, `sequence`, `CommandSequence`, `objectLiteral`,
-`templateLiteral` and `memberExpression`. There is no `def` case, and `Runtime` does not
-override `execute()`. A `DefNode` falls to `default:` → `evaluateExpression` →
-`evaluateAST`, which throws on the unknown type.
+`RuntimeBase.execute()`'s switch had no `def` case, and `Runtime` does not
+override `execute()`, so a `DefNode` fell to `default:` → `evaluateExpression` →
+`evaluateAST`, which throws on the unknown type. On a page the attribute
+processor caught that into a `console.error` naming an internal node type —
+telling an author nothing about `def` being unimplemented.
 
-On a page, `attribute-processor` catches that into a `console.error` naming an internal
-node type — which tells an author nothing about `def` being unimplemented.
+The parser half of #768's shared `parseErrorAndFinallyBlocks()` was real, and
+`DefNode` did carry `errorSymbol` / `errorHandler` / `finallyHandler` with
+passing tests for that shape. **The syntax looked supported and nothing executed
+it.** So the task was never "wire catch/finally onto def" — it was "make `def`
+execute at all."
 
-Consequence worth noting: in a `Program`, `executeProgram` buckets event handlers first
-and runs them before other statements, so a handler alongside a `def` **does** register —
-and then the `def` throws, aborting every statement after it.
-
-So the parser half of #768's shared `parseErrorAndFinallyBlocks()` is real and `DefNode`
-does carry `errorSymbol` / `errorHandler` / `finallyHandler`, with passing tests for that
-shape in `hyperscript-parser.test.ts`. The syntax looks supported. Nothing executes it.
-
-**The task is not "wire catch/finally onto def". It is "make `def` execute at all."**
+Secondary consequence, now fixed: in a `Program`, `executeProgram` buckets event
+handlers first, so a handler alongside a `def` **did** register — and then the
+`def` threw, aborting every statement after it.
 
 ---
 
-## No other path installs a top-level def
+## No other path installed a top-level def
 
 | Probe | Result |
 | ----- | ------ |
-| `case 'def'` across `packages/` | only `ast-utils/generator.ts` and `semantic/src/ast-builder` — both codegen/rendering, neither executes |
-| `'def'` in `compatibility/`, `api/`, `dom/`, `core/` | none (one unrelated `"abc" < "def"` string comparison) |
-| `features/def` / `DefFeature` / `TypedDefFeature` consumers | only `src/index.ts` re-exports, plus its own 3 test files |
+| `case 'def'` across `packages/` | only `ast-utils/generator.ts` and `semantic/src/ast-builder` — codegen, not execution |
+| `'def'` in `compatibility/`, `api/`, `dom/`, `core/` | none |
+| `features/def` / `DefFeature` consumers | only `src/index.ts` re-exports plus its own tests |
 | `def` in `parser/hybrid/` | none — the hybrid parser cannot parse `def` at all |
 | `registerNodeEvaluator` | only the extension mechanism; nothing registers `'def'` |
 
-**One place `def` does work:** inside a `worker` feature. `packages/realtime/src/worker.ts`
-hand-rolls its own def parsing into a `workerFeature` node's `defs[]` and never touches
-`DefNode` (its comment says so explicitly: "core's parseDefFeature is not exposed on
-ParserContext"). That confirms the gap is specifically top-level `def` reaching
-`RuntimeBase.execute`, and is a second, unrelated implementation of the same syntax.
+**One place `def` already worked:** inside a `worker` feature.
+`packages/realtime/src/worker.ts` hand-rolls its own def parsing into a
+`workerFeature` node's `defs[]` and never touches `DefNode` (its comment says so:
+"core's parseDefFeature is not exposed on ParserContext"). Unrelated code path,
+left alone.
 
 ---
 
-## `features/def.ts` — verdict: **bypass**
+## `features/def.ts` — bypassed, not reused
 
-1574 lines, two parallel implementations, zero production callers. It cannot be adapted
-cheaply, and the evidence is not marginal:
+1574 lines, two parallel implementations, zero production callers. Not adaptable:
 
-- **`DefFeature.executeFunction`** is a hand-rolled mini-interpreter branching on **string**
-  args — `const toIndex = args.indexOf('to')`, `if (args[0] === 'global')` — not the
-  `CommandNode`s the real parser emits. It cannot execute a real `DefNode.body`.
-- **`TypedDefFeatureImplementation.executeCatchBlock`** builds a `_catchContext`, marks it
-  unused with an eslint-disable, and `return 'handled';` — the literal string.
-  `executeFinallyBlock` is `if (!func.finallyBlock) return; return;`. Both are stubs.
-- Its catch shape is `{parameter, body}`, not the parser's
-  `{errorSymbol, errorHandler, finallyHandler}`, so even the data model needs translating.
+- **`DefFeature.executeFunction`** is a hand-rolled mini-interpreter branching on
+  **string** args (`args.indexOf('to')`, `args[0] === 'global'`), not the
+  `CommandNode`s the real parser emits.
+- **`TypedDefFeatureImplementation.executeCatchBlock`** builds a `_catchContext`,
+  marks it unused with an eslint-disable, and `return 'handled';` — the literal
+  string. `executeFinallyBlock` is `if (!func.finallyBlock) return; return;`.
+- Its catch shape is `{parameter, body}`, not
+  `{errorSymbol, errorHandler, finallyHandler}`.
 
-Confirmed no consumer outside `packages/core` imports `TypedDefFeatureImplementation`,
-`createDefFeature` or `enhancedDefImplementation`.
-
-**Do not delete it in the same PR** — `src/index.ts` re-exports it publicly, so removal is
-semver-visible. File it as its own cleanup: drop the module and the `index.ts` exports in a
-breaking-change batch.
+It is now marked `@deprecated` (module docblock + the `src/index.ts` export
+block). Deleting it is semver-visible — four public exports — so that belongs in
+the next breaking-change batch.
 
 ---
 
-## Options
+## What upstream does, and where we deliberately diverge
 
-### A — thin `case 'def'` in `RuntimeBase.execute` (recommended)
+Read from the vendored `node_modules/hyperscript.org/dist/_hyperscript.js`:
 
-Install an async closure into `context.globals` that copies `context.locals`, binds
-`params[i] = args[i]`, delegates the body to the existing `executeCommandSequenceWithResult`
-(which already converts the `return` signal to `ok(returnValue)`), and wraps it in the exact
-try/catch/finally shape #768 put in `createEventHandler` — including
-`if (!errorHandler || isControlFlowError(e)) throw e;` and
-`fnContext.locals.set(errorSymbol, e)`.
+| Question | Upstream | Us |
+| -------- | -------- | -- |
+| namespaced `def utils.foo()` | splits on `.`, `assignToNamespace` walks/creates **nested objects** (`utils = { foo: fn }`) | installs under the **flat key** `"utils.foo"` |
+| what `me` binds to | the element the def was declared on (`makeContext(source, feature, target, null)`) | inherits the declaring context |
+| install target | `assignToNamespace(elt, …)`: `null` or `<body>` → `#globalScope`, which **is** `self`/`window`; any other element → per-element storage inherited down the DOM via `addFeatures`' ancestor walk | **`context.globals`** |
+| caller context | passed as a trailing argument (`arguments[args.length]`), plus `func.hyperfunc` / `hypername` markers | not modelled |
+| return | sync `ctx.meta.returnValue` if returned, else a Promise | always async |
 
-`context.globals` works because `createEventHandler` snapshots `locals` but passes `globals`
-by reference, and `evaluateIdentifier` resolves locals → globals → context props →
-`globalThis`. So a `def` registered in `executeProgram`'s later bucket is still visible to a
-handler bound in the earlier one.
+**The install-target divergence is the deliberate one.** Upstream puts
+body-level defs on the real `window`. We use `context.globals` instead — which
+`evaluateIdentifier` already resolves (locals → globals → context props →
+globalThis) and which `createEventHandler` passes **by reference**, so a handler
+registered earlier still sees a def installed later. The trade: no global
+namespace pollution, no teardown problem, and jsdom test isolation is preserved;
+the cost is that `window.myFunc` does not exist, so external JS cannot call a
+hyperscript def, and a page mixing hyperfixi with real `_hyperscript` will not
+share function scope.
 
-~1 day, medium risk. Also widen `DefNode`'s three error fields from `CommandNode[]` to
-`ASTNode[]` to match `EventHandlerNode`.
-
-**Open questions it must answer first** (these are the real risk, not the plumbing):
-namespaced `def utils.foo()` (the parser emits the dotted name as one string), what `me`
-binds to inside the body, `def` nested in a `behavior`, and whether functions are
-per-document or per-element.
-
-### A′ — same, but onto `globalThis` (upstream semantics)
-
-Same size, higher risk: global collisions, no teardown, and it breaks the jsdom test
-isolation the rest of the suite relies on. Only if interop with a real `_hyperscript` page
-is a requirement.
-
-### B — adapt `TypedDefFeatureImplementation`
-
-2–3 days, high risk, and the end state is A wearing a 1574-line coat. Rejected — see above.
-
-### C — loud rejection stopgap
-
-```ts
-case 'def':
-  throw new Error("'def' functions are parsed but not yet executable — see #NNN");
-```
-
-~10 lines, near-zero risk. This is the same trade just made for `catch`/`finally` in the
-hybrid bundles: it converts an opaque internal error into a statement about what the engine
-supports. **Ship this if the answer is "not now"** — it costs almost nothing and stops the
-current message from misleading.
+This is reversible in the compatible direction: the per-element half, and an
+opt-in `globalThis` assignment, can be added later without changing what already
+works.
 
 ---
 
-## Recommendation
+## What shipped
 
-Answer the four open questions under A, then implement A. If they can't be answered soon,
-land C in the meantime — the status quo error message is actively misleading, and C is
-cheap enough that it doesn't compete with A for effort.
+`RuntimeBase.installFunction`, dispatched from a new `case 'def'`:
+
+- fresh `locals` per call, seeded from the declaring scope, so parameter binding
+  never leaks back out
+- parameters bound positionally; an unpassed parameter is `undefined`
+- body delegated to the existing `executeCommandSequenceWithResult`, which
+  already converts the `return` signal to `ok(returnValue)` — that is the whole
+  of return handling
+- error handling in **exactly** #768's shape, because upstream shares one
+  `parseErrorAndFinally` between `on` and `def` and the two must not drift: the
+  error binds as a local under the author's symbol, a handled error does **not**
+  propagate, `finally` runs on both paths, and control-flow signals never route
+  to `catch`
+
+Plus a **phase 0** in `executeProgram`: defs install before init blocks run. A
+`def` is a declaration and an `init` is executable code that may call it — the
+same reasoning that already puts handler registration ahead of init.
+
+20 tests in `src/runtime/def-execution.test.ts`, including the three that matter
+most: `call greet('x')` from hyperscript reaching the def, a def calling another
+def, and the return value surfacing as `it`/`result`.
+
+---
+
+## Known gaps (all deliberate, none blocking)
+
+- Namespaced defs are flat keys, so `call utils.calc()` works but `utils` is not
+  a traversable object.
+- No caller-context trailing argument, no `hyperfunc`/`hypername` markers.
+- No per-element scoping or ancestor-walk inheritance.
+- The hybrid and lite bundles still cannot parse `def` at all — unchanged, and
+  consistent with how they treat `catch`/`finally`.

--- a/packages/core/src/features/def.ts
+++ b/packages/core/src/features/def.ts
@@ -15,12 +15,9 @@
  *   - Its catch shape is `{parameter, body}`, not the parser's
  *     `{errorSymbol, errorHandler, finallyHandler}`.
  *
- * Top-level `def` does not execute at all today — `RuntimeBase.execute()` has no
- * `def` case, so a `DefNode` reaches `evaluateAST` and throws
- * `Unknown AST node type: def`. Do NOT reach for this module when implementing
- * that; bypass it. The analysis, the options and the four open design questions
- * are in `docs-internal/HANDOFF-def-execution.md`, and
- * `src/runtime/def-execution.test.ts` pins the current behavior.
+ * `def` execution lives in `RuntimeBase.installFunction` (see
+ * `src/runtime/def-execution.test.ts`), which was written deliberately WITHOUT
+ * this module — see `docs-internal/HANDOFF-def-execution.md` for why.
  *
  * Slated for removal together with its `src/index.ts` exports in the next
  * breaking-change batch — deleting it is semver-visible, which is the only

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,9 +54,9 @@ export { Lexer, Tokens } from './tokenizer';
 /**
  * @deprecated These four are dead scaffolding with no production callers, and
  * they cannot execute a `DefNode` from the parser (see the module docblock in
- * `./features/def`). Top-level `def` does not execute at all today. Slated for
- * removal in the next breaking-change batch; they remain only because dropping
- * a public export is semver-visible.
+ * `./features/def`). Real `def` execution lives in
+ * `RuntimeBase.installFunction`. Slated for removal in the next breaking-change
+ * batch; they remain only because dropping a public export is semver-visible.
  */
 export {
   TypedDefFeatureImplementation,

--- a/packages/core/src/runtime/def-execution.test.ts
+++ b/packages/core/src/runtime/def-execution.test.ts
@@ -24,10 +24,10 @@
  * drift. See runtime/on-handler-catch.test.ts for the sibling suite.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { Runtime } from './runtime';
 import { parse } from '../parser/parser';
-import { createContext } from '../core/context';
+import { createContext, getSharedGlobals } from '../core/context';
 import type { ExecutionContext } from '../types/core';
 import type { DefNode } from '../types/base-types';
 
@@ -250,5 +250,83 @@ end`)
       expect(context.globals.has('greet')).toBe(true);
       expect(added).toHaveLength(1);
     });
+  });
+});
+
+/**
+ * The property the whole install-target decision rests on: a `def` must be
+ * visible page-wide, not just to the element that declared it.
+ *
+ * Every test above passes an explicit `new Map()` to createContext to isolate
+ * itself — which means none of them can see this. They would all pass just as
+ * happily if `def` were per-element, i.e. if it were far more broken than the
+ * design claims.
+ *
+ * So this block deliberately does NOT pass a globals map, reproducing what
+ * `dom/attribute-processor.ts` actually does (`createContext(element)` with no
+ * second argument, for every element on the page). That falls back to the
+ * module-level `sharedGlobals`, so all contexts share one map by reference.
+ *
+ * This is also the evidence that `context.globals` is the right home rather
+ * than a compromise: it is where `$globalVar` already lives, so `def` is
+ * consistent with the global-variable mechanism sitting next to it instead of
+ * being the one construct that writes somewhere else. (Upstream _hyperscript
+ * puts both in the same place too — `#globalScope`, which is `window`; we
+ * changed the container, not the namespace semantics.)
+ */
+describe('def visibility across elements (production context shape)', () => {
+  const runtime = new Runtime();
+  const declared: string[] = [];
+
+  afterEach(() => {
+    // These tests write to the module-level sharedGlobals on purpose, so clean
+    // up after themselves rather than leaking into any other suite.
+    const globals = getSharedGlobals();
+    for (const name of declared) globals.delete(name);
+    declared.length = 0;
+  });
+
+  const execOn = async (element: Element, src: string): Promise<void> => {
+    const result = parse(src);
+    expect(result.success).toBe(true);
+    await runtime.execute(result.node!, createContext(element));
+  };
+
+  it('shares one globals map across separately-created contexts', () => {
+    const a = createContext(document.createElement('div'));
+    const b = createContext(document.createElement('div'));
+    // Same object, not merely equal contents — createEventHandler spreads the
+    // context, so a def installed later is only visible to a handler
+    // registered earlier if globals is shared BY REFERENCE.
+    expect(a.globals).toBe(b.globals);
+  });
+
+  it('makes a def declared on one element callable from another', async () => {
+    declared.push('crossElementProbe');
+    const probe = document.createElement('div');
+    probe.id = 'def-cross';
+    document.body.appendChild(probe);
+
+    await execOn(
+      document.createElement('div'),
+      'def crossElementProbe(n)\n  put n into #def-cross\nend'
+    );
+    // A different element entirely, with its own context.
+    await execOn(document.createElement('div'), "call crossElementProbe('from-elsewhere')");
+
+    expect(probe.textContent).toBe('from-elsewhere');
+    probe.remove();
+  });
+
+  it('puts defs in the same scope $globalVar already uses', async () => {
+    declared.push('crossElementVar');
+    const a = document.createElement('div');
+    const b = createContext(document.createElement('div'));
+
+    await execOn(a, "set $crossElementVar to 'hello'");
+
+    // If this holds, `def` living in globals is consistent with the language's
+    // existing page-wide scope rather than a container invented for it.
+    expect(b.globals.get('crossElementVar')).toBe('hello');
   });
 });

--- a/packages/core/src/runtime/def-execution.test.ts
+++ b/packages/core/src/runtime/def-execution.test.ts
@@ -1,36 +1,27 @@
 /**
- * SPIKE — characterizing, not aspirational. These assert what `def` does TODAY.
+ * `def` execution.
  *
- * `def … end` parses fine: parser.ts:parseDefFeature produces a DefNode carrying
- * `errorSymbol` / `errorHandler` / `finallyHandler`, and hyperscript-parser.test.ts
- * has passing tests for that shape. So the syntax LOOKS supported.
+ * These started life (PR #779) as characterizing tests asserting that `def` did
+ * NOT work: it parsed into a DefNode carrying params, body and
+ * errorSymbol/errorHandler/finallyHandler, then fell through
+ * RuntimeBase.execute()'s switch to evaluateAST and threw
+ * `Unknown AST node type: def`. The syntax looked supported and executed
+ * nothing — so the downstream report's "parsed and silently dropped" was too
+ * generous; it threw, into a console.error naming an internal node type.
  *
- * Nothing executes it. RuntimeBase.execute()'s switch dispatches command,
- * eventHandler, event, behavior, Program, initBlock, block, sequence,
- * CommandSequence, objectLiteral, templateLiteral and memberExpression — there
- * is no `def` case, and `Runtime` does not override execute(). A DefNode falls
- * to `default:` -> evaluateExpression -> evaluateAST, which throws
- * `Unknown AST node type: def`.
+ * They are now inverted: each one asserts the behavior it previously denied.
  *
- * So the downstream report's framing ("parsed and silently dropped") is too
- * generous: it is parsed and then THROWS. On a page the attribute processor
- * catches that into a console.error naming an internal node type, which tells
- * an author nothing about `def` being unimplemented.
+ * Scope decisions, deliberately narrower than upstream:
+ *   - the function installs into `context.globals`, NOT the real `window`.
+ *     Upstream assigns body-level defs to globalThis and element-level defs to
+ *     per-element storage inherited down the DOM; we trade that compatibility
+ *     for not polluting the global namespace with no teardown.
+ *   - a namespaced `def utils.foo()` installs under the FLAT key "utils.foo"
+ *     rather than creating a nested `utils` object.
  *
- * A separate implementation sits in src/features/def.ts (TypedDefFeatureImplementation
- * and DefFeature, ~1574 lines) with ZERO production callers — only src/index.ts
- * re-exports and its own tests. It cannot execute a real DefNode.body: its
- * mini-interpreter branches on string args (`args.indexOf('to')`) rather than
- * the CommandNodes the parser emits, its executeCatchBlock returns the string
- * 'handled', and its executeFinallyBlock is a bare `return`. Its catch shape is
- * `{parameter, body}`, not the parser's `{errorSymbol, errorHandler, finallyHandler}`.
- *
- * One place `def` DOES work: inside a `worker` feature, which hand-rolls its own
- * def parsing (packages/realtime/src/worker.ts) into a `workerFeature` node and
- * never touches DefNode. That confirms the gap is specifically top-level `def`
- * reaching RuntimeBase.execute.
- *
- * INVERT these when a `case 'def'` lands.
+ * Error handling mirrors what #768 did for `on` handlers, because upstream
+ * shares one `parseErrorAndFinally` between the two features and they must not
+ * drift. See runtime/on-handler-catch.test.ts for the sibling suite.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -40,9 +31,23 @@ import { createContext } from '../core/context';
 import type { ExecutionContext } from '../types/core';
 import type { DefNode } from '../types/base-types';
 
-describe('def — current runtime behavior (spike)', () => {
+describe('def execution', () => {
   let runtime: Runtime;
   let context: ExecutionContext;
+
+  /** Parse and execute a source, returning nothing — installs happen as a side effect. */
+  const run = async (src: string): Promise<unknown> => {
+    const result = parse(src);
+    expect(result.success).toBe(true);
+    return runtime.execute(result.node!, context);
+  };
+
+  /** The installed callable for `name`. */
+  const fnFor = (name: string): ((...args: unknown[]) => Promise<unknown>) => {
+    const fn = context.globals.get(name);
+    expect(typeof fn).toBe('function');
+    return fn as (...args: unknown[]) => Promise<unknown>;
+  };
 
   beforeEach(() => {
     runtime = new Runtime();
@@ -68,80 +73,182 @@ describe('def — current runtime behavior (spike)', () => {
     expect(def.finallyHandler?.length).toBeGreaterThan(0);
   });
 
-  it('CURRENT: executing a def throws "Unknown AST node type: def"', async () => {
-    const result = parse('def greet(n)\n  return n\nend');
-    await expect(runtime.execute(result.node!, context)).rejects.toThrow(
-      'Unknown AST node type: def'
-    );
+  it('installs a callable instead of throwing Unknown AST node type', async () => {
+    await expect(run('def greet(n)\n  return n\nend')).resolves.not.toThrow();
+    expect(context.globals.has('greet')).toBe(true);
+    expect(typeof context.globals.get('greet')).toBe('function');
   });
 
-  it('CURRENT: installs the function nowhere', async () => {
-    const result = parse('def greet(n)\n  return n\nend');
-    await runtime.execute(result.node!, context).catch(() => {});
-
-    expect(context.globals.has('greet')).toBe(false);
-    expect(context.locals.has('greet')).toBe(false);
-    expect((globalThis as Record<string, unknown>).greet).toBeUndefined();
+  it('binds parameters and returns a value', async () => {
+    await run('def identity(n)\n  return n\nend');
+    await expect(fnFor('identity')(42)).resolves.toBe(42);
   });
 
-  it('CURRENT: the def BODY never runs', async () => {
+  it('binds multiple parameters positionally', async () => {
+    await run('def pick2(a, b)\n  return b\nend');
+    await expect(fnFor('pick2')('first', 'second')).resolves.toBe('second');
+  });
+
+  it('leaves an unpassed parameter undefined rather than erroring', async () => {
+    await run('def maybe(a)\n  return a\nend');
+    await expect(fnFor('maybe')()).resolves.toBeUndefined();
+  });
+
+  it('runs the body for its side effects', async () => {
     const probe = document.createElement('div');
     probe.id = 'def-probe';
     document.body.appendChild(probe);
 
-    const result = parse("def sideEffect()\n  put 'ran' into #def-probe\nend");
-    await runtime.execute(result.node!, context).catch(() => {});
+    await run("def sideEffect()\n  put 'ran' into #def-probe\nend");
+    await fnFor('sideEffect')();
 
-    expect(probe.textContent).toBe('');
+    expect(probe.textContent).toBe('ran');
     probe.remove();
   });
 
-  it('CURRENT: in a Program the handler binds, then the def aborts the rest', async () => {
-    // executeProgram buckets eventHandlers first and runs them before
-    // otherStatements, so the handler DOES register — and then the def throws,
-    // taking every statement after it with it.
-    const result = parse(`def greet(n)
+  it('gives each call its own locals, seeded from the declaring scope', async () => {
+    context.locals.set('outer', 'visible');
+    await run('def readsOuter(n)\n  return outer\nend');
+
+    await expect(fnFor('readsOuter')(1)).resolves.toBe('visible');
+    // The parameter binding must not leak back out to the declaring scope.
+    expect(context.locals.has('n')).toBe(false);
+  });
+
+  it('installs a namespaced def under its flat dotted name', async () => {
+    await run('def utils.calc(a)\n  return a\nend');
+    expect(context.globals.has('utils.calc')).toBe(true);
+    await expect(fnFor('utils.calc')(7)).resolves.toBe(7);
+  });
+
+  describe('catch / finally', () => {
+    it('routes a thrown error to catch and does not re-propagate', async () => {
+      await run("def risky()\n  throw 'boom'\ncatch e\n  return 'caught'\nend");
+      await expect(fnFor('risky')()).resolves.toBe('caught');
+    });
+
+    it('binds the error under the author symbol', async () => {
+      const probe = document.createElement('div');
+      probe.id = 'def-err';
+      document.body.appendChild(probe);
+
+      await run("def risky()\n  throw 'boom'\ncatch e\n  put e into #def-err\nend");
+      await fnFor('risky')();
+
+      // Upstream binds the Error object itself, not its message.
+      expect(probe.textContent).toContain('boom');
+      probe.remove();
+    });
+
+    it('does not enter catch when the body succeeds', async () => {
+      await run("def fine()\n  return 'ok'\ncatch e\n  return 'caught'\nend");
+      await expect(fnFor('fine')()).resolves.toBe('ok');
+    });
+
+    it('runs finally on the success path', async () => {
+      await run("def fin()\n  return 'ok'\nfinally\n  set $ran to 'yes'\nend");
+      await expect(fnFor('fin')()).resolves.toBe('ok');
+      expect(context.globals.get('ran')).toBe('yes');
+    });
+
+    it('runs finally on the failure path and still reports the error', async () => {
+      await run("def boom()\n  throw 'boom'\nfinally\n  set $ran to 'yes'\nend");
+      // `finally` alone must not swallow — only `catch` handles.
+      await expect(fnFor('boom')()).rejects.toThrow('boom');
+      expect(context.globals.get('ran')).toBe('yes');
+    });
+
+    it('runs catch then finally, in that order', async () => {
+      await run(
+        "def both()\n  throw 'boom'\ncatch e\n  set $order to 'caught'\nfinally\n  set $order to ($order + '-finally')\nend"
+      );
+      await fnFor('both')();
+      expect(context.globals.get('order')).toBe('caught-finally');
+    });
+
+    it('lets an error escape a def with no error blocks', async () => {
+      await run("def bare()\n  throw 'boom'\nend");
+      await expect(fnFor('bare')()).rejects.toThrow('boom');
+    });
+  });
+
+  describe('called from hyperscript', () => {
+    // The assertion that actually matters: `call` resolves the name through
+    // evaluateIdentifier (locals -> globals -> context props -> globalThis) and
+    // invokes the installed closure. Everything above tests the callable in
+    // isolation; this tests that authors can reach it.
+    it('call reaches the def and runs its body', async () => {
+      const probe = document.createElement('div');
+      probe.id = 'def-e2e';
+      document.body.appendChild(probe);
+
+      await run('def shout(n)\n  put n into #def-e2e\nend');
+      await run("call shout('hi')");
+
+      expect(probe.textContent).toBe('hi');
+      probe.remove();
+    });
+
+    it('call surfaces the return value as it/result', async () => {
+      await run('def answer()\n  return 42\nend');
+      await run('call answer()');
+      expect(context.result).toBe(42);
+    });
+
+    it('a def can call another def', async () => {
+      const probe = document.createElement('div');
+      probe.id = 'def-nested';
+      document.body.appendChild(probe);
+
+      await run('def inner(n)\n  put n into #def-nested\nend');
+      await run("def outer()\n  call inner('nested')\nend");
+      await run('call outer()');
+
+      expect(probe.textContent).toBe('nested');
+      probe.remove();
+    });
+  });
+
+  describe('program integration', () => {
+    it('installs before init blocks run, so init can call a def', async () => {
+      const probe = document.createElement('div');
+      probe.id = 'def-init';
+      document.body.appendChild(probe);
+
+      // `def` is a declaration; `init` is executable code that may use it. The
+      // def therefore installs in its own phase ahead of init, exactly as
+      // handlers register before init can send to them.
+      await run(`def label()
+  return 'from-def'
+end
+init
+  put 'ready' into #def-init
+end`);
+
+      expect(context.globals.has('label')).toBe(true);
+      expect(probe.textContent).toBe('ready');
+      probe.remove();
+    });
+
+    it('no longer aborts the statements that follow it', async () => {
+      // Previously the def threw here, taking every later statement with it.
+      const added: Array<(e: Event) => unknown> = [];
+      const el = context.me as HTMLElement;
+      el.addEventListener = ((_type: string, fn: unknown) => {
+        added.push(fn as (e: Event) => unknown);
+      }) as unknown as typeof el.addEventListener;
+
+      await expect(
+        run(`def greet(n)
   return n
 end
 on click
   call greet('x')
-end`);
-    expect(result.success).toBe(true);
+end`)
+      ).resolves.not.toThrow();
 
-    const added: Array<(e: Event) => unknown> = [];
-    const el = context.me as HTMLElement;
-    el.addEventListener = ((_type: string, fn: unknown) => {
-      added.push(fn as (e: Event) => unknown);
-    }) as unknown as typeof el.addEventListener;
-
-    await expect(runtime.execute(result.node!, context)).rejects.toThrow(
-      'Unknown AST node type: def'
-    );
-    expect(added).toHaveLength(1);
-  });
-
-  it('CURRENT: calling the never-installed name fails at call time', async () => {
-    const result = parse("call greet('x')");
-    await expect(runtime.execute(result.node!, context)).rejects.toThrow(
-      /Cannot call non-function|greet/
-    );
-  });
-
-  it('CURRENT: catch never runs, because the body never runs', async () => {
-    // The whole point of the reported defect: `def … catch … end` looks
-    // supported and does nothing. Not even the error path.
-    const probe = document.createElement('div');
-    probe.id = 'def-catch-probe';
-    document.body.appendChild(probe);
-
-    const result = parse(`def risky()
-  throw 'boom'
-catch e
-  put 'caught' into #def-catch-probe
-end`);
-    await runtime.execute(result.node!, context).catch(() => {});
-
-    expect(probe.textContent).toBe('');
-    probe.remove();
+      expect(context.globals.has('greet')).toBe(true);
+      expect(added).toHaveLength(1);
+    });
   });
 });

--- a/packages/core/src/runtime/runtime-base.ts
+++ b/packages/core/src/runtime/runtime-base.ts
@@ -4,7 +4,13 @@
  * Designed for tree-shaking: strict dependency injection pattern.
  */
 
-import type { ASTNode, ExecutionContext, CommandNode, EventHandlerNode } from '../types/base-types';
+import type {
+  ASTNode,
+  ExecutionContext,
+  CommandNode,
+  EventHandlerNode,
+  DefNode,
+} from '../types/base-types';
 
 import type { ExecutionResult, ExecutionSignal, ControlFlowError } from '../types/result';
 
@@ -582,6 +588,10 @@ export class RuntimeBase {
           );
         }
 
+        case 'def': {
+          return this.installFunction(node as DefNode, context);
+        }
+
         case 'Program': {
           return await this.executeProgram(node as ASTNode & { features?: ASTNode[] }, context);
         }
@@ -935,6 +945,76 @@ export class RuntimeBase {
   // Structure Executors (Program, Block, Sequence)
   // --------------------------------------------------------------------------
 
+  /**
+   * Install a `def` function into scope.
+   *
+   * `def … end` parsed cleanly long before anything executed it: the switch above
+   * had no `def` case, so a DefNode fell through to `evaluateAST` and threw
+   * `Unknown AST node type: def` — the syntax looked supported and did nothing.
+   *
+   * The function goes into `context.globals`, which `evaluateIdentifier` already
+   * resolves (locals -> globals -> context props -> globalThis) and which
+   * `createEventHandler` passes by reference, so a handler registered earlier
+   * still sees a def installed later. Upstream _hyperscript instead assigns
+   * body-level defs onto the real `window` and element-level defs into
+   * per-element storage inherited down the DOM; we deliberately diverge, to
+   * avoid polluting the global namespace with no teardown. A namespaced
+   * `def utils.foo()` therefore installs under the flat key `"utils.foo"` rather
+   * than creating a nested object.
+   *
+   * Error handling is the shape #768 gave `on` handlers, and for the same
+   * reason — upstream shares one `parseErrorAndFinally` between the two
+   * features, so they must not drift: the error binds as a local under the
+   * author's symbol, a handled error does NOT propagate, `finally` runs on both
+   * paths, and control-flow signals never route to `catch`.
+   */
+  protected installFunction(node: DefNode, context: ExecutionContext): void {
+    const runtime = this;
+    const params = node.params ?? [];
+    const body = (node.body ?? []) as ASTNode[];
+    const errorHandler = node.errorHandler as ASTNode[] | undefined;
+    const finallyHandler = node.finallyHandler as ASTNode[] | undefined;
+    const errorSymbol = node.errorSymbol;
+
+    const fn = async (...args: unknown[]): Promise<unknown> => {
+      // Fresh locals per call, seeded from the declaring scope. Globals stay by
+      // reference so a def can see (and set) globals like any other code.
+      const fnContext: ExecutionContext = {
+        ...context,
+        locals: new Map(context.locals),
+      };
+      params.forEach((name, i) => {
+        if (name) fnContext.locals.set(name, args[i]);
+      });
+
+      const run = async (commands: ASTNode[]): Promise<unknown> => {
+        // executeCommandSequenceWithResult already turns the `return` signal
+        // into ok(returnValue), so this is the whole of return handling.
+        const result = await runtime.executeCommandSequenceWithResult(commands, fnContext);
+        if (!isOk(result)) throw asControlFlowError(result.error);
+        return result.value;
+      };
+
+      if (!errorHandler && !finallyHandler) {
+        return await run(body);
+      }
+
+      try {
+        return await run(body);
+      } catch (e) {
+        if (!errorHandler || isControlFlowError(e)) throw e;
+        if (errorSymbol) fnContext.locals.set(errorSymbol, e);
+        return await run(errorHandler);
+      } finally {
+        if (finallyHandler) {
+          await run(finallyHandler);
+        }
+      }
+    };
+
+    context.globals.set(node.name, fn);
+  }
+
   protected async executeProgram(
     node: ASTNode & { statements?: ASTNode[] },
     context: ExecutionContext
@@ -947,17 +1027,28 @@ export class RuntimeBase {
     // Event handlers MUST be registered before init blocks run
     // This ensures that events sent during init are properly received
     const eventHandlers: ASTNode[] = [];
+    const defs: ASTNode[] = [];
     const initBlocks: ASTNode[] = [];
     const otherStatements: ASTNode[] = [];
 
     for (const statement of node.statements) {
       if (statement.type === 'eventHandler') {
         eventHandlers.push(statement);
+      } else if (statement.type === 'def') {
+        defs.push(statement);
       } else if (statement.type === 'initBlock') {
         initBlocks.push(statement);
       } else {
         otherStatements.push(statement);
       }
+    }
+
+    // Phase 0: Install function declarations. `def` is a declaration, not
+    // executable code, and an `init` block is the reverse — so a def has to be
+    // callable before init runs, exactly as a handler has to be registered
+    // before init can send to it.
+    for (const def of defs) {
+      this.execute(def, context);
     }
 
     // Phase 1: Register all event handlers first


### PR DESCRIPTION
**Stacked on #781.** Closes the original item 1 from the 2.9.1 downstream report.

### What was broken
`def … end` parsed into a `DefNode` carrying params, body and `errorSymbol`/`errorHandler`/`finallyHandler` — with passing tests for that shape — and then **nothing executed it**. `RuntimeBase.execute()`'s switch had no `def` case, so the node fell to `default:` → `evaluateAST` and threw `Unknown AST node type: def`.

The report called this "parsed and silently dropped"; it was worse — it threw, into a `console.error` naming an internal node type. In a `Program` it was worse still: handlers registered first, then the def threw and aborted every statement after it.

Investigation in `docs-internal/HANDOFF-def-execution.md` (updated); the spike that pinned the old behavior is #779.

### What shipped
`installFunction`, dispatched from a new `case 'def'`:

- fresh `locals` per call seeded from the declaring scope, so parameter binding never leaks back out
- parameters bound positionally; an unpassed parameter is `undefined`
- body delegated to the existing `executeCommandSequenceWithResult`, which already converts the `return` signal to `ok(returnValue)` — that's the whole of return handling
- error handling in **exactly** #768's shape, because upstream shares one `parseErrorAndFinally` between `on` and `def` and they must not drift: error binds as a local under the author's symbol, a handled error does **not** propagate, `finally` runs on both paths, control-flow signals never route to `catch`

Plus a **phase 0** in `executeProgram`: defs install before init blocks run. A `def` is a declaration and an `init` is executable code that may call it — the same reasoning that already puts handler registration ahead of init.

### Where this deliberately diverges from upstream
Read from the vendored engine: upstream's `assignToNamespace` puts body-level defs on `#globalScope` — which **is** `self`/`window` — and element-level defs into per-element storage inherited down the DOM by an ancestor walk; `def utils.foo()` creates a nested `utils` object.

We install into **`context.globals`** instead. `evaluateIdentifier` already resolves it (locals → globals → context props → globalThis), and `createEventHandler` passes globals **by reference**, so a handler registered earlier still sees a def installed later.

| | gained | given up |
|---|---|---|
| `context.globals` | no global namespace pollution, no teardown problem, jsdom test isolation preserved | `window.myFunc` doesn't exist — external JS can't call a def, and a page mixing hyperfixi with real `_hyperscript` won't share function scope |

Namespaced defs install under the flat key `"utils.foo"` rather than building a nested object. **Reversible in the compatible direction**: per-element scoping and an opt-in `globalThis` assignment can be added later without changing what works now.

### Known gaps (deliberate, listed in the handoff)
No caller-context trailing argument, no `hyperfunc`/`hypername` markers, no per-element scoping. The hybrid and lite bundles still can't parse `def` at all — unchanged, and consistent with how they treat `catch`/`finally`.

### Verification
20 tests replacing the spike's characterizing set — each now asserts the behavior it previously denied. The three that matter most are end-to-end: `call greet('x')` from hyperscript reaching the def, a def calling another def, and the return value surfacing as `it`/`result`.

Core suite green (7594), repo-wide gate green, both size gates pass (`runtime-base.ts` ships in every full bundle; max drift 0.3%, well inside ±2%).

`features/def.ts` stays deprecated and unused; its docblock now points at `installFunction` rather than claiming `def` is unimplemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)