### PR TITLE
test(testing-framework): arbitrate execution-gate families 1/2 in real Chrome

### DIFF
--- a/docs-internal/HANDOFF-shipped-examples-execution.md
+++ b/docs-internal/HANDOFF-shipped-examples-execution.md
@@ -40,20 +40,44 @@ hyperfixi-recovers 25, `fetch` 13, js-blocks 11, …).
 ## The finding families (burn-down list)
 
 The 46 baseline entries collapse to six families — reasons live per-entry in
-the baseline JSON:
+the baseline JSON. Families 1, 2, and 4 were **arbitrated in real Chrome on
+2026-07-27** (see "Real-browser arbitration" below); their entries are now
+permanent with verdict reasons, except the one reclassified defect in family 2:
 
-1. **Element-target write semantics** (24): `increment #count` / `decrement` /
-   `set #x to v` — hyperfixi writes `textContent` in place; upstream's diff is
-   `-div:14#count`, the element GONE from the after-snapshot. Which engine
-   matches real-browser behavior is the open question — check in a browser
-   before "fixing" either.
-2. **show/hide strategy** (13): hyperfixi uses class + inline display; upstream
-   consults computed styles and is inert under jsdom. Includes the
-   form-validation and tabs entries (their `show`/`hide` legs are what differ).
+1. **Element-target write semantics** (24) — **VERDICT: not a jsdom artifact;
+   permanent engine difference.** Upstream's idRef assignment is
+   `IdRef.set → runtime.replaceInDom → elt.replaceWith(...)`: in real Chrome,
+   `increment #count` REPLACES the div with the literal text `NaN`
+   (`parseFloat` of an element object), exactly matching its jsdom `-key`
+   diff. hyperfixi writes the value in place and the element survives — which
+   is what the shipped pages are authored for (`count-mirror`'s
+   `on change in #count` needs the element to exist). No fix on either side.
+   The `set #count to 0` satellite (below) also dissolved.
+2. **show/hide strategy** (13) — **VERDICT: permanent strategy difference,
+   plus ONE reclassified hyperfixi defect.** The original reason was doubly
+   wrong: upstream show/hide never consults computed styles (only `toggle`
+   does) and is not jsdom-inert — it manages ONLY the inline `display`
+   property, identically in jsdom and Chrome. Consequence, Chrome-verified:
+   upstream `show` cannot reveal a stylesheet-hidden element (the modal stays
+   `display:none`; tabs never switch), while hyperfixi's deliberate
+   class+inline strategy (commit 6e33c7c9) matches the pages' authored
+   `.show` CSS rules — those pages work under hyperfixi only. For
+   inline-hidden and already-visible targets the visible outcomes match; the
+   signature delta is hyperfixi's `.show` marker class.
+   **Exception — real hyperfixi bug:** the recipes.html entry
+   (`show <blockquote/> in the next <div/> when its textContent contains my
+   value`): upstream filters correctly in Chrome (match shown, non-match
+   hidden); hyperfixi is a complete no-op in the shipped bundle and mis-targets
+   `me` under the gate's Runtime path. Queued in
+   [PARSER_NEXT_STEPS.md](PARSER_NEXT_STEPS.md).
 3. **`swap` extension** (4): upstream parses the source but has no `swap`
    command — no oracle for the effect, only for the no-crash.
-4. **Boolean-attribute toggles** (3): `toggle @disabled` representation
-   differs.
+4. **Boolean-attribute toggles** (3) — **VERDICT (bonus arbitration):
+   representation-only, permanent.** Both engines disable the control in
+   Chrome; hyperfixi writes canonical `disabled=""` (falsy attribute value),
+   upstream writes the literal string `"undefined"` (truthy). The
+   `#disabled-status` span delta is downstream: the sibling handler tests
+   `if #target-btn's @disabled`, which reads hyperfixi's `""` as false.
 5. **Unmet event filter still fires** (~~1~~ → **FIXED 2026-07-27**, the same
    day the gate landed): the runtime never read `EventHandlerNode.condition` —
    every filtered handler ran unfiltered. Fixed in `runtime-base.ts`
@@ -66,10 +90,38 @@ the baseline JSON:
 6. **js property-path argument** (1): `put document.getElementById(...).value
    into #result4` — hyperfixi produces no effect. REAL BUG CANDIDATE.
 
-Also surfaced, outside the allowlist (it diverges as part of family 1):
-`set #count to 0` produces NOTHING on hyperfixi while `increment #count` on
-the same page works — the `set <idref> to <value>` form looks broken on its
-own.
+~~Also surfaced (part of family 1): `set #count to 0` produces NOTHING on
+hyperfixi — the `set <idref> to <value>` form looks broken on its own.~~
+**RESOLVED 2026-07-27, not a bug:** test-classic-i18n.html's `#count` opens at
+`0`, so hyperfixi's write is 0-over-0 — invisible to the signature diff (the
+same masking class the "per-handler isolation" lesson below describes). Probes:
+the identical shape with a different start value writes in place on both the
+gate's parse+Runtime path (jsdom) and the shipped browser bundle (real Chrome,
+arbitration spec probe `f1c`).
+
+## Real-browser arbitration (2026-07-27)
+
+Families 1/2 (and 4, opportunistically) were arbitrated in real Chrome:
+
+- Fixture: `packages/core/src/compatibility/browser-tests/debug/fixtures/execution-arbitration.html`
+  — replicates each divergent shape exactly (counter, set-idref,
+  stylesheet-hidden modal with `.show` CSS, inline-hidden, already-visible,
+  tabs, recipes filtered-show, `toggle @disabled`); `?engine=hyperfixi|upstream`
+  picks the engine via `document.write`.
+- Spec: `packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts`
+  — run from `packages/core`:
+  `npx playwright test --project=debug execution-arbitration`. It asserts only
+  harness sanity and prints per-probe observations (element survival + text for
+  family 1, computed display for family 2) for human reading.
+- The upstream mechanisms were also confirmed in source
+  (`node_modules/hyperscript.org/dist/_hyperscript.js`, v0.9.93): `IdRef.set →
+  replaceInDom` for family 1; `HIDE_SHOW_STRATEGIES.display` touching only
+  inline `display` (computed styles only in the `toggle` path) for family 2.
+
+Net: jsdom was exonerated for both families — every diff the gate recorded is
+the engine's genuine behavior. The arbitration's real findings were the
+recipes.html filtered-show hyperfixi defect and the dissolution of the
+set-idref candidate.
 
 ## Harness lessons (they cost hours; read before touching)
 
