### PR TITLE
refactor(core): Arc C step 3 — delete the command-result propagation loop

### DIFF
--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -80,13 +80,13 @@ generators with `--check` CI gates, `typecheck:scripts`, and ghost tests.
 | Arc | Value | Gate today | Detail |
 | --- | ----- | ---------- | ------ |
 | ~~D — target-resolution consolidation~~ | **DONE** (#796/#797/#798) | ✅ + 36 new tests pinning the rung order and both selector shapes | [HANDOFF-command-arch-target-resolution.md](./HANDOFF-command-arch-target-resolution.md) — now a record, not a plan |
-| C — output contract | **~20 live `it` divergences, *plus* `it` disagreeing between execution paths** | **none, and measurably so** — disabling the mechanism fails only its own 4 unit tests | [HANDOFF-command-arch-output-contract.md](./HANDOFF-command-arch-output-contract.md) — **revises the plan below** |
+| ~~C — output contract~~ | **DONE** (#801/#802/#803/#805/#806) | ✅ the per-command `it` audit, both execution paths, 45 of 59 commands | [HANDOFF-command-arch-output-contract.md](./HANDOFF-command-arch-output-contract.md) — now a record, not a plan |
 | A — command manifest | kills ~15 of ~30 registration points | ✅ partial: verify:reference, capability-ghosts, command-tiers, bundle-manifest-consistency | gates carry the migration; manifest replaces the lists they guard |
 | B — metadata single-sourcing | types see metadata; docs generated | ✅ partial: typecheck:scripts, metadataOf() throws | decorator statics invisible to TS remain the root cause |
 | E — generated static bundles | 4 executors → 1 template source | ✅ partial: bundle-size ±5% + ceilings, compat matrix, parser-template drift test | drift test becomes a generator |
 | F — schema-driven mappers | ~30 of 47 mappers deleted | ✅ semantic suite + ten-signal ratchet + R2 | mapper/`semantic-integration` switch duplication is data |
 
-## The arcs — remaining sequence C → A → B → E → F (D is done)
+## The arcs — remaining sequence A → B → E → F (C and D are done)
 
 ### Arc D — target-resolution consolidation — ✅ DONE 2026-07-28
 
@@ -112,10 +112,28 @@ Two things later arcs should carry forward:
   `target-elements.ts` as `toElementListFiltered` / `toElementListStrict`, both
   tested. Deciding whether they should agree wants its own change.
 
-### Arc C — command output contract (medium-large; highest correctness value; start here)
+### Arc C — command output contract — ✅ DONE 2026-07-28
 
-The wrapper-`it` class is ~20 live divergences, not a latent risk — hence ranked
-ahead of the manifest.
+Landed as #801 (step 0, one propagation call site), #802 (step 1, the audit),
+#803 (step 2 spec) + #805 (the `unless` fix step 2 surfaced), and #806 (step 3,
+the deletion). Detail and per-step outcomes live in
+[HANDOFF-command-arch-output-contract.md](./HANDOFF-command-arch-output-contract.md).
+
+Three things later arcs should carry forward:
+
+- **`it` and `result` are now ONE slot**, resolved through either name (upstream's
+  model). Commands self-assign `it`; nothing propagates from a command's return
+  value any more. If you add a command that should set `it`, self-assign it —
+  there is no longer a runtime mechanism that will infer it from your output shape.
+- **The audit test is the gate.** `runtime/__tests__/command-output-contract.test.ts`
+  records what `it` holds after every registered command on BOTH execution paths,
+  and ratchets the registry list in both directions. A new command must be given a
+  row or a documented skip.
+- **One decision left open:** whether `settle` and `transition` should self-assign
+  the element at all (upstream sets no result for either). Both are pinned by
+  audit rows, so either direction is a visible change.
+
+Superseded plan, kept for the record:
 
 > **Read [HANDOFF-command-arch-output-contract.md](./HANDOFF-command-arch-output-contract.md)
 > first — it REVISES steps 2 and 3 below.** The brief's exploration measured
@@ -272,6 +290,22 @@ not the core abstractions.
 
 ## History
 
+- **2026-07-28** — **Arc C complete** (#801 → #802 → #803 → #805 → #806, merged
+  sequentially into main, full CI matrix on each). The seven-branch
+  `unwrapCommandResult` propagation is gone; command self-assignment is the sole
+  `it` mechanism, and it runs on every execution path. All 14 known-wrong audit
+  rows flipped and the defect list is empty; four commands (`settle`, `pick`,
+  `render`, `transition`) converged because the loop had been overwriting a value
+  they had already set correctly. **No command was migrated** — the step-2
+  decision table predicted that, and it held.
+  Two findings worth carrying: (a) the loop wrote `result` as well as `it`, and
+  commands write only `it`, so the deletion would have silently broken
+  `put result into …` inside handlers — fixed by making `it`/`result` one slot
+  resolved through either name (upstream's model) rather than by touching ~20
+  commands; (b) `get` is invisible to the immediately-following command
+  (`get 42 then put it into #probe` → empty, but works with any command in
+  between). Verified pre-existing on main, pinned as a KNOWN DEFECT test, not
+  fixed — it wants its own triage.
 - **2026-07-28** — **Arc C steps 0 and 1 landed** (#801, #802), and **step 2
   specified** against an upstream-parity pass. Two findings that belong outside
   the arc as well as in it:

--- a/docs-internal/HANDOFF-command-arch-output-contract.md
+++ b/docs-internal/HANDOFF-command-arch-output-contract.md
@@ -6,7 +6,10 @@
 > Format follows [HANDOFF-command-arch-target-resolution.md](./HANDOFF-command-arch-target-resolution.md)
 > (Arc D, complete).
 >
-> **Status: brief written, arc not started.** Next action: step 0.
+> **Status: ARC COMPLETE (2026-07-28).** Steps 0 (#801), 1 (#802), 2 (#803 spec
+> + #805 the `unless` fix) and 3 (#806) are all merged. **This file is now a
+> record, not a plan — stop updating it**, except for the one open decision
+> named at the end of the Status log. Read that log for per-step outcomes.
 >
 > **This brief REVISES the queue doc's Arc C plan.** The exploration that
 > produced it measured something the queue's audit did not: `it` is set by
@@ -340,7 +343,20 @@ too, so it is not evidence either way.
 Each PR flips the affected rows in the step-1 audit table, so the diff shows
 exactly which `it` values changed. That is the review artifact.
 
-### Step 3 — delete `unwrapCommandResult`, the loop, and the `:121` collapse
+### Step 3 — delete `unwrapCommandResult`, the loop, and the `:121` collapse — DONE (#806)
+
+> Landed 2026-07-28. One thing the plan below did NOT anticipate, found while
+> implementing and worth reading before touching `it`/`result` again: the loop
+> wrote **both** `it` and `result`, while commands self-assign **only `it`**. So
+> deleting it would have silently broken the `result` symbol inside handlers —
+> `set x to 5 then put result into #probe` rendered `5` in a handler and nothing
+> in a sequence, and `start view transition … then put result into #panel` is a
+> *documented example* that depends on it. The fix was not a per-command
+> migration but making `it` and `result` genuinely one slot resolved through
+> either name (upstream's model: `result` canonical, `it` its alias) — four
+> resolvers, no command touched. `resolveIdentifierSync` already did
+> `context.it ?? context.result`; the registered expressions were the
+> inconsistent copies.
 
 Delete the function, replace the two (by then one) call sites with nothing, and
 retire `runtime.test.ts:950-986`'s six positive cases (plus step 0's four
@@ -425,10 +441,16 @@ commands. If it does, something out of scope was touched.
   `it` holds surfaces in expression evaluation, not in the runtime.
 - **Mechanism 1 depends on the adapter's write-back** at
   `command-adapter.ts:338`. If a future refactor stops copying the typed context
-  back, every self-assigning command silently stops setting `it` — and, per
-  Consequence 3, nothing in the suite would fail. Worth its own test.
-- `export { X } from './f'` creates **no local binding** — relevant when moving
-  `unwrapCommandResult`/`propagateCommandResult` between modules.
+  back, every self-assigning command stops setting `it`. **CORRECTED
+  2026-07-28 — this is well guarded, contrary to what this line first claimed.**
+  Measured by disabling the write-back and running the suite: **23 tests fail
+  across 7 files**, including ones that predate this arc (`def-execution`,
+  `append`, `prepend`, `make`, `htmx-wire`, `runtime`). The original claim
+  ("nothing in the suite would fail") was inferred from Consequence 3 rather
+  than measured, and it was wrong — Consequence 3 is specific to the *return-value*
+  mechanism. **Do not add a dedicated test for this; it would be redundant.**
+- `export { X } from './f'` creates **no local binding** — relevant if the
+  deleted propagation helpers are ever reintroduced elsewhere.
 - The MCP server serves **stale dist** after rebuilds; a tool refusing with
   "serving STALE code" is the guard working — restart, don't debug.
 
@@ -503,3 +525,45 @@ commands. If it does, something out of scope was touched.
   `unless` to `if not(...)` and never had the bug — the canonical class was the
   broken copy, the #792 pattern again. **With this, step 2's remaining work is
   only the settle/transition judgment call; everything else is step 3.**
+- 2026-07-28 — **step 3 merged (#806) — arc complete.** `unwrapCommandResult`,
+  `propagateCommandResult` and both call sites are gone; `runtime.test.ts`'s ten
+  direct tests and the audit's whole branch-classification section went with
+  them (the mechanism they described no longer exists). Outcomes:
+  - **All 14 defect rows flipped and the defect list is now empty.** Ten
+    (`wait`, `go`, `push`, `replace`, `scroll`, `copy`, `beep`, `start`,
+    `toggle`, `put`) leave `it` at its initial value, matching both upstream and
+    their own sequence-path behaviour. Four — `settle`, `pick`, `render`,
+    `transition` — **converged**: each had already assigned `it` correctly and
+    the loop was overwriting it, so deletion alone fixed them. The step-2
+    decision table predicted every one of these; **no command was migrated.**
+  - **Path disagreements 30 → 26**, and the remainder are ALL the initial-value
+    non-goal (`null` vs the DOM event, for void commands). No wrapper leaks
+    remain. A new disagreement of any other kind now means a second propagation
+    mechanism has grown back.
+  - **The unplanned find:** the loop wrote both `it` AND `result`, while
+    commands self-assign only `it` — so deleting it would have silently broken
+    the `result` symbol in handlers (`set x to 5 then put result into #probe`
+    worked in a handler and nowhere else; `start view transition … then put
+    result into #panel` is a documented example that depends on it). Fixed by
+    making `it`/`result` one slot resolved through either name — the
+    `it`/`its`/`result` expressions plus the sync/async identifier resolvers and
+    `render.ts` — rather than by touching ~20 commands. `resolveIdentifierSync`
+    already did `context.it ?? context.result`; the registered expressions were
+    the inconsistent copies. Four new tests in `runtime.test.ts` pin it,
+    including inside a handler. One existing test
+    (`references/index.test.ts`, "should return undefined when not set") pinned
+    the OLD independence and was deliberately updated, with a second case added
+    for the genuinely-both-unset path.
+  - **Pre-existing defect found and pinned, NOT fixed:** `get` is invisible to
+    the immediately-following command — `get 42 then put it into #probe` yields
+    `''`, but insert any command between them and it yields `42`. Verified
+    identical on main before this change, so it is a `get` sequencing bug, not
+    an Arc C consequence. Pinned as a KNOWN DEFECT test in `runtime.test.ts` so
+    the knowledge survives; it wants its own triage.
+  - Core suite 7834 → 7795 (net −39: ~54 tests deleted with the mechanism, ~15
+    added). Full CI green.
+- **Open decision this arc did NOT close:** whether `settle` and `transition`
+  should self-assign the element at all. Upstream sets no result for either;
+  hyperfixi does, and after step 3 that value is what BOTH paths hold. Both are
+  now pinned by audit rows, so either direction is a visible, testable change.
+  This is the only remaining Arc C item.

--- a/packages/core/src/commands/templates/render.ts
+++ b/packages/core/src/commands/templates/render.ts
@@ -575,9 +575,11 @@ export class RenderCommand {
 
     // Check context properties
     if (name === 'me') return context.me;
-    if (name === 'it') return context.it;
+    // `it`/`result` are one slot resolved through either name — see the note in
+    // parser/runtime.ts's resolveVariable.
+    if (name === 'it') return context.it ?? context.result;
     if (name === 'you') return context.you;
-    if (name === 'result') return context.result;
+    if (name === 'result') return context.result ?? context.it;
 
     // Check globals
     if (context.globals?.has(name)) {

--- a/packages/core/src/dom/attribute-processor.ts
+++ b/packages/core/src/dom/attribute-processor.ts
@@ -6,7 +6,6 @@
 import { hyperscript, config } from '../api/hyperscript-api';
 import type { CompileError } from '../api/hyperscript-api';
 import { createContext } from '../core/context';
-import { propagateCommandResult } from '../runtime/runtime-base';
 import { debug } from '../utils/debug';
 
 // Type declarations for window extensions used by external packages
@@ -490,8 +489,10 @@ export class AttributeProcessor {
           (eventContext as any).event = event;
 
           for (const command of ast.commands) {
-            const cmdResult = await hyperscript.execute(command, eventContext);
-            propagateCommandResult(eventContext, cmdResult);
+            // No return-value propagation into `it`/`result` — commands that
+            // produce a value self-assign. Mirrors the handler-body executor in
+            // runtime-base.ts; see the comment there.
+            await hyperscript.execute(command, eventContext);
           }
         }
 

--- a/packages/core/src/expressions/references/index.test.ts
+++ b/packages/core/src/expressions/references/index.test.ts
@@ -83,8 +83,21 @@ describe('Reference Expressions', () => {
         expect(result).toEqual({ key: 'value' });
       });
 
-      it('should return undefined when not set', async () => {
+      it('falls back to `result` when `it` is unset — they are one slot', async () => {
+        // DELIBERATE CHANGE (Arc C step 3). `it` is upstream's alias for
+        // `result`, and `resolveIdentifierSync` already resolved it as
+        // `context.it ?? context.result`; this expression was the inconsistent
+        // copy. Making them alias is what lets `put result into …` keep working
+        // now that the handler-body propagation loop — previously the only
+        // writer of `result` — is gone. Commands self-assign `it` only.
         context.it = undefined;
+        const result = await referenceExpressions.it.evaluate(context);
+        expect(result).toBe('test-result');
+      });
+
+      it('should return undefined when NEITHER `it` nor `result` is set', async () => {
+        context.it = undefined;
+        context.result = undefined;
         const result = await referenceExpressions.it.evaluate(context);
         expect(result).toBeUndefined();
       });

--- a/packages/core/src/expressions/references/index.ts
+++ b/packages/core/src/expressions/references/index.ts
@@ -49,7 +49,12 @@ export const itExpression: ExpressionImplementation = {
   evaluatesTo: 'Any',
 
   async evaluate(context: ExecutionContext): Promise<unknown> {
-    return context.it;
+    // `it` and `result` are ONE slot, as upstream (`result` canonical, `it` its
+    // alias) — hence the fallback in both directions here and in
+    // `resultExpression`. Commands self-assign `it`; before Arc C step 3 the
+    // handler-body propagation loop was the only writer of `result`, so
+    // `put result into …` resolved inside a handler and nowhere else.
+    return context.it ?? context.result;
   },
 
   validate: validateNoArgs,
@@ -62,7 +67,7 @@ export const itsExpression: ExpressionImplementation = {
 
   async evaluate(context: ExecutionContext): Promise<unknown> {
     // 'its' refers to the same context as 'it' - they are aliases
-    return context.it;
+    return context.it ?? context.result;
   },
 
   validate: validateNoArgs,
@@ -74,7 +79,8 @@ export const resultExpression: ExpressionImplementation = {
   evaluatesTo: 'Any',
 
   async evaluate(context: ExecutionContext): Promise<unknown> {
-    return context.result;
+    // See `itExpression` — one slot, resolved through either name.
+    return context.result ?? context.it;
   },
 
   validate: validateNoArgs,

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -384,6 +384,8 @@ function resolveIdentifierSync(name: string, context: ExecutionContext, scope?: 
   if (name === 'me' || name === 'my' || name === 'I') return context.me;
   if (name === 'you' || name === 'your' || name === 'yourself') return context.you;
   if (name === 'it' || name === 'its') return context.it ?? context.result;
+  // `result` is the same slot under its canonical name — mirrors resultExpression.
+  if (name === 'result') return context.result ?? context.it;
   if (name === 'window') return typeof window !== 'undefined' ? window : globalThis;
   if (name === 'document') return typeof document !== 'undefined' ? document : undefined;
   // Element-scoped `:name` — read from the owner element's store, no fallthrough.
@@ -547,6 +549,9 @@ async function evaluateIdentifier(node: IdentifierNode, context: ExecutionContex
   }
   if (name === 'it' || name === 'its') {
     return getExpr(context, 'it').evaluate(context);
+  }
+  if (name === 'result') {
+    return getExpr(context, 'result').evaluate(context);
   }
   if (name === 'window') {
     return getExpr(context, 'window').evaluate(context);
@@ -1261,8 +1266,21 @@ function resolveTemplateVariable(varName: string, context: ExecutionContext): un
   }
   if (varName === 'me' && context.me) return context.me;
   if (varName === 'you' && context.you) return context.you;
-  if (varName === 'it' && context.it) return context.it;
-  if (varName === 'result' && context.result) return context.result;
+  // `it` and `result` are the SAME slot, as upstream (`result` is canonical,
+  // `it` its alias) — so each falls back to the other. Commands self-assign
+  // `it`; before the Arc C step-3 deletion, the handler-body propagation loop
+  // was the only thing that also wrote `result`, which is why `put result
+  // into …` worked inside a handler and nowhere else. Resolving through both
+  // makes the two agree on every execution path without asking ~20 commands
+  // to write the slot twice. Symmetric with the same fallback at :386/:409.
+  if (varName === 'it') {
+    const v = context.it ?? context.result;
+    if (v) return v;
+  }
+  if (varName === 'result') {
+    const v = context.result ?? context.it;
+    if (v) return v;
+  }
   if (typeof window !== 'undefined' && varName === 'window') return window;
   if (context.globals?.has(varName)) return context.globals.get(varName);
   return undefined;

--- a/packages/core/src/runtime/__tests__/command-output-contract.test.ts
+++ b/packages/core/src/runtime/__tests__/command-output-contract.test.ts
@@ -2,33 +2,34 @@
  * The command output contract — Arc C's audit
  *
  * Arc C of `docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md`; the brief is
- * `docs-internal/HANDOFF-command-arch-output-contract.md`. This file is step 1:
- * the authoritative inventory, landed as a test so the migration ratchets it
- * down instead of being argued from prose.
+ * `docs-internal/HANDOFF-command-arch-output-contract.md`. Landed as step 1 (the
+ * inventory) and ratcheted down by step 3 (the deletion).
  *
- * ## Why it asserts what it asserts
+ * ## What it pins
  *
- * `it` is set by TWO independent mechanisms:
+ * `it` is set by command **self-assignment**: `Object.assign(context, { it })`
+ * inside the command's own `execute()`, copied back onto the real context by the
+ * adapter (`runtime/command-adapter.ts`). That is now the ONLY mechanism, and it
+ * runs on every execution path.
  *
- * 1. **Command self-assignment** — `Object.assign(context, { it })` inside the
- *    command's own `execute()`, copied back onto the real context by the
- *    adapter (`runtime/command-adapter.ts`). Runs on **every** execution path.
- * 2. **Runtime propagation** — `propagateCommandResult` / `unwrapCommandResult`
- *    (`runtime/runtime-base.ts`), which sniffs the command's RETURN value.
- *    Runs in **event-handler bodies only**. The `then`-joined sequence executor
- *    (`executeCommandSequenceWithResult`, the path `hyperscript.eval` takes)
- *    never calls it.
+ * It used to have a rival. `unwrapCommandResult` sniffed each command's RETURN
+ * value through seven branches and ran in **event-handler bodies only** — never
+ * in the `then`-joined sequence executor. So the same command could leave `it`
+ * holding different things depending on how it was invoked. All seven branches
+ * turned out to be redundant with self-assignment; what the loop uniquely
+ * contributed was ~21 internal wrappers leaking into `it` and an array collapse
+ * that took the first element of `toggle`/`put`'s element list. Step 3 deleted
+ * it, and the four commands it had been actively corrupting (settle, pick,
+ * render, transition) converged with no per-command change.
  *
- * So the same command can leave `it` holding different things depending on how
- * it was invoked. That is the defect this arc closes, and it is why every row
- * below records BOTH paths. Recording only one would make a migration look
- * complete while half the divergence survived.
+ * Every row still records BOTH paths, because that is the property worth
+ * guarding: the 26 remaining disagreements are all the initial-value non-goal
+ * (`null` vs the DOM event for void commands), and a NEW disagreement of any
+ * other kind means a second propagation mechanism has grown back.
  *
- * **These expectations document current behavior, including the wrong parts.**
- * A row marked `defect:` is a known-bad value with the step that fixes it. When
- * a migration lands, the row FLIPS — that diff is the review artifact, and is
- * the whole reason this is an explicit table rather than a snapshot file
- * (a snapshot gets re-blessed on first failure; a hand-edited row does not).
+ * When a change moves a row, the row FLIPS — that diff is the review artifact,
+ * and is why this is an explicit table rather than a snapshot file (a snapshot
+ * gets re-blessed on first failure; a hand-edited row does not).
  *
  * Do NOT "fix" a failing row by editing the expectation unless you are the
  * change that deliberately moved it.
@@ -37,42 +38,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { hyperscript } from '../../api/hyperscript-api';
 import { Runtime } from '../runtime';
-import { unwrapCommandResult } from '../runtime-base';
-
-// Output types, imported so the literals below are COMPILER-CHECKED against the
-// real interfaces. If a command changes its output shape, the literal stops
-// typechecking — the classification cannot silently drift from the code.
-import type { CallCommandOutput } from '../../commands/execution/call';
-import type { JsCommandOutput } from '../../commands/advanced/js';
-import type { RepeatCommandOutput } from '../../commands/control-flow/repeat';
-import type { ConditionalCommandOutput } from '../../commands/control-flow/if';
-import type { GetCommandOutput } from '../../commands/data/get';
-import type { SetCommandOutput } from '../../commands/data/set';
-import type { InsertionCommandOutput } from '../../commands/content/insertion-base';
-import type { FetchCommandOutput } from '../../commands/async/fetch';
-import type { MeasureCommandOutput } from '../../commands/animation/measure';
-import type { DefaultCommandOutput } from '../../commands/data/default';
-import type { WaitCommandOutput } from '../../commands/async/wait';
-import type { HaltCommandOutput } from '../../commands/control-flow/halt';
-import type { GoCommandOutput } from '../../commands/navigation/go';
-import type { HistoryCommandOutput } from '../../commands/navigation/push-url';
-import type { ScrollCommandOutput } from '../../commands/navigation/scroll-to';
-import type { SettleCommandOutput } from '../../commands/animation/settle';
-import type { TakeCommandOutput } from '../../commands/animation/take';
-import type { TransitionCommandOutput } from '../../commands/animation/transition';
-import type { StartViewTransitionOutput } from '../../commands/animation/start-view-transition';
-import type { PickCommandOutput } from '../../commands/utility/pick';
-import type { CopyCommandOutput } from '../../commands/utility/copy';
-import type { BeepCommandOutput } from '../../commands/utility/beep';
-import type { TellCommandOutput } from '../../commands/utility/tell';
-import type { RenderCommandOutput } from '../../commands/templates/render';
-import type { PseudoCommandOutput } from '../../commands/execution/pseudo-command';
-import type { SignalCommandOutput } from '../../commands/control-flow/signal-base';
-import type { ReturnCommandOutput } from '../../commands/control-flow/return';
-import type { ThrowCommandOutput } from '../../commands/control-flow/throw';
-import type { InstallCommandOutput } from '../../commands/behaviors/install';
-import type { AsyncCommandOutput } from '../../commands/advanced/async';
-import type { ProcessPartialsResult } from '../../commands/dom/process-partials';
 
 // ===========================================================================
 // Harness
@@ -101,7 +66,7 @@ let seq = 0;
  * Compared as a STRING rather than by identity so a flipped row reads as a
  * legible diff (`'null'` → `'<P>'`) instead of an object dump, and so the table
  * doubles as documentation. Key names are kept for wrappers because the key set
- * is exactly what `unwrapCommandResult` sniffs on.
+ * is exactly what a wrapper leak used to look like.
  */
 function describeIt(v: unknown): string {
   if (v === undefined) return 'undefined';
@@ -217,24 +182,13 @@ const AUDIT: Record<string, AuditRow> = {
   // arc (see the brief) and these rows exist to keep it visible, not to fix it.
   add: { snippet: 'add .active to #probe', sequence: 'null', handler: 'Event' },
   remove: { snippet: 'remove .active from #probe', sequence: 'null', handler: 'Event' },
-  toggle: {
-    snippet: 'toggle .active on .item',
-    sequence: 'null',
-    handler: '<P>',
-    defect:
-      'ARRAY COLLAPSE (step 3). toggle returns HTMLElement[]; unwrapCommandResult collapses any ' +
-      'array to val[0], so `it` is the FIRST of two matched elements. This violates the selector-shape ' +
-      'rule Arc D pinned (`.cls` keeps the collection — see helpers/__tests__/target-elements.test.ts). ' +
-      "Same shape as append's pre-#792 `.cls` no-op, seen from the propagation end.",
-  },
-  put: {
-    snippet: 'put "Hello" into #probe',
-    sequence: 'null',
-    handler: '<DIV>',
-    defect:
-      'ARRAY COLLAPSE (step 3). put returns HTMLElement[]; same val[0] collapse as toggle. Note put ' +
-      'ALSO self-assigns `it` to the inserted value, which the propagation then overwrites with the element.',
-  },
+  // toggle and put return HTMLElement[]. The deleted propagation collapsed any
+  // array to val[0], so `it` was the FIRST of two matched elements — violating
+  // the selector-shape rule Arc D pinned (`.cls` keeps the collection). Upstream
+  // sets no result for either, so they now behave exactly like the other void
+  // rows. put self-assigns only on its VARIABLE path (`put x into y`), not here.
+  toggle: { snippet: 'toggle .active on .item', sequence: 'null', handler: 'Event' },
+  put: { snippet: 'put "Hello" into #probe', sequence: 'null', handler: 'Event' },
   show: { snippet: 'show #probe', sequence: 'null', handler: 'Event' },
   hide: { snippet: 'hide #probe', sequence: 'null', handler: 'Event' },
   empty: { snippet: 'empty #probe', sequence: 'null', handler: 'Event' },
@@ -249,93 +203,32 @@ const AUDIT: Record<string, AuditRow> = {
   if: { snippet: 'if true then log "y" end', sequence: 'null', handler: 'Event' },
   log: { snippet: 'log "Hello World"', sequence: 'null', handler: 'Event' },
 
-  // ---- wrapper leaks: the propagation loop puts an internal wrapper object in
-  // `it`. Nothing can usefully consume `{halted,timestamp}` or
-  // `{url,title,mode}`. Fixed by step 3 (delete the loop).
-  wait: {
-    snippet: 'wait 1ms',
-    sequence: 'null',
-    handler: '{type,result,duration}',
-    defect:
-      'WRAPPER LEAK (step 3). WaitCommandOutput reaches `it`. wait ALSO self-assigns `it` to the ' +
-      'received Event on its event branch — the propagation overwrites that.',
-  },
-  go: {
-    snippet: 'go to #probe',
-    sequence: 'null',
-    handler: '{result,type}',
-    defect: 'WRAPPER LEAK (step 3). GoCommandOutput reaches `it`.',
-  },
-  push: {
-    snippet: 'push url "/page/2"',
-    sequence: 'null',
-    handler: '{url,title,mode}',
-    defect: 'WRAPPER LEAK (step 3). HistoryCommandOutput reaches `it`.',
-  },
-  replace: {
-    snippet: 'replace url "/search"',
-    sequence: 'null',
-    handler: '{url,title,mode}',
-    defect: 'WRAPPER LEAK (step 3). Same implementation as `push` (aliased).',
-  },
-  scroll: {
-    snippet: 'scroll to #probe',
-    sequence: 'null',
-    handler: '{element,position,smooth}',
-    defect: 'WRAPPER LEAK (step 3). ScrollCommandOutput reaches `it`.',
-  },
-  copy: {
-    snippet: 'copy "Hello World"',
-    sequence: 'null',
-    handler: '{success,text,format,method}',
-    defect: 'WRAPPER LEAK (step 3). CopyCommandOutput reaches `it`.',
-  },
-  beep: {
-    snippet: 'beep 42',
-    sequence: 'null',
-    handler: '{expressionCount,debugged,outputs}',
-    defect: 'WRAPPER LEAK (step 3). BeepCommandOutput reaches `it`.',
-  },
+  // ---- formerly wrapper leaks. The propagation loop put an internal wrapper
+  // object in `it` (`{halted,timestamp}`, `{url,title,mode}`, …) — values
+  // nothing could usefully consume. Upstream sets no result for any of these,
+  // so with the loop gone they leave `it` at its initial value, matching the
+  // void family above and matching their own sequence-path behaviour.
+  wait: { snippet: 'wait 1ms', sequence: 'null', handler: 'Event' },
+  go: { snippet: 'go to #probe', sequence: 'null', handler: 'Event' },
+  push: { snippet: 'push url "/page/2"', sequence: 'null', handler: 'Event' },
+  replace: { snippet: 'replace url "/search"', sequence: 'null', handler: 'Event' },
+  scroll: { snippet: 'scroll to #probe', sequence: 'null', handler: 'Event' },
+  copy: { snippet: 'copy "Hello World"', sequence: 'null', handler: 'Event' },
+  beep: { snippet: 'beep 42', sequence: 'null', handler: 'Event' },
   start: {
     snippet: 'start view transition add .highlight to #probe end',
     sequence: 'null',
-    handler: '{usedViewTransition,commandsExecuted}',
-    defect: 'WRAPPER LEAK (step 3). StartViewTransitionOutput reaches `it`.',
-  },
-  transition: {
-    snippet: 'transition opacity to 0.5',
-    sequence: '<DIV>',
-    handler: '{element,property,fromValue,toValue,duration,completed}',
-    defect: 'WRAPPER LEAK (step 3). The sequence path already holds the element.',
+    handler: 'Event',
   },
 
-  // ---- the sharpest rows: the command ALREADY set `it` correctly, and the
-  // propagation loop overwrote it with the wrapper. Mechanism 2 is not filling
-  // a gap here; it is destroying a correct value.
-  settle: {
-    snippet: 'settle #probe',
-    sequence: '<DIV>',
-    handler: '{element,settled,timeout,duration}',
-    defect:
-      'OVERWRITES A CORRECT VALUE (step 3). settle self-assigns `it` to the element; the propagation ' +
-      'loop replaces it with SettleCommandOutput. The sequence column is what both paths should read.',
-  },
-  pick: {
-    snippet: 'pick first 1 of ["a","b"]',
-    sequence: 'Array(1)',
-    handler: '{selectedItem,sourceLength,sourceType,variant}',
-    defect:
-      'OVERWRITES A CORRECT VALUE (step 3). pick self-assigns the selection; the propagation loop ' +
-      'replaces it with PickCommandOutput.',
-  },
-  render: {
-    snippet: 'render #tpl',
-    sequence: '<DIV>',
-    handler: '{element,rendered,directivesProcessed}',
-    defect:
-      'OVERWRITES A CORRECT VALUE (step 3). render self-assigns the rendered element; the propagation ' +
-      'loop replaces it with RenderCommandOutput.',
-  },
+  // ---- the rows that prove the point: each command had ALREADY assigned `it`
+  // correctly, and the propagation loop overwrote it with the wrapper. Deleting
+  // the loop makes both paths agree on the value the command itself chose —
+  // no per-command change was needed for any of them.
+  settle: { snippet: 'settle #probe', sequence: '<DIV>', handler: '<DIV>' },
+  pick: { snippet: 'pick first 1 of ["a","b"]', sequence: 'Array(1)', handler: 'Array(1)' },
+  render: { snippet: 'render #tpl', sequence: '<DIV>', handler: '<DIV>' },
+  transition: { snippet: 'transition opacity to 0.5', sequence: '<DIV>', handler: '<DIV>' },
 
   // ---- unless: fixed. This audit originally recorded an AST node in `it` on
   // BOTH paths; tracing it found the body never executed at all (parseInput
@@ -407,275 +300,30 @@ describe('the `it` contract, per command, per execution path', () => {
     });
   }
 
-  it('the two paths disagree for 30 of the 45 exercised commands', () => {
-    // The headline number, asserted so a migration cannot shrink it silently
-    // — or grow it. Step 3 should drive this down; nothing else should move it.
-    // (Was 29 at the audit's landing; the unless fix moved it to 30, because a
-    // fixed unless behaves like if — null on the sequence path, the DOM event
-    // in a handler — which is the initial-value divergence, the non-goal. The
-    // broken unless "agreed" only because both paths held the same leaked AST
-    // node.)
+  it('the two paths disagree for 26 of the 45 exercised commands', () => {
+    // The headline number, asserted so a change cannot move it silently.
+    //
+    // 29 when the audit landed → 30 after the unless fix → **26** after step 3
+    // deleted the propagation loop. The four that converged are settle, pick,
+    // render and transition: each had already assigned `it` correctly and the
+    // loop was overwriting it with a wrapper, so removing the loop made both
+    // paths agree on the command's own value — with no per-command change.
+    //
+    // The 26 that remain are ALL the initial-value divergence, which is this
+    // arc's declared non-goal: neither mechanism fires for a void command, so
+    // `it` keeps what the context was built with — `null` for a sequence, the
+    // DOM event inside a handler (runtime-base.ts). Closing that gap is a
+    // context-construction question, not a command-output one. Nothing left
+    // here is a wrapper leak.
     const disagreeing = Object.entries(AUDIT).filter(([, r]) => r.sequence !== r.handler);
-    expect(disagreeing).toHaveLength(30);
+    expect(disagreeing).toHaveLength(26);
   });
 
-  it('names every row whose recorded value is known-wrong', () => {
-    // 14 defect rows: 2 array collapses (toggle, put), 9 wrapper leaks, and
-    // 3 overwrites-a-correct-value (settle, pick, render). The void rows are
-    // NOT counted (they are the initial-value non-goal, deliberately left
-    // undecorated), and unless left this list when its fix landed.
+  it('has no known-wrong rows left', () => {
+    // Step 3 emptied this list. It stays as a ratchet: a future change that
+    // knowingly records a bad value has to add a `defect:` string, and that
+    // makes this test fail loudly rather than the value slipping in silently.
     const defective = Object.entries(AUDIT).filter(([, r]) => r.defect);
-    expect(defective.map(([n]) => n).sort()).toEqual(
-      [
-        'beep',
-        'copy',
-        'go',
-        'pick',
-        'push',
-        'put',
-        'render',
-        'replace',
-        'scroll',
-        'settle',
-        'start',
-        'toggle',
-        'transition',
-        'wait',
-      ].sort()
-    );
-  });
-});
-
-// ===========================================================================
-// 3. The mechanism — which branch each output shape hits
-// ===========================================================================
-
-/**
- * Every command output interface, as a compiler-checked literal.
- *
- * The type annotations are load-bearing: they are what ties this catalog to the
- * real command code. Change `WaitCommandOutput` and this file stops compiling,
- * rather than silently cataloging a shape that no longer exists.
- *
- * Step 3 deletes `unwrapCommandResult`, and this section with it. Until then it
- * is the inventory of what the seven sniffing branches actually do.
- */
-describe('unwrapCommandResult — the seven branches and what falls through', () => {
-  describe('branches that match by design', () => {
-    it('call → { result, wasAsync }', () => {
-      const o: CallCommandOutput = { result: 'v', wasAsync: false, expressionType: 'value' };
-      expect(unwrapCommandResult(o)).toBe('v');
-    });
-
-    it('js → { result, executed } (and preserveArrayResult skips the collapse)', () => {
-      const o: JsCommandOutput = {
-        result: [1, 2],
-        executed: true,
-        codeLength: 3,
-        preserveArrayResult: true,
-      };
-      expect(unwrapCommandResult(o)).toEqual([1, 2]);
-    });
-
-    it('repeat → { type, lastResult }', () => {
-      const o: RepeatCommandOutput = {
-        type: 'times',
-        iterations: 2,
-        completed: true,
-        lastResult: 'last',
-      };
-      expect(unwrapCommandResult(o)).toBe('last');
-    });
-
-    it('if/unless → { conditionResult, executedBranch }, skipping when no branch result', () => {
-      const o: ConditionalCommandOutput = {
-        mode: 'if',
-        conditionResult: true,
-        executedBranch: 'then',
-        result: undefined,
-      };
-      expect(unwrapCommandResult(o)).toBeUndefined();
-    });
-
-    it('get → lone { value }', () => {
-      const o: GetCommandOutput = { value: 42 };
-      expect(unwrapCommandResult(o)).toBe(42);
-    });
-
-    it('set → { target, value, targetType }', () => {
-      const o: SetCommandOutput = { target: 'x', value: 7, targetType: 'variable' };
-      expect(unwrapCommandResult(o)).toBe(7);
-    });
-
-    it('append/prepend → the same envelope as set', () => {
-      const o: InsertionCommandOutput = { target: 'x', value: 'AB', targetType: 'variable' };
-      expect(unwrapCommandResult(o)).toBe('AB');
-    });
-
-    it('fetch → { data, status, headers }', () => {
-      const o = {
-        status: 200,
-        statusText: 'OK',
-        headers: new Headers(),
-        data: { items: [] },
-        url: '/x',
-        duration: 1,
-      } as unknown as FetchCommandOutput;
-      expect(unwrapCommandResult(o)).toEqual({ items: [] });
-    });
-  });
-
-  describe('accidental matches — right answer, wrong reason', () => {
-    it('measure hits the CALL branch because it happens to have result+wasAsync', () => {
-      const o: MeasureCommandOutput = {
-        result: 3,
-        wasAsync: false,
-        element: document.createElement('div'),
-        property: 'width',
-        value: 3,
-        unit: 'px',
-      };
-      // Yields the right number, but via a branch written for `call`. measure
-      // also self-assigns, so deleting the branch is a no-op for it.
-      expect(unwrapCommandResult(o)).toBe(3);
-    });
-
-    it('default hits the SET branch because it happens to have value+target+targetType', () => {
-      const o: DefaultCommandOutput = {
-        target: 'x',
-        value: 9,
-        wasSet: true,
-        targetType: 'variable',
-      };
-      expect(unwrapCommandResult(o)).toBe(9);
-    });
-  });
-
-  describe('a fall-through hiding inside a matched branch', () => {
-    it('repeat with NO lastResult falls through with its whole wrapper', () => {
-      // `lastResult` is optional, so `'lastResult' in obj` is false and the
-      // branch does not fire. Not recorded in the queue doc; found by this audit.
-      const o: RepeatCommandOutput = { type: 'times', iterations: 2, completed: true };
-      expect(unwrapCommandResult(o)).toEqual({ type: 'times', iterations: 2, completed: true });
-    });
-  });
-
-  describe('fall-throughs — the whole wrapper becomes `it`', () => {
-    const el = () => document.createElement('div');
-
-    // Each case asserts identity with its input: nothing was unwrapped.
-    const cases: Array<[string, unknown]> = [
-      ['wait', { type: 'time', result: 5, duration: 5 } satisfies WaitCommandOutput],
-      ['halt', { halted: true, timestamp: 1 } satisfies HaltCommandOutput],
-      ['go', { result: '/x', type: 'url' } satisfies GoCommandOutput],
-      ['push-url/replace-url', { url: '/x', mode: 'push' } satisfies HistoryCommandOutput],
-      ['scroll', { element: el(), position: 'start', smooth: false } satisfies ScrollCommandOutput],
-      [
-        'settle',
-        { element: el(), settled: true, timeout: 1, duration: 1 } satisfies SettleCommandOutput,
-      ],
-      ['take', { targetElement: el(), property: 'p', value: 'v' } satisfies TakeCommandOutput],
-      [
-        'transition',
-        {
-          element: el(),
-          property: 'opacity',
-          fromValue: '1',
-          toValue: '0',
-          duration: 1,
-          completed: true,
-        } satisfies TransitionCommandOutput,
-      ],
-      [
-        'start view transition',
-        { usedViewTransition: false, commandsExecuted: 1 } satisfies StartViewTransitionOutput,
-      ],
-      [
-        'pick',
-        {
-          selectedItem: 'a',
-          sourceLength: 2,
-          sourceType: 'array',
-          variant: 'first',
-        } as PickCommandOutput,
-      ],
-      [
-        'copy',
-        {
-          success: true,
-          text: 't',
-          format: 'text',
-          method: 'clipboard-api',
-        } satisfies CopyCommandOutput,
-      ],
-      ['beep', { expressionCount: 1, debugged: true, outputs: [] } satisfies BeepCommandOutput],
-      [
-        'tell',
-        { targetElements: [], commandResults: [], executionCount: 0 } satisfies TellCommandOutput,
-      ],
-      [
-        'render',
-        {
-          element: el(),
-          rendered: '<i></i>',
-          directivesProcessed: [],
-        } satisfies RenderCommandOutput,
-      ],
-      [
-        'pseudo-command',
-        { result: 'r', methodName: 'm', target: null } satisfies PseudoCommandOutput,
-      ],
-      ['break/continue/exit', { signalType: 'break', timestamp: 1 } as SignalCommandOutput],
-      ['return', { returnValue: 1, timestamp: 1 } satisfies ReturnCommandOutput],
-      ['throw', { error: new Error('x') } satisfies ThrowCommandOutput],
-      [
-        'install',
-        {
-          success: true,
-          behaviorName: 'B',
-          installedCount: 1,
-          instances: [],
-        } satisfies InstallCommandOutput,
-      ],
-      [
-        'async',
-        { commandCount: 1, results: [], executed: true, duration: 1 } satisfies AsyncCommandOutput,
-      ],
-      [
-        'process partials',
-        {
-          count: 0,
-          targets: [],
-          errors: [],
-          validationWarnings: [],
-        } as ProcessPartialsResult,
-      ],
-    ];
-
-    it.each(cases)('%s falls through unchanged', (_name, output) => {
-      expect(unwrapCommandResult(output)).toBe(output);
-    });
-
-    it('covers 21 distinct fall-through output types', () => {
-      // Matches the figure the queue doc re-verified. Independently derived
-      // here by classifying every command's declared execute return type.
-      expect(cases).toHaveLength(21);
-    });
-  });
-
-  describe('the :121 array collapse', () => {
-    it('collapses ANY array to its first element', () => {
-      // What makes `toggle .a on .items` leave `it` as one element. Contrast
-      // with the selector-shape rule Arc D pinned, where `.cls` keeps the
-      // collection (helpers/__tests__/target-elements.test.ts). Step 3 decides
-      // this policy; the recommendation in the brief is "no collapse".
-      const a = document.createElement('p');
-      const b = document.createElement('p');
-      expect(unwrapCommandResult([a, b])).toBe(a);
-    });
-
-    it('leaves an EMPTY array alone', () => {
-      expect(unwrapCommandResult([])).toEqual([]);
-    });
+    expect(defective.map(([n]) => n)).toEqual([]);
   });
 });

--- a/packages/core/src/runtime/runtime-base.ts
+++ b/packages/core/src/runtime/runtime-base.ts
@@ -63,94 +63,6 @@ import {
 } from '../registry/runtime-integration';
 
 /**
- * Unwrap a command's return value to extract the user-facing result.
- *
- * Commands return different wrapper shapes (CallCommand, JsCommand, FetchCommand, etc.).
- * This function extracts the meaningful value from those wrappers so it can be assigned
- * to `context.it` / `context.result` between sequential command executions.
- *
- * Returns `undefined` when the result should NOT update the context (e.g. IfCommand
- * with no branch result), signalling the caller to skip assignment.
- */
-export function unwrapCommandResult(result: unknown): unknown | undefined {
-  if (result === undefined) return undefined;
-
-  let val: unknown = result;
-  if (val && typeof val === 'object') {
-    const obj = val as Record<string, unknown>;
-
-    // CallCommand returns { result, wasAsync }
-    if ('result' in obj && 'wasAsync' in obj) {
-      val = obj.result;
-    }
-    // JsCommand returns { result, executed, codeLength, parameters, preserveArrayResult }
-    else if ('result' in obj && 'executed' in obj) {
-      val = obj.result;
-      // JsCommand sets preserveArrayResult to skip array unwrapping
-      if (obj.preserveArrayResult) {
-        return val !== undefined ? val : undefined;
-      }
-    }
-    // RepeatCommand/IfCommand returns { type, lastResult }
-    else if ('lastResult' in obj && 'type' in obj) {
-      val = obj.lastResult;
-    }
-    // IfCommand returns { conditionResult, executedBranch, result }
-    // Don't clobber context.result with if command metadata
-    else if ('conditionResult' in obj && 'executedBranch' in obj) {
-      if (obj.result !== undefined) {
-        val = obj.result;
-      } else {
-        return undefined; // don't update context
-      }
-    }
-    // GetCommand returns { value }
-    else if ('value' in obj && Object.keys(obj).length === 1) {
-      val = obj.value;
-    }
-    // SetCommand returns { target, value, targetType }
-    else if ('value' in obj && 'target' in obj && 'targetType' in obj) {
-      val = obj.value;
-    }
-    // FetchCommand returns { status, statusText, headers, data, url, duration }
-    // In _hyperscript, 'it' should be the actual data (not the wrapper)
-    else if ('data' in obj && 'status' in obj && 'headers' in obj) {
-      val = obj.data;
-    }
-  }
-  if (Array.isArray(val) && val.length > 0) val = val[0];
-
-  return val;
-}
-
-/**
- * Propagate one command's return value into `it` / `result`.
- *
- * The single definition of the runtime-side half of the `it` contract. It runs
- * in **event-handler bodies only** — `runtime-base`'s `runCommands` and the
- * lazy `_="on …"` attribute stub in `dom/attribute-processor.ts`. The
- * `then`-joined command sequence (`executeCommandSequenceWithResult`, and so
- * `hyperscript.eval`) does NOT call this, which is why `it` can differ between
- * the two paths for the same command.
- *
- * That asymmetry is a known defect, not a design: commands also set `it`
- * themselves (`Object.assign(context, { it })` inside `execute()`, copied back
- * by the adapter), and that mechanism DOES run on every path. See
- * `docs-internal/HANDOFF-command-arch-output-contract.md` — this function and
- * its `unwrapCommandResult` sniffing are slated for deletion in favour of
- * self-assignment. It exists as one function so that change lands once.
- *
- * @param context Execution context to mutate.
- * @param result Raw value returned by the command's `execute()`.
- */
-export function propagateCommandResult(context: object, result: unknown): void {
-  const val = unwrapCommandResult(result);
-  if (val !== undefined) {
-    Object.assign(context, { it: val, result: val });
-  }
-}
-
-/**
  * Pattern from expression evaluator where a space-separated "word token" is
  * interpreted as an implicit command invocation (e.g. "add .class").
  */
@@ -1776,11 +1688,21 @@ export class RuntimeBase {
       }
 
       // Execution
+      //
+      // No `it`/`result` propagation from the command's RETURN value: commands
+      // that produce a user-facing value assign `context.it` themselves inside
+      // execute(), and the adapter copies that back — a mechanism that runs on
+      // EVERY execution path, unlike this loop, which only ever ran here and in
+      // the lazy attribute stub. The removed `unwrapCommandResult` sniffed
+      // return shapes through seven branches; all seven were redundant with
+      // self-assignment, and what it uniquely contributed was ~21 internal
+      // wrapper objects leaking into `it` plus an array collapse that took the
+      // first element of `toggle`/`put`'s element list. See
+      // docs-internal/HANDOFF-command-arch-output-contract.md.
       const runCommands = async (toRun: ASTNode[]): Promise<void> => {
         for (const command of toRun) {
           try {
-            const result = await runtime.execute(command, eventContext);
-            propagateCommandResult(eventContext, result);
+            await runtime.execute(command, eventContext);
           } catch (e) {
             if (isControlFlowError(e)) {
               if (e.isHalt || e.isExit) break;

--- a/packages/core/src/runtime/runtime.test.ts
+++ b/packages/core/src/runtime/runtime.test.ts
@@ -947,81 +947,66 @@ describe('RuntimeBase Method Coverage', () => {
     });
   });
 
-  describe('unwrapCommandResult()', () => {
-    // Import directly for testing
-    it('should return undefined for undefined input', async () => {
-      const { unwrapCommandResult } = await import('./runtime-base');
-      expect(unwrapCommandResult(undefined)).toBeUndefined();
+  describe('`it` / `result` are one slot (Arc C step 3)', () => {
+    // The handler-body propagation loop used to write BOTH `it` and `result`
+    // from each command's return value. It was deleted because all seven of
+    // its sniffing branches were redundant with commands' own self-assignment
+    // — but self-assignment writes only `it`, so `put result into …` would
+    // have silently stopped resolving inside handlers. Resolution now falls
+    // back in both directions, which is upstream's model (`result` canonical,
+    // `it` its alias) and makes the two agree on every execution path.
+    //
+    // Asserted end-to-end through the real runtime because the regression this
+    // guards is a resolver change, not a function's return value.
+    let host: HTMLElement;
+
+    beforeEach(() => {
+      document.body.innerHTML = '<div id="host"></div><div id="probe"></div>';
+      host = document.getElementById('host') as HTMLElement;
     });
 
-    it('should unwrap CallCommand result', async () => {
-      const { unwrapCommandResult } = await import('./runtime-base');
-      expect(unwrapCommandResult({ result: 'value', wasAsync: false })).toBe('value');
+    async function run(src: string): Promise<string> {
+      const { hyperscript } = await import('../api/hyperscript-api');
+      await hyperscript.eval(src, host);
+      return document.getElementById('probe')!.textContent || '';
+    }
+
+    it('resolves `result` from a value a command assigned to `it`', async () => {
+      expect(await run('set x to 5 then put result into #probe')).toBe('5');
     });
 
-    it('should unwrap GetCommand result', async () => {
-      const { unwrapCommandResult } = await import('./runtime-base');
-      expect(unwrapCommandResult({ value: 42 })).toBe(42);
+    it('resolves `it` from a value a command assigned to `result`', async () => {
+      // `call` writes both; this pins the other direction of the fallback.
+      expect(await run('call Math.max(1,2) then put it into #probe')).toBe('2');
     });
 
-    it('should unwrap FetchCommand result', async () => {
-      const { unwrapCommandResult } = await import('./runtime-base');
-      expect(unwrapCommandResult({ data: { items: [] }, status: 200, headers: {} })).toEqual({
-        items: [],
-      });
+    it('resolves `result` inside an event-handler body', async () => {
+      // The case the deleted loop used to carry on its own.
+      await run('on probe set x to 5 then put result into #probe');
+      host.dispatchEvent(new CustomEvent('probe'));
+      const deadline = Date.now() + 2000;
+      const probe = document.getElementById('probe')!;
+      while (!probe.textContent && Date.now() < deadline) {
+        await new Promise(r => setTimeout(r, 5));
+      }
+      expect(probe.textContent).toBe('5');
     });
 
-    it('should return undefined for IfCommand with no result', async () => {
-      const { unwrapCommandResult } = await import('./runtime-base');
-      expect(
-        unwrapCommandResult({ conditionResult: true, executedBranch: 'then' })
-      ).toBeUndefined();
+    it('resolves `result` from a js block', async () => {
+      expect(await run('js return 7 end then put result into #probe')).toBe('7');
     });
 
-    it('should pass through primitive values', async () => {
-      const { unwrapCommandResult } = await import('./runtime-base');
-      expect(unwrapCommandResult('hello')).toBe('hello');
-      expect(unwrapCommandResult(42)).toBe(42);
-      expect(unwrapCommandResult(true)).toBe(true);
-    });
-  });
-
-  describe('propagateCommandResult()', () => {
-    // The runtime-side half of the `it` contract, shared by the event-handler
-    // body loop and the lazy-attribute stub. Its load-bearing property is the
-    // `undefined` GUARD: a void command must leave `it` alone rather than
-    // blanking it, which is what lets a `then`-joined chain carry `it` across a
-    // `log`/`add`/`show` in the middle. Inlining the unwrap at a call site and
-    // dropping the guard is the regression this pins.
-
-    it('assigns both it and result when the command returned a value', async () => {
-      const { propagateCommandResult } = await import('./runtime-base');
-      const context = { it: 'stale', result: 'stale' };
-      propagateCommandResult(context, { value: 42 });
-      expect(context).toEqual({ it: 42, result: 42 });
-    });
-
-    it('leaves it UNTOUCHED when the command returned undefined', async () => {
-      const { propagateCommandResult } = await import('./runtime-base');
-      const context = { it: 'keep me', result: 'keep me' };
-      propagateCommandResult(context, undefined);
-      expect(context).toEqual({ it: 'keep me', result: 'keep me' });
-    });
-
-    it('leaves it untouched when the wrapper unwraps to undefined', async () => {
-      // IfCommand with no branch result — the unwrap returns undefined to
-      // signal "do not update", which is distinct from "update it to undefined".
-      const { propagateCommandResult } = await import('./runtime-base');
-      const context = { it: 'keep me', result: 'keep me' };
-      propagateCommandResult(context, { conditionResult: true, executedBranch: 'then' });
-      expect(context).toEqual({ it: 'keep me', result: 'keep me' });
-    });
-
-    it('propagates a falsy-but-defined value rather than skipping it', async () => {
-      const { propagateCommandResult } = await import('./runtime-base');
-      const context = { it: 'stale', result: 'stale' };
-      propagateCommandResult(context, { value: 0 });
-      expect(context).toEqual({ it: 0, result: 0 });
+    it('KNOWN DEFECT (pre-existing, not Arc C): `get` is invisible to the NEXT command', async () => {
+      // `get 42 then put it into #probe` yields '' — but insert any command
+      // between them and it yields '42'. Verified identical on main before the
+      // step-3 deletion, so this is a `get`-specific sequencing defect, not a
+      // consequence of removing the propagation loop, and not the `it`/`result`
+      // alias (it reproduces through `it` alone).
+      //
+      // Pinned rather than dropped so the knowledge is not lost. If you fix
+      // `get`, this test tells you to update it — both lines should become '42'.
+      expect(await run('get 42 then put it into #probe')).toBe('');
+      expect(await run('get 42 then log result then put it into #probe')).toBe('42');
     });
   });
 


### PR DESCRIPTION
**Closes Arc C.** `unwrapCommandResult`, `propagateCommandResult` and both call sites are gone. Command self-assignment — `Object.assign(context, { it })` inside `execute()`, copied back by the adapter — is now the sole mechanism that sets `it`, and unlike the deleted loop it runs on **every** execution path.

Follows #801 (step 0) · #802 (step 1, the audit) · #803 (step 2 spec) · #805 (the `unless` fix step 2 surfaced).

## What went

The loop sniffed each command's **return value** through seven branches and ran only in event-handler bodies and the lazy attribute stub — never in the `then`-joined sequence executor. All seven branches were verified redundant with self-assignment in #802. What it uniquely contributed was ~21 internal wrappers leaking into `it`, plus an unconditional array collapse taking the first element of `toggle`/`put`'s element list — the same asymmetry Arc D pinned at the selector end, seen from the propagation end.

**The `:121` array policy is decided, not inherited: no collapse.** A command yielding an element list surfaces the list; the `#id`→element unwrap belongs at the selector layer, where Arc D put the rule. A grep of `examples/` found nothing relying on `it` after a `toggle`/`put` in a handler.

## Audit outcome — the review artifact

| | |
| --- | --- |
| defect rows | **14 → 0** |
| path disagreements | **30 → 26** |
| commands migrated | **0** |

Ten rows (`wait`, `go`, `push`, `replace`, `scroll`, `copy`, `beep`, `start`, `toggle`, `put`) now leave `it` at its initial value — matching upstream *and* their own sequence-path behaviour. Four — **`settle`, `pick`, `render`, `transition`** — **converged**: each had already assigned `it` correctly and the loop was overwriting it, so deletion alone fixed them.

The step-2 decision table predicted every one of these, and no command needed migrating. The 26 remaining disagreements are all the initial-value non-goal (`null` vs the DOM event, for void commands) — no wrapper leaks remain, so a new disagreement of any other kind now means a second propagation mechanism has grown back.

## The unplanned part

The loop wrote **both** `it` and `result`; commands self-assign only `it`. So deleting it would have silently broken the `result` symbol inside handlers. Measured before changing anything:

| `… then put result into #probe` | sequence | handler |
| --- | --- | --- |
| `set x to 5` | (empty) | **5** |
| `js return 7 end` | (empty) | **7** |

And `start view transition … then put result into #panel` is a **documented example** that depends on it.

Fixed by making `it` and `result` genuinely **one slot resolved through either name** — upstream's model, where `result` is canonical and `it` its alias — rather than asking ~20 commands to write the slot twice. Four resolvers changed (the `it`/`its`/`result` expressions, the sync and async identifier paths, `render.ts`); no command touched. `resolveIdentifierSync` already did `context.it ?? context.result`, so the registered expressions were the inconsistent copies. Four new tests pin it, including inside a handler.

**One test deliberately updated:** `references/index.test.ts`'s "should return undefined when not set" pinned the *old* independence of the two slots. Rewritten to pin the alias, with a second case added for the genuinely-both-unset path.

## Pinned, not fixed

`get` is invisible to the immediately-following command: `get 42 then put it into #probe` yields `''`, but insert any command between them and it yields `42`. **Verified identical on main before this change** — a `get` sequencing defect, not an Arc C consequence. Recorded as a KNOWN DEFECT test so the knowledge survives; it wants its own triage.

## Correction to the brief

The risk register claimed nothing guards the adapter's context write-back. That was inferred, not measured, and it is **wrong**: disabling it fails **23 tests across 7 files**, several predating this arc. The suggestion to add a dedicated test is withdrawn as redundant.

## Testing

| | |
| --- | --- |
| baseline before editing | 7834 passed, 128 skipped |
| after | **7795 passed** (net −39: ~54 deleted with the mechanism they described, ~15 added) |
| `npm run typecheck --prefix packages/core` | clean |
| `oxlint` on touched files | only pre-existing warnings, untouched lines |

The Playwright compatibility matrix and the multilingual R2 execution ratchet are the gates that can see an `it` change beyond the unit suite; both run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)