### PR TITLE
refactor(core): Arc C step 0 — one propagation call site, not two

### DIFF
--- a/packages/core/src/dom/attribute-processor.ts
+++ b/packages/core/src/dom/attribute-processor.ts
@@ -6,7 +6,7 @@
 import { hyperscript, config } from '../api/hyperscript-api';
 import type { CompileError } from '../api/hyperscript-api';
 import { createContext } from '../core/context';
-import { unwrapCommandResult } from '../runtime/runtime-base';
+import { propagateCommandResult } from '../runtime/runtime-base';
 import { debug } from '../utils/debug';
 
 // Type declarations for window extensions used by external packages
@@ -491,10 +491,7 @@ export class AttributeProcessor {
 
           for (const command of ast.commands) {
             const cmdResult = await hyperscript.execute(command, eventContext);
-            const val = unwrapCommandResult(cmdResult);
-            if (val !== undefined) {
-              Object.assign(eventContext, { it: val, result: val });
-            }
+            propagateCommandResult(eventContext, cmdResult);
           }
         }
 

--- a/packages/core/src/runtime/runtime-base.ts
+++ b/packages/core/src/runtime/runtime-base.ts
@@ -124,6 +124,33 @@ export function unwrapCommandResult(result: unknown): unknown | undefined {
 }
 
 /**
+ * Propagate one command's return value into `it` / `result`.
+ *
+ * The single definition of the runtime-side half of the `it` contract. It runs
+ * in **event-handler bodies only** — `runtime-base`'s `runCommands` and the
+ * lazy `_="on …"` attribute stub in `dom/attribute-processor.ts`. The
+ * `then`-joined command sequence (`executeCommandSequenceWithResult`, and so
+ * `hyperscript.eval`) does NOT call this, which is why `it` can differ between
+ * the two paths for the same command.
+ *
+ * That asymmetry is a known defect, not a design: commands also set `it`
+ * themselves (`Object.assign(context, { it })` inside `execute()`, copied back
+ * by the adapter), and that mechanism DOES run on every path. See
+ * `docs-internal/HANDOFF-command-arch-output-contract.md` — this function and
+ * its `unwrapCommandResult` sniffing are slated for deletion in favour of
+ * self-assignment. It exists as one function so that change lands once.
+ *
+ * @param context Execution context to mutate.
+ * @param result Raw value returned by the command's `execute()`.
+ */
+export function propagateCommandResult(context: object, result: unknown): void {
+  const val = unwrapCommandResult(result);
+  if (val !== undefined) {
+    Object.assign(context, { it: val, result: val });
+  }
+}
+
+/**
  * Pattern from expression evaluator where a space-separated "word token" is
  * interpreted as an implicit command invocation (e.g. "add .class").
  */
