### PR TITLE
refactor(core): settle/transition no longer self-assign `it` — upstream parity

### DIFF
--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -129,9 +129,14 @@ Three things later arcs should carry forward:
   records what `it` holds after every registered command on BOTH execution paths,
   and ratchets the registry list in both directions. A new command must be given a
   row or a documented skip.
-- **One decision left open:** whether `settle` and `transition` should self-assign
-  the element at all (upstream sets no result for either). Both are pinned by
-  audit rows, so either direction is a visible change.
+- **Decided (#808):** `settle`/`transition` no longer self-assign — upstream
+  parity, removed while #806's both-paths state was still unreleased (the only
+  moment it was free). The command-set rule is uniform: **a command sets `it`
+  iff upstream sets `result` for it** — with ONE recorded exception still open:
+  **send/trigger** self-assign the dispatched Event (`trigger.ts`,
+  `(context as any).it = event`) where upstream sets nothing. Different
+  usefulness profile (post-dispatch `defaultPrevented` is not re-derivable), so
+  it wants its own decision; nothing else in the command set diverges.
 
 Superseded plan, kept for the record:
 
@@ -290,6 +295,11 @@ not the core abstractions.
 
 ## History
 
+- **2026-07-28** — **Arc C's last open item closed (#808):** settle/transition
+  self-assigns removed for upstream parity, while the #806 state was still
+  unreleased and the removal therefore free. Command-set rule now uniform
+  (`it` iff upstream sets `result`); the send/trigger sibling is recorded above
+  as the one deliberate open question.
 - **2026-07-28** — **Arc C complete** (#801 → #802 → #803 → #805 → #806, merged
   sequentially into main, full CI matrix on each). The seven-branch
   `unwrapCommandResult` propagation is gone; command self-assignment is the sole

--- a/docs-internal/HANDOFF-command-arch-output-contract.md
+++ b/docs-internal/HANDOFF-command-arch-output-contract.md
@@ -263,8 +263,8 @@ Every `defect:` row from the step-1 audit, with its step-2 action:
 | `put` | no | `null` (element path) | **none** — see note below |
 | `copy` | not upstream (extension) | `null` | **none** |
 | `push` / `replace` | not upstream (extension) | `null` | **none** |
