### PR TITLE
fix(parser): treat `then` as a command separator inside block bodies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,6 +515,15 @@ committed copy — re-run `npm run populate` before any local gate/probe work.)
 
 ## Architecture
 
+> **Known core-parser defects and their queue live in
+> `docs-internal/PARSER_NEXT_STEPS.md`** — the counterpart to
+> `MULTILINGUAL_NEXT_STEPS.md`, for the `packages/core/src/parser/` track. Check it
+> before triaging a parse bug; several are already diagnosed with a written brief.
+> Two entries there are held by a gate that fails on its own (the `and` KNOWN GAP
+> tests, the shipped-sources allowlist ratchet) — the rest have no gate and are why
+> the doc exists. `docs-internal/PARSER_FIX_STATUS.md` is an **archived**
+> single-defect report, not an index, despite its name.
+
 ### Command Pattern
 
 All 58 commands use `CommandImplementation<TInput, TOutput, TypedExecutionContext>`:

--- a/docs-internal/HANDOFF-if-block-then-separator.md
+++ b/docs-internal/HANDOFF-if-block-then-separator.md
@@ -1,5 +1,41 @@
 # Handoff: `then` inside an `if` body silently hoists the body out of the conditional
 
+> **RESOLVED.** Fixed in the `then`-as-command-separator change; this document is
+> kept as history. Read the corrections below before trusting the triage in it.
+>
+> **What the fix was.** `parseIfCommand`'s two branch loops were replaced by one
+> `parseIfBranchCommands` helper that consumes a separating `then` (and skips `--`
+> comments), and the header-`then` consumption now checks the token instead of
+> trusting the `hasThen` lookahead flag. `Parser.parseCommandBlock` (def / init /
+> catch / finally) and `parseTellCommand` had the same missing-separator defect and
+> were fixed alongside. Coverage:
+> `packages/core/src/parser/__tests__/then-as-separator.test.ts` (parse shape) and
+> `packages/core/src/api/if-body-then-execution.test.ts` (DOM effect).
+>
+> **Correction 1 — "suspect 1" was misdiagnosed.** The line-crossing lookahead is
+> real but is NOT worth bounding, and bounding it was tried and rejected. The
+> damage came from the *unconditional* `ctx.advance()` that trusted the flag; once
+> that checks the token, a wrongly-set `hasThen` is harmless (it only feeds
+> `isMultiLine`, and those shapes are multi-line anyway). A line bound would also
+> reclassify the legitimate `then`-on-the-next-line form
+> (`parser-integration.test.ts:381`). The single-line shapes it would newly reach
+> are broken by an **independent** pre-existing defect in the implicit-multi-line
+> scan: `if 1 is 1 log 'a'\nlog 'b'` already mis-nests with no `then` involved.
+>
+> **Correction 2 — the `infinite-scroll.html` recommendation (step 3) was wrong.**
+> Its `end`s were balanced all along; there was no "genuinely missing `end`". Its
+> entire hyperfixi error was a *second* gap in the same branch loop — `--` comments
+> in an `if` body were not skipped, though every sibling body loop skips them. It
+> came clean with no edit to the example. Upstream still rejects that file, but over
+> the multi-line `make a <li>…</li>` element literal with `#{}` interpolation, which
+> it does not support — so we are now more permissive there. Noted in the allowlist,
+> not chased.
+>
+> **Still open:** `and` is not a command separator anywhere (the pratt parser
+> absorbs it as a binary operator before any body loop sees it) — pinned as a KNOWN
+> GAP in both test files. And `examples/drag-and-drop/sortable-list.html` (step 4)
+> is untouched and still allowlisted.
+
 Found by the shipped-sources validity gate added in #784. Everything below is
 verified against `main` @ `fe478dd1` + that branch; the oracle is
 `loadCanonicalParser()` in

--- a/docs-internal/HANDOFF-implicit-multiline-if.md
+++ b/docs-internal/HANDOFF-implicit-multiline-if.md
@@ -1,0 +1,122 @@
+# Handoff: a single-line `if` swallows the following line into its block
+
+Found while fixing the `then`-as-command-separator defect
+(`HANDOFF-if-block-then-separator.md`). **Independent of it** — this reproduces
+with no `then` anywhere — and it survived that fix untouched. Everything below is
+verified against `fix/then-as-block-body-separator`; the oracle is
+`loadCanonicalParser()` in
+[canonical-validity.ts](../packages/testing-framework/src/multilingual/canonical-validity.ts)
+(the real `hyperscript.org` engine, headless).
+
+---
+
+## Severity: a command that must always run silently does not
+
+This is the **mirror image** of the `then` defect. That one hoisted a conditional
+body OUT of its `if`, so it ran unconditionally. This one pulls an unconditional
+command IN, so it stops running when the condition is false.
+
+```hyperscript
+if 1 is 2 add .a to #t     -- single-line if, condition FALSE
+add .b to #t               -- sibling; must run regardless
+```
+
+```
+ok: true   errors: ["Expected 'end' after if block"]
+
+command:if
+ .args
+    binaryExpression
+    block
+       command:add   <-- .a
+       command:add   <-- .b   <-- SWALLOWED into the block
+```
+
+Executed in jsdom with that false condition, **neither** class is applied.
+`add .b to #t` never runs. Upstream runs it.
+
+Same `ok: true` + recovered-error shape as the `then` defect, so `compileSync`
+callers see success and the page quietly does the wrong thing.
+
+## Minimal repro
+
+```hyperscript
+if 1 is 1 log 'a'
+log 'b'
+```
+
+- upstream `hyperscript.org`: **valid** — `log 'b'` is a sibling of the `if`
+- hyperfixi: `Expected 'end' after if block`, and `log 'b'` lands inside the block
+
+Confirmed upstream-valid in all four shapes tested: bare two-line, inside an
+`on click` handler, with a true condition, and with a false one.
+
+## Ruled out
+
+| Shape | Result |
+| ----- | ------ |
+| `on click if 1 is 2 log 'a'` (single-line, nothing after) | clean, correct |
+| `on click if 1 is 2 then log 'a' end` + next line | clean, correct — `log 'b'` stays a sibling |
+| any shape involving a body `then` | fixed separately; not this |
+
+So the trigger is precisely: **an `if` in its single-line form (no `then`, no
+`end`) with any command on a following line.** The explicit `then … end` form is
+unaffected, which is the workaround.
+
+It scales — three trailing lines are all swallowed, not just one.
+
+## Where it is
+
+[`parseIfCommand`](../packages/core/src/parser/command-parsers/control-flow-commands.ts),
+the implicit-multi-line lookahead (the `hasImplicitMultiLineEnd` scan, immediately
+after the `hasThen` scan). Its stated rule is right:
+
+> Only check the FIRST command's line position. If the first command is on a
+> DIFFERENT line than `if`, it's multi-line; if on the SAME line, it's single-line.
+
+The bug is that the scan does not **stop** once it has answered that question. It
+finds `log 'a'` on the `if`'s own line, correctly declines to set
+`hasImplicitMultiLineEnd`, and then — because that branch has no `break` — keeps
+walking. It reaches `log 'b'` on the next line, sets the flag, and breaks. So the
+"FIRST command" rule is defeated by the second command.
+
+The comment at that site even says `// Don't break - continue scanning to find
+'else' or 'end' on same line`, which is the deliberate reason the `break` is
+absent: it wants to catch `if x > 3 set y to 1 else set y to 2 end`. Any fix has
+to keep that case working — the scan needs to distinguish "still looking for a
+same-line `else`/`end`" from "already found a same-line first command, so stop
+considering later-line commands."
+
+## Why the `then` fix did not touch it
+
+Bounding the `hasThen` lookahead to the `if`'s own line was considered and
+rejected during that work, specifically because of this defect: the line bound
+would route *more* inputs down this already-broken path, converting one silent
+wrong answer into a different silent wrong answer. See the comment at the
+`hasThen` scan. **Fix this first**; then re-evaluate whether the lookahead bound
+buys anything.
+
+## Constraint on the fix
+
+Do not reach for "make the single-line form require `end`". Upstream supports the
+bare single-line `if`, it is used in shipped examples, and the strictness question
+is separate — the same trap the `then` handoff warned about.
+
+## Verification harness
+
+No shipped example currently trips this, so the shipped-sources gate is **not**
+the regression test here — it would pass a broken fix. Write the coverage first:
+
+```bash
+npm run test:check --prefix packages/core
+```
+
+Add cases beside the existing ones in
+`packages/core/src/parser/__tests__/then-as-separator.test.ts` (parse shape) and
+`packages/core/src/api/if-body-then-execution.test.ts` (DOM effect). Assert
+**structurally and behaviourally** — asserting `success`/`ok` proves nothing, both
+are already true against the bug. The behavioural assertion is the one that
+matters: false condition, sibling command must still run.
+
+Keep the guards those files already carry; `if`-block termination is load-bearing
+(7629 tests).

