### PR TITLE
fix(core): enforce event filters — `on keydown[key=='Escape']` gates the body

### DIFF
--- a/docs-internal/HANDOFF-shipped-examples-execution.md
+++ b/docs-internal/HANDOFF-shipped-examples-execution.md
@@ -28,9 +28,12 @@ committed allowlist, no stale allowlist entry. The allowlist key embeds a
 source hash, so fixing a handler forces its entry's removal — the list only
 ratchets down.
 
-Current numbers (2026-07-27): 55 pages, 333 handlers, 162 compared
-(74 real matches, 42 vacuous empty-vs-empty pairs — counted separately, never
-as parity), 46 allowlisted divergences in six triaged families, 171 skips each
+Current numbers (2026-07-27, post filter fix): 55 pages, 333 handlers, 162
+compared (74 real matches, 43 vacuous empty-vs-empty pairs — counted
+separately, never as parity; the fixed filter handler converged INTO the
+vacuous column, both engines now correctly doing nothing on an unmet filter),
+**45** allowlisted divergences (46 at introduction; the event-filter fix
+converged one and the stale-entry ratchet forced its removal), 171 skips each
 with a recorded reason (upstream-rejects 51, non-event handlers 27, `wait` 26,
 hyperfixi-recovers 25, `fetch` 13, js-blocks 11, …).
 
@@ -51,12 +54,15 @@ the baseline JSON:
    command — no oracle for the effect, only for the no-crash.
 4. **Boolean-attribute toggles** (3): `toggle @disabled` representation
    differs.
-5. **Unmet event filter still fires** (1): `on keydown[key=='Escape'] from
-   window hide .modal-overlay` — the dispatched Event has no `.key`, so the
-   filter is false; upstream correctly does nothing, **hyperfixi hides every
-   modal anyway**. REAL BUG CANDIDATE — the strongest single finding. Verify
-   the filter path in `packages/core` and fix; the gate entry then goes stale
-   and forces its own removal.
+5. **Unmet event filter still fires** (~~1~~ → **FIXED 2026-07-27**, the same
+   day the gate landed): the runtime never read `EventHandlerNode.condition` —
+   every filtered handler ran unfiltered. Fixed in `runtime-base.ts`
+   (`createEventHandler` evaluates the condition with event properties
+   resolvable as bare identifiers); or-join legs stay unfiltered pending
+   per-event condition representation (queued). The fix triggered THIS gate's
+   stale-entry assertion and shrank the baseline 46 → 45 — the ratchet's first
+   full cycle, exactly as designed. Coverage:
+   `packages/core/src/api/event-filter-execution.test.ts`.
 6. **js property-path argument** (1): `put document.getElementById(...).value
    into #result4` — hyperfixi produces no effect. REAL BUG CANDIDATE.
 

--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -24,7 +24,7 @@ ones, because the gate *is* the tracking mechanism.
 
 | Item | Severity | Gate | Detail |
 | ---- | -------- | ---- | ------ |
-| **Unmet event filter still fires** | **high** — `on keydown[key=='Escape']` runs with no `.key`; upstream correctly does not | ✅ execution-gate allowlist entry | found by the execution gate; family 5 in [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md) |
+| **Or-join filters have no per-event representation** | low — `on click or keypress[key=='Enter']` runs keypress unfiltered (upstream filters that leg); single-event filters ARE enforced | ✅ KNOWN GAP test | `packages/core/src/api/event-filter-execution.test.ts`; the runtime-side note at the `applicableCondition` site in `runtime-base.ts` |
 | **`tell` never consumes a terminating `end`** | medium — no real `tell … end` block form; upstream requires one | **none** | comment at `packages/core/src/parser/command-parsers/utility-commands.ts` (the `ELSE`/`END` break in `parseTellCommand`) |
 | **`set <idref> to <value>` / js property-path args no-op** | medium — silent no-effect on shipped pages | ✅ execution-gate allowlist entries | families 1/6 in [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md) |
 | `and` is not a command separator anywhere | low — consistent everywhere, so no surprise | ✅ 2 `KNOWN GAP` tests | `packages/core/src/parser/__tests__/then-as-separator.test.ts` |
@@ -38,11 +38,16 @@ ones, because the gate *is* the tracking mechanism.
 - **`sortable-list.html`** — the allowlist key embeds `sha1(source)`, and
   assertion 3 of the shipped-sources gate **fails** when an allowlisted source
   goes clean. The list can only ratchet down. It cannot be silently forgotten.