@@ -103,11 +155,22 @@ own.
 
 ## What v2 could add (deliberately out of scope)
 
-- `on load` / custom events (`hello`, `close`, `dragstart`) — 8 skips.
-- Timer/`wait` handlers under fake timers — 26 skips, the largest
-  deterministic-in-principle class.
-- `<script type="text/hyperscript">` blocks (behaviors/functions defined
-  on-page).
-- Doc-tree snippets, by synthesizing fixture pages.
-- Real-browser (Playwright) arbitration for family 1/2 divergences where
-  jsdom itself is the suspect.
+Re-evaluated 2026-07-27, after the family-1/2 arbitration burned down the
+"pending investigation" reasons. In value order:
+
+1. **Timer/`wait` handlers under fake timers — 26 skips, now clearly the
+   largest coverage win** (next-biggest classes are hyperfixi-recovers 25 and
+   upstream-rejects 51, neither of which fake timers help). Both engines
+   schedule `wait` via `setTimeout` on globalThis, so vitest fake timers can
+   advance them deterministically. One implementation caveat: the harness's
+   own `settle()` uses `setTimeout` too — it must be captured as a real-timer
+   escape hatch (or replaced with `vi.advanceTimersByTimeAsync` +
+   `vi.runAllTicks`) before faking, or the sweep deadlocks itself.
+2. `on load` / custom events (`hello`, `close`, `dragstart`) — 8 skips.
+3. `<script type="text/hyperscript">` blocks (behaviors/functions defined
+   on-page).
+4. Doc-tree snippets, by synthesizing fixture pages.
+5. ~~Real-browser (Playwright) arbitration for family 1/2~~ — **done**, and
+   cheaper than expected as a standing artifact: the debug-project spec above
+   re-runs on demand. Extend its fixture when a future family needs
+   arbitration rather than building a new harness.

--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -26,7 +26,8 @@ ones, because the gate *is* the tracking mechanism.
 | ---- | -------- | ---- | ------ |
 | **Or-join filters have no per-event representation** | low — `on click or keypress[key=='Enter']` runs keypress unfiltered (upstream filters that leg); single-event filters ARE enforced | ✅ KNOWN GAP test | `packages/core/src/api/event-filter-execution.test.ts`; the runtime-side note at the `applicableCondition` site in `runtime-base.ts` |
 | **`tell` never consumes a terminating `end`** | medium — no real `tell … end` block form; upstream requires one | **none** | comment at `packages/core/src/parser/command-parsers/utility-commands.ts` (the `ELSE`/`END` break in `parseTellCommand`) |