--- a/docs-internal/PARSER_FIX_STATUS.md
+++ b/docs-internal/PARSER_FIX_STATUS.md
@@ -1,5 +1,21 @@
 # Parser Fix Status Report
 
+> **RESOLVED — archived 2026-07-27. Do not read this as current status.**
+>
+> This is a **single-defect** report from 2026-01-30, not a parser index. Its name
+> has misled readers for six months; the standing parser queue is
+> [PARSER_NEXT_STEPS.md](PARSER_NEXT_STEPS.md).
+>
+> The defect below is fixed. Verified 2026-07-27:
+> `npx vitest run src/parser/behavior-parser.test.ts` → **24 passed (24)**, none
+> skipped. Both named tests still exist and still assert
+> (`behavior-parser.test.ts:471` and `:498`), so this is a real pass, not the
+> "mark them `.skip()`" outcome floated under Option 3 below.
+>
+> Which of the three options was taken, and in which commit, was never recorded —
+> the "Next Steps" section at the bottom was never answered in writing. Kept for
+> the debugging archaeology only.
+
 ## Problem Summary
 
 The core parser cannot parse behavior definitions when parameter names match command names (e.g., `trigger`).

--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -1,0 +1,74 @@
+# Core parser — next steps
+
+> **Entry point, written 2026-07-27.** Standing queue for the **core parser**
+> track (`packages/core/src/parser/`), the counterpart to
+> [MULTILINGUAL_NEXT_STEPS.md](MULTILINGUAL_NEXT_STEPS.md). Read this first, then
+> the linked HANDOFF for per-defect detail.
+>
+> **Pointer-only by design.** Never restate a repro or a diagnosis here — that is
+> what the HANDOFF docs are for, and duplicated detail is the first thing to rot.
+> One line per item; the linked source is authoritative.
+>
+> Not scoped to a release. Nothing below is release-blocking; these are
+> correctness papercuts in a shipped parser. Tying them to a version means either
+> the version slips and this lies, or they defer and this rots — which is exactly
+> how [PARSER_FIX_STATUS.md](PARSER_FIX_STATUS.md) died (its name promised an
+> index, it delivered a six-month-old snapshot of one already-fixed defect).
+
+## Read this before triaging anything below
+
+**Which entries are load-bearing.** Two of these are protected by a gate that
+fails loudly on its own; the rest can be lost entirely. Know which you are
+looking at before deciding what to work on — and do **not** "tidy up" the gated
+ones, because the gate *is* the tracking mechanism.
+
+| Item | Severity | Gate | Detail |
+| ---- | -------- | ---- | ------ |
+| **Implicit-multiline `if` swallows the next line** | **high** — an unconditional command silently stops running | **none** | [HANDOFF-implicit-multiline-if.md](HANDOFF-implicit-multiline-if.md) |
+| **`tell` never consumes a terminating `end`** | medium — no real `tell … end` block form; upstream requires one | **none** | comment at `packages/core/src/parser/command-parsers/utility-commands.ts` (the `ELSE`/`END` break in `parseTellCommand`) |
+| **Nothing executes a shipped example** | medium — `examples/**` is parsed but never run | **none** | "Wider question" in [HANDOFF-if-block-then-separator.md](HANDOFF-if-block-then-separator.md) |
+| `and` is not a command separator anywhere | low — consistent everywhere, so no surprise | ✅ 2 `KNOWN GAP` tests | `packages/core/src/parser/__tests__/then-as-separator.test.ts` |
+| `sortable-list.html` recovers with errors | low — one shipped example | ✅ allowlist ratchet | `packages/testing-framework/baselines/shipped-sources-validity.json` |
+
+### Why the gated two need no doc to survive
+
+- **`and`** — the two `KNOWN GAP` tests assert the *current, wrong* shape. Anyone
+  who fixes the pratt parser breaks them immediately and is forced to decide
+  deliberately. That is the intended design; the tests are not stale assertions.
+- **`sortable-list.html`** — the allowlist key embeds `sha1(source)`, and
+  assertion 3 of the shipped-sources gate **fails** when an allowlisted source
+  goes clean. The list can only ratchet down. It cannot be silently forgotten.
+
+The ungated three have no such mechanism. **They are what this document is for.**
+
+## Notes on the ungated three
+
+**Implicit-multiline `if`** is the one to do first. It is the mirror image of the
+`then` defect fixed in #785 (that one pushed a conditional body *out* so it ran
+unconditionally; this one pulls an unconditional command *in* so it stops
+running), and it is the reason #785 left the `hasThen` lookahead unbounded —
+bounding it routes more inputs down this already-broken path. Fix this, then
+re-evaluate that bound. **The shipped-sources gate is not the regression test
+here** — no shipped example trips it, so the gate would pass a broken fix. Write
+the coverage first.
+
+**No execution test for `examples/**`** is the systemic one. #785 added
+`packages/core/src/api/if-body-then-execution.test.ts`, which is the right shape
+(compile, run in jsdom, assert the DOM) but only covers hand-written sources. The
+R2 execution ratchet does this for 47 curated corpus patterns
+(`avgExecutionFidelity`); extending something like it to `examples/**` is the
+natural follow-on. It is what would have caught the #785 defect on *behaviour*
+rather than on a diagnostic — `native-dialog.html` shipped with its conditional
+body running unconditionally and every parse-level gate was green.
+
+## History
+
+- **#785** (2026-07-27) — `then` as a command separator in `if`/`unless`, `def` /
+  `init` / `catch` / `finally`, and `tell` bodies; `--` comments in `if` bodies;
+  shipped-sources allowlist 4 → 1. Brief:
+  [HANDOFF-if-block-then-separator.md](HANDOFF-if-block-then-separator.md)
+  (carries two corrections to its own original triage — read its header).
+- **#784** — shipped-sources validity gate + `ParseResult.recovered`. Brief:
+  [HANDOFF-parse-success-and-doc-examples.md](HANDOFF-parse-success-and-doc-examples.md).
+- 2026-01-30 — behavior parameters shadowing command names. **Resolved**;
+  archived at [PARSER_FIX_STATUS.md](PARSER_FIX_STATUS.md).

