### PR TITLE
refactor(core): Arc D step 1 — collapse put's private insertContent onto the shared DOM helper

### DIFF
--- a/packages/core/src/commands/dom/put.test.ts
+++ b/packages/core/src/commands/dom/put.test.ts
@@ -112,7 +112,7 @@ describe('PutCommand', () => {
       );
 
       expect(input.value).toBe('Hello World');
-      expect(input.position).toBe('replace');
+      expect(input.position).toBe('into');
       expect(input.targets).toHaveLength(1);
       expect(input.targets[0].id).toBe('target');
     });
@@ -139,7 +139,7 @@ describe('PutCommand', () => {
   });
 
   describe('Parsing - Position Keywords', () => {
-    it('should map "into" to replace position', async () => {
+    it('should map "into" to the into position', async () => {
       const evaluator = createMockEvaluator();
       const context = createMockContext(createMockElement('target'));
 
@@ -153,10 +153,10 @@ describe('PutCommand', () => {
         context
       );
 
-      expect(input.position).toBe('replace');
+      expect(input.position).toBe('into');
     });
 
-    it('should map "before" to beforebegin position', async () => {
+    it('should map "before" to the before position', async () => {
       const evaluator = createMockEvaluator();
       const context = createMockContext(createMockElement('target'));
 
@@ -170,10 +170,10 @@ describe('PutCommand', () => {
         context
       );
 
-      expect(input.position).toBe('beforebegin');
+      expect(input.position).toBe('before');
     });
 
-    it('should map "after" to afterend position', async () => {
+    it('should map "after" to the after position', async () => {
       const evaluator = createMockEvaluator();
       const context = createMockContext(createMockElement('target'));
 
@@ -187,10 +187,10 @@ describe('PutCommand', () => {
         context
       );
 
-      expect(input.position).toBe('afterend');
+      expect(input.position).toBe('after');
     });
 
-    it('should map "at start of" to afterbegin position', async () => {
+    it('should map "at start of" to the prepend position', async () => {
       const evaluator = createMockEvaluator();
       const context = createMockContext(createMockElement('target'));
 
@@ -204,10 +204,10 @@ describe('PutCommand', () => {
         context
       );
 
-      expect(input.position).toBe('afterbegin');
+      expect(input.position).toBe('prepend');
     });
 
-    it('should map "at end of" to beforeend position', async () => {
+    it('should map "at end of" to the append position', async () => {
       const evaluator = createMockEvaluator();
       const context = createMockContext(createMockElement('target'));
 
@@ -221,7 +221,7 @@ describe('PutCommand', () => {
         context
       );
 
-      expect(input.position).toBe('beforeend');
+      expect(input.position).toBe('append');
     });
   });
 
@@ -240,7 +240,7 @@ describe('PutCommand', () => {
       );
 
       expect(input.value).toBe('Hello');
-      expect(input.position).toBe('replace');
+      expect(input.position).toBe('into');
       expect(input.targets).toHaveLength(1);
     });
 
@@ -257,7 +257,7 @@ describe('PutCommand', () => {
         context
       );
 
-      expect(input.position).toBe('beforebegin');
+      expect(input.position).toBe('before');
     });
 
     it('should parse semantic parser format with after modifier', async () => {
@@ -273,7 +273,7 @@ describe('PutCommand', () => {
         context
       );
 
-      expect(input.position).toBe('afterend');
+      expect(input.position).toBe('after');
     });
   });
 
@@ -337,7 +337,7 @@ describe('PutCommand', () => {
 
       expect(input.targets).toEqual([element]);
       expect(input.memberPath).toBe('textContent');
-      expect(input.position).toBe('replace');
+      expect(input.position).toBe('into');
     });
 
     it('should resolve "#el\'s innerHTML" as a property-write target', async () => {
@@ -402,14 +402,14 @@ describe('PutCommand', () => {
   });
 
   describe('Execution - Content Insertion', () => {
-    it('should insert text content with replace position', async () => {
+    it('should insert text content with the into position', async () => {
       const context = createMockContext();
       const target = createMockElement('target');
 
       const input: PutCommandInput = {
         value: 'New Content',
         targets: [target],
-        position: 'replace',
+        position: 'into',
       };
 
       await command.execute(input, context);
@@ -417,14 +417,14 @@ describe('PutCommand', () => {
       expect(target.textContent).toBe('New Content');
     });
 
-    it('should insert HTML content with replace position', async () => {
+    it('should insert HTML content with the into position', async () => {
       const context = createMockContext();
       const target = createMockElement('target');
 
       const input: PutCommandInput = {
         value: '<strong>Bold</strong>',
         targets: [target],
-        position: 'replace',
+        position: 'into',
       };
 
       await command.execute(input, context);
@@ -432,7 +432,7 @@ describe('PutCommand', () => {
       expect(target.innerHTML).toBe('<strong>Bold</strong>');
     });
 
-    it('should insert HTMLElement with replace position', async () => {
+    it('should insert HTMLElement with the into position', async () => {
       const context = createMockContext();
       const target = createMockElement('target');
       const newElement = document.createElement('p');
@@ -441,7 +441,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: newElement,
         targets: [target],
-        position: 'replace',
+        position: 'into',
       };
 
       await command.execute(input, context);
@@ -460,7 +460,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: '<span>Before</span>',
         targets: [target],
-        position: 'beforebegin',
+        position: 'before',
       };
 
       await command.execute(input, context);
@@ -479,7 +479,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: '<span>After</span>',
         targets: [target],
-        position: 'afterend',
+        position: 'after',
       };
 
       await command.execute(input, context);
@@ -496,7 +496,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: '<strong>First</strong>',
         targets: [target],
-        position: 'afterbegin',
+        position: 'prepend',
       };
 
       await command.execute(input, context);
@@ -513,7 +513,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: '<strong>Last</strong>',
         targets: [target],
-        position: 'beforeend',
+        position: 'append',
       };
 
       await command.execute(input, context);
@@ -530,7 +530,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: 'Shared Content',
         targets: [target1, target2],
-        position: 'replace',
+        position: 'into',
       };
 
       await command.execute(input, context);
@@ -548,7 +548,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: 'custom-value',
         targets: [target],
-        position: 'replace',
+        position: 'into',
         memberPath: 'className',
       };
 
@@ -566,7 +566,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: 'test-value',
         targets: [target],
-        position: 'replace',
+        position: 'into',
         memberPath: 'customData.nested',
       };
 
@@ -582,7 +582,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: 'value',
         targets: [target],
-        position: 'replace',
+        position: 'into',
         memberPath: 'nonexistent.property',
       };
 
@@ -597,7 +597,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: 42,
         targets: [],
-        position: 'replace',
+        position: 'into',
         variableName: 'myVar',
       };
 
@@ -613,7 +613,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: 'Hello',
         targets: [],
-        position: 'replace',
+        position: 'into',
         variableName: 'greeting',
       };
 
@@ -631,7 +631,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: null,
         targets: [target],
-        position: 'replace',
+        position: 'into',
       };
 
       await command.execute(input, context);
@@ -646,7 +646,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: undefined,
         targets: [target],
-        position: 'replace',
+        position: 'into',
       };
 
       await command.execute(input, context);
@@ -661,7 +661,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: 123,
         targets: [target],
-        position: 'replace',
+        position: 'into',
       };
 
       await command.execute(input, context);
@@ -676,7 +676,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: 'Plain text with < and > symbols',
         targets: [target],
-        position: 'replace',
+        position: 'into',
       };
 
       await command.execute(input, context);
@@ -693,7 +693,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: '',
         targets: [target],
-        position: 'replace',
+        position: 'into',
       };
 
       await command.execute(input, context);
@@ -711,7 +711,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: 'Content',
         targets: [target1, target2],
-        position: 'replace',
+        position: 'into',
       };
 
       const result = await command.execute(input, context);
@@ -725,7 +725,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: 42,
         targets: [],
-        position: 'replace',
+        position: 'into',
         variableName: 'myVar',
       };
 
@@ -880,7 +880,7 @@ describe('PutCommand', () => {
       const input: PutCommandInput = {
         value: 42,
         targets: [],
-        position: 'replace',
+        position: 'into',
         variableName: 'myVar',
       };
 

--- a/packages/core/src/commands/dom/put.ts
+++ b/packages/core/src/commands/dom/put.ts
@@ -22,6 +22,11 @@ import {
   resolvePropertyTargetFromString,
 } from '../helpers/property-target';
 import {
+  insertContentSemantic,
+  type ContentInsertPosition,
+  type SemanticPosition,
+} from '../helpers/dom-mutation';
+import {
   command,
   meta,
   createFactory,
@@ -29,12 +34,17 @@ import {
   type CommandMetadata,
 } from '../decorators';
 
-export type InsertPosition = 'replace' | 'beforeend' | 'afterend' | 'beforebegin' | 'afterbegin';
+/**
+ * @deprecated Use `ContentInsertPosition` from `commands/helpers/dom-mutation`,
+ * which this now aliases (the two were value-identical duplicates). `put`'s own
+ * input carries `SemanticPosition` names, shared with `append`/`prepend`.
+ */
+export type InsertPosition = ContentInsertPosition;
 
 export interface PutCommandInput {
   value: any;
   targets: HTMLElement[];
-  position: InsertPosition;
+  position: SemanticPosition;
   memberPath?: string;
   variableName?: string;
 }
@@ -130,7 +140,7 @@ export class PutCommand implements DecoratedCommand {
         return {
           value,
           targets: [propertyTarget.element],
-          position: 'replace',
+          position: 'into',
           memberPath: propertyTarget.property,
         };
       }
@@ -147,7 +157,7 @@ export class PutCommand implements DecoratedCommand {
               return {
                 value,
                 targets: [context.me as HTMLElement],
-                position: 'replace',
+                position: 'into',
                 memberPath: prop.name,
               };
             }
@@ -178,7 +188,7 @@ export class PutCommand implements DecoratedCommand {
             return {
               value,
               targets: [target.element],
-              position: 'replace',
+              position: 'into',
               memberPath: target.property,
             };
           }
@@ -231,24 +241,27 @@ export class PutCommand implements DecoratedCommand {
     } else {
       for (const t of targets) {
         const content = this.parseValue(value);
-        this.insertContent(t, content, position);
+        // NOTE: an Element value can only exist in one place, so across multiple
+        // targets it MOVES and ends up inside the last one. Strings are copied.
+        insertContentSemantic(t, content, position);
       }
     }
     return targets;
   }
 
-  private mapPosition(prep: string): InsertPosition {
+  /** Preposition surface form → the shared semantic position vocabulary. */
+  private mapPosition(prep: string): SemanticPosition {
     switch (prep) {
       case 'into':
-        return 'replace';
+        return 'into';
       case 'before':
-        return 'beforebegin';
+        return 'before';
       case 'after':
-        return 'afterend';
+        return 'after';
       case 'at start of':
-        return 'afterbegin';
+        return 'prepend';
       case 'at end of':
-        return 'beforeend';
+        return 'append';
       default:
         throw new Error(`Invalid position: ${prep}`);
     }
@@ -270,45 +283,6 @@ export class PutCommand implements DecoratedCommand {
   private parseValue(v: any): string | HTMLElement {
     if (isHTMLElement(v)) return v as HTMLElement;
     return v == null ? '' : String(v);
-  }
-
-  private insertContent(
-    target: HTMLElement,
-    content: string | HTMLElement,
-    pos: InsertPosition
-  ): void {
-    if (pos === 'replace') {
-      if (isHTMLElement(content)) {
-        target.innerHTML = '';
-        target.appendChild(content as HTMLElement);
-      } else {
-        const hasHTML = content.includes('<') && content.includes('>');
-        if (hasHTML) target.innerHTML = content;
-        else target.textContent = content;
-      }
-      return;
-    }
-    if (isHTMLElement(content)) {
-      const el = content as HTMLElement;
-      switch (pos) {
-        case 'beforebegin':
-          target.parentElement?.insertBefore(el, target);
-          break;
-        case 'afterbegin':
-          target.insertBefore(el, target.firstChild);
-          break;
-        case 'beforeend':
-          target.appendChild(el);
-          break;
-        case 'afterend':
-          target.parentElement?.insertBefore(el, target.nextSibling);
-          break;
-      }
-    } else {
-      const hasHTML = content.includes('<') && content.includes('>');
-      if (hasHTML) target.insertAdjacentHTML(pos, content);
-      else target.insertAdjacentText(pos, content);
-    }
   }
 
   /**


### PR DESCRIPTION
Arc D step 1 of the command-architecture queue
([queue doc](../blob/main/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md) ·
[arc brief](../blob/main/docs-internal/HANDOFF-command-arch-target-resolution.md)).
Pure refactor, no intended behavior change.

## What

`put.ts` carried a private `insertContent` that was a branch-for-branch copy of
`commands/helpers/dom-mutation.ts` — the same replace/element/text dispatch, the
same `insertAdjacentHTML`/`insertAdjacentText` split. It was the last hand-rolled
copy; append/prepend already route through the helper via `insertContentSemantic`.
Deferred from #792.

- **The 38-line private copy is deleted**; `execute` calls `insertContentSemantic`.
  This *adds* the helper's happy-dom hang guard (an invalid position throws rather
  than hanging) — belt-and-braces, since `mapPosition` already rejects unknown
  prepositions upstream, so it is not a live-bug fix.
- **`PutCommandInput.position` now carries the shared `SemanticPosition` vocabulary**
  (`into` / `before` / `after` / `prepend` / `append`) rather than a second,
  put-local spelling of the same five values. `mapPosition` keeps its
  throw-on-unknown. The exported `InsertPosition` type stays as a **deprecated alias
  of `ContentInsertPosition`** — the two were value-identical duplicates — so no
  public type disappears.
- Carries insertion-base's "an Element MOVES across multiple targets" note onto
  put's insertion loop, which has always had the same behavior.

## On the test diff

The put suite's `position:` literals move to the new vocabulary with the input type.
Those are white-box assertions on the input's *internal spelling* — every DOM-outcome
expectation in the file (`textContent`, `innerHTML`, `firstElementChild`, return
values) is untouched. This is the shape the arc brief prescribes for step 1, which
names the exact mapping.

## Gates

| Gate | Result |
| ---- | ------ |
| put suite (`src/commands/dom/put.test.ts`) | 45/45 |
| core quick validation | 7702 passed / 128 skipped — **identical to the pre-edit baseline** |
| `typecheck` | clean |
| `verify:reference` | clean (not expected to fire — no command added or removed) |
| prettier / eslint | clean on changed files |

R2 execution subset and the other nine ratchet signals run in this PR's
`multilingual-validation` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)