### PR TITLE
chore(publish): verify RELEASE_BUMP_TOKEN during a dry run

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -306,6 +306,49 @@ jobs:
           # them appeared in the summary).
           echo "all_packages=$(echo $ALL_PACKAGES | tr -s '[:space:]' ' ')" >> $GITHUB_OUTPUT
 
+      # The bump step below only runs for a REAL release, so the credential it
+      # depends on was untestable until packages were already on npm — which is
+      # precisely how v2.9.1 broke (RELEASE_BUMP_TOKEN denied, both landing paths
+      # failed, main left a version behind). A dry run now proves the token can
+      # push before anyone commits to a release.
+      #
+      # `origin/main:main` pushes the commit that is ALREADY on main, so this is
+      # a genuine no-op ("Everything up-to-date") when permitted, and the same
+      # denial when not. It cannot move the branch.
+      #
+      # Non-fatal on purpose: a dry run's job is to report, and a missing token
+      # is a valid configuration (the PR fallback exists for it). The warning is
+      # loud because that fallback stalls — PRs opened with GITHUB_TOKEN do not
+      # trigger CI, so main's required checks never start and auto-merge never
+      # fires.
+      - name: Verify RELEASE_BUMP_TOKEN can push (dry run only)
+        if: ${{ github.event.inputs.dry-run == 'true' }}
+        env:
+          RELEASE_BUMP_TOKEN: ${{ secrets.RELEASE_BUMP_TOKEN }}
+        run: |
+          set -o pipefail
+          if [ -z "$RELEASE_BUMP_TOKEN" ]; then
+            echo "::warning::RELEASE_BUMP_TOKEN is not set. A real release will fall back to a release-bump PR, which stalls: PRs opened with GITHUB_TOKEN do not trigger CI, so the required checks never start and auto-merge never fires. Expect to land the bump by hand."
+            exit 0
+          fi
+
+          BRANCH="${{ github.ref_name }}"
+          # FETCH_HEAD rather than origin/$BRANCH: actions/checkout does a
+          # shallow single-ref fetch, so the remote-tracking ref is not
+          # guaranteed to exist, but FETCH_HEAD always is.
+          git fetch origin "$BRANCH" --quiet
+
+          # actions/checkout persists GITHUB_TOKEN as an http.extraheader that
+          # silently overrides URL credentials — clear it so we test the token
+          # we actually mean to test.
+          if git -c http.https://github.com/.extraheader= \
+              push "https://x-access-token:${RELEASE_BUMP_TOKEN}@github.com/${{ github.repository }}.git" \
+              "FETCH_HEAD:${BRANCH}" 2>&1 | tee /tmp/token-check.log; then
+            echo "✓ RELEASE_BUMP_TOKEN can push to $BRANCH — a real release will land its bump directly."
+          else
+            echo "::warning::RELEASE_BUMP_TOKEN cannot push to $BRANCH. For a fine-grained PAT, check that Repository access includes ${{ github.repository }} AND Permissions -> Repository -> Contents is 'Read and write'; for a classic PAT, the 'repo' scope. A real release would fall back to a release-bump PR, which stalls on required checks that never start."
+          fi
+
       - name: Commit version changes
         id: bump
         # When version-type=current, the bump was already committed by hand

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -345,6 +345,15 @@ jobs:
               push "https://x-access-token:${RELEASE_BUMP_TOKEN}@github.com/${{ github.repository }}.git" \
               "FETCH_HEAD:${BRANCH}" 2>&1 | tee /tmp/token-check.log; then
             echo "✓ RELEASE_BUMP_TOKEN can push to $BRANCH — a real release will land its bump directly."
