### PR TITLE
fix(i18n): correct three malformed event terms (de, pl, pt)

### DIFF
--- a/packages/i18n/src/dictionaries/de.ts
+++ b/packages/i18n/src/dictionaries/de.ts
@@ -122,7 +122,9 @@ export const de: Dictionary = {
     reset: 'zurücksetzen',
     load: 'laden',
     unload: 'entladen',
-    resize: 'größeändern',
+    // 'größeändern' was a malformed compound: German either separates the verb
+    // phrase ('Größe ändern') or compounds with the linking -n- ('Größenänderung').
+    resize: 'größenänderung',
     scroll: 'scrollen',
     touchstart: 'berührungstart',
     touchend: 'berührungend',

--- a/packages/i18n/src/dictionaries/pl.ts
+++ b/packages/i18n/src/dictionaries/pl.ts
@@ -116,7 +116,8 @@ export const pl: Dictionary = {
     reset: 'zresetuj', // Batch 3: resetuj captured on.event as expression (broken listener) — profile word round-trips
     load: 'załaduj',
     unload: 'wyładuj',
-    resize: 'zmieńrozmiar',
+    // 'zmieńrozmiar' was a fused two-word phrase; Polish writes 'zmiana rozmiaru'.
+    resize: 'zmiana rozmiaru',
     scroll: 'przewiń',
     touchstart: 'dotykstart',
     touchend: 'dotykkoniec',

--- a/packages/i18n/src/dictionaries/pt.ts
+++ b/packages/i18n/src/dictionaries/pt.ts
@@ -96,8 +96,11 @@ export const pt: Dictionary = {
     mouseleave: 'mouseSair',
     // V3 Batch 2: camelCase forms split to the S5b/tokenizer-known forms (the
     // fused spellings captured event=expression:undefined — broken listeners)
-    mousedown: 'mouse baixo',
-    mouseup: 'mouse cima',
+    // pt-BR idiom is "pressionado"/"solto", not the spatial baixo/cima calque —
+    // cf. MDN pt-BR ("um botão ... é pressionado") and Scratch pt-BR
+    // ("mouse pressionado?"). The calques stay as profile parse alternatives.
+    mousedown: 'mouse pressionado',
+    mouseup: 'mouse solto',
     mouseover: 'mouse sobre',
     mouseout: 'mouse fora',
     mousemove: 'mouseMover',

--- a/packages/semantic/src/generators/profiles/german.ts
+++ b/packages/semantic/src/generators/profiles/german.ts
@@ -168,7 +168,15 @@ export const germanProfile: LanguageProfile = {
     // `resize` event (window-resize): the i18n dict emits größeändern; without it
     // the word tokenized as an identifier → event:expression (the on.event R1
     // residue). Registering it as the resize event yields event:literal="resize".
-    resize: { primary: 'größeändern', normalized: 'resize' },
+    // 'größeändern' was a malformed compound — German either separates the verb
+    // phrase or compounds with the linking -n-. Noun form chosen as primary: it
+    // stays a single token, so it also works as an `on-`/`al-` attribute name,
+    // which a spaced phrase cannot.
+    resize: {
+      primary: 'Größenänderung',
+      alternatives: ['größenänderung', 'Größe ändern', 'größeändern'],
+      normalized: 'resize',
+    },
     // Event modifiers (for repeat until event)
     until: { primary: 'bis', normalized: 'until' },
     event: { primary: 'Ereignis', alternatives: ['Event'], normalized: 'event' },

--- a/packages/semantic/src/generators/profiles/polish.ts
+++ b/packages/semantic/src/generators/profiles/polish.ts
@@ -296,7 +296,13 @@ export const polishProfile: LanguageProfile = {
     click: { primary: 'kliknięciu', alternatives: ['klikniecie', 'klik'], normalized: 'click' },
     // `resize` event (window-resize): dict emits zmieńrozmiar; register it so the
     // event types as literal="resize" (matching en) instead of expression.
-    resize: { primary: 'zmieńrozmiar', normalized: 'resize' },
+    // 'zmieńrozmiar' fused a two-word phrase; Polish writes 'zmiana rozmiaru'
+    // (noun) or 'zmień rozmiar' (imperative). Fused form kept as an alternative.
+    resize: {
+      primary: 'zmiana rozmiaru',
+      alternatives: ['zmień rozmiar', 'zmieńrozmiar'],
+      normalized: 'resize',
+    },
     hover: { primary: 'najechaniu', alternatives: ['hover'], normalized: 'hover' },
     submit: { primary: 'wysłaniu', alternatives: ['wyslaniu', 'submit'], normalized: 'submit' },
     // i18n dict emits `wejście` for `input`; recognize it so `on input` types as literal.

--- a/packages/semantic/src/generators/profiles/portuguese.ts
+++ b/packages/semantic/src/generators/profiles/portuguese.ts
@@ -188,8 +188,19 @@ export const portugueseProfile: LanguageProfile = {
     // register so both the on.event and the repeat until-event type as literal.
     // Completes the V3 Batch 2 fused-form split (see keydown/mouseover above);
     // the camelCase spellings stay as parse alternatives for back-compat.
-    mousedown: { primary: 'mouse baixo', alternatives: ['mouseBaixo'], normalized: 'mousedown' },
-    mouseup: { primary: 'mouse cima', alternatives: ['mouseCima'], normalized: 'mouseup' },
+    // baixo/cima was a spatial calque of down/up. pt-BR says "pressionado"/
+    // "solto" — cf. MDN pt-BR and Scratch pt-BR ("mouse pressionado?").
+    // Note this vocabulary is Brazilian: pt-PT would say "rato", not "mouse".
+    mousedown: {
+      primary: 'mouse pressionado',
+      alternatives: ['mouse baixo', 'mouseBaixo'],
+      normalized: 'mousedown',
+    },
+    mouseup: {
+      primary: 'mouse solto',
+      alternatives: ['mouse liberado', 'mouse cima', 'mouseCima'],
+      normalized: 'mouseup',
+    },
     // Event modifiers (for repeat until event)
     until: { primary: 'até', normalized: 'until' },
     event: { primary: 'evento', normalized: 'event' },

--- a/packages/semantic/src/parser/generated/language-grammar.ts
+++ b/packages/semantic/src/parser/generated/language-grammar.ts
@@ -675,7 +675,9 @@ export const KEYWORD_LANGUAGE_MAP: Record<string, readonly string[]> = {
   gönder: ['tr'],
   gönderme: ['tr'],
   göster: ['tr'],
+  'größe ändern': ['de'],
   größeändern: ['de'],
+  größenänderung: ['de'],
   gửi: ['vi'],
   gulir: ['id'],
   gulung: ['id'],
@@ -1095,6 +1097,9 @@ export const KEYWORD_LANGUAGE_MAP: Record<string, readonly string[]> = {
   mostrare: ['it'],
   'mouse baixo': ['pt'],
   'mouse cima': ['pt'],
+  'mouse liberado': ['pt'],
+  'mouse pressionado': ['pt'],
+  'mouse solto': ['pt'],
   mousebaixo: ['pt'],
   mousecima: ['pt'],
   mpito: ['sw'],
@@ -1983,7 +1988,9 @@ export const KEYWORD_LANGUAGE_MAP: Record<string, readonly string[]> = {
   zeigen: ['de'],
   zeruj: ['pl'],
   zmiana: ['pl'],
+  'zmiana rozmiaru': ['pl'],
   zmianie: ['pl'],
+  'zmień rozmiar': ['pl'],
   zmieńrozmiar: ['pl'],
   zmierz: ['pl'],
   zmniejsz: ['pl'],
@@ -3459,7 +3466,7 @@ export const SCRIPT_RANGES: readonly {
 ];
 
 /**
- * Total keywords: 3257
+ * Total keywords: 3264
  * Total languages: 24
  * Ambiguous keywords (match 2+ languages): 195
  */

--- a/packages/semantic/test/multilingual-roadmap-fixes.test.ts
+++ b/packages/semantic/test/multilingual-roadmap-fixes.test.ts
@@ -1259,10 +1259,12 @@ describe('Event-keyword alignment: i18n-emitted event words recognized (on.event
     // resize (window-resize): dict emits a native verb the profiles didn't list as
     // an event → it typed as expression. Registered as the resize event in the 6
     // space-using Latin profiles (de/es/fr/it/pl/pt). resize has no command homonym.
+    ['de', 'resize', 'bei größenänderung umschalten .x'],
     ['de', 'resize', 'bei größeändern umschalten .x'],
     ['es', 'resize', 'en redimensionar alternar .x'],
     ['fr', 'resize', 'sur redimensionner basculer .x'],
     ['it', 'resize', 'su ridimensiona commutare .x'],
+    ['pl', 'resize', 'gdy zmiana rozmiaru przełącz .x'],
     ['pl', 'resize', 'gdy zmieńrozmiar przełącz .x'],
     ['pt', 'resize', 'em redimensionar alternar .x'],
     // mousedown (repeat-until-event handler event): dict emits a native form the
@@ -1272,6 +1274,7 @@ describe('Event-keyword alignment: i18n-emitted event words recognized (on.event
     // the fused spellings stay registered as alternatives, so both must type literal.
     ['es', 'mousedown', 'en ratón abajo alternar .x'],
     ['es', 'mousedown', 'en ratónabajo alternar .x'],
+    ['pt', 'mousedown', 'em mouse pressionado alternar .x'],
     ['pt', 'mousedown', 'em mouse baixo alternar .x'],
     ['pt', 'mousedown', 'em mouseBaixo alternar .x'],
     ['ja', 'mousedown', '.x を マウス押下 で 切り替え'],


### PR DESCRIPTION
Found while auditing the vocabulary [loka-js](https://github.com/codetalcott/loka-js) newly exposes as authoring tokens. Each was reachable but not a form a native speaker would write. Follows #804, and corrects part of it.

## de `resize` — malformed compound

`größeändern` is neither valid option. German either separates the verb phrase (**Größe ändern**) or compounds with the linking *-n-* (**Größenänderung**). MDN's German `resize` page uses both forms; `größeändern` appears nowhere.

The noun is primary because it stays a **single token**, so it can also serve as an `on-`/`al-` attribute name — a spaced phrase cannot, since HTML attribute names can't contain spaces.

## pl `resize` — fused phrase

`zmieńrozmiar` fuses two words. Polish writes **zmiana rozmiaru** (noun) or **zmień rozmiar** (imperative). Polish developer sources use the noun phrase consistently.

## pt `mousedown`/`mouseup` — calque, and my own regression

`mouse baixo` / `mouse cima` calque the spatial down/up. Brazilian Portuguese uses **pressionado** / **solto**:

- MDN pt-BR: *"um botão de um dispositivo apontador é pressionado"*
- Scratch pt-BR: `mouse pressionado?`

These came from #804, where I followed the neighbouring `mouse sobre` / `mouse fora` pattern — reasonable, but it propagated the calque. This corrects it.

Worth noting the "down" calque is **not** universally wrong: Scratch's Quechua (`ukucha urayman`) and Swahili (`kipanya chini`) both use the spatial metaphor. It's Portuguese specifically that doesn't.

### pt-BR vs pt-PT

This vocabulary is Brazilian throughout — `mouse`, where European Portuguese says `rato`. Scratch maintains **pt-BR and pt-PT as separate locales** for exactly this reason:

```
pt-BR   mouse pressionado?
pt-PT   o botão do rato está pressionado
```

Recorded in a profile comment rather than resolved here — splitting the locale is a larger decision than this PR.

## Compatibility

Every previous spelling stays registered as a parse alternative, so this is additive: nothing that parsed before stops parsing, and only the rendered/preferred form changes. `multilingual-roadmap-fixes.test.ts` asserts both old and new spellings type as `literal`.

Grammar regenerated: **3257 → 3264** keywords, all additions, none removed.

## Tests

`semantic` 7646 passed / 10 skipped · `i18n` 949 passed.

## Caveat

This is corroborated from MDN localized pages, Scratch's translation corpus (75+ locales, volunteer-translated), and Microsoft's German terminology — not a native-speaker review. The de and pl fixes are orthographic and high-confidence; the pt change is idiomatic preference, better-sourced than what it replaces but still worth a Brazilian reviewer's eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)