-| **`set <idref> to <value>` / js property-path args no-op** | medium — silent no-effect on shipped pages | ✅ execution-gate allowlist entries | families 1/6 in [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md) |
+| **Filtered scoped `show` (`show <sel/> in <expr> when <cond>`) does nothing** | medium — shipped recipes.html quote search is dead; upstream filters correctly (real-Chrome-verified, and the two hyperfixi paths fail differently: bundle no-ops, gate's Runtime path mis-targets `me`) | ✅ execution-gate allowlist entry | family 2 exception in [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md) |
+| **js property-path argument no-op** — `put document.getElementById(...).value into #x` | medium — silent no-effect on a shipped page | ✅ execution-gate allowlist entry | family 6 in [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md) |
 | `and` is not a command separator anywhere | low — consistent everywhere, so no surprise | ✅ 2 `KNOWN GAP` tests | `packages/core/src/parser/__tests__/then-as-separator.test.ts` |
 | `sortable-list.html` recovers with errors | low — one shipped example | ✅ allowlist ratchet | `packages/testing-framework/baselines/shipped-sources-validity.json` |
 
@@ -38,8 +39,8 @@ ones, because the gate *is* the tracking mechanism.
 - **`sortable-list.html`** — the allowlist key embeds `sha1(source)`, and
   assertion 3 of the shipped-sources gate **fails** when an allowlisted source
   goes clean. The list can only ratchet down. It cannot be silently forgotten.
-- **The execution-gate entries** (`set <idref>` / js-path no-ops) — same
-  mechanism as `sortable-list.html`: their allowlist keys in
+- **The execution-gate entries** (the filtered-`show` defect, the js-path
+  no-op) — same mechanism as `sortable-list.html`: their allowlist keys in
   `packages/testing-framework/baselines/shipped-examples-execution.json` embed a
   source hash, and the gate's stale-entry assertion fails when a divergence
   converges, forcing the entry's removal in the fixing change. This is not
@@ -62,7 +63,11 @@ what would have caught the #785 defect on *behaviour* rather than on a
 diagnostic. Design, current numbers, the divergence families, and the
 harness lessons: [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md).
 Its first sweep produced two bug candidates: the unmet-event-filter defect
-(**fixed** — see History) and the `set <idref>` / js-path no-ops row above.
+(**fixed** — see History) and a `set <idref>` / js-path no-op row. The
+2026-07-27 real-browser arbitration (see History) **cleared the `set <idref>`
+half** (a same-value write invisible to the signature diff, not a no-op) and
+**added the filtered-`show` defect** — the two current execution-gate rows
+above.
 
 **Expression-first condition parsing** is the deferred follow-on from the `if`
 family (see History). #786 replaced the raw "is this token spelled like a
@@ -80,6 +85,14 @@ regression episode that motivates it:
 
 ## History
 
+- **2026-07-27** — execution-gate families 1/2 arbitrated in real Chrome
+  (Playwright debug spec, standing artifact — see the HANDOFF's "Real-browser
+  arbitration" section): jsdom exonerated for both; family 1 (element-target
+  writes) and family 2 (show/hide strategy) are permanent engine differences,
+  reasons rewritten to verdicts. The `set <idref>` bug candidate dissolved
+  (same-value write); one new defect found and queued (filtered scoped `show`,
+  table above). Brief:
+  [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md).
 - **2026-07-27** — event filters enforced: `on keydown[key=='Escape']` ran on
   ANY key because the runtime never read `EventHandlerNode.condition` (parsed,
   typed, documented, never consumed). The gate's first finding, fixed the same

--- a/packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Real-browser arbitration for the shipped-examples execution gate —
+ * baseline families 1 (element-target writes) and 2 (show/hide strategy).
+ *
+ * The gate (packages/testing-framework/src/multilingual/shipped-examples-execution.ts)
+ * diffs both engines under jsdom; for these two families jsdom itself was the
+ * suspect. This spec loads the same shapes in real Chrome against each engine
+ * (fixtures/execution-arbitration.html?engine=hyperfixi|upstream), performs the
+ * same trigger, and reports the OBSERVED outcome per engine — element survival
+ * and text for family 1, computed display (visibility) for family 2.
+ *
+ * It asserts only harness sanity (engine loaded, probe elements present);
+ * the per-probe observations are printed as JSON for human arbitration. See
+ * docs-internal/HANDOFF-shipped-examples-execution.md for the verdicts this
+ * produced.
+ *
+ * Run (from packages/core):
+ *   npx playwright test --project=debug execution-arbitration
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+const FIXTURE =
+  '/packages/core/src/compatibility/browser-tests/debug/fixtures/execution-arbitration.html';
+
+interface ElementObservation {
+  exists: boolean;
+  text?: string;
+  computedDisplay?: string;
+  classes?: string[];
+  inlineStyle?: string;
+  parentHTML?: string;
+}
+
+async function observe(
+  page: Page,
+  selector: string,
+  parentOf?: string
+): Promise<ElementObservation> {
+  return page.evaluate(
+    ({ sel, parentSel }) => {
+      const el = document.querySelector(sel);
+      if (!el) {
+        const parent = parentSel ? document.querySelector(parentSel) : null;
+        return {
+          exists: false,
+          parentHTML: parent
+            ? parent.innerHTML.replace(/\s+/g, ' ').trim().slice(0, 200)
+            : undefined,
+        };
+      }
+      return {
+        exists: true,
+        text: (el.textContent ?? '').trim().slice(0, 80),
+        computedDisplay: getComputedStyle(el).display,
+        classes: Array.from(el.classList),
+        inlineStyle: el.getAttribute('style') ?? '',
+      };
+    },
+    { sel: selector, parentSel: parentOf }
+  );
+}
+
+async function loadFixture(page: Page, engine: 'hyperfixi' | 'upstream'): Promise<void> {
+  await page.goto(`${FIXTURE}?engine=${engine}`);
+  // Both engines process `_` attributes at DOMContentLoaded; give them a beat.
+  await page.waitForTimeout(400);
+  const loaded = await page.evaluate(() => ({
+    hyperfixi: typeof (window as never as Record<string, unknown>).hyperfixi !== 'undefined',
+    upstream: typeof (window as never as Record<string, unknown>)._hyperscript !== 'undefined',
+  }));
+  expect(
+    loaded[engine === 'upstream' ? 'upstream' : 'hyperfixi'],
+    `${engine} engine global present`
+  ).toBe(true);
+}
+
+async function runProbes(page: Page, engine: 'hyperfixi' | 'upstream') {
+  const results: Record<string, unknown> = { engine };
+
+  // ---- Family 1: element-target writes ----
+  await loadFixture(page, engine);
+  await page.click('#b-inc');
+  await page.waitForTimeout(100);
+  results['f1a increment #count1 (was "0")'] = await observe(page, '#count1', 'body');
+
+  await page.click('#b-dec');
+  await page.waitForTimeout(100);
+  results['f1b decrement #count2 (was "5")'] = await observe(page, '#count2', 'body');
+
+  await page.click('#b-set');
+  await page.waitForTimeout(100);
+  results['f1c set #count3 to 0 (was "5")'] = await observe(page, '#count3', 'body');
+
+  // ---- Family 2: show/hide ----
+  // Fresh page per probe group so earlier probes cannot contaminate.
+  await loadFixture(page, engine);
+  await page.click('#b-show-modal');
+  await page.waitForTimeout(100);
+  results['f2a show #modal (stylesheet-hidden, .show CSS rule)'] = await observe(page, '#modal');
+
+  await page.click('#b-hide-modal');
+  await page.waitForTimeout(100);
+  results['f2a2 then hide #modal'] = await observe(page, '#modal');
+
+  await page.click('#b-show-inline');
+  await page.waitForTimeout(100);
+  results['f2b show #inline-hidden (inline display:none)'] = await observe(page, '#inline-hidden');
+
+  await page.click('#b-show-vis');
+  await page.waitForTimeout(100);
+  results['f2c show #vis-box (already visible)'] = await observe(page, '#vis-box');
+
+  await page.click('#b-hide-vis');
+  await page.waitForTimeout(100);
+  results['f2c2 then hide #vis-box'] = await observe(page, '#vis-box');
+
+  await loadFixture(page, engine);
+  await page.click('#tab2');
+  await page.waitForTimeout(100);
+  results['f2d tabs: click Tab 2 → #panel1'] = await observe(page, '#panel1');
+  results['f2d tabs: click Tab 2 → #panel2'] = await observe(page, '#panel2');
+
+  await loadFixture(page, engine);
+  // "code" appears in q1 only; recipes.html filtered-show shape.
+  await page.locator('#quote-search').pressSequentially('code');
+  await page.waitForTimeout(150);
+  results['f2e filtered show → #q1 (matches "code")'] = await observe(page, '#q1');
+  results['f2e filtered show → #q2 (no match)'] = await observe(page, '#q2');
+  results['f2e filtered show → input itself'] = await observe(page, '#quote-search');
+
+  // ---- Family 4 (bonus): boolean-attribute toggle ----
+  await loadFixture(page, engine);
+  await page.click('#b-toggle-disabled');
+  await page.waitForTimeout(100);
+  results['f4 toggle @disabled → #target-btn'] = await page.evaluate(() => {
+    const el = document.querySelector('#target-btn') as HTMLButtonElement;
+    return {
+      hasAttr: el.hasAttribute('disabled'),
+      attrValue: el.getAttribute('disabled'),
+      disabledProp: el.disabled,
+    };
+  });
+
+  return results;
+}
+
+test.describe('execution-gate arbitration: hyperfixi vs upstream in real Chrome', () => {
+  test('hyperfixi observations', async ({ page }) => {
+    const results = await runProbes(page, 'hyperfixi');
+    console.log('\n===== HYPERFIXI (real Chrome) =====\n' + JSON.stringify(results, null, 2));
+  });
+
+  test('upstream observations', async ({ page }) => {
+    const results = await runProbes(page, 'upstream');
+    console.log('\n===== UPSTREAM (real Chrome) =====\n' + JSON.stringify(results, null, 2));
+  });
+});

--- a/packages/core/src/compatibility/browser-tests/debug/fixtures/execution-arbitration.html
+++ b/packages/core/src/compatibility/browser-tests/debug/fixtures/execution-arbitration.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Execution-gate arbitration fixture</title>
+  <!--
+    Real-browser arbitration fixture for the shipped-examples execution gate's
+    baseline families 1 (element-target writes) and 2 (show/hide strategy).
+    Each block replicates the exact shape of a shipped example that diverges
+    between engines under jsdom. Load with ?engine=hyperfixi (default) or
+    ?engine=upstream; the spec (execution-arbitration.spec.ts) drives both and
+    compares the VISIBLE outcomes, not the mechanisms.
+  -->
+  <style>
+    /* modal.html shape: stylesheet-hidden + a `.show` reveal rule */
+    .modal-overlay { display: none; }
+    .modal-overlay.show { display: flex; }
+    /* form-validation.html shape (same class of CSS, kept for clarity) */
+    .error-message { display: none; }
+    .error-message.show { display: block; }
+    /* showcase.html tabs shape */
+    .tab-panel { display: none; }
+    .tab-panel.active { display: block; }
+  </style>
+  <script>
+    var engine = new URLSearchParams(location.search).get('engine') || 'hyperfixi';
+    document.write(engine === 'upstream'
+      ? '<script src="/node_modules/hyperscript.org/dist/_hyperscript.js"><\/script>'
+      : '<script src="/packages/core/dist/hyperfixi.js"><\/script>');
+  </script>
+</head>
+<body>
+  <!-- Family 1a: increment on an element target (counter.html shape) -->
+  <div id="count1" class="counter-display">0</div>
+  <button id="b-inc" _="on click increment #count1">inc</button>
+
+  <!-- Family 1b: decrement -->
+  <div id="count2" class="counter-display">5</div>
+  <button id="b-dec" _="on click decrement #count2">dec</button>
+
+  <!-- Family 1c: set <idref> to <value> (test-classic-i18n.html shape) -->
+  <span id="count3" class="counter">5</span>
+  <button id="b-set" _="on click set #count3 to 0">set</button>
+
+  <!-- Family 2a: show a stylesheet-hidden element (modal.html shape) -->
+  <div id="modal" class="modal-overlay">modal content</div>
+  <button id="b-show-modal" _="on click show #modal">show modal</button>
+  <button id="b-hide-modal" _="on click hide #modal">hide modal</button>
+
+  <!-- Family 2b: show an inline-hidden element -->
+  <div id="inline-hidden" style="display:none">inline hidden</div>
+  <button id="b-show-inline" _="on click show #inline-hidden">show inline</button>
+
+  <!-- Family 2c: show an already-visible element (show-hide.html #content1 shape) -->
+  <div id="vis-box">visible box</div>
+  <button id="b-show-vis" _="on click show #vis-box">show vis</button>
+  <button id="b-hide-vis" _="on click hide #vis-box">hide vis</button>
+
+  <!-- Family 2d: tabs — hide stylesheet-hidden panels then show one (showcase.html shape) -->
+  <div>
+    <button class="tab-btn active" id="tab1" _="on click remove .active from .tab-btn then add .active to me then hide .tab-panel then show #panel1">Tab 1</button>
+    <button class="tab-btn" id="tab2" _="on click remove .active from .tab-btn then add .active to me then hide .tab-panel then show #panel2">Tab 2</button>
+  </div>
+  <div class="tab-panel active" id="panel1">Panel 1</div>
+  <div class="tab-panel" id="panel2">Panel 2</div>
+
+  <!-- Family 2e: filtered show (recipes.html quote-search shape) -->
+  <input id="quote-search" type="text" placeholder="Search quotes…"
+         _="on keyup show <blockquote/> in the next <div/> when its textContent contains my value">
+  <div class="quotes">
+    <blockquote id="q1">"Talk is cheap. Show me the code." — Linus Torvalds</blockquote>
+    <blockquote id="q2">"Programs must be written for people to read." — Harold Abelson</blockquote>
+  </div>
+
+  <!-- Family 4 (bonus probe): boolean-attribute toggle (toggle-attributes.html shape) -->
+  <button id="target-btn" class="demo-target">Target</button>
+  <button id="b-toggle-disabled" _="on click toggle @disabled on #target-btn">toggle disabled</button>
+</body>
+</html>

--- a/packages/testing-framework/baselines/shipped-examples-execution.json
+++ b/packages/testing-framework/baselines/shipped-examples-execution.json
@@ -17,7 +17,7 @@
         "Δinput:45 cls[show] attr[placeholder=Search quotes…,type=text] style[] text[]"
       ],
       "upstream": [],
-      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+      "reason": "hyperfixi DEFECT — arbitrated in real Chrome 2026-07-27: filtered scoped show (`show <sel/> in <expr> when <cond>`) is a no-op in the shipped browser bundle and mis-targets `me` under the gate Runtime path, while upstream correctly shows matching blockquotes and hides the rest. Queued in docs-internal/PARSER_NEXT_STEPS.md."
     },
     {
       "key": "examples/dialogs/modal.html::37ad17f250::click",
@@ -28,7 +28,7 @@
         "Δdiv:16#info-modal cls[modal-overlay show] attr[id=info-modal] style[] text[]"
       ],
       "upstream": [],
