### PR TITLE
test: shipped-examples execution gate — upstream as the behavioral oracle

### DIFF
--- a/docs-internal/HANDOFF-shipped-examples-execution.md
+++ b/docs-internal/HANDOFF-shipped-examples-execution.md
@@ -1,0 +1,107 @@
+# Handoff: the shipped-examples execution gate
+
+> **Landed 2026-07-27** (branch `feat/shipped-examples-execution-gate`). Closes
+> the "Nothing executes a shipped example" entry in
+> [PARSER_NEXT_STEPS.md](PARSER_NEXT_STEPS.md) — the systemic gap behind both
+> `if`-defect arcs: every parse-level gate stayed green while
+> `native-dialog.html` shipped with its conditional body running
+> unconditionally (#785), and again while five upstream-valid shapes regressed
+> on a PR branch (#786).
+
+## What it is
+
+`packages/testing-framework/src/multilingual/shipped-examples-execution.ts`
+(+ `.test.ts`, + `baselines/shipped-examples-execution.json`).
+
+Every eligible `_="…"` handler in `examples/**` is executed on BOTH engines in
+jsdom — hyperfixi via parse + a fresh `Runtime` with the element as context
+(the browser attribute-processor shape), upstream `hyperscript.org` via
+`processNode` — its trigger event dispatched, and the two DOM **effect
+signatures** diffed against each other. Upstream is the behavioral oracle, the
+role R4 gives it for validity. The signature machinery is shared with the R2
+execution ratchet (`effect-signature.ts`), deliberately: the two gates can
+never disagree about what a DOM effect is.
+
+Three assertions, matching the shipped-sources gate: sanity floors (pages,
+handlers, comparisons, **non-vacuous** matches), no NEW divergence outside the
+committed allowlist, no stale allowlist entry. The allowlist key embeds a
+source hash, so fixing a handler forces its entry's removal — the list only
+ratchets down.
+
+Current numbers (2026-07-27): 55 pages, 333 handlers, 162 compared
+(74 real matches, 42 vacuous empty-vs-empty pairs — counted separately, never
+as parity), 46 allowlisted divergences in six triaged families, 171 skips each
+with a recorded reason (upstream-rejects 51, non-event handlers 27, `wait` 26,
+hyperfixi-recovers 25, `fetch` 13, js-blocks 11, …).
+
+## The finding families (burn-down list)
+
+The 46 baseline entries collapse to six families — reasons live per-entry in
+the baseline JSON:
+
+1. **Element-target write semantics** (24): `increment #count` / `decrement` /
+   `set #x to v` — hyperfixi writes `textContent` in place; upstream's diff is
+   `-div:14#count`, the element GONE from the after-snapshot. Which engine
+   matches real-browser behavior is the open question — check in a browser
+   before "fixing" either.
+2. **show/hide strategy** (13): hyperfixi uses class + inline display; upstream
+   consults computed styles and is inert under jsdom. Includes the
+   form-validation and tabs entries (their `show`/`hide` legs are what differ).
+3. **`swap` extension** (4): upstream parses the source but has no `swap`
+   command — no oracle for the effect, only for the no-crash.
+4. **Boolean-attribute toggles** (3): `toggle @disabled` representation
+   differs.
+5. **Unmet event filter still fires** (1): `on keydown[key=='Escape'] from
+   window hide .modal-overlay` — the dispatched Event has no `.key`, so the
+   filter is false; upstream correctly does nothing, **hyperfixi hides every
+   modal anyway**. REAL BUG CANDIDATE — the strongest single finding. Verify
+   the filter path in `packages/core` and fix; the gate entry then goes stale
+   and forces its own removal.
+6. **js property-path argument** (1): `put document.getElementById(...).value
+   into #result4` — hyperfixi produces no effect. REAL BUG CANDIDATE.
+
+Also surfaced, outside the allowlist (it diverges as part of family 1):
+`set #count to 0` produces NOTHING on hyperfixi while `increment #count` on
+the same page works — the `set <idref> to <value>` form looks broken on its
+own.
+
+## Harness lessons (they cost hours; read before touching)
+
+- **jsdom globals must be RE-pointed every swap.** Copying only missing keys
+  left every DOM constructor bound to the first page; both engines'
+  `instanceof` checks then silently failed for later pages' elements
+  (upstream produced empty signatures for `on click put 'Hello' into #output`).
+  `installGlobals` tracks what it owns and re-points it each call.
+- **The api singleton binds its first document.** `hyperscript.eval` resolved
+  later pages' selectors against page 1 (correct in a browser — document
+  identity never changes in a realm; fatal in a multi-page harness). Fresh
+  `Runtime` + `createContext(el)` per handler is the R2-proven shape.
+- **Per-handler isolation, not sequential dispatch.** Dispatching all handlers
+  in order on one page amplified ONE real divergence into a page of cascades
+  (upstream's inert element-`decrement` made `put 0 into #count` write
+  0-over-0 — invisible — so everything after diverged too), and let
+  double-failures hide as empty-vs-empty "matches". Fresh page pair per
+  handler; `vacuous` tracked separately from `match`.
+- **Flat snapshot indices cascade.** One engine-inserted element shifted every
+  later `tag[i]` key and turned a one-line diff into a churn storm. Elements
+  are stamped `data-exec-key` before the run (same page → same stamping both
+  engines); keys are identity, not position.
+- **Engine bookkeeping is not behavior.** `data-hyperscript-powered`,
+  `data-original-display`, `_`, `data-exec-key` are excluded from signatures
+  (`ENGINE_ATTRS`). This changed exactly one R2 locked signature
+  (`hide-with-transition`) and no fidelity numbers.
+- **The vitest file MUST run in the node environment** (`@vitest-environment
+  node` in its docblock). Under happy-dom the bootstrap refuses to overwrite
+  globals it does not own and every hyperfixi signature comes back empty —
+  0 real matches vs 74.
+
+## What v2 could add (deliberately out of scope)
+
+- `on load` / custom events (`hello`, `close`, `dragstart`) — 8 skips.
+- Timer/`wait` handlers under fake timers — 26 skips, the largest
+  deterministic-in-principle class.
+- `<script type="text/hyperscript">` blocks (behaviors/functions defined
+  on-page).
+- Doc-tree snippets, by synthesizing fixture pages.
+- Real-browser (Playwright) arbitration for family 1/2 divergences where
+  jsdom itself is the suspect.

--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -24,12 +24,13 @@ ones, because the gate *is* the tracking mechanism.
 
 | Item | Severity | Gate | Detail |
 | ---- | -------- | ---- | ------ |
+| **Unmet event filter still fires** | **high** — `on keydown[key=='Escape']` runs with no `.key`; upstream correctly does not | ✅ execution-gate allowlist entry | found by the execution gate; family 5 in [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md) |
 | **`tell` never consumes a terminating `end`** | medium — no real `tell … end` block form; upstream requires one | **none** | comment at `packages/core/src/parser/command-parsers/utility-commands.ts` (the `ELSE`/`END` break in `parseTellCommand`) |
-| **Nothing executes a shipped example** | medium — `examples/**` is parsed but never run | **none** | "Wider question" in [HANDOFF-if-block-then-separator.md](HANDOFF-if-block-then-separator.md) |
+| **`set <idref> to <value>` / js property-path args no-op** | medium — silent no-effect on shipped pages | ✅ execution-gate allowlist entries | families 1/6 in [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md) |
 | `and` is not a command separator anywhere | low — consistent everywhere, so no surprise | ✅ 2 `KNOWN GAP` tests | `packages/core/src/parser/__tests__/then-as-separator.test.ts` |
 | `sortable-list.html` recovers with errors | low — one shipped example | ✅ allowlist ratchet | `packages/testing-framework/baselines/shipped-sources-validity.json` |
 
-### Why the gated two need no doc to survive
+### Why the gated entries need no doc to survive
 
 - **`and`** — the two `KNOWN GAP` tests assert the *current, wrong* shape. Anyone
   who fixes the pratt parser breaks them immediately and is forced to decide
@@ -37,10 +38,25 @@ ones, because the gate *is* the tracking mechanism.
 - **`sortable-list.html`** — the allowlist key embeds `sha1(source)`, and
   assertion 3 of the shipped-sources gate **fails** when an allowlisted source
   goes clean. The list can only ratchet down. It cannot be silently forgotten.
+- **The execution-gate entries** (event filter; `set <idref>` / js-path no-ops) —
+  same mechanism as `sortable-list.html`: their allowlist keys in
+  `packages/testing-framework/baselines/shipped-examples-execution.json` embed a
+  source hash, and the gate's stale-entry assertion fails when a divergence
+  converges, forcing the entry's removal in the fixing change.
 
-The ungated two have no such mechanism. **They are what this document is for.**
+The ungated one (`tell`) has no such mechanism. **It is what this document is
+for.**
 
-## Notes on the ungated two
+## Notes
+
+**The `examples/**` execution gap is CLOSED** (2026-07-27): the shipped-examples
+execution gate runs every eligible `_=` handler on both hyperfixi and the real
+`hyperscript.org` engine in jsdom and ratchets on DOM-effect divergence —
+upstream as the behavioral oracle, the R4 pattern applied to behavior. It is
+what would have caught the #785 defect on *behaviour* rather than on a
+diagnostic. Design, current numbers, the six divergence families, and the
+harness lessons: [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md).
+Its first sweep produced the two bug-candidate rows in the table above.
 
 **Expression-first condition parsing** is the deferred follow-on from the `if`
 family (see History). #786 replaced the raw "is this token spelled like a
@@ -56,17 +72,13 @@ work rather than extending `OPERAND_INTRODUCERS` piecemeal. Detail + the
 regression episode that motivates it:
 [HANDOFF-command-word-in-if-condition.md](HANDOFF-command-word-in-if-condition.md).
 
-**No execution test for `examples/**`** is the systemic one. #785 added
-`packages/core/src/api/if-body-then-execution.test.ts`, which is the right shape
-(compile, run in jsdom, assert the DOM) but only covers hand-written sources. The
-R2 execution ratchet does this for 47 curated corpus patterns
-(`avgExecutionFidelity`); extending something like it to `examples/**` is the
-natural follow-on. It is what would have caught the #785 defect on *behaviour*
-rather than on a diagnostic — `native-dialog.html` shipped with its conditional
-body running unconditionally and every parse-level gate was green.
-
 ## History
 
+- **2026-07-27** — shipped-examples execution gate landed: `examples/**`
+  handlers executed on both engines in jsdom, DOM-effect divergence ratcheted
+  against `hyperscript.org` as the behavioral oracle. 46 divergences baselined
+  in six families; two promoted to bug-candidate rows above. Brief:
+  [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md).
 - **2026-07-27 (#786, repair commit)** — command-name words in `if`/`unless`
   conditions (`if log is 3 add .a` died with "Expected condition"; in a handler
   the `if` vanished and its body ran unconditionally, `ok: true`). Fixed by

--- a/packages/testing-framework/baselines/shipped-examples-execution.json
+++ b/packages/testing-framework/baselines/shipped-examples-execution.json
@@ -1,0 +1,518 @@
+{
+  "//": [
+    "Allowlist for the shipped-examples execution gate (shipped-examples-execution.test.ts).",
+    "Each entry is a shipped handler whose DOM effect DIVERGES between hyperfixi and the",
+    "real hyperscript.org engine when its trigger event is dispatched in jsdom.",
+    "Keys embed a hash of the source: editing the handler changes the key, so entries go",
+    "stale and the stale-entry assertion forces their removal — the list only ratchets down.",
+    "Reasons are family-level triage; see docs-internal/HANDOFF-shipped-examples-execution.md."
+  ],
+  "allowedDivergences": [
+    {
+      "key": "examples/behaviors/recipes.html::4e3f86c536::keyup",
+      "file": "examples/behaviors/recipes.html",
+      "event": "keyup",
+      "excerpt": "on keyup show <blockquote/> in the next <div/> when its textContent contains my value",
+      "hyperfixi": [
+        "Δinput:45 cls[show] attr[placeholder=Search quotes…,type=text] style[] text[]"
+      ],
+      "upstream": [],
+      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+    },
+    {
+      "key": "examples/dialogs/modal.html::37ad17f250::click",
+      "file": "examples/dialogs/modal.html",
+      "event": "click",
+      "excerpt": "on click show #info-modal",
+      "hyperfixi": [
+        "Δdiv:16#info-modal cls[modal-overlay show] attr[id=info-modal] style[] text[]"
+      ],
+      "upstream": [],
+      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+    },
+    {
+      "key": "examples/dialogs/modal.html::8dbe740dd3::click",
+      "file": "examples/dialogs/modal.html",
+      "event": "click",
+      "excerpt": "on click show #confirm-modal",
+      "hyperfixi": [
+        "Δdiv:31#confirm-modal cls[modal-overlay show] attr[id=confirm-modal] style[] text[]"
+      ],
+      "upstream": [],
+      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+    },
+    {
+      "key": "examples/dialogs/modal.html::c9f964d2a2::click",
+      "file": "examples/dialogs/modal.html",
+      "event": "click",
+      "excerpt": "on click show #form-modal",
+      "hyperfixi": [
+        "Δdiv:46#form-modal cls[modal-overlay show] attr[id=form-modal] style[] text[]"
+      ],
+      "upstream": [],
+      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+    },
+    {
+      "key": "examples/dialogs/modal.html::27fb619873::keydown",
+      "file": "examples/dialogs/modal.html",
+      "event": "keydown",
+      "excerpt": "on keydown[key=='Escape'] from window hide .modal-overlay",
+      "hyperfixi": [
+        "Δdiv:16#info-modal cls[modal-overlay] attr[id=info-modal] style[display: none;] text[]",
+        "Δdiv:31#confirm-modal cls[modal-overlay] attr[id=confirm-modal] style[display: none;] text[]",
+        "Δdiv:46#form-modal cls[modal-overlay] attr[id=form-modal] style[display: none;] text[]",
+        "Δdiv:68#behavior-modal cls[modal-overlay] attr[id=behavior-modal] style[display: none;] text[]"
+      ],
+      "upstream": [],
+      "reason": "hyperfixi runs the handler although the event filter [key=='Escape'] is unmet (dispatched Event has no .key; undefined=='Escape' is false) — REAL BUG CANDIDATE, queued in PARSER_NEXT_STEPS.md"
+    },
+    {
+      "key": "examples/events-and-dom/counter.html::6f9009e740::click",
+      "file": "examples/events-and-dom/counter.html",
+      "event": "click",
+      "excerpt": "on click decrement #count",
+      "hyperfixi": [
+        "Δdiv:14#count cls[counter-display] attr[id=count] style[] text[-1]",
+        "Δspan:20#count-mirror cls[] attr[id=count-mirror] style[] text[-1]"
+      ],
+      "upstream": ["-div:14#count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/events-and-dom/counter.html::7f5ebb38b0::click",
+      "file": "examples/events-and-dom/counter.html",
+      "event": "click",
+      "excerpt": "on click increment #count",
+      "hyperfixi": [
+        "Δdiv:14#count cls[counter-display] attr[id=count] style[] text[1]",
+        "Δspan:20#count-mirror cls[] attr[id=count-mirror] style[] text[1]"
+      ],
+      "upstream": ["-div:14#count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/events-and-dom/show-hide.html::8aeb3a46f9::click",
+      "file": "examples/events-and-dom/show-hide.html",
+      "event": "click",
+      "excerpt": "on click show #content1",
+      "hyperfixi": ["Δdiv:26#content1 cls[content-box show] attr[id=content1] style[] text[]"],
+      "upstream": [],
+      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+    },
+    {
+      "key": "examples/experiments/01-polyglot-playground.html::6f9009e740::click",
+      "file": "examples/experiments/01-polyglot-playground.html",
+      "event": "click",
+      "excerpt": "on click decrement #count",
+      "hyperfixi": ["Δdiv:29#count cls[demo-counter] attr[id=count] style[] text[-1]"],
+      "upstream": ["-div:29#count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/experiments/01-polyglot-playground.html::7f5ebb38b0::click",
+      "file": "examples/experiments/01-polyglot-playground.html",
+      "event": "click",
+      "excerpt": "on click increment #count",
+      "hyperfixi": ["Δdiv:29#count cls[demo-counter] attr[id=count] style[] text[1]"],
+      "upstream": ["-div:29#count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/experiments/02-multilingual-sync.html::227e004ae8::click",
+      "file": "examples/experiments/02-multilingual-sync.html",
+      "event": "click",
+      "excerpt": "on click decrement #shared-count then call window.logAction('decrement')",
+      "hyperfixi": [
+        "Δdiv:11#shared-count cls[shared-counter] attr[id=shared-count] style[] text[-1]"
+      ],
+      "upstream": ["-div:11#shared-count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/experiments/02-multilingual-sync.html::aeeb82b882::click",
+      "file": "examples/experiments/02-multilingual-sync.html",
+      "event": "click",
+      "excerpt": "on click increment #shared-count then call window.logAction('increment')",
+      "hyperfixi": [
+        "Δdiv:11#shared-count cls[shared-counter] attr[id=shared-count] style[] text[1]"
+      ],
+      "upstream": ["-div:11#shared-count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/experiments/03-adaptive-rtl-ltr.html::f701a8b242::click",
+      "file": "examples/experiments/03-adaptive-rtl-ltr.html",
+      "event": "click",
+      "excerpt": "on click decrement #counter",
+      "hyperfixi": ["Δdiv:35#counter cls[counter-value] attr[id=counter] style[] text[-1]"],
+      "upstream": ["-div:35#counter"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/experiments/03-adaptive-rtl-ltr.html::0d0a6b9a18::click",
+      "file": "examples/experiments/03-adaptive-rtl-ltr.html",
+      "event": "click",
+      "excerpt": "on click increment #counter",
+      "hyperfixi": ["Δdiv:35#counter cls[counter-value] attr[id=counter] style[] text[1]"],
+      "upstream": ["-div:35#counter"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/forms/form-validation.html::e85adbe538::input",
+      "file": "examples/forms/form-validation.html",
+      "event": "input",
+      "excerpt": "on input if my value contains '@' add .valid to me remove .error from me hide #email-error else add ",
+      "hyperfixi": [
+        "Δdiv:25#email-error cls[error-message show] attr[id=email-error] style[] text[\n                        ❌ Email must contain @ symbol\n                    ]",
+        "Δinput:24#email cls[error] attr[id=email,placeholder=you@example.com,type=email] style[] text[]"
+      ],
+      "upstream": [
+        "Δinput:24#email cls[error] attr[id=email,placeholder=you@example.com,type=email] style[] text[]"
+      ],
+      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+    },
+    {
+      "key": "examples/forms/form-validation.html::6b07d036d3::input",
+      "file": "examples/forms/form-validation.html",
+      "event": "input",
+      "excerpt": "on input if my value's length >= 8 add .valid to me remove .error from me hide #password-error else ",
+      "hyperfixi": [
+        "Δdiv:29#password-error cls[error-message show] attr[id=password-error] style[] text[\n                        ❌ Password must be at least 8 characters\n          ",
+        "Δinput:28#password cls[error] attr[id=password,placeholder=Enter password (min 8 characters),type=password] style[] text[]"
+      ],
+      "upstream": [
+        "Δinput:28#password cls[error] attr[id=password,placeholder=Enter password (min 8 characters),type=password] style[] text[]"
+      ],
+      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+    },
+    {
+      "key": "examples/forms/form-validation.html::467bb365ef::input",
+      "file": "examples/forms/form-validation.html",
+      "event": "input",
+      "excerpt": "on input if my value == #password's value add .valid to me remove .error from me hide #confirm-error",
+      "hyperfixi": [
+        "Δdiv:33#confirm-error cls[error-message show] attr[id=confirm-error] style[] text[\n                        ❌ Passwords do not match\n                    ]",
+        "Δinput:32#confirm cls[error] attr[id=confirm,placeholder=Re-enter password,type=password] style[] text[]"
+      ],
+      "upstream": [
+        "Δinput:32#confirm cls[error] attr[id=confirm,placeholder=Re-enter password,type=password] style[] text[]"
+      ],
+      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+    },
+    {
+      "key": "examples/multilingual/adaptive-rtl-ltr.html::f701a8b242::click",
+      "file": "examples/multilingual/adaptive-rtl-ltr.html",
+      "event": "click",
+      "excerpt": "on click decrement #counter",
+      "hyperfixi": ["Δdiv:35#counter cls[counter-value] attr[id=counter] style[] text[-1]"],
+      "upstream": ["-div:35#counter"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/multilingual/adaptive-rtl-ltr.html::0d0a6b9a18::click",
+      "file": "examples/multilingual/adaptive-rtl-ltr.html",
+      "event": "click",
+      "excerpt": "on click increment #counter",
+      "hyperfixi": ["Δdiv:35#counter cls[counter-value] attr[id=counter] style[] text[1]"],
+      "upstream": ["-div:35#counter"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/multilingual/index.html::6f9009e740::click",
+      "file": "examples/multilingual/index.html",
+      "event": "click",
+      "excerpt": "on click decrement #count",
+      "hyperfixi": ["Δdiv:51#count cls[counter-display] attr[id=count] style[] text[-1]"],
+      "upstream": ["-div:51#count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/multilingual/index.html::7f5ebb38b0::click",
+      "file": "examples/multilingual/index.html",
+      "event": "click",
+      "excerpt": "on click increment #count",
+      "hyperfixi": ["Δdiv:51#count cls[counter-display] attr[id=count] style[] text[1]"],
+      "upstream": ["-div:51#count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/multilingual/multilingual-sync.html::227e004ae8::click",
+      "file": "examples/multilingual/multilingual-sync.html",
+      "event": "click",
+      "excerpt": "on click decrement #shared-count then call window.logAction('decrement')",
+      "hyperfixi": [
+        "Δdiv:11#shared-count cls[shared-counter] attr[id=shared-count] style[] text[-1]"
+      ],
+      "upstream": ["-div:11#shared-count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/multilingual/multilingual-sync.html::aeeb82b882::click",
+      "file": "examples/multilingual/multilingual-sync.html",
+      "event": "click",
+      "excerpt": "on click increment #shared-count then call window.logAction('increment')",
+      "hyperfixi": [
+        "Δdiv:11#shared-count cls[shared-counter] attr[id=shared-count] style[] text[1]"
+      ],
+      "upstream": ["-div:11#shared-count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/multilingual/polyglot-playground.html::6f9009e740::click",
+      "file": "examples/multilingual/polyglot-playground.html",
+      "event": "click",
+      "excerpt": "on click decrement #count",
+      "hyperfixi": ["Δdiv:29#count cls[demo-counter] attr[id=count] style[] text[-1]"],
+      "upstream": ["-div:29#count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/multilingual/polyglot-playground.html::7f5ebb38b0::click",
+      "file": "examples/multilingual/polyglot-playground.html",
+      "event": "click",
+      "excerpt": "on click increment #count",
+      "hyperfixi": ["Δdiv:29#count cls[demo-counter] attr[id=count] style[] text[1]"],
+      "upstream": ["-div:29#count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/multilingual/showcase.html::406e02080b::click",
+      "file": "examples/multilingual/showcase.html",
+      "event": "click",
+      "excerpt": "on click decrement #counter-value",
+      "hyperfixi": [
+        "Δdiv:36#counter-value cls[counter-value] attr[id=counter-value] style[] text[-1]"
+      ],
+      "upstream": ["-div:36#counter-value"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/multilingual/showcase.html::3d4a481500::click",
+      "file": "examples/multilingual/showcase.html",
+      "event": "click",
+      "excerpt": "on click increment #counter-value",
+      "hyperfixi": [
+        "Δdiv:36#counter-value cls[counter-value] attr[id=counter-value] style[] text[1]"
+      ],
+      "upstream": ["-div:36#counter-value"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/multilingual/showcase.html::1db01d96f1::click",
+      "file": "examples/multilingual/showcase.html",
+      "event": "click",
+      "excerpt": "on click remove .active from .tab-btn then add .active to me then hide .tab-panel then show #panel1",
+      "hyperfixi": [
+        "Δdiv:96#panel1 cls[active show tab-panel] attr[id=panel1] style[display: block;] text[Content for Tab 1. This demonstrates multi-element coordination.]",
+        "Δdiv:97#panel2 cls[tab-panel] attr[id=panel2] style[display: none;] text[Content for Tab 2. The code removes .active from all tabs, then adds it to the clicked ",
+        "Δdiv:98#panel3 cls[tab-panel] attr[id=panel3] style[display: none;] text[Content for Tab 3. This pattern is common in UI frameworks.]"
+      ],
+      "upstream": [
+        "Δdiv:97#panel2 cls[tab-panel] attr[id=panel2] style[display: none;] text[Content for Tab 2. The code removes .active from all tabs, then adds it to the clicked ",
+        "Δdiv:98#panel3 cls[tab-panel] attr[id=panel3] style[display: none;] text[Content for Tab 3. This pattern is common in UI frameworks.]"
+      ],
+      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+    },
+    {
+      "key": "examples/multilingual/showcase.html::38866ac528::click",
+      "file": "examples/multilingual/showcase.html",
+      "event": "click",
+      "excerpt": "on click remove .active from .tab-btn then add .active to me then hide .tab-panel then show #panel2",
+      "hyperfixi": [
+        "Δbutton:92#tabs-demo-tab1 cls[tab-btn] attr[id=tabs-demo-tab1] style[] text[Tab 1]",
+        "Δbutton:93#tabs-demo-tab2 cls[active tab-btn] attr[id=tabs-demo-tab2] style[] text[Tab 2]",
+        "Δdiv:96#panel1 cls[active tab-panel] attr[id=panel1] style[display: none;] text[Content for Tab 1. This demonstrates multi-element coordination.]",
+        "Δdiv:97#panel2 cls[show tab-panel] attr[id=panel2] style[display: block;] text[Content for Tab 2. The code removes .active from all tabs, then adds it to the cl",
+        "Δdiv:98#panel3 cls[tab-panel] attr[id=panel3] style[display: none;] text[Content for Tab 3. This pattern is common in UI frameworks.]"
+      ],
+      "upstream": [
+        "Δbutton:92#tabs-demo-tab1 cls[tab-btn] attr[id=tabs-demo-tab1] style[] text[Tab 1]",
+        "Δbutton:93#tabs-demo-tab2 cls[active tab-btn] attr[id=tabs-demo-tab2] style[] text[Tab 2]",
+        "Δdiv:96#panel1 cls[active tab-panel] attr[id=panel1] style[display: none;] text[Content for Tab 1. This demonstrates multi-element coordination.]",
+        "Δdiv:98#panel3 cls[tab-panel] attr[id=panel3] style[display: none;] text[Content for Tab 3. This pattern is common in UI frameworks.]"
+      ],
+      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+    },
+    {
+      "key": "examples/multilingual/showcase.html::118be448a2::click",
+      "file": "examples/multilingual/showcase.html",
+      "event": "click",
+      "excerpt": "on click remove .active from .tab-btn then add .active to me then hide .tab-panel then show #panel3",
+      "hyperfixi": [
+        "Δbutton:92#tabs-demo-tab1 cls[tab-btn] attr[id=tabs-demo-tab1] style[] text[Tab 1]",
+        "Δbutton:94#tabs-demo-tab3 cls[active tab-btn] attr[id=tabs-demo-tab3] style[] text[Tab 3]",
+        "Δdiv:96#panel1 cls[active tab-panel] attr[id=panel1] style[display: none;] text[Content for Tab 1. This demonstrates multi-element coordination.]",
+        "Δdiv:97#panel2 cls[tab-panel] attr[id=panel2] style[display: none;] text[Content for Tab 2. The code removes .active from all tabs, then adds it to the clicked ",
+        "Δdiv:98#panel3 cls[show tab-panel] attr[id=panel3] style[display: block;] text[Content for Tab 3. This pattern is common in UI frameworks.]"
+      ],
+      "upstream": [
+        "Δbutton:92#tabs-demo-tab1 cls[tab-btn] attr[id=tabs-demo-tab1] style[] text[Tab 1]",
+        "Δbutton:94#tabs-demo-tab3 cls[active tab-btn] attr[id=tabs-demo-tab3] style[] text[Tab 3]",
+        "Δdiv:96#panel1 cls[active tab-panel] attr[id=panel1] style[display: none;] text[Content for Tab 1. This demonstrates multi-element coordination.]",
+        "Δdiv:97#panel2 cls[tab-panel] attr[id=panel2] style[display: none;] text[Content for Tab 2. The code removes .active from all tabs, then adds it to the clicked "
+      ],
+      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+    },
+    {
+      "key": "examples/multilingual/test-classic-i18n.html::7f5ebb38b0::click",
+      "file": "examples/multilingual/test-classic-i18n.html",
+      "event": "click",
+      "excerpt": "on click increment #count",
+      "hyperfixi": ["Δspan:17#count cls[counter] attr[id=count] style[] text[1]"],
+      "upstream": ["-span:17#count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/multilingual/test-classic-i18n.html::ffd8337a94::click",
+      "file": "examples/multilingual/test-classic-i18n.html",
+      "event": "click",
+      "excerpt": "on click set #count to 0",
+      "hyperfixi": [],
+      "upstream": ["-span:17#count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/swap-and-morph/swap-morph.html::f3c10ab34d::click",
+      "file": "examples/swap-and-morph/swap-morph.html",
+      "event": "click",
+      "excerpt": "on click set newCard to '<div class=card>Card added at start</div>' swap afterBegin of #strategies-l",
+      "hyperfixi": ["+div[31] cls[card] attr[] style[] text[Card added at start]"],
+      "upstream": [],
+      "reason": "hyperfixi `swap` command extension: upstream parses the source but has no swap command, so it no-ops"
+    },
+    {
+      "key": "examples/swap-and-morph/swap-morph.html::6e8c21c053::click",
+      "file": "examples/swap-and-morph/swap-morph.html",
+      "event": "click",
+      "excerpt": "on click set newCard to '<div class=card>Card added at end</div>' swap beforeEnd of #strategies-list",
+      "hyperfixi": ["+div[31] cls[card] attr[] style[] text[Card added at end]"],
+      "upstream": [],
+      "reason": "hyperfixi `swap` command extension: upstream parses the source but has no swap command, so it no-ops"
+    },
+    {
+      "key": "examples/swap-and-morph/swap-morph.html::6a5ba2e70d::click",
+      "file": "examples/swap-and-morph/swap-morph.html",
+      "event": "click",
+      "excerpt": "on click set newItem to '<div class=item>New Item (afterBegin)</div>' swap afterBegin of #item-list ",
+      "hyperfixi": ["+div[48] cls[item] attr[] style[] text[New Item (afterBegin)]"],
+      "upstream": [],
+      "reason": "hyperfixi `swap` command extension: upstream parses the source but has no swap command, so it no-ops"
+    },
+    {
+      "key": "examples/swap-and-morph/swap-morph.html::d66ad4c5eb::click",
+      "file": "examples/swap-and-morph/swap-morph.html",
+      "event": "click",
+      "excerpt": "on click set newItem to '<div class=item>New Item (beforeEnd)</div>' swap beforeEnd of #item-list wi",
+      "hyperfixi": ["+div[51] cls[item] attr[] style[] text[New Item (beforeEnd)]"],
+      "upstream": [],
+      "reason": "hyperfixi `swap` command extension: upstream parses the source but has no swap command, so it no-ops"
+    },
+    {
+      "key": "examples/swap-and-morph/test-property-access.html::e264f605a5::click",
+      "file": "examples/swap-and-morph/test-property-access.html",
+      "event": "click",
+      "excerpt": "on click put document.getElementById('test-input').value into #result4",
+      "hyperfixi": [],
+      "upstream": ["Δdiv:24#result4 cls[result] attr[id=result4] style[] text[null]"],
+      "reason": "js property-path argument (`document.getElementById(...).value`): hyperfixi produces no effect — REAL BUG CANDIDATE"
+    },
+    {
+      "key": "examples/toggle-and-state/toggle-attributes.html::34237b9d73::click",
+      "file": "examples/toggle-and-state/toggle-attributes.html",
+      "event": "click",
+      "excerpt": "on click toggle @disabled on #target-btn",
+      "hyperfixi": [
+        "Δbutton:52#target-btn cls[demo-target] attr[disabled=,id=target-btn] style[] text[\n                    Target Button\n                ]"
+      ],
+      "upstream": [
+        "Δbutton:52#target-btn cls[demo-target] attr[disabled=undefined,id=target-btn] style[] text[\n                    Target Button\n                ]",
+        "Δspan:55#disabled-status cls[] attr[id=disabled-status] style[] text[disabled]"
+      ],
+      "reason": "boolean-attribute toggle representation differs between engines. Pending investigation"
+    },
+    {
+      "key": "examples/toggle-and-state/toggle-attributes.html::6812ec8c63::click",
+      "file": "examples/toggle-and-state/toggle-attributes.html",
+      "event": "click",
+      "excerpt": "on click toggle @required on #email-input",
+      "hyperfixi": [
+        "Δinput:66#email-input cls[demo-target] attr[id=email-input,placeholder=Enter email...,required=,type=email] style[] text[]"
+      ],
+      "upstream": [
+        "Δinput:66#email-input cls[demo-target] attr[id=email-input,placeholder=Enter email...,required=undefined,type=email] style[] text[]"
+      ],
+      "reason": "boolean-attribute toggle representation differs between engines. Pending investigation"
+    },
+    {
+      "key": "examples/toggle-and-state/toggle-attributes.html::1d1cf3bb14::click",
+      "file": "examples/toggle-and-state/toggle-attributes.html",
+      "event": "click",
+      "excerpt": "on click toggle @disabled on #prop-btn",
+      "hyperfixi": [
+        "Δbutton:131#prop-btn cls[demo-target] attr[disabled=,id=prop-btn] style[] text[\n                    Another Target\n                ]"
+      ],
+      "upstream": [
+        "Δbutton:131#prop-btn cls[demo-target] attr[disabled=undefined,id=prop-btn] style[] text[\n                    Another Target\n                ]"
+      ],
+      "reason": "boolean-attribute toggle representation differs between engines. Pending investigation"
+    },
+    {
+      "key": "examples/vite-plugin-multilingual/index.html::3fed702e4e::click",
+      "file": "examples/vite-plugin-multilingual/index.html",
+      "event": "click",
+      "excerpt": "on click show #en-content",
+      "hyperfixi": [
+        "Δdiv:40#en-content cls[show] attr[id=en-content] style[] text[English content that can be shown/hidden.]"
+      ],
+      "upstream": [],
+      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+    },
+    {
+      "key": "examples/vite-plugin-multilingual/index.html::b0b708a0c6::click",
+      "file": "examples/vite-plugin-multilingual/index.html",
+      "event": "click",
+      "excerpt": "on click decrement #en-count",
+      "hyperfixi": ["Δspan:43#en-count cls[counter] attr[id=en-count] style[] text[-1]"],
+      "upstream": ["-span:43#en-count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/vite-plugin-multilingual/index.html::712d7ec0b1::click",
+      "file": "examples/vite-plugin-multilingual/index.html",
+      "event": "click",
+      "excerpt": "on click increment #en-count",
+      "hyperfixi": ["Δspan:43#en-count cls[counter] attr[id=en-count] style[] text[1]"],
+      "upstream": ["-span:43#en-count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/vite-plugin-test/index.html::cbac0b8e43::click",
+      "file": "examples/vite-plugin-test/index.html",
+      "event": "click",
+      "excerpt": "on click show #content",
+      "hyperfixi": [
+        "Δdiv:7#content cls[show] attr[id=content] style[] text[This content can be shown/hidden.]"
+      ],
+      "upstream": [],
+      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+    },
+    {
+      "key": "examples/vite-plugin-test/index.html::6f9009e740::click",
+      "file": "examples/vite-plugin-test/index.html",
+      "event": "click",
+      "excerpt": "on click decrement #count",
+      "hyperfixi": ["Δspan:14#count cls[counter] attr[id=count] style[] text[-1]"],
+      "upstream": ["-span:14#count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    },
+    {
+      "key": "examples/vite-plugin-test/index.html::7f5ebb38b0::click",
+      "file": "examples/vite-plugin-test/index.html",
+      "event": "click",
+      "excerpt": "on click increment #count",
+      "hyperfixi": ["Δspan:14#count cls[counter] attr[id=count] style[] text[1]"],
+      "upstream": ["-span:14#count"],
+      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+    }
+  ]
+}

--- a/packages/testing-framework/src/multilingual/effect-signature.ts
+++ b/packages/testing-framework/src/multilingual/effect-signature.ts
@@ -1,0 +1,92 @@
+/**
+ * DOM effect signatures — shared by the R2 execution validator (corpus
+ * patterns vs the en reference) and the shipped-examples execution gate
+ * (shipped handlers vs the upstream engine).
+ *
+ * A signature is a before/after diff of every element's identity-relevant
+ * state: classes, attributes, inline style, and leaf text. Selectors, classes,
+ * and attribute names are code (not translated), so signatures are directly
+ * comparable across languages — and across engines, which is what makes the
+ * upstream-oracle comparison possible at all.
+ *
+ * Extracted verbatim from validators/execution-validator.ts (R2), which now
+ * imports from here. Any change to the serialization changes BOTH gates'
+ * signatures at once, deliberately: the two must never disagree about what a
+ * DOM effect is.
+ */
+
+/**
+ * Attributes that are ENGINE bookkeeping, not page behavior: hyperscript
+ * source (`_`), hyperfixi's processed-marker, show/hide display memo, and the
+ * shipped-examples harness's identity keys. Excluded from signatures so a
+ * cross-engine comparison measures what the handler DID to the page, not how
+ * each engine annotates its own work. For R2 this changed exactly one locked
+ * signature (`hide-with-transition`, which loses its data-original-display
+ * memo) and no fidelity numbers — translations are compared against a same-run
+ * en reference, so both sides drop the memo together.
+ */
+const ENGINE_ATTRS = new Set([
+  '_',
+  'data-hyperscript-powered',
+  'data-original-display',
+  'data-exec-key',
+]);
+
+/**
+ * Serialize the identity-relevant state of one element.
+ * Leaf text only — container text would duplicate every child mutation.
+ */
+export function serializeElement(el: Element): string {
+  const attrs = Array.from(el.attributes)
+    .filter(a => a.name !== 'class' && a.name !== 'style' && !ENGINE_ATTRS.has(a.name))
+    .map(a => `${a.name}=${a.value}`)
+    .sort()
+    .join(',');
+  const classes = Array.from(el.classList).sort().join(' ');
+  const style = (el as HTMLElement).getAttribute('style') ?? '';
+  const text =
+    el.childNodes.length === 0 || (el.childNodes.length === 1 && el.firstChild?.nodeType === 3)
+      ? (el.textContent ?? '')
+      : '';
+  return `cls[${classes}] attr[${attrs}] style[${style}] text[${text}]`;
+}
+
+/**
+ * Snapshot every element under <body>. <body> participates under its own
+ * stable key (body-targeted effects must be visible).
+ *
+ * Keying: `data-exec-key` when present (stamped by the shipped-examples
+ * harness BEFORE the engine runs, so the key is the element's IDENTITY — an
+ * engine inserting or removing one element cannot shift every later element's
+ * key, which flat indices did: one injected node turned a one-line diff into a
+ * whole-page churn storm). Elements without a key (added during the run, and
+ * the whole R2 corpus fixture, which is never stamped) fall back to `#id` /
+ * `tag[document-order-index]` — R2's original keying, byte-identical for its
+ * signatures.
+ */
+export function snapshot(document: Document): Map<string, string> {
+  const out = new Map<string, string>();
+  out.set('body', serializeElement(document.body));
+  document.body.querySelectorAll('*').forEach((el, i) => {
+    const execKey = el.getAttribute?.('data-exec-key');
+    const key = execKey
+      ? `${el.tagName.toLowerCase()}:${execKey}${el.id ? `#${el.id}` : ''}`
+      : el.id
+        ? `#${el.id}`
+        : `${el.tagName.toLowerCase()}[${i}]`;
+    out.set(key, serializeElement(el));
+  });
+  return out;
+}
+
+/** Sorted, stable list of per-element changes between two snapshots. */
+export function diffSnapshots(before: Map<string, string>, after: Map<string, string>): string[] {
+  const effects: string[] = [];
+  for (const [k, v] of after) {
+    const b = before.get(k);
+    if (b === undefined) effects.push(`+${k} ${v}`);
+    else if (b !== v) effects.push(`Δ${k} ${v}`);
+  }
+  for (const k of before.keys()) if (!after.has(k)) effects.push(`-${k}`);
+  return effects.sort();
+}

--- a/packages/testing-framework/src/multilingual/shipped-examples-execution.test.ts
+++ b/packages/testing-framework/src/multilingual/shipped-examples-execution.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Shipped-examples execution gate (see shipped-examples-execution.ts for the
+ * why and the execution model).
+ *
+ * Executes every eligible `_="…"` handler shipped in `examples/**` on BOTH
+ * hyperfixi and the real `hyperscript.org` engine, in jsdom, and ratchets on
+ * divergence of their DOM effect signatures. Upstream is the behavioral
+ * oracle — the same role R4 gives it for validity. This is the gate that would
+ * have caught the #785 defect (a conditional body running unconditionally on a
+ * shipped page) on BEHAVIOR: every parse-level gate stayed green while it
+ * shipped.
+ *
+ * Assertions, matching the shipped-sources gate:
+ *   1. sanity — pages walked, handlers extracted, comparisons actually ran
+ *      (guards the silent-zero failure mode);
+ *   2. no NEW divergence appears outside the committed allowlist;
+ *   3. no allowlisted key has silently converged (stale entries must be
+ *      removed so the list only ever ratchets down).
+ *
+ * To update after an intentional change: re-run and regenerate
+ * `baselines/shipped-examples-execution.json` (the allowlist key embeds a
+ * source hash, so FIXING a handler changes its key and assertion 3 forces the
+ * entry's removal).
+ *
+ * Node-only (walks the repo, imports hyperscript.org off disk). The sweep
+ * swaps jsdom globals per handler execution — safe because vitest isolates
+ * test files per worker.
+ *
+ * @vitest-environment node
+ * The node environment is REQUIRED, not a preference: under the suite default
+ * (happy-dom) the DOM constructors already exist on globalThis, the harness's
+ * globals bootstrap refuses to overwrite what it does not own, and both
+ * engines then bind happy-dom's constructors — every instanceof against a
+ * jsdom element fails and every hyperfixi signature comes back empty
+ * (measured: 0 real matches under happy-dom vs 74 under node).
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  runShippedExamplesExecution,
+  triggerEventOf,
+  keyFor,
+  type ExecutionParityResult,
+} from './shipped-examples-execution';
+
+interface AllowlistDoc {
+  allowedDivergences: Array<{
+    key: string;
+    file: string;
+    event: string;
+    excerpt: string;
+    reason: string;
+  }>;
+}
+
+const baselinePath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../baselines/shipped-examples-execution.json'
+);
+const allowlist = JSON.parse(readFileSync(baselinePath, 'utf8')) as AllowlistDoc;
+const allowed = new Set(allowlist.allowedDivergences.map(e => e.key));
+
+describe('shipped-examples execution gate', () => {
+  let result: ExecutionParityResult;
+
+  beforeAll(async () => {
+    result = await runShippedExamplesExecution();
+
+    // Visibility, not assertions: what the sweep could not compare, and why.
+    // A silently shrinking denominator is this gate's own blind spot.
+    const reasons = new Map<string, number>();
+    for (const s of result.skipped) {
+      const r = s.reason.split(':')[0] ?? s.reason;
+      reasons.set(r, (reasons.get(r) ?? 0) + 1);
+    }
+    const vacuous = result.compared.filter(c => c.vacuous).length;
+    console.log(
+      `[shipped-examples-execution] pages=${result.pages} handlers=${result.handlers} ` +
+        `compared=${result.compared.length} (vacuous=${vacuous}) skipped=${result.skipped.length}`
+    );
+    for (const [r, n] of [...reasons].sort((a, b) => b[1] - a[1])) {
+      console.log(`[shipped-examples-execution]   skip ×${n}: ${r}`);
+    }
+  }, 240_000);
+
+  it('walks pages and compares handlers (sanity: extraction and both engines working)', () => {
+    // Floors well below current values (55 / 333 / 162 / 74) but far above
+    // zero: a broken walk, extractor, or engine bootstrap fails loudly here
+    // instead of making assertions 2-3 vacuously pass.
+    expect(result.pages).toBeGreaterThan(40);
+    expect(result.handlers).toBeGreaterThan(250);
+    expect(result.compared.length).toBeGreaterThan(120);
+    // Vacuous (empty-vs-empty) pairs are NOT parity evidence — the floor is on
+    // real, non-empty signature matches.
+    const realMatches = result.compared.filter(c => c.match && !c.vacuous).length;
+    expect(realMatches).toBeGreaterThan(60);
+  });
+
+  it('has no NEW divergence from upstream outside the allowlist', () => {
+    const unexpected = result.compared.filter(c => !c.match && !allowed.has(c.key));
+    expect(
+      unexpected,
+      unexpected.length
+        ? `\nShipped handlers whose DOM effect DIVERGES from the hyperscript.org engine ` +
+            `(fix the behavior, or allowlist with a family reason):\n` +
+            unexpected
+              .map(
+                f =>
+                  `  [${f.key}]\n` +
+                  `      "${f.excerpt}"\n` +
+                  `      hyperfixi: ${JSON.stringify(f.hyperfixiEffects).slice(0, 300)}\n` +
+                  `      upstream : ${JSON.stringify(f.upstreamEffects).slice(0, 300)}`
+              )
+              .join('\n') +
+            `\n\nTriage guidance: an EMPTY hyperfixi signature with a non-empty upstream one usually\n` +
+            `means hyperfixi silently dropped behavior (the #785 class). The reverse often means a\n` +
+            `deliberate hyperfixi extension or a jsdom limitation on the upstream side — check the\n` +
+            `existing family reasons in baselines/shipped-examples-execution.json before adding a new one.`
+        : ''
+    ).toEqual([]);
+  });
+
+  it('has no stale allowlist entries (a now-converged handler must be removed so the list ratchets down)', () => {
+    const stillDiverging = new Set(result.compared.filter(c => !c.match).map(c => c.key));
+    const stale = allowlist.allowedDivergences.map(e => e.key).filter(k => !stillDiverging.has(k));
+    expect(
+      stale,
+      stale.length
+        ? `\nThese allowlisted handlers no longer diverge (fixed, or edited — the key embeds a\n` +
+            `source hash; or no longer eligible, in which case the coverage loss should be deliberate).\n` +
+            `Remove them from baselines/shipped-examples-execution.json:\n  ${stale.join('\n  ')}`
+        : ''
+    ).toEqual([]);
+  });
+});
+
+describe('harness pieces', () => {
+  it('extracts the trigger event from the leading on-clause', () => {
+    expect(triggerEventOf('on click add .a to me')).toBe('click');
+    expect(triggerEventOf('  on  every  click log me')).toBe('click');
+    expect(triggerEventOf("on keydown[key=='Escape'] from window hide .x")).toBe('keydown');
+    expect(triggerEventOf('on draggable:start add .drag')).toBe('draggable:start');
+    expect(triggerEventOf('on click or keyup toggle .a')).toBe('click');
+    expect(triggerEventOf('install Draggable')).toBeNull();
+    expect(triggerEventOf('init set x to 1')).toBeNull();
+  });
+
+  it('keys embed the source hash, so an edited handler changes key', () => {
+    const a = keyFor({ file: 'f.html', source: 'on click add .a', event: 'click' });
+    const b = keyFor({ file: 'f.html', source: 'on click add .b', event: 'click' });
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^f\.html::[0-9a-f]{10}::click$/);
+  });
+});

--- a/packages/testing-framework/src/multilingual/shipped-examples-execution.ts
+++ b/packages/testing-framework/src/multilingual/shipped-examples-execution.ts
@@ -1,0 +1,499 @@
+/**
+ * Shipped-examples execution gate — upstream as the behavioral oracle
+ * -------------------------------------------------------------------
+ * Every parse-level gate in this repo went green while `native-dialog.html`
+ * shipped with a conditional body running unconditionally (#785), and again
+ * while five upstream-valid `if` shapes regressed on a PR branch (#786). The
+ * class they cannot see is BEHAVIOR: a handler that parses cleanly and then
+ * does the wrong thing on the page.
+ *
+ * This gate executes the handlers we actually ship. For each `_="…"` attribute
+ * in `examples/**`, the full page is loaded into two jsdom instances — one
+ * processed by hyperfixi (parse + a fresh Runtime with the element as context,
+ * the same shape the browser attribute processor uses), one by the real
+ * `hyperscript.org` engine (`processNode`) — the handler's trigger event is
+ * dispatched, and the resulting DOM effect signatures (../effect-signature.ts,
+ * shared with the R2 execution ratchet) are diffed against each other.
+ * Upstream plays the role R4 gives it for validity: the oracle. A divergence
+ * means hyperfixi's runtime behavior differs from upstream's ON A SHIPPED
+ * PAGE — exactly the #785/#786 failure mode, caught on behavior instead of by
+ * luck.
+ *
+ * ## Fair denominator (mirrors R4)
+ * A handler is only compared when BOTH engines accept its source: hyperfixi
+ * must compile it clean (`ok: true`, no recovered errors — recovering sources
+ * are the shipped-sources gate's business) and upstream must parse it (a
+ * hyperfixi-only extension has no oracle). It must also be deterministically
+ * executable in jsdom: triggered by a dispatchable event, free of network /
+ * timer / navigation constructs. Every exclusion is recorded with a reason —
+ * the skip list is part of the result, never silent (`no silent caps`).
+ *
+ * ## Execution model
+ * Per handler and engine: a FRESH jsdom of the whole page, every eligible
+ * handler installed (page-like — bubbling into sibling handlers stays real and
+ * symmetric), then ONLY the probed handler's event dispatched, with a
+ * before/after snapshot around it. See runHandlerOnEngine for why isolation is
+ * worth its cost.
+ *
+ * ## Node-only
+ * Imports the real `hyperscript.org` build off disk and swaps jsdom globals
+ * per handler execution (both engines resolve `document` lazily through
+ * globalThis — the same mechanism the R2 validator relies on). Cannot run in a
+ * browser suite, and under vitest REQUIRES the node environment (see the test
+ * file's docblock).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { JSDOM } from 'jsdom';
+import { snapshot, diffSnapshots } from './effect-signature';
+
+/** Repo root, from `packages/testing-framework/src/multilingual/`. */
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+/**
+ * Only `examples/**` — unlike the shipped-sources validity gate, execution
+ * needs the surrounding PAGE (the handler's selectors resolve against it), and
+ * doc snippets have none.
+ */
+const DEFAULT_ROOTS = ['examples'];
+
+/**
+ * Events the harness can dispatch deterministically. `on load` is excluded
+ * (fires through engine-specific initialization, not a dispatchable event);
+ * anything not listed is skipped with a reason.
+ */
+const SAFE_EVENTS = new Set([
+  'click',
+  'dblclick',
+  'mousedown',
+  'mouseup',
+  'mouseenter',
+  'mouseleave',
+  'mouseover',
+  'mouseout',
+  'pointerdown',
+  'pointerup',
+  'input',
+  'change',
+  'keydown',
+  'keyup',
+  'focus',
+  'blur',
+]);
+
+/**
+ * Constructs that make an execution nondeterministic in jsdom (network,
+ * timers, animation, navigation, module-level installs) — with, for each, the
+ * reason it is excluded. Matched against the whole source.
+ */
+const DISQUALIFIERS: Array<{ pattern: RegExp; reason: string }> = [
+  { pattern: /\bfetch\b/, reason: 'network (fetch)' },
+  { pattern: /\bwait\b/, reason: 'timers (wait)' },
+  { pattern: /\bsettle\b/, reason: 'animation settling' },
+  { pattern: /\btransition\b/, reason: 'animation (transition)' },
+  { pattern: /\brepeat\s+forever\b/, reason: 'unbounded loop' },
+  { pattern: /\bgo\s+to\s+url\b/i, reason: 'navigation' },
+  { pattern: /\binstall\s/, reason: 'behavior install (registries differ by design)' },
+  { pattern: /(^|\s)js(\s|\()/, reason: 'js interop block' },
+  { pattern: /\beventsource\b/i, reason: 'SSE' },
+  { pattern: /\bsocket\b/i, reason: 'WebSocket' },
+  { pattern: /\bnavigator\b/, reason: 'browser API jsdom does not implement' },
+  { pattern: /\bbeep!/, reason: 'debug construct' },
+  {
+    pattern: /\bnew Date\b|\bMath\.random\b|toLocaleTimeString|Date\.now/,
+    reason: 'nondeterministic value (time/random) — signatures would flake across the two runs',
+  },
+];
+
+/** A handler extracted from a shipped page. */
+export interface ShippedHandler {
+  /** Repo-relative path of the page. */
+  file: string;
+  /** Document-order index among the page's `[_]` elements — the element's identity across jsdom instances. */
+  index: number;
+  /** The hyperscript source. */
+  source: string;
+  /** The trigger event parsed from the leading `on` clause, when any. */
+  event: string | null;
+}
+
+export interface SkippedHandler extends ShippedHandler {
+  reason: string;
+}
+
+/** One compared handler: both engines ran it; signatures either match or not. */
+export interface ComparedHandler extends ShippedHandler {
+  /** Stable key: file + source hash + event. Fixing a source changes its key. */
+  key: string;
+  event: string;
+  hyperfixiEffects: string[];
+  upstreamEffects: string[];
+  match: boolean;
+  /**
+   * Both signatures empty. NOT evidence of parity — a genuinely effect-free
+   * handler (bare `halt`, a `log`) and a both-engines-broken handler look the
+   * same. Counted separately; never let vacuous pairs inflate the match count.
+   */
+  vacuous: boolean;
+  /** Single-line excerpt, for reading the baseline without opening the file. */
+  excerpt: string;
+}
+
+export interface ExecutionParityResult {
+  /** Pages walked. */
+  pages: number;
+  /** Handlers found (before eligibility). */
+  handlers: number;
+  /** Handlers executed on both engines. */
+  compared: ComparedHandler[];
+  /** Handlers excluded, each with its reason. */
+  skipped: SkippedHandler[];
+}
+
+/** Stable key for one handler execution. */
+export function keyFor(h: { file: string; source: string; event: string }): string {
+  const hash = createHash('sha1').update(h.source).digest('hex').slice(0, 10);
+  return `${h.file}::${hash}::${h.event}`;
+}
+
+/** First `on <event>` name, if the source is an event handler. */
+export function triggerEventOf(source: string): string | null {
+  // `on every click`, `on click[filter]`, `on click from #x`, `on click or keyup`
+  // all yield their first event name; modifiers/filters are dropped.
+  const m = source.match(/^\s*on\s+(?:every\s+)?([\w-]+(?::[\w-]+)?)/);
+  return m ? (m[1] ?? null) : null;
+}
+
+function walkHtml(dir: string, acc: string[] = []): string[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return acc;
+  }
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name.startsWith('.')) {
+      continue;
+    }
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkHtml(full, acc);
+    else if (entry.name.endsWith('.html')) acc.push(full);
+  }
+  return acc;
+}
+
+/** Extract the page's `[_]` handlers in document order. */
+export function extractHandlers(file: string, html: string): ShippedHandler[] {
+  const dom = new JSDOM(html);
+  const out: ShippedHandler[] = [];
+  dom.window.document.querySelectorAll('[_]').forEach((el: Element, index: number) => {
+    const source = el.getAttribute('_') ?? '';
+    out.push({ file, index, source, event: triggerEventOf(source) });
+  });
+  return out;
+}
+
+/** Minimal engine surfaces, injected by `initEngines`. */
+export interface Engines {
+  /** hyperfixi compile check (fair-denominator side 1). */
+  compileClean(source: string): boolean;
+  /** upstream parse check (fair-denominator side 2). Returns error strings; [] = valid. */
+  upstreamErrors(source: string): string[];
+  /** Install a handler on an element via hyperfixi (the public eval surface). */
+  hyperfixiInstall(source: string, el: Element): Promise<void>;
+  /** Install a handler on an element via the upstream engine. */
+  upstreamInstall(el: Element): void;
+}
+
+/**
+ * Keys this module has installed onto globalThis from a jsdom window. Tracked
+ * so every later `installGlobals` RE-points them at the new page's window —
+ * merely skipping keys that already exist left every DOM constructor
+ * (`HTMLElement`, `Element`, …) bound to the FIRST page forever, and both
+ * engines' `instanceof` checks then silently failed for later pages' elements
+ * (measured: upstream produced empty signatures for `on click put 'Hello' into
+ * #output` — the simplest possible handler — on every page after the first).
+ */
+const installedGlobalKeys = new Set<string>();
+
+/**
+ * Point the process globals at a page's jsdom (jsdom-global style: everything
+ * the window owns that node does not, plus the DOM-critical names node has
+ * opinions about). Both engines resolve `document` lazily through globalThis,
+ * so this is what "switching pages" means.
+ */
+export function installGlobals(dom: JSDOM): void {
+  const g = globalThis as Record<string, unknown>;
+  const win = dom.window as unknown as Record<string, unknown>;
+  for (const key of Object.getOwnPropertyNames(win)) {
+    if (key in globalThis && !installedGlobalKeys.has(key)) continue; // node's own — leave it
+    try {
+      g[key] = win[key];
+      installedGlobalKeys.add(key);
+    } catch {
+      /* read-only */
+    }
+  }
+  for (const key of ['window', 'document', 'Event', 'CustomEvent', 'navigator']) {
+    try {
+      Object.defineProperty(g, key, {
+        value: key === 'window' ? dom.window : win[key],
+        configurable: true,
+        writable: true,
+      });
+      installedGlobalKeys.add(key);
+    } catch {
+      /* read-only */
+    }
+  }
+}
+
+/**
+ * Errors thrown inside dispatched listeners surface as unhandled rejections
+ * (handlers are async) and would crash the sweep. Trapped, not asserted: a
+ * runtime error that damages behavior diverges in its effect signature, which
+ * is the comparison — same stance as the R2 validator.
+ */
+let rejectionTrapInstalled = false;
+function installRejectionTrap(): void {
+  if (rejectionTrapInstalled) return;
+  process.on('unhandledRejection', () => {
+    /* swallowed — the effect signature is the assertion */
+  });
+  rejectionTrapInstalled = true;
+}
+
+/**
+ * Load both engines ONCE, after bootstrapping jsdom globals (both packages
+ * touch DOM constructors at module evaluation). Callers then swap pages via
+ * `installGlobals`.
+ */
+export async function initEngines(): Promise<Engines> {
+  installRejectionTrap();
+  installGlobals(new JSDOM('<!doctype html><html><body></body></html>'));
+
+  // Install goes through parse + a FRESH Runtime per handler with the element
+  // as context — the same shape the browser attribute processor uses, and the
+  // same shape the R2 validator proved stable across per-page document swaps.
+  // (The api singleton `hyperscript.eval` binds document-dependent state at
+  // first use, which is correct in a browser — document identity never changes
+  // within a realm — but silently resolves later PAGES' selectors against the
+  // first page here. Measured: a two-page probe no-opped page 2's toggle.)
+  const core = (await import('@hyperfixi/core')) as unknown as {
+    hyperscript: {
+      compileSync(code: string): { ok: boolean; errors?: Array<{ message: string }> };
+    };
+    parse(code: string): { success: boolean; node?: unknown };
+    Runtime: new () => { execute(ast: unknown, ctx: unknown): Promise<unknown> };
+    createContext(el: HTMLElement): unknown;
+  };
+
+  const require = createRequire(import.meta.url);
+  const esm = path.join(path.dirname(require.resolve('hyperscript.org')), '_hyperscript.esm.js');
+  const hs = (await import(pathToFileURL(esm).href)).default as {
+    parse(src: string): { errors?: Array<{ message: string }> };
+    processNode(el: Node): void;
+  };
+
+  return {
+    compileClean(source) {
+      try {
+        const r = core.hyperscript.compileSync(source);
+        return r.ok && (r.errors ?? []).length === 0;
+      } catch {
+        return false;
+      }
+    },
+    upstreamErrors(source) {
+      try {
+        return (hs.parse(source)?.errors ?? []).map(e => e.message);
+      } catch (e) {
+        return ['threw: ' + (e as Error).message.split('\n')[0]];
+      }
+    },
+    async hyperfixiInstall(source, el) {
+      const parsed = core.parse(source);
+      if (!parsed.success || !parsed.node) {
+        throw new Error('parse failed at install (eligibility should have caught this)');
+      }
+      const runtime = new core.Runtime();
+      await runtime.execute(parsed.node, core.createContext(el as HTMLElement));
+    },
+    upstreamInstall(el) {
+      hs.processNode(el);
+    },
+  };
+}
+
+/** Drain micro/macrotasks after a dispatch (same window the R2 validator uses). */
+const SETTLE_MS = 20;
+const settle = () => new Promise(r => setTimeout(r, SETTLE_MS));
+
+/**
+ * Execute ONE handler on one engine, in ISOLATION: a fresh jsdom of the page,
+ * every eligible handler installed (as on a real page — bubbling into sibling
+ * handlers stays page-like and symmetric across engines), then ONLY the probed
+ * handler's event dispatched, with a before/after snapshot around it.
+ *
+ * Isolation is deliberate, and worth its jsdom-per-handler cost: a sequential
+ * dispatch-them-all model was measured amplifying ONE real divergence into a
+ * page's worth of cascades (upstream's inert element-`decrement` made the
+ * following `put 0 into #count` write 0-over-0 — invisible — so every later
+ * handler on the page diverged too), and letting double-failures hide as
+ * empty-vs-empty "matches". Fresh state per handler makes each comparison
+ * independently triageable.
+ *
+ * Runtime errors do not abort — the effect signature is the comparison, and an
+ * error that damages behavior diverges in its effects.
+ */
+async function runHandlerOnEngine(
+  html: string,
+  eligible: Array<ShippedHandler & { event: string }>,
+  target: ShippedHandler & { event: string },
+  install: (h: ShippedHandler & { event: string }, el: Element) => Promise<void> | void
+): Promise<string[]> {
+  // No pretendToBeVisual: nothing eligible needs rAF (animation constructs are
+  // disqualified), and its frame timer would keep node alive after the sweep.
+  const dom = new JSDOM(html);
+  try {
+    installGlobals(dom);
+    const doc = dom.window.document;
+    const els = doc.querySelectorAll('[_]');
+
+    // Stamp identity keys BEFORE anything runs: same page → same stamping on
+    // both engines, so snapshot keys are the element's identity and an
+    // engine-inserted node cannot shift them (see snapshot()).
+    doc.body
+      .querySelectorAll('*')
+      .forEach((el: Element, i: number) => el.setAttribute('data-exec-key', String(i)));
+
+    for (const h of eligible) {
+      const el = els[h.index];
+      if (!el) continue;
+      try {
+        await install(h, el);
+      } catch {
+        /* recorded via the empty signature */
+      }
+    }
+
+    const el = els[target.index];
+    if (!el) return ['<element not found>'];
+    if ((target.event === 'input' || target.event === 'change') && 'value' in el) {
+      (el as HTMLInputElement).value = 'test';
+    }
+    const before = snapshot(doc);
+    el.dispatchEvent(new dom.window.Event(target.event, { bubbles: true, cancelable: true }));
+    await settle();
+    return diffSnapshots(before, snapshot(doc));
+  } finally {
+    // Release the page's timers/listeners so the process can exit; the next
+    // page (or the caller's bootstrap dom) re-points the globals.
+    dom.window.close();
+  }
+}
+
+/**
+ * The sweep: walk `examples/**`, extract handlers, apply the fair-denominator
+ * filters (each skip reasoned), and execute every eligible handler on both
+ * engines.
+ */
+export async function runShippedExamplesExecution(opts?: {
+  roots?: string[];
+  repoRoot?: string;
+  engines?: Engines;
+}): Promise<ExecutionParityResult> {
+  const repoRoot = opts?.repoRoot ?? REPO_ROOT;
+  const roots = opts?.roots ?? DEFAULT_ROOTS;
+  const engines = opts?.engines ?? (await initEngines());
+
+  const compared: ComparedHandler[] = [];
+  const skipped: SkippedHandler[] = [];
+  let pages = 0;
+  let handlers = 0;
+
+  for (const root of roots) {
+    for (const full of walkHtml(path.join(repoRoot, root))) {
+      const rel = path.relative(repoRoot, full);
+      const html = fs.readFileSync(full, 'utf8');
+      const pageHandlers = extractHandlers(rel, html);
+      if (pageHandlers.length === 0) continue;
+      pages++;
+      handlers += pageHandlers.length;
+
+      const eligible: Array<ShippedHandler & { event: string }> = [];
+      for (const h of pageHandlers) {
+        if (!h.event) {
+          skipped.push({ ...h, reason: 'not an `on <event>` handler' });
+          continue;
+        }
+        if (!SAFE_EVENTS.has(h.event)) {
+          skipped.push({ ...h, reason: `event not dispatchable deterministically (${h.event})` });
+          continue;
+        }
+        const disq = DISQUALIFIERS.find(d => d.pattern.test(h.source));
+        if (disq) {
+          skipped.push({ ...h, reason: disq.reason });
+          continue;
+        }
+        if (!engines.compileClean(h.source)) {
+          skipped.push({
+            ...h,
+            reason: 'hyperfixi does not compile it clean (shipped-sources gate territory)',
+          });
+          continue;
+        }
+        const upstreamErrs = engines.upstreamErrors(h.source);
+        if (upstreamErrs.length > 0) {
+          skipped.push({ ...h, reason: `upstream rejects it (no oracle): ${upstreamErrs[0]}` });
+          continue;
+        }
+        eligible.push(h as ShippedHandler & { event: string });
+      }
+      if (eligible.length === 0) continue;
+
+      // Both engines log runtime errors to the console during dispatch
+      // (COMMAND FAILED etc.). That is expected data here — the effect
+      // signature carries the consequence — so silence the console for the
+      // engine runs only, restoring even on a throw.
+      const saved = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+        debug: console.debug,
+      };
+      const noop = () => {};
+      console.log = console.warn = console.error = console.debug = noop;
+      try {
+        for (const h of eligible) {
+          const ours = await runHandlerOnEngine(html, eligible, h, (hh, el) =>
+            engines.hyperfixiInstall(hh.source, el)
+          );
+          const theirs = await runHandlerOnEngine(html, eligible, h, (_hh, el) =>
+            engines.upstreamInstall(el)
+          );
+          compared.push({
+            ...h,
+            key: keyFor(h),
+            hyperfixiEffects: ours,
+            upstreamEffects: theirs,
+            match: JSON.stringify(ours) === JSON.stringify(theirs),
+            vacuous: ours.length === 0 && theirs.length === 0,
+            excerpt: h.source.replace(/\s+/g, ' ').trim().slice(0, 100),
+          });
+        }
+      } finally {
+        console.log = saved.log;
+        console.warn = saved.warn;
+        console.error = saved.error;
+        console.debug = saved.debug;
+      }
+    }
+  }
+
+  return { pages, handlers, compared, skipped };
+}

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
@@ -339,8 +339,10 @@ describe('R2 execution validator (lock)', () => {
     // The three wave-9 additions. Each en reference must produce a non-empty,
     // deterministic signature against the existing fixture. The `*opacity`
     // hide/show STRATEGIES are synchronous (no timer): hide writes display:none
-    // + a data-original-display marker on #btn; show adds the visibility class
-    // on #modal. chained-access-possessive-dot writes the parent (.card) display.
+    // on #btn (its data-original-display memo is engine bookkeeping, excluded
+    // from signatures since the shared effect-signature module — see
+    // ENGINE_ATTRS there); show adds the visibility class on #modal.
+    // chained-access-possessive-dot writes the parent (.card) display.
     const cases: ReadonlyArray<[string, string, string[]]> = [
       [
         'chained-access-possessive-dot',
@@ -350,7 +352,7 @@ describe('R2 execution validator (lock)', () => {
       [
         'hide-with-transition',
         'on click hide me with *opacity',
-        ['Δ#btn cls[] attr[data-original-display=,id=btn] style[display: none;] text[Click]'],
+        ['Δ#btn cls[] attr[id=btn] style[display: none;] text[Click]'],
       ],
       [
         'show-with-transition',

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.ts
@@ -31,6 +31,7 @@ import { JSDOM } from 'jsdom';
 import { parseSemantic, buildAST } from '@lokascript/semantic';
 import { getAllPatterns, getTranslationsByLanguage } from '@hyperfixi/patterns-reference';
 import type { LanguageCode } from '../types';
+import { snapshot, diffSnapshots } from '../effect-signature';
 
 /**
  * The curated execution subset: simple, deterministic, fixture-friendly
@@ -287,53 +288,12 @@ export interface ExecutionResult {
   executionFidelity?: number;
 }
 
-/**
- * Serialize the identity-relevant state of every element under <body>.
- * Keyed by #id when present, else tag[document-order-index]; the fixture is
- * identical across languages, so keys are comparable.
- */
-function serializeElement(el: Element): string {
-  const attrs = Array.from(el.attributes)
-    .filter(a => a.name !== 'class' && a.name !== 'style')
-    .map(a => `${a.name}=${a.value}`)
-    .sort()
-    .join(',');
-  const classes = Array.from(el.classList).sort().join(' ');
-  const style = (el as HTMLElement).getAttribute('style') ?? '';
-  // Leaf text only — container text would duplicate every child mutation.
-  const text =
-    el.childNodes.length === 0 || (el.childNodes.length === 1 && el.firstChild?.nodeType === 3)
-      ? (el.textContent ?? '')
-      : '';
-  return `cls[${classes}] attr[${attrs}] style[${style}] text[${text}]`;
-}
-
-function snapshot(document: Document): Map<string, string> {
-  const out = new Map<string, string>();
-  // body participates under its own stable key: body-targeted effects
-  // (`add .modal-open to body`, modal-open/modal-close-button) must be
-  // visible in the signature now that the runtime resolves `body`. Before
-  // wave 3b these writes fell back to `me` (visible by accident); a correct
-  // body write was invisible and a dropped one unscoreable.
-  out.set('body', serializeElement(document.body));
-  document.body.querySelectorAll('*').forEach((el, i) => {
-    const key = el.id ? `#${el.id}` : `${el.tagName.toLowerCase()}[${i}]`;
-    out.set(key, serializeElement(el));
-  });
-  return out;
-}
-
-/** Sorted, stable list of per-element changes between two snapshots. */
-function diffSnapshots(before: Map<string, string>, after: Map<string, string>): string[] {
-  const effects: string[] = [];
-  for (const [k, v] of after) {
-    const b = before.get(k);
-    if (b === undefined) effects.push(`+${k} ${v}`);
-    else if (b !== v) effects.push(`Δ${k} ${v}`);
-  }
-  for (const k of before.keys()) if (!after.has(k)) effects.push(`-${k}`);
-  return effects.sort();
-}
+// Effect-signature machinery (serializeElement/snapshot/diffSnapshots) moved to
+// ../effect-signature.ts (imported at the top), shared with the
+// shipped-examples execution gate so the two can never disagree about what a
+// DOM effect is. Notes that used to live on the local copies (leaf-text-only
+// rationale; body's own stable key, added in wave 3b when the runtime learned
+// to resolve `body`) moved with them.
 
 /** How long to let the dispatched handler settle (ms). The subset contains no
  * waits/transitions/fetches, so this only needs to drain micro/macrotasks. */


### PR DESCRIPTION
Closes the top systemic entry in `docs-internal/PARSER_NEXT_STEPS.md`: **nothing
executed a shipped example.** Every parse-level gate stayed green while
`native-dialog.html` shipped with its conditional body running unconditionally
(#785), and again while five upstream-valid `if` shapes regressed on a PR branch
(#786). The class none of them can see is *behavior*.

## What it does

Every eligible `_="…"` handler in `examples/**` executes on **both engines** in
jsdom — hyperfixi via parse + fresh `Runtime` with the element as context (the
browser attribute-processor shape), upstream `hyperscript.org` via `processNode`
— its trigger event is dispatched, and the two **DOM effect signatures** are
diffed. Upstream is the behavioral oracle: the role R4 gives it for validity,
applied to behavior. A divergence means hyperfixi's runtime differs from
upstream **on a shipped page** — the #785 failure mode, caught in CI instead of
by luck.

- **Fair denominator (mirrors R4):** compared only when hyperfixi compiles clean
  AND upstream parses; deterministically executable (no network/timers/animation
  — every exclusion recorded with a reason, no silent caps).
- **Per-handler isolation:** fresh page pair per handler, all handlers installed
  (page-like bubbling, symmetric), only the probed one dispatched. Sequential
  dispatch was measured amplifying one real divergence into a page of cascades.
- **Vacuous pairs** (empty-vs-empty) counted separately — never as parity.
- **Shared signature machinery:** extracted from the R2 validator into
  `effect-signature.ts` so the two gates can never disagree about what a DOM
  effect is. One R2 locked signature updated (`data-original-display` is engine
  bookkeeping, now excluded); **fidelity numbers unchanged** — verified by a full
  multilingual `--regression` run, all 10 signals green.
- **Ratchet assertions** matching the shipped-sources gate: sanity floors, no
  NEW divergence outside the allowlist, no stale allowlist entry (keys embed a
  source hash — fixing a handler forces its entry's removal).

## First sweep

55 pages · 333 handlers · 162 compared · **74 real matches** · 42 vacuous · 46
divergences baselined in **six triaged families** (element-target writes 24,
show/hide strategy 13, `swap` extension 4, boolean-attr toggles 3, plus two
single-entry families). 171 skips, each reasoned.

**Two real bug candidates found on the first run, now queued:**

1. `on keydown[key=='Escape'] from window hide .modal-overlay` — the dispatched
   Event has no `.key`, the filter is unmet, upstream correctly no-ops —
   **hyperfixi hides every modal anyway.**
2. `set <idref> to <value>` and js property-path arguments
   (`put document.getElementById(...).value into #x`) silently no-op.

Both sit in the allowlist with their family reasons; fixing either forces its
entry out via the stale-entry assertion.

## Docs

`docs-internal/HANDOFF-shipped-examples-execution.md` carries the design, the
burn-down list, the v2 scope (timers under fake clocks, custom events,
`text/hyperscript` blocks, Playwright arbitration), and the harness lessons that
cost hours (globals re-pointing, the api singleton binding its first document,
identity-keyed snapshots, the mandatory node vitest environment).
`PARSER_NEXT_STEPS.md` marks the gap closed and promotes the two findings.

## Gates

- testing-framework: 274 passed, typecheck clean, prettier clean
- multilingual `--full --regression`: all 10 signals green (R2 unchanged)
- full workspace `test:check`: exit 0
- new gate runtime: ~12s, exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
