### PR TITLE
docs: Arc C step 2 — a decision table, not a decision rule

### DIFF
--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -272,6 +272,27 @@ not the core abstractions.
 
 ## History
 
+- **2026-07-28** — **Arc C steps 0 and 1 landed** (#801, #802), and **step 2
+  specified** against an upstream-parity pass. Two findings that belong outside
+  the arc as well as in it:
+  - **`unless` never executes its body.** `control-flow/if.ts` `parseInput`
+    gives `unless` an *array* (`raw.args.slice(1)`) where `if` gets the block
+    *node* (`raw.args[1]`); `executeCommands` returns any entry without an
+    `.execute` method verbatim, which a parsed AST node is, so the body is
+    skipped and the node lands in `it` via an `unless`-only self-assign.
+    Verified: `unless false then add .ran to #probe end` adds nothing.
+    `unless.test.ts` is green because it feeds **mocks carrying `.execute()`** —
+    a shape the parser never produces. **A live bug in a shipped, documented
+    command**; it wants its own PR, not a slot inside step 2.
+  - **Five commands' own documented `metadata.examples` do not parse** (`async`,
+    `default`, `process`, `pseudo-command`, `take`) — found because the step-1
+    audit drew its snippets from `metadata.examples` rather than hand-authoring
+    them. Skipped in the audit with their error text; candidates for
+    [PARSER_NEXT_STEPS.md](./PARSER_NEXT_STEPS.md).
+
+  Step 2 itself turned out to be nearly empty: fourteen of the fifteen defect
+  rows need no per-command change, because their sequence-path value is already
+  upstream-correct and step 3's deletion converges them. Table in the brief.
 - **2026-07-28** — **Arc C brief written**
   ([HANDOFF-command-arch-output-contract.md](./HANDOFF-command-arch-output-contract.md)),
   arc not started. Two measurements changed the plan. (a) `it` is set by two

--- a/docs-internal/HANDOFF-command-arch-output-contract.md
+++ b/docs-internal/HANDOFF-command-arch-output-contract.md
@@ -210,12 +210,117 @@ fixes it.
 
 ### Step 2 — make self-assignment the sole mechanism
 
-Per-command, smallest PRs that are still reviewable. For each command in the
-fall-through set, decide from the audit table:
+**Revised 2026-07-28, after step 1 landed.** The original text gave a decision
+*rule* and no decisions; the audit plus an upstream-parity pass turns it into a
+table. The headline: **step 2 is nearly empty.** Almost every wrapper-leak
+command's sequence-path value is already upstream-correct, so step 3's deletion
+does the work. What remains is one bug fix and two judgment calls.
 
