### PR TITLE
fix(core): a single-line `if` no longer swallows the following line

### DIFF
--- a/docs-internal/HANDOFF-command-word-in-if-condition.md
+++ b/docs-internal/HANDOFF-command-word-in-if-condition.md
@@ -1,5 +1,45 @@
 # Handoff: a command-name word in a single-line `if` condition breaks the condition
 
+> **RESOLVED 2026-07-27** (same PR as the two swallow fixes, #786) for every
+> shape below. `parseIfCommand` no longer decides structure by asking "is this
+> token spelled like a command?" in isolation — the three sites that did (the
+> `hasThen` scan, the implicit-multi-line scan, the single-line condition loop)
+> now use command **position**:
+>
+> 1. **The condition is never empty** → the first token after `if`/`unless` is
+>    never the body. The condition loop's first expression parse is unguarded;
+>    the form-detection scans exempt the first token (`isBodyCommandStart`).
+> 2. **A token right after an operator is an operand** → `OPERAND_INTRODUCERS`
+>    (`is`, `not`, comparison/arithmetic ops, …) in the same helper covers
+>    `if x is set …`.
+> 3. **A newline without `then` breaks a command chain** → the `hasThen` scan
+>    stops at a command starting a LATER line; same-line commands and their
+>    joining `then`s bind the body (upstream keeps then-joined commands in the
+>    body).
+>
+> **A cautionary episode is recorded below** (§ "How the first fix attempt made
+> it worse"): the first version of the two swallow-fix bounds used the raw
+> name-test and *regressed five upstream-valid shapes vs main* — caught only by
+> branch-vs-main probing, because no in-repo source uses command-word
+> conditions, so **every gate stayed green through all of it**.
+>
+> Coverage: the `a command-name word in the condition does not break the if` and
+> chain-rule guard blocks in
+> `packages/core/src/parser/__tests__/then-as-separator.test.ts`, and the
+> command-word/then-joined DOM block in
+> `packages/core/src/api/if-body-then-execution.test.ts`. 12 of the 14 cases
+> fail against the pre-repair parser.
+>
+> **Residual, low, open in [PARSER_NEXT_STEPS.md](PARSER_NEXT_STEPS.md):** a
+> command-word in a mid-condition position that is neither first nor
+> operator-preceded (e.g. after a possessive: `if x's set is 3` + newline body)
+> can still mislead the form scans. The operand list is extensible for cheap
+> wins (`'s`, `the`, `my`, `of` — positions that can never precede a command),
+> but the fix that removes the heuristics entirely is **expression-first
+> condition parsing**: parse the condition via `parseExpression()` from token
+> zero, then classify the form from what follows. Viable — the pratt parser
+> accepts command-word operands (`add is 3` parses cleanly, probe P1).
+
 Found 2026-07-27 while fixing the implicit-multiline `if` defect
 ([HANDOFF-implicit-multiline-if.md](HANDOFF-implicit-multiline-if.md)).
 **Independent of it** — it reproduces before and after that fix, and the fix only
@@ -62,7 +102,42 @@ runs zero times, `conditionTokens` is empty, and it throws
 Note this is the same class of question the two lookaheads above it get wrong in
 their own ways, and the same `checkIsCommand()` heuristic. A real fix probably has
 to consult the expression parser rather than a name-set — a command name is only a
-command in command *position*.
+command in command *position*. (The landed fix approximates command position with
+two structural facts — see the RESOLVED header; the full expression-first version
+remains the queued follow-on.)
+
+## How the first fix attempt made it worse
+
+The two swallow-fix bounds (the implicit-scan line bound and the first version of
+the `hasThen` bound, which broke at the **first command token**) were built on the
+same raw name-test this defect lives in. Result, measured by branch-vs-main
+single-file probes: **five upstream-valid shapes that parsed cleanly on `main`
+regressed on the PR branch**, four loudly and one silently:
+
+| # | Shape | main | first-attempt branch | Cause |
+| - | ----- | ---- | ------------------- | ----- |
+| A | `if log is 3` ⏎ body ⏎ `end` | clean | fatal | implicit-scan line bound |
+| B | `if log is 3 then` ⏎ body ⏎ `end` | clean | fatal | first-command `hasThen` bound |
+| C | `if x is set then` ⏎ body ⏎ `end` | clean | fatal | first-command `hasThen` bound |
+| C2 | `if x is set` ⏎ `then` body ⏎ `end` | clean | fatal | first-command `hasThen` bound |
+| D | `if c add .a to #t then add .b to #t` | both conditional | `.b` unconditional — **silent** | first-command `hasThen` bound |
+
+They regressed because `main`'s scan bugs had been accidentally *rescuing*
+command-word conditions: misclassifying these shapes as multi-line routed the
+condition through `parseExpression()`, which handles command-word operands fine.
+Correct bounds + a name-test = the underlying defect exposed on new routes.
+
+Two lessons worth keeping:
+
+1. **Every gate was green through all of it** — 7600+ unit tests, the
+   10-signal multilingual ratchet, the workspace suite. No in-repo source or
+   corpus pattern puts a command-word in an `if` condition, so the gates are
+   structurally blind here. The only detector was probing candidate shapes
+   **branch-vs-main** (single-file `git checkout main -- <file>` swap) against
+   the upstream oracle.
+2. **A bound built on a broken classifier inherits the breakage.** The repair
+   was not a third patch around `checkIsCommand()` but replacing the question
+   it answers (spelling → position).
 
 ## Ruled out
 

--- a/docs-internal/HANDOFF-command-word-in-if-condition.md
+++ b/docs-internal/HANDOFF-command-word-in-if-condition.md
@@ -1,0 +1,92 @@
+# Handoff: a command-name word in a single-line `if` condition breaks the condition
+
+Found 2026-07-27 while fixing the implicit-multiline `if` defect
+([HANDOFF-implicit-multiline-if.md](HANDOFF-implicit-multiline-if.md)).
+**Independent of it** — it reproduces before and after that fix, and the fix only
+changed which of two wrong answers you get at top level. The oracle is
+`loadCanonicalParser()` in
+[canonical-validity.ts](../packages/testing-framework/src/multilingual/canonical-validity.ts)
+(the real `hyperscript.org` engine, headless); upstream accepts every source
+below.
+
+---
+
+## Severity: in a handler, the `if` disappears and its body runs unconditionally
+
+The trigger is a **single-line `if`/`unless` whose condition STARTS with a bare
+identifier that is also a command name** — `log`, `set`, `add`, … Two different
+failures depending on where it sits:
+
+**Inside an event handler — silent, and the dangerous one:**
+
+```hyperscript
+on click if log is 3 add .a to #target     -- `log is 3` is FALSE
+```
+
+```
+ok: true   errors: ["Unexpected token: is at line 1, column 17"]
+
+eventHandler
+  command:log     <-- the condition's first word, promoted to a command
+  command:add     <-- the if's BODY, now an unconditional sibling
+```
+
+The `if` node is **gone**. Verified in jsdom: clicking applies `.a` even though
+the condition is false. Same silent `ok: true` + recovered-error shape as #785
+and the implicit-multiline defect — the third member of that family.
+
+**At top level — loud:**
+
+```hyperscript
+if log is 3 add .a to #t
+```
+
+fails fatally with `Expected condition after if/unless` (`success: false`,
+`__ERROR__` node). `hyperscript.eval` of that source throws
+`Compilation failed: Expected condition after if/unless`.
+
+## Where it is
+
+The **single-line** condition loop in
+[`parseIfCommand`](../packages/core/src/parser/command-parsers/control-flow-commands.ts)
+(the `else` branch of `if (isMultiLine)`, the `while` guarded by
+`!ctx.checkIsCommand() && !ctx.isCommand(ctx.peek().value)`).
+
+The loop's job is to consume condition tokens and stop at the command that starts
+the body. It decides that purely by asking "is this token a command name?", which
+cannot distinguish a command from an identifier that merely shares its spelling.
+With `log` as the first condition token the guard is false immediately, the loop
+runs zero times, `conditionTokens` is empty, and it throws
+`Expected condition after if/unless`.
+
+Note this is the same class of question the two lookaheads above it get wrong in
+their own ways, and the same `checkIsCommand()` heuristic. A real fix probably has
+to consult the expression parser rather than a name-set — a command name is only a
+command in command *position*.
+
+## Ruled out
+
+| Shape | Result |
+| ----- | ------ |
+| `if x is 3 add .a to #t` (ordinary identifier) | clean, correct |
+| `if 3 is log add .a to #t` (command word NOT first) | clean, correct |
+| `if it.log is 3 …`, `if my.log is 3 …` (property path) | clean, correct |
+| `if log is 3 then add .a to #t end` (explicit `then … end`) | clean, correct |
+| `if log add .a to #t` (bare, no comparison) | same fatal error |
+| `unless log is 3 add .a to #t` | same fatal error (shares parseIfCommand) |
+
+The explicit `then … end` form is unaffected, which is the workaround — it routes
+through `parseExpression()` instead of this loop.
+
+## Verification harness
+
+No shipped example trips this, so the shipped-sources gate is **not** the
+regression test — it would pass a broken fix. Write coverage first, beside the
+existing cases in
+`packages/core/src/parser/__tests__/then-as-separator.test.ts` (parse shape) and
+`packages/core/src/api/if-body-then-execution.test.ts` (DOM effect).
+
+Assert **structurally and behaviourally**. For the handler shape `success`/`ok`
+are already true against the bug, so they prove nothing; the assertion that
+matters is that the `if` node still exists and that its body does NOT run on a
+false condition.

--- a/docs-internal/HANDOFF-implicit-multiline-if.md
+++ b/docs-internal/HANDOFF-implicit-multiline-if.md
@@ -15,12 +15,17 @@
 > against the unfixed parser; the other 6 are guards that must pass in both
 > states.
 >
-> **One residual left open**, tracked in
-> [PARSER_NEXT_STEPS.md](PARSER_NEXT_STEPS.md): a single-line `if` whose
-> *following* line contains a body `then` is still swallowed, via the separate
-> `hasThen` lookahead. See "Why the `then` fix did not touch it" below — the
-> re-evaluation it calls for was done, and the answer is a **first-command**
-> bound, not the line bound #785 rejected.
+> **The `hasThen` residual is also fixed** (same branch, follow-up commit): a
+> single-line `if` whose *following* line contained a body `then` was still
+> swallowed, because that lookahead crosses newlines. See "Why the `then` fix did
+> not touch it" below — the re-evaluation it calls for was done, and the answer is
+> a **first-command** bound (a header `then` always precedes the body), not the
+> `commandToken.line` bound #785 rejected, which would break the legitimate
+> `then`-on-the-next-line header form.
+>
+> A separate, unrelated defect in the same function was found during this work and
+> is now the top of the queue:
+> [HANDOFF-command-word-in-if-condition.md](HANDOFF-command-word-in-if-condition.md).
 
 Found while fixing the `then`-as-command-separator defect
 (`HANDOFF-if-block-then-separator.md`). **Independent of it** — this reproduces

--- a/docs-internal/HANDOFF-implicit-multiline-if.md
+++ b/docs-internal/HANDOFF-implicit-multiline-if.md
@@ -15,16 +15,16 @@
 > against the unfixed parser; the other 6 are guards that must pass in both
 > states.
 >
-> **The `hasThen` residual is also fixed** (same branch, follow-up commit): a
+> **The `hasThen` residual is also fixed** (same branch, follow-up commits): a
 > single-line `if` whose *following* line contained a body `then` was still
 > swallowed, because that lookahead crosses newlines. See "Why the `then` fix did
 > not touch it" below — the re-evaluation it calls for was done, and the answer is
-> a **first-command** bound (a header `then` always precedes the body), not the
-> `commandToken.line` bound #785 rejected, which would break the legitimate
-> `then`-on-the-next-line header form.
->
-> A separate, unrelated defect in the same function was found during this work and
-> is now the top of the queue:
+> the **command-chain rule** (a `then` binds only while the scan has not crossed
+> onto a line that starts a new command; same-line then-joined bodies bind, per
+> upstream), not the `commandToken.line` bound #785 rejected, which would break
+> the legitimate `then`-on-the-next-line header form. A plain first-command bound
+> was tried in between and over-corrected — that episode, and the wider defect it
+> exposed in the same function (both fixed on this branch), are in
 > [HANDOFF-command-word-in-if-condition.md](HANDOFF-command-word-in-if-condition.md).
 
 Found while fixing the `then`-as-command-separator defect

--- a/docs-internal/HANDOFF-implicit-multiline-if.md
+++ b/docs-internal/HANDOFF-implicit-multiline-if.md
@@ -1,5 +1,27 @@
 # Handoff: a single-line `if` swallows the following line into its block
 
+> **RESOLVED 2026-07-27.** Fixed in `parseIfCommand`'s implicit-multi-line scan:
+> once the FIRST command is found on the `if`'s own line, the scan now stops the
+> moment it leaves that line, so a later-line command can no longer set
+> `hasImplicitMultiLineEnd`. The deliberate missing `break` is preserved — the
+> scan still runs past the same-line first command to find a same-line
+> `else`/`end`.
+>
+> Coverage: 11 parse-shape cases in
+> `packages/core/src/parser/__tests__/then-as-separator.test.ts` (describe: *a
+> single-line if does not swallow the following line*) and 5 DOM-effect cases in
+> `packages/core/src/api/if-body-then-execution.test.ts` (describe: *a command
+> after a single-line if runs regardless of the condition*). 10 of the 16 fail
+> against the unfixed parser; the other 6 are guards that must pass in both
+> states.
+>
+> **One residual left open**, tracked in
+> [PARSER_NEXT_STEPS.md](PARSER_NEXT_STEPS.md): a single-line `if` whose
+> *following* line contains a body `then` is still swallowed, via the separate
+> `hasThen` lookahead. See "Why the `then` fix did not touch it" below — the
+> re-evaluation it calls for was done, and the answer is a **first-command**
+> bound, not the line bound #785 rejected.
+
 Found while fixing the `then`-as-command-separator defect
 (`HANDOFF-if-block-then-separator.md`). **Independent of it** — this reproduces
 with no `then` anywhere — and it survived that fix untouched. Everything below is

--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -24,7 +24,7 @@ ones, because the gate *is* the tracking mechanism.
 
 | Item | Severity | Gate | Detail |
 | ---- | -------- | ---- | ------ |
-| **Implicit-multiline `if` swallows the next line** | **high** — an unconditional command silently stops running | **none** | [HANDOFF-implicit-multiline-if.md](HANDOFF-implicit-multiline-if.md) |
+| **Single-line `if` + next-line body `then` still swallowed** | medium — same silent class as the fixed defect, narrower trigger | **none** | comment at the `hasThen` scan in `packages/core/src/parser/command-parsers/control-flow-commands.ts` |
 | **`tell` never consumes a terminating `end`** | medium — no real `tell … end` block form; upstream requires one | **none** | comment at `packages/core/src/parser/command-parsers/utility-commands.ts` (the `ELSE`/`END` break in `parseTellCommand`) |
 | **Nothing executes a shipped example** | medium — `examples/**` is parsed but never run | **none** | "Wider question" in [HANDOFF-if-block-then-separator.md](HANDOFF-if-block-then-separator.md) |
 | `and` is not a command separator anywhere | low — consistent everywhere, so no surprise | ✅ 2 `KNOWN GAP` tests | `packages/core/src/parser/__tests__/then-as-separator.test.ts` |
@@ -43,14 +43,21 @@ The ungated three have no such mechanism. **They are what this document is for.*
 
 ## Notes on the ungated three
 
-**Implicit-multiline `if`** is the one to do first. It is the mirror image of the
-`then` defect fixed in #785 (that one pushed a conditional body *out* so it ran
-unconditionally; this one pulls an unconditional command *in* so it stops
-running), and it is the reason #785 left the `hasThen` lookahead unbounded —
-bounding it routes more inputs down this already-broken path. Fix this, then
-re-evaluate that bound. **The shipped-sources gate is not the regression test
-here** — no shipped example trips it, so the gate would pass a broken fix. Write
-the coverage first.
+**The `hasThen` residual** is what is left of the implicit-multiline `if` defect
+(resolved — see History). A single-line `if` whose *following* line contains a
+body `then` — `if 1 is 1 log 'a'` then `set x to 1 then log 'b'` — is still read
+as multi-line and swallows that line, because the `hasThen` lookahead crosses
+newlines and cannot tell a header `then` from a body one.
+
+The re-evaluation #785 and the handoff both called for has been **done**, and the
+answer is not the bound they considered. A **line** bound (`commandToken.line`)
+is still wrong — it breaks the legitimate `then`-on-the-next-line header form. A
+**first-command** bound is right: a header `then` always precedes the body, so
+stopping the scan at the first command token separates the two directly, and it
+preserves the next-line header form. Measured green on the core suite (7645) and
+on the full multilingual `--regression` run, but deliberately **not landed** — it
+needs its own coverage first, per the rule below that the shipped-sources gate
+will pass a broken fix.
 
 **No execution test for `examples/**`** is the systemic one. #785 added
 `packages/core/src/api/if-body-then-execution.test.ts`, which is the right shape