-- **The execution-gate entries** (event filter; `set <idref>` / js-path no-ops) —
-  same mechanism as `sortable-list.html`: their allowlist keys in
+- **The execution-gate entries** (`set <idref>` / js-path no-ops) — same
+  mechanism as `sortable-list.html`: their allowlist keys in
   `packages/testing-framework/baselines/shipped-examples-execution.json` embed a
   source hash, and the gate's stale-entry assertion fails when a divergence
-  converges, forcing the entry's removal in the fixing change.
+  converges, forcing the entry's removal in the fixing change. This is not
+  theoretical: the event-filter fix (History) triggered exactly that assertion
+  and shrank the baseline 46 → 45 in the same change.
+- **Or-join filters** — the KNOWN GAP test pins the current unfiltered behavior
+  of BOTH legs; per-event condition representation flips both halves, so the
+  fix is forced to be deliberate and visible.
 
 The ungated one (`tell`) has no such mechanism. **It is what this document is
 for.**
@@ -54,9 +59,10 @@ execution gate runs every eligible `_=` handler on both hyperfixi and the real
 `hyperscript.org` engine in jsdom and ratchets on DOM-effect divergence —
 upstream as the behavioral oracle, the R4 pattern applied to behavior. It is
 what would have caught the #785 defect on *behaviour* rather than on a
-diagnostic. Design, current numbers, the six divergence families, and the
+diagnostic. Design, current numbers, the divergence families, and the
 harness lessons: [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md).
-Its first sweep produced the two bug-candidate rows in the table above.
+Its first sweep produced two bug candidates: the unmet-event-filter defect
+(**fixed** — see History) and the `set <idref>` / js-path no-ops row above.
 
 **Expression-first condition parsing** is the deferred follow-on from the `if`
 family (see History). #786 replaced the raw "is this token spelled like a
@@ -74,6 +80,15 @@ regression episode that motivates it:
 
 ## History
 
+- **2026-07-27** — event filters enforced: `on keydown[key=='Escape']` ran on
+  ANY key because the runtime never read `EventHandlerNode.condition` (parsed,
+  typed, documented, never consumed). The gate's first finding, fixed the same
+  day; the fix triggered the gate's stale-entry ratchet, shrinking its baseline
+  46 → 45 in the same change — the loop's first full cycle. Filters resolve
+  bare identifiers from the event (upstream semantics), run after arg
+  destructuring, and gate SINGLE-event handlers only (or-join legs need
+  per-event conditions — the new table row). Coverage:
+  `packages/core/src/api/event-filter-execution.test.ts`.
 - **2026-07-27** — shipped-examples execution gate landed: `examples/**`
   handlers executed on both engines in jsdom, DOM-effect divergence ratcheted
   against `hyperscript.org` as the behavioral oracle. 46 divergences baselined