-      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+      "reason": "show/hide strategy — arbitrated in real Chrome 2026-07-27 (execution-arbitration.spec.ts): upstream show/hide manages ONLY the inline display property (computed styles are consulted by toggle alone; the earlier inert-under-jsdom framing was wrong) and cannot reveal stylesheet-hidden elements in ANY environment; hyperfixi deliberately adds a .show marker class and restores inline display (commit 6e33c7c9), which these pages own .show CSS rules are authored for. Permanent strategy difference: visible outcomes match for inline-hidden and already-visible targets; stylesheet-hidden targets (modals, tabs, error boxes) open under hyperfixi only."
     },
     {
       "key": "examples/dialogs/modal.html::8dbe740dd3::click",
@@ -39,7 +39,7 @@
         "Δdiv:31#confirm-modal cls[modal-overlay show] attr[id=confirm-modal] style[] text[]"
       ],
       "upstream": [],
-      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+      "reason": "show/hide strategy — arbitrated in real Chrome 2026-07-27 (execution-arbitration.spec.ts): upstream show/hide manages ONLY the inline display property (computed styles are consulted by toggle alone; the earlier inert-under-jsdom framing was wrong) and cannot reveal stylesheet-hidden elements in ANY environment; hyperfixi deliberately adds a .show marker class and restores inline display (commit 6e33c7c9), which these pages own .show CSS rules are authored for. Permanent strategy difference: visible outcomes match for inline-hidden and already-visible targets; stylesheet-hidden targets (modals, tabs, error boxes) open under hyperfixi only."
     },
     {
       "key": "examples/dialogs/modal.html::c9f964d2a2::click",
@@ -50,7 +50,7 @@
         "Δdiv:46#form-modal cls[modal-overlay show] attr[id=form-modal] style[] text[]"
       ],
       "upstream": [],
