### PR TITLE
docs: command-arch queue re-verification + Arc D handoff brief

### DIFF
--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -32,9 +32,10 @@ including `transfer`, which never existed anywhere), and the bundle-generator
 capability lists. Six independent rot instances, one cause: *lists that describe
 code, that nothing compares to the code*. Exhibit: when this doc was written the
 actual count was 59, the root CLAUDE.md said 58 (corrected in the same commit as
-this doc), and `runtime/runtime.ts` still says "48 commands" in three places
-with several per-category group comments undercounting — those are left alone
-deliberately, because Arc A makes the number derived rather than re-typed.
+this doc), and `runtime/runtime.ts` still says "48 commands" in **six** places
+(:3, :10, :135, :164, :168, :178) with several per-category group comments
+undercounting — those are left alone deliberately, because Arc A makes the
+number derived rather than re-typed.
 
 **The command set is executed in 4 semi-independent implementations.** Full
 runtime classes, the lite-plus inline executor, the hybrid-complete inline
@@ -79,7 +80,7 @@ generators with `--check` CI gates, `typecheck:scripts`, and ghost tests.
 | Arc | Value | Gate today | Detail |
 | --- | ----- | ---------- | ------ |
 | D — target-resolution consolidation | S effort, pure refactor | ✅ suites + R2 execution subset | proven model: `attribute-target.ts` / `property-target.ts` extractions from #792 |
-| C — output contract | **~20 live `it` divergences** | **none** — only 6 positive unwrap cases tested | the ungated one; it is what this document is for |
+| C — output contract | **~20 live `it` divergences** | **none for the `it` contract** — R2 covers only the DOM-visible half; 6 positive unwrap cases tested, no fall-throughs | the ungated one; it is what this document is for |
 | A — command manifest | kills ~15 of ~30 registration points | ✅ partial: verify:reference, capability-ghosts, command-tiers, bundle-manifest-consistency | gates carry the migration; manifest replaces the lists they guard |
 | B — metadata single-sourcing | types see metadata; docs generated | ✅ partial: typecheck:scripts, metadataOf() throws | decorator statics invisible to TS remain the root cause |
 | E — generated static bundles | 4 executors → 1 template source | ✅ partial: bundle-size ±5% + ceilings, compat matrix, parser-template drift test | drift test becomes a generator |
@@ -108,13 +109,22 @@ extracted `commands/helpers/attribute-target.ts` and reused
    `resolveTargetElements()` API. Contained: `evaluateSelectorSync`
    (`parser/runtime.ts:441`) has exactly one caller (:337) and is unexported,
    but it mirrors async `evaluateSelector` — migrate the pair together. Gate:
-   new unit tests pinning both shapes.
+   new unit tests pinning both shapes. **Pairs with Arc C step 3**: the `:121`
+   array collapse is this same asymmetry seen from the propagation end. If C is
+   in flight, land the two together rather than at opposite ends of the queue.
 
 ### Arc C — command output contract (medium-large; highest correctness value)
 
 The wrapper-`it` class is ~20 live divergences, not a latent risk — hence ranked
 ahead of the manifest.
 