--- a/examples/fetch-and-async/fetch-data.html
+++ b/examples/fetch-and-async/fetch-data.html
@@ -128,7 +128,6 @@
                    add .loading to me
                    fetch 'https://jsonplaceholder.typicode.com/todos/1' as json
                    log 'Fetch result:', it
-                   log 'typeof it:', (typeof it)
                    put it into todoData
                    log 'todoData:', todoData
                    put `<h3>Todo #${todoData.id}</h3>

--- a/packages/core/src/api/if-body-then-execution.test.ts
+++ b/packages/core/src/api/if-body-then-execution.test.ts
@@ -1,0 +1,89 @@
+/**
+ * if-body-then-execution.test.ts
+ *
+ * The behavioural half of the `then`-as-separator fix (parse-shape half:
+ * `src/parser/__tests__/then-as-separator.test.ts`).
+ *
+ * A `then` used as a command separator inside an `if` body used to truncate the
+ * block and hoist the remainder out as a SIBLING of the `if`. Nothing about that
+ * was visible from `ok`/`success` — both stayed true — so the only symptom was a
+ * conditional body running when its condition was FALSE. It shipped that way in
+ * examples/dialogs/native-dialog.html.
+ *
+ * These tests assert on the DOM effect, not on the AST. That is the assertion
+ * that would have caught the shipped bug on behaviour; the parse-shape tests
+ * would not have, on their own.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { hyperscript } from './hyperscript-api.js';
+
+function setupTarget(): HTMLElement {
+  document.body.innerHTML = '<div id="host"></div><div id="target"></div>';
+  return document.getElementById('host') as HTMLElement;
+}
+
+const target = (): HTMLElement => document.getElementById('target') as HTMLElement;
+
+describe('an if body joined by `then` obeys its condition', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('does NOT run a `then`-joined body when the condition is false', () => {
+    const host = setupTarget();
+
+    return hyperscript
+      .eval('if 1 is 2\n  add .first to #target then add .second to #target\nend', host)
+      .then(() => {
+        expect(target().classList.contains('first')).toBe(false);
+        // The regression: `add .second` was hoisted out of the conditional and
+        // ran unconditionally.
+        expect(target().classList.contains('second')).toBe(false);
+      });
+  });
+
+  it('runs every command of a `then`-joined body when the condition is true', () => {
+    const host = setupTarget();
+
+    return hyperscript
+      .eval('if 1 is 1\n  add .first to #target then add .second to #target\nend', host)
+      .then(() => {
+        expect(target().classList.contains('first')).toBe(true);
+        expect(target().classList.contains('second')).toBe(true);
+      });
+  });
+
+  it('runs the else branch, not the then branch, when the condition is false', () => {
+    const host = setupTarget();
+
+    return hyperscript
+      .eval(
+        'if 1 is 2\n' +
+          '  add .then-first to #target then add .then-second to #target\n' +
+          'else\n' +
+          '  add .else-first to #target then add .else-second to #target\n' +
+          'end',
+        host
+      )
+      .then(() => {
+        expect(target().classList.contains('then-first')).toBe(false);
+        expect(target().classList.contains('then-second')).toBe(false);
+        expect(target().classList.contains('else-first')).toBe(true);
+        expect(target().classList.contains('else-second')).toBe(true);
+      });
+  });
+
+  it('still runs a command that follows the closing `end`', () => {
+    // The counterpart guard: a `then`-joined command AFTER the `end` belongs to
+    // the enclosing sequence and must run regardless of the condition.
+    const host = setupTarget();
+
+    return hyperscript
+      .eval('if 1 is 2\n  add .inside to #target\nend then add .after to #target', host)
+      .then(() => {
+        expect(target().classList.contains('inside')).toBe(false);
+        expect(target().classList.contains('after')).toBe(true);
+      });
+  });
+});

--- a/packages/core/src/parser/__tests__/then-as-separator.test.ts
+++ b/packages/core/src/parser/__tests__/then-as-separator.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Regression tests: `then` as a COMMAND SEPARATOR inside a block body.
+ *
+ * Upstream hyperscript has one recursive `parseCommandList` that consumes a
+ * joining `then` after every command, so `then` separates commands in EVERY
+ * body. hyperfixi had five independent body loops and three of them dropped it:
+ * `parseIfCommand`'s two branch loops, `Parser.parseCommandBlock` (def / init /
+ * catch / finally), and `parseTellCommand`.
+ *
+ * The `if` case was the dangerous one. The loop broke at the body's `then`,
+ * `consume('end')` failed non-throwingly (so `ok` stayed true), and the
+ * enclosing sequence loop — which DOES consume `then` — picked up the rest of
+ * the body as SIBLINGS of the `if`. The conditional body therefore ran
+ * UNCONDITIONALLY, silently. It shipped in examples/dialogs/native-dialog.html.
+ *
+ * So these assertions are STRUCTURAL on purpose. Asserting `success === true`
+ * would have passed against the bug — `success` was already true. Every case
+ * checks where the commands actually landed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse } from '../parser';
+
+function parseNode(input: string) {
+  const result = parse(input);
+  expect(
+    result.success,
+    `Expected parse to succeed for:\n${input}\nError: ${result.error?.message}`
+  ).toBe(true);
+  expect(result.node).toBeDefined();
+  return result.node as any;
+}
+
+/** Recovered (non-fatal) diagnostics — the channel `ok: true` hides. */
+const recoveredErrors = (result: any): string[] =>
+  (result.errors ?? []).map((e: { message: string }) => e.message);
+
+/**
+ * Parse and additionally require a CLEAN result — no recovered errors.
+ *
+ * `success`/`ok` were both true against the bug, so they prove nothing here.
+ * `errors`/`recovered` (the flag added in #784) are the channel that does.
+ */
+function parseClean(input: string) {
+  const result = parse(input);
+  expect(recoveredErrors(result), `Expected NO recovered errors for:\n${input}`).toEqual([]);
+  expect(result.recovered).toBeFalsy();
+  return parseNode(input);
+}
+
+/** `if`/`unless` node → the commands of its then-branch. */
+const thenBranch = (ifNode: any): any[] => ifNode.args?.[1]?.commands ?? [];
+/** `if`/`unless` node → the commands of its else-branch. */
+const elseBranch = (ifNode: any): any[] => ifNode.args?.[2]?.commands ?? [];
+
+const names = (commands: any[]): string[] => commands.map(c => c.name ?? c.type);
+
+describe('`then` as a command separator in if/unless bodies', () => {
+  it('keeps both commands in the block (implicit multi-line if)', () => {
+    // The handoff's minimal repro. Before the fix: block was EMPTY, `get` was
+    // deleted outright, and `log` became a sibling of the `if`.
+    const node = parseClean("if 1 is 1\n  get #u then log 'a'\nend");
+
+    expect(node.name).toBe('if');
+    expect(names(thenBranch(node))).toEqual(['get', 'log']);
+  });
+
+  it('keeps both commands in the block when the if carries its own `then`', () => {
+    // Distinct mechanism: here the header-`then` lookahead is correct, so this
+    // shape is broken purely by the branch loop dropping the separator. A fix
+    // that only repaired the lookahead would leave this one broken.
+    const node = parseClean("if 1 is 1 then\n  get #u then log 'a'\nend");
+
+    expect(names(thenBranch(node))).toEqual(['get', 'log']);
+  });
+
+  it('keeps both commands in the ELSE block', () => {
+    const node = parseClean("if 1 is 2\n  log 'x'\nelse\n  get #u then log 'y'\nend");
+
+    expect(names(thenBranch(node))).toEqual(['log']);
+    expect(names(elseBranch(node))).toEqual(['get', 'log']);
+  });
+
+  it('handles `then` in both branches of an `else if` chain', () => {
+    const node = parseClean(
+      "if 1 is 2\n  log 'a' then log 'b'\nelse if 1 is 1\n  log 'c' then log 'd'\nend"
+    );
+
+    expect(names(thenBranch(node))).toEqual(['log', 'log']);
+
+    // `else if` is modelled as a nested `if` occupying the else block.
+    const nested = elseBranch(node);
+    expect(names(nested)).toEqual(['if']);
+    expect(names(thenBranch(nested[0]))).toEqual(['log', 'log']);
+  });
+
+  it('handles `then` inside an if nested in an if body', () => {
+    const node = parseClean(
+      "if 1 is 1\n  if 2 is 2\n    get #u then log 'inner'\n  end\n  log 'outer'\nend"
+    );
+
+    const outer = thenBranch(node);
+    expect(names(outer)).toEqual(['if', 'log']);
+    expect(names(thenBranch(outer[0]))).toEqual(['get', 'log']);
+  });
+
+  it('mixes `then`-joined and newline-separated commands in one body', () => {
+    const node = parseClean("if 1 is 1\n  get #u then log 'a'\n  log 'b'\nend");
+
+    expect(names(thenBranch(node))).toEqual(['get', 'log', 'log']);
+  });
+
+  it('applies to `unless`, which shares parseIfCommand', () => {
+    const node = parseClean("unless 1 is 2\n  get #u then log 'a'\nend");
+
+    expect(node.name).toBe('unless');
+    expect(names(thenBranch(node))).toEqual(['get', 'log']);
+  });
+
+  it('does not hoist the body out of the conditional inside an event handler', () => {
+    // The severity case: with a FALSE condition, a hoisted body would run
+    // unconditionally. Assert the handler has exactly [if, log 'after'] and that
+    // 'BODY RAN' lives inside the if.
+    const node = parseClean(
+      "on click\n  if 1 is 2\n    get #u then log 'BODY RAN'\n  end\n  log 'after'"
+    );
+
+    expect(names(node.commands)).toEqual(['if', 'log']);
+    expect(node.commands[1].args[0].value).toBe('after');
+    expect(names(thenBranch(node.commands[0]))).toEqual(['get', 'log']);
+  });
+
+  it('parses the shipped native-dialog handler cleanly', () => {
+    // examples/dialogs/native-dialog.html:315-328 — the source that surfaced this.
+    const node = parseClean(
+      'on close from #form-dialog\n' +
+        '  get #form-dialog\n' +
+        '  set returnValue to it.returnValue\n' +
+        "  if returnValue is 'confirmed'\n" +
+        '    get #username then set username to it.value\n' +
+        '    get #role then set role to it.value\n' +
+        '    get #result-text\n' +
+        '    show #form-result\n' +
+        '  else\n' +
+        '    get #result-text\n' +
+        '    show #form-result\n' +
+        '  end'
+    );
+
+    expect(names(node.commands)).toEqual(['get', 'set', 'if']);
+    const ifNode = node.commands[2];
+    expect(names(thenBranch(ifNode))).toEqual(['get', 'set', 'get', 'set', 'get', 'show']);
+    expect(names(elseBranch(ifNode))).toEqual(['get', 'show']);
+  });
+
+  // ─── Guards: the fix must not over-consume ────────────────────────
+
+  it('still lets `end` close the block before a trailing `then`', () => {
+    // The over-consumption guard. `remove .loading` belongs to the HANDLER, not
+    // the if body — the body loop must stop at `end` and let the handler loop
+    // take the `then`.
+    const node = parseClean('on click if x > 0 then add .positive end then remove .loading');
+
+    expect(names(node.commands)).toEqual(['if', 'remove']);
+    expect(names(thenBranch(node.commands[0]))).toEqual(['add']);
+  });
+
+  it('still requires `end`, and reports its absence', () => {
+    // Deliberate strictness: upstream tolerates an unterminated `if/then` at the
+    // end of a handler and we do not. That is a separate decision — this fix must
+    // not quietly loosen it just because the diagnostic was the visible symptom.
+    const result = parse("if 1 is 1 then log 'a' then log 'b'");
+
+    expect(recoveredErrors(result)).toContain("Expected 'end' after if block");
+    // ...and the body is still assembled correctly despite the error.
+    expect(names(thenBranch(result.node as any))).toEqual(['log', 'log']);
+  });
+
+  it('leaves the `then`-on-the-next-line header form working', () => {
+    // The `if`'s own `then` may sit on the line after the condition. The
+    // header-`then` consumption checks the token rather than trusting the
+    // lookahead flag, which is what keeps this shape working.
+    const node = parseClean('if count > 10\n  then add .warning\n  else remove .warning\nend');
+
+    expect(names(thenBranch(node))).toEqual(['add']);
+    expect(names(elseBranch(node))).toEqual(['remove']);
+  });
+
+  it('skips `--` comments between body commands', () => {
+    // Same outlier, different token: every sibling body loop skips comments
+    // (parser.ts:3277, and the junk-skip at :1117) and this one did not, so a
+    // comment broke the block with the same bogus "Expected 'end'". This is what
+    // remained of examples/fetch-and-async/infinite-scroll.html once `then` was
+    // fixed — its `end`s were balanced all along.
+    const node = parseClean('if 1 is 1\n  add .a to #x\n  -- a comment\n  add .b to #x\nend');
+
+    expect(names(thenBranch(node))).toEqual(['add', 'add']);
+  });
+
+  it('skips a trailing `--` comment at the end of a body', () => {
+    const node = parseClean('if 1 is 1\n  add .a to #x\n  -- trailing comment\nend');
+
+    expect(names(thenBranch(node))).toEqual(['add']);
+  });
+
+  it('skips `--` comments in an else body', () => {
+    const node = parseClean('if 1 is 2\n  add .a to #x\nelse\n  -- why\n  add .b to #x\nend');
+
+    expect(names(elseBranch(node))).toEqual(['add']);
+  });
+
+  it('already supported `,` as a body separator (regression guard)', () => {
+    // `,` is absorbed by the argument loop before the block loop sees it, so this
+    // was never broken. Pinned so a future change to the separator handling
+    // cannot regress it.
+    const node = parseClean("if 1 is 1\n  log 'a', log 'b'\nend");
+
+    expect(names(thenBranch(node))).toEqual(['log', 'log']);
+  });
+
+  it('KNOWN GAP: `and` is not a command separator anywhere', () => {
+    // Not this defect, and not fixed here. The pratt parser absorbs `and` as a
+    // binary operator long before any body loop sees it — the same at top level
+    // (`on click add .a and remove .b` → `add(.a and remove)`) as in a body. The
+    // residual "Expected 'end'" below belongs to that separate expression-parser
+    // gap; it is pinned so its eventual fix is a deliberate, visible change.
+    const result = parse('if 1 is 1\n  add .a and remove .b\nend');
+
+    expect(names(thenBranch(result.node as any))).toEqual(['add']);
+    expect(recoveredErrors(result)).toContain("Expected 'end' after if block");
+  });
+});
+
+describe('`then` as a command separator in def/init/catch/finally bodies', () => {
+  // These were a HARD failure before the fix ("Unexpected token: then"), not a
+  // silent hoist: parseCommandBlock broke at the `then` and the caller then
+  // failed on the missing `end`.
+
+  it('keeps both commands in a def body', () => {
+    const node = parseClean("def f()\n  get #u then log 'a'\nend");
+
+    expect(node.type).toBe('def');
+    expect(names(node.body)).toEqual(['get', 'log']);
+  });
+
+  it('keeps both commands in a top-level init block', () => {
+    const node = parseClean("init\n  get #u then log 'a'\nend");
+
+    expect(names(node.commands ?? node.body)).toEqual(['get', 'log']);
+  });
+
+  it('keeps both commands in catch and finally blocks', () => {
+    const node = parseClean(
+      "on click\n  log 'body'\ncatch e\n  get #u then log 'caught'\nfinally\n  get #v then log 'done'\nend"
+    );
+
+    expect(names(node.errorHandler)).toEqual(['get', 'log']);
+    expect(names(node.finallyHandler)).toEqual(['get', 'log']);
+  });
+});
+
+describe('`then` as a command separator in tell bodies', () => {
+  it('keeps a `then`-joined command inside the tell body', () => {
+    // Upstream's TellCommand.parse takes a `commandList` for its body, and every
+    // commandList consumes a joining `then`. Before the fix `log 'b'` escaped and
+    // ran once instead of once per target.
+    const node = parseClean("on click tell #x add .a then log 'b'");
+
+    expect(names(node.commands)).toEqual(['tell']);
+    const tellArgs = node.commands[0].args;
+    // args[0] is the target; the rest are the body commands.
+    expect(names(tellArgs.slice(1))).toEqual(['add', 'log']);
+  });
+
+  it('KNOWN GAP: `and` between tell commands is swallowed by the expression parser', () => {
+    // `parseTellCommand` has always matched `and` as a separator, but it is dead
+    // code for the same reason as the `if` case above: the pratt parser absorbs
+    // `and` into the preceding command's arguments before the body loop runs, so
+    // the second `add` becomes an identifier operand. Pinned as a known gap.
+    const node = parseClean('on click tell #x add .a and add .b');
+
+    const tellArgs = node.commands[0].args;
+    expect(names(tellArgs.slice(1))).toEqual(['add']);
+    expect(tellArgs[1].args[0].type).toBe('binaryExpression');
+  });
+});

--- a/packages/core/src/parser/command-parsers/control-flow-commands.ts
+++ b/packages/core/src/parser/command-parsers/control-flow-commands.ts
@@ -15,7 +15,7 @@ import { createBlock, createStringLiteral } from '../helpers/ast-helpers';
 import { debug } from '../../utils/debug';
 import { KEYWORDS } from '../parser-constants';
 import { consumeOptionalKeyword } from '../helpers/parsing-helpers';
-import { isIdentifierLike, isEvent } from '../token-predicates';
+import { isIdentifierLike, isEvent, isComment } from '../token-predicates';
 
 /**
  * Parse halt command
@@ -319,6 +319,64 @@ export function parseRepeatCommand(ctx: ParserContext, commandToken: Token): Com
 }
 
 /**
+ * Parse the command list of one `if`/`unless` branch.
+ *
+ * `then`, `and` and `,` are command SEPARATORS, not block terminators — the same
+ * rule the enclosing sequence loops use (parser.ts:3181, :2867) and the canonical
+ * body loop uses (parser.ts:1130), and the same rule upstream applies uniformly
+ * via its single recursive `parseCommandList`. Only `end` — and `else`, for the
+ * then-branch — closes the block.
+ *
+ * Leaving a separator in the stream is what made a conditional body run
+ * UNCONDITIONALLY: the loop broke at the body's `then`, `consume('end')` failed
+ * (non-throwing, so `ok` stayed true), and the enclosing sequence loop — which
+ * does consume `then` — picked up the rest of the body as SIBLINGS of the `if`.
+ *
+ * Deliberately NOT `ctx.parseCommandListUntilTerminator`: that helper swallows
+ * errors raised while parsing body commands (parser.ts:1084-1105), including the
+ * unclosed-paren errors `parseCommandSequence` explicitly preserves, and its
+ * junk-skipping does not guard `on`/`catch`/`finally`.
+ *
+ * Uses check()+advance() rather than ctx.match(): the control-flow unit-test
+ * mocks override check/advance/peek against their own cursor but inherit a
+ * `match` bound to a different position counter
+ * (__test-utils__/parser-context-mock.ts:40).
+ */
+function parseIfBranchCommands(ctx: ParserContext, stopAtElse: boolean): ASTNode[] {
+  const commands: ASTNode[] = [];
+  const atTerminator = (): boolean =>
+    ctx.check(KEYWORDS.END) || (stopAtElse && ctx.check(KEYWORDS.ELSE));
+
+  while (!ctx.isAtEnd() && !atTerminator()) {
+    // Skip `--` comments, as every sibling body loop does (parser.ts:3277 for
+    // def/init/catch/finally, and the junk-skip at :1117 for repeat/for). This
+    // loop was the only one that did not, so a comment between two commands
+    // broke the block and produced the same bogus "Expected 'end' after if
+    // block" as the missing-separator defect — which is what was left of
+    // examples/fetch-and-async/infinite-scroll.html once `then` was fixed.
+    if (isComment(ctx.peek())) {
+      ctx.advance();
+      continue;
+    }
+    if (!ctx.checkIsCommand() && !ctx.isCommand(ctx.peek().value)) break;
+    ctx.advance(); // parseCommand() reads the command token via previous()
+    const cmd = ctx.parseCommand();
+    if (cmd) {
+      commands.push(cmd);
+    }
+    // Separator between two body commands. `and` and `,` are matched for parity
+    // with the sibling loops; in practice neither reaches here today (the pratt
+    // parser absorbs `and` as a binary operator, and `,` is taken by the
+    // argument loop), so only `then` changes behaviour.
+    if (ctx.check(KEYWORDS.THEN) || ctx.check(KEYWORDS.AND) || ctx.check(',')) {
+      ctx.advance();
+    }
+  }
+
+  return commands;
+}
+
+/**
  * Parse if command
  *
  * Syntax:
@@ -351,7 +409,19 @@ export function parseIfCommand(ctx: ParserContext, commandToken: Token): Command
   // 2. Implicit multi-line (no 'then' but multiple commands on separate lines): if <condition>\n  <cmd>\n  <cmd>\n end
   // 3. Single-line (no 'then', single command on same line): if <condition> <command>
 
-  // Look ahead to find 'then' keyword (not just check current token)
+  // Look ahead to find 'then' keyword (not just check current token).
+  //
+  // NOTE: this scan crosses newlines, so it can be set by a `then` that belongs
+  // to a BODY command rather than to the `if` header. That is tolerated on
+  // purpose: `hasThen` only feeds `isMultiLine`, and a body spanning lines is
+  // multi-line either way, while the header-`then` consumption below now checks
+  // the token instead of trusting this flag. Bounding the scan to
+  // `commandToken.line` was tried and rejected — it is a near-no-op given that
+  // check, it would reclassify the legitimate `then`-on-the-next-line form
+  // (parser-integration.test.ts:381), and the single-line shapes it would newly
+  // reach are broken by an INDEPENDENT pre-existing defect in the implicit
+  // multi-line scan below: `if 1 is 1 log 'a'\nlog 'b'` already swallows
+  // `log 'b'` into the block with a bogus "Expected 'end'", no `then` involved.
   let hasThen = false;
   const savedPosForThen = ctx.savePosition();
   const maxThenLookahead = 500; // Increased to handle large conditional expressions
@@ -487,23 +557,18 @@ export function parseIfCommand(ctx: ParserContext, commandToken: Token): Command
 
   if (isMultiLine) {
     // Multi-line form: if condition then ... end (or if condition ... end)
-    if (hasThen) {
-      ctx.advance(); // consume 'then' if present
-    }
+    //
+    // Consume the header `then` only if it is ACTUALLY the next token. `hasThen`
+    // is a lookahead flag that can be set by a `then` belonging to a body command
+    // (the scan above crosses newlines), and advancing on the flag alone deleted
+    // the body's first token — that is why the reported repro produced an EMPTY
+    // if-block with `get #username` missing from the AST entirely. Checking the
+    // token also routes through the multilingual keyword resolver, which the raw
+    // `token.value === KEYWORDS.THEN` comparison in the lookahead does not.
+    consumeOptionalKeyword(ctx, KEYWORDS.THEN);
 
     // Parse command block until 'else' or 'end'