-      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+      "reason": "show/hide strategy — arbitrated in real Chrome 2026-07-27 (execution-arbitration.spec.ts): upstream show/hide manages ONLY the inline display property (computed styles are consulted by toggle alone; the earlier inert-under-jsdom framing was wrong) and cannot reveal stylesheet-hidden elements in ANY environment; hyperfixi deliberately adds a .show marker class and restores inline display (commit 6e33c7c9), which these pages own .show CSS rules are authored for. Permanent strategy difference: visible outcomes match for inline-hidden and already-visible targets; stylesheet-hidden targets (modals, tabs, error boxes) open under hyperfixi only."
     },
     {
       "key": "examples/events-and-dom/counter.html::6f9009e740::click",
@@ -62,7 +62,7 @@
         "Δspan:20#count-mirror cls[] attr[id=count-mirror] style[] text[-1]"
       ],
       "upstream": ["-div:14#count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/events-and-dom/counter.html::7f5ebb38b0::click",
@@ -74,7 +74,7 @@
         "Δspan:20#count-mirror cls[] attr[id=count-mirror] style[] text[1]"
       ],
       "upstream": ["-div:14#count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/events-and-dom/show-hide.html::8aeb3a46f9::click",
@@ -83,7 +83,7 @@
       "excerpt": "on click show #content1",
       "hyperfixi": ["Δdiv:26#content1 cls[content-box show] attr[id=content1] style[] text[]"],
       "upstream": [],
-      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+      "reason": "show/hide strategy — arbitrated in real Chrome 2026-07-27 (execution-arbitration.spec.ts): upstream show/hide manages ONLY the inline display property (computed styles are consulted by toggle alone; the earlier inert-under-jsdom framing was wrong) and cannot reveal stylesheet-hidden elements in ANY environment; hyperfixi deliberately adds a .show marker class and restores inline display (commit 6e33c7c9), which these pages own .show CSS rules are authored for. Permanent strategy difference: visible outcomes match for inline-hidden and already-visible targets; stylesheet-hidden targets (modals, tabs, error boxes) open under hyperfixi only."
     },
     {
       "key": "examples/experiments/01-polyglot-playground.html::6f9009e740::click",
@@ -92,7 +92,7 @@
       "excerpt": "on click decrement #count",
       "hyperfixi": ["Δdiv:29#count cls[demo-counter] attr[id=count] style[] text[-1]"],
       "upstream": ["-div:29#count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/experiments/01-polyglot-playground.html::7f5ebb38b0::click",
@@ -101,7 +101,7 @@
       "excerpt": "on click increment #count",
       "hyperfixi": ["Δdiv:29#count cls[demo-counter] attr[id=count] style[] text[1]"],
       "upstream": ["-div:29#count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/experiments/02-multilingual-sync.html::227e004ae8::click",
@@ -112,7 +112,7 @@
         "Δdiv:11#shared-count cls[shared-counter] attr[id=shared-count] style[] text[-1]"
       ],
       "upstream": ["-div:11#shared-count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/experiments/02-multilingual-sync.html::aeeb82b882::click",
@@ -123,7 +123,7 @@
         "Δdiv:11#shared-count cls[shared-counter] attr[id=shared-count] style[] text[1]"
       ],
       "upstream": ["-div:11#shared-count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/experiments/03-adaptive-rtl-ltr.html::f701a8b242::click",
@@ -132,7 +132,7 @@
       "excerpt": "on click decrement #counter",
       "hyperfixi": ["Δdiv:35#counter cls[counter-value] attr[id=counter] style[] text[-1]"],
       "upstream": ["-div:35#counter"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/experiments/03-adaptive-rtl-ltr.html::0d0a6b9a18::click",
@@ -141,7 +141,7 @@
       "excerpt": "on click increment #counter",
       "hyperfixi": ["Δdiv:35#counter cls[counter-value] attr[id=counter] style[] text[1]"],
       "upstream": ["-div:35#counter"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/forms/form-validation.html::e85adbe538::input",
@@ -155,7 +155,7 @@
       "upstream": [
         "Δinput:24#email cls[error] attr[id=email,placeholder=you@example.com,type=email] style[] text[]"
       ],
-      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+      "reason": "show/hide strategy — arbitrated in real Chrome 2026-07-27 (execution-arbitration.spec.ts): upstream show/hide manages ONLY the inline display property (computed styles are consulted by toggle alone; the earlier inert-under-jsdom framing was wrong) and cannot reveal stylesheet-hidden elements in ANY environment; hyperfixi deliberately adds a .show marker class and restores inline display (commit 6e33c7c9), which these pages own .show CSS rules are authored for. Permanent strategy difference: visible outcomes match for inline-hidden and already-visible targets; stylesheet-hidden targets (modals, tabs, error boxes) open under hyperfixi only."
     },
     {
       "key": "examples/forms/form-validation.html::6b07d036d3::input",
@@ -169,7 +169,7 @@
       "upstream": [
         "Δinput:28#password cls[error] attr[id=password,placeholder=Enter password (min 8 characters),type=password] style[] text[]"
       ],
-      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+      "reason": "show/hide strategy — arbitrated in real Chrome 2026-07-27 (execution-arbitration.spec.ts): upstream show/hide manages ONLY the inline display property (computed styles are consulted by toggle alone; the earlier inert-under-jsdom framing was wrong) and cannot reveal stylesheet-hidden elements in ANY environment; hyperfixi deliberately adds a .show marker class and restores inline display (commit 6e33c7c9), which these pages own .show CSS rules are authored for. Permanent strategy difference: visible outcomes match for inline-hidden and already-visible targets; stylesheet-hidden targets (modals, tabs, error boxes) open under hyperfixi only."
     },
     {
       "key": "examples/forms/form-validation.html::467bb365ef::input",
@@ -183,7 +183,7 @@
       "upstream": [
         "Δinput:32#confirm cls[error] attr[id=confirm,placeholder=Re-enter password,type=password] style[] text[]"
       ],
-      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+      "reason": "show/hide strategy — arbitrated in real Chrome 2026-07-27 (execution-arbitration.spec.ts): upstream show/hide manages ONLY the inline display property (computed styles are consulted by toggle alone; the earlier inert-under-jsdom framing was wrong) and cannot reveal stylesheet-hidden elements in ANY environment; hyperfixi deliberately adds a .show marker class and restores inline display (commit 6e33c7c9), which these pages own .show CSS rules are authored for. Permanent strategy difference: visible outcomes match for inline-hidden and already-visible targets; stylesheet-hidden targets (modals, tabs, error boxes) open under hyperfixi only."
     },
     {
       "key": "examples/multilingual/adaptive-rtl-ltr.html::f701a8b242::click",
@@ -192,7 +192,7 @@
       "excerpt": "on click decrement #counter",
       "hyperfixi": ["Δdiv:35#counter cls[counter-value] attr[id=counter] style[] text[-1]"],
       "upstream": ["-div:35#counter"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/multilingual/adaptive-rtl-ltr.html::0d0a6b9a18::click",
@@ -201,7 +201,7 @@
       "excerpt": "on click increment #counter",
       "hyperfixi": ["Δdiv:35#counter cls[counter-value] attr[id=counter] style[] text[1]"],
       "upstream": ["-div:35#counter"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/multilingual/index.html::6f9009e740::click",
@@ -210,7 +210,7 @@
       "excerpt": "on click decrement #count",
       "hyperfixi": ["Δdiv:51#count cls[counter-display] attr[id=count] style[] text[-1]"],
       "upstream": ["-div:51#count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/multilingual/index.html::7f5ebb38b0::click",
@@ -219,7 +219,7 @@
       "excerpt": "on click increment #count",
       "hyperfixi": ["Δdiv:51#count cls[counter-display] attr[id=count] style[] text[1]"],
       "upstream": ["-div:51#count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/multilingual/multilingual-sync.html::227e004ae8::click",
@@ -230,7 +230,7 @@
         "Δdiv:11#shared-count cls[shared-counter] attr[id=shared-count] style[] text[-1]"
       ],
       "upstream": ["-div:11#shared-count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/multilingual/multilingual-sync.html::aeeb82b882::click",
@@ -241,7 +241,7 @@
         "Δdiv:11#shared-count cls[shared-counter] attr[id=shared-count] style[] text[1]"
       ],
       "upstream": ["-div:11#shared-count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/multilingual/polyglot-playground.html::6f9009e740::click",
@@ -250,7 +250,7 @@
       "excerpt": "on click decrement #count",
       "hyperfixi": ["Δdiv:29#count cls[demo-counter] attr[id=count] style[] text[-1]"],
       "upstream": ["-div:29#count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/multilingual/polyglot-playground.html::7f5ebb38b0::click",
@@ -259,7 +259,7 @@
       "excerpt": "on click increment #count",
       "hyperfixi": ["Δdiv:29#count cls[demo-counter] attr[id=count] style[] text[1]"],
       "upstream": ["-div:29#count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/multilingual/showcase.html::406e02080b::click",
@@ -270,7 +270,7 @@
         "Δdiv:36#counter-value cls[counter-value] attr[id=counter-value] style[] text[-1]"
       ],
       "upstream": ["-div:36#counter-value"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/multilingual/showcase.html::3d4a481500::click",
@@ -281,7 +281,7 @@
         "Δdiv:36#counter-value cls[counter-value] attr[id=counter-value] style[] text[1]"
       ],
       "upstream": ["-div:36#counter-value"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/multilingual/showcase.html::1db01d96f1::click",
@@ -297,7 +297,7 @@
         "Δdiv:97#panel2 cls[tab-panel] attr[id=panel2] style[display: none;] text[Content for Tab 2. The code removes .active from all tabs, then adds it to the clicked ",
         "Δdiv:98#panel3 cls[tab-panel] attr[id=panel3] style[display: none;] text[Content for Tab 3. This pattern is common in UI frameworks.]"
       ],
-      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+      "reason": "show/hide strategy — arbitrated in real Chrome 2026-07-27 (execution-arbitration.spec.ts): upstream show/hide manages ONLY the inline display property (computed styles are consulted by toggle alone; the earlier inert-under-jsdom framing was wrong) and cannot reveal stylesheet-hidden elements in ANY environment; hyperfixi deliberately adds a .show marker class and restores inline display (commit 6e33c7c9), which these pages own .show CSS rules are authored for. Permanent strategy difference: visible outcomes match for inline-hidden and already-visible targets; stylesheet-hidden targets (modals, tabs, error boxes) open under hyperfixi only."
     },
     {
       "key": "examples/multilingual/showcase.html::38866ac528::click",
@@ -317,7 +317,7 @@
         "Δdiv:96#panel1 cls[active tab-panel] attr[id=panel1] style[display: none;] text[Content for Tab 1. This demonstrates multi-element coordination.]",
         "Δdiv:98#panel3 cls[tab-panel] attr[id=panel3] style[display: none;] text[Content for Tab 3. This pattern is common in UI frameworks.]"
       ],
-      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+      "reason": "show/hide strategy — arbitrated in real Chrome 2026-07-27 (execution-arbitration.spec.ts): upstream show/hide manages ONLY the inline display property (computed styles are consulted by toggle alone; the earlier inert-under-jsdom framing was wrong) and cannot reveal stylesheet-hidden elements in ANY environment; hyperfixi deliberately adds a .show marker class and restores inline display (commit 6e33c7c9), which these pages own .show CSS rules are authored for. Permanent strategy difference: visible outcomes match for inline-hidden and already-visible targets; stylesheet-hidden targets (modals, tabs, error boxes) open under hyperfixi only."
     },
     {
       "key": "examples/multilingual/showcase.html::118be448a2::click",
@@ -337,7 +337,7 @@
         "Δdiv:96#panel1 cls[active tab-panel] attr[id=panel1] style[display: none;] text[Content for Tab 1. This demonstrates multi-element coordination.]",
         "Δdiv:97#panel2 cls[tab-panel] attr[id=panel2] style[display: none;] text[Content for Tab 2. The code removes .active from all tabs, then adds it to the clicked "
       ],
-      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+      "reason": "show/hide strategy — arbitrated in real Chrome 2026-07-27 (execution-arbitration.spec.ts): upstream show/hide manages ONLY the inline display property (computed styles are consulted by toggle alone; the earlier inert-under-jsdom framing was wrong) and cannot reveal stylesheet-hidden elements in ANY environment; hyperfixi deliberately adds a .show marker class and restores inline display (commit 6e33c7c9), which these pages own .show CSS rules are authored for. Permanent strategy difference: visible outcomes match for inline-hidden and already-visible targets; stylesheet-hidden targets (modals, tabs, error boxes) open under hyperfixi only."
     },
     {
       "key": "examples/multilingual/test-classic-i18n.html::7f5ebb38b0::click",
@@ -346,7 +346,7 @@
       "excerpt": "on click increment #count",
       "hyperfixi": ["Δspan:17#count cls[counter] attr[id=count] style[] text[1]"],
       "upstream": ["-span:17#count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/multilingual/test-classic-i18n.html::ffd8337a94::click",
@@ -355,7 +355,7 @@
       "excerpt": "on click set #count to 0",
       "hyperfixi": [],
       "upstream": ["-span:17#count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes. The hyperfixi-empty signature on THIS entry is a same-value write (the page opens with #count already 0), not a no-op."
     },
     {
       "key": "examples/swap-and-morph/swap-morph.html::f3c10ab34d::click",
@@ -414,7 +414,7 @@
         "Δbutton:52#target-btn cls[demo-target] attr[disabled=undefined,id=target-btn] style[] text[\n                    Target Button\n                ]",
         "Δspan:55#disabled-status cls[] attr[id=disabled-status] style[] text[disabled]"
       ],
-      "reason": "boolean-attribute toggle representation differs between engines. Pending investigation"
+      "reason": "boolean-attribute toggle — arbitrated in real Chrome 2026-07-27: both engines disable the control (disabled property true); hyperfixi writes canonical disabled=\"\" (a FALSY attribute value), upstream writes the literal string \"undefined\" (truthy). Representation-only, permanent; the #disabled-status delta is downstream truthiness of those values in the sibling `if X's @disabled` handler."
     },
     {
       "key": "examples/toggle-and-state/toggle-attributes.html::6812ec8c63::click",
@@ -427,7 +427,7 @@
       "upstream": [
         "Δinput:66#email-input cls[demo-target] attr[id=email-input,placeholder=Enter email...,required=undefined,type=email] style[] text[]"
       ],
-      "reason": "boolean-attribute toggle representation differs between engines. Pending investigation"
+      "reason": "boolean-attribute toggle — arbitrated in real Chrome 2026-07-27: both engines disable the control (disabled property true); hyperfixi writes canonical disabled=\"\" (a FALSY attribute value), upstream writes the literal string \"undefined\" (truthy). Representation-only, permanent; the #disabled-status delta is downstream truthiness of those values in the sibling `if X's @disabled` handler."
     },
     {
       "key": "examples/toggle-and-state/toggle-attributes.html::1d1cf3bb14::click",
@@ -440,7 +440,7 @@
       "upstream": [
         "Δbutton:131#prop-btn cls[demo-target] attr[disabled=undefined,id=prop-btn] style[] text[\n                    Another Target\n                ]"
       ],
-      "reason": "boolean-attribute toggle representation differs between engines. Pending investigation"
+      "reason": "boolean-attribute toggle — arbitrated in real Chrome 2026-07-27: both engines disable the control (disabled property true); hyperfixi writes canonical disabled=\"\" (a FALSY attribute value), upstream writes the literal string \"undefined\" (truthy). Representation-only, permanent; the #disabled-status delta is downstream truthiness of those values in the sibling `if X's @disabled` handler."
     },
     {
       "key": "examples/vite-plugin-multilingual/index.html::3fed702e4e::click",
@@ -451,7 +451,7 @@
         "Δdiv:40#en-content cls[show] attr[id=en-content] style[] text[English content that can be shown/hidden.]"
       ],
       "upstream": [],
-      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+      "reason": "show/hide strategy — arbitrated in real Chrome 2026-07-27 (execution-arbitration.spec.ts): upstream show/hide manages ONLY the inline display property (computed styles are consulted by toggle alone; the earlier inert-under-jsdom framing was wrong) and cannot reveal stylesheet-hidden elements in ANY environment; hyperfixi deliberately adds a .show marker class and restores inline display (commit 6e33c7c9), which these pages own .show CSS rules are authored for. Permanent strategy difference: visible outcomes match for inline-hidden and already-visible targets; stylesheet-hidden targets (modals, tabs, error boxes) open under hyperfixi only."
     },
     {
       "key": "examples/vite-plugin-multilingual/index.html::b0b708a0c6::click",
@@ -460,7 +460,7 @@
       "excerpt": "on click decrement #en-count",
       "hyperfixi": ["Δspan:43#en-count cls[counter] attr[id=en-count] style[] text[-1]"],
       "upstream": ["-span:43#en-count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/vite-plugin-multilingual/index.html::712d7ec0b1::click",
@@ -469,7 +469,7 @@
       "excerpt": "on click increment #en-count",
       "hyperfixi": ["Δspan:43#en-count cls[counter] attr[id=en-count] style[] text[1]"],
       "upstream": ["-span:43#en-count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/vite-plugin-test/index.html::cbac0b8e43::click",
@@ -480,7 +480,7 @@
         "Δdiv:7#content cls[show] attr[id=content] style[] text[This content can be shown/hidden.]"
       ],
       "upstream": [],
-      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
+      "reason": "show/hide strategy — arbitrated in real Chrome 2026-07-27 (execution-arbitration.spec.ts): upstream show/hide manages ONLY the inline display property (computed styles are consulted by toggle alone; the earlier inert-under-jsdom framing was wrong) and cannot reveal stylesheet-hidden elements in ANY environment; hyperfixi deliberately adds a .show marker class and restores inline display (commit 6e33c7c9), which these pages own .show CSS rules are authored for. Permanent strategy difference: visible outcomes match for inline-hidden and already-visible targets; stylesheet-hidden targets (modals, tabs, error boxes) open under hyperfixi only."
     },
     {
       "key": "examples/vite-plugin-test/index.html::6f9009e740::click",
@@ -489,7 +489,7 @@
       "excerpt": "on click decrement #count",
       "hyperfixi": ["Δspan:14#count cls[counter] attr[id=count] style[] text[-1]"],
       "upstream": ["-span:14#count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     },
     {
       "key": "examples/vite-plugin-test/index.html::7f5ebb38b0::click",
@@ -498,7 +498,7 @@
       "excerpt": "on click increment #count",
       "hyperfixi": ["Δspan:14#count cls[counter] attr[id=count] style[] text[1]"],
       "upstream": ["-span:14#count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
+      "reason": "element-target write semantics — arbitrated in real Chrome 2026-07-27 (packages/core/src/compatibility/browser-tests/debug/execution-arbitration.spec.ts): upstream idRef assignment is replaceInDom — the element is REPLACED by the stringified value (literal NaN for increment/decrement, which parseFloat an element object), identical to its jsdom `-key` diff; hyperfixi writes the value in place and the element survives. Not a jsdom artifact; permanent deliberate engine difference — the shipped pages are authored for in-place writes."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Real-browser (Playwright) arbitration of the two "pending investigation" families in the shipped-examples execution gate's baseline — the top follow-on in `docs-internal/HANDOFF-shipped-examples-execution.md`. **jsdom is exonerated for both families**: every diff the gate recorded is the engine's genuine behavior, reproduced exactly in real Chrome.

### Verdicts

- **Family 1 — element-target writes (24 entries): permanent engine difference, no fix either side.** Upstream's idRef assignment is `IdRef.set → replaceInDom → elt.replaceWith(...)`: in real Chrome, `increment #count` replaces the div with the literal text `NaN` (`parseFloat` of an element object), exactly matching its jsdom `-key` diff. hyperfixi writes the value in place and the element survives — what the shipped pages are authored for.
- **Family 2 — show/hide (13 entries): permanent strategy difference, except one reclassified defect.** The old reason was doubly wrong: upstream show/hide never consults computed styles (only `toggle` does) and is not jsdom-inert — it manages ONLY the inline `display` property, identically everywhere. Chrome-confirmed: upstream `show` cannot reveal a stylesheet-hidden element (the modal stays `display:none`, tabs never switch); hyperfixi's deliberate class+inline strategy (6e33c7c9) matches the pages' authored `.show` CSS rules.
- **Reclassified defect (recipes.html):** filtered scoped show — `show <blockquote/> in the next <div/> when its textContent contains my value` — upstream filters correctly in Chrome; hyperfixi is a complete no-op in the shipped bundle and mis-targets `me` on the gate's Runtime path. Queued in `PARSER_NEXT_STEPS.md`.
- **`set <idref> to <value>` bug candidate DISSOLVED:** that page's `#count` opens at `0`, so the gate saw an invisible 0-over-0 write. Probed working on both the gate path and the shipped bundle.
- **Family 4 (bonus, 3 entries):** representation-only — canonical `disabled=""` (falsy) vs upstream's literal string `"undefined"` (truthy); the `#disabled-status` delta is downstream truthiness.

### Changes

- Standing arbitration harness under the Playwright **debug** project (excluded from normal runs/CI): `execution-arbitration.spec.ts` + fixture. Re-run from `packages/core`: `npx playwright test --project=debug execution-arbitration`.
- All 45 family-1/2/4 baseline reasons rewritten to arbitrated verdicts (keys untouched — the gate asserts on keys only).
- Handoff: family verdicts, arbitration section, `set <idref>` resolution, v2 list re-ranked (`wait` under fake timers is the top coverage win; `settle()`'s own `setTimeout` must escape the fake clock).
- `PARSER_NEXT_STEPS.md`: filtered-show defect queued; set-idref/js-path row split; History entry.

## Test plan

- [x] Execution gate green: `npx vitest run src/multilingual/shipped-examples-execution.test.ts` (5/5 — no new divergence, no stale entries)
- [x] `npm run test:check --prefix packages/testing-framework` (274 passed)
- [x] Arbitration spec runs green in Chrome against both engines (observations in the handoff)
- [x] `effect-signature.ts` untouched → no multilingual `--regression` rerun required

🤖 Generated with [Claude Code](https://claude.com/claude-code)