+0. **Collapse the two propagation call sites first.** `unwrapCommandResult` is
+   called independently from `runtime-base.ts:1756` and
+   `dom/attribute-processor.ts:494`. Deleting sniffing branches (step 3) while
+   two copies of the loop exist is precisely the *duplication hides which
+   implementation is the truth* disease this queue's preamble names — sitting
+   inside the arc meant to cure it. Cheap and mechanical, and it makes every
+   later step land once instead of twice.
 1. **Audit first**: a test that instantiates every registered command, catalogs
    its execute-output shape against the seven sniffing branches
    (`result+wasAsync` / `result+executed` / `lastResult+type` /
@@ -127,11 +137,22 @@ ahead of the manifest.
    #792 adopted for append/prepend) or a void return for commands that should
    not touch `it` at all (e.g. `wait`; upstream doesn't set result there). The
    per-command decision is recorded in the audit snapshot. Each migration ships
-   with an event-handler `it` assertion (the #792 test shape) — **each one is a
-   deliberate behavior change to `it`**, which is why the arc is sequenced in
-   small PRs.
-3. Delete the sniffing branches last, and decide the :121 array policy
-   deliberately rather than by inheritance.
+   with an event-handler `it` assertion (the #792 test shape). **Each one is a
+   deliberate behavior change to `it`** — but read that phrase with its blast
+   radius attached, because on its own it reads scarier than the work is: for
+   the ~20 fall-throughs `it` currently holds a wrapper *nothing can usefully
+   consume* (what reads `{ halted, timestamp, eventHalted }`?). The genuinely
+   observable changes are the few whose wrapper happens to be readable, plus the
+   two accidental matches. Small sequential PRs are for reviewability — not
+   because each one carries real user-visible risk. That is what makes this arc
+   safe to sequence this early.
+3. Delete the sniffing branches, and decide the :121 array policy deliberately
+   rather than by inheritance. **`:121` is not a tail-end cleanup — it is Arc D
+   step 3's defect from the other end.** The selector-shape asymmetry
+   (`#id`→element, `.cls`→array) is what makes the collapse fire, so
+   `toggle .a on .items` silently leaves `it` as the *first* element: the same
+   shape as append's pre-#792 `.cls` no-op. Land it with Arc D step 3, or record
+   why not.
 
 ### Arc A — command manifest (medium)
 
@@ -156,9 +177,10 @@ Replace `@meta`'s runtime `defineProperty` statics with
 type system (the invisibility is why `scripts/` typechecking stayed off for six
 months, and why `metadataOf()` exists). Verified 2026-07-28: the three decorator
 symbols are module-private with zero external readers (the exported getters are
-dead); the only live instance-side readers are `command-adapter.ts:421` (name
-fallback) and **:440 — the aliases read, which is load-bearing: dropping it
-silently un-registers alias keywords** — plus a cosmetic projection (:212-221)
+dead); the only live instance-side readers are
+`packages/core/src/runtime/command-adapter.ts:421` (name fallback) and **:440 —
+the aliases read, which is load-bearing: dropping it silently un-registers alias
+keywords** — plus a cosmetic projection (:212-221)
 and `command-pattern-validator`. Keep instance `.metadata` working via an
 instance field/getter, or point the two adapter sites at
 `impl.constructor.metadata`. Current props are `configurable: false`: hybrid
@@ -188,12 +210,14 @@ absolute ceilings), the Playwright bundle compatibility matrix,
 
 ### Arc F — semantic schema-driven mappers + scaffolder (medium)
 
-Verified: 47 mappers in `ast-builder/command-mappers.ts`; ~30 are mechanically
-identical (patient→args plus one role→modifier rename); ~10 carry real logic
-(go's `'back'` literal, wait's event/duration branch, pick/swap/set/put/send/
-morph) plus 7 block mappers. The role→preposition mapping already exists as
-switches in **two** places (each mapper, and `semantic-integration.ts:386`) —
-it is data. Add `astModifier` to `RoleSpec`, implement one generic schema-driven
+Verified: 47 mappers in `packages/semantic/src/ast-builder/command-mappers.ts`;
+~30 are mechanically identical (patient→args plus one role→modifier rename); ~10
+carry real logic (go's `'back'` literal, wait's event/duration branch,
+pick/swap/set/put/send/morph) plus 7 block mappers — all 47 in that one file,
+registered into a single `mappers` Map. The role→preposition mapping already
+exists as switches in **two** places, and the second one is **not** in this
+package: each mapper, and `packages/core/src/parser/semantic-integration.ts:386`.
+It is data. Add `astModifier` to `RoleSpec`, implement one generic schema-driven
 mapper as the fallback, keep `registerCommandMapper` as the override, migrate
 the ~30, keep the rest. Then an `add-command` scaffolder (sibling of
 `packages/semantic/scripts/add-language.ts`) that stubs the core file,
@@ -219,7 +243,7 @@ not the core abstractions.
 - tsup multi-entry `splitting: false` **forks singletons** — verify at dist
   level, not just via test-config aliases.
 - **Stacked PRs get zero CI** and still report clean — arcs merge sequentially.
-- `command-adapter.ts:440` (aliases from instance metadata) is load-bearing;
+- `runtime/command-adapter.ts:440` (aliases from instance metadata) is load-bearing;
   silently dropping it un-registers alias keywords.
 - Decorator-installed props are `configurable: false` — never re-decorate a
   migrated class.
@@ -237,3 +261,15 @@ not the core abstractions.
   derive-don't-trust `verify:reference`). The Arc C audit figures (seven unwrap
   branches, ~20 fall-through commands, two accidental matches) were verified
   against main `6825d3d9` during the exploration for this document.
+- **2026-07-28** — Re-verified against main `e0d01c09` (a read-only pass over
+  every line reference and count in this doc). All figures held; two were
+  understated and are now corrected. The `runtime.ts` "48 commands" docstrings
+  are **six**, not three. The Arc C fall-through set measured by classifying
+  every command's declared execute-output type against the seven branches is
+  **21 distinct output types** — ~25 commands, since `signal-base` backs
+  break/continue/exit and `push-url` backs push-url/replace-url. "~20" is left
+  in the prose above as the deliberately round figure; 25 is the number the
+  step-1 audit test should expect to catalog. The same pass added Arc C step 0
+  and the Arc C↔D `:121` pairing, and qualified Arc C's "gate today" (R2 does
+  cover the DOM-visible half of an `it`-propagation change; it just cannot see
+  `it` holding a wrapper, since nothing asserts on `it`).