-    const thenCommands: ASTNode[] = [];
-    while (!ctx.isAtEnd() && !ctx.check(KEYWORDS.ELSE) && !ctx.check(KEYWORDS.END)) {
-      if (ctx.checkIsCommand() || ctx.isCommand(ctx.peek().value)) {
-        ctx.advance(); // consume command token
-        const cmd = ctx.parseCommand();
-        if (cmd) {
-          thenCommands.push(cmd);
-        }
-      } else {
-        break;
-      }
-    }
+    const thenCommands: ASTNode[] = parseIfBranchCommands(ctx, true);
 
     // Validate: error if then block is empty and we're at end of input (incomplete statement)
     if (thenCommands.length === 0 && ctx.isAtEnd()) {
@@ -548,18 +613,7 @@ export function parseIfCommand(ctx: ParserContext, commandToken: Token): Command
         consumedElseIf = true;
       } else {
         // Regular else block
-        const elseCommands: ASTNode[] = [];
-        while (!ctx.isAtEnd() && !ctx.check(KEYWORDS.END)) {
-          if (ctx.checkIsCommand() || ctx.isCommand(ctx.peek().value)) {
-            ctx.advance(); // consume command token
-            const cmd = ctx.parseCommand();
-            if (cmd) {
-              elseCommands.push(cmd);
-            }
-          } else {
-            break;
-          }
-        }
+        const elseCommands: ASTNode[] = parseIfBranchCommands(ctx, false);
 
         // Add else block
         args.push(

--- a/packages/core/src/parser/command-parsers/utility-commands.ts
+++ b/packages/core/src/parser/command-parsers/utility-commands.ts
@@ -737,13 +737,17 @@ export function parseTellCommand(ctx: ParserContext, identifierNode: IdentifierN
         break;
       }
 
-      // Handle 'and' between commands (tell x add .a and add .b)
-      if (ctx.match(KEYWORDS.AND)) {
+      // Separator between two commands in the tell body (tell x add .a and add .b,
+      // tell x add .a then add .b). Upstream's TellCommand.parse takes a
+      // `commandList` for its body, and every commandList consumes a joining
+      // `then` — so a `then`-joined command belongs INSIDE the tell (running once
+      // per target), not after it. Breaking here let it escape the body.
+      if (ctx.match(KEYWORDS.AND) || ctx.match(KEYWORDS.THEN)) {
         continue;
       }
 
       // Check for control flow boundaries after parsing a command
-      if (ctx.check(KEYWORDS.THEN) || ctx.check(KEYWORDS.ELSE) || ctx.check(KEYWORDS.END)) {
+      if (ctx.check(KEYWORDS.ELSE) || ctx.check(KEYWORDS.END)) {
         break;
       }
 

--- a/packages/core/src/parser/command-parsers/utility-commands.ts
+++ b/packages/core/src/parser/command-parsers/utility-commands.ts
@@ -746,7 +746,17 @@ export function parseTellCommand(ctx: ParserContext, identifierNode: IdentifierN
         continue;
       }
 
-      // Check for control flow boundaries after parsing a command
+      // Check for control flow boundaries after parsing a command.
+      //
+      // KNOWN GAP: breaking on `end` is all we do with it — `tell` never CONSUMES
+      // its terminator, so `tell #x add .a end` leaves the `end` in the stream for
+      // whatever encloses us (inside a handler it is taken as the handler's own
+      // `end`). Upstream REQUIRES the terminator: TellCommand.parse calls
+      // `requireToken("end")` unless it is already at a feature start, which means
+      // hyperfixi has no real `tell … end` block form, only this inline one.
+      // Closing that is a termination-semantics change, not a separator fix, so it
+      // was deliberately left out of the `then`-separator work above.
+      // Tracked in docs-internal/PARSER_NEXT_STEPS.md.
       if (ctx.check(KEYWORDS.ELSE) || ctx.check(KEYWORDS.END)) {
         break;
       }

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -3282,6 +3282,13 @@ export class Parser {
         this.advance();
         const cmd = this.parseCommand();
         commands.push(cmd);
+        // `then`/`and`/`,` separate two commands in a body — same rule as the
+        // sequence loops (:3181, :2867) and the canonical body loop (:1130).
+        // Without this, `def f() get #u then log 'a' end` broke the block here
+        // and then failed hard on the missing `end` ("Unexpected token: then").
+        if (this.match('then', 'and', ',')) {
+          continue;
+        }
       } else {
         break;
       }

--- a/packages/testing-framework/baselines/shipped-sources-validity.json
+++ b/packages/testing-framework/baselines/shipped-sources-validity.json
@@ -1,36 +1,16 @@
 {
   "description": "Allowlist for the shipped-sources validity gate (packages/testing-framework/src/multilingual/shipped-sources-validity.test.ts). Each entry is a hyperscript source we ship that hyperfixi parses in the recovers-with-errors state (ok:true with a non-empty errors array). A NEW such source outside this list, or an allowlisted key that becomes clean, both fail the gate. Shrink this list as fixes land.",
-  "note": "The `key` is file::sha1(source)[0:10], so it CHANGES when the source is edited — a fix cannot silently keep its allowlist cover, it drops off and the stale-entry test demands removal. `upstream` records the real hyperscript.org verdict for each, which is what distinguishes a malformed example (upstream also rejects) from a hyperfixi parser defect (upstream accepts). All four below predate the gate; they were found by it, not by the handoff that motivated it.",
+  "note": "The `key` is file::sha1(source)[0:10], so it CHANGES when the source is edited — a fix cannot silently keep its allowlist cover, it drops off and the stale-entry test demands removal. `upstream` records the real hyperscript.org verdict, which is what distinguishes a malformed example (upstream also rejects) from a hyperfixi parser defect (upstream accepts). Three of the original four entries were cleared by the `then`-as-command-separator work: native-dialog and infinite-scroll by the parser fix (parseIfCommand's branch loops dropped BOTH the `then` separator and `--` comments, which every sibling body loop already handled), and fetch-data by deleting its `log 'typeof it:', (typeof it)` line — `typeof` is JavaScript, not a hyperscript operator.",
+  "infiniteScrollFollowUp": "The handoff's guess that infinite-scroll.html also had a genuinely missing `end` was WRONG — its `end`s were balanced all along, and the whole hyperfixi error was the comment-in-if-body defect. Upstream still rejects it (\"Expected 'end' but found 'on'\", \"Unexpected Token : {\") over the multi-line `make a <li>…</li>` element literal with `#{}` interpolation, which upstream does not support in that form. So we are now MORE permissive than upstream on that file. That laxness divergence is real but out of this gate's scope — the gate tracks hyperfixi's recovered state only.",
   "checkedAtGeneration": 454,
-  "cleanAtGeneration": 408,
+  "cleanAtGeneration": 411,
   "allowedRecovered": [
-    {
-      "key": "examples/dialogs/native-dialog.html::ecfd89d643",
-      "file": "examples/dialogs/native-dialog.html",
-      "error": "Expected 'end' after if block",
-      "upstream": "VALID",
-      "reason": "HYPERFIXI PARSER DEFECT, not a malformed example — upstream accepts this source, and its `end` is present. Isolated cause: a `then` used as a COMMAND SEPARATOR inside an `if` body makes the parser lose the block's `end`. Minimal repro (upstream-valid, hyperfixi reports \"Expected 'end' after if block\"):\n    if 1 is 1\\n get #u then log 'a'\\nend\nThe same source with the body's `then` removed parses clean, and it reproduces whether or not the `if` itself carries an explicit `then`. Here the trigger is `get #username then set username to it.value`. Do NOT 'fix' the example — fix the parser. Separately, upstream also tolerates an `if/then` with no `end` at the end of a handler, which we reject; that is a second, independent laxness gap."
-    },
     {
       "key": "examples/drag-and-drop/sortable-list.html::d64eff65f5",
       "file": "examples/drag-and-drop/sortable-list.html",
       "error": "Expected property name after '.' - malformed member access",
       "upstream": "You must parenthesize math operations with different operators",
       "reason": "MIXED — both engines reject, but for unrelated reasons, so this is two bugs in one file. Upstream's is an authoring bug with a known fix: `set midpoint to box.top + box.height / 2` mixes `+` and `/` without parens, which hyperscript forbids (x2 occurrences); `box.top + (box.height / 2)` is the fix. Hyperfixi's complaint is DIFFERENT ('malformed member access') and survives that fix, so it is likely a second parser-side gap around the `add { prop: value; }` inline-style syntax — confirm before editing the example."
-    },
-    {
-      "key": "examples/fetch-and-async/fetch-data.html::1d94c11092",
-      "file": "examples/fetch-and-async/fetch-data.html",
-      "error": "Expected closing parenthesis ')' after expression - unclosed parentheses",
-      "upstream": "Expected ')' but found 'it'",
-      "reason": "Genuinely malformed, and the clearest fix of the four: `log 'typeof it:', (typeof it)` uses `typeof`, which is JavaScript and not a hyperscript operator (upstream: \"Expected ')' but found 'it'\"). The comma-separated `log 'x', it` form is also used throughout. Rewrite as separate `log` commands with no `typeof`; no parser change needed."
-    },
-    {
-      "key": "examples/fetch-and-async/infinite-scroll.html::7b89d333ac",
-      "file": "examples/fetch-and-async/infinite-scroll.html",
-      "error": "Expected 'end' after if block",
-      "upstream": "Expected 'end' but found 'on'",
-      "reason": "MIXED, and must be triaged AFTER the native-dialog parser fix. Hyperfixi's message is the same \"Expected 'end' after if block\" signature as native-dialog, so part of it is likely that same then-in-if-body defect. But upstream ALSO rejects this one (\"Expected 'end' but found 'on'\"), so there is a genuinely missing `end` on top. Fix the parser first, re-run the gate, and see what residue is left before editing the example."
     }
   ]
 }


### PR DESCRIPTION
Fixes the defect handed off in `docs-internal/HANDOFF-if-block-then-separator.md`, found by the shipped-sources validity gate added in #784.

## The defect

A `then` joining two commands inside an `if` body silently truncated the block and hoisted the remainder out as a **sibling** of the `if`, so the conditional body ran **unconditionally**:

```hyperscript
if 1 is 2                        -- FALSE
  get #u then log 'BODY RAN'
end
```

`compileSync` returned `ok: true` (with a bogus `Expected 'end' after if block`), which is why this shipped in `examples/dialogs/native-dialog.html` and nothing caught it.

It is not specific to `if`. Upstream has one recursive `parseCommandList` that consumes a joining `then` after **every** command; hyperfixi has five independent body loops and three disagreed:

| Loop | Symptom before |
| --- | --- |
| `parseIfCommand` branch loops | silent hoist out of the conditional (`ok: true`) |
| `Parser.parseCommandBlock` (def / init / catch / finally) | hard failure, `Unexpected token: then` |
| `parseTellCommand` | the next command escaped the tell body |

The `if` case had a second mechanism: the header-`then` consumption advanced unconditionally on the `hasThen` lookahead flag. That scan crosses newlines, so a body `then` set it and the advance **deleted the body's first token** — hence the reported empty block with `get #username` absent from the AST entirely. It now checks the token.

## Reviewer notes — three things worth knowing

1. **`tell` semantics changed.** A `then`-joined command after `tell` now runs **once per target** instead of once. That is upstream's behaviour (`TellCommand.parse` takes a `commandList`). No shipped example and no existing test asserted the old shape.
2. **`and` is still not a command separator anywhere, and this does not change that.** `on click add .a and remove .b` parses `.a and remove` as a binaryExpression at top level too — the pratt parser absorbs it before any body loop sees it. Pinned as `KNOWN GAP` tests so its eventual fix is deliberate.
3. **The handoff's triage was wrong in two places**, both corrected in the doc:
   - Its "suspect 1" (line-crossing lookahead) was not the thing to fix — the unconditional advance that trusted the flag was. Bounding the lookahead was tried and **rejected**: it is a near-no-op once the token is checked, it would reclassify the legitimate `then`-on-the-next-line form, and the shapes it would newly reach are broken by an independent defect (see below).
   - `infinite-scroll.html` had **no missing `end`** — its `end`s were balanced all along. Its entire hyperfixi error was a *second* gap in the same branch loop: `--` comments in an `if` body were not skipped, though every sibling loop skips them. It came clean with no edit to the example.

## Also in this PR

- `examples/fetch-and-async/fetch-data.html` — dropped `log 'typeof it:', (typeof it)`; `typeof` is JavaScript, not a hyperscript operator (handoff step 1, pure authoring fix).
- Shipped-sources allowlist ratchets **4 → 1** (clean 408 → 411, checked 454 unchanged). Only `sortable-list.html` remains — untouched, handoff step 4.
- `docs-internal/HANDOFF-implicit-multiline-if.md` — a **new, independent** defect found during this work and not fixed here. It is the mirror image: a single-line `if` swallows the *following* line into its block, so an unconditional command silently stops running when the condition is false. Verified in jsdom; upstream accepts the source. Cause is located in the doc.

## Deliberately unchanged

- **The `end` requirement.** Upstream separately tolerates an unterminated `if/then` at the end of a handler; that is its own strictness decision and conflating it would mask the hoisting defect. A test pins that the missing-`end` error is still reported.
- `tell` still never consumes a terminating `end` (pre-existing, noted in the commit).
- `parser/hybrid/parser-core.ts` was already correct, so the lite/hybrid bundles are unaffected.

## Verification

| Gate | Result |
| --- | --- |
| `test:check --prefix packages/core` | **7629 pass**, 0 flips (7603 + 26 new) |
| `typecheck` | clean |
| `test:shipped-sources` | 3/3, allowlist 4 → 1 |
| multilingual `--regression` | no regression, all ten ratchets |
| `bundle-size-snapshot --check` | within ±5% (worst +0.6% gzip) |
| `check:test-list` / `check:ci-order` | OK |
| Playwright `src/compatibility/` | 1109 pass / 11 fail — **identical 11 fail on `main`**, verified by checkout+rebuild |

New coverage, in two halves because the parse-shape half alone would not have caught this:

- `packages/core/src/parser/__tests__/then-as-separator.test.ts` (22 cases) — every affected body kind, the shipped native-dialog handler verbatim, plus guards that must **not** change (`end` still delimits before a trailing `then`; the missing-`end` error is still reported; `then`-on-the-next-line still works).
- `packages/core/src/api/if-body-then-execution.test.ts` (4 cases) — runs a `then`-joined body with a **false** condition and asserts the DOM was not touched.

Assertions are structural and behavioural, never `success`/`ok` — both were already true against the bug. Verified non-vacuous: **17 of the 23 fail** against the pre-fix parser; the 6 that pass either way are the guards and known-gap pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)