### PR TITLE
fix: malformed doc examples + ParseResult.recovered, with a gate to hold the line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       protocol: ${{ steps.filter.outputs.protocol }}
       goclient: ${{ steps.filter.outputs.goclient }}
+      docsources: ${{ steps.filter.outputs.docsources }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -99,6 +100,17 @@ jobs:
               - 'protocol/**'
             goclient:
               - 'clients/go-client/**'
+            # The trees the shipped-sources validity gate walks (its
+            # DEFAULT_ROOTS). These are all EXCLUDED from `code` above, so
+            # without their own filter the one gate that reads them would never
+            # run on a diff that only touches them — i.e. never on the PRs most
+            # likely to introduce a malformed example. Deliberately narrow: a
+            # README typo elsewhere still skips the npm stack, and protocol/
+            # and clients/ diffs are unaffected.
+            docsources:
+              - 'examples/**'
+              - 'docs/**'
+              - 'packages/core/docs/**'
 
   # ============================================
   # Job 1: Build All Packages (runs once, shared by all jobs)
@@ -110,7 +122,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # `docsources` is here so a docs/examples-only PR still produces the core
+    # build the shipped-sources gate needs. Everything else downstream stays
+    # gated on `code` alone, so that PR pays for one build and one small job,
+    # not the full fan-out.
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.docsources == 'true'
 
     steps:
       - name: Checkout
@@ -308,6 +324,53 @@ jobs:
             packages/speech/dist/
             packages/intent-element/dist/
           retention-days: 3
+
+  # ============================================
+  # Job 1.5: Shipped-Sources Validity
+  # Every hyperscript source in examples/ and the doc trees must not parse in
+  # the recovers-with-errors state (ok:true WITH a non-empty errors array) —
+  # the state in which a genuinely malformed source neither throws nor reports
+  # failure, which is how five of them shipped undetected.
+  #
+  # Its own job rather than a step in unit-tests, because it must also run on
+  # docs/examples-only PRs (see the `docsources` filter): those skip `code`, so
+  # a step inside unit-tests would never fire on exactly the diffs that can
+  # introduce the bug. Small and fast — one vitest file over a built core.
+  # ============================================
+  shipped-sources:
+    name: Shipped Sources Validity
+    runs-on: ubuntu-latest
+    needs: build
+    # PR-only, same reasoning as export-validation.
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-artifacts
+          path: packages
+
+      - name: Rebuild workspace links
+        run: |
+          rm -rf node_modules/@hyperfixi node_modules/@lokascript
+          npm install
+
+      - name: Shipped-sources validity gate
+        run: npm run test:shipped-sources --prefix packages/testing-framework
 
   # ============================================
   # Job 2: Export Validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,7 +329,7 @@ the committed baseline:
   lowest R1 languages are now th/ms/de/fr ≈ 0.985 — the remaining headroom is
   thin and flat).
 
-> **Figures snapshot:** as of the **2026-07-11** baseline (`c5c884cc`). They drift as work lands
+> **Figures snapshot:** as of the **2026-07-27** baseline (`77f9c2bc`). They drift as work lands
 > — the **authoritative** numbers always live in the committed baseline,
 > `packages/testing-framework/baselines/multilingual-priority.json` (its `timestamp`
 > and `commit` fields stamp each regeneration). Treat the prose here as orientation,
@@ -410,8 +410,9 @@ yields a 0 delta):
    parser rejects (signals 1–8 never parse the rendered surface). Full mode only;
    triage failures with `tools/triage-foreign-residual.ts`. The same allowlist backs the
    standalone vitest gate (`foreign-canonical-validity.test.ts`), so the two cannot
-   disagree; the en-side twin (`canonical-validity.test.ts`, allowlist of exactly 1:
-   `pick-text-range`) remains vitest-only.
+   disagree; the en-side twin (`canonical-validity.test.ts`) remains vitest-only, and
+   its allowlist is now **empty** — 134/134 corpus references render canonically
+   valid. (It formerly held one entry, `pick-text-range`.)
 
 10. **per-pattern parse ratchet (R5)** — a pattern that parsed in the baseline no
     longer parses at all, at **tolerance 0**. Not redundant with signal 1: every