--- a/docs-internal/HANDOFF-command-arch-target-resolution.md
+++ b/docs-internal/HANDOFF-command-arch-target-resolution.md
@@ -1,0 +1,181 @@
+# HANDOFF — command-arch Arc D: target-resolution consolidation
+
+> **Arc brief, written 2026-07-28.** Detail for Arc D of
+> [COMMAND_ARCHITECTURE_NEXT_STEPS.md](./COMMAND_ARCHITECTURE_NEXT_STEPS.md)
+> (the queue holds one paragraph; this file is authoritative for the arc). Pure
+> refactor, no intended behavior change. Model already proven: #792 extracted
+> `commands/helpers/attribute-target.ts` and reused `property-target.ts`; both
+> are now shared by set/append/prepend.
+>
+> **Status: not started.** Update the per-step status lines below as PRs land;
+> when the arc completes, add one History line to the queue doc and stop
+> updating this file.
+
+## Objective
+
+Three consolidations, one PR each, merged sequentially:
+
+1. Delete `put.ts`'s private DOM-insertion copy in favor of
+   `helpers/dom-mutation.ts`.
+2. Extract the writable-target dispatch ladder (today duplicated between
+   `set.ts` and `content/insertion-base.ts`) into
+   `commands/helpers/write-target.ts`.
+3. Put the selector-shape asymmetry (`#id` → element, `.cls` → array) behind
+   one documented `resolveTargetElements()` API with shape-pinning tests.
+
+## Current verified state (2026-07-28, working tree at `7cb80479`)
+
+All line refs re-checked while writing this brief. They will drift — re-verify
+anchors at the start of each implementation session (`grep -n` the symbol, don't
+trust the number).
+
+### Step 1 anchors — put's insertion copy
+
+- `commands/dom/put.ts:275-312` — `private insertContent(...)`. Compared
+  branch-by-branch against `helpers/dom-mutation.ts` (`insertContent` :103 →
+  `insertReplace` :141 / `insertElement` :161 / `insertText` :189): **logic is
+  identical** (replace: element → clear+append, string → `looksLikeHTML` →
+  innerHTML/textContent; non-replace: same four element branches, same
+  `insertAdjacentHTML`/`insertAdjacentText` split). The **only** divergence:
+  the helper's `insertText` carries the happy-dom hang guard (invalid position
+  → throw instead of hang, dom-mutation.ts:192-205); put's copy does not.
+  Collapsing therefore *adds* defense-in-depth, changes nothing else. (Put is
+  guarded upstream anyway — `mapPosition` :240 throws on unknown prepositions —
+  so this is belt-and-braces, not a live-bug fix.)
+- Position vocabulary: put's exported `InsertPosition` (:32) is value-identical
+  to the helper's `ContentInsertPosition`. **No external importers** — grep for
+  `InsertPosition` hits only put.ts and the helpers' own type. `parseInput` is
+  the sole producer of `PutCommandInput` and `execute` the sole consumer, so
+  changing the internal position representation is contained to put.ts.
+- Recommended shape (what the queue doc intends): re-point `mapPosition` at
+  `SemanticPosition` names (`into`→`into`, `before`→`before`, `after`→`after`,
+  `at start of`→`prepend`, `at end of`→`append`) and call
+  `insertContentSemantic` — the exact path append/prepend already use
+  (`insertion-base.ts:229`). Keep `mapPosition`'s throw-on-unknown. Keep the
+  `InsertPosition` type export as a deprecated alias of
+  `ContentInsertPosition` rather than deleting a public type.
+
+### Step 2 anchors — the duplicated writable-target ladder
+
+- `commands/data/set.ts` — `parseInput` :76-229 plus
+  `tryParseMemberExpression` :308. Rung order (order is load-bearing, comments
+  in-file say why): **plugin node-writers** (`getRegisteredNodeWriter`, e.g.
+  reactivity's `^count`) → **attribute** (`resolveAttributeWriteTarget`; must
+  precede property/member or the computed-member path keys the write on the
+  attribute's *current value*) → **property** (`resolveAnyPropertyTarget`,
+  with the `*style` split) → **memberExpression/propertyAccess** → variable
+  tail (scope tags `:name`/`global`).
+- `commands/content/insertion-base.ts` — `parseInput` :100-159, a second copy
+  of the same ladder minus plugin writers, plus two rungs set lacks:
+  **selector-source** (keeps the selector *string* so a multi-match resolves at
+  execute time, :119) and **bare-reference-name** (keeps the *name* so execute
+  can read-modify-write the binding, :145).
+- Extraction target: `commands/helpers/write-target.ts` returning a
+  discriminated union that covers the superset of rungs. Both existing input
+  types are already discriminated unions (`SetCommandInput`,
+  `InsertionCommandInput` :56-63) — the helper's union should subsume them, and
+  each command keeps its own execute-side switch. Preserve rung ORDER exactly;
+  set keeps its plugin-writer rung first, insertion-base simply doesn't request
+  it.
+
+### Step 3 anchors — the selector-shape asymmetry
+
+- `parser/runtime.ts:441` `evaluateSelectorSync` — unexported, **exactly one
+  caller** (:337, inside `evaluateExpressionSync`). Async mirror
+  `evaluateSelector` at :1634. Both implement the same deliberate rule: bare
+  `#id` unwraps to `elements[0] ?? null`; query-form (`<#id/>`,
+  `fromQuery: true`) and class/other selectors return the collection.
+- **The asymmetry is upstream parity (IdRef → element vs QueryRef →
+  ElementCollection), not a defect. Do not "fix" it.** The defect class is
+  command-side code mishandling one of the two shapes — append's pre-#792
+  `.cls` silent no-op, and the `unwrapCommandResult` `val[0]` collapse
+  (`runtime-base.ts:121`) are the same bug from opposite ends. Step 3 =
+  centralize the rule behind one documented API, pin BOTH shapes with unit
+  tests, and migrate the sync/async pair together.
+- Also in scope here: put's private `resolveTargets` :257 / `looksLikeCss` :331
+  / `resolveEvaluatedAsElements` :318 vs insertion-base's `insertIntoSelector`
+  :213 / `asElementList` :265 — a third duplication of "value → element list",
+  including the shared "unmatched selector throws" contract
+  (insertion-base :218 comments "Same contract as `put`"). Fold these into the
+  same helper.
+- **Arc C pairing (recorded decision needed).** The queue doc pairs this step
+  with Arc C step 3 (the `:121` collapse is this asymmetry seen from the
+  propagation end). If Arc C hasn't started when this step is reached: land
+  step 3 with the shape-pinning tests and leave `:121` untouched, noting in the
+  PR that the tests are the ratchet Arc C will build on — or hold step 3 until
+  C step 3 is ready and land them together. Either is fine; record which in
+  this file.
+
+## Gates, per step
+
+| Step | Suites | Command |
+| ---- | ------ | ------- |
+| all | quick validation | `npm run test:quick --prefix packages/core` |
+| 1 | put suite | `npm test --prefix packages/core -- --run src/commands/dom/put.test.ts` (note: NOT under `__tests__/`) |
+| 2 | set suites (4 files) + append/prepend | `npm test --prefix packages/core -- --run src/commands/data/__tests__/ src/commands/content/__tests__/` |
+| 2 | element-scoped `:greeting` multiword case | `cd packages/core && npx playwright test src/compatibility/browser-tests/test-multiword-commands.spec.ts` (Playwright MUST run from packages/core) |
+| 3 | new shape-pinning unit tests | added in the step-3 PR; both `#id` and `.cls`/`<#id/>` shapes, sync and async |
+| all | R2 execution subset (+ the other 9 ratchet signals) | runs automatically in the PR's `multilingual-validation` CI job; local repro is in root CLAUDE.md § "Running the multilingual --regression gate locally" |
+
+`npm run verify:reference` is NOT expected to fire — this arc adds no commands
+and changes no command lists. If it fails, something out of scope was touched.
+
+## Non-goals (Arc D specifically)
+
+- **No behavior changes.** Any test that changes expectation is a stop-and-ask,
+  not an update. (Exception: a test that asserts the happy-dom hang-guard's
+  *absence* — none known — would flip from silent to throw; that's the helper's
+  documented contract winning.)
+- The `#id`/`.cls` shape rule itself — upstream parity, stays.
+- `unwrapCommandResult` and the `:121` collapse — Arc C's, except via the
+  recorded pairing decision above.
+- The bundle-generator template copies of put/append logic — Arc E's.
+- The four-executor duplication generally — Arc E's.
+- Anything in `packages/semantic` mappers — Arc F's.
+
+## Session handling
+
+- **One PR per step, merged into main before the next starts.** Stacked PRs get
+  zero CI and still report clean (`ci.yml` fires only on PRs into
+  main/develop). These are core-code PRs, so the full CI matrix runs — that's
+  the point, don't try to shortcut it.
+- **Prefer a fresh session per step.** Each step is independently landable and
+  this file is the continuity mechanism — a new session re-reads the queue doc
+  + this brief and starts clean rather than dragging two PRs of context.
+- **Start-of-session protocol:** (1) read the queue doc's Arc D paragraph +
+  this file; (2) `git log --oneline -5` to see what's landed since; (3)
+  re-verify this brief's line anchors by symbol, not number; (4) on a cold
+  tree, `npm install` first, and remember `npm run build` is NOT
+  dependency-ordered (root CLAUDE.md § Cold start); (5) baseline
+  `npm run test:quick --prefix packages/core` BEFORE editing so a pre-existing
+  red isn't attributed to the refactor.
+- **End-of-session protocol:** update the Status line below (step, PR number,
+  merged/open, surprises worth the next session's attention). If a step
+  revealed something that changes a later step's plan, edit that step's section
+  here — this file is authoritative for the arc, per the queue's pointer-only
+  rule.
+- Core vitest wraps in `timeout 120`; **exit code 124 = success** (esbuild
+  daemon hang, known issue).
+- If using lokascript MCP tools after rebuilding core: a tool refusing with
+  "serving STALE code" is the freshness guard working — restart the server,
+  don't debug the tool.
+
+## Risk register (arc-specific; general one is in the queue doc)
+
+- `export { X } from './f'` creates **no local binding** — relevant when moving
+  `resolveTargets`-family helpers out of put.ts.
+- Rung order in the write-target ladder is semantics, not style: attribute
+  before property/member (set.ts:105-109's comment), plugin writers first,
+  raw-AST resolution before evaluation (insertion-base's divergence-fix #792
+  depends on it).
+- Element content **moves** rather than copies across multi-element targets
+  (insertion-base :227-228) — keep that comment with the code wherever
+  insertion loops end up.
+- put's `execute` returns `HTMLElement[]` (or `undefined` on the variable
+  path) — one of Arc C's fall-throughs. Do not "improve" it here; Arc C owns
+  the output contract, and changing it in a pure-refactor PR muddies both arcs.
+
+## Status log
+
+- 2026-07-28 — brief written; arc not started. Next action: step 1 PR
+  (put `insertContent` collapse).

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance for working with the `@hyperfixi/core` package.
 
 ## Package Purpose
 
-Main hyperscript runtime, parser, and 58 command implementations. This is the primary package for HyperFixi development.
+Main hyperscript runtime, parser, and 59 command implementations. This is the primary package for HyperFixi development.
 
 ## Essential Commands
 


### PR DESCRIPTION
## Summary

Two doc commits that set up implementation of the command-architecture queue's Arc D (target-resolution consolidation):

- **Queue re-verification pass** (`COMMAND_ARCHITECTURE_NEXT_STEPS.md`): read-only re-check of every line reference and count against main `e0d01c09`. All figures held; two were understated and are corrected (the `runtime.ts` "48 commands" docstrings are **six**, not three; the Arc C fall-through set is **21 output types / ~25 commands**). Adds Arc C step 0 (collapse the two `unwrapCommandResult` call sites first), the Arc C↔D `:121` pairing, and the R2 qualification on Arc C's gate row. Also fixes the core CLAUDE.md command count (58 → 59).
- **Arc D handoff brief** (`HANDOFF-command-arch-target-resolution.md`): the per-arc brief the queue mandates at arc start. Anchors verified against the working tree while writing it:
  - put's private `insertContent` (put.ts:275-312) is **logic-identical** to the `dom-mutation.ts` helper family except for the missing happy-dom hang guard — the step-1 collapse strictly adds defense-in-depth.
  - put's exported `InsertPosition` type has **no external importers**, so the collapse is contained to one file.
  - The `#id`→element / `.cls`→array selector-shape asymmetry is **upstream parity** (IdRef vs QueryRef) in both `evaluateSelector` and its sync mirror — step 3 centralizes and test-pins the rule rather than removing it.
  - Gates table corrects one path: put's suite is `src/commands/dom/put.test.ts`, not under `__tests__/`.

The brief also carries the arc's session protocol: one PR per step merged sequentially (stacked PRs get zero CI), fresh session per step with the brief as the continuity mechanism, start/end-of-session checklists, and an arc-specific risk register.

## Test plan

Doc-only diff — the path-gated CI classifier skips the npm stack; required checks report skipped and satisfy branch protection. No code paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)