@@ -1753,10 +1780,7 @@ export class RuntimeBase {
         for (const command of toRun) {
           try {
             const result = await runtime.execute(command, eventContext);
-            const val = unwrapCommandResult(result);
-            if (val !== undefined) {
-              Object.assign(eventContext, { it: val, result: val });
-            }
+            propagateCommandResult(eventContext, result);
           } catch (e) {
             if (isControlFlowError(e)) {
               if (e.isHalt || e.isExit) break;

--- a/packages/core/src/runtime/runtime.test.ts
+++ b/packages/core/src/runtime/runtime.test.ts
@@ -986,6 +986,45 @@ describe('RuntimeBase Method Coverage', () => {
     });
   });
 
+  describe('propagateCommandResult()', () => {
+    // The runtime-side half of the `it` contract, shared by the event-handler
+    // body loop and the lazy-attribute stub. Its load-bearing property is the
+    // `undefined` GUARD: a void command must leave `it` alone rather than
+    // blanking it, which is what lets a `then`-joined chain carry `it` across a
+    // `log`/`add`/`show` in the middle. Inlining the unwrap at a call site and
+    // dropping the guard is the regression this pins.
+
+    it('assigns both it and result when the command returned a value', async () => {
+      const { propagateCommandResult } = await import('./runtime-base');
+      const context = { it: 'stale', result: 'stale' };
+      propagateCommandResult(context, { value: 42 });
+      expect(context).toEqual({ it: 42, result: 42 });
+    });
+
+    it('leaves it UNTOUCHED when the command returned undefined', async () => {
+      const { propagateCommandResult } = await import('./runtime-base');
+      const context = { it: 'keep me', result: 'keep me' };
+      propagateCommandResult(context, undefined);
+      expect(context).toEqual({ it: 'keep me', result: 'keep me' });
+    });
+
+    it('leaves it untouched when the wrapper unwraps to undefined', async () => {
+      // IfCommand with no branch result — the unwrap returns undefined to
+      // signal "do not update", which is distinct from "update it to undefined".
+      const { propagateCommandResult } = await import('./runtime-base');
+      const context = { it: 'keep me', result: 'keep me' };
+      propagateCommandResult(context, { conditionResult: true, executedBranch: 'then' });
+      expect(context).toEqual({ it: 'keep me', result: 'keep me' });
+    });
+
+    it('propagates a falsy-but-defined value rather than skipping it', async () => {
+      const { propagateCommandResult } = await import('./runtime-base');
+      const context = { it: 'stale', result: 'stale' };
+      propagateCommandResult(context, { value: 0 });
+      expect(context).toEqual({ it: 0, result: 0 });
+    });
+  });
+
   describe('Behavior timeout protection', () => {
     it('should timeout on slow init block', async () => {
       // Use a very short timeout


### PR DESCRIPTION
First step of Arc C ([queue](../blob/main/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md), [brief](../blob/main/docs-internal/HANDOFF-command-arch-output-contract.md) landed in #800).

## What

`unwrapCommandResult` was called from two places, each wrapping it in the same four-line unwrap-and-assign loop:

- `runtime/runtime-base.ts` — the event-handler body executor
- `dom/attribute-processor.ts` — the lazy `_="on …"` attribute stub, first event only

Steps 2 and 3 of the arc change what that loop does. With two copies, every one of those changes lands twice — which is the *duplication hides which implementation is the truth* disease the queue's preamble names, sitting inside the arc meant to cure it.

Extracted `propagateCommandResult(context, result)` next to `unwrapCommandResult`; both sites call it.

`unwrapCommandResult` stays exported — `runtime.test.ts` imports it directly, and step 1's audit classifies with it.

## Why the docstring says what it says

The helper carries the context anyone touching it needs, because it is genuinely surprising: **this path runs in event-handler bodies only.** `executeCommandSequenceWithResult` — the `then`-joined path `hyperscript.eval` takes — never calls it. Commands *also* set `it` themselves inside `execute()`, and that mechanism runs on every path. The two disagree today for 18 of 29 probed commands. Full measurement in the brief.

## Tests

Four new, pinning the helper's load-bearing property — the **`undefined` guard**:

- a void command must leave `it` **alone** rather than blanking it (what lets `it` survive a `log`/`add`/`show` mid-chain)
- "unwrapped to undefined" (IfCommand with no branch result) means the same thing, and is distinct from "set `it` to undefined"
- a falsy-but-defined `0` must still propagate

Inlining the unwrap at a call site and dropping the guard is the regression these catch.

## Verification

| | |
| --- | --- |
| baseline (before edits) | 7738 passed, 128 skipped |
| after the refactor, before new tests | **7738 passed** — no behavior change |
| after the new tests | 7742 passed, every increment a new test |

`npm run typecheck --prefix packages/core` clean. `oxlint` on the three touched files reports only pre-existing warnings on untouched lines.

Note per the brief's risk register: a green core suite is **not** evidence that an `it`-propagation change is behavior-neutral — stubbing this mechanism out entirely fails only its own 4 unit tests. That is why this step is a pure refactor and why step 1 lands the audit before anything migrates. Here the "7738 → 7738" reading is meaningful only because the change is textually mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)