@@ -63,6 +70,13 @@ body running unconditionally and every parse-level gate was green.
 
 ## History
 
+- **2026-07-27** — implicit-multiline `if` swallowing the following line into its
+  block. The lookahead answered the "FIRST command's line" question correctly and
+  then kept walking, so the second command overrode the answer; it is now bounded
+  to the `if`'s own line once that first command is found, which preserves the
+  same-line `else`/`end` hunt the missing `break` exists for. Brief:
+  [HANDOFF-implicit-multiline-if.md](HANDOFF-implicit-multiline-if.md) (read its
+  RESOLVED header — one residual stays open, at the top of the table above).
 - **#785** (2026-07-27) — `then` as a command separator in `if`/`unless`, `def` /
   `init` / `catch` / `finally`, and `tell` bodies; `--` comments in `if` bodies;
   shipped-sources allowlist 4 → 1. Brief:

--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -24,7 +24,6 @@ ones, because the gate *is* the tracking mechanism.
 
 | Item | Severity | Gate | Detail |
 | ---- | -------- | ---- | ------ |
-| **A command-name word in a single-line `if` condition** | **high** — in a handler the `if` vanishes and its body runs unconditionally | **none** | [HANDOFF-command-word-in-if-condition.md](HANDOFF-command-word-in-if-condition.md) |
 | **`tell` never consumes a terminating `end`** | medium — no real `tell … end` block form; upstream requires one | **none** | comment at `packages/core/src/parser/command-parsers/utility-commands.ts` (the `ELSE`/`END` break in `parseTellCommand`) |
 | **Nothing executes a shipped example** | medium — `examples/**` is parsed but never run | **none** | "Wider question" in [HANDOFF-if-block-then-separator.md](HANDOFF-if-block-then-separator.md) |
 | `and` is not a command separator anywhere | low — consistent everywhere, so no surprise | ✅ 2 `KNOWN GAP` tests | `packages/core/src/parser/__tests__/then-as-separator.test.ts` |