+            # A green result here is only as strong as the branch it pushed to.
+            # An unprotected branch needs Contents: write and nothing else;
+            # main additionally needs the token's identity to bypass the six
+            # required checks (possible only because enforce_admins is off).
+            # Passing on a feature branch therefore does NOT prove a release
+            # dispatched on main will land — say so, rather than let a ✓ imply it.
+            if [ "$BRANCH" != "main" ]; then
+              echo "::notice::That check ran against '$BRANCH', which is not branch-protected. It proves the token has Contents: write, but NOT that it can push to main past its required checks. Re-run this dry run with the workflow dispatched on main for the definitive answer."
+            fi
           else
             echo "::warning::RELEASE_BUMP_TOKEN cannot push to $BRANCH. For a fine-grained PAT, check that Repository access includes ${{ github.repository }} AND Permissions -> Repository -> Contents is 'Read and write'; for a classic PAT, the 'repo' scope. A real release would fall back to a release-bump PR, which stalls on required checks that never start."
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -489,10 +489,24 @@ committed copy — re-run `npm run populate` before any local gate/probe work.)
 > `main` is push-protected. The workflow tries `RELEASE_BUMP_TOKEN` (admin PAT, direct push),
 > then a plain push, then a `release-bump/vX.Y.Z` branch + PR. On v2.6.0 and again on v2.9.1
 > **all** paths failed and the bump was landed by hand (#603, #772). The workflow now fails
-> loudly instead of going green, but for the fallback to actually work the repo needs
-> _Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and
-> approve pull requests"_ enabled, or a valid `RELEASE_BUMP_TOKEN` (which removes the need for
-> a PR at all). After any release, confirm `main`'s version matches npm.
+> loudly instead of going green.
+>
+> **`RELEASE_BUMP_TOKEN` is required, not just preferred.** The PR fallback does not finish on
+> its own: PRs opened with `GITHUB_TOKEN` do not trigger CI, so `main`'s six required checks
+> never start, `gh pr merge --auto` never fires, and the PR sits pending until a human pushes
+> an empty commit or closes/reopens it. Enabling _Settings → Actions → General → Workflow
+> permissions → "Allow GitHub Actions to create and approve pull requests"_ lets the PR be
+> **created**; only the token makes a release hands-off.
+>
+> If the token is denied (`Permission to … denied to <user>` — note that this means it
+> authenticated fine and is NOT expired), then for a fine-grained PAT check that _Repository
+> access_ includes this repo and _Permissions → Repository → Contents_ is **Read and write**;
+> for a classic PAT, the `repo` scope. Editing a fine-grained PAT's permissions in place keeps
+> the same token string, so the stored secret stays valid and its `updatedAt` will not change.
+>
+> Run the workflow with `dry-run=true` to verify the token can push before committing to a
+> release — that step is a no-op push of `main` onto itself. After any real release, confirm
+> `main`'s version matches npm.
 
 **Archived Workflows:**
 


### PR DESCRIPTION
**Stacked on #782.** Closes the gap #778 left open.

### The problem
The bump step only runs for a real release, so the credential it depends on was **untestable until packages were already on npm**. That is exactly how v2.9.1 broke: `RELEASE_BUMP_TOKEN` denied, both landing paths failed, `main` a version behind until someone noticed. #778 makes that fail loudly — but "loudly, mid-release, after publishing" is still the worst possible moment to find out.

### The check
A dry run now proves the token can push before anyone commits to a release:

```
git push "https://x-access-token:$RELEASE_BUMP_TOKEN@github.com/<repo>.git" FETCH_HEAD:$BRANCH
```

`FETCH_HEAD` is the commit **already on the branch**, so this is a genuine no-op (`Everything up-to-date`) when permitted and the same denial when not. It cannot move the branch.

Two details that are load-bearing:
- **`FETCH_HEAD` rather than `origin/$BRANCH`** — `actions/checkout` does a shallow single-ref fetch, so the remote-tracking ref isn't guaranteed to exist; `FETCH_HEAD` always is.
- **Clearing `http.extraheader`** — `actions/checkout` persists `GITHUB_TOKEN` as an extraheader that silently overrides URL credentials. Without this the check would test the *wrong* token and pass regardless.

Non-fatal in every branch, including an unset secret: a dry run's job is to report, and the fallback is a valid configuration. The warnings carry the actual remediation, not just the symptom.

### Why the token is *required*, not preferred
Recorded in CLAUDE.md, because the release note didn't say it and it's the crux: **the PR fallback does not finish on its own.** PRs opened with `GITHUB_TOKEN` do not trigger CI, so `main`'s six required checks never start, `gh pr merge --auto` never fires, and the PR sits pending until a human pushes an empty commit or closes/reopens it.

Enabling *Allow GitHub Actions to create and approve pull requests* lets the PR be **created**. Only the token makes a release hands-off.

### Two diagnostics worth not re-deriving
- `Permission to … denied to <user>` means the token **authenticated** and is **not expired** — an expired one gives `Invalid username or password`. So that error always points at scope, never at age.
- Editing a fine-grained PAT's permissions **in place** keeps the same token string, so the stored secret stays valid and its `updatedAt` does not change. An unchanged timestamp is not evidence the fix didn't apply.

### Verification
YAML parses; the new `run` block passes `bash -n`; the step is gated on `dry-run == 'true'` and ordered between *Publish packages* and *Commit version changes*. Outcome simulated across all three states (unset / valid / denied) — every one exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)