### PR TITLE
docs: Arc C brief — the command output contract, with a revised plan

### DIFF
--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -80,7 +80,7 @@ generators with `--check` CI gates, `typecheck:scripts`, and ghost tests.
 | Arc | Value | Gate today | Detail |
 | --- | ----- | ---------- | ------ |
 | ~~D — target-resolution consolidation~~ | **DONE** (#796/#797/#798) | ✅ + 36 new tests pinning the rung order and both selector shapes | [HANDOFF-command-arch-target-resolution.md](./HANDOFF-command-arch-target-resolution.md) — now a record, not a plan |
-| C — output contract | **~20 live `it` divergences** | **none for the `it` contract** — R2 covers only the DOM-visible half; 6 positive unwrap cases tested, no fall-throughs | the ungated one; it is what this document is for |
+| C — output contract | **~20 live `it` divergences, *plus* `it` disagreeing between execution paths** | **none, and measurably so** — disabling the mechanism fails only its own 4 unit tests | [HANDOFF-command-arch-output-contract.md](./HANDOFF-command-arch-output-contract.md) — **revises the plan below** |
 | A — command manifest | kills ~15 of ~30 registration points | ✅ partial: verify:reference, capability-ghosts, command-tiers, bundle-manifest-consistency | gates carry the migration; manifest replaces the lists they guard |
 | B — metadata single-sourcing | types see metadata; docs generated | ✅ partial: typecheck:scripts, metadataOf() throws | decorator statics invisible to TS remain the root cause |
 | E — generated static bundles | 4 executors → 1 template source | ✅ partial: bundle-size ±5% + ceilings, compat matrix, parser-template drift test | drift test becomes a generator |
@@ -116,6 +116,18 @@ Two things later arcs should carry forward:
 
 The wrapper-`it` class is ~20 live divergences, not a latent risk — hence ranked
 ahead of the manifest.
+
+> **Read [HANDOFF-command-arch-output-contract.md](./HANDOFF-command-arch-output-contract.md)
+> first — it REVISES steps 2 and 3 below.** The brief's exploration measured
+> that `it` is set by **two** independent mechanisms: command self-assignment
+> (which works on every execution path) and the `unwrapCommandResult` loop
+> (which runs only in event-handler bodies, not in `then`-joined sequences). All
+> seven sniffing branches turned out to be redundant with self-assignment, so
+> the destination moved from "migrate ~25 commands to the envelope" to **delete
+> the propagation loop** — the envelope is read only by the mechanism that
+> doesn't run everywhere, so migrating to it preserves the path disagreement
+> rather than fixing it. The brief is authoritative; the steps below are kept
+> for the record.
 
 0. **Collapse the two propagation call sites first.** `unwrapCommandResult` is
    called independently from `runtime-base.ts:1756` and
@@ -260,6 +272,28 @@ not the core abstractions.
 
 ## History
 
+- **2026-07-28** — **Arc C brief written**
+  ([HANDOFF-command-arch-output-contract.md](./HANDOFF-command-arch-output-contract.md)),
+  arc not started. Two measurements changed the plan. (a) `it` is set by two
+  independent mechanisms, and the queue described only one: commands
+  self-assign `context.it` (copied back by the adapter at
+  `command-adapter.ts:338`, works on **every** path), while
+  `unwrapCommandResult` runs **only** in event-handler bodies and the lazy
+  attribute stub — `executeCommandSequenceWithResult` (`runtime-base.ts:824`,
+  the `then`-joined path `hyperscript.eval` takes) never unwraps. So `it`
+  already **disagrees between execution paths** for 18 of 29 probed commands,
+  and for `settle`/`pick` the loop demonstrably *overwrites a correct value the
+  command had already set*. All seven sniffing branches were then verified
+  redundant — every branch owner also self-assigns. (b) Stubbing
+  `unwrapCommandResult` to return `undefined` and running the full core suite
+  fails **only its own 4 unit tests**: 7735 pass. The gate isn't merely thin,
+  it is absent, which is why step 1's audit has to assert on `it` end-to-end
+  through both paths rather than on the function in isolation. The queue's
+  "21 distinct output types / ~25 commands" figure was independently
+  corroborated, as were both accidental matches (`measure` on `result`+`wasAsync`,
+  `default` on `value`+`target`+`targetType`); one new near-miss found —
+  `RepeatCommandOutput.lastResult` is optional, so a `repeat` with no body
+  result falls through with its whole wrapper.
 - **2026-07-28** — **Arc D complete** (#796 → #797 → #798, merged sequentially
   into main; full CI matrix on each, including the ten-signal multilingual
   ratchet). Three rules that existed in two or three places each now have one

--- a/docs-internal/HANDOFF-command-arch-output-contract.md
+++ b/docs-internal/HANDOFF-command-arch-output-contract.md
@@ -1,0 +1,314 @@
+# HANDOFF — command-arch Arc C: the command output contract
+
+> **Arc brief, written 2026-07-28.** Detail for Arc C of
+> [COMMAND_ARCHITECTURE_NEXT_STEPS.md](./COMMAND_ARCHITECTURE_NEXT_STEPS.md)
+> (the queue holds one paragraph; this file is authoritative for the arc).
+> Format follows [HANDOFF-command-arch-target-resolution.md](./HANDOFF-command-arch-target-resolution.md)
+> (Arc D, complete).
+>
+> **Status: brief written, arc not started.** Next action: step 0.
+>
+> **This brief REVISES the queue doc's Arc C plan.** The exploration that
+> produced it measured something the queue's audit did not: `it` is set by
+> **two independent mechanisms**, only one of which the queue describes, and the
+> mechanism it describes is **redundant with the other in every case where it is
+> correct**. Read [What changed](#what-changed-vs-the-queue-docs-plan) before
+> following the queue's step 2/3 wording — the destination moved from "migrate
+> ~25 commands to an envelope" to "delete the propagation loop".
+
+## Verified state (2026-07-28, main `e9c579bb`, working tree clean)
+
+Line refs will drift — re-verify by symbol (`grep -n`), not by number.
+
+### The two mechanisms that set `it`
+
+**Mechanism 1 — command self-assignment.** A command does
+`Object.assign(context, { it: X })` inside its own `execute()`. It receives the
+*typed* context, and the adapter copies the mutation back onto the real context
+at `runtime/command-adapter.ts:338`
+(`Object.assign(context, ContextBridge.fromTyped(typedContext, context))`).
+**This works on every execution path.** ~20 commands use it.
+
+**Mechanism 2 — runtime propagation via `unwrapCommandResult`.** The function is
+`runtime/runtime-base.ts:75`; it sniffs the command's *return value* through
+seven branches and ends with an unconditional array collapse at `:121`. It is
+called from exactly two places, both of which are the same four-line loop:
+
+| Call site | Path it governs |
+| --------- | --------------- |
+| `runtime/runtime-base.ts:1756` | event-handler bodies (`on click …`) |
+| `dom/attribute-processor.ts:494` | the lazy `_="on …"` attribute stub, first event only |
+
+**`executeCommandSequenceWithResult` (`runtime-base.ts:824`) — the `then`-joined
+command sequence, and the path `hyperscript.eval` takes — does NOT unwrap at
+all.** It accumulates `lastResult` and assigns `it` only for a `return` signal.
+So mechanism 2 governs *one* of the two ways a command sequence runs.
+
+### Consequence 1 — `it` already disagrees between execution paths
+
+Measured by running each snippet twice — once as a `then`-joined sequence, once
+as the body of an `on probe` handler — and reading `it` out through a `js(it)`
+block. **18 of 29 probed commands disagree.** The interesting rows:
+
+| Command | `it` in a `then` sequence | `it` in an event handler |
+| ------- | ------------------------- | ------------------------ |
+| `settle #x` | `<DIV>` (the element — settle.ts self-assigns) | `{element,settled,timeout,duration}` |
+| `pick first 1 of [...]` | `Array(1)` (pick self-assigns) | `{selectedItem,sourceLength,sourceType,variant}` |
+| `wait 1ms` | `null` | `{type,result,duration}` |
+| `scroll to #x` | `null` | `{element,position,smooth}` |
+| `push url "/x"` | `null` | `{url,title,mode}` |
+| `go to #x` | `null` | `{result,type}` |
+| `toggle .a on .item` | `null` | `<P>` — the **first** of two matched (`:121`) |
+| `put "hi" into #x` | `null` | `<DIV>` (`:121`) |
+
+The `settle` and `pick` rows are the sharpest statement of the defect: the
+command **already set `it` correctly**, and the propagation loop then overwrote
+it with the wrapper. Mechanism 2 is not filling a gap there; it is destroying a
+correct value.
+
+(A third group — `add`, `log`, `if`, `empty`, `remove`, `show`, `focus` — also
+shows as "disagreeing", but for a different and **out-of-scope** reason: they
+return void, so neither mechanism fires and `it` keeps its *initial* value, which
+is `null` on the sequence path and the DOM event on the handler path
+(`runtime-base.ts:1697`). That is an initial-value question, not a wrapper leak.
+Do not fold it into this arc.)
+
+### Consequence 2 — all seven sniffing branches are redundant
+
+Every command that a branch was written for also self-assigns. Verified
+line-by-line:
+
+| Branch (`runtime-base.ts:75-122`) | Owner | Self-assigns at |
+| --------------------------------- | ----- | --------------- |
+| `result` + `wasAsync` | call | `execution/call.ts:104` |
+| `result` + `executed` | js | `advanced/js.ts:134` |
+| `lastResult` + `type` | repeat | `control-flow/repeat.ts:300` |
+| `conditionResult` + `executedBranch` | if/unless | `control-flow/if.ts:150` |
+| lone `value` | get | `data/get.ts:78` |
+| `value` + `target` + `targetType` | set, append/prepend | `data/set.ts:247`, `content/insertion-base.ts:174` |
+| `data` + `status` + `headers` | fetch | `async/fetch.ts:268` |
+
+So mechanism 2 contributes **nothing correct**. What it contributes is the ~21
+wrapper leaks and the `:121` collapse.
+
+### Consequence 3 — the suite is blind to this mechanism
+
+Stubbing `unwrapCommandResult` to `return undefined` unconditionally (i.e.
+simulating the loop's deletion) and running the full core suite:
+
+```
+Test Files  1 failed | 297 passed | 1 skipped (299)
+     Tests  4 failed | 7735 passed | 128 skipped (7867)
+```
+
+The only four failures are `runtime.test.ts:950`'s **direct unit tests of the
+function itself**. **Zero behavioral tests fail.** Read that precisely: it does
+NOT mean deleting the loop changes nothing — the probe above shows `it` really
+does change on the handler path. It means the 7738-test suite **cannot see this
+arc's blast radius at all**, which is exactly why step 1 (the audit) must land
+before any migration, and why the audit has to assert on `it` end-to-end rather
+than on the function in isolation.
+
+Residual gates that *could* see a change and that the local suite does not cover:
+the Playwright bundle-compatibility matrix, the shipped-examples execution gate,
+and the multilingual R2 execution ratchet. All three run in PR CI.
+
+### The output-type inventory (corroborates the queue's figures)
+
+Classifying every registered command's declared `execute` return type against the
+seven branches yields **21 distinct fall-through output types** across ~24
+commands (`signal-base` backs break/continue/exit; `push-url` backs
+push-url/replace-url) — matching the queue doc's re-verified "21 distinct output
+types / ~25 commands". Two accidental matches confirmed:
+
+- **`MeasureCommandOutput`** `{result, wasAsync, element, property, value, unit}`
+  hits branch 1 (`result`+`wasAsync`) by key-name accident. It happens to yield
+  the right number, and measure also self-assigns (`animation/measure.ts:120`).
+- **`DefaultCommandOutput`** `{target, value, wasSet, existingValue?, targetType}`
+  hits branch 6 (`value`+`target`+`targetType`) by key-name accident.
+
+One near-miss worth recording, because it is a fall-through hiding inside a
+"matched" branch: **`RepeatCommandOutput.lastResult` is optional.** When absent,
+`'lastResult' in obj` is false and the whole `{type, iterations, completed}`
+wrapper becomes `it`.
+
+## What changed vs. the queue doc's plan
+
+The queue's step 2 says: migrate each command to either the
+`{ target?, value, targetType }` envelope or a void return. The envelope half is
+now known to be the wrong destination — **an envelope is only read by mechanism
+2, which does not run on the sequence path.** Migrating a command to the envelope
+makes it correct in event handlers and leaves it unchanged (still `null`) in a
+`then` sequence, i.e. it preserves the path disagreement.
+
+The void-return half is right, and for a better reason than the queue gives: a
+void return removes mechanism 2 from the picture entirely, leaving self-assignment
+as the single mechanism — which is the one that already works everywhere.
+
+**Revised destination: delete `unwrapCommandResult` and its loop; make
+self-assignment the sole `it` contract.** The migration is then per-command:
+*does this command set `it` correctly on the sequence path today?* If yes, nothing
+to do. If no and it should, add a self-assign. The probe says that second list is
+short, and `toggle`/`put` are its main members — where the value mechanism 2
+currently supplies is *already wrong-shaped* anyway, because `:121` collapses the
+element list to its first element.
+
+## The steps
+
+### Step 0 — collapse the two propagation call sites (mechanical)
+
+The four-line loop at `runtime-base.ts:1756` and `attribute-processor.ts:494` is
+duplicated verbatim:
+
+```ts
+const val = unwrapCommandResult(result);
+if (val !== undefined) {
+  Object.assign(eventContext, { it: val, result: val });
+}
+```
+
+Extract one exported helper (suggested: `propagateCommandResult(context, result)`
+in `runtime/runtime-base.ts`, next to `unwrapCommandResult`) and call it from
+both. Pure refactor, no behavior change. Its value is that steps 2 and 3 then
+land **once** instead of twice — this is the *duplication hides which
+implementation is the truth* disease the queue's preamble names, sitting inside
+the arc meant to cure it.
+
+Keep `unwrapCommandResult` exported: `runtime.test.ts:950` imports it directly,
+and step 1's audit wants to classify with it.
+
+### Step 1 — the audit, as a test (the arc's gate)
+
+This is the landing that makes the rest safe, and per Consequence 3 it is the
+**only** thing standing between step 2 and an unmeasured behavior change.
+
+Shape:
+
+1. **A ratchet on the command list.** `runtime.getRegistry().getCommandNames()`
+   must equal the audit table's keys, both directions. A new command cannot be
+   added without classifying it. (This is the arc's "derive, don't trust" — the
+   registry is the source, the table is checked against it, neither is trusted
+   alone.)
+2. **Per command, both paths.** For each entry, run a representative snippet
+   twice — once as a `then`-joined sequence, once as an `on probe` handler body —
+   and record what `it` holds. The probe harness that produced the table above is
+   the working model: read `it` out through a trailing
+   `then js(it) window.__it = it end`.
+3. **Assert the disagreement set explicitly**, rather than snapshotting a blob.
+   A snapshot of 59 rows will be re-blessed on the first failure; an explicit
+   `PATH_DISAGREEMENTS` set with a comment per entry will not.
+4. **Classify the return shape** against the seven branches, so the ~21
+   fall-throughs and the two accidental matches are named in code.
+
+Commands that cannot run in jsdom (`go` to a URL, `fetch`, `breakpoint`,
+`install`) get an explicit `skip` with a reason string, and the ratchet counts
+skips — a silent omission is what this arc exists to prevent.
+
+Expect step 1 to land RED-adjacent: it documents current behavior, including the
+wrong parts. Every wrong row gets a comment saying it is wrong and which step
+fixes it.
+
+### Step 2 — make self-assignment the sole mechanism
+
+Per-command, smallest PRs that are still reviewable. For each command in the
+fall-through set, decide from the audit table:
+
+- **sequence path already correct** → no code change; the fix arrives with step 3.
+- **should set `it`, currently doesn't on either path** → add the self-assign.
+- **should not touch `it`** → nothing.
+
+Each PR flips the affected rows in the step-1 audit table, so the diff shows
+exactly which `it` values changed. That is the review artifact.
+
+### Step 3 — delete `unwrapCommandResult`, the loop, and the `:121` collapse
+
+Delete the function, replace the two (by then one) call sites with nothing, and
+retire `runtime.test.ts:950-986`'s six positive cases.
+
+**The `:121` array policy is decided here, and Arc D left it a pinned rule to
+decide against.** Read `commands/helpers/__tests__/target-elements.test.ts` and
+`parser/__tests__/selector-shape.test.ts` first. They pin:
+
+- `#id` matched → the element; `#id` unmatched → `null`
+- `.cls` → the collection **always**, including a single match (a one-element
+  array, not the element) and no match (`[]`, not `null`)
+
+`:121` violates that rule: it collapses **any** array to `val[0]`, so
+`toggle .a on .items` leaves `it` as the first element — the same shape as
+append's pre-#792 `.cls` no-op, and the exact asymmetry the pinned tests say is
+deliberate at the *selector* end. **Recommended policy: no collapse.** A command
+that yields an element list should surface the list; the `#id`→element unwrap
+already happened at the selector layer, which is where the rule lives. Deleting
+the function deletes the collapse, so step 3 gets this for free — but record the
+decision explicitly rather than letting it fall out of the deletion, because
+`toggle` and `put` are the two commands whose `it` visibly changes shape.
+
+## Gates, per step
+
+| Step | Suites | Command |
+| ---- | ------ | ------- |
+| all | quick validation | `npm run test:quick --prefix packages/core` |
+| 0 | runtime + attribute-processor | `npm test --prefix packages/core -- --run src/runtime/ src/dom/` |
+| 1 | the new audit test itself | added in the step-1 PR |
+| 2, 3 | audit test (rows flip deliberately) + full core suite | `npm run test:quick --prefix packages/core` |
+| 2, 3 | **Playwright compatibility matrix** — one of the few gates that can see an `it` change | `cd packages/core && npx playwright test src/compatibility/` (MUST run from packages/core) |
+| 2, 3 | R2 execution subset + the other 9 ratchet signals | runs automatically in the PR's `multilingual-validation` CI job |
+
+`npm run verify:reference` is NOT expected to fire — this arc adds and removes no
+commands. If it does, something out of scope was touched.
+
+## Non-goals (Arc C specifically)
+
+- **The initial value of `it` in an event-handler body** (`runtime-base.ts:1697`
+  sets it to the DOM event; the sequence path starts `null`). A real divergence,
+  visible in the probe, and **not this arc** — it is about context construction,
+  not command output. Record it; don't fix it here.
+- `context.result` vs `context.it` aliasing. The loop sets both; commands mostly
+  set only `it`. Out of scope unless step 2 makes it unavoidable.
+- The hook registry's `afterExecute(hookCtx, result)` — it sees the raw return
+  value, and should keep doing so. The wrapper is a legitimate *hook* payload;
+  the defect is only that it reaches `it`.
+- Command **input** parsing, the decorator statics (Arc B), the registration
+  lists (Arc A), the four executors (Arc E), semantic mappers (Arc F).
+
+## Session handling
+
+- **One PR per step, merged into main before the next starts.** Stacked PRs get
+  zero CI and still report clean (`ci.yml` fires only on PRs into main/develop).
+- **Prefer a fresh session per step**; this file is the continuity mechanism.
+- **Start-of-session protocol:** (1) read the queue doc's Arc C paragraph + this
+  file; (2) `git log --oneline -5`; (3) re-verify line anchors by symbol;
+  (4) cold tree → `npm install` first (`npm run build` is NOT dependency-ordered,
+  root CLAUDE.md § Cold start); (5) baseline
+  `npm run test:quick --prefix packages/core` BEFORE editing.
+- **End-of-session protocol:** update the Status log below. If a step changes a
+  later step's plan, edit that step's section here — this file is authoritative
+  for the arc, per the queue's pointer-only rule.
+- Core vitest wraps in `timeout 120`; **exit code 124 = success** (esbuild daemon
+  hang, known issue).
+
+## Risk register (arc-specific; the general one is in the queue doc)
+
+- **The local suite cannot see this arc.** Consequence 3 is the single most
+  important line in this brief. Never read a green `test:quick` as evidence that
+  a step 2/3 change was behavior-neutral — it is evidence of nothing. The audit
+  test from step 1 is the only local instrument.
+- **`it` is read far from where it is written.** `parser/runtime.ts:386` and
+  `:1264` resolve `it`/`its` and fall back to `context.result`. A change to what
+  `it` holds surfaces in expression evaluation, not in the runtime.
+- **Mechanism 1 depends on the adapter's write-back** at
+  `command-adapter.ts:338`. If a future refactor stops copying the typed context
+  back, every self-assigning command silently stops setting `it` — and, per
+  Consequence 3, nothing in the suite would fail. Worth its own test.
+- `export { X } from './f'` creates **no local binding** — relevant when moving
+  `unwrapCommandResult`/`propagateCommandResult` between modules.
+- The MCP server serves **stale dist** after rebuilds; a tool refusing with
+  "serving STALE code" is the guard working — restart, don't debug.
+
+## Status log
+
+- 2026-07-28 — brief written; arc not started. The exploration behind it ran two
+  experiments worth not repeating: the dual-path `it` probe (table under
+  Consequence 1) and the stub-the-unwrap blast-radius run (Consequence 3). Both
+  were run against main `e9c579bb` with a clean tree and reverted. Next action:
+  step 0 PR.


### PR DESCRIPTION
Arc C of `docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md` had no handoff brief. This adds one, in the format Arc D's brief established — and revises the queue's step 2/3 plan against two measurements taken during the exploration.

## `it` is set by two mechanisms, not one

The queue described only one of them.

| Mechanism | Where | Which paths it governs |
| --- | --- | --- |
| **1 — command self-assignment** (`Object.assign(context, { it: X })` inside `execute()`) | ~20 commands; copied back onto the real context at `command-adapter.ts:338` | **every** execution path |
| **2 — `unwrapCommandResult`** (`runtime-base.ts:75`) | `runtime-base.ts:1756`, `attribute-processor.ts:494` | event-handler bodies + the lazy attribute stub **only** |

`executeCommandSequenceWithResult` (`runtime-base.ts:824`) — the `then`-joined path `hyperscript.eval` takes — never unwraps.

**So `it` already disagrees between execution paths: 18 of 29 probed commands.**

| Command | `it` in a `then` sequence | `it` in an event handler |
| --- | --- | --- |
| `settle #x` | `<DIV>` (settle self-assigns) | `{element,settled,timeout,duration}` |
| `pick first 1 of [...]` | `Array(1)` (pick self-assigns) | `{selectedItem,sourceLength,sourceType,variant}` |
| `wait 1ms` | `null` | `{type,result,duration}` |
| `toggle .a on .item` | `null` | `<P>` — the **first** of two matched (the `:121` collapse) |

`settle` and `pick` are the sharpest rows: the command already set `it` correctly and the propagation loop overwrote it with the wrapper.

All seven sniffing branches were then verified redundant — every branch owner also self-assigns (call `:104`, js `:134`, repeat `:300`, if `:150`, get `:78`, set `:247`/insertion-base `:174`, fetch `:268`). Mechanism 2 contributes nothing correct; what it contributes is the ~21 wrapper leaks and the array collapse.

**That moves the destination.** An envelope is read only by mechanism 2, so migrating commands to it makes them correct in handlers and leaves them unchanged in sequences — it preserves the path disagreement rather than fixing it. Revised plan: delete the loop, make self-assignment the sole contract.

## The suite is blind to this arc

Stubbing `unwrapCommandResult` to `return undefined` (simulating the deletion) and running the full core suite:

```
Test Files  1 failed | 297 passed | 1 skipped (299)
     Tests  4 failed | 7735 passed | 128 skipped (7867)
```

The four failures are its own unit tests at `runtime.test.ts:950`. **Zero behavioral tests fail.**

Read precisely: this is *not* evidence that deleting the loop is behavior-neutral — the probe above shows `it` really does change. It is evidence that no local gate can see this arc at all. Hence step 1's audit must assert on `it` end-to-end through **both** paths, and a green `test:quick` must never be read as clearing a step 2/3 change. That caveat is in the brief's risk register as its most important line.

## Also

Independently corroborated the queue's existing figures (21 distinct fall-through output types across ~24 commands; both accidental matches — `measure` on `result`+`wasAsync`, `default` on `value`+`target`+`targetType`). Found one near-miss the queue didn't record: `RepeatCommandOutput.lastResult` is **optional**, so a `repeat` whose body yields nothing falls through with its whole wrapper.

Scoped out deliberately and recorded as a non-goal: the event-handler body initialises `it` to the DOM event (`runtime-base.ts:1697`) while the sequence path starts `null`. Real divergence, visible in the probe, but it is about context construction rather than command output.

## Testing

Docs-only. Both experiments were run against main `e9c579bb` with a clean tree and reverted; baseline `test:quick` was green (7738 passed) before and the tree is unchanged. The path-gated CI skips the npm stack for doc-only diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)