### PR TITLE
refactor(core): Arc D step 3 — centralize the selector-shape rule in helpers/target-elements.ts

### DIFF
--- a/docs-internal/HANDOFF-command-arch-target-resolution.md
+++ b/docs-internal/HANDOFF-command-arch-target-resolution.md
@@ -7,9 +7,10 @@
 > `commands/helpers/attribute-target.ts` and reused `property-target.ts`; both
 > are now shared by set/append/prepend.
 >
-> **Status: not started.** Update the per-step status lines below as PRs land;
-> when the arc completes, add one History line to the queue doc and stop
-> updating this file.
+> **Status: all three steps implemented (2026-07-28).** Step 1 merged (#796);
+> steps 2 (#797) and 3 landed behind it. See the Status log at the bottom for
+> per-step outcomes and the two decisions this arc had to record. When the arc
+> completes, add one History line to the queue doc and stop updating this file.
 
 ## Objective
 
@@ -98,13 +99,30 @@ trust the number).
   including the shared "unmatched selector throws" contract
   (insertion-base :218 comments "Same contract as `put`"). Fold these into the
   same helper.
-- **Arc C pairing (recorded decision needed).** The queue doc pairs this step
-  with Arc C step 3 (the `:121` collapse is this asymmetry seen from the
-  propagation end). If Arc C hasn't started when this step is reached: land
-  step 3 with the shape-pinning tests and leave `:121` untouched, noting in the
-  PR that the tests are the ratchet Arc C will build on — or hold step 3 until
-  C step 3 is ready and land them together. Either is fine; record which in
-  this file.
+- **CORRECTION (found while implementing, 2026-07-28).** The
+  `resolveEvaluatedAsElements` / `asElementList` pair is **not** a duplication —
+  the two differ in two observable ways:
+  1. **Mixed array.** put FILTERS (`[el, 'junk']` → `[el]`, writes into `el`);
+     append/prepend REJECT, so the value stays an Array target and the content
+     is pushed into it (upstream's dispatch order).
+  2. **Array-likes.** put gates on `instanceof NodeList`; insertion-base
+     duck-types `length` + `item`, so it accepts an HTMLCollection and put does
+     not.
+  Unifying them is therefore a behavior change, not a refactor. They were moved
+  into the shared module as `toElementListFiltered` / `toElementListStrict` —
+  adjacent, documented, and both pinned by tests — with the divergence left
+  intact. **Whether to reconcile them is an open decision, not an oversight**;
+  it wants its own change with its own gate. `looksLikeCss` turned out to be
+  put-only (nothing else in core defines an equivalent), so it stayed in put.
+- **Arc C pairing — DECIDED 2026-07-28: landed step 3 alone.** Arc C had not
+  started when step 3 was reached, so step 3 shipped with the shape-pinning
+  tests and left `unwrapCommandResult`'s `:121` collapse untouched. Those tests
+  (`commands/helpers/__tests__/target-elements.test.ts`) are the ratchet Arc C
+  step 3 builds on — in particular the two cases a "simplifying" change breaks
+  first: `#id` unmatched → `null` while `.cls` unmatched → `[]`, and a
+  single-match `.cls` staying a one-element array rather than collapsing to the
+  element. Arc C step 3 now has a pinned rule to decide the `:121` policy
+  against instead of inheriting it.
 
 ## Gates, per step
 
@@ -175,7 +193,47 @@ and changes no command lists. If it fails, something out of scope was touched.
   path) — one of Arc C's fall-throughs. Do not "improve" it here; Arc C owns
   the output contract, and changing it in a pure-refactor PR muddies both arcs.
 
+## What the arc left behind
+
+Three helper modules under `commands/helpers/`, each the single definition of a
+rule that used to exist in two or three places:
+
+| Module | Defines | Consumers |
+| ------ | ------- | --------- |
+| `dom-mutation.ts` (pre-existing) | content insertion at a position | put, append, prepend |
+| `write-target.ts` (step 2) | the writable-target **rung order** | set, append, prepend |
+| `target-elements.ts` (step 3) | the selector **shape rule**, the query contract, both list coercions | `parser/runtime.ts` (sync + async), put, append, prepend |
+
+Two new test files are the gates: `write-target.test.ts` (11 cases, rung order
+and rung opt-in) and `target-elements.test.ts` (20 cases, both selector shapes
+and both coercions).
+
 ## Status log
 
 - 2026-07-28 — brief written; arc not started. Next action: step 1 PR
   (put `insertContent` collapse).
+- 2026-07-28 — **step 1 merged (#796)**, full CI green. Surprise worth carrying:
+  the put suite asserts `input.position` ~42 times, so re-pointing `mapPosition`
+  at `SemanticPosition` names (which the brief prescribes) churns the test file.
+  Those are white-box assertions on the input's internal spelling — every
+  DOM-outcome expectation was left untouched, so this is not the "test changes
+  expectation → stop and ask" case the non-goals mean. `InsertPosition` was kept
+  as a deprecated alias of `ContentInsertPosition` rather than deleted; it is
+  publicly re-exported from `commands/index.ts`.
+- 2026-07-28 — **step 2 opened (#797)**. The two ladders overlapped less than
+  the brief's line-anchors suggest: #792 had already shared the attribute and
+  property RUNGS, so what was actually duplicated was the **order** around them
+  plus the rung-selection. `resolveWriteTarget` therefore takes opt-in flags
+  (`nodeWriters`, `selectorSource`, `styleSplit`, `bareReference`) rather than
+  merging the tails — set's evaluated-value tail (object literal, "the X of Y"
+  string, CSS shorthand, possessive string, element, element array) has no
+  counterpart in insertion-base and stayed in set.
+- 2026-07-28 — **step 3 implemented** (branched on #797; rebase onto main once
+  that merges). Two decisions recorded above: the Arc C pairing (landed alone,
+  tests are C's ratchet) and the `toElementListFiltered`/`toElementListStrict`
+  divergence (preserved and documented rather than unified — see the CORRECTION
+  under step 3's anchors).
+- **Open follow-up left by this arc:** decide whether put's and append/prepend's
+  element-list coercions should agree. It is the only Arc D item deliberately
+  not closed, it is a behavior decision rather than a refactor, and both
+  behaviors are now pinned by tests so either direction is a visible change.

--- a/packages/core/src/commands/content/insertion-base.ts
+++ b/packages/core/src/commands/content/insertion-base.ts
@@ -46,6 +46,7 @@ import {
   type PropertyTarget,
 } from '../helpers/property-target';
 import { resolveWriteTarget, type WriteTarget } from '../helpers/write-target';
+import { queryTargetElements, toElementListStrict } from '../helpers/target-elements';
 import type { DecoratedCommand, CommandMetadata } from '../decorators';
 
 /** Where content lands, and how scalar values combine. */
@@ -148,7 +149,7 @@ export abstract class ContentInsertionCommand implements DecoratedCommand {
 
     // Anything else: evaluate and dispatch on the runtime value.
     const value = await evaluator.evaluate(toNode as ASTNode, context);
-    const elements = this.asElementList(value);
+    const elements = toElementListStrict(value);
     if (elements) return { kind: 'elements', elements, content };
     return { kind: 'value', target: value, content };
   }
@@ -206,14 +207,9 @@ export abstract class ContentInsertionCommand implements DecoratedCommand {
 
   /** Resolve a selector to elements and insert into every match. */
   private insertIntoSelector(selector: string, content: unknown): HTMLElement[] {
-    if (typeof document === 'undefined') throw new Error('DOM not available');
-    const els = Array.from(document.querySelectorAll(selector)).filter((e): e is HTMLElement =>
-      isHTMLElement(e)
-    );
-    // Same contract as `put`: an unmatched selector is a programming error, not
-    // a silent no-op.
-    if (!els.length) throw new Error(`No elements: "${selector}"`);
-    return this.insertIntoEach(els, content);
+    // `queryTargetElements` carries the contract shared with `put`: an unmatched
+    // selector is a programming error, not a silent no-op.
+    return this.insertIntoEach(queryTargetElements(selector), content);
   }
 
   private insertIntoEach(elements: HTMLElement[], content: unknown): HTMLElement[] {
@@ -254,26 +250,6 @@ export abstract class ContentInsertionCommand implements DecoratedCommand {
     if (current instanceof Set) return 'set';
     if (isHTMLElement(current)) return 'element';
     return 'result';
-  }
-
-  /** An evaluated value that is element-like, or null. */
-  private asElementList(value: unknown): HTMLElement[] | null {
-    if (isHTMLElement(value)) return [value as HTMLElement];
-    if (Array.isArray(value) && value.length > 0 && value.every(v => isHTMLElement(v))) {
-      return value as HTMLElement[];
-    }
-    if (
-      value &&
-      typeof value === 'object' &&
-      typeof (value as { length?: unknown }).length === 'number' &&
-      typeof (value as { item?: unknown }).item === 'function'
-    ) {
-      const list = Array.from(value as ArrayLike<unknown>).filter((v): v is HTMLElement =>
-        isHTMLElement(v)
-      );
-      return list.length ? list : null;
-    }
-    return null;
   }
 
   private executeVariable(

--- a/packages/core/src/commands/dom/put.ts
+++ b/packages/core/src/commands/dom/put.ts
@@ -26,6 +26,7 @@ import {
   type ContentInsertPosition,
   type SemanticPosition,
 } from '../helpers/dom-mutation';
+import { queryTargetElements, toElementListFiltered } from '../helpers/target-elements';
 import {
   command,
   meta,
@@ -202,7 +203,7 @@ export class PutCommand implements DecoratedCommand {
         } else {
           // Evaluate to check if variable holds an element reference (matches _hyperscript semantics)
           const ev = await evaluator.evaluate(targetArg, context);
-          const resolved = this.resolveEvaluatedAsElements(ev);
+          const resolved = toElementListFiltered(ev);
           if (resolved) {
             return { value, targets: resolved, position, memberPath };
           }
@@ -210,7 +211,7 @@ export class PutCommand implements DecoratedCommand {
         }
       } else {
         const ev = await evaluator.evaluate(targetArg, context);
-        const resolved = this.resolveEvaluatedAsElements(ev);
+        const resolved = toElementListFiltered(ev);
         if (resolved) {
           return { value, targets: resolved, position, memberPath };
         } else if (typeof ev === 'string') {
@@ -273,33 +274,12 @@ export class PutCommand implements DecoratedCommand {
         throw new Error('put: no target and context.me is null');
       return [ctx.me as HTMLElement];
     }
-    const els = Array.from(document.querySelectorAll(sel)).filter((e): e is HTMLElement =>
-      isHTMLElement(e)
-    );
-    if (!els.length) throw new Error(`No elements: "${sel}"`);
-    return els;
+    return queryTargetElements(sel);
   }
 
   private parseValue(v: any): string | HTMLElement {
     if (isHTMLElement(v)) return v as HTMLElement;
     return v == null ? '' : String(v);
-  }
-
-  /**
-   * Attempt to resolve an evaluated value as element target(s).
-   * Returns an array of HTMLElements if the value is element-like, or null otherwise.
-   */
-  private resolveEvaluatedAsElements(ev: unknown): HTMLElement[] | null {
-    if (isHTMLElement(ev)) return [ev as HTMLElement];
-    if (Array.isArray(ev)) {
-      const elements = ev.filter(isHTMLElement) as HTMLElement[];
-      return elements.length > 0 ? elements : null;
-    }
-    if (typeof NodeList !== 'undefined' && ev instanceof NodeList) {
-      const elements = Array.from(ev).filter(isHTMLElement) as HTMLElement[];
-      return elements.length > 0 ? elements : null;
-    }
-    return null;
   }
 
   private looksLikeCss(s: string): boolean {

--- a/packages/core/src/commands/helpers/__tests__/target-elements.test.ts
+++ b/packages/core/src/commands/helpers/__tests__/target-elements.test.ts
@@ -1,0 +1,155 @@
+/**
+ * target-elements — selector shape and element-list coercion
+ *
+ * The `#id` → element / `.cls` → collection asymmetry is deliberate upstream
+ * parity (IdRef → getElementById vs QueryRef/ClassRef → ElementCollection), and
+ * it was implemented twice in `parser/runtime.ts` — once async, once in the sync
+ * mirror. These tests pin BOTH shapes so the single definition can't drift and a
+ * future change to the rule has to be deliberate.
+ *
+ * They are also the ratchet Arc C step 3 builds on: `unwrapCommandResult`'s
+ * `val[0]` collapse (`runtime-base.ts`) is this same asymmetry seen from the
+ * propagation end, and deciding that policy needs the rule pinned first.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  resolveTargetElements,
+  queryTargetElements,
+  toElementListFiltered,
+  toElementListStrict,
+} from '../target-elements';
+
+describe('resolveTargetElements — the selector shape rule', () => {
+  const a = { tag: 'a' };
+  const b = { tag: 'b' };
+
+  describe('bare `#id` unwraps to a single element', () => {
+    it('returns the first match', () => {
+      expect(resolveTargetElements([a], '#id', false)).toBe(a);
+    });
+
+    it('returns null when nothing matched — not an empty array', () => {
+      expect(resolveTargetElements([], '#id', false)).toBeNull();
+    });
+
+    it('treats an absent fromQuery flag as a bare ref', () => {
+      expect(resolveTargetElements([a], '#id')).toBe(a);
+    });
+
+    it('passes a non-array result through untouched (async caller)', () => {
+      expect(resolveTargetElements(a, '#id', false)).toBe(a);
+    });
+  });
+
+  describe('everything else keeps the collection', () => {
+    it('keeps a class selector as an array', () => {
+      expect(resolveTargetElements([a, b], '.cls', false)).toEqual([a, b]);
+    });
+
+    it('keeps an EMPTY class match as an array, not null', () => {
+      // The counterpart to the `#id` → null case: `.cls` callers assert
+      // iterability, so an unmatched class ref must stay an empty collection.
+      expect(resolveTargetElements([], '.cls', false)).toEqual([]);
+    });
+
+    it('keeps a query-form `<#id/>` as a collection despite the `#`', () => {
+      expect(resolveTargetElements([a], '#id', true)).toEqual([a]);
+    });
+
+    it('keeps an attribute selector as a collection', () => {
+      expect(resolveTargetElements([a, b], '[data-x]', false)).toEqual([a, b]);
+    });
+
+    it('keeps a single-match class ref as a one-element array, not the element', () => {
+      expect(resolveTargetElements([a], '.cls', false)).toEqual([a]);
+    });
+
+    it('passes through when the selector is not a string', () => {
+      expect(resolveTargetElements([a, b], undefined, false)).toEqual([a, b]);
+    });
+  });
+});
+
+describe('queryTargetElements', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div class="x" id="one"></div><div class="x"></div>';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('returns every match for a multi-match selector', () => {
+    expect(queryTargetElements('.x')).toHaveLength(2);
+  });
+
+  it('returns a single match as a one-element array', () => {
+    expect(queryTargetElements('#one')).toEqual([document.getElementById('one')]);
+  });
+
+  it('throws on an unmatched selector rather than returning empty', () => {
+    // The contract put and append/prepend share: an unmatched selector is a
+    // programming error, not a silent no-op.
+    expect(() => queryTargetElements('.nope')).toThrow('No elements');
+  });
+});
+
+describe('element-list coercion — the two rules differ, deliberately', () => {
+  let el: HTMLElement;
+  let other: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<p class="p"></p><p class="p"></p>';
+    [el, other] = Array.from(document.querySelectorAll('p')) as HTMLElement[];
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('agreement', () => {
+    it('both wrap a lone element', () => {
+      expect(toElementListFiltered(el)).toEqual([el]);
+      expect(toElementListStrict(el)).toEqual([el]);
+    });
+
+    it('both accept an all-element array', () => {
+      expect(toElementListFiltered([el, other])).toEqual([el, other]);
+      expect(toElementListStrict([el, other])).toEqual([el, other]);
+    });
+
+    it('both reject a non-element value', () => {
+      expect(toElementListFiltered('hello')).toBeNull();
+      expect(toElementListStrict('hello')).toBeNull();
+    });
+
+    it('both reject an empty array', () => {
+      expect(toElementListFiltered([])).toBeNull();
+      expect(toElementListStrict([])).toBeNull();
+    });
+  });
+
+  describe('divergence (preserved, not unified)', () => {
+    it('filtered keeps the element subset of a mixed array; strict rejects it', () => {
+      // put writes into `el`; append/prepend leave it an Array target and push
+      // the content into the array instead. Reconciling these is a behavior
+      // decision, out of scope for the Arc D refactor.
+      expect(toElementListFiltered([el, 'junk'])).toEqual([el]);
+      expect(toElementListStrict([el, 'junk'])).toBeNull();
+    });
+
+    it('strict duck-types array-likes, so an HTMLCollection is accepted', () => {
+      const collection = document.getElementsByTagName('p');
+      expect(toElementListStrict(collection)).toEqual([el, other]);
+      // filtered gates on `instanceof NodeList`, which an HTMLCollection is not.
+      expect(toElementListFiltered(collection)).toBeNull();
+    });
+
+    it('both accept a NodeList', () => {
+      const nodes = document.querySelectorAll('p');
+      expect(toElementListFiltered(nodes)).toEqual([el, other]);
+      expect(toElementListStrict(nodes)).toEqual([el, other]);
+    });
+  });
+});

--- a/packages/core/src/commands/helpers/target-elements.ts
+++ b/packages/core/src/commands/helpers/target-elements.ts
@@ -1,0 +1,140 @@
+/**
+ * Target-element resolution — the selector SHAPE rule, and value→elements coercion
+ *
+ * ## The shape rule (`resolveTargetElements`)
+ *
+ * A bare `#id` selector resolves to a SINGLE element (or null); a class selector,
+ * and any query-form ref (`<#id/>`, parsed with `fromQuery: true`), resolves to
+ * the COLLECTION.
+ *
+ * **This asymmetry is deliberate upstream parity, not a defect.** It mirrors
+ * _hyperscript's `IdRef` → `getElementById` versus `QueryRef` → `ElementCollection`.
+ * Do not "fix" it by making both shapes agree.
+ *
+ * The real defect class is command-side code that mishandles ONE of the two
+ * shapes. Two instances, from opposite ends:
+ *
+ * - append's pre-#792 silent no-op on `.cls` — the consuming end, fixed.
+ * - `unwrapCommandResult`'s `val[0]` collapse in `runtime-base.ts` — the
+ *   propagation end, which makes `toggle .a on .items` leave `it` holding only
+ *   the FIRST element. Still open; it belongs to Arc C step 3.
+ *
+ * `parser/runtime.ts` implemented the rule twice — once in async `evaluateSelector`
+ * and once in its sync mirror `evaluateSelectorSync`. Two copies of a rule this
+ * subtle is how the halves drift apart, so this is now the single definition, and
+ * `__tests__/target-elements.test.ts` pins BOTH shapes for BOTH callers.
+ *
+ * ## Element-list coercion (`toElementListFiltered` / `toElementListStrict`)
+ *
+ * `put` and `append`/`prepend` each coerce an evaluated target value to a list of
+ * elements, and they do it DIFFERENTLY. The two live here side by side so the
+ * difference is visible and tested rather than buried in two command files. See
+ * each function for what diverges; reconciling them would be a behavior change,
+ * so it is deliberately not part of this refactor.
+ */
+
+import { isHTMLElement } from '../../utils/element-check';
+
+/**
+ * Apply the selector shape rule to a set of matches.
+ *
+ * @param matches - What the query produced (normally an array of elements; the
+ *   async caller may hand through a non-array, which passes back unchanged)
+ * @param selector - The selector text the matches came from
+ * @param fromQuery - True for query-form refs (`<#id/>`), which always keep the
+ *   collection
+ * @returns A single element (or null) for a bare `#id`; the collection otherwise
+ *
+ * @example
+ * ```typescript
+ * resolveTargetElements([el], '#id', false);      // el      — IdRef
+ * resolveTargetElements([], '#id', false);        // null    — IdRef, unmatched
+ * resolveTargetElements([a, b], '.cls', false);   // [a, b]  — class ref
+ * resolveTargetElements([el], '#id', true);       // [el]    — QueryRef `<#id/>`
+ * ```
+ */
+export function resolveTargetElements(
+  matches: unknown,
+  selector: unknown,
+  fromQuery?: boolean
+): unknown {
+  // Query-form refs and every non-`#` selector keep the collection.
+  if (fromQuery || typeof selector !== 'string' || !selector.startsWith('#')) {
+    return matches;
+  }
+  // Bare `#id` unwraps to a single element, or null when nothing matched.
+  return Array.isArray(matches) ? (matches[0] ?? null) : matches;
+}
+
+/**
+ * Query a selector to its matching elements.
+ *
+ * The contract `put` and `append`/`prepend` share: an unmatched selector is a
+ * programming error, not a silent no-op, so it throws rather than returning an
+ * empty list.
+ *
+ * @param selector - CSS selector text
+ * @returns The matching HTMLElements (never empty)
+ * @throws If the DOM is unavailable, or the selector matches nothing
+ */
+export function queryTargetElements(selector: string): HTMLElement[] {
+  if (typeof document === 'undefined') throw new Error('DOM not available');
+  const elements = Array.from(document.querySelectorAll(selector)).filter((e): e is HTMLElement =>
+    isHTMLElement(e)
+  );
+  if (!elements.length) throw new Error(`No elements: "${selector}"`);
+  return elements;
+}
+
+/**
+ * Coerce an evaluated value to elements, keeping the element SUBSET of a mixed
+ * array — `put`'s rule.
+ *
+ * Diverges from {@link toElementListStrict} in two ways, both observable:
+ * a mixed array yields its elements here but is rejected there, and array-likes
+ * are recognized by `instanceof NodeList` here rather than by duck-typing (so an
+ * HTMLCollection is not accepted).
+ *
+ * @returns The elements, or null when the value is not element-like
+ */
+export function toElementListFiltered(value: unknown): HTMLElement[] | null {
+  if (isHTMLElement(value)) return [value as HTMLElement];
+  if (Array.isArray(value)) {
+    const elements = value.filter(isHTMLElement) as HTMLElement[];
+    return elements.length > 0 ? elements : null;
+  }
+  if (typeof NodeList !== 'undefined' && value instanceof NodeList) {
+    const elements = Array.from(value).filter(isHTMLElement) as HTMLElement[];
+    return elements.length > 0 ? elements : null;
+  }
+  return null;
+}
+
+/**
+ * Coerce an evaluated value to elements, rejecting a mixed array — `append`/
+ * `prepend`'s rule.
+ *
+ * Rejecting matters there: a mixed array must stay a plain Array target so the
+ * content is PUSHED into it, which is upstream's dispatch order. Array-likes are
+ * duck-typed (`length` + `item`), so an HTMLCollection is accepted too.
+ *
+ * @returns The elements, or null when the value is not element-like
+ */
+export function toElementListStrict(value: unknown): HTMLElement[] | null {
+  if (isHTMLElement(value)) return [value as HTMLElement];
+  if (Array.isArray(value) && value.length > 0 && value.every(v => isHTMLElement(v))) {
+    return value as HTMLElement[];
+  }
+  if (
+    value &&
+    typeof value === 'object' &&
+    typeof (value as { length?: unknown }).length === 'number' &&
+    typeof (value as { item?: unknown }).item === 'function'
+  ) {
+    const list = Array.from(value as ArrayLike<unknown>).filter((v): v is HTMLElement =>
+      isHTMLElement(v)
+    );
+    return list.length ? list : null;
+  }
+  return null;
+}

--- a/packages/core/src/parser/__tests__/selector-shape.test.ts
+++ b/packages/core/src/parser/__tests__/selector-shape.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Selector shape — end-to-end through BOTH evaluator entry points
+ *
+ * `commands/helpers/__tests__/target-elements.test.ts` pins the rule itself.
+ * This file pins the WIRING: that the sync evaluator and the async evaluator
+ * both route through `resolveTargetElements`, and therefore agree.
+ *
+ * The two used to carry independent copies of the rule (`evaluateSelectorSync`
+ * and `evaluateSelector` in `parser/runtime.ts`), which is what made drift
+ * possible — so "sync and async produce the same shape" is the property worth
+ * asserting, not just "the shape is right".
+ *
+ * The rule is upstream parity: IdRef (`#id`) → a single element, ClassRef
+ * (`.cls`) and QueryRef (`<…/>`) → the collection. Do not "fix" the asymmetry.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { evaluateExpressionFromSource, evaluateExpressionFromSourceSync } from '../runtime';
+import { createMockHyperscriptContext } from '../../test-setup';
+import type { ExecutionContext } from '../../types/core';
+
+describe('selector shape — sync and async agree', () => {
+  let context: ExecutionContext;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="solo" class="item"></div>
+      <div class="item"></div>
+    `;
+    context = createMockHyperscriptContext(document.body) as ExecutionContext;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  /** Evaluate one source string both ways and assert the halves agree. */
+  async function bothWays(source: string): Promise<unknown> {
+    const sync = evaluateExpressionFromSourceSync(source, context);
+    const async_ = await evaluateExpressionFromSource(source, context);
+    expect(sync, `sync and async disagree for \`${source}\``).toEqual(async_);
+    return sync;
+  }
+
+  it('unwraps a matched bare `#id` to the element itself', async () => {
+    const result = await bothWays('#solo');
+    expect(result).toBe(document.getElementById('solo'));
+  });
+
+  it('yields null for an unmatched bare `#id` — not an empty collection', async () => {
+    expect(await bothWays('#nope')).toBeNull();
+  });
+
+  it('keeps a multi-match `.cls` as the whole collection', async () => {
+    const result = (await bothWays('.item')) as unknown[];
+    expect(Array.from(result)).toHaveLength(2);
+  });
+
+  it('keeps a SINGLE-match `.cls` as a collection, not the element', async () => {
+    // The counterpart to the `#id` case, and the one a "simplifying" change
+    // breaks first: `.cls` callers assert iterability.
+    document.body.innerHTML = '<div class="only"></div>';
+    const result = (await bothWays('.only')) as unknown[];
+    expect(Array.from(result)).toHaveLength(1);
+  });
+
+  it('keeps an unmatched `.cls` as an EMPTY collection, not null', async () => {
+    const result = (await bothWays('.absent')) as unknown[];
+    expect(Array.from(result)).toHaveLength(0);
+  });
+});

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -19,6 +19,7 @@ import {
 export { setGlobal };
 import { getElementVar, setElementVar } from '../core/context';
 import { convertToNumber } from '../commands/helpers/variable-access';
+import { resolveTargetElements } from '../commands/helpers/target-elements';
 
 // Static imports limited to plain utilities + lazy-evaluating collection helpers,
 // which aren't registered as ExpressionImplementations. Named-expression dispatch
@@ -470,12 +471,7 @@ function evaluateSelectorSync(node: SelectorNode, context: ExecutionContext): un
     (typeof document !== 'undefined' ? document : null);
   if (!doc) throw new NotSyncEvaluable('selector');
   const elements = Array.from(doc.querySelectorAll(escaped));
-  // Bare `#id` unwraps to a single element/null; query-form (`<#id/>`) and class
-  // selectors return the collection — matches evaluateSelector.
-  if (!node.fromQuery && selector.startsWith('#')) {
-    return elements[0] ?? null;
-  }
-  return elements;
+  return resolveTargetElements(elements, selector, node.fromQuery);
 }
 
 /**
@@ -1630,6 +1626,10 @@ async function evaluateCallExpression(node: CallNode, context: ExecutionContext)
  * Canonical previously unwrapped all array results to first element, which
  * broke `.class` callers asserting iterability. Aligning with upstream:
  * only `#id` selectors yield a single element.
+ *
+ * The shape rule itself lives in `resolveTargetElements`
+ * (`commands/helpers/target-elements.ts`), shared with the sync mirror
+ * `evaluateSelectorSync` so the two halves cannot drift.
  */
 async function evaluateSelector(node: SelectorNode, context: ExecutionContext): Promise<any> {
   let selector = node.value;
@@ -1667,15 +1667,7 @@ async function evaluateSelector(node: SelectorNode, context: ExecutionContext): 
   const escaped = typeof selector === 'string' ? escapeSelectorForQuery(node, selector) : selector;
   const result = await getExpr(context, 'elementWithSelector').evaluate(context, escaped);
 
-  // Bare `#id` unwraps to single element. `<#id/>` (query-form, marked by
-  // parser with `fromQuery: true`) always returns the collection — matches
-  // upstream's QueryRef → ElementCollection vs IdRef → getElementById.
-  if (!node.fromQuery && typeof selector === 'string' && selector.startsWith('#')) {
-    if (Array.isArray(result)) return result[0] ?? null;
-    return result;
-  }
-
-  return result;
+  return resolveTargetElements(result, selector, node.fromQuery);
 }
 
 /**


### PR DESCRIPTION
Arc D step 3 — the final step of the arc
([queue doc](../blob/main/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md) ·
[arc brief](../blob/main/docs-internal/HANDOFF-command-arch-target-resolution.md)).
Follows #796 and #797. Pure refactor, no intended behavior change.

## What

The `#id` → element / `.cls` → collection asymmetry is **deliberate upstream
parity** (IdRef → `getElementById` vs QueryRef/ClassRef → ElementCollection),
not a defect — but `parser/runtime.ts` implemented it **twice**, once in async
`evaluateSelector` and once in its sync mirror `evaluateSelectorSync`. Two copies
of a rule this subtle is how the halves drift apart. `resolveTargetElements()` is
now the single definition, and the pair was migrated together.

Folded into the same helper module:

- **`queryTargetElements()`** — the selector→elements query whose *"an unmatched
  selector throws rather than silently no-op'ing"* contract put and append/prepend
  already shared in prose (insertion-base's comment literally read `Same contract
  as put`). put picks up the `typeof document` guard it lacked, turning a
  ReferenceError into a clear message.
- **`toElementListFiltered()` / `toElementListStrict()`** — see below.

## The one correction to the brief

The brief expected put's `resolveEvaluatedAsElements` and insertion-base's
`asElementList` to be one duplicated function. **They are not**, and both
differences are observable:

| | put (`Filtered`) | append/prepend (`Strict`) |
| --- | --- | --- |
| `[el, 'junk']` | → `[el]`, writes into `el` | → rejected; stays an Array target and the content is **pushed into it** (upstream's dispatch order) |
| array-likes | `instanceof NodeList` | duck-typed `length`+`item`, so an **HTMLCollection is accepted** |

Unifying them would therefore be a behavior change, not a refactor. They now sit
**side by side in one module with the divergence documented and tested**, instead
of buried in two command files. Reconciling them is left as its own decision —
recorded as the arc's one open follow-up in the brief.

## Gate

`helpers/__tests__/target-elements.test.ts` (20 cases) pins **both** selector
shapes — including the two a "simplifying" change breaks first:

- `#id` unmatched yields `null` while `.cls` unmatched yields `[]`
- a single-match `.cls` stays a one-element array rather than collapsing to the element

## Arc C pairing — decided

Arc C has not started, so per the brief's recorded-decision option this lands
alone and leaves `unwrapCommandResult`'s `val[0]` collapse (`runtime-base.ts`)
untouched. **These tests are the ratchet Arc C step 3 builds on** — that collapse
is this same asymmetry seen from the propagation end, and Arc C now has a pinned
rule to decide its policy against rather than inheriting it. Decision recorded in
the brief.

## Gates

| Gate | Result |
| ---- | ------ |
| core quick validation | 7733 passed / 128 skipped (7713 + the 20 new cases) |
| new `target-elements` shape tests | 20/20 |
| `typecheck` / prettier | clean |
| local Playwright `browser-tests/` | 1111 passed; the 10 failures are **pre-existing** — verified identical on `main` with a main-built bundle, and CI's Browser Tests job is green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)