@@ -39,21 +38,23 @@ ones, because the gate *is* the tracking mechanism.
   assertion 3 of the shipped-sources gate **fails** when an allowlisted source
   goes clean. The list can only ratchet down. It cannot be silently forgotten.
 
-The ungated three have no such mechanism. **They are what this document is for.**
+The ungated two have no such mechanism. **They are what this document is for.**
 
-## Notes on the ungated three
+## Notes on the ungated two
 
-**The command-word condition** is the one to do first, and the third member of the
-family the other two `if` defects belong to. All three are `parseIfCommand`
-deciding structure from a token-level "is this a command?" question that cannot
-tell a command from an identifier spelled the same way, or a header keyword from a
-body one. This one is the worst of the three in a handler: the `if` node is
-dropped outright and its body becomes an unconditional sibling, with `ok: true`.
-
-A real fix likely has to stop asking `checkIsCommand()` in isolation — a command
-name is only a command in command *position*. Note that both fixes already landed
-here are narrow line-bounds around the same heuristic, not repairs to it; a third
-patch in that style may not be the right answer.
+**Expression-first condition parsing** is the deferred follow-on from the `if`
+family (see History). #786 replaced the raw "is this token spelled like a
+command?" test with a positional approximation (`isBodyCommandStart`: first-token
+exemption, operand rule, chain rule), which fixed every measured shape — but it is
+still a heuristic. The residual it leaves is LOW and known: a command-word in a
+mid-condition position that is neither first nor operator-preceded (e.g. after a
+possessive, `if x's set is 3` + newline body) can still mislead the form scans.
+The real fix parses the condition via `parseExpression()` from token zero and
+classifies the form from what follows — viable, since the pratt parser accepts
+command-word operands (`add is 3` parses cleanly). Fold the residual into that
+work rather than extending `OPERAND_INTRODUCERS` piecemeal. Detail + the
+regression episode that motivates it:
+[HANDOFF-command-word-in-if-condition.md](HANDOFF-command-word-in-if-condition.md).
 
 **No execution test for `examples/**`** is the systemic one. #785 added
 `packages/core/src/api/if-body-then-execution.test.ts`, which is the right shape
@@ -66,12 +67,23 @@ body running unconditionally and every parse-level gate was green.
 
 ## History
 
+- **2026-07-27 (#786, repair commit)** — command-name words in `if`/`unless`
+  conditions (`if log is 3 add .a` died with "Expected condition"; in a handler
+  the `if` vanished and its body ran unconditionally, `ok: true`). Fixed by
+  replacing the spelling test with command **position** (`isBodyCommandStart` +
+  an unguarded first condition parse). The same commit repaired **five
+  upstream-valid shapes the two entries below had regressed vs main** — their
+  bounds were built on the same broken classifier, and every gate stayed green
+  through it because no in-repo source uses command-word conditions. The
+  `hasThen` bound became the command-CHAIN rule (same-line then-joined bodies
+  bind; a command starting a later line breaks the chain). Full episode:
+  [HANDOFF-command-word-in-if-condition.md](HANDOFF-command-word-in-if-condition.md).
 - **2026-07-27** — the `hasThen` residual of the entry below: a single-line `if`
   whose FOLLOWING line carried a body `then` was still swallowed, because that
-  lookahead crosses newlines. Bounded at the **first command** — a header `then`
-  always precedes the body — which is the re-evaluation #785 asked for; the
-  `commandToken.line` bound it had considered stays rejected, since a header
-  `then` may sit on the line after the condition.
+  lookahead crosses newlines. First bounded at the first command — over-corrected,
+  see the entry above — and settled as the chain rule; the `commandToken.line`
+  bound #785 considered stays rejected, since a header `then` may sit on the line
+  after the condition.
 - **2026-07-27** — implicit-multiline `if` swallowing the following line into its
   block. The lookahead answered the "FIRST command's line" question correctly and
   then kept walking, so the second command overrode the answer; it is now bounded

--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -24,7 +24,7 @@ ones, because the gate *is* the tracking mechanism.
 
 | Item | Severity | Gate | Detail |
 | ---- | -------- | ---- | ------ |
-| **Single-line `if` + next-line body `then` still swallowed** | medium — same silent class as the fixed defect, narrower trigger | **none** | comment at the `hasThen` scan in `packages/core/src/parser/command-parsers/control-flow-commands.ts` |
+| **A command-name word in a single-line `if` condition** | **high** — in a handler the `if` vanishes and its body runs unconditionally | **none** | [HANDOFF-command-word-in-if-condition.md](HANDOFF-command-word-in-if-condition.md) |
 | **`tell` never consumes a terminating `end`** | medium — no real `tell … end` block form; upstream requires one | **none** | comment at `packages/core/src/parser/command-parsers/utility-commands.ts` (the `ELSE`/`END` break in `parseTellCommand`) |
 | **Nothing executes a shipped example** | medium — `examples/**` is parsed but never run | **none** | "Wider question" in [HANDOFF-if-block-then-separator.md](HANDOFF-if-block-then-separator.md) |
 | `and` is not a command separator anywhere | low — consistent everywhere, so no surprise | ✅ 2 `KNOWN GAP` tests | `packages/core/src/parser/__tests__/then-as-separator.test.ts` |
@@ -43,21 +43,17 @@ The ungated three have no such mechanism. **They are what this document is for.*
 
 ## Notes on the ungated three
 
-**The `hasThen` residual** is what is left of the implicit-multiline `if` defect
-(resolved — see History). A single-line `if` whose *following* line contains a
-body `then` — `if 1 is 1 log 'a'` then `set x to 1 then log 'b'` — is still read
-as multi-line and swallows that line, because the `hasThen` lookahead crosses
-newlines and cannot tell a header `then` from a body one.
+**The command-word condition** is the one to do first, and the third member of the
+family the other two `if` defects belong to. All three are `parseIfCommand`
+deciding structure from a token-level "is this a command?" question that cannot
+tell a command from an identifier spelled the same way, or a header keyword from a
+body one. This one is the worst of the three in a handler: the `if` node is
+dropped outright and its body becomes an unconditional sibling, with `ok: true`.
 
-The re-evaluation #785 and the handoff both called for has been **done**, and the
-answer is not the bound they considered. A **line** bound (`commandToken.line`)
-is still wrong — it breaks the legitimate `then`-on-the-next-line header form. A
-**first-command** bound is right: a header `then` always precedes the body, so
-stopping the scan at the first command token separates the two directly, and it
-preserves the next-line header form. Measured green on the core suite (7645) and
-on the full multilingual `--regression` run, but deliberately **not landed** — it
-needs its own coverage first, per the rule below that the shipped-sources gate
-will pass a broken fix.
+A real fix likely has to stop asking `checkIsCommand()` in isolation — a command
+name is only a command in command *position*. Note that both fixes already landed
+here are narrow line-bounds around the same heuristic, not repairs to it; a third
+patch in that style may not be the right answer.
 
 **No execution test for `examples/**`** is the systemic one. #785 added
 `packages/core/src/api/if-body-then-execution.test.ts`, which is the right shape
@@ -70,6 +66,12 @@ body running unconditionally and every parse-level gate was green.
 
 ## History
 
+- **2026-07-27** — the `hasThen` residual of the entry below: a single-line `if`
+  whose FOLLOWING line carried a body `then` was still swallowed, because that
+  lookahead crosses newlines. Bounded at the **first command** — a header `then`
+  always precedes the body — which is the re-evaluation #785 asked for; the
+  `commandToken.line` bound it had considered stays rejected, since a header
+  `then` may sit on the line after the condition.
 - **2026-07-27** — implicit-multiline `if` swallowing the following line into its
   block. The lookahead answered the "FIRST command's line" question correctly and
   then kept walking, so the second command overrode the answer; it is now bounded

--- a/packages/core/src/api/if-body-then-execution.test.ts
+++ b/packages/core/src/api/if-body-then-execution.test.ts
@@ -174,6 +174,56 @@ describe('a command after a single-line if runs regardless of the condition', ()
 });
 
 /**
+ * The behavioural half of the command-word-condition fix and the chain rule
+ * (parse-shape halves in `src/parser/__tests__/then-as-separator.test.ts`).
+ *
+ * A condition STARTING with a command-name word (`if log is 3 …`) used to kill
+ * the parse — silently inside a handler, where recovery dropped the `if` and its
+ * body ran unconditionally. And a SAME-LINE then-joined body (`if c add .a then
+ * add .b`) briefly had its second command evicted as an unconditional sibling by
+ * the first-command bound. Both are the same failure the rest of this file
+ * exists for: a command running, or not running, against its condition.
+ * See docs-internal/HANDOFF-command-word-in-if-condition.md.
+ */
+describe('a command-word condition and a same-line then-joined body obey the condition', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('does NOT run the body of a command-word condition that is false', () => {
+    // `log` resolves to no value, so `log is 3` is false. The silent case:
+    // recovery used to run `add .a` unconditionally. The sibling line must still
+    // run — both fixes composed.
+    const host = setupTarget();
+
+    return hyperscript.eval('if log is 3 add .a to #target\nadd .b to #target', host).then(() => {
+      expect(target().classList.contains('a')).toBe(false);
+      expect(target().classList.contains('b')).toBe(true);
+    });
+  });
+
+  it('does NOT run a same-line then-joined body when the condition is false', () => {
+    // BOTH adds are conditional (upstream keeps then-joined commands in the
+    // body). The first-command bound briefly made `.b` unconditional.
+    const host = setupTarget();
+
+    return hyperscript.eval('if 1 is 2 add .a to #target then add .b to #target', host).then(() => {
+      expect(target().classList.contains('a')).toBe(false);
+      expect(target().classList.contains('b')).toBe(false);
+    });
+  });
+
+  it('runs the whole same-line then-joined body when the condition is true', () => {
+    const host = setupTarget();
+
+    return hyperscript.eval('if 1 is 1 add .a to #target then add .b to #target', host).then(() => {
+      expect(target().classList.contains('a')).toBe(true);
+      expect(target().classList.contains('b')).toBe(true);
+    });
+  });
+});
+
+/**
  * The behavioural half of the residual where the two defects above meet
  * (parse-shape half: the `a body `then` on a later line does not make a
  * single-line if multi-line` block in

--- a/packages/core/src/api/if-body-then-execution.test.ts
+++ b/packages/core/src/api/if-body-then-execution.test.ts
@@ -87,3 +87,88 @@ describe('an if body joined by `then` obeys its condition', () => {
       });
   });
 });
+
+/**
+ * The behavioural half of the mirror-image defect (parse-shape half: the
+ * `a single-line if does not swallow the following line` block in
+ * `src/parser/__tests__/then-as-separator.test.ts`).
+ *
+ * `parseIfCommand`'s implicit-multi-line lookahead decided the form from the
+ * first command's line and then kept scanning, so the NEXT line's command was
+ * pulled INTO the if-block. With a false condition that command silently stopped
+ * running — while `ok`/`success` stayed true and the only trace was a recovered
+ * "Expected 'end' after if block".
+ *
+ * These assert the DOM, because that is the only place the damage was visible.
+ * See docs-internal/HANDOFF-implicit-multiline-if.md.
+ */
+describe('a command after a single-line if runs regardless of the condition', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('runs the following line when the condition is FALSE', () => {
+    // THE case. `.b` was swallowed into the false branch and never applied.
+    const host = setupTarget();
+
+    return hyperscript.eval('if 1 is 2 add .a to #target\nadd .b to #target', host).then(() => {
+      expect(target().classList.contains('a')).toBe(false);
+      expect(target().classList.contains('b')).toBe(true);
+    });
+  });
+
+  it('runs both when the condition is TRUE', () => {
+    // The bug was invisible here — a swallowed command still runs on a true
+    // condition — so this pins that the fix did not overcorrect.
+    const host = setupTarget();
+
+    return hyperscript.eval('if 1 is 1 add .a to #target\nadd .b to #target', host).then(() => {
+      expect(target().classList.contains('a')).toBe(true);
+      expect(target().classList.contains('b')).toBe(true);
+    });
+  });
+
+  it('runs every following line, not just the first', () => {
+    const host = setupTarget();
+
+    return hyperscript
+      .eval('if 1 is 2 add .a to #target\nadd .b to #target\nadd .c to #target', host)
+      .then(() => {
+        expect(target().classList.contains('a')).toBe(false);
+        expect(target().classList.contains('b')).toBe(true);
+        expect(target().classList.contains('c')).toBe(true);
+      });
+  });
+
+  it('keeps consecutive single-line ifs independently conditional', () => {
+    // Each `if` governs only its own line: `.a` suppressed, `.b` applied,
+    // `.c` unconditional.
+    const host = setupTarget();
+
+    return hyperscript
+      .eval('if 1 is 2 add .a to #target\nif 1 is 1 add .b to #target\nadd .c to #target', host)
+      .then(() => {
+        expect(target().classList.contains('a')).toBe(false);
+        expect(target().classList.contains('b')).toBe(true);
+        expect(target().classList.contains('c')).toBe(true);
+      });
+  });
+
+  it('still runs the same-line `else` branch, and the line after it', () => {
+    // The guard, behaviourally: a same-line `else`/`end` keeps the multi-line
+    // reading (so the else branch exists at all) while the following line stays
+    // unconditional. Collapsing that shape to single-line would drop `.else-ran`.
+    const host = setupTarget();
+
+    return hyperscript
+      .eval(
+        'if 1 is 2 add .then-ran to #target else add .else-ran to #target end\nadd .after to #target',
+        host
+      )
+      .then(() => {
+        expect(target().classList.contains('then-ran')).toBe(false);
+        expect(target().classList.contains('else-ran')).toBe(true);
+        expect(target().classList.contains('after')).toBe(true);
+      });
+  });
+});