--- a/docs-internal/HANDOFF-if-block-then-separator.md
+++ b/docs-internal/HANDOFF-if-block-then-separator.md
@@ -1,0 +1,189 @@
+# Handoff: `then` inside an `if` body silently hoists the body out of the conditional
+
+Found by the shipped-sources validity gate added in #784. Everything below is
+verified against `main` @ `fe478dd1` + that branch; the oracle is
+`loadCanonicalParser()` in
+[canonical-validity.ts](../packages/testing-framework/src/multilingual/canonical-validity.ts)
+(the real `hyperscript.org` engine, headless).
+
+**Do not re-derive the triage.** The negative results in § "Ruled out" cost more to
+find than the positive one.
+
+---
+
+## Severity: this is not a spurious diagnostic
+
+The visible symptom is a bogus `Expected 'end' after if block` on a source whose
+`end` is present. The actual damage is to the AST:
+
+```hyperscript
+on click
+  if 1 is 2                        -- condition is FALSE
+    get #u then log 'BODY RAN'
+  end
+  log 'after'
+```
+
+```
+ok: true   errors: ["Expected 'end' after if block"]
+
+eventHandler
+ .commands
+    command:if
+     .args
+        binaryExpression
+        block            <-- EMPTY
+    command:log          <-- 'BODY RAN', hoisted OUT of the conditional
+    command:log          <-- 'after'
+```
+
+The `if` gets an **empty block** and its body becomes a **sibling** of the `if`. So
+the conditional body runs **unconditionally**. And because `compileSync` returns
+`ok: true`, this is the AST that actually executes — the page silently does the
+wrong thing rather than failing.
+
+This is also a worked example of why `ParseResult.recovered` (added in #784) exists:
+`success`/`ok` are both true here.
+
+## Minimal repro
+
+```hyperscript
+if 1 is 1
+  get #u then log 'a'
+end
+```
+
+- upstream `hyperscript.org`: **valid**
+- hyperfixi: `Expected 'end' after if block`, body hoisted as above
+
+The trigger is a **`then` used as a command separator inside the `if` body**.
+Removing it — same structure, same `end` — parses clean and nests correctly.
+
+In the shipped example that surfaced this
+(`examples/dialogs/native-dialog.html`) the trigger is
+`get #username then set username to it.value`.
+
+## Ruled out
+
+Each of these was tested and is **clean** in hyperfixi and valid upstream, so none
+of them is the cause. Do not re-chase them:
+
+| Shape | Result |
+| ----- | ------ |
+| `if <cond> then` + body + `end` | clean |
+| `if <cond>` (no `then`) + body + `end` | clean |
+| `if <cond>` (no `then`) + body + `else` + body + `end` | clean |
+| `if <cond> then` + body + `else` + body + `end` | clean |
+| the full native-dialog shape with the body's `then` removed | clean |
+| nested `if` inside `if`, both with `then` + `end` | clean |
+
+In particular the **optional `then` on the `if` itself is not the problem** — it
+works in all six shapes above. The problem is specifically `then` *inside the body*.
+
+## Two suspects — and the second is the important one
+
+**Suspect 1 — the `hasThen` lookahead.**
+[`parseIfCommand`](../packages/core/src/parser/command-parsers/control-flow-commands.ts#L346),
+lines 354-375, decides whether this is the explicit `if … then … end` form by
+scanning forward for a `then`:
+
+```ts
+const maxThenLookahead = 500;
+for (let i = 0; i < maxThenLookahead && !ctx.isAtEnd(); i++) {
+  const token = ctx.peek();
+  if (token.value === KEYWORDS.THEN) { hasThen = true; break; }
+  if (token.value === KEYWORDS.END || … BEHAVIOR || DEF || ON) break;
+  ctx.advance();
+}
+```
+
+It stops at `end`/`behavior`/`def`/`on` but **not at a line boundary**, so it will
+happily cross newlines into the body and bind a `then` that belongs to a body
+command. An `if`'s own `then` must be on the condition's line; this scan does not
+enforce that. Adding a line-boundary stop is the obvious first thing to try.
+
+**Suspect 2 — block-body termination, and suspect 1 does NOT explain it.**
+The bug **also reproduces when the `if` carries its own explicit `then`**:
+
+```hyperscript
+on click
+  if 1 is 1 then
+    get #u then set x to it
+    log 'a'
+  else
+    log 'b'
+  end
+```
+
+Here the lookahead finds the `if`'s own `then` first, so `hasThen` is set
+correctly — yet it still fails. So there is a second mechanism, most likely in how
+the block body decides where it ends.
+[`isCommandTerminator`](../packages/core/src/parser/token-predicates.ts#L350)
+treats `then` as a terminator (correct for "where do this command's arguments
+end?"), so the question to answer is whether that terminator is being consumed as
+a *block* boundary somewhere rather than a *command* boundary.
+
+**Start by explaining both shapes.** A fix that only addresses suspect 1 will look
+right against `native-dialog.html` and still leave the explicit-`then` case broken.
+
+## Constraint on the fix
+
+Do not loosen the `end` requirement generally to make the error go away. There is a
+**separate, independent** laxness difference: upstream tolerates an `if/then` with
+**no `end` at all** at the end of a handler (`on click if 1 is 1 then log 'a'`),
+which we reject. That is worth its own decision — it is a deliberate strictness
+choice, not this bug — and conflating the two would mask the hoisting defect rather
+than fix it.
+
+## Verification harness
+
+The gate from #784 is already the regression test:
+
+```bash
+npm run test:shipped-sources --prefix packages/testing-framework
+```
+
+Allowlist: `packages/testing-framework/baselines/shipped-sources-validity.json`.
+The key embeds a sha1 of the source, so a fixed source stops matching, its entry
+goes stale, and the third assertion **requires** you to remove it. The list can
+only ratchet down.
+
+Add unit coverage next to the existing control-flow tests as well — the gate proves
+the shipped examples are clean, not that the parser is right.
+
+Full suite before proposing the fix: `npm run test:check --prefix packages/core`
+(7603 tests today). `if`-block termination is load-bearing.
+
+## Recommended order for the four allowlisted sources
+
+1. **`fetch-and-async/fetch-data.html`** — do first, it is free and independent.
+   `log 'typeof it:', (typeof it)` uses `typeof`, which is JavaScript, not a
+   hyperscript operator (upstream: `Expected ')' but found 'it'`). Pure authoring
+   fix, no parser change.
+2. **This defect** — one root cause, and the only one of the four where editing the
+   example would be the *wrong* move. Fixing it is what makes step 3 tractable.
+3. **`fetch-and-async/infinite-scroll.html`** — re-triage **after** step 2. It
+   carries the same `Expected 'end' after if block` signature *and* a genuinely
+   missing `end` (upstream rejects it too: `Expected 'end' but found 'on'`). Fixing
+   the parser first tells you which part is really authoring error instead of
+   guessing.
+4. **`drag-and-drop/sortable-list.html`** — last; two unrelated bugs in one file.
+   Upstream's is real and fixable: `set midpoint to box.top + box.height / 2` mixes
+   `+` and `/` without parens, which hyperscript forbids (×2 occurrences) →
+   `box.top + (box.height / 2)`. Hyperfixi's complaint is *different*
+   (`malformed member access`) and will survive that fix — likely a further gap
+   around the `add { prop: value; }` inline-style syntax. Confirm before editing, or
+   you will fix the wrong thing.
+
+Steps 2 and 4 are parser changes and belong in their own PR(s); #784 deliberately
+changes no parser behaviour.
+
+## Wider question worth asking
+
+`native-dialog.html` shipped with its conditional body running unconditionally, and
+nothing caught it. The gate catches it now, but only because someone parses these
+files — there is still no test that *executes* a shipped example and asserts what it
+does. The R2 execution ratchet does this for 47 curated corpus patterns
+(`avgExecutionFidelity`); extending something like it to `examples/**` is the
+natural follow-on, and is what would have caught this on behaviour rather than on a
+diagnostic.

--- a/docs-internal/HANDOFF-parse-success-and-doc-examples.md
+++ b/docs-internal/HANDOFF-parse-success-and-doc-examples.md
@@ -1,0 +1,212 @@
+# Handoff: `parse()` success/errors consistency, and five malformed doc examples
+
+Follow-ups from the 2.9.1 downstream-report arc (PRs #774–#783, merged 2026-07-27,
+`main` @ `c0492d42`). Both items were surfaced by that work rather than fixed by it.
+
+Everything below is verified against `main` as of this commit. The oracle throughout
+is the real upstream engine, already wired up as
+`loadCanonicalParser()` in
+[canonical-validity.ts](../packages/testing-framework/src/multilingual/canonical-validity.ts) —
+it loads `node_modules/hyperscript.org/dist/_hyperscript.esm.js` headlessly and
+returns the grammar errors for a source. Use it; don't re-derive judgements by hand.
+
+---
+
+## Item 1 — `parse()` returns `success: true` with a non-empty `errors` array
+
+### What's true today
+
+The parser is deliberately resilient: it recovers from some malformed input and
+returns a usable-but-degraded AST **plus** diagnostics. `ParseResult.errors` is even
+documented as "All accumulated errors (resilient parsing)". So the state is
+intentional; what is not intentional is that `success` says nothing about it.
+
+```text
+parse('put 1 2 3 into')  ->  success: true,  errors: [1 error]
+parse('set')             ->  success: false, errors: [2 errors]
+parse('toggle .active')  ->  success: true,  errors: []
+```
+
+`success: true` therefore means "an AST exists", not "the input was valid" — and
+~213 non-test call sites across the monorepo check `.success`.
+
+### What #780 already fixed, and what it left
+
+PR #780 stopped the diagnostics being *lost*: `compileSync` now carries recovered
+errors through, and `validate()` reports `valid: false` when any are present. The
+two questions were split deliberately —
+
+- `CompileResult.ok` — "did we produce something runnable?" **unchanged**, so
+  resilient execution behaves exactly as before and no page that works today breaks.
+- `ValidateResult.valid` — "is this correct?" now false on recovered errors.
+
+See `packages/core/src/api/validate-surfaces-recovered-errors.test.ts`.
+
+**What it did not do** is make `success` itself consistent. Every one of those ~213
+call sites still reads a flag that can be `true` for malformed input. #780 patched
+the two public surfaces that were visibly disagreeing; the underlying signal is
+unchanged.
+
+### Why this wasn't taken on
+
+It is a semantics change to the parser's primary return value, and the blast radius
+is the whole monorepo. There are at least three defensible designs and picking one
+is a judgement call, not a refactor:
+
+1. **Leave `success` alone, document it.** Rename nothing; state in the type that
+   `success` means "AST produced" and that callers wanting validity must check
+   `errors`. Cheapest, and arguably already true — but leaves a footgun with a
+   misleading name.
+2. **Make `success` mean "no errors".** Most honest reading of the name. Every
+   currently-recovering call site starts seeing `success: false`, so each of the 213
+   needs auditing for whether it wanted "runnable" or "valid". This is the big one.
+3. **Add a third field** (`recovered: boolean`, or `severity`), leave `success` as
+   "AST produced". Non-breaking, self-documenting, but adds surface area and does
+   not stop anyone reading `success` and getting it wrong.
+
+My weak preference is (3) then (1): (3) makes the distinction visible at the type
+level without a 213-site audit, and (1) alone is too easy to ignore. But this is the
+owner's call — do not treat that as decided.
+
+### Where to start
+
+- `packages/core/src/parser/parser.ts` — the `success: true` returns are at roughly
+  lines 309, 418, 505, 535, 581 (they set `warnings` but never `errors`).
+- `packages/core/src/types/core.ts:271` — the `ParseResult` interface.
+- `packages/core/src/api/hyperscript-api.ts` — `compileSync` (~line 850) and
+  `validate` (~line 1097), already updated by #780; whatever you do should stay
+  consistent with them.
+- `packages/language-server/src/server.ts:665,732` reads `result.errors` directly
+  without consulting `success`, which is why the LSP was right when `validate()` was
+  wrong. It is the existing precedent for "errors are the truth".
+
+### Do not regress
+
+The 22 tests in `validate-surfaces-recovered-errors.test.ts` and
+`send-trigger-parity.test.ts` pin the current split. In particular, **`ok` must stay
+true for a recovered parse** — making execution refuse degraded ASTs would break
+pages that work today, and that is a separate (much bigger) decision.
+
+---
+
+## Item 2 — malformed hyperscript in the docs and examples
+
+### Correcting the count: **five, not six**
+
+The earlier "six" figure included one false finding. Fixing it first, so nobody
+chases it:
+
+**NOT a bug — `examples/events-and-dom/send-events.html:80,85`.** These sit inside
+`<div class="code">` blocks: escaped source displayed *as documentation*
+(`&lt;button _="on click send hello to &lt;form /&gt;"&gt;`). The regex sweep that
+found them extracted from the escaped display text. The file's live attribute is
+line 62, `_="on click send hello to #target-form"`, which is correct.
+
+**Method note for whoever re-runs this:** a raw-text regex over `.html` cannot tell a
+live attribute from a code sample. Either parse the HTML and read attributes via the
+DOM, or skip any match inside a `<pre>`/`<code>`/`.code` block. Expect other false
+positives of this shape in any sweep that doesn't.
+
+### The five real ones
+
+Each verified twice: the current source produces hyperfixi errors, and the proposed
+fix parses clean. Upstream's verdict is given because it diagnoses the root cause
+more precisely in several cases.
+
+| # | Location | Problem |
+| - | -------- | ------- |
+| 1 | `examples/vite-plugin-test/index.html:65` | `has` is not an operator, and the `if` has no `end` |
+| 2 | `packages/core/docs/LOCAL_VARIABLES_GUIDE.md:520` | `put` with no target |
+| 3 | `packages/core/docs/LOCAL_VARIABLES_GUIDE.md:521` | same |
+| 4 | `packages/core/docs/README.md:55` | `{id}` is not interpolation — needs `${id}` |
+| 5 | `patterns.db` id `set-color-variable` | `*--css-var` is not supported syntax |
+
+**1 — `examples/vite-plugin-test/index.html:65`**
+
+```diff
+-  on click if me has .active then remove .active else add .active
++  on click if me matches .active then remove .active else add .active end
+```
+
+Two defects. `has` is not a hyperscript operator (upstream: `Expected 'end' but
+found 'has'`) — the membership operator is `matches`, or `I match`. And the `if`
+block is unterminated (ours: `Expected 'end' after if block`). Both engines accept
+the replacement.
+
+**2 & 3 — `packages/core/docs/LOCAL_VARIABLES_GUIDE.md:520-521`**
+
+```diff
+-  on click set :count to 1 put :count
++  on click set :count to 1 then put :count into #out
+```
+
+`put` requires a target keyword. Both engines say so, nearly identically. Pick a
+target id that exists in the surrounding example — `#out` is a placeholder.
+
+**4 — `packages/core/docs/README.md:55`** (a multi-line attribute spanning lines 54–56)
+
+```diff
+   _="on showProduct(id)
+-       fetch /products/{id} and put it into me
++       fetch /products/${id} and put it into me
+        then remove .hidden from me"
+```
+
+`{id}` is not interpolation syntax — it parses as an object literal, which is why
+ours reports `Expected ':' after property name in object literal`. `${id}` is
+correct and, since #776, is carried whole into the URL and emitted as a
+`templateLiteral` so it actually interpolates.
+
+Note the two engines fail here for *different* reasons. Upstream reports
+`Unexpected Token : and`, because `and` as a command separator is a **hyperfixi
+extension upstream does not have** — it is used throughout our docs
+(`fetch /content and put it into #target`) and is not a defect. Do not "fix" the
+`and`; only the interpolation is wrong.
+
+**5 — `patterns.db`, pattern id `set-color-variable`**
+
+```diff
+-  on click set the *--primary-color of #theme to "#ff6600"
++  on click call #theme.style.setProperty("--primary-color", "#ff6600")
+```
+
+This is a **feature gap, not a typo**. Upstream accepts `set *color of #x to "red"`
+but rejects `*--primary-color` — the `*` style-property prefix does not extend to CSS
+custom properties in either engine. `setProperty` is accepted by both.
+
+Two options, and this one needs a decision rather than a patch:
+
+- **Rewrite the pattern** to the `setProperty` form (above). Cheapest; the pattern
+  keeps demonstrating "set a CSS variable" with syntax that works.
+- **Implement `*--var` support** and keep the pattern as the motivating case. Larger,
+  diverges from upstream, and needs its own design.
+
+Changing a pattern is not free: `patterns.db` rows feed the multilingual corpus, so
+edit the seed in
+[init-db.ts](../packages/patterns-reference/scripts/init-db.ts), re-run
+`npm run populate --prefix packages/patterns-reference`, and expect the multilingual
+baseline to move — regenerate it with `--save-baseline` and commit the result, per
+the root CLAUDE.md procedure. The other four are plain doc edits with no such
+coupling.
+
+### Re-running the sweep
+
+The triage that produced this list: for every hyperscript source in `examples/`,
+`docs/`, `packages/core/docs/` and `patterns.db`, parse with hyperfixi; where
+`success === true` **and** `errors` is non-empty, ask upstream for a second opinion.
+Upstream accepting means *we* have a false positive; upstream rejecting means the
+source is genuinely malformed.
+
+That sweep is worth keeping as a gate once these five are fixed — it is what caught
+both the `send`-vs-`trigger` divergence and the `parseTriggerCommand` hang in #780,
+and neither was reachable from the existing suites. Currently it lives only in a
+scratchpad script; promoting it to `packages/testing-framework` with an allowlist of
+known-acceptable rows would stop this class regressing. Note it needs
+`loadCanonicalParser`, so it is Node-only and cannot run in a browser suite.
+
+### Expected end state
+
+After the five fixes, the sweep should report **zero** sources where hyperfixi
+recovers-with-errors — meaning `validate()` returns `valid: true` for every example
+we ship. That is a much better invariant to gate on than the current "six known
+exceptions".

--- a/docs-internal/HANDOFF-parse-success-and-doc-examples.md
+++ b/docs-internal/HANDOFF-parse-success-and-doc-examples.md
@@ -15,11 +15,13 @@ Follow-ups from the 2.9.1 downstream-report arc (PRs #774–#783, merged 2026-07
 > 1. **The sweep is incomplete for `examples/`.** Four more shipped sources parse
 >    recovers-with-errors: `dialogs/native-dialog.html`,
 >    `drag-and-drop/sortable-list.html`, `fetch-and-async/fetch-data.html`,
->    `fetch-and-async/infinite-scroll.html`. Three are genuinely malformed (upstream
->    rejects too). The fourth, **`native-dialog.html`, is a hyperfixi PARSER DEFECT —
->    upstream ACCEPTS it** and we report `Expected 'end' after if block`. All four are
->    allowlisted in `baselines/shipped-sources-validity.json` with their upstream
->    verdict, and are the obvious next queue.
+>    `fetch-and-async/infinite-scroll.html`. All four are allowlisted in
+>    `baselines/shipped-sources-validity.json` with their upstream verdict.
+>    `native-dialog.html` is a hyperfixi **parser defect** — upstream accepts it —
+>    and it is worse than a bad diagnostic: the conditional body is hoisted out of
+>    the `if` and **runs unconditionally**, at `ok: true`. Triage, minimal repro,
+>    ruled-out hypotheses and the recommended order for all four are in
+>    **[HANDOFF-if-block-then-separator.md](HANDOFF-if-block-then-separator.md)**.
 > 2. **`examples/vite-plugin-test/` is gitignored and untracked** (`.gitignore:2`), so
 >    finding #1 was never a shipped source. It is fixed on disk but cannot be
 >    committed, and CI never sees it.

--- a/docs-internal/HANDOFF-parse-success-and-doc-examples.md
+++ b/docs-internal/HANDOFF-parse-success-and-doc-examples.md
@@ -3,6 +3,31 @@
 Follow-ups from the 2.9.1 downstream-report arc (PRs #774–#783, merged 2026-07-27,
 `main` @ `c0492d42`). Both items were surfaced by that work rather than fixed by it.
 
+> **STATUS — both items are DONE** (branch `fix/doc-examples-and-parse-recovered`,
+> 2026-07-27). Item 2: all five sources fixed and verified on both engines. Item 1:
+> resolved as option (3), an additive `ParseResult.recovered`. The sweep is now a
+> permanent gate. Two claims below were measured and found WRONG during the work —
+> they are corrected in place and flagged **[CORRECTED]** so the record is not
+> misleading; the reasoning built on them is left as written.
+>
+> Three things the work turned up that this note did not know:
+>
+> 1. **The sweep is incomplete for `examples/`.** Four more shipped sources parse
+>    recovers-with-errors: `dialogs/native-dialog.html`,
+>    `drag-and-drop/sortable-list.html`, `fetch-and-async/fetch-data.html`,
+>    `fetch-and-async/infinite-scroll.html`. Three are genuinely malformed (upstream
+>    rejects too). The fourth, **`native-dialog.html`, is a hyperfixi PARSER DEFECT —
+>    upstream ACCEPTS it** and we report `Expected 'end' after if block`. All four are
+>    allowlisted in `baselines/shipped-sources-validity.json` with their upstream
+>    verdict, and are the obvious next queue.
+> 2. **`examples/vite-plugin-test/` is gitignored and untracked** (`.gitignore:2`), so
+>    finding #1 was never a shipped source. It is fixed on disk but cannot be
+>    committed, and CI never sees it.
+> 3. **`verify-engines.ts` had the same bug in a second place.** Its lokascript leg
+>    gated on `compileSync().ok` while its upstream leg required zero errors, so
+>    `set-color-variable` was stamped `engine: "lokascript"` for a source hyperfixi
+>    does not cleanly accept either. Both legs now use the same bar.
+
 Everything below is verified against `main` as of this commit. The oracle throughout
 is the real upstream engine, already wired up as
 `loadCanonicalParser()` in
@@ -29,6 +54,20 @@ parse('toggle .active')  ->  success: true,  errors: []
 
 `success: true` therefore means "an AST exists", not "the input was valid" — and
 ~213 non-test call sites across the monorepo check `.success`.
+
+> **[CORRECTED] The 213 figure is wrong by more than an order of magnitude.** For the
+> hyperscript `ParseResult` specifically it is **11 non-test sites, all inside
+> `packages/core`, zero in any other package** (plus 332 test assertions). The other
+> ~130 non-test `.success` reads belong to unrelated types — Zod `safeParse`, the
+> `TypedResult` union in `expressions/**`, the semantic adapter's
+> `SemanticParseAttempt`, testing-framework's own `ParseResult`. Nine of the 11 are the
+> identical guard `if (!r.success || !r.node) throw` — runnable checks that are already
+> correct under today's semantics. This makes option (2) far cheaper than priced below,
+> but also less necessary; the decision recorded at the end still went to (3), because
+> `ParseResult` is a **published** export (semver-major to redefine `success`) and
+> because (2) would put the "`ok` must stay true" invariant on a hand-edit at
+> `hyperscript-api.ts:861`. The real cost of (2) is re-verifying the 332 test
+> assertions, not the 11 sources.
 
 ### What #780 already fixed, and what it left
 
@@ -68,6 +107,20 @@ My weak preference is (3) then (1): (3) makes the distinction visible at the typ
 level without a 213-site audit, and (1) alone is too easy to ignore. But this is the
 owner's call — do not treat that as decided.
 
+> **DECIDED (2026-07-27): (3) plus (1).** `ParseResult.recovered` is set in
+> `Parser.parse()` — the single place `errors` is attached, so it cannot drift from it
+> — and `success` is documented on the type as "AST produced, NOT a validity claim".
+> `CompileResult.ok` is untouched, so the must-not-regress invariant holds by
+> construction rather than by care.
+>
+> The audit also turned up **one live instance of #780's defect in a second surface**:
+> the classic-i18n `compile()` shim (`browser-bundle-classic-i18n.ts:502-504`) copied
+> the singular `error` and dropped `errors`, so it returned `{ success: true,
+> errors: [] }` for input carrying a real diagnostic. Demo pages consume it
+> (`examples/animation/color-cycling-debug.html:158`,
+> `examples/multilingual/test-classic-i18n.html:178,191,192`). Fixed, with a guard
+> verified to fail without the fix.
+
 ### Where to start
 
 - `packages/core/src/parser/parser.ts` — the `success: true` returns are at roughly
@@ -79,6 +132,13 @@ owner's call — do not treat that as decided.
 - `packages/language-server/src/server.ts:665,732` reads `result.errors` directly
   without consulting `success`, which is why the LSP was right when `validate()` was
   wrong. It is the existing precedent for "errors are the truth".
+
+  > **[CORRECTED] Line numbers drifted, and the point is stronger than stated.** The
+  > real reads are **729 / 732 / 754** (plus a second pair at 1317-1319). More to the
+  > point, the server does not read `.success` *anywhere* — `grep` for it in
+  > `packages/language-server/src/` returns nothing, as it does for
+  > `mcp-server/src/tools/lsp-bridge.ts`. Both get it right by ignoring the flag
+  > entirely, which is the cleanest statement of "errors are the truth".
 
 ### Do not regress
 
@@ -132,6 +192,11 @@ Two defects. `has` is not a hyperscript operator (upstream: `Expected 'end' but
 found 'has'`) — the membership operator is `matches`, or `I match`. And the `if`
 block is unterminated (ours: `Expected 'end' after if block`). Both engines accept
 the replacement.
+
+> **[CORRECTED] This file is not a shipped source.** `examples/vite-plugin-test/` is
+> gitignored (`.gitignore:2`) and untracked, so the fix applies on disk but cannot be
+> committed, and neither CI nor the new gate ever sees it. The diagnosis above is
+> right; only its status as one of "five real ones" is not. The tracked count is four.
 
 **2 & 3 — `packages/core/docs/LOCAL_VARIABLES_GUIDE.md:520-521`**
 
@@ -189,6 +254,28 @@ baseline to move — regenerate it with `--save-baseline` and commit the result,
 the root CLAUDE.md procedure. The other four are plain doc edits with no such
 coupling.
 
+> **DECIDED (2026-07-27): a third option — keep the `of`-possessive, swap the
+> property.** `on click set the *background-color of #theme to "#ff6600"`, verified
+> valid on both engines. Neither listed option was right, because this row turns out
+> to be the corpus's **only exerciser of the selector-head branch** of
+> `tryMatchOfPossessiveExpression` (`semantic/src/parser/pattern-matcher.ts:1525`) —
+> and `pattern-matcher.ts:2382` names `set-color-variable` when justifying its
+> `source`-only marker gating. The `setProperty` rewrite would have dropped that from
+> 24-language corpus coverage to three hardcoded unit tests, while adding nothing
+> (`call-function` already covers the `call` shape). Retitled, since it no longer
+> demonstrates a custom property.
+>
+> **Baseline impact was nil**: the regenerated baseline moves only `bundleSize` and
+> the stamps. Not one per-pattern metric changed. Translations are auto-generated
+> (`translation_method DEFAULT 'auto-generated'`), so no hand-authoring was needed.
+>
+> **The R4 warning above was backwards, and worth understanding.** This row's en code
+> was upstream-*invalid*, so it was silently EXCLUDED from both canonical-validity
+> denominators. Making it valid *adds* it: the en-side went 133 → **134** checked,
+> 134 valid, allowlist still empty; the foreign R4 gate passes with no new invalid
+> pairs. Making a corpus row valid can therefore only ever grow those denominators —
+> the risk is new exposure, not regression.
+
 ### Re-running the sweep
 
 The triage that produced this list: for every hyperscript source in `examples/`,
@@ -210,3 +297,33 @@ After the five fixes, the sweep should report **zero** sources where hyperfixi
 recovers-with-errors — meaning `validate()` returns `valid: true` for every example
 we ship. That is a much better invariant to gate on than the current "six known
 exceptions".
+
+> **DONE, and the count was not zero.** The gate is
+> `packages/testing-framework/src/multilingual/shipped-sources-validity.ts` +
+> `.test.ts`, allowlist in `baselines/shipped-sources-validity.json`, npm script
+> `test:shipped-sources`. It sweeps **454 sources, 408 clean, 4 allowlisted** — the
+> four `examples/**` findings listed at the top of this note, none of which this
+> handoff knew about. The corpus half did reach zero: `set-color-variable` was the
+> only recovers-with-errors row in all 164.
+>
+> Three scoping decisions worth knowing before touching it:
+>
+> - **Only `ok:true`-with-errors is gated.** `ok:false` is a much larger and mostly
+>   legitimate class (non-English sources needing the multilingual path, plugin syntax
+>   whose feature is not installed, deliberate "this does not work" snippets). Gating
+>   it would drown the signal, and an outright failure is loud anyway.
+> - **Bare `hyperscript`-fenced blocks are excluded.** In this repo they are
+>   overwhelmingly syntax *notation* (`send <event> to <target>`), which no parser can
+>   accept. Only `_=`/`hx-live` attributes and `<script type="text/hyperscript">`
+>   bodies are collected, from `.html` files and from `html`-fenced blocks in `.md`.
+> - **CI needed a new path filter.** The `code` filter excludes `**/*.md`, `docs/**`
+>   and `examples/**` — exactly the trees this gate walks — so a step in `unit-tests`
+>   would never have run on a docs/examples-only PR, i.e. never on the diffs most
+>   likely to introduce the bug. There is now a narrow `docsources` filter (the gate's
+>   three roots) which also un-gates `build`, plus a small dedicated job.
+>
+> The method note above is now enforced structurally rather than by discipline:
+> extraction goes through the DOM via `extractHyperscriptFromMarkup`, exported from
+> `@hyperfixi/patterns-reference` and shared with `verify-engines.ts` so the two
+> cannot drift. Escaped text in a `<pre>`/`.code` block decodes to a text node, never
+> an attribute, so the `send-events.html` false-positive class is unreachable.

--- a/packages/core/docs/LOCAL_VARIABLES_GUIDE.md
+++ b/packages/core/docs/LOCAL_VARIABLES_GUIDE.md
@@ -517,8 +517,8 @@ When using global variables, document their purpose:
 
 ```hyperscript
 <!-- Each handler gets its own :count -->
-<button _="on click set :count to 1 put :count">Button 1</button>
-<button _="on click set :count to 2 put :count">Button 2</button>
+<button _="on click set :count to 1 then put :count into #out">Button 1</button>
+<button _="on click set :count to 2 then put :count into #out">Button 2</button>
 ```
 
 ### Problem: Complex Concatenation Not Working

--- a/packages/core/docs/README.md
+++ b/packages/core/docs/README.md
@@ -13,22 +13,25 @@ A common challenge in web applications is keeping disparate parts of the UI in s
 **Use Case:** A user updates their profile. After the `fetch` confirms the update was successful, it sends a `profileUpdated` event with the new user data as a payload.
 
 ```html
-<form _="on submit fetch /user/profile with method: 'POST', body: formToJSON(me)
-         then send profileUpdated({user: it}) to body">
-  <input name="name" type="text"/>
+<form
+  _="on submit fetch /user/profile with method: 'POST', body: formToJSON(me)
+         then send profileUpdated({user: it}) to body"
+>
+  <input name="name" type="text" />
   <button type="submit">Save</button>
 </form>
 
 ---
 
 <div id="main-nav">
-  Welcome, <span _="on profileUpdated(user) from body put user.name into me">
-    Current User Name
-  </span>
+  Welcome,
+  <span _="on profileUpdated(user) from body put user.name into me"> Current User Name </span>
 </div>
 
-<h1 _="on profileUpdated(user) from body
-         set my.textContent to `Welcome back, ${user.name}!`">
+<h1
+  _="on profileUpdated(user) from body
+         set my.textContent to `Welcome back, ${user.name}!`"
+>
   Welcome back...
 </h1>
 ```
@@ -45,17 +48,19 @@ This is the reverse pattern and is equally powerful. An action in one component 
 
 ```html
 <div id="product-gallery">
-  <img src="thumb1.jpg" _="on click send showProduct(id: 1) to #product-modal">
-  <img src="thumb2.jpg" _="on click send showProduct(id: 2) to #product-modal">
+  <img src="thumb1.jpg" _="on click send showProduct(id: 1) to #product-modal" />
+  <img src="thumb2.jpg" _="on click send showProduct(id: 2) to #product-modal" />
 </div>
 
 ---
 
-<div id="product-modal" class="hidden"
-     _="on showProduct(id)
-          fetch /products/{id} and put it into me
-          then remove .hidden from me">
-  </div>
+<div
+  id="product-modal"
+  class="hidden"
+  _="on showProduct(id)
+          fetch /products/${id} and put it into me
+          then remove .hidden from me"
+></div>
 ```
 
 **Why this is powerful:** The thumbnails are "dumb." They only know how to announce that a product should be shown. The modal is completely self-contained. It defines the logic for how it gets populated and displayed. This separation of concerns is a hallmark of clean architecture.
@@ -68,15 +73,15 @@ You can chain these patterns to create complex workflows that remain readable an
 
 ```html
 <div id="checkout-flow">
-
   <div id="step-1">
-    <button _="on click
+    <button
+      _="on click
                  fetch /cart/validate with method: 'POST'
-                 then send loadStep(url: it.nextStepUrl) to #checkout-flow">
+                 then send loadStep(url: it.nextStepUrl) to #checkout-flow"
+    >
       Validate Items
     </button>
   </div>
-
 </div>
 
 <script type="text/hyperscript">
@@ -90,6 +95,7 @@ You can chain these patterns to create complex workflows that remain readable an
 ```
 
 **Why this is powerful:** The logic for the entire flow is not hard-coded.
+
 1. The button in Step 1 triggers a `fetch`.
 2. The server response (`it`) contains the URL for the next step (`it.nextStepUrl`).
 3. The `then` clause uses this URL to `send` a `loadStep` event to the main `#checkout-flow` container.

--- a/packages/core/src/api/validate-surfaces-recovered-errors.test.ts
+++ b/packages/core/src/api/validate-surfaces-recovered-errors.test.ts
@@ -19,6 +19,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { hyperscript } from './hyperscript-api';
+import { parse } from '../parser/parser';
 
 /** Malformed, recovered by the parser, and rejected by upstream _hyperscript. */
 const RECOVERED = 'put 1 2 3 into';
@@ -70,5 +71,71 @@ describe('compile() keeps executing what it always executed', () => {
     const result = hyperscript.compileSync(FATAL);
     expect(result.ok).toBe(false);
     expect(result.ast).toBeUndefined();
+  });
+});
+
+/**
+ * `success` answers "is there an AST?", never "was the input valid?". That is
+ * intentional — every execute path wants the former — but the name reads like
+ * the latter, and nothing on the result said otherwise. `recovered` is the
+ * missing signal, set in the one place `errors` is attached so it cannot drift.
+ */
+describe('ParseResult.recovered marks a degraded AST', () => {
+  it('is true, alongside success, when the parser recovered', () => {
+    const result = parse(RECOVERED);
+    expect(result.success).toBe(true); // an AST exists...
+    expect(result.recovered).toBe(true); // ...but it is degraded
+    expect(result.errors?.length).toBeGreaterThan(0);
+  });
+
+  it('is absent for a clean parse', () => {
+    const result = parse('toggle .active');
+    expect(result.success).toBe(true);
+    expect(result.recovered).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+  });
+
+  it('tracks errors exactly — never set without them, never omitted with them', () => {
+    // The invariant that makes `recovered` safe to trust: it is derived from
+    // the same array in the same statement, so no parse can disagree.
+    for (const source of [RECOVERED, FATAL, 'toggle .active', 'on click add .x to me']) {
+      const result = parse(source);
+      expect(Boolean(result.recovered)).toBe((result.errors?.length ?? 0) > 0);
+    }
+  });
+
+  it('reports the singular `error` as undefined on a recovered parse', () => {
+    // This asymmetry is the root cause, not an incidental detail: recovery
+    // paths restore `this.error` but never unwind `this.errors`. Anything
+    // reading only `error` therefore sees a clean parse — which is exactly the
+    // bug fixed in the classic compile shim below.
+    const result = parse(RECOVERED);
+    expect(result.error).toBeUndefined();
+    expect(result.errors?.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * The classic-i18n bundle ships its own `compile()` shim for _hyperscript API
+ * compatibility. It read the singular `error` and dropped `errors`, so it
+ * reported `{ success: true, errors: [] }` for genuinely malformed input —
+ * #780's defect, surviving in a second surface. Demo pages consume it
+ * (examples/animation/color-cycling-debug.html, test-classic-i18n.html).
+ */
+describe('classic-i18n compile() shim reports recovered errors', () => {
+  it('does not claim a clean compile for a recovered parse', async () => {
+    const api = (await import('../compatibility/browser-bundle-classic-i18n')).default;
+    const result = api.compile(RECOVERED);
+    // `success` stays true — the shim mirrors ParseResult, and the AST is
+    // still what the runtime has always run. The diagnostics must be there.
+    expect(result.success).toBe(true);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('still reports no errors for a clean parse', async () => {
+    const api = (await import('../compatibility/browser-bundle-classic-i18n')).default;
+    const result = api.compile('toggle .active');
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
   });
 });

--- a/packages/core/src/compatibility/browser-bundle-classic-i18n.ts
+++ b/packages/core/src/compatibility/browser-bundle-classic-i18n.ts
@@ -501,7 +501,12 @@ const api = {
       return {
         success: result.success,
         ast: result.node,
-        errors: result.error ? [result.error] : [],
+        // Prefer the accumulated `errors` over the singular `error`: a
+        // resilient parse that recovered leaves `error` restored to undefined
+        // while `errors` holds the diagnostics, so reading only `error` here
+        // reported `{ success: true, errors: [] }` for genuinely malformed
+        // input. Same defect #780 fixed in compileSync.
+        errors: result.errors ?? (result.error ? [result.error] : []),
         tokens: result.tokens || [],
         compilationTime: performance.now() - startTime,
       };

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -258,9 +258,17 @@ export class Parser {
     // Clear Pratt expression cache for this parse
     this.prattCache.clear();
     const result = this.parseInternal();
-    // Attach accumulated errors for resilient parsing
+    // Attach accumulated errors for resilient parsing.
+    //
+    // This is the ONE place both facts are in hand, which is why `recovered`
+    // is set here rather than at the `parseInternal()` return literals: those
+    // never see `this.errors`, so a per-literal flag would drift. `success`
+    // is derived from the singular `this.error`, which recovery paths restore
+    // (see parseCommandWithErrorRecovery) without unwinding this array — so a
+    // recovered parse is `success: true` with a non-empty `errors`.
     if (this.errors.length > 0) {
       result.errors = [...this.errors];
+      result.recovered = true;
     }
     return result;
   }

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -48,12 +48,7 @@ export type ElementType = 'command' | 'expression' | 'feature' | 'keyword' | 'sp
 export type ElementStatus = 'Draft' | 'Review' | 'Approved' | 'Deprecated';
 
 export type ExpressionCategory =
-  | 'Arithmetic'
-  | 'Logical'
-  | 'Comparison'
-  | 'Reference'
-  | 'Conversion'
-  | 'Special';
+  'Arithmetic' | 'Logical' | 'Comparison' | 'Reference' | 'Conversion' | 'Special';
 
 export type Associativity = 'Left' | 'Right' | 'None';
 
@@ -269,11 +264,32 @@ export interface ParseWarning {
 }
 
 export interface ParseResult<T = ASTNode> {
+  /**
+   * An AST was produced — **not** a validity claim.
+   *
+   * The parser is deliberately resilient: it recovers from some malformed
+   * input and returns a usable-but-degraded AST *plus* diagnostics. Such a
+   * parse is `success: true` with a non-empty `errors`. Callers that want
+   * "is this runnable?" should read this flag (that is what every execute
+   * path does); callers that want "is this correct?" must check `recovered`
+   * or `errors.length === 0`.
+   */
   success: boolean;
   node?: T;
   ast?: T; // Alias for node - some code uses ast instead of node
   error?: ParseError;
   errors?: ParseError[]; // All accumulated errors (resilient parsing)
+  /**
+   * The parse recovered from at least one error, so `node` is degraded.
+   * Mirrors `errors.length > 0`, and is set in `Parser.parse()` — the single
+   * place `errors` is attached — so the two cannot drift apart.
+   *
+   * Exists because `success` alone cannot express the difference: the parser's
+   * recovery paths restore the singular `this.error` but never unwind the
+   * push onto `this.errors`, which is exactly how a recovered parse ends up
+   * reporting `success: true`.
+   */
+  recovered?: boolean;
   warnings?: ParseWarning[];
   tokens: Token[];
 }

--- a/packages/patterns-reference/data/engine-verification.json
+++ b/packages/patterns-reference/data/engine-verification.json
@@ -1,11 +1,11 @@
 {
   "meta": {
     "bar": {
-      "lokascript": "compileSync(code).ok via @hyperfixi/core (same call as the browser _= path), with @hyperfixi/reactivity and @hyperfixi/realtime installed (both ship pre-installed in hyperfixi.js), plus a jsdom top-level install smoke (no error within 500ms settle window)",
+      "lokascript": "compileSync(code).ok with zero recovered errors via @hyperfixi/core (same call as the browser _= path), with @hyperfixi/reactivity and @hyperfixi/realtime installed (both ship pre-installed in hyperfixi.js), plus a jsdom top-level install smoke (no error within 500ms settle window)",
       "hyperscript": "upstream _hyperscript parse with zero recovered errors (extensions loaded: socket, worker, eventsource); parse-level only",
       "html": "HTML-markup patterns: each _= / script-tag snippet verified individually; hx-live/sse-*/ws-* attributes are hyperfixi-only and block the upstream claim"
     },
-    "lokascriptVersion": "2.6.0",
+    "lokascriptVersion": "2.9.1",
     "hyperscriptVersion": "0.9.93"
   },
   "engines": {
@@ -129,7 +129,7 @@
     "send-event-to-form": "both",
     "send-with-detail": "both",
     "set-attribute": "both",
-    "set-color-variable": "lokascript",
+    "set-color-variable": "both",
     "set-inner-html-possessive-dot": "both",
     "set-opacity": "both",
     "set-style": "both",
@@ -677,8 +677,7 @@
     },
     "set-color-variable": {
       "lokascript": true,
-      "hyperscript": false,
-      "hyperscriptError": "Unexpected value: *"
+      "hyperscript": true
     },
     "set-inner-html-possessive-dot": {
       "lokascript": true,

--- a/packages/patterns-reference/scripts/init-db.ts
+++ b/packages/patterns-reference/scripts/init-db.ts
@@ -892,9 +892,21 @@ const SEED_EXAMPLES: SeedExample[] = [
   },
   {
     id: 'set-color-variable',
-    title: 'Set CSS Variable',
-    raw_code: 'on click set the *--primary-color of #theme to "#ff6600"',
-    description: 'Set a CSS custom property',
+    title: 'Set Style Property on Another Element',
+    // NOTE: this row used to be `set the *--primary-color of #theme to …`.
+    // The `*` style prefix does NOT extend to CSS custom properties in either
+    // engine (upstream: "Unexpected value: *"; hyperfixi recovered with 2
+    // errors, making it the corpus's only recovers-with-errors row). Plain
+    // style properties in the same `of`-possessive form are accepted by both.
+    // Do not restore the `--var` form without implementing support first.
+    //
+    // The `of`-possessive is why this row is kept rather than rewritten to
+    // `call #theme.style.setProperty(…)`: it is the corpus's only exerciser of
+    // the SELECTOR-head branch of tryMatchOfPossessiveExpression
+    // (semantic/src/parser/pattern-matcher.ts), and pattern-matcher.ts names
+    // set-color-variable when justifying its `source`-only marker gating.
+    raw_code: 'on click set the *background-color of #theme to "#ff6600"',
+    description: 'Set a style property on a different element via the of-possessive',
     feature: 'css-styles',
   },
   {

--- a/packages/patterns-reference/scripts/verify-engines.ts
+++ b/packages/patterns-reference/scripts/verify-engines.ts
@@ -5,13 +5,20 @@
  * engines and records which accept it:
  *
  *   - `lokascript` — @hyperfixi/core (this repo). Bar: `compileSync(code).ok`
- *     (the exact call the browser `_=` attribute path makes, so "compiles"
- *     here means "the shipped hyperfixi.js bundle would accept it"), PLUS an
- *     install smoke: the compiled AST executes top-level in jsdom (event
- *     handlers register, init blocks run) without a synchronous error inside
- *     a short settle window. The @hyperfixi/reactivity plugin is installed
- *     first — it is part of the shipped ecosystem and registers the
- *     `live`/`when`/`bind`/`$var`/caret-var syntax.
+ *     with ZERO recovered errors (the exact call the browser `_=` attribute
+ *     path makes, so "compiles" here means "the shipped hyperfixi.js bundle
+ *     would accept it"), PLUS an install smoke: the compiled AST executes
+ *     top-level in jsdom (event handlers register, init blocks run) without a
+ *     synchronous error inside a short settle window. The @hyperfixi/reactivity
+ *     plugin is installed first — it is part of the shipped ecosystem and
+ *     registers the `live`/`when`/`bind`/`$var`/caret-var syntax.
+ *
+ *     The "zero recovered errors" half matters: the parser is resilient, so
+ *     `ok` stays true for input it recovered from (that is deliberate — see
+ *     ParseResult.success). Gating on `ok` alone therefore stamped
+ *     `lokascript` on patterns hyperfixi does not cleanly accept either,
+ *     which is how `set-color-variable` (`*--primary-color`, rejected by BOTH
+ *     engines) carried a lokascript verdict. Both legs now use the same bar.
  *   - `hyperscript` — upstream _hyperscript (hyperscript.org, pinned in
  *     devDependencies) with its official socket/worker/eventsource
  *     extensions loaded. Bar: `_hyperscript.parse(code)` reports zero parse
@@ -258,7 +265,9 @@ async function main(): Promise<void> {
 
   const verifyLokascriptSnippet = async (code: string): Promise<string | null> => {
     const compiled = hyperscript.compileSync(code);
-    if (!compiled.ok) {
+    // Symmetric with the upstream leg's `errors.length === 0`. `ok` alone is
+    // "is there a runnable AST?", which stays true for a recovered parse.
+    if (!compiled.ok || compiled.errors?.length) {
       return compiled.errors?.[0]?.message ?? 'compile failed';
     }
     // Install smoke: top-level execute must not fail synchronously or within
@@ -384,7 +393,7 @@ async function main(): Promise<void> {
     meta: {
       bar: {
         lokascript:
-          'compileSync(code).ok via @hyperfixi/core (same call as the browser _= path), with @hyperfixi/reactivity and @hyperfixi/realtime installed (both ship pre-installed in hyperfixi.js), plus a jsdom top-level install smoke (no error within 500ms settle window)',
+          'compileSync(code).ok with zero recovered errors via @hyperfixi/core (same call as the browser _= path), with @hyperfixi/reactivity and @hyperfixi/realtime installed (both ship pre-installed in hyperfixi.js), plus a jsdom top-level install smoke (no error within 500ms settle window)',
         hyperscript: `upstream _hyperscript parse with zero recovered errors (extensions loaded: ${upstreamExtensions.join(', ') || 'none'}); parse-level only`,
         html: 'HTML-markup patterns: each _= / script-tag snippet verified individually; hx-live/sse-*/ws-* attributes are hyperfixi-only and block the upstream claim',
       },

--- a/packages/patterns-reference/scripts/verify-engines.ts
+++ b/packages/patterns-reference/scripts/verify-engines.ts
@@ -54,6 +54,7 @@
 
 import { JSDOM } from 'jsdom';
 import Database from 'better-sqlite3';
+import { extractHyperscriptFromMarkup, type MarkupSnippets } from '../src/html-snippets';
 import { writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
@@ -64,9 +65,6 @@ const PKG_ROOT = join(__dirname, '..');
 const DB_PATH = join(PKG_ROOT, 'data', 'patterns.db');
 const OUT_PATH = join(PKG_ROOT, 'data', 'engine-verification.json');
 const require_ = createRequire(import.meta.url);
-
-/** Attribute prefixes that only the hyperfixi htmx-compat layer implements. */
-const HYPERFIXI_ONLY_ATTR_PREFIXES = ['hx-live', 'sse-', 'ws-'];
 
 /** Settle window for the lokascript install smoke (ms). */
 const INSTALL_SETTLE_MS = 500;
@@ -178,42 +176,14 @@ function installDomGlobals(): JSDOM {
   return dom;
 }
 
-/** Extract verifiable hyperscript snippets from an HTML-markup pattern. */
-function extractSnippets(dom: JSDOM, markup: string): { snippets: string[]; hyperfixiOnly: boolean } {
-  const container = dom.window.document.createElement('div');
-  container.innerHTML = markup;
-  const snippets: string[] = [];
-  let hyperfixiOnly = false;
-
-  for (const el of container.querySelectorAll('*')) {
-    for (const attr of el.attributes) {
-      if (attr.name === '_' && attr.value.trim()) {
-        snippets.push(attr.value);
-      }
-      // hx-live values ARE hyperscript (the htmx-compat layer compiles them),
-      // so verify them like `_=` snippets. The other hyperfixi-only attribute
-      // values (sse-connect URLs, sse-swap event names, ws-connect URLs) are
-      // not hyperscript and carry no snippet to verify.
-      if (attr.name === 'hx-live' && attr.value.trim()) {
-        snippets.push(attr.value);
-      }
-      if (HYPERFIXI_ONLY_ATTR_PREFIXES.some(p => attr.name.startsWith(p))) {
-        hyperfixiOnly = true;
-      }
-    }
-    if (
-      el.tagName === 'SCRIPT' &&
-      (el.getAttribute('type') === 'text/hyperscript' ||
-        el.getAttribute('type') === 'text/hyperscript-template')
-    ) {
-      if (el.getAttribute('type') === 'text/hyperscript-template') {
-        hyperfixiOnly = true;
-      } else if (el.textContent?.trim()) {
-        snippets.push(el.textContent);
-      }
-    }
-  }
-  return { snippets, hyperfixiOnly };
+/**
+ * Extract verifiable hyperscript snippets from an HTML-markup pattern.
+ *
+ * Delegates to the shared extractor so this harness and the testing-framework's
+ * shipped-sources gate cannot drift on what counts as a live source.
+ */
+function extractSnippets(dom: JSDOM, markup: string): MarkupSnippets {
+  return extractHyperscriptFromMarkup(dom.window.document, markup);
 }
 
 async function main(): Promise<void> {

--- a/packages/patterns-reference/src/html-snippets.ts
+++ b/packages/patterns-reference/src/html-snippets.ts
@@ -1,0 +1,114 @@
+/**
+ * Extract hyperscript sources out of HTML markup, via the DOM.
+ *
+ * Shared by the two harnesses that need it: `scripts/verify-engines.ts` (which
+ * classifies each corpus pattern's `engine` column) and the testing-framework's
+ * shipped-sources validity gate.
+ *
+ * **Why the DOM and not a regex.** A raw-text regex over `.html` cannot tell a
+ * live attribute from a code sample: a `<pre>`/`<code>`/`.code` block showing
+ * escaped source (`&lt;button _="…"&gt;`) matches just as well as the real
+ * thing. That is not hypothetical — it is how an earlier sweep "found" two
+ * malformed sources in `examples/events-and-dom/send-events.html` that were
+ * only ever display text. Parsing the markup makes the distinction structural:
+ * escaped text decodes into a text node, never into an attribute, so it cannot
+ * be reached by an attribute walk.
+ *
+ * Do not reuse `@hyperfixi/vite-plugin`'s scanner for this purpose — it is
+ * deliberately a regex (it scans partial source files that need not be
+ * well-formed HTML) and has exactly that blind spot.
+ */
+
+/** Attribute prefixes that only the hyperfixi htmx-compat layer implements. */
+const HYPERFIXI_ONLY_ATTR_PREFIXES = ['hx-live', 'sse-', 'ws-'];
+
+/**
+ * The DOM surface this module needs, declared structurally.
+ *
+ * This package compiles with `lib: ["ES2022"]` (it is Node-oriented — a SQLite
+ * pattern database), so the ambient `Document`/`Element` types are not in
+ * scope. Declaring the three members used here keeps the extractor usable from
+ * a jsdom window, a browser document, or a happy-dom one without dragging the
+ * whole DOM lib into the package's build.
+ */
+export interface MinimalAttr {
+  name: string;
+  value: string;
+}
+
+export interface MinimalElement {
+  tagName: string;
+  attributes: ArrayLike<MinimalAttr>;
+  textContent: string | null;
+  getAttribute(name: string): string | null;
+}
+
+export interface MinimalContainer extends MinimalElement {
+  innerHTML: string;
+  querySelectorAll(selectors: string): ArrayLike<MinimalElement>;
+}
+
+export interface MinimalDocument {
+  createElement(tagName: string): MinimalContainer;
+}
+
+export interface MarkupSnippets {
+  /** Every hyperscript source found, in document order. */
+  snippets: string[];
+  /**
+   * The markup uses at least one attribute upstream `_hyperscript` has no
+   * concept of, so it cannot be claimed as upstream-compatible regardless of
+   * how its snippets parse.
+   */
+  hyperfixiOnly: boolean;
+}
+
+/**
+ * Pull every hyperscript source out of `markup`.
+ *
+ * Collects `_="…"` attributes, `hx-live="…"` values (which ARE hyperscript —
+ * the htmx-compat layer compiles them), and `<script type="text/hyperscript">`
+ * bodies. The other hyperfixi-only attribute values (`sse-connect` URLs,
+ * `sse-swap` event names, `ws-connect` URLs) are not hyperscript and carry no
+ * snippet to verify, but they do set `hyperfixiOnly`.
+ *
+ * `doc` is any DOM `Document` — a jsdom window's, or the ambient one in a
+ * browser/jsdom test environment. Markup that fails to parse yields no
+ * snippets rather than throwing.
+ */
+export function extractHyperscriptFromMarkup(doc: MinimalDocument, markup: string): MarkupSnippets {
+  const container = doc.createElement('div');
+  try {
+    container.innerHTML = markup;
+  } catch {
+    return { snippets: [], hyperfixiOnly: false };
+  }
+
+  const snippets: string[] = [];
+  let hyperfixiOnly = false;
+
+  for (const el of Array.from(container.querySelectorAll('*'))) {
+    for (const attr of Array.from(el.attributes)) {
+      if (attr.name === '_' && attr.value.trim()) {
+        snippets.push(attr.value);
+      }
+      if (attr.name === 'hx-live' && attr.value.trim()) {
+        snippets.push(attr.value);
+      }
+      if (HYPERFIXI_ONLY_ATTR_PREFIXES.some(p => attr.name.startsWith(p))) {
+        hyperfixiOnly = true;
+      }
+    }
+
+    if (el.tagName === 'SCRIPT') {
+      const type = el.getAttribute('type');
+      if (type === 'text/hyperscript-template') {
+        hyperfixiOnly = true;
+      } else if (type === 'text/hyperscript' && el.textContent?.trim()) {
+        snippets.push(el.textContent);
+      }
+    }
+  }
+
+  return { snippets, hyperfixiOnly };
+}

--- a/packages/patterns-reference/src/index.ts
+++ b/packages/patterns-reference/src/index.ts
@@ -276,6 +276,14 @@ export function createPatternsReference(options?: ConnectionOptions): PatternsRe
 }
 
 /**
+ * DOM-based extraction of hyperscript out of HTML markup. Shared with the
+ * testing-framework's shipped-sources validity gate so both harnesses agree on
+ * what counts as a live source (and neither regresses to a regex).
+ */
+export { extractHyperscriptFromMarkup } from './html-snippets';
+export type { MarkupSnippets } from './html-snippets';
+
+/**
  * Version of the package.
  */
 export const VERSION = '0.1.0';

--- a/packages/testing-framework/baselines/canonical-validity.json
+++ b/packages/testing-framework/baselines/canonical-validity.json
@@ -1,7 +1,7 @@
 {
   "description": "Allowlist for the canonical-validity gate (packages/testing-framework/src/multilingual/canonical-validity.test.ts). Each id renders to English that the real hyperscript.org parser rejects. A NEW invalid render outside this list, or an allowlisted id that becomes valid, both fail the gate. Shrink this list as renderer fixes land.",
   "note": "These are the ranked worklist for the deferred full renderer sweep; the fetch `from`+quote family was fixed (renderSuppress) and is intentionally NOT here. See docs-internal/HANDOFF_semantic-roundtrip-validity.md § FINDINGS.",
-  "corpusCheckedAtGeneration": 133,
-  "validAtGeneration": 133,
+  "corpusCheckedAtGeneration": 134,
+  "validAtGeneration": 134,
   "allowedInvalid": []
 }

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-24T21:28:04.054Z",
-  "commit": "96e9e015",
+  "timestamp": "2026-07-27T15:52:45.356Z",
+  "commit": "77f9c2bc",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -16,7 +16,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -650,7 +650,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1284,7 +1284,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1909,7 +1909,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2543,7 +2543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3177,7 +3177,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3811,7 +3811,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4445,7 +4445,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5079,7 +5079,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5713,7 +5713,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6347,7 +6347,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6981,7 +6981,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7615,7 +7615,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8249,7 +8249,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8883,7 +8883,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9517,7 +9517,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10151,7 +10151,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10785,7 +10785,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11419,7 +11419,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12053,7 +12053,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12687,7 +12687,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13321,7 +13321,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13955,7 +13955,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14589,7 +14589,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 555920,
+      "bundleSize": 557526,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15212,7 +15212,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 555920,
+      "size": 557526,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/baselines/shipped-sources-validity.json
+++ b/packages/testing-framework/baselines/shipped-sources-validity.json
@@ -9,28 +9,28 @@
       "file": "examples/dialogs/native-dialog.html",
       "error": "Expected 'end' after if block",
       "upstream": "VALID",
-      "reason": "HYPERFIXI PARSER DEFECT, not a malformed example — upstream accepts this source. A trailing `if` inside an event handler, with the handler's end implying the block's end. Fixing the doc would be wrong; the parser should accept it. Needs its own investigation."
+      "reason": "HYPERFIXI PARSER DEFECT, not a malformed example — upstream accepts this source, and its `end` is present. Isolated cause: a `then` used as a COMMAND SEPARATOR inside an `if` body makes the parser lose the block's `end`. Minimal repro (upstream-valid, hyperfixi reports \"Expected 'end' after if block\"):\n    if 1 is 1\\n get #u then log 'a'\\nend\nThe same source with the body's `then` removed parses clean, and it reproduces whether or not the `if` itself carries an explicit `then`. Here the trigger is `get #username then set username to it.value`. Do NOT 'fix' the example — fix the parser. Separately, upstream also tolerates an `if/then` with no `end` at the end of a handler, which we reject; that is a second, independent laxness gap."
     },
     {
       "key": "examples/drag-and-drop/sortable-list.html::d64eff65f5",
       "file": "examples/drag-and-drop/sortable-list.html",
       "error": "Expected property name after '.' - malformed member access",
       "upstream": "You must parenthesize math operations with different operators",
-      "reason": "Genuinely malformed — both engines reject, for different reasons. Deferred: needs the example's intent re-derived before rewriting."
+      "reason": "MIXED — both engines reject, but for unrelated reasons, so this is two bugs in one file. Upstream's is an authoring bug with a known fix: `set midpoint to box.top + box.height / 2` mixes `+` and `/` without parens, which hyperscript forbids (x2 occurrences); `box.top + (box.height / 2)` is the fix. Hyperfixi's complaint is DIFFERENT ('malformed member access') and survives that fix, so it is likely a second parser-side gap around the `add { prop: value; }` inline-style syntax — confirm before editing the example."
     },
     {
       "key": "examples/fetch-and-async/fetch-data.html::1d94c11092",
       "file": "examples/fetch-and-async/fetch-data.html",
       "error": "Expected closing parenthesis ')' after expression - unclosed parentheses",
       "upstream": "Expected ')' but found 'it'",
-      "reason": "Genuinely malformed — both engines reject. Uses `log 'x', it` comma-argument form and `(typeof it)`; neither parses. Deferred."
+      "reason": "Genuinely malformed, and the clearest fix of the four: `log 'typeof it:', (typeof it)` uses `typeof`, which is JavaScript and not a hyperscript operator (upstream: \"Expected ')' but found 'it'\"). The comma-separated `log 'x', it` form is also used throughout. Rewrite as separate `log` commands with no `typeof`; no parser change needed."
     },
     {
       "key": "examples/fetch-and-async/infinite-scroll.html::7b89d333ac",
       "file": "examples/fetch-and-async/infinite-scroll.html",
       "error": "Expected 'end' after if block",
       "upstream": "Expected 'end' but found 'on'",
-      "reason": "Genuinely malformed — both engines reject. An unterminated `if` inside `init`, before the following `on scroll` handler. Deferred."
+      "reason": "MIXED, and must be triaged AFTER the native-dialog parser fix. Hyperfixi's message is the same \"Expected 'end' after if block\" signature as native-dialog, so part of it is likely that same then-in-if-body defect. But upstream ALSO rejects this one (\"Expected 'end' but found 'on'\"), so there is a genuinely missing `end` on top. Fix the parser first, re-run the gate, and see what residue is left before editing the example."
     }
   ]
 }

--- a/packages/testing-framework/baselines/shipped-sources-validity.json
+++ b/packages/testing-framework/baselines/shipped-sources-validity.json
@@ -1,0 +1,36 @@
+{
+  "description": "Allowlist for the shipped-sources validity gate (packages/testing-framework/src/multilingual/shipped-sources-validity.test.ts). Each entry is a hyperscript source we ship that hyperfixi parses in the recovers-with-errors state (ok:true with a non-empty errors array). A NEW such source outside this list, or an allowlisted key that becomes clean, both fail the gate. Shrink this list as fixes land.",
+  "note": "The `key` is file::sha1(source)[0:10], so it CHANGES when the source is edited — a fix cannot silently keep its allowlist cover, it drops off and the stale-entry test demands removal. `upstream` records the real hyperscript.org verdict for each, which is what distinguishes a malformed example (upstream also rejects) from a hyperfixi parser defect (upstream accepts). All four below predate the gate; they were found by it, not by the handoff that motivated it.",
+  "checkedAtGeneration": 454,
+  "cleanAtGeneration": 408,
+  "allowedRecovered": [
+    {
+      "key": "examples/dialogs/native-dialog.html::ecfd89d643",
+      "file": "examples/dialogs/native-dialog.html",
+      "error": "Expected 'end' after if block",
+      "upstream": "VALID",
+      "reason": "HYPERFIXI PARSER DEFECT, not a malformed example — upstream accepts this source. A trailing `if` inside an event handler, with the handler's end implying the block's end. Fixing the doc would be wrong; the parser should accept it. Needs its own investigation."
+    },
+    {
+      "key": "examples/drag-and-drop/sortable-list.html::d64eff65f5",
+      "file": "examples/drag-and-drop/sortable-list.html",
+      "error": "Expected property name after '.' - malformed member access",
+      "upstream": "You must parenthesize math operations with different operators",
+      "reason": "Genuinely malformed — both engines reject, for different reasons. Deferred: needs the example's intent re-derived before rewriting."
+    },
+    {
+      "key": "examples/fetch-and-async/fetch-data.html::1d94c11092",
+      "file": "examples/fetch-and-async/fetch-data.html",
+      "error": "Expected closing parenthesis ')' after expression - unclosed parentheses",
+      "upstream": "Expected ')' but found 'it'",
+      "reason": "Genuinely malformed — both engines reject. Uses `log 'x', it` comma-argument form and `(typeof it)`; neither parses. Deferred."
+    },
+    {
+      "key": "examples/fetch-and-async/infinite-scroll.html::7b89d333ac",
+      "file": "examples/fetch-and-async/infinite-scroll.html",
+      "error": "Expected 'end' after if block",
+      "upstream": "Expected 'end' but found 'on'",
+      "reason": "Genuinely malformed — both engines reject. An unterminated `if` inside `init`, before the following `on scroll` handler. Deferred."
+    }
+  ]
+}

--- a/packages/testing-framework/package.json
+++ b/packages/testing-framework/package.json
@@ -40,7 +40,8 @@
     "analyze-failures": "tsx src/multilingual/tools/analyze-failures.ts",
     "typecheck": "tsc --noEmit",
     "test:check": "VITEST_QUIET=1 bash ../../scripts/vitest-run.sh --reporter=dot",
-    "test:canonical": "FOREIGN_CANONICAL_VALIDITY=1 VITEST_TIMEOUT=300 bash ../../scripts/vitest-run.sh --reporter=dot src/multilingual/canonical-validity.test.ts src/multilingual/foreign-canonical-validity.test.ts"
+    "test:canonical": "FOREIGN_CANONICAL_VALIDITY=1 VITEST_TIMEOUT=300 bash ../../scripts/vitest-run.sh --reporter=dot src/multilingual/canonical-validity.test.ts src/multilingual/foreign-canonical-validity.test.ts",
+    "test:shipped-sources": "VITEST_TIMEOUT=300 bash ../../scripts/vitest-run.sh --reporter=dot src/multilingual/shipped-sources-validity.test.ts"
   },
   "keywords": [
     "hyperscript",

--- a/packages/testing-framework/src/multilingual/canonical-validity.ts
+++ b/packages/testing-framework/src/multilingual/canonical-validity.ts
@@ -15,8 +15,9 @@
  *
  * The FOREIGN-side sibling (foreign-canonical-validity.ts) is folded into
  * `multilingual/cli.ts`'s `--regression` gate as the R4 canonical-validity
- * ratchet. This en-side check remains vitest-only (its allowlist holds exactly
- * one entry, pick-text-range). The same loader recipe now also ships in the
+ * ratchet. This en-side check remains vitest-only; its allowlist is currently
+ * EMPTY (134/134 corpus references render valid — it formerly held one entry,
+ * pick-text-range). The same loader recipe now also ships in the
  * build-time `@hyperscript-tools/i18n` transpiler (`src/validate.ts`, CLI
  * `--check`, Eleventy `parseCheck`) to gate its ENGLISH side (input + foreign→
  * English output). Faithful foreign-OUTPUT gating still awaits the v2

--- a/packages/testing-framework/src/multilingual/shipped-sources-validity.test.ts
+++ b/packages/testing-framework/src/multilingual/shipped-sources-validity.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Shipped-sources validity gate (see shipped-sources-validity.ts for the why).
+ *
+ * Compiles every hyperscript source we ship in `examples/` and the doc trees,
+ * and ratchets on the recovers-with-errors state (`ok: true` with a non-empty
+ * `errors`). Three assertions, matching the canonical-validity gates:
+ *   1. sanity — sources were actually found and mostly compile clean;
+ *   2. no NEW recovering source appears outside the committed allowlist;
+ *   3. no allowlisted key has silently become clean (stale entries must be
+ *      removed so the list only ever shrinks).
+ *
+ * To update after an intentional fix: re-run and rewrite
+ * `baselines/shipped-sources-validity.json`. Note the allowlist key embeds a
+ * hash of the source, so FIXING a source changes its key — the entry goes
+ * stale and assertion 3 makes removing it mandatory.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { JSDOM } from 'jsdom';
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  checkShippedSourcesValidity,
+  type ShippedSourcesResult,
+  type CompileForValidity,
+} from './shipped-sources-validity';
+
+interface AllowlistDoc {
+  allowedRecovered: Array<{
+    key: string;
+    file: string;
+    error: string;
+    upstream: string;
+    reason: string;
+  }>;
+}
+
+const baselinePath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../baselines/shipped-sources-validity.json'
+);
+const allowlist = JSON.parse(readFileSync(baselinePath, 'utf8')) as AllowlistDoc;
+const allowed = new Set(allowlist.allowedRecovered.map(e => e.key));
+
+describe('shipped-sources validity gate', () => {
+  let result: ShippedSourcesResult;
+
+  beforeAll(async () => {
+    // Import core through its built entry, the same surface a consumer gets.
+    const core = (await import('@hyperfixi/core')) as unknown as {
+      hyperscript: { compileSync: CompileForValidity };
+    };
+    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    result = checkShippedSourcesValidity(
+      code => core.hyperscript.compileSync(code),
+      dom.window.document as unknown as Parameters<typeof checkShippedSourcesValidity>[1]
+    );
+  }, 120_000);
+
+  it('finds and compiles the shipped sources (sanity: trees walked, extraction working)', () => {
+    // Guards the silent-zero failure mode: a broken walk or extractor would
+    // make every other assertion vacuously pass.
+    expect(result.checked).toBeGreaterThan(100);
+    expect(result.clean).toBeGreaterThan(100);
+  });
+
+  it('has no NEW source that parses with recovered errors outside the allowlist', () => {
+    const unexpected = result.findings.filter(f => !allowed.has(f.key));
+    expect(
+      unexpected,
+      unexpected.length
+        ? `\nNew shipped sources that parse ok:true WITH errors (fix the source, or allowlist with a reason):\n` +
+            unexpected
+              .map(f => `  [${f.key}]\n      "${f.excerpt}"\n      -> ${f.error}`)
+              .join('\n') +
+            `\n\nAsk the real hyperscript.org engine for a second opinion before deciding:\n` +
+            `upstream REJECTING means the source is malformed; upstream ACCEPTING means this is a hyperfixi parser defect.\n` +
+            `See loadCanonicalParser() in canonical-validity.ts.`
+        : ''
+    ).toEqual([]);
+  });
+
+  it('has no stale allowlist entries (a now-clean source must be removed so the list ratchets down)', () => {
+    const stillFailing = new Set(result.findings.map(f => f.key));
+    const stale = allowlist.allowedRecovered.map(e => e.key).filter(key => !stillFailing.has(key));
+    expect(
+      stale,
+      stale.length
+        ? `\nThese allowlisted sources no longer recover-with-errors (fixed, or edited — the key embeds a source hash).\n` +
+            `Remove them from baselines/shipped-sources-validity.json:\n  ${stale.join('\n  ')}`
+        : ''
+    ).toEqual([]);
+  });
+});

--- a/packages/testing-framework/src/multilingual/shipped-sources-validity.ts
+++ b/packages/testing-framework/src/multilingual/shipped-sources-validity.ts
@@ -1,0 +1,194 @@
+/**
+ * Shipped-sources validity gate
+ * -----------------------------
+ * Every hyperscript source we ship in `examples/` and the doc trees, parsed
+ * with hyperfixi, must not land in the *recovers-with-errors* state:
+ * `ok === true` with a non-empty `errors`.
+ *
+ * That state is the blind spot this gate exists for. The parser is
+ * deliberately resilient — it recovers from some malformed input and returns a
+ * usable-but-degraded AST plus diagnostics — so genuinely broken sources
+ * neither throw nor report `ok: false`. Nothing in the existing suites looks at
+ * the combination, which is how five malformed examples shipped undetected
+ * (an `if` with no `end`, a `put` with no target, `{id}` where `${id}` was
+ * meant, and a `*--css-var` neither engine supports). The same sweep is what
+ * caught the `send`-vs-`trigger` divergence and the `parseTriggerCommand` hang
+ * in #780, neither of which was reachable from the existing tests.
+ *
+ * Deliberately NOT gated: `ok === false`. That is a much larger and mostly
+ * legitimate class — non-English sources (which need the multilingual path,
+ * not `compileSync`), plugin syntax whose feature is not installed, and
+ * intentionally-broken "this does not work" doc snippets. Gating it would
+ * drown the signal. A source that fails outright is also loud; one that
+ * silently recovers is not, and that asymmetry is the whole point.
+ *
+ * Node-only: the second-opinion path needs `loadCanonicalParser()`, which
+ * imports the real `hyperscript.org` build off disk. Cannot run in a browser
+ * suite.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { extractHyperscriptFromMarkup } from '@hyperfixi/patterns-reference';
+
+/** Repo root, from `packages/testing-framework/src/multilingual/`. */
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+/** Trees whose hyperscript we ship to users. */
+const DEFAULT_ROOTS = ['examples', 'docs', 'packages/core/docs'];
+
+/**
+ * Paths excluded from the sweep, each with the reason it is not a shipped
+ * source. Keep this list short and justified — every entry is coverage lost.
+ */
+const EXCLUDED = [
+  {
+    match: (rel: string) => rel.includes(`${path.sep}archive${path.sep}`),
+    reason: 'historical phase/summary docs, not shipped guidance',
+  },
+];
+
+export interface ShippedSource {
+  /** Repo-relative path of the file the source came from. */
+  file: string;
+  /** How it was extracted, for triage. */
+  kind: 'html-attribute' | 'markdown-html-block';
+  /** The hyperscript source itself. */
+  source: string;
+}
+
+export interface ShippedSourceFinding extends ShippedSource {
+  /** Stable allowlist key: file plus a hash of the source. */
+  key: string;
+  /** First hyperfixi diagnostic. */
+  error: string;
+  /** Single-line excerpt, for reading the baseline without opening the file. */
+  excerpt: string;
+}
+
+export interface ShippedSourcesResult {
+  /** Sources extracted and compiled. */
+  checked: number;
+  /** Sources that compiled with no diagnostics. */
+  clean: number;
+  /** Sources in the recovers-with-errors state. */
+  findings: ShippedSourceFinding[];
+}
+
+/** Minimal shape of `hyperscript.compileSync`, injected so this stays testable. */
+export type CompileForValidity = (code: string) => {
+  ok: boolean;
+  errors?: Array<{ message: string }>;
+};
+
+/**
+ * A stable key for an individual snippet.
+ *
+ * Hashing the source (rather than using its index in the file) means the key
+ * survives reordering, and — the point — CHANGES when the snippet is fixed, so
+ * a stale allowlist entry cannot silently keep covering a source that has been
+ * edited. The stale-entry test turns that into a hard failure.
+ */
+function keyFor(file: string, source: string): string {
+  return `${file}::${createHash('sha1').update(source).digest('hex').slice(0, 10)}`;
+}
+
+function walk(dir: string, acc: string[] = []): string[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return acc;
+  }
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name.startsWith('.')) {
+      continue;
+    }
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, acc);
+    else if (/\.(html|md)$/.test(entry.name)) acc.push(full);
+  }
+  return acc;
+}
+
+/**
+ * Collect every hyperscript source we ship.
+ *
+ * HTML files contribute their `_=` / `hx-live` attributes and
+ * `<script type="text/hyperscript">` bodies, read through the DOM (see
+ * `extractHyperscriptFromMarkup` for why not a regex). Markdown contributes
+ * the same, extracted from its fenced ```html blocks.
+ *
+ * Bare fenced ```hyperscript blocks are deliberately NOT collected: in this
+ * repo they are overwhelmingly syntax *notation* rather than code
+ * (`send <event> to <target>`, `copy <source> as <format>`), which no parser
+ * can accept and which it would be wrong to demand parses. The sources that
+ * actually run on a page are the attributes.
+ */
+export function collectShippedSources(
+  doc: Parameters<typeof extractHyperscriptFromMarkup>[0],
+  opts?: { roots?: string[]; repoRoot?: string }
+): ShippedSource[] {
+  const repoRoot = opts?.repoRoot ?? REPO_ROOT;
+  const roots = opts?.roots ?? DEFAULT_ROOTS;
+  const out: ShippedSource[] = [];
+
+  for (const root of roots) {
+    for (const full of walk(path.join(repoRoot, root))) {
+      const rel = path.relative(repoRoot, full);
+      if (EXCLUDED.some(e => e.match(rel))) continue;
+      const text = fs.readFileSync(full, 'utf8');
+
+      if (full.endsWith('.html')) {
+        for (const source of extractHyperscriptFromMarkup(doc, text).snippets) {
+          out.push({ file: rel, kind: 'html-attribute', source });
+        }
+      } else {
+        for (const block of text.matchAll(/```html\n([\s\S]*?)```/g)) {
+          for (const source of extractHyperscriptFromMarkup(doc, block[1] ?? '').snippets) {
+            out.push({ file: rel, kind: 'markdown-html-block', source });
+          }
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Compile every shipped source and report the ones that recovered with errors.
+ */
+export function checkShippedSourcesValidity(
+  compile: CompileForValidity,
+  doc: Parameters<typeof extractHyperscriptFromMarkup>[0],
+  opts?: { roots?: string[]; repoRoot?: string }
+): ShippedSourcesResult {
+  const sources = collectShippedSources(doc, opts);
+  const findings: ShippedSourceFinding[] = [];
+  let clean = 0;
+
+  for (const s of sources) {
+    let result: ReturnType<CompileForValidity>;
+    try {
+      result = compile(s.source);
+    } catch {
+      // A throw is the loud failure mode, not this gate's business.
+      continue;
+    }
+    const errors = result.errors ?? [];
+    if (result.ok && errors.length > 0) {
+      findings.push({
+        ...s,
+        key: keyFor(s.file, s.source),
+        error: errors[0]?.message ?? 'recovered with errors',
+        excerpt: s.source.replace(/\s+/g, ' ').trim().slice(0, 100),
+      });
+    } else if (result.ok) {
+      clean++;
+    }
+  }
+
+  return { checked: sources.length, clean, findings };
+}


### PR DESCRIPTION
Closes the two open items from the 2.9.1 downstream-report arc
(`docs-internal/HANDOFF-parse-success-and-doc-examples.md`).

Both items share one root cause: the parser is deliberately resilient, so a
malformed source returns `success: true` **with** a non-empty `errors` array.
Nothing throws, nothing reports failure, and no existing suite looks at the
combination — which is how five malformed examples shipped, and how the same
ambiguity crept into the corpus tooling.

## Item 2 — malformed shipped sources

Four tracked doc edits, each verified on both hyperfixi and the real
`hyperscript.org` engine (via `loadCanonicalParser()`):

| File | Fix |
| --- | --- |
| `packages/core/docs/LOCAL_VARIABLES_GUIDE.md:520-521` | `put` needs a target keyword |
| `packages/core/docs/README.md:56` | `{id}` parses as an object literal; `${id}` interpolates |
| `patterns.db` `set-color-variable` | `*--primary-color` is unsupported in **both** engines |

The README example still reports `Unexpected Token : and` upstream. That is
expected and not a defect — `and` as a command separator is a hyperfixi
extension used throughout our docs.

### Two corrections to the handoff

- **`examples/vite-plugin-test/index.html` is gitignored and untracked**
  (`.gitignore:2`), so it was never a shipped source. Fixed on disk; the
  tracked count is four, not five.
- **`set-color-variable` took a third option** — keep the `of`-possessive,
  swap the property. It is the corpus's only exerciser of the *selector-head*
  branch of `tryMatchOfPossessiveExpression`, and `pattern-matcher.ts:2382`
  names it when justifying a `source`-only gating decision. The suggested
  `call … setProperty` rewrite would have dropped that from 24-language
  coverage to three unit tests while adding nothing (`call-function` already
  covers the `call` shape).

Baseline impact is nil: only `bundleSize` and the stamps moved — **not one
per-pattern metric changed**. The predicted R4 risk ran the *other* way: this
row's English was previously upstream-invalid, so it was silently excluded
from both canonical denominators. Making it valid **adds** it — en-side
133 → 134 checked, 134 valid, allowlist still empty; foreign R4 green.

## Item 1 — `parse()` returning success with errors

Resolved as the additive option: `ParseResult.recovered`, set in
`Parser.parse()` — the single place `errors` is attached, so it cannot drift.
`success` is now documented on the type as "AST produced, NOT a validity
claim".

**`CompileResult.ok` is untouched**, so the must-not-regress invariant holds by
construction rather than by care. Redefining `success` was rejected because
`ParseResult` is a published export (semver-major) and because it would put
that invariant on a hand-edit at `hyperscript-api.ts:861`.

> The handoff's **"~213 call sites" is wrong by an order of magnitude**. For
> the hyperscript `ParseResult` it is **11 non-test sites, all in
> `packages/core`, zero elsewhere** — nine of them the identical runnable guard
> `if (!r.success || !r.node) throw`, already correct. The other ~130 reads
> belong to unrelated types (Zod `safeParse`, the `TypedResult` union, the
> semantic adapter).

### One live bug fixed

The classic-i18n `compile()` shim copied the singular `error` and dropped
`errors`, returning `{ success: true, errors: [] }` for input carrying a real
diagnostic — #780's defect surviving in a second surface, consumed by two demo
pages. The new guard was verified to fail without the fix.

## Also in scope (approved)

- **`verify-engines.ts` used different bars on its two legs** — lokascript
  gated on `compileSync().ok` (true for a recovered parse) while upstream
  required zero errors. That is why `set-color-variable` was stamped
  `engine: "lokascript"` for a source hyperfixi does not cleanly accept either.
  Squared; exactly one verdict moves, and no other row demotes — independent
  confirmation it was the only recovers-with-errors row in all 164.
- **The sweep is now a permanent gate** —
  `packages/testing-framework/src/multilingual/shipped-sources-validity.ts`.
- **Doc drift** corrected in root `CLAUDE.md`, `canonical-validity.ts`, and the
  handoff (which now marks in place the claims this work disproved).

## The new gate, and what it found

454 sources swept, 408 clean, **4 allowlisted** — all pre-existing, none from
the handoff's list:

- `dialogs/native-dialog.html` — **a hyperfixi PARSER DEFECT, not a doc bug.**
  Upstream *accepts* it; we report `Expected 'end' after if block`.
- `sortable-list.html`, `fetch-data.html`, `infinite-scroll.html` — genuinely
  malformed (upstream rejects too), deferred pending each example's intent.

Three scoping decisions worth review:

- Only `ok:true`-with-errors is gated. `ok:false` is a much larger, mostly
  legitimate class (non-English sources, uninstalled plugin syntax, deliberate
  "this does not work" snippets) and would drown the signal.
- Bare `hyperscript`-fenced blocks are excluded — in this repo they are
  overwhelmingly syntax *notation* (`send <event> to <target>`).
- **CI needed a new path filter.** The `code` filter excludes `**/*.md`,
  `docs/**` and `examples/**` — exactly the trees this gate walks — so a step
  in `unit-tests` would never have run on a docs-only PR, i.e. never on the
  diffs most likely to introduce the bug. There is now a narrow `docsources`
  filter (the gate's three roots) that also un-gates `build`, plus a small
  dedicated job. gomod/protocol PRs and README typos elsewhere still skip the
  npm stack.

Extraction goes through the DOM via `extractHyperscriptFromMarkup`, lifted out
of `verify-engines.ts` into `@hyperfixi/patterns-reference` so the two
harnesses cannot drift. A regex cannot tell a live attribute from an escaped
code sample — the exact false positive the handoff had to retract. The refactor
is behaviour-preserving: re-running `verify:engines` produces byte-identical
output.

The allowlist key embeds a sha1 of the source, so fixing a source changes its
key: the entry goes stale and the third assertion makes removal mandatory. The
list can only ratchet down.

## Verification

- Full monorepo `npm run test:check` — exit 0, no failures
- `npm run lint` — exit 0
- Multilingual `--regression` — green on all ten signals
- Both canonical-validity gates green (foreign via `FOREIGN_CANONICAL_VALIDITY=1`
  against a freshly populated DB)
- Gate discrimination proven both ways: reintroducing the `{id}` defect fails
  it; reverting the classic-i18n fix fails its guard

`patterns.db` is intentionally not committed (regenerate with `npm run populate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)