--- a/packages/core/src/api/event-filter-execution.test.ts
+++ b/packages/core/src/api/event-filter-execution.test.ts
@@ -1,0 +1,144 @@
+/**
+ * event-filter-execution.test.ts
+ *
+ * Event filters (`on keydown[key=='Escape'] …`) must gate the handler body.
+ *
+ * The parser has always delivered the bracketed expression as
+ * `EventHandlerNode.condition`, but the runtime never consumed it — every
+ * filtered handler ran UNFILTERED. Found by the shipped-examples execution
+ * gate: `on keydown[key=='Escape'] from window hide .modal-overlay`
+ * (examples/dialogs/modal.html) hid every modal on ANY key, while upstream
+ * `hyperscript.org` correctly did nothing. No parse-level gate could see it:
+ * the AST was perfect, the behavior was wrong.
+ *
+ * Upstream semantics pinned here: bare identifiers in the filter resolve to
+ * properties of the event (`key`, `shiftKey`), destructured args are in scope
+ * (`on boom(x)[x > 3]`), and an unmet — or throwing — filter means the body
+ * does not run. These assert the DOM, because that is where the damage was.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { hyperscript } from './hyperscript-api.js';
+
+function setupTarget(): HTMLElement {
+  document.body.innerHTML = '<button id="host">go</button><div id="target"></div>';
+  return document.getElementById('host') as HTMLElement;
+}
+
+const target = (): HTMLElement => document.getElementById('target') as HTMLElement;
+
+const settle = () => new Promise(r => setTimeout(r, 20));
+
+describe('event filters gate the handler body', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('does NOT run when the key filter is unmet', async () => {
+    // THE case: this shipped in modal.html and ran on every key.
+    const host = setupTarget();
+    await hyperscript.eval("on keydown[key=='Escape'] add .ef-esc to #target", host);
+
+    host.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+    await settle();
+    expect(target().classList.contains('ef-esc')).toBe(false);
+  });
+
+  it('runs when the key filter is met', async () => {
+    const host = setupTarget();
+    await hyperscript.eval("on keydown[key=='Escape'] add .ef-esc2 to #target", host);
+
+    host.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    await settle();
+    expect(target().classList.contains('ef-esc2')).toBe(true);
+  });
+
+  it('resolves a bare boolean event property (shiftKey)', async () => {
+    const host = setupTarget();
+    await hyperscript.eval('on click[shiftKey] add .ef-shift to #target', host);
+
+    host.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    expect(target().classList.contains('ef-shift')).toBe(false);
+
+    host.dispatchEvent(new MouseEvent('click', { shiftKey: true, bubbles: true }));
+    await settle();
+    expect(target().classList.contains('ef-shift')).toBe(true);
+  });
+
+  it('sees destructured event args in the filter', async () => {
+    // Args are bound BEFORE the filter runs, so `on boom(x)[x > 3]` works —
+    // x comes from event.detail per the arg-destructuring rules.
+    const host = setupTarget();
+    await hyperscript.eval('on boom(x)[x > 3] add .ef-big to #target', host);
+
+    host.dispatchEvent(new CustomEvent('boom', { bubbles: true, detail: { x: 1 } }));
+    await settle();
+    expect(target().classList.contains('ef-big')).toBe(false);
+
+    host.dispatchEvent(new CustomEvent('boom', { bubbles: true, detail: { x: 5 } }));
+    await settle();
+    expect(target().classList.contains('ef-big')).toBe(true);
+  });
+
+  it('treats a filter naming a nonexistent property as unmet, without crashing', async () => {
+    const host = setupTarget();
+    await hyperscript.eval('on click[definitelyNotAProperty] add .ef-never to #target', host);
+
+    host.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    expect(target().classList.contains('ef-never')).toBe(false);
+  });
+
+  it('leaves unfiltered handlers untouched', async () => {
+    // The over-correction guard: a handler with no filter must run exactly as
+    // before.
+    const host = setupTarget();
+    await hyperscript.eval('on click add .ef-always to #target', host);
+
+    host.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    expect(target().classList.contains('ef-always')).toBe(true);
+  });
+
+  it('KNOWN GAP: a filter on an or-joined handler applies to NO leg', async () => {
+    // The parser attaches one `condition` to the whole node even when the
+    // filter belongs to a single leg (`on click or keydown[key=='Enter']` —
+    // upstream filters ONLY keydown). Gating every leg on it would break the
+    // unfiltered click leg, so multi-event handlers deliberately keep their
+    // historical unfiltered behavior until conditions are per-event. Pinned so
+    // the eventual per-event fix is a deliberate, visible change — both halves
+    // below flip when it lands.
+    const host = setupTarget();
+    await hyperscript.eval("on click or keydown[key=='Enter'] add .ef-multi to #target", host);
+
+    // The click leg must keep running (upstream: unfiltered).
+    host.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    expect(target().classList.contains('ef-multi')).toBe(true);
+
+    // The keydown leg ALSO runs on a wrong key (upstream would filter it) —
+    // the documented gap, not an endorsement.
+    target().classList.remove('ef-multi');
+    host.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+    await settle();
+    expect(target().classList.contains('ef-multi')).toBe(true);
+  });
+
+  it('gates the shipped modal shape: keydown[key==Escape] from window', async () => {
+    // examples/dialogs/modal.html:—the source the execution gate flagged.
+    // Unique class name because the window-target listener outlives this test.
+    document.body.innerHTML = '<button id="host">go</button><div class="ef-modal"></div>';
+    const host = document.getElementById('host') as HTMLElement;
+    const modal = document.querySelector('.ef-modal') as HTMLElement;
+    await hyperscript.eval("on keydown[key=='Escape'] from window hide .ef-modal", host);
+
+    host.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+    await settle();
+    expect(modal.style.display).not.toBe('none');
+
+    host.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    await settle();
+    expect(modal.style.display).toBe('none');
+  });
+});

--- a/packages/core/src/runtime/runtime-base.ts
+++ b/packages/core/src/runtime/runtime-base.ts
@@ -139,6 +139,31 @@ function isImplicitCommand(val: unknown): val is ImplicitCommandResult {
 /** Track event recursion depth per-event without expando properties on Event objects */
 const eventRecursionDepth = new WeakMap<Event, number>();
 