-| `settle` | **no** | `<DIV>` — hyperfixi extension | **decide** (below) |
-| `transition` | **no** | `<DIV>` — hyperfixi extension | **decide** (below) |
+| `settle` | **no** | ~~`<DIV>`~~ | **DECIDED** (#808) — self-assign removed; now `null`/Event |
+| `transition` | **no** | ~~`<DIV>`~~ | **DECIDED** (#808) — self-assign removed; now `null`/Event |
 | `unless` | not upstream (extension) | ~~AST node~~ | **FIXED** (#805) — now `null`/Event, matching `if` |
 
 For all fourteen "none" rows the handler column is wrong and the sequence column
@@ -325,7 +325,15 @@ rather than inside step 2 — the `it` leak is a symptom, and the fix (route
 contract. The `unless`-only self-assign should go with it: once the body runs
 through `executeBlock`, `unless` has no reason to set `it` when `if` does not.
 
-#### The two judgment calls: `settle` and `transition`
+#### The two judgment calls: `settle` and `transition` — DECIDED (#808): removed
+
+> Landed 2026-07-28. Both self-assigns removed for upstream parity, decided on
+> three measurements: zero in-repo reliance (examples, behaviors, compat
+> suites, docs, their own metadata.examples); the element is re-nameable one
+> clause later; and — decisive — the removal was only free while #806's
+> both-paths-agree state was unreleased. The command-set rule is now uniform
+> (`it` iff upstream sets `result`), with send/trigger recorded in the queue
+> doc as the one open sibling. The discussion below is preserved as written.
 
 Both self-assign the element, and upstream sets nothing. After step 3 the
 sequence value is what both paths will hold, so this decides what `it` is after
@@ -562,8 +570,12 @@ commands. If it does, something out of scope was touched.
     the knowledge survives; it wants its own triage.
   - Core suite 7834 → 7795 (net −39: ~54 tests deleted with the mechanism, ~15
     added). Full CI green.
-- **Open decision this arc did NOT close:** whether `settle` and `transition`
-  should self-assign the element at all. Upstream sets no result for either;
-  hyperfixi does, and after step 3 that value is what BOTH paths hold. Both are
-  now pinned by audit rows, so either direction is a visible, testable change.
-  This is the only remaining Arc C item.
+- 2026-07-28 — **the open decision closed (#808): settle/transition self-assigns
+  removed** (upstream parity). Decided from measurement, not taste: zero in-repo
+  reliance; in every released version the handler path delivered a wrapper, not
+  the element, so no shipped cohort ever saw the behaviour being removed; and
+  the removal was free only while #806 was unreleased. Audit rows flipped to
+  `null`/Event, disagreement assert 26 → 28, seven unit pins flipped in place.
+  Suite 7795 → 7795. **The arc is now fully closed.** The one recorded sibling —
+  send/trigger's `it = event` where upstream sets nothing — is the queue doc's
+  follow-up, deliberately not folded in here.

--- a/packages/core/src/commands/animation/__tests__/settle.test.ts
+++ b/packages/core/src/commands/animation/__tests__/settle.test.ts
@@ -326,14 +326,18 @@ describe('SettleCommand (Standalone V2)', () => {
       expect(result.element).toBe(element);
     });
 
-    it('should set context.it to the target element', async () => {
+    it('leaves context.it untouched — upstream parity', async () => {
+      // DELIBERATE CHANGE (Arc C close-out). Upstream's settle sets no result;
+      // the self-assign this replaced was a silent divergence, and the element
+      // is re-nameable one clause later (`settle #x then add .done to #x`).
+      // The settled element still surfaces on the command output.
       const context = createMockContext();
-      const element = context.me as HTMLElement;
 
       expect(context.it).toBeUndefined();
-      await command.execute({}, context);
+      const result = await command.execute({}, context);
 
-      expect(context.it).toBe(element);
+      expect(result.element).toBe(context.me);
+      expect(context.it).toBeUndefined();
     });
 
     it('should use default timeout of 5000ms when not specified', async () => {
@@ -367,7 +371,7 @@ describe('SettleCommand (Standalone V2)', () => {
         const result = await command.execute({ target: '#settle-target' }, context);
 
         expect(result.element).toBe(targetEl);
-        expect(context.it).toBe(targetEl);
+        expect(context.it).toBeUndefined(); // no self-assign — upstream parity
       } finally {
         document.body.removeChild(targetEl);
       }
@@ -438,7 +442,7 @@ describe('SettleCommand (Standalone V2)', () => {
       expect(result.element).toBe(meEl);
       expect(result.settled).toBe(true);
       expect(result.timeout).toBe(5000);
-      expect(context.it).toBe(meEl);
+      expect(context.it).toBeUndefined(); // no self-assign — upstream parity
     });
 
     it('should settle on specified target with custom timeout', async () => {
@@ -466,7 +470,7 @@ describe('SettleCommand (Standalone V2)', () => {
         expect(result.element).toBe(targetEl);
         expect(result.settled).toBe(true);
         expect(result.timeout).toBe(2500);
-        expect(context.it).toBe(targetEl);
+        expect(context.it).toBeUndefined(); // no self-assign — upstream parity
         expect(waitForAnimationComplete).toHaveBeenCalledWith(
           targetEl,
           300, // from default mocked getComputedStyle (0.3s)

--- a/packages/core/src/commands/animation/__tests__/transition.test.ts
+++ b/packages/core/src/commands/animation/__tests__/transition.test.ts
@@ -396,15 +396,19 @@ describe('TransitionCommand (Standalone V2)', () => {
   // ====================================================================
 
   describe('execute - context', () => {
-    it('should set context.it to the resolved element', async () => {
+    it('leaves context.it untouched — upstream parity', async () => {
+      // DELIBERATE CHANGE (Arc C close-out). Upstream's transition sets no
+      // result; same reasoning as settle. The element still surfaces on the
+      // command output.
       const context = createMockContext();
       const element = context.me as HTMLElement;
 
       expect(context.it).toBeUndefined();
 
-      await command.execute({ property: 'opacity', value: '1' }, context);
+      const result = await command.execute({ property: 'opacity', value: '1' }, context);
 
-      expect(context.it).toBe(element);
+      expect(result.element).toBe(element);
+      expect(context.it).toBeUndefined();
     });
 
     it('should use default duration of 300ms when not specified', async () => {
@@ -449,7 +453,7 @@ describe('TransitionCommand (Standalone V2)', () => {
       expect(result.toValue).toBe('0');
       expect(result.duration).toBe(300);
       expect(result.completed).toBe(true);
-      expect(context.it).toBe(element);
+      expect(context.it).toBeUndefined(); // no self-assign — upstream parity
     });
 
     it('should end-to-end transition with target, duration, and timing', async () => {
@@ -491,7 +495,7 @@ describe('TransitionCommand (Standalone V2)', () => {
         expect(result.toValue).toBe('red');
         expect(result.duration).toBe(500);
         expect(result.completed).toBe(true);
-        expect(context.it).toBe(targetEl);
+        expect(context.it).toBeUndefined(); // no self-assign — upstream parity
 
         expect(waitForTransitionEnd).toHaveBeenCalledWith(targetEl, 'background-color', 500);
       } finally {

--- a/packages/core/src/commands/animation/settle.ts
+++ b/packages/core/src/commands/animation/settle.ts
@@ -122,7 +122,12 @@ export class SettleCommand implements DecoratedCommand {
     const result = await waitForAnimationComplete(targetElement, totalAnimationTime, timeout);
     const duration = Date.now() - startTime;
 
-    Object.assign(context, { it: targetElement });
+    // No `it` assignment — upstream parity. Upstream's settle sets no result,
+    // and the element was explicitly named one clause earlier (`settle #x then
+    // add .done to #x`, or `tell #x`). The self-assign this replaces was a
+    // silent divergence: hyperfixi-only chains like `settle #x then … it` would
+    // break on the canonical engine. Decided in Arc C's close-out — see
+    // docs-internal/HANDOFF-command-arch-output-contract.md.
     return { element: targetElement, settled: result.completed, timeout, duration };
   }
 }

--- a/packages/core/src/commands/animation/transition.ts
+++ b/packages/core/src/commands/animation/transition.ts
@@ -163,8 +163,7 @@ export class TransitionCommand implements DecoratedCommand {
       targetElement.style.removeProperty(property);
     }
 
-    Object.assign(context, { it: targetElement });
-
+    // No `it` assignment — upstream parity; same reasoning as settle.ts.
     return {
       element: targetElement,
       property,

--- a/packages/core/src/runtime/__tests__/command-output-contract.test.ts
+++ b/packages/core/src/runtime/__tests__/command-output-contract.test.ts
@@ -223,12 +223,21 @@ const AUDIT: Record<string, AuditRow> = {
 
   // ---- the rows that prove the point: each command had ALREADY assigned `it`
   // correctly, and the propagation loop overwrote it with the wrapper. Deleting
-  // the loop makes both paths agree on the value the command itself chose —
-  // no per-command change was needed for any of them.
-  settle: { snippet: 'settle #probe', sequence: '<DIV>', handler: '<DIV>' },
+  // the loop made both paths agree on the value the command itself chose.
+  // These two stay self-assigning because UPSTREAM sets `result` for them —
+  // the rule is "a command sets `it` iff upstream sets `result`".
   pick: { snippet: 'pick first 1 of ["a","b"]', sequence: 'Array(1)', handler: 'Array(1)' },
   render: { snippet: 'render #tpl', sequence: '<DIV>', handler: '<DIV>' },
-  transition: { snippet: 'transition opacity to 0.5', sequence: '<DIV>', handler: '<DIV>' },
+
+  // ---- settle and transition joined the void family in the Arc C close-out:
+  // they used to self-assign the target element, but upstream sets NO result
+  // for either, making that a silent divergence (hyperfixi-only chains like
+  // `settle #x then … it` would break on the canonical engine). The self-assigns
+  // were removed while the both-paths-agree state was still unreleased — the
+  // only moment the removal was free. The element still surfaces on each
+  // command's output, and was explicitly named one clause earlier anyway.
+  settle: { snippet: 'settle #probe', sequence: 'null', handler: 'Event' },
+  transition: { snippet: 'transition opacity to 0.5', sequence: 'null', handler: 'Event' },
 
   // ---- unless: fixed. This audit originally recorded an AST node in `it` on
   // BOTH paths; tracing it found the body never executed at all (parseInput
@@ -300,23 +309,23 @@ describe('the `it` contract, per command, per execution path', () => {
     });
   }
 
-  it('the two paths disagree for 26 of the 45 exercised commands', () => {
+  it('the two paths disagree for 28 of the 45 exercised commands', () => {
     // The headline number, asserted so a change cannot move it silently.
     //
-    // 29 when the audit landed → 30 after the unless fix → **26** after step 3
-    // deleted the propagation loop. The four that converged are settle, pick,
-    // render and transition: each had already assigned `it` correctly and the
-    // loop was overwriting it with a wrapper, so removing the loop made both
-    // paths agree on the command's own value — with no per-command change.
+    // 29 when the audit landed → 30 after the unless fix → 26 after step 3
+    // deleted the propagation loop → **28** after the close-out removed
+    // settle/transition's self-assigns (upstream parity), moving them into the
+    // initial-value family below.
     //
-    // The 26 that remain are ALL the initial-value divergence, which is this
-    // arc's declared non-goal: neither mechanism fires for a void command, so
-    // `it` keeps what the context was built with — `null` for a sequence, the
-    // DOM event inside a handler (runtime-base.ts). Closing that gap is a
-    // context-construction question, not a command-output one. Nothing left
-    // here is a wrapper leak.
+    // The 28 are ALL the initial-value divergence, which is this arc's
+    // declared non-goal: nothing sets `it` for these commands, so it keeps
+    // what the context was built with — `null` for a sequence, the DOM event
+    // inside a handler (runtime-base.ts). Closing that gap is a
+    // context-construction question, not a command-output one. Nothing here
+    // is a wrapper leak; a NEW disagreement of any other kind means a second
+    // propagation mechanism has grown back.
     const disagreeing = Object.entries(AUDIT).filter(([, r]) => r.sequence !== r.handler);
-    expect(disagreeing).toHaveLength(26);
+    expect(disagreeing).toHaveLength(28);
   });
 
   it('has no known-wrong rows left', () => {


### PR DESCRIPTION
Closes the one decision Arc C left open. Upstream's `settle` and `transition` set no `result`; hyperfixi's self-assign of the target element was a silent divergence — hyperfixi-only chains like `settle #x then add .done to it` would break on the canonical engine, the wrong direction for a project whose headline is "_hyperscript compatible".

## Why now and not later

In every **released** version, the handler path — the dominant `_="…"` usage — delivered a useless wrapper for these two commands (the propagation loop overwrote the element), so only programmatic `eval()` sequences ever saw it. The both-paths-agree state created by #806 is **still unreleased**: removing the self-assigns before it ships means no cohort ever depends on it, and the removal is free. One release later it would be a real breaking change.

## Evidence gathered before deciding

- Zero reliance on `it` after `settle`/`transition` in `examples/`, `packages/behaviors`, the compatibility suites, `docs/`, or the two commands' own `metadata.examples`.
- The element is re-nameable one clause later (`settle #x then add .done to #x`, or `tell #x`) — unlike, say, `fetch`, where `it` carries a value you can't otherwise name.
- The element still surfaces on each command's **output object** (`result.element`), so nothing is lost programmatically.

## The rule is now uniform

**A command sets `it` iff upstream sets `result` for it** — `pick`, `render`, `measure`, `make`, `wait` (event variant), `fetch`, `js`, `call`/`get`, `increment`/`decrement` keep their self-assigns because upstream sets `result` for each.

One recorded exception, deliberately not decided here: **`send`/`trigger`** (`(context as any).it = event` in trigger.ts; upstream sets nothing). The dispatched Event's post-dispatch state (`defaultPrevented`) is less trivially re-derivable than a just-named element, so it gets its own decision — recorded in the queue doc as a follow-up.

## Changes

| | |
| --- | --- |
| `settle.ts` / `transition.ts` | the two `Object.assign(context, { it: targetElement })` lines removed, each replaced by a comment recording the decision |
| audit table | `settle`/`transition` move from the converged rows to the initial-value family (`null`/`Event`); disagreement assert 26 → 28 with the history comment explaining the growth is the two ex-extensions joining the declared non-goal, not a regression |
| unit tests | seven pins across `settle.test.ts`/`transition.test.ts` flip from asserting the self-assign to asserting its absence, each marked as the deliberate change |

## Testing

| | |
| --- | --- |
| baseline (main, #806) | 7795 passed, 128 skipped |
| after | **7795 passed** — every change flips an existing expectation in place |
| `npm run typecheck --prefix packages/core` | clean |

A docs commit follows on this branch (brief status log + queue History) once this PR's number is known — the #805 lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)