--- a/packages/core/src/api/if-body-then-execution.test.ts
+++ b/packages/core/src/api/if-body-then-execution.test.ts
@@ -172,3 +172,44 @@ describe('a command after a single-line if runs regardless of the condition', ()
       });
   });
 });
+
+/**
+ * The behavioural half of the residual where the two defects above meet
+ * (parse-shape half: the `a body `then` on a later line does not make a
+ * single-line if multi-line` block in
+ * `src/parser/__tests__/then-as-separator.test.ts`).
+ *
+ * The `hasThen` lookahead crosses newlines, so a `then` used as a command
+ * separator on a LATER line classified the `if` as multi-line and pulled that
+ * whole line into the block — reaching the same silent failure as the defects
+ * above by a third route. Bounding that scan at the first command fixed it.
+ */
+describe('a `then`-joined line after a single-line if runs regardless of the condition', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('runs BOTH commands of the following `then`-joined line when the condition is FALSE', () => {
+    const host = setupTarget();
+
+    return hyperscript
+      .eval('if 1 is 2 add .a to #target\nadd .b to #target then add .c to #target', host)
+      .then(() => {
+        expect(target().classList.contains('a')).toBe(false);
+        expect(target().classList.contains('b')).toBe(true);
+        expect(target().classList.contains('c')).toBe(true);
+      });
+  });
+
+  it('runs all three when the condition is TRUE', () => {
+    const host = setupTarget();
+
+    return hyperscript
+      .eval('if 1 is 1 add .a to #target\nadd .b to #target then add .c to #target', host)
+      .then(() => {
+        expect(target().classList.contains('a')).toBe(true);
+        expect(target().classList.contains('b')).toBe(true);
+        expect(target().classList.contains('c')).toBe(true);
+      });
+  });
+});

--- a/packages/core/src/parser/__tests__/then-as-separator.test.ts
+++ b/packages/core/src/parser/__tests__/then-as-separator.test.ts
@@ -361,6 +361,68 @@ describe('a single-line if does not swallow the following line', () => {
   });
 });
 
+/**
+ * The residual of the two defects above, where they meet.
+ *
+ * Fixing the implicit-multi-line scan left one way for a single-line `if` to
+ * still swallow its following line: the SEPARATE `hasThen` lookahead. That scan
+ * crosses newlines, so a `then` used as a command separator on a LATER line set
+ * `hasThen`, the `if` was classified multi-line, and the whole following line was
+ * pulled into the block — the same silent "unconditional command stops running"
+ * failure, reached by a different route.
+ *
+ * #785 considered bounding that scan to `commandToken.line` and rejected it,
+ * partly because the implicit-multi-line scan was broken anyway. It is now fixed,
+ * but the LINE bound is still wrong on its own terms: a header `then` is allowed
+ * to sit on the line after the condition (`leaves the `then`-on-the-next-line
+ * header form working`, above), so a line bound would misclassify that form.
+ *
+ * The bound that works is at the FIRST COMMAND. A header `then` always precedes
+ * the body, so any `then` found after a command token belongs to the body. That
+ * distinction is what these tests pin — the two guards at the end are the shapes
+ * a line bound would have broken.
+ *
+ * See docs-internal/PARSER_NEXT_STEPS.md.
+ */
+describe('a body `then` on a later line does not make a single-line if multi-line', () => {
+  it('leaves the following `then`-joined line a SIBLING of the if', () => {
+    const node = parseClean("if 1 is 1 log 'a'\nset x to 1 then log 'b'");
+
+    expect(names(node.commands)).toEqual(['if', 'set', 'log']);
+    expect(names(thenBranch(node.commands[0]))).toEqual(['log']);
+  });
+
+  it('keeps the `then`-joined line out of a FALSE branch', () => {
+    // The severity shape: both `add`s were swallowed into a false branch, so
+    // neither ran. The DOM proof is in if-body-then-execution.test.ts.
+    const node = parseClean('if 1 is 2 add .a to #t\nadd .b to #t then add .c to #t');
+
+    expect(names(node.commands)).toEqual(['if', 'add', 'add']);
+    expect(names(thenBranch(node.commands[0]))).toEqual(['add']);
+    expect(node.commands[1].args[0].value).toBe('.b');
+    expect(node.commands[2].args[0].value).toBe('.c');
+  });
+
+  // ─── Guards: the bound is at the first COMMAND, not at the line ───────────
+
+  it('still treats a same-line header `then` as multi-line', () => {
+    // The bound must not fire before the header `then` is seen.
+    const node = parseClean("if 1 is 1 then log 'a' end");
+
+    expect(names(thenBranch(node))).toEqual(['log']);
+  });
+
+  it('still finds a header `then` past a command-like word in the condition', () => {
+    // `set` is a command name, so a first-command bound could stop the scan
+    // inside the CONDITION and lose the header `then` that follows it. The
+    // condition is consumed as an expression before the body begins, so it must
+    // not — pinned because this is the bound's sharpest edge.
+    const node = parseClean("if x is set then log 'a' end");
+
+    expect(names(thenBranch(node))).toEqual(['log']);
+  });
+});
+
 describe('`then` as a command separator in def/init/catch/finally bodies', () => {
   // These were a HARD failure before the fix ("Unexpected token: then"), not a
   // silent hoist: parseCommandBlock broke at the `then` and the caller then

--- a/packages/core/src/parser/__tests__/then-as-separator.test.ts
+++ b/packages/core/src/parser/__tests__/then-as-separator.test.ts
@@ -231,6 +231,136 @@ describe('`then` as a command separator in if/unless bodies', () => {
   });
 });
 
