### PR TITLE
refactor(core): Arc D step 2 — extract the writable-target ladder into helpers/write-target.ts

### DIFF
--- a/packages/core/src/commands/content/insertion-base.ts
+++ b/packages/core/src/commands/content/insertion-base.ts
@@ -41,12 +41,11 @@ import { isHTMLElement } from '../../utils/element-check';
 import { getVariableValue, setVariableValue } from '../helpers/variable-access';
 import { insertContentSemantic, type SemanticPosition } from '../helpers/dom-mutation';
 import {
-  resolveAnyPropertyTarget,
   readPropertyTarget,
   writePropertyTarget,
   type PropertyTarget,
 } from '../helpers/property-target';
-import { resolveAttributeWriteTarget } from '../helpers/attribute-target';
+import { resolveWriteTarget, type WriteTarget } from '../helpers/write-target';
 import type { DecoratedCommand, CommandMetadata } from '../decorators';
 
 /** Where content lands, and how scalar values combine. */
@@ -75,6 +74,28 @@ export interface InsertionCommandOutput {
 /** Content coerced for DOM insertion: elements stay live, everything else stringifies. */
 function toInsertable(content: unknown): string | HTMLElement {
   return isHTMLElement(content) ? (content as HTMLElement) : String(content);
+}
+
+/**
+ * Map a resolved {@link WriteTarget} onto the insertion input union.
+ *
+ * The `node-write` and `style` rungs are unreachable here: append/prepend don't
+ * request plugin writers or the `*prop` split (read/writePropertyTarget already
+ * route a `*` prefix to inline style, so `*opacity` stays a property target).
+ */
+function toInsertionInput(target: WriteTarget, content: unknown): InsertionCommandInput {
+  switch (target.kind) {
+    case 'selector':
+      return { kind: 'selector', selector: target.selector, content };
+    case 'attribute':
+      return { kind: 'attribute', elements: target.elements, name: target.name, content };
+    case 'property':
+      return { kind: 'property', property: target.target, content };
+    case 'variable':
+      return { kind: 'variable', name: target.name, scope: target.scope, content };
+    default:
+      throw new Error(`unrequested write-target rung '${target.kind}'`);
+  }
 }
 
 export abstract class ContentInsertionCommand implements DecoratedCommand {
@@ -111,47 +132,21 @@ export abstract class ContentInsertionCommand implements DecoratedCommand {
       ExpressionNode | undefined;
     if (!toNode) return { kind: 'implicit', content };
 
-    const node = toNode as unknown as Record<string, unknown>;
-    const nodeType = node.type as string | undefined;
+    // The raw-AST write-target ladder, shared with `set`
+    // (`helpers/write-target.ts`, which documents why the rung order is
+    // semantics). append/prepend request selector-source — so a multi-match
+    // selector inserts into every element — and bare-reference capture, so
+    // execute can read-modify-write the binding rather than lose it to
+    // evaluation. A standalone `@attr` scopes to `me`: append/prepend have no
+    // `on` modifier (MULTI_WORD_PATTERNS lists only `to`).
+    const writeTarget = await resolveWriteTarget(toNode, evaluator, context, {
+      scopeElements: async () => (isHTMLElement(context.me) ? [context.me as HTMLElement] : []),
+      selectorSource: true,
+      bareReference: true,
+    });
+    if (writeTarget) return toInsertionInput(writeTarget, content);
 
-    // (1) Selector nodes keep their SOURCE text — resolving at execute time lets
-    //     a multi-match selector insert into every element.
-    if (nodeType === 'selector' && typeof node.value === 'string') {
-      return { kind: 'selector', selector: node.value, content };
-    }
-
-    // (2) Attribute write targets (`@attr`, `@attr of X`, `X[@attr]`), recognized
-    //     before evaluation. Standalone `@attr` scopes to `me` — append/prepend
-    //     have no `on` modifier (MULTI_WORD_PATTERNS lists only `to`).
-    const attrTarget = await resolveAttributeWriteTarget(toNode, evaluator, context, async () =>
-      isHTMLElement(context.me) ? [context.me as HTMLElement] : []
-    );
-    if (attrTarget) {
-      return {
-        kind: 'attribute',
-        elements: attrTarget.elements,
-        name: attrTarget.name,
-        content,
-      };
-    }
-
-    // (3) Property targets: `#el's value`, `my innerHTML`, `the X of Y`, `*opacity`.
-    const propertyTarget = await resolveAnyPropertyTarget(toNode as ASTNode, evaluator, context);
-    if (propertyTarget) return { kind: 'property', property: propertyTarget, content };
-
-    // (4) Bare references keep their NAME so execute can read+write the binding.
-    //     Evaluating would yield the current value and lose it. The parser's
-    //     scope tag routes `:name` to element scope and `$name`/`global` to globals.
-    if (
-      (nodeType === 'identifier' || nodeType === 'variable' || nodeType === 'symbol') &&
-      typeof node.name === 'string'
-    ) {
-      const rawScope = node.scope as string | undefined;
-      const scope = rawScope === 'element' || rawScope === 'global' ? rawScope : undefined;
-      return { kind: 'variable', name: node.name, scope, content };
-    }
-
-    // (5) Anything else: evaluate and dispatch on the runtime value.
+    // Anything else: evaluate and dispatch on the runtime value.
     const value = await evaluator.evaluate(toNode as ASTNode, context);
     const elements = this.asElementList(value);
     if (elements) return { kind: 'elements', elements, content };

--- a/packages/core/src/commands/data/set.ts
+++ b/packages/core/src/commands/data/set.ts
@@ -27,10 +27,9 @@ import { setVariableValue } from '../helpers/variable-access';
 import { setElementVar } from '../../core/context';
 import {
   isPropertyTargetString,
-  resolveAnyPropertyTarget,
   resolvePropertyTargetFromString,
 } from '../helpers/property-target';
-import { resolveAttributeWriteTarget } from '../helpers/attribute-target';
+import { resolveWriteTarget, type WriteTarget } from '../helpers/write-target';
 import {
   command,
   meta,
@@ -38,7 +37,7 @@ import {
   type DecoratedCommand,
   type CommandMetadata,
 } from '../decorators';
-import { getRegisteredNodeWriter, type NodeWriterFn } from '../../parser/extensions';
+import type { NodeWriterFn } from '../../parser/extensions';
 
 /** Typed input for SetCommand (Discriminated Union) */
 export type SetCommandInput =
@@ -60,6 +59,39 @@ export interface SetCommandOutput {
   target: string | HTMLElement;
   value: unknown;
   targetType: 'variable' | 'attribute' | 'property';
+}
+
+/**
+ * Map a resolved {@link WriteTarget} onto SetCommand's input union.
+ *
+ * The `selector` and `variable` rungs are unreachable here: set does not request
+ * them (a bare identifier is set's variable-assignment path, and a `selector`
+ * node is its "set #element to value → textContent" path — both belong to the
+ * evaluated tail in `parseInput`).
+ */
+function toSetInput(target: WriteTarget, value: unknown): SetCommandInput {
+  switch (target.kind) {
+    case 'node-write':
+      return { type: 'node-write', node: target.node, value, writer: target.writer };
+    case 'attribute':
+      return { type: 'attribute', elements: target.elements, name: target.name, value };
+    case 'style':
+      return {
+        type: 'style',
+        element: target.element,
+        property: target.property,
+        value: String(value),
+      };
+    case 'property':
+      return {
+        type: 'property',
+        element: target.target.element,
+        property: target.target.property,
+        value,
+      };
+    default:
+      throw new Error(`set: unrequested write-target rung '${target.kind}'`);
+  }
 }
 
 @meta({
@@ -89,56 +121,20 @@ export class SetCommand implements DecoratedCommand {
     // to element scope / globals instead of execution-locals.
     const argScope = firstArg?.scope as 'element' | 'global' | 'local' | undefined;
 
-    // Plugin-defined write targets — e.g. `set ^count to 0` routes through
-    // the reactivity plugin's caretVar writer. Dispatch BEFORE evaluating
-    // firstArg so the writer can interpret the raw AST node (the target
-    // value at this point hasn't been written yet).
-    const firstArgType = firstArg?.type as string | undefined;
-    if (firstArgType) {
-      const writer = getRegisteredNodeWriter(firstArgType);
-      if (writer) {
-        const value = await this.extractValue(raw, evaluator, context);
-        return { type: 'node-write', node: firstArg as ASTNode, value, writer };
-      }
-    }
-
-    // Attribute write targets: `set @attr to V`, `set [@attr] to V`,
-    // `set @attr of X to V`, `set X[@attr] to V`. Intercept before the generic
-    // property/member paths so the attributeAccess node routes to setAttribute
-    // (otherwise the computed-member path would key the write on the attribute's
-    // *current* value instead of writing the attribute).
-    const attrTarget = await resolveAttributeWriteTarget(firstArg, evaluator, context, () =>
-      this.resolveTargets(raw.modifiers.on, evaluator, context)
-    );
-    if (attrTarget) {
-      const value = await this.extractValue(raw, evaluator, context);
-      return { type: 'attribute', elements: attrTarget.elements, name: attrTarget.name, value };
-    }
-
-    // Unified PropertyTarget resolution: handles propertyOfExpression, propertyAccess, possessiveExpression
-    const propertyTarget = await resolveAnyPropertyTarget(
-      firstArg as import('../../types/base-types').ASTNode,
-      evaluator,
-      context
-    );
-    if (propertyTarget) {
-      const value = await this.extractValue(raw, evaluator, context);
-      // Handle CSS style properties (*opacity syntax)
-      if (propertyTarget.property.startsWith('*')) {
-        const styleProp = propertyTarget.property.substring(1);
-        return {
-          type: 'style',
-          element: propertyTarget.element,
-          property: styleProp,
-          value: String(value),
-        };
-      }
-      return {
-        type: 'property',
-        element: propertyTarget.element,
-        property: propertyTarget.property,
-        value,
-      };
+    // The raw-AST write-target ladder, shared with append/prepend
+    // (`helpers/write-target.ts`, which documents why the rung order is
+    // semantics). set requests the plugin-writer rung — `set ^count to 0` routes
+    // through the reactivity plugin's caretVar writer, and it must see the raw
+    // node because the target value hasn't been written yet — and the `*prop`
+    // style split. It does NOT request selector-source or bare-reference
+    // capture; those shapes are set's evaluated tail below.
+    const writeTarget = await resolveWriteTarget(firstArg, evaluator, context, {
+      scopeElements: () => this.resolveTargets(raw.modifiers.on, evaluator, context),
+      nodeWriters: true,
+      styleSplit: true,
+    });
+    if (writeTarget) {
+      return toSetInput(writeTarget, await this.extractValue(raw, evaluator, context));
     }
 
     // Handle memberExpression / propertyAccess: "set my innerHTML to X", "set event.dataTransfer.effectAllowed to X"

--- a/packages/core/src/commands/helpers/__tests__/write-target.test.ts
+++ b/packages/core/src/commands/helpers/__tests__/write-target.test.ts
@@ -1,0 +1,225 @@
+/**
+ * write-target — rung ladder tests
+ *
+ * The ladder's ORDER is semantics, not style, and it is now defined in exactly
+ * one place. These tests are the ratchet on that: they pin which rung wins when
+ * two could match, and pin that an un-requested rung is skipped rather than
+ * reordered. Behavioral coverage of each command's use of the ladder stays in
+ * the set / append / prepend suites.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resolveWriteTarget } from '../write-target';
+import {
+  getParserExtensionRegistry,
+  type ParserExtensionSnapshot,
+} from '../../../parser/extensions';
+import type { ASTNode } from '../../../types/base-types';
+import type { ExecutionContext } from '../../../types/core';
+import type { ExpressionEvaluator } from '../../../core/expression-evaluator';
+
+function makeEvaluator(values: Map<unknown, unknown> = new Map()): ExpressionEvaluator {
+  return {
+    evaluate: vi.fn(async (node: ASTNode) => {
+      if (values.has(node)) return values.get(node);
+      const n = node as unknown as Record<string, unknown>;
+      if (n.type === 'literal' || n.type === 'string') return n.value;
+      return null;
+    }),
+  } as unknown as ExpressionEvaluator;
+}
+
+describe('resolveWriteTarget', () => {
+  let me: HTMLElement;
+  let context: ExecutionContext;
+  let scopeElements: () => Promise<HTMLElement[]>;
+  let extensions: ParserExtensionSnapshot;
+
+  beforeEach(() => {
+    me = document.createElement('div');
+    document.body.appendChild(me);
+    context = {
+      me,
+      you: null,
+      locals: new Map(),
+      globals: new Map(),
+      result: undefined,
+      it: undefined,
+    } as ExecutionContext;
+    scopeElements = async () => [me];
+    // The extension registry is a cross-bundle singleton — snapshot so a
+    // registered writer cannot leak into another suite.
+    extensions = getParserExtensionRegistry().snapshot();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    getParserExtensionRegistry().restore(extensions);
+  });
+
+  describe('rung order', () => {
+    it('resolves a plugin node-writer ahead of every built-in rung', async () => {
+      const writer = vi.fn();
+      getParserExtensionRegistry().registerNodeWriter('caretVar', writer);
+      // Also a bare-reference shape, so rung 5 would match if rung 1 did not win.
+      const node = { type: 'caretVar', name: 'count' } as unknown as ASTNode;
+
+      const target = await resolveWriteTarget(node, makeEvaluator(), context, {
+        scopeElements,
+        nodeWriters: true,
+        bareReference: true,
+      });
+
+      expect(target).toEqual({ kind: 'node-write', node, writer });
+    });
+
+    it('resolves `X[@attr]` as an attribute write, not a computed member read', async () => {
+      // The load-bearing case: an attributeAccess reaching the property/member
+      // rung would key the write on the attribute's CURRENT VALUE.
+      const objectNode = { type: 'selector', value: '#el' } as unknown as ASTNode;
+      const node = {
+        type: 'memberExpression',
+        object: objectNode,
+        property: { type: 'attributeAccess', attributeName: 'data-state' },
+      } as unknown as ASTNode;
+      const evaluator = makeEvaluator(new Map([[objectNode, me]]));
+
+      const target = await resolveWriteTarget(node, evaluator, context, { scopeElements });
+
+      expect(target).toEqual({ kind: 'attribute', elements: [me], name: 'data-state' });
+    });
+
+    it('scopes a standalone `@attr` to the caller-supplied elements', async () => {
+      const a = document.createElement('span');
+      const b = document.createElement('span');
+      const node = {
+        type: 'attributeAccess',
+        attributeName: 'aria-selected',
+      } as unknown as ASTNode;
+
+      const target = await resolveWriteTarget(node, makeEvaluator(), context, {
+        scopeElements: async () => [a, b],
+      });
+
+      expect(target).toEqual({ kind: 'attribute', elements: [a, b], name: 'aria-selected' });
+    });
+  });
+
+  describe('opt-in rungs are skipped, not reordered', () => {
+    const selectorNode = { type: 'selector', value: '.items' } as unknown as ASTNode;
+
+    it('keeps a selector’s source text only when selectorSource is requested', async () => {
+      const requested = await resolveWriteTarget(selectorNode, makeEvaluator(), context, {
+        scopeElements,
+        selectorSource: true,
+      });
+      expect(requested).toEqual({ kind: 'selector', selector: '.items' });
+
+      // set does not request it: the node falls through to set's evaluated tail.
+      const notRequested = await resolveWriteTarget(selectorNode, makeEvaluator(), context, {
+        scopeElements,
+      });
+      expect(notRequested).toBeNull();
+    });
+
+    it('keeps a bare reference’s name only when bareReference is requested', async () => {
+      const node = { type: 'identifier', name: 'total', scope: 'element' } as unknown as ASTNode;
+
+      const requested = await resolveWriteTarget(node, makeEvaluator(), context, {
+        scopeElements,
+        bareReference: true,
+      });
+      expect(requested).toEqual({ kind: 'variable', name: 'total', scope: 'element' });
+
+      const notRequested = await resolveWriteTarget(node, makeEvaluator(), context, {
+        scopeElements,
+      });
+      expect(notRequested).toBeNull();
+    });
+
+    it('drops an unrecognized scope tag rather than passing it through', async () => {
+      const node = { type: 'identifier', name: 'total', scope: 'local' } as unknown as ASTNode;
+
+      const target = await resolveWriteTarget(node, makeEvaluator(), context, {
+        scopeElements,
+        bareReference: true,
+      });
+
+      expect(target).toEqual({ kind: 'variable', name: 'total', scope: undefined });
+    });
+
+    it('splits `*prop` into a style write only when styleSplit is requested', async () => {
+      const objectNode = { type: 'selector', value: '#el' } as unknown as ASTNode;
+      const node = {
+        type: 'possessiveExpression',
+        object: objectNode,
+        property: { type: 'identifier', name: '*opacity' },
+      } as unknown as ASTNode;
+
+      const split = await resolveWriteTarget(
+        node,
+        makeEvaluator(new Map([[objectNode, me]])),
+        context,
+        {
+          scopeElements,
+          styleSplit: true,
+        }
+      );
+      expect(split).toEqual({ kind: 'style', element: me, property: 'opacity' });
+
+      // append/prepend leave it a property target — read/writePropertyTarget
+      // already route the `*` prefix to inline style.
+      const unsplit = await resolveWriteTarget(
+        node,
+        makeEvaluator(new Map([[objectNode, me]])),
+        context,
+        { scopeElements }
+      );
+      expect(unsplit).toEqual({ kind: 'property', target: { element: me, property: '*opacity' } });
+    });
+
+    it('does not consult the node-writer registry unless nodeWriters is requested', async () => {
+      const writer = vi.fn();
+      getParserExtensionRegistry().registerNodeWriter('caretVar', writer);
+      const node = { type: 'caretVar', name: 'count' } as unknown as ASTNode;
+
+      const target = await resolveWriteTarget(node, makeEvaluator(), context, { scopeElements });
+
+      expect(target).toBeNull();
+    });
+  });
+
+  describe('fall-through', () => {
+    it('returns null for a node no requested rung recognizes', async () => {
+      const node = { type: 'positionalExpression', operator: 'first' } as unknown as ASTNode;
+
+      const target = await resolveWriteTarget(node, makeEvaluator(), context, {
+        scopeElements,
+        nodeWriters: true,
+        selectorSource: true,
+        styleSplit: true,
+        bareReference: true,
+      });
+
+      expect(target).toBeNull();
+    });
+
+    it('returns null for an absent target node', async () => {
+      expect(
+        await resolveWriteTarget(undefined, makeEvaluator(), context, { scopeElements })
+      ).toBeNull();
+    });
+
+    it('does not resolve the attribute scope for a non-attribute node', async () => {
+      const scope = vi.fn(async () => [me]);
+      const node = { type: 'identifier', name: 'total' } as unknown as ASTNode;
+
+      await resolveWriteTarget(node, makeEvaluator(), context, {
+        scopeElements: scope,
+        bareReference: true,
+      });
+
+      expect(scope).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/src/commands/helpers/write-target.ts
+++ b/packages/core/src/commands/helpers/write-target.ts
@@ -1,0 +1,136 @@
+/**
+ * Writable-target resolution — the shared rung ladder
+ *
+ * `set`, `append` and `prepend` all open by answering the same question: given a
+ * raw target AST node, what kind of writable slot is it? Each carried its own
+ * copy of the ladder, and the ORDER of its rungs is semantics rather than style
+ * — the per-rung notes below say why. This module is the one place that order is
+ * defined.
+ *
+ * IMPORTANT: every rung inspects the RAW AST node, before evaluation. Evaluating
+ * a write target yields its *current value*, and a write keyed on that value
+ * silently targets the wrong thing — the defect class #792 fixed for
+ * append/prepend, where `@attr`, `#el's value` and `my innerHTML` created junk
+ * locals named after the current value and never touched the DOM.
+ *
+ * Callers opt into the rungs they have; a rung that is not requested is skipped,
+ * never reordered. `set` requests the plugin node-writers and the `*prop` style
+ * split; `append`/`prepend` request selector-source and bare-reference capture
+ * instead. `null` means "none of the requested rungs matched" — the caller falls
+ * through to its own evaluated-value tail, which is where the commands genuinely
+ * diverge and which deliberately stays out of here.
+ */
+
+import type { ExecutionContext } from '../../types/core';
+import type { ASTNode } from '../../types/base-types';
+import type { ExpressionEvaluator } from '../../core/expression-evaluator';
+import { resolveAnyPropertyTarget, type PropertyTarget } from './property-target';
+import { resolveAttributeWriteTarget } from './attribute-target';
+import { getRegisteredNodeWriter, type NodeWriterFn } from '../../parser/extensions';
+
+/**
+ * A recognized writable slot.
+ *
+ * Subsumes the target halves of both `SetCommandInput` and
+ * `InsertionCommandInput`; each command maps the rung it gets onto its own input
+ * union and keeps its own execute-side switch.
+ */
+export type WriteTarget =
+  | { kind: 'node-write'; node: ASTNode; writer: NodeWriterFn }
+  | { kind: 'selector'; selector: string }
+  | { kind: 'attribute'; elements: HTMLElement[]; name: string }
+  | { kind: 'style'; element: HTMLElement; property: string }
+  | { kind: 'property'; target: PropertyTarget }
+  | { kind: 'variable'; name: string; scope?: 'element' | 'global' };
+
+export interface WriteTargetOptions {
+  /**
+   * Elements a standalone `@attr` applies to. `set` passes its `on`-modifier
+   * resolver (which can match many elements, e.g. `on .tab`); append/prepend
+   * pass `me`, having no `on` modifier.
+   */
+  scopeElements: () => Promise<HTMLElement[]>;
+  /** Rung 1 — consult the plugin node-writer registry (e.g. reactivity's `^count`). */
+  nodeWriters?: boolean;
+  /** Rung 2 — keep a selector node's SOURCE text so a multi-match resolves at execute time. */
+  selectorSource?: boolean;
+  /** Rung 4 — split a `*prop` property target into a distinct style write. */
+  styleSplit?: boolean;
+  /** Rung 5 — keep a bare reference's NAME so execute can read-modify-write the binding. */
+  bareReference?: boolean;
+}
+
+/**
+ * Walk the rung ladder and return the first writable slot that matches.
+ *
+ * @param node - The raw target AST node (NOT evaluated)
+ * @param evaluator - Used only for the object side of `of` / member / property shapes
+ * @param context - Execution context
+ * @param options - Which optional rungs to request, plus the `@attr` fallback scope
+ * @returns The matched write target, or null to fall through to the caller's tail
+ */
+export async function resolveWriteTarget(
+  node: ASTNode | Record<string, unknown> | undefined,
+  evaluator: ExpressionEvaluator,
+  context: ExecutionContext,
+  options: WriteTargetOptions
+): Promise<WriteTarget | null> {
+  if (!node) return null;
+
+  const n = node as Record<string, unknown>;
+  const nodeType = n.type as string | undefined;
+
+  // (1) Plugin-defined write targets — e.g. `set ^count to 0` routes through the
+  //     reactivity plugin's caretVar writer. First, so a plugin can claim a node
+  //     type before any built-in rung interprets it.
+  if (options.nodeWriters && nodeType) {
+    const writer = getRegisteredNodeWriter(nodeType);
+    if (writer) return { kind: 'node-write', node: node as ASTNode, writer };
+  }
+
+  // (2) Selector nodes keep their SOURCE text — resolving at execute time lets a
+  //     multi-match selector write into every element instead of just the first.
+  if (options.selectorSource && nodeType === 'selector' && typeof n.value === 'string') {
+    return { kind: 'selector', selector: n.value };
+  }
+
+  // (3) Attribute write targets: `@attr`, `[@attr]`, `@attr of X`, `X[@attr]`.
+  //     MUST precede the property/member rungs — an attributeAccess that reached
+  //     the computed-member path would key the write on the attribute's *current
+  //     value* rather than writing the attribute.
+  const attribute = await resolveAttributeWriteTarget(
+    node,
+    evaluator,
+    context,
+    options.scopeElements
+  );
+  if (attribute) {
+    return { kind: 'attribute', elements: attribute.elements, name: attribute.name };
+  }
+
+  // (4) Property targets: `#el's value`, `my innerHTML`, `the X of Y`, `*opacity`.
+  const property = await resolveAnyPropertyTarget(node as ASTNode, evaluator, context);
+  if (property) {
+    // `set` splits `*prop` out into a style write; append/prepend do not, because
+    // read/writePropertyTarget already route the `*` prefix to inline style.
+    if (options.styleSplit && property.property.startsWith('*')) {
+      return { kind: 'style', element: property.element, property: property.property.substring(1) };
+    }
+    return { kind: 'property', target: property };
+  }
+
+  // (5) Bare references keep their NAME so execute can read+write the binding;
+  //     evaluating would yield the current value and lose the slot. The parser's
+  //     scope tag routes `:name` to element scope and `$name`/`global` to globals.
+  if (
+    options.bareReference &&
+    (nodeType === 'identifier' || nodeType === 'variable' || nodeType === 'symbol') &&
+    typeof n.name === 'string'
+  ) {
+    const rawScope = n.scope as string | undefined;
+    const scope = rawScope === 'element' || rawScope === 'global' ? rawScope : undefined;
+    return { kind: 'variable', name: n.name, scope };
+  }
+
+  return null;
+}


### PR DESCRIPTION
Arc D step 2 of the command-architecture queue
([queue doc](../blob/main/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md) ·
[arc brief](../blob/main/docs-internal/HANDOFF-command-arch-target-resolution.md)).
Follows #796. Pure refactor, no intended behavior change.

## What

`set` and `content/insertion-base` (append/prepend) each opened `parseInput` by
answering the same question — *given a raw target AST node, what kind of writable
slot is this?* — with their own copy of the rung ladder. #792 had already shared
the two heaviest rungs (`attribute-target.ts`, `property-target.ts`); what stayed
duplicated was **the order around them**, which is semantics rather than style and
was documented in prose in two separate places.

`resolveWriteTarget()` is now the one place that order lives:

| # | Rung | Requested by |
| - | ---- | ------------ |
| 1 | plugin node-writers | `set` (reactivity's `^count`) |
| 2 | selector-source | append/prepend (multi-match resolves at execute time) |
| 3 | attribute | **always** — must precede property/member |
| 4 | property, with the `*prop` style split | always / split by `set` only |
| 5 | bare-reference name | append/prepend (read-modify-write the binding) |

Callers opt into the rungs they have, so an unrequested rung is **skipped, never
reordered**. Each command keeps its own execute-side switch and its own
evaluated-value tail — the tails are where the two genuinely diverge, so they
deliberately stay out of the helper, and `resolveWriteTarget` returning `null`
is what hands control back to them.

## Gate

Rung order and rung opt-in are now ratcheted by
`helpers/__tests__/write-target.test.ts` (11 cases). The load-bearing one:
`X[@attr]` resolves as an **attribute write**, not a computed-member read that
would key the write on the attribute's *current value* — the defect class #792
existed to fix, which previously had no direct test.

| Gate | Result |
| ---- | ------ |
| set suites (4 files) + append/prepend | 277/277 |
| new `write-target` rung tests | 11/11 |
| core quick validation | 7713 passed / 128 skipped (baseline 7702 + the 11 new cases) |
| Playwright `test-multiword-commands` (element-scoped `:greeting`) | 4/4 |
| `typecheck` / prettier | clean |

R2 execution subset and the other nine ratchet signals run in this PR's
`multilingual-validation` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)