-- **sequence path already correct** → no code change; the fix arrives with step 3.
-- **should set `it`, currently doesn't on either path** → add the self-assign.
-- **should not touch `it`** → nothing.
+#### The oracle
+
+For each command, the question "should this set `it`?" is answered by upstream
+_hyperscript, whose commands assign `context.result` (the value `it` aliases)
+only when they produce one. Reproduce the survey from a checkout of
+`_hyperscript`:
+
+```bash
+cd _hyperscript/src/parsetree/commands
+# each command class carries `static keyword = "…"`; check whether its body
+# assigns ctx.result / context.result
+grep -n 'static keyword\|\(ctx\|context\)\.result *=' *.js
+```
+
+Upstream commands that **do** set `result`: `wait` (event variant only),
+`pick`, `render`, `measure`, `make`, `fetch`, `js`, `call`/`get`,
+`increment`/`decrement`, `ask`/`answer`. Everything else — including `go`,
+`scroll`, `settle`, `transition`, `start`, `beep!`, `toggle`, `put`, `take`,
+`set`, `tell`, `send`/`trigger` — does **not**.
+
+Note `wait`'s split, because it is the one that looks like a defect and isn't:
+upstream sets `context.result = evt` inside the **event** listener
+(`commands/events.js`, the `wait for click` variant) and never for
+`wait 2s`. hyperfixi matches this already (`async/wait.ts` self-assigns the
+event). The audit's `wait 1ms` row showing `null` on the sequence path is
+therefore **correct**, not a gap.
+
+#### The decision table
+
+Every `defect:` row from the step-1 audit, with its step-2 action:
+
+| Command | Upstream sets `result`? | hyperfixi sequence path | Step-2 action |
+| ------- | ----------------------- | ----------------------- | ------------- |
+| `wait` | yes — event variant only | `null` (time) / event (event) | **none** — already correct |
+| `pick` | yes | `Array(1)` | **none** — already correct |
+| `render` | yes | `<DIV>` | **none** — already correct |
+| `go` | no | `null` | **none** |
+| `scroll` | no | `null` | **none** |
+| `start` | no | `null` | **none** |
+| `beep` | no | `null` | **none** |
+| `toggle` | no | `null` | **none** — do NOT add a self-assign |
+| `put` | no | `null` (element path) | **none** — see note below |
+| `copy` | not upstream (extension) | `null` | **none** |
+| `push` / `replace` | not upstream (extension) | `null` | **none** |
+| `settle` | **no** | `<DIV>` — hyperfixi extension | **decide** (below) |
+| `transition` | **no** | `<DIV>` — hyperfixi extension | **decide** (below) |
+| `unless` | not upstream (extension) | AST node | **FIX** (below) |
+
+For all fourteen "none" rows the handler column is wrong and the sequence column
+is right, so **deleting the loop in step 3 converges them onto the correct value
+with no per-command change at all.** That is the payoff from the revised
+destination: the envelope migration the queue originally prescribed would have
+touched every one of these.
+
+`put` note: `dom/put.ts` self-assigns `it` on its **variable** path only
+(`put x into y`); the element path returns `HTMLElement[]` and assigns nothing.
+The audit's `null` is that element path, and it matches upstream. Not an
+inconsistency.
+
+#### The one fix: `unless`
+
+The audit recorded `unless` leaving an AST node in `it`. Tracing it found a
+larger bug: **`unless` never executes its body at all.**
+
+- `control-flow/if.ts` `parseInput` sets `thenCommands = raw.args.slice(1)` for
+  `unless` — an **array** — while the `if` path takes `raw.args[1]`, the block
+  **node**.
+- `executeCommandsOrBlock` routes a block node to `executeBlock` (which runs it
+  through `_runtimeExecute`) and an array to `executeCommands`.
+- `executeCommands` handles only entries with an `.execute` method or a
+  function; anything else hits `else lastResult = cmd`, returning the raw node.
+  A parsed AST block node has neither. So the body is **skipped** and the node
+  is returned.
+- `execute` then does `if (mode === 'unless') Object.assign(context, { it: result })`
+  — an `unless`-only self-assign — which puts that node in `it`.
+
+Verified: `unless false then add .ran to #probe end` leaves `#probe` without the
+class, while `if true then add .ran to #probe end` adds it.
+
+**Why the existing suite is green:** `control-flow/__tests__/unless.test.ts`
+builds `thenCommands` from **mock objects carrying `.execute()`**, a shape the
+parser never produces. The tests exercise the one branch of `executeCommands`
+that works. Fixing this must include a test that goes through the real parser.
+
+**This is a live user-facing bug in a shipped, documented command, and it is
+only incidentally Arc C's.** Consider landing it as its own PR ahead of the arc
+rather than inside step 2 — the `it` leak is a symptom, and the fix (route
+`unless` through the same block path as `if`) is unrelated to the output
+contract. The `unless`-only self-assign should go with it: once the body runs
+through `executeBlock`, `unless` has no reason to set `it` when `if` does not.
+
+#### The two judgment calls: `settle` and `transition`
+
+Both self-assign the element, and upstream sets nothing. After step 3 the
+sequence value is what both paths will hold, so this decides what `it` is after
+`settle #x` — the element, or untouched.
+
+Neither is obviously wrong: returning the element makes `settle #x then add .a to it`
+work, which reads well and costs nothing. But it is a **deliberate divergence
+from upstream**, and it is currently undocumented and untested as such. Decide
+it explicitly and record it in the audit row either way. Note `measure` is the
+precedent for a documented divergence being fine — upstream sets `result` there
+too, so it is not evidence either way.
+
+#### Working shape
 
 Each PR flips the affected rows in the step-1 audit table, so the diff shows
 exactly which `it` values changed. That is the review artifact.
@@ -223,7 +328,14 @@ exactly which `it` values changed. That is the review artifact.
 ### Step 3 — delete `unwrapCommandResult`, the loop, and the `:121` collapse
 
 Delete the function, replace the two (by then one) call sites with nothing, and
-retire `runtime.test.ts:950-986`'s six positive cases.
+retire `runtime.test.ts:950-986`'s six positive cases (plus step 0's four
+`propagateCommandResult` cases, which go with the helper).
+
+**Per step 2's decision table, this step does most of the arc's work**: fourteen
+commands whose handler-path `it` is wrong and whose sequence-path `it` is already
+upstream-correct converge with no per-command change. Expect fourteen audit rows
+to flip in this one PR — that is the intended shape, not a sign the change is too
+big. The audit's asserted disagreement count (29 of 45) drops in the same diff.
 
 **The `:121` array policy is decided here, and Arc D left it a pinned rule to
 decide against.** Read `commands/helpers/__tests__/target-elements.test.ts` and
@@ -345,3 +457,21 @@ commands. If it does, something out of scope was touched.
   - **The headline number is asserted: 29 of the 45 exercised commands disagree
     between the two paths.** Step 3 should drive that down; nothing else should
     move it.