+/**
+ * The MIRROR IMAGE of the defect above, found while fixing it and independent of
+ * it — no `then` appears anywhere in these sources.
+ *
+ * `parseIfCommand`'s implicit-multi-line lookahead is supposed to decide the form
+ * from the FIRST command's line only: same line as the `if` → single-line,
+ * different line → multi-line. It answered that correctly and then kept walking,
+ * because the branch has no `break` (deliberately — it is still hunting a
+ * same-line `else`/`end`, which the guards at the bottom pin). It reached the
+ * NEXT line's command, set the multi-line flag, and the "FIRST command" rule was
+ * defeated by the second command.
+ *
+ * The result: `if 1 is 1 log 'a'` followed by `log 'b'` swallowed `log 'b'` into
+ * the if-block, so a command that must always run stopped running whenever the
+ * condition was false. Where the `then` defect hoisted a conditional body OUT so
+ * it ran unconditionally, this pulls an unconditional command IN.
+ *
+ * Same `ok: true` + recovered-"Expected 'end'" shape, so these assertions are
+ * structural for the same reason: `success` proves nothing, it was already true.
+ * The behavioural half is in `src/api/if-body-then-execution.test.ts`.
+ *
+ * Every source below is accepted by upstream `hyperscript.org`.
+ * See docs-internal/HANDOFF-implicit-multiline-if.md.
+ */
+describe('a single-line if does not swallow the following line', () => {
+  it('leaves the next line a SIBLING of the if (minimal repro)', () => {
+    const node = parseClean("if 1 is 1 log 'a'\nlog 'b'");
+
+    expect(names(node.commands)).toEqual(['if', 'log']);
+    expect(names(thenBranch(node.commands[0]))).toEqual(['log']);
+    expect(node.commands[0].args[1].commands[0].args[0].value).toBe('a');
+    expect(node.commands[1].args[0].value).toBe('b');
+  });
+
+  it('keeps the sibling out of the block when the condition is FALSE', () => {
+    // The severity case at parse level: `add .b` swallowed into a false branch
+    // silently stops running. The DOM proof is in if-body-then-execution.test.ts.
+    const node = parseClean('if 1 is 2 add .a to #t\nadd .b to #t');
+
+    expect(names(node.commands)).toEqual(['if', 'add']);
+    expect(names(thenBranch(node.commands[0]))).toEqual(['add']);
+    expect(node.commands[1].args[0].value).toBe('.b');
+  });
+
+  it('scales — three trailing lines all stay siblings', () => {
+    // It was not one line: the scan swallowed everything up to the next boundary.
+    const node = parseClean("if 1 is 1 log 'a'\nlog 'b'\nlog 'c'");
+
+    expect(names(node.commands)).toEqual(['if', 'log', 'log']);
+    expect(names(thenBranch(node.commands[0]))).toEqual(['log']);
+  });
+
+  it('leaves the next line a sibling inside an event handler', () => {
+    const node = parseClean('on click\n  if 1 is 2 add .a to #t\n  add .b to #t');
+
+    expect(names(node.commands)).toEqual(['if', 'add']);
+    expect(names(thenBranch(node.commands[0]))).toEqual(['add']);
+  });
+
+  it('keeps consecutive single-line ifs independent', () => {
+    // The second `if` was swallowed into the first one's block, which nested two
+    // independent conditions.
+    const node = parseClean(
+      'on click\n  if 1 is 2 add .a to #t\n  if 1 is 1 add .b to #t\n  add .c to #t'
+    );
+
+    expect(names(node.commands)).toEqual(['if', 'if', 'add']);
+    expect(names(thenBranch(node.commands[0]))).toEqual(['add']);
+    expect(names(thenBranch(node.commands[1]))).toEqual(['add']);
+  });
+
+  it('applies to `unless`, which shares parseIfCommand', () => {
+    const node = parseClean("unless 1 is 1 log 'a'\nlog 'b'");
+
+    expect(names(node.commands)).toEqual(['unless', 'log']);
+    expect(names(thenBranch(node.commands[0]))).toEqual(['log']);
+  });
+
+  it('keeps a single-line if nested in a multi-line body from eating its sibling', () => {
+    // `log 'outer'` belongs to the OUTER body, not to the inner single-line if.
+    const node = parseClean("if 1 is 1\n  if 2 is 2 log 'inner'\n  log 'outer'\nend");
+
+    const outer = thenBranch(node);
+    expect(names(outer)).toEqual(['if', 'log']);
+    expect(names(thenBranch(outer[0]))).toEqual(['log']);
+    expect(outer[1].args[0].value).toBe('outer');
+  });
+
+  // ─── Guards: the missing `break` is deliberate, and must stay missing ──────
+
+  it('still treats a SAME-LINE `else`/`end` as multi-line', () => {
+    // This is why the branch has no `break`: the scan must run past the same-line
+    // first command to find this `else`. A fix that simply added the `break`
+    // would collapse this into a single-line `if` and drop the else entirely.
+    const node = parseClean('if x > 3 set y to 1 else set y to 2 end');
+
+    expect(names(thenBranch(node))).toEqual(['set']);
+    expect(names(elseBranch(node))).toEqual(['set']);
+  });
+
+  it('still finds the same-line `else`/`end` when another line follows', () => {
+    // The two rules meeting: same-line else/end wins, and the next line is still
+    // a sibling. Both halves have to hold at once.
+    const node = parseClean("on click if x > 3 set y to 1 else set y to 2 end\n  log 'after'");
+
+    expect(names(node.commands)).toEqual(['if', 'log']);
+    expect(names(thenBranch(node.commands[0]))).toEqual(['set']);
+    expect(names(elseBranch(node.commands[0]))).toEqual(['set']);
+    expect(node.commands[1].args[0].value).toBe('after');
+  });
+
+  it('leaves the genuine implicit multi-line form alone', () => {
+    // The other side of the FIRST-command rule: first command on a DIFFERENT
+    // line is multi-line, and both commands belong to the block.
+    const node = parseClean("if 1 is 1\n  log 'a'\n  log 'b'\nend");
+
+    expect(names(thenBranch(node))).toEqual(['log', 'log']);
+  });
+
+  it('lets an OUTER block claim the `end` on the next line', () => {
+    // The case the scan's different-line rule exists for, cited at that site: in
+    // a behavior, `if no x set x to 1` is single-line and the following `end`
+    // closes the enclosing `init`, not the `if`.
+    const node = parseClean('behavior B\n  init\n    if no x set x to 1\n  end\nend');
+
+    expect(names(node.initBlock.commands)).toEqual(['if']);
+    expect(names(thenBranch(node.initBlock.commands[0]))).toEqual(['set']);
+  });
+});
+
 describe('`then` as a command separator in def/init/catch/finally bodies', () => {
   // These were a HARD failure before the fix ("Unexpected token: then"), not a
   // silent hoist: parseCommandBlock broke at the `then` and the caller then

--- a/packages/core/src/parser/__tests__/then-as-separator.test.ts
+++ b/packages/core/src/parser/__tests__/then-as-separator.test.ts
@@ -377,12 +377,18 @@ describe('a single-line if does not swallow the following line', () => {
  * to sit on the line after the condition (`leaves the `then`-on-the-next-line
  * header form working`, above), so a line bound would misclassify that form.
  *
- * The bound that works is at the FIRST COMMAND. A header `then` always precedes
- * the body, so any `then` found after a command token belongs to the body. That
- * distinction is what these tests pin — the two guards at the end are the shapes
- * a line bound would have broken.
+ * The bound that works is the COMMAND-CHAIN rule: a `then` binds the `if` only
+ * while the scan has not crossed onto a line that STARTS a new command. Commands
+ * on the `if`'s own line are the single-line body — their joining `then`s bind
+ * (upstream keeps then-joined commands in the body). A command starting a LATER
+ * line begins a sibling, so a `then` beyond it is that sibling's separator.
  *
- * See docs-internal/PARSER_NEXT_STEPS.md.
+ * A plain FIRST-command bound was tried first and over-corrected: it also broke
+ * at command-WORDS inside the condition (`if log is 3 then …`,
+ * `if x is set then …`) and evicted same-line then-joined bodies (`if c add .a
+ * then add .b` — upstream: BOTH conditional), regressing five upstream-valid
+ * shapes that the guards below now pin. See
+ * docs-internal/HANDOFF-command-word-in-if-condition.md.
  */
 describe('a body `then` on a later line does not make a single-line if multi-line', () => {
   it('leaves the following `then`-joined line a SIBLING of the if', () => {
@@ -403,7 +409,7 @@ describe('a body `then` on a later line does not make a single-line if multi-lin
     expect(node.commands[2].args[0].value).toBe('.c');
   });
 
-  // ─── Guards: the bound is at the first COMMAND, not at the line ───────────
+  // ─── Guards: the chain rule, not a first-command break ────────────────────
 
   it('still treats a same-line header `then` as multi-line', () => {
     // The bound must not fire before the header `then` is seen.
@@ -420,6 +426,122 @@ describe('a body `then` on a later line does not make a single-line if multi-lin
     const node = parseClean("if x is set then log 'a' end");
 
     expect(names(thenBranch(node))).toEqual(['log']);
+  });
+
+  it('keeps a SAME-LINE then-joined body inside the if', () => {
+    // Upstream keeps then-joined commands in the body: BOTH adds are
+    // conditional here. The first-command bound broke the scan at `add .a` and
+    // evicted `add .b` as an unconditional sibling — the exact silent class this
+    // file exists to kill, on a same-line shape. The recovered "Expected 'end'"
+    // is deliberate strictness (`still requires end`, above), not part of the
+    // defect.
+    const result = parse('on click if 1 is 2 add .a to #t then add .b to #t');
+
+    expect(names((result.node as any).commands)).toEqual(['if']);
+    expect(names(thenBranch((result.node as any).commands[0]))).toEqual(['add', 'add']);
+    expect(recoveredErrors(result)).toContain("Expected 'end' after if block");
+  });
+
+  it('still finds a header `then` on the next line past a command-word operand', () => {
+    // C2 of the regression set: `set` is an operand of `is`, and the header
+    // `then` sits on the following line. The chain rule must not count an
+    // operand as a command, or the scan stops at the newline and the header
+    // `then` is lost.
+    const node = parseClean("if x is set\n  then log 'a'\nend");
+
+    expect(names(thenBranch(node))).toEqual(['log']);
+  });
+
+  it('still finds a header `then` when the body is on the next line', () => {
+    // C of the regression set: nothing after the header `then` on the if line.
+    const node = parseClean("if x is set then\n  log 'a'\nend");
+
+    expect(names(thenBranch(node))).toEqual(['log']);
+  });
+});
+
+/**
+ * A command-NAME word in an `if`/`unless` condition.
+ *
+ * `parseIfCommand` used to decide structure by asking "is this token spelled
+ * like a command?" at three sites (the two form-detection scans and the
+ * single-line condition loop). That question cannot tell a command from an
+ * identifier that shares its spelling, so a condition STARTING with `log`,
+ * `set`, `add`, … broke: the condition loop's guard was false at token zero,
+ * zero condition tokens were parsed, and the parse died with "Expected
+ * condition after if/unless" — loudly at top level, SILENTLY inside a handler,
+ * where recovery dropped the `if` node and promoted the body to an
+ * unconditional sibling.
+ *
+ * Two structural facts replace the name test:
+ *   1. the condition is never empty, so the first token after `if` is never the
+ *      body (the condition loop's first parse is unguarded);
+ *   2. a token right after an operator is an operand (`if x is set …`).
+ *
+ * Every source here is accepted by upstream `hyperscript.org`. See
+ * docs-internal/HANDOFF-command-word-in-if-condition.md.
+ */
+describe('a command-name word in the condition does not break the if', () => {
+  it('parses a condition that STARTS with a command word (single-line)', () => {
+    // The headline case: was a FATAL "Expected condition after if/unless".
+    const node = parseClean('if log is 3 add .a to #t');
+
+    expect(node.name).toBe('if');
+    expect(node.args[0].type).toBe('binaryExpression');
+    expect(names(thenBranch(node))).toEqual(['add']);
+  });
+
+  it('keeps the if ALIVE inside an event handler', () => {
+    // The silent case: recovery used to drop the `if` entirely — the handler
+    // became [log, add], with the body promoted to an unconditional sibling and
+    // ok still true. The DOM proof is in if-body-then-execution.test.ts.
+    const node = parseClean('on click if log is 3 add .a to #t');
+
+    expect(names(node.commands)).toEqual(['if']);
+    expect(names(thenBranch(node.commands[0]))).toEqual(['add']);
+  });
+
+  it('applies to `unless`, which shares parseIfCommand', () => {
+    const node = parseClean('unless log is 3 add .a to #t');
+
+    expect(node.name).toBe('unless');
+    expect(names(thenBranch(node))).toEqual(['add']);
+  });
+
+  it('parses the implicit multi-line form (A of the regression set)', () => {
+    const node = parseClean('if log is 3\n  add .a to #t\nend');
+
+    expect(names(thenBranch(node))).toEqual(['add']);
+  });
+
+  it('parses the `then` + next-line body form (B of the regression set)', () => {
+    const node = parseClean('if log is 3 then\n  add .a to #t\nend');
+
+    expect(names(thenBranch(node))).toEqual(['add']);
+  });
+
+  it('parses a command-word OPERAND with an implicit next-line body', () => {
+    // No `then` anywhere: only the operand rule keeps `set` out of the
+    // form-detection here.
+    const node = parseClean("if x is set\n  log 'a'\nend");
+
+    expect(names(thenBranch(node))).toEqual(['log']);
+  });
+
+  it('handles the same command word as condition AND body', () => {
+    const node = parseClean('if add is 3 add .a to #t');
+
+    expect(node.args[0].type).toBe('binaryExpression');
+    expect(names(thenBranch(node))).toEqual(['add']);
+  });
+
+  it('keeps the following line a sibling when the condition starts with a command word', () => {
+    // Composition with the swallow fix above: both rules must hold at once.
+    const node = parseClean('if log is 3 add .a to #t\nadd .b to #t');
+
+    expect(names(node.commands)).toEqual(['if', 'add']);
+    expect(names(thenBranch(node.commands[0]))).toEqual(['add']);
+    expect(node.commands[1].args[0].value).toBe('.b');
   });
 });
 

--- a/packages/core/src/parser/command-parsers/control-flow-commands.ts
+++ b/packages/core/src/parser/command-parsers/control-flow-commands.ts
@@ -417,23 +417,19 @@ export function parseIfCommand(ctx: ParserContext, commandToken: Token): Command
   // multi-line either way, while the header-`then` consumption below now checks
   // the token instead of trusting this flag.
   //
-  // Bounding the scan to `commandToken.line` remains WRONG: it would reclassify
-  // the legitimate `then`-on-the-next-line header form
+  // The scan IS bounded, but at the first COMMAND (below) — not at
+  // `commandToken.line`. #785 considered the line bound and rejected it; that
+  // remains the right call, because a header `then` is allowed to sit on the line
+  // AFTER the condition, so a line bound reclassifies that legitimate form
   // (parser-integration.test.ts:381, and the guard in then-as-separator.test.ts).
   //
-  // #785 gave a second reason for leaving this unbounded — that the single-line
-  // shapes a bound would newly reach were broken anyway by the implicit
-  // multi-line scan below. That defect is now FIXED (see the line-bound in that
-  // scan, and docs-internal/HANDOFF-implicit-multiline-if.md), so only the
-  // next-line-header reason still stands.
-  //
-  // Residual, deliberately NOT fixed here: a single-line `if` whose FOLLOWING
-  // line contains a body `then` (`if 1 is 1 log 'a'` + `set x to 1 then log 'b'`)
-  // is still misread as multi-line and swallows that line. Bounding this scan at
-  // the FIRST COMMAND — not at the line — fixes it while preserving the
-  // next-line header form, since a header `then` always precedes the body. That
-  // change measured green on the core suite and the multilingual ratchet; it is
-  // queued in docs-internal/PARSER_NEXT_STEPS.md to land with its own coverage.
+  // #785's other reason for leaving this unbounded entirely — that the
+  // single-line shapes a bound would newly reach were broken anyway by the
+  // implicit multi-line scan below — no longer applies; that defect is fixed
+  // (see the line-bound there, and docs-internal/HANDOFF-implicit-multiline-if.md).
+  // Unbounded, this scan crossed newlines into a BODY `then` on a later line and
+  // made a single-line `if` multi-line, swallowing that whole line — the same
+  // silent failure by a third route.
   let hasThen = false;
   const savedPosForThen = ctx.savePosition();
   const maxThenLookahead = 500; // Increased to handle large conditional expressions
@@ -450,6 +446,14 @@ export function parseIfCommand(ctx: ParserContext, commandToken: Token): Command
       token.value === KEYWORDS.DEF ||
       token.value === KEYWORDS.ON
     ) {
+      break;
+    }
+    // Bound at the FIRST COMMAND: a header `then` always precedes the body, so
+    // any `then` beyond this point belongs to a BODY command and must not make
+    // the `if` multi-line. This is what separates the two directly — a bound on
+    // `commandToken.line` cannot, because the header `then` is allowed to sit on
+    // the line AFTER the condition.
+    if (ctx.checkIsCommand() || ctx.isCommand(token.value?.toLowerCase())) {
       break;
     }
     ctx.advance();

--- a/packages/core/src/parser/command-parsers/control-flow-commands.ts
+++ b/packages/core/src/parser/command-parsers/control-flow-commands.ts
@@ -401,6 +401,61 @@ function parseIfBranchCommands(ctx: ParserContext, stopAtElse: boolean): ASTNode
  * @param commandToken - The 'if' command token
  * @returns CommandNode representing the if command
  */
+/**
+ * Operators/connectives whose FOLLOWING token is an expression operand, never a
+ * command start. The token-level approximation of "command position": a command
+ * name is only a command in command position, and after `is`/`not`/… it is an
+ * identifier operand (`if x is set …` — `set` is a value, not the body).
+ */
+const OPERAND_INTRODUCERS = new Set([
+  'is',
+  'am',
+  'are',
+  'not',
+  'no',
+  'and',
+  'or',
+  '==',
+  '===',
+  '!=',
+  '!==',
+  '<',
+  '>',
+  '<=',
+  '>=',
+  '+',
+  '-',
+  '*',
+  '/',
+  'mod',
+]);
+
+/**
+ * Would this token START a body command, given the token before it?
+ *
+ * `checkIsCommand()`/`isCommand()` alone answer "is this spelled like a
+ * command?", which misclassifies two condition positions:
+ *
+ * 1. The FIRST token after `if`/`unless` — the condition is never empty, so the
+ *    first token is always condition, even spelled like a command
+ *    (`if log is 3 …`).
+ * 2. A token right after an operator — it is an operand (`if x is set …`).
+ *
+ * Both misclassifications previously made the form-detection scans (and the
+ * single-line condition loop) treat the condition's first word as the body,
+ * failing shapes upstream accepts. See
+ * docs-internal/HANDOFF-command-word-in-if-condition.md.
+ */
+function isBodyCommandStart(ctx: ParserContext, prevToken: Token | null, token: Token): boolean {
+  if (prevToken === null) {
+    return false; // first token after if/unless — always condition
+  }
+  if (OPERAND_INTRODUCERS.has(prevToken.value?.toLowerCase?.() ?? '')) {
+    return false; // operand position
+  }
+  return ctx.checkIsCommand() || ctx.isCommand(token.value?.toLowerCase());
+}
+
 export function parseIfCommand(ctx: ParserContext, commandToken: Token): CommandNode {
   const args: ASTNode[] = [];
 
@@ -417,22 +472,28 @@ export function parseIfCommand(ctx: ParserContext, commandToken: Token): Command
   // multi-line either way, while the header-`then` consumption below now checks
   // the token instead of trusting this flag.
   //
-  // The scan IS bounded, but at the first COMMAND (below) — not at
-  // `commandToken.line`. #785 considered the line bound and rejected it; that
-  // remains the right call, because a header `then` is allowed to sit on the line
-  // AFTER the condition, so a line bound reclassifies that legitimate form
-  // (parser-integration.test.ts:381, and the guard in then-as-separator.test.ts).
+  // The scan IS bounded, but by the COMMAND-CHAIN rule, not by
+  // `commandToken.line`. #785 considered the plain line bound and rejected it;
+  // that remains the right call, because a header `then` is allowed to sit on
+  // the line AFTER the condition, so a line bound reclassifies that legitimate
+  // form (parser-integration.test.ts:381, and the guard in
+  // then-as-separator.test.ts).
   //
-  // #785's other reason for leaving this unbounded entirely — that the
-  // single-line shapes a bound would newly reach were broken anyway by the
-  // implicit multi-line scan below — no longer applies; that defect is fixed
-  // (see the line-bound there, and docs-internal/HANDOFF-implicit-multiline-if.md).
-  // Unbounded, this scan crossed newlines into a BODY `then` on a later line and
-  // made a single-line `if` multi-line, swallowing that whole line — the same
-  // silent failure by a third route.
+  // The rule: a `then` binds this `if` only while the scan has not crossed onto
+  // a line that STARTS a new command. Commands on the `if`'s own line are the
+  // single-line body — their joining `then`s bind (upstream keeps then-joined
+  // commands in the body: `if c add .a then add .b` is BOTH conditional). A
+  // command starting a LATER line begins a SIBLING, so a `then` beyond it is
+  // that sibling's separator and must not make this `if` multi-line
+  // (`if 1 is 1 log 'a'` newline `set x to 1 then log 'b'` — the second line
+  // must stay outside the block). A pure first-command bound was tried and
+  // over-corrected: it also broke at command-WORDS inside the condition
+  // (`if log is 3 then …`, `if x is set then …`), failing shapes upstream
+  // accepts — see docs-internal/HANDOFF-command-word-in-if-condition.md.
   let hasThen = false;
   const savedPosForThen = ctx.savePosition();
   const maxThenLookahead = 500; // Increased to handle large conditional expressions
+  let prevForThen: Token | null = null;
   for (let i = 0; i < maxThenLookahead && !ctx.isAtEnd(); i++) {
     const token = ctx.peek();
     if (token.value === KEYWORDS.THEN) {
@@ -448,13 +509,16 @@ export function parseIfCommand(ctx: ParserContext, commandToken: Token): Command
     ) {
       break;
     }
-    // Bound at the FIRST COMMAND: a header `then` always precedes the body, so
-    // any `then` beyond this point belongs to a BODY command and must not make
-    // the `if` multi-line. This is what separates the two directly — a bound on
-    // `commandToken.line` cannot, because the header `then` is allowed to sit on
-    // the line AFTER the condition.
-    if (ctx.checkIsCommand() || ctx.isCommand(token.value?.toLowerCase())) {
+    // Chain-break bound: a command starting a LATER line begins a sibling.
+    if (
+      token.line !== undefined &&
+      token.line !== commandToken.line &&
+      isBodyCommandStart(ctx, prevForThen, token)
+    ) {
       break;
+    }
+    if (!isComment(token)) {
+      prevForThen = token;
     }
     ctx.advance();
   }
@@ -475,6 +539,13 @@ export function parseIfCommand(ctx: ParserContext, commandToken: Token): Command
     // Set once the FIRST command is found on the `if`'s own line — i.e. the form
     // question is already answered as single-line. See the line-bound below.
     let firstCommandOnIfLine = false;
+    // Previous non-comment token, for isBodyCommandStart: the first token after
+    // `if` is always condition, and a token after an operator is an operand —
+    // without those two exemptions a command-WORD in the condition
+    // (`if log is 3 …`, `if x is set …`) was read as the body's first command
+    // and the form detection collapsed. See
+    // docs-internal/HANDOFF-command-word-in-if-condition.md.
+    let prevToken: Token | null = null;
 
     // Scan forward to find the FIRST command after the condition
     while (!ctx.isAtEnd() && ctx.current - savedPosition < maxLookahead) {
@@ -518,7 +589,7 @@ export function parseIfCommand(ctx: ParserContext, commandToken: Token): Command
       }
 
       // When we find the FIRST command, check its line position
-      if (ctx.checkIsCommand() || ctx.isCommand(tokenValue)) {
+      if (isBodyCommandStart(ctx, prevToken, token)) {
         // If first command is on a DIFFERENT line than if, it's multi-line
         // If first command is on the SAME line as if, it's single-line
         if (token.line !== undefined && token.line !== ifStatementLine) {
@@ -529,6 +600,9 @@ export function parseIfCommand(ctx: ParserContext, commandToken: Token): Command
         firstCommandOnIfLine = true;
       }
 
+      if (!isComment(token)) {
+        prevToken = token;
+      }
       ctx.advance();
     }
 
@@ -550,13 +624,24 @@ export function parseIfCommand(ctx: ParserContext, commandToken: Token): Command
     const maxIterations = 20; // Safety limit to prevent infinite loops
     let iterations = 0;
 
+    // The FIRST expression parse is unguarded: the condition is never empty, so
+    // the first token after `if` can never be the body command — even when it is
+    // spelled like one (`if log is 3 add .a to #t` — the condition is
+    // `log is 3`). With the guard applied from token 0, that shape parsed ZERO
+    // condition tokens and died with "Expected condition after if/unless"
+    // (silently, when inside a handler — see
+    // docs-internal/HANDOFF-command-word-in-if-condition.md). The command guard
+    // applies from the second parse on, where a command token really does start
+    // the body.
+    let firstConditionParse = true;
+
     while (
       !ctx.isAtEnd() &&
-      !ctx.checkIsCommand() &&
-      !ctx.isCommand(ctx.peek().value) &&
       !ctx.check(KEYWORDS.THEN) &&
+      (firstConditionParse || (!ctx.checkIsCommand() && !ctx.isCommand(ctx.peek().value))) &&
       iterations < maxIterations
     ) {
+      firstConditionParse = false;
       const beforePos = ctx.savePosition();
       // Use parseLogicalAnd() to handle binary operators like 'is a' and unary operators like 'not'
       // This is one level below parseLogicalOr() to avoid consuming 'or' which might be part of pattern syntax

--- a/packages/core/src/parser/command-parsers/control-flow-commands.ts
+++ b/packages/core/src/parser/command-parsers/control-flow-commands.ts
@@ -415,13 +415,25 @@ export function parseIfCommand(ctx: ParserContext, commandToken: Token): Command
   // to a BODY command rather than to the `if` header. That is tolerated on
   // purpose: `hasThen` only feeds `isMultiLine`, and a body spanning lines is
   // multi-line either way, while the header-`then` consumption below now checks
-  // the token instead of trusting this flag. Bounding the scan to
-  // `commandToken.line` was tried and rejected — it is a near-no-op given that
-  // check, it would reclassify the legitimate `then`-on-the-next-line form
-  // (parser-integration.test.ts:381), and the single-line shapes it would newly
-  // reach are broken by an INDEPENDENT pre-existing defect in the implicit
-  // multi-line scan below: `if 1 is 1 log 'a'\nlog 'b'` already swallows
-  // `log 'b'` into the block with a bogus "Expected 'end'", no `then` involved.
+  // the token instead of trusting this flag.
+  //
+  // Bounding the scan to `commandToken.line` remains WRONG: it would reclassify
+  // the legitimate `then`-on-the-next-line header form
+  // (parser-integration.test.ts:381, and the guard in then-as-separator.test.ts).
+  //
+  // #785 gave a second reason for leaving this unbounded — that the single-line
+  // shapes a bound would newly reach were broken anyway by the implicit
+  // multi-line scan below. That defect is now FIXED (see the line-bound in that
+  // scan, and docs-internal/HANDOFF-implicit-multiline-if.md), so only the
+  // next-line-header reason still stands.
+  //
+  // Residual, deliberately NOT fixed here: a single-line `if` whose FOLLOWING
+  // line contains a body `then` (`if 1 is 1 log 'a'` + `set x to 1 then log 'b'`)
+  // is still misread as multi-line and swallows that line. Bounding this scan at
+  // the FIRST COMMAND — not at the line — fixes it while preserving the
+  // next-line header form, since a header `then` always precedes the body. That
+  // change measured green on the core suite and the multilingual ratchet; it is
+  // queued in docs-internal/PARSER_NEXT_STEPS.md to land with its own coverage.
   let hasThen = false;
   const savedPosForThen = ctx.savePosition();
   const maxThenLookahead = 500; // Increased to handle large conditional expressions
@@ -456,11 +468,29 @@ export function parseIfCommand(ctx: ParserContext, commandToken: Token): Command
     const savedPosition = ctx.savePosition();
     const ifStatementLine = commandToken.line; // Line where 'if' keyword appears
     const maxLookahead = 100;
+    // Set once the FIRST command is found on the `if`'s own line — i.e. the form
+    // question is already answered as single-line. See the line-bound below.
+    let firstCommandOnIfLine = false;
 
     // Scan forward to find the FIRST command after the condition
     while (!ctx.isAtEnd() && ctx.current - savedPosition < maxLookahead) {
       const token = ctx.peek();
       const tokenValue = token.value?.toLowerCase();
+
+      // Once the first command has been seen on the `if`'s own line, the only
+      // reason to keep scanning is a same-line `else`/`end` (see below), so the
+      // moment the scan leaves that line there is nothing left for it to find.
+      //
+      // Without this bound the scan ran on into the NEXT line, found the
+      // following sibling command, and set `hasImplicitMultiLineEnd` — defeating
+      // the "FIRST command" rule by the second command. `if 1 is 1 log 'a'` +
+      // `log 'b'` on the next line swallowed `log 'b'` into the if-block, so it
+      // stopped running whenever the condition was false, with only a recovered
+      // "Expected 'end' after if block" (ok/success both stayed true) to show for
+      // it. See docs-internal/HANDOFF-implicit-multiline-if.md.
+      if (firstCommandOnIfLine && token.line !== undefined && token.line !== ifStatementLine) {
+        break;
+      }
 
       // Stop at structural boundaries
       if (
@@ -492,6 +522,7 @@ export function parseIfCommand(ctx: ParserContext, commandToken: Token): Command
           break;
         }
         // Don't break - continue scanning to find 'else' or 'end' on same line
+        firstCommandOnIfLine = true;
       }
 
       ctx.advance();


### PR DESCRIPTION
Works the top entry of `docs-internal/PARSER_NEXT_STEPS.md`, its sequenced follow-up,
and — after branch-vs-main probing caught the first attempt regressing five shapes —
the command-word-condition defect underneath all of it. Four commits, each with its
own coverage; the fourth repairs the second's over-correction before any of it
reached `main`.

## 1. The defect — `93225096`

`parseIfCommand`'s implicit-multi-line lookahead decides the form from the FIRST
command's line: same line as the `if` means single-line, a different line means
multi-line. It answered that correctly and then kept walking, reached the NEXT
line's command, and set `hasImplicitMultiLineEnd` — so the rule was defeated by
the second command.

```hyperscript
if 1 is 2 add .a to #t     -- condition FALSE
add .b to #t               -- sibling; must run regardless
```

Both `add`s landed inside the block, so neither class was applied. Upstream
`hyperscript.org` accepts this source and runs `add .b`.

This is the mirror image of the `then` defect fixed in #785: that one hoisted a
conditional body OUT so it ran unconditionally, this pulls an unconditional
command IN so it stops running. Same shape as #785 in the channel that matters —
`ok`/`success` both stayed true, and the only trace was a recovered
`Expected 'end' after if block`.

The scan is now bounded to the `if`'s own line once the first command is found
there. **The branch's missing `break` is deliberate and stays missing** — the scan
must still run past that command to find a same-line `else`/`end`
(`if x > 3 set y to 1 else set y to 2 end`), which the guards pin.

## 2. The `hasThen` follow-up — `3a5dd9a3`, corrected by `bb2074e3`

#785 left the `hasThen` lookahead unbounded partly *because* of the defect above,
and asked for a re-evaluation once it was fixed. Fixing the implicit scan left one
more route to the same failure: `hasThen` crosses newlines, so a `then` used as a
command separator on a LATER line made a single-line `if` multi-line and swallowed
that whole line.

This commit bounded the scan at the **first command token**. That was an
over-correction — see commit 4 — and the bound that survives is the
**command-chain rule**: a `then` binds the `if` only while the scan has not
crossed onto a line that starts a new command. Same-line then-joined bodies bind
(upstream keeps then-joined commands in the body); a command starting a later
line begins a sibling. The `commandToken.line` bound #785 rejected stays
rejected — a header `then` may sit on the line after the condition.

## 3. Queue entry — `f8db9a78`

Filed `HANDOFF-command-word-in-if-condition.md`: a single-line `if`/`unless`
whose condition starts with a bare identifier that is also a command name
(`log`, `set`, `add`, …) breaks — loudly at top level, **silently in a handler**,
where recovery drops the `if` node and its body runs unconditionally. Filed as
"not fixed here"; superseded by commit 4, which fixes it.

## 4. The repair — `bb2074e3`

Probing candidate shapes **branch-vs-main** (single-file swap, upstream oracle)
showed commits 1–2 had regressed **five upstream-valid shapes** that parsed
cleanly on `main` — four fatal, one silent:

| # | Shape | main | pre-repair branch |
| - | ----- | ---- | ----------------- |
| A | `if log is 3` ⏎ body ⏎ `end` | clean | fatal |
| B | `if log is 3 then` ⏎ body ⏎ `end` | clean | fatal |
| C | `if x is set then` ⏎ body ⏎ `end` | clean | fatal |
| C2 | `if x is set` ⏎ `then` body ⏎ `end` | clean | fatal |
| D | `if c add .a to #t then add .b to #t` | both conditional | `.b` unconditional — **silent** |

Cause: the bounds were built on `checkIsCommand()`, the same broken classifier as
the queued defect — it answers "is this token *spelled* like a command?", and
`main`'s scan bugs had been accidentally rescuing command-word conditions by
misrouting them through `parseExpression()` (which handles command-word operands
fine). **Every gate stayed green throughout** — no in-repo source or corpus
pattern puts a command word in an `if` condition, so the gates are structurally
blind here; branch-vs-main probing was the only detector.

The repair replaces the question with command **position** (`isBodyCommandStart`):

1. **The condition is never empty** → the first token after `if`/`unless` is
   never the body. The condition loop's first expression parse is unguarded,
   which fixes the queued defect outright: `if log is 3 add .a to #t` parses
   with condition `log is 3`, in every form, handler included.
2. **A token right after an operator is an operand** → `if x is set …` keeps
   `set` in the condition.
3. **A newline without `then` breaks a command chain** → the chain rule above.

Residual (low, queued): command-words in mid-condition positions that are neither
first nor operator-preceded can still mislead the form scans; the follow-on that
removes the heuristics entirely is expression-first condition parsing (viable —
the pratt parser accepts command-word operands, measured). The handoff carries
the full episode and design.

## Coverage

The shipped-sources gate is **not** the regression test for any of this — no
shipped example trips these shapes, so it would pass a broken fix. Coverage was
written first at each step, into the two files #785 established, keeping their
existing guards:

| | parse shape | DOM effect |
| --- | --- | --- |
| implicit-multiline (commit 1) | 11 cases | 5 cases |
| `hasThen` bound (commit 2) | 4 cases | 2 cases |
| repair + command-word class (commit 4) | 11 cases | 3 cases |

Parse-shape cases go through `parseClean`, so each asserts the recovered-error
channel is empty *and* where the commands actually landed — `success`/`ok` prove
nothing, they were already true against every bug here. Red-verified by stashing
each fix: 13/22 (commits 1–2) and 12/14 (commit 4) fail against the respective
unfixed parser; the rest are guards that must pass in both states. Every new test
source is upstream-verified via `loadCanonicalParser()`.

## Gates (re-run after every commit)

- `test:check --prefix packages/core` — **7665 passed** (7629 baseline + 36)
- `typecheck --prefix packages/core` — clean
- multilingual `--full --bundle browser-priority --regression` — no regression on
  all 10 signals (against a freshly `populate`d DB)
- full workspace `test:check` — exit 0
- prettier — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