+/**
+ * Every identifier name referenced anywhere in an expression tree. Used by the
+ * event-filter evaluation to decide which event properties to expose as locals
+ * (`on keydown[key=='Escape']` — `key` must resolve to `event.key`). A generic
+ * object walk rather than a typed visitor: filter expressions are small, and
+ * the walk must see identifiers wherever a node shape nests them.
+ */
+function collectIdentifierNames(node: unknown, out: Set<string> = new Set()): Set<string> {
+  if (node === null || typeof node !== 'object') return out;
+  if (Array.isArray(node)) {
+    for (const item of node) collectIdentifierNames(item, out);
+    return out;
+  }
+  const obj = node as Record<string, unknown>;
+  if (obj.type === 'identifier' && typeof obj.name === 'string') {
+    out.add(obj.name);
+  }
+  for (const key of Object.keys(obj)) {
+    // Positions/tokens carry no identifiers worth exposing.
+    if (key === 'start' || key === 'end' || key === 'line' || key === 'column') continue;
+    collectIdentifierNames(obj[key], out);
+  }
+  return out;
+}
+
 export interface RuntimeBaseOptions {
   /**
    * The registry instance containing allowed commands.
@@ -1338,6 +1363,7 @@ export class RuntimeBase {
       target,
       args,
       selector,
+      condition,
       attributeName,
       watchTarget,
       modifiers,
@@ -1469,13 +1495,24 @@ export class RuntimeBase {
     // STANDARD CASE: DOM Event Listeners
     // Create handler via helper to limit closure scope — only captures what's needed,
     // not the full executeEventHandler scope (node, targets, globalTarget, eventNames, etc.)
+    // KNOWN GAP: the filter is applied only to SINGLE-event handlers. The
+    // parser attaches ONE `condition` to the whole node even when the filter
+    // syntactically belongs to one leg of an `or`-join — upstream gives each
+    // event spec its own filter (`on click or keypress[key=='Enter']` filters
+    // ONLY keypress). Gating every leg on the shared condition would break the
+    // unfiltered legs (a plain click would evaluate `key=='Enter'` and never
+    // run), so multi-event handlers keep their historical unfiltered behavior
+    // until conditions are represented per event. Queued in
+    // docs-internal/PARSER_NEXT_STEPS.md.
+    const applicableCondition = eventNames.length === 1 ? condition : undefined;
     const baseEventHandler = RuntimeBase.createEventHandler(
       this,
       commands,
       context,
       selector,
       args,
-      { errorSymbol, errorHandler, finallyHandler }
+      { errorSymbol, errorHandler, finallyHandler },
+      applicableCondition
     );
 
     // Apply event modifiers
@@ -1629,7 +1666,8 @@ export class RuntimeBase {
       errorSymbol?: string;
       errorHandler?: ASTNode[];
       finallyHandler?: ASTNode[];
-    }
+    },
+    condition?: ASTNode
   ): (domEvent: Event) => Promise<void> {
     return async (domEvent: Event) => {
       // Recursion Guard (uses WeakMap instead of expando property on Event)
@@ -1674,6 +1712,39 @@ export class RuntimeBase {
         for (const argName of args) {
           const value = eventObj[argName] ?? detail?.[argName] ?? null;
           eventContext.locals.set(argName, value);
+        }
+      }
+
+      // Event filter (`on keydown[key=='Escape'] …`): upstream evaluates the
+      // bracketed expression against the EVENT before running the body — bare
+      // identifiers in the filter resolve to properties of the event. The
+      // parser has always delivered it as `node.condition`, but nothing here
+      // consumed it, so every filtered handler ran UNFILTERED (found by the
+      // shipped-examples execution gate: the modal.html Escape filter hid
+      // every modal on any key; upstream correctly did nothing).
+      //
+      // Placed AFTER arg destructuring so `on pointerdown(x, y)[x > 3]` can
+      // reference destructured args. Identifiers the filter names are resolved
+      // from the event into locals first — unless already bound (behavior-init
+      // locals and the `target` local take precedence). An evaluation ERROR
+      // also skips the body: upstream wraps the body in `if (<filter>)`, so a
+      // throwing filter never runs it either.
+      if (condition) {
+        const eventProps = domEvent as unknown as Record<string, unknown>;
+        for (const name of collectIdentifierNames(condition)) {
+          if (!eventContext.locals.has(name) && name in eventProps) {
+            eventContext.locals.set(name, eventProps[name]);
+          }
+        }
+        let filterResult: unknown;
+        try {
+          filterResult = await runtime.evaluateExpression(condition, eventContext);
+        } catch (e) {
+          debug.runtime(`Event filter threw; skipping handler body:`, e);
+          return;
+        }
+        if (!filterResult) {
+          return;
         }
       }
 

--- a/packages/testing-framework/baselines/shipped-examples-execution.json
+++ b/packages/testing-framework/baselines/shipped-examples-execution.json
@@ -53,20 +53,6 @@
       "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
     },
     {
-      "key": "examples/dialogs/modal.html::27fb619873::keydown",
-      "file": "examples/dialogs/modal.html",
-      "event": "keydown",
-      "excerpt": "on keydown[key=='Escape'] from window hide .modal-overlay",
-      "hyperfixi": [
-        "Δdiv:16#info-modal cls[modal-overlay] attr[id=info-modal] style[display: none;] text[]",
-        "Δdiv:31#confirm-modal cls[modal-overlay] attr[id=confirm-modal] style[display: none;] text[]",
-        "Δdiv:46#form-modal cls[modal-overlay] attr[id=form-modal] style[display: none;] text[]",
-        "Δdiv:68#behavior-modal cls[modal-overlay] attr[id=behavior-modal] style[display: none;] text[]"
-      ],
-      "upstream": [],
-      "reason": "hyperfixi runs the handler although the event filter [key=='Escape'] is unmet (dispatched Event has no .key; undefined=='Escape' is false) — REAL BUG CANDIDATE, queued in PARSER_NEXT_STEPS.md"
-    },
-    {
       "key": "examples/events-and-dom/counter.html::6f9009e740::click",
       "file": "examples/events-and-dom/counter.html",
       "event": "click",


### PR DESCRIPTION
The shipped-examples execution gate's strongest first-sweep finding, fixed —
and the gate's ratchet completing its first full cycle.

## The bug

The parser has always delivered the bracketed filter as
`EventHandlerNode.condition` — typed, documented, and **never read by the
runtime**. Every filtered handler in every hyperfixi deployment ran unfiltered.
Shipped: `on keydown[key=='Escape'] from window hide .modal-overlay`
(`examples/dialogs/modal.html`) hid every modal on ANY key. Upstream
`hyperscript.org` correctly does nothing. No parse-level gate could see it —
the AST was perfect, the behavior was wrong. Found by #787's upstream-oracle
diff on its first run.

## The fix

`createEventHandler` evaluates the condition after context hydration and arg
destructuring (so `on boom(x)[x > 3]` sees destructured args), with the
identifiers the filter references resolved from the event into locals first —
upstream semantics: bare identifiers in a filter are event properties (`key`,
`shiftKey`). Behavior-init locals and the `target` local take precedence. Falsy
skips the body; a THROWING filter also skips (upstream wraps the body in
`if (<filter>)`, so a throwing filter never runs it either).

**Deliberate KNOWN GAP:** the filter applies to SINGLE-event handlers only. The
parser attaches one condition to the whole node even when the filter belongs to
one leg of an `or`-join (`on click or keypress[key=='Enter']` — upstream
filters ONLY keypress). Gating every leg on the shared condition would break
the unfiltered legs — measured: it would have broken the click leg of R2's
`multiple-events` pattern. Multi-event handlers keep their historical
unfiltered behavior until conditions are represented per event; pinned by a
KNOWN GAP test whose both halves flip when that lands, and queued in
`PARSER_NEXT_STEPS.md`.

## The ratchet's first full cycle

With the fix in place and the old baseline, the gate **fails** on its
stale-entry assertion, naming exactly the fixed handler's key — so the second
commit removes it, shrinking the allowlist 46 → 45. Gate finds bug → fix lands
→ gate forces its own baseline down. This is the loop #787 was built for,
demonstrated end-to-end on its first finding.

## Coverage

8 DOM-effect cases in `packages/core/src/api/event-filter-execution.test.ts`:
unmet/met key filter, bare boolean property (`shiftKey`), destructured-arg
filter, nonexistent-property filter (unmet, no crash), unfiltered-handler
guard, the or-join KNOWN GAP pin, and the shipped modal shape (`from window`).
**5 of 8 fail against the unfixed runtime**; the met-filter and unfiltered
cases are guards that pass in both states.

## Gates

- core: **7673 passed**, typecheck clean
- multilingual `--full --regression`: all 10 signals green (R2's
  `multiple-events` or-join pattern verified unaffected)
- shipped-examples execution gate: green at 45 entries (and red-verified
  against the stale baseline)
- full workspace `test:check`: exit 0; prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