+- 2026-07-28 — **step 2 specified** (docs only; no code). Ran an upstream-parity
+  pass over `_hyperscript/src/parsetree/commands` to answer, per command, "should
+  this set `it`?", and turned step 2 from a decision *rule* into a decision
+  *table*. Two results worth carrying:
+  - **Step 2 is nearly empty.** Fourteen of the fifteen `defect:` rows need no
+    per-command change — their sequence-path value already matches upstream, so
+    step 3's deletion converges them. The envelope migration the queue originally
+    prescribed would have touched every one of them for no gain.
+  - **`unless` is worse than the audit could see: its body never executes.**
+    `parseInput` hands `unless` an *array* where `if` gets the block *node*, and
+    `executeCommands` silently returns any entry lacking an `.execute` method —
+    which a parsed AST node does. The `it` leak is that returned node. The
+    existing `unless.test.ts` is green because it feeds **mock objects with
+    `.execute()`**, a shape the parser never produces. This is a live bug in a
+    shipped command and only incidentally Arc C's; it deserves its own PR ahead
+    of the arc, with a test that goes through the real parser.
+  - Two genuine judgment calls left open and named: `settle` and `transition`
+    self-assign the element where upstream sets nothing.


### PR DESCRIPTION
Step 2's section in the Arc C brief gave a three-way decision *rule* and named no commands — it was written before the step-1 audit existed. With the audit's 15 `defect:` rows plus an upstream-parity pass, it becomes a table. Follows #800 (brief), #801 (step 0), #802 (step 1). Docs only.

## The oracle

Upstream _hyperscript commands assign `context.result` — the value `it` aliases — only when they produce one. Surveyed `_hyperscript/src/parsetree/commands` by class keyword; the brief records the reproduction command and the resulting yes/no list.

Commands that **do** set it: `wait` (event variant only), `pick`, `render`, `measure`, `make`, `fetch`, `js`, `call`/`get`, `increment`/`decrement`, `ask`/`answer`. `go`, `scroll`, `settle`, `transition`, `start`, `beep!`, `toggle`, `put`, `take`, `set`, `tell`, `send`/`trigger` do **not**.

`wait` is the row that looks like a defect and isn't: upstream sets `context.result = evt` inside the event listener (`wait for click`) and never for `wait 2s`. hyperfixi already matches, so the audit's `null` for `wait 1ms` is correct.

## Step 2 is nearly empty

**Fourteen of the fifteen defect rows need no per-command change.** Their sequence-path value already matches upstream and the handler path is the wrong one, so step 3's deletion converges them for free. The envelope migration the queue originally prescribed would have touched every one of them for no gain — this is the concrete payoff from the revised destination in #800.

Step 3's section now says to expect fourteen audit rows to flip in that one PR, so the size of that diff reads as intended rather than alarming.

## What actually remains

### `unless` never executes its body

Worse than the audit could see, and traced to a specific line:

- `parseInput` gives `unless` an **array** (`raw.args.slice(1)`) where `if` gets the block **node** (`raw.args[1]`).
- `executeCommandsOrBlock` routes block nodes to `executeBlock` (real execution) and arrays to `executeCommands`.
- `executeCommands` handles only entries with an `.execute` method or a function; anything else hits `else lastResult = cmd` and is returned verbatim. A parsed AST node is exactly that.

So the body is **skipped** and the node lands in `it` via an `unless`-only self-assign. Verified: `unless false then add .ran to #probe end` adds nothing; the `if` form works.

**Why the suite is green:** `unless.test.ts` builds `thenCommands` from **mock objects carrying `.execute()`** — a shape the parser never produces. The tests exercise the one branch of `executeCommands` that works. Any fix needs a test that goes through the real parser.

This is a live user-facing bug in a shipped, documented command and only incidentally Arc C's, so it is recorded in the **queue doc's History** as well rather than buried in an arc brief. It wants its own PR ahead of the arc.

### Two judgment calls, named and left open

`settle` and `transition` self-assign the element where upstream sets nothing. After step 3 that value is what *both* paths hold, so it needs deciding rather than inheriting — and recording in the audit row either way. Neither direction is obviously wrong; the brief says so instead of picking silently.

## Also promoted to the queue History

The five commands whose own documented `metadata.examples` do not parse — `async`, `default`, `process`, `pseudo-command`, `take` — found because the step-1 audit drew its snippets from `metadata.examples` rather than hand-authoring them. Candidates for `PARSER_NEXT_STEPS.md`; out of scope for this arc.

## Testing

Docs only, no code changes. The `unless` and `put` claims were verified by running code against `main` at `7feb7bc6`; the scratch tests were removed and the tree is clean. Path-gated CI skips the npm stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)