### PR TITLE
fix(lsp): COMMAND_KEYWORDS advertised two commands that do not parse

### DIFF
--- a/docs-internal/HANDOFF-command-arch-manifest.md
+++ b/docs-internal/HANDOFF-command-arch-manifest.md
@@ -7,7 +7,9 @@
 > (Arc C, complete) and [HANDOFF-command-arch-target-resolution.md](./HANDOFF-command-arch-target-resolution.md)
 > (Arc D, complete).
 >
-> **Status: BRIEF WRITTEN, ARC NOT STARTED.** Next action: step 1 PR.
+> **Status: PRE-ARC GHOST FIX LANDED (Finding 5); ARC STEPS NOT STARTED.**
+> Next action: step 1 PR. Baseline for step 1 is **7800**, not 7795 — the ghost
+> fix added five tests.
 >
 > **This brief REVISES the queue doc's Arc A plan — specifically its migration
 > ORDER and its manifest SHAPE.** Three of the paragraph's claims were measured
@@ -135,9 +137,23 @@ queue's claim holds.
 the LSP tier lists. A command exported, referenced, and counted but **never
 registered** passes `verify:reference` clean. Its scope is 3 of the ~20 places.
 
-### Finding 5 — a new ghost class, in a list the queue does not name
+### Finding 5 — a new ghost class, in a list the queue does not name — **FIXED**
 
-`lsp-metadata.ts` `COMMAND_KEYWORDS` advertises **`pushUrl`** and
+> **Landed as the standalone pre-arc PR** (branch
+> `fix/lsp-metadata-url-command-ghosts`), the way `unless` landed ahead of Arc C.
+> The two entries became `'push'` / `'replace'` — a **rename, not a deletion**:
+> deleting would have dropped LSP completions for a real shipped command and
+> then re-added them at step 4.3. Because the rename also fills two of the six
+> gaps below, **step 4.3's gap count is now 4**, not 6.
+>
+> The PR also added `packages/core/src/lsp-metadata.test.ts` — a **bidirectional**
+> gate, since writing another one-directional ghost test would have reproduced
+> the exact defect Claim 3 documents. Mutation-verified both ways: re-introducing
+> `pushUrl` fails it, and dropping `toggle` fails it (the direction
+> `capability-ghosts` and `command-tiers` cannot see). Step 1's audit should
+> absorb it.
+
+`lsp-metadata.ts` `COMMAND_KEYWORDS` advertised **`pushUrl`** and
 **`replaceUrl`**. Neither parses:
 
 ```text
@@ -146,16 +162,12 @@ REJECTS  replaceUrl "/x"     PARSES  replace url "/x"
 ```
 
 This is precisely the `transfer` class that motivated `command-tiers.test.ts`,
-alive in a sibling list that has **no ghost test**. `COMMAND_KEYWORDS` feeds
+alive in a sibling list that had **no ghost test**. `COMMAND_KEYWORDS` feeds
 `ALL_KEYWORDS` (`lsp-metadata.ts:212`), which `language-server/src/server.ts:1544`
-uses as its canonical keyword list — so the LSP offers two completions the engine
+uses as its canonical keyword list — so the LSP offered two completions the engine
 rejects. Six registered commands (`process`, `pseudo-command`, `push`, `replace`,
-`scroll`, `start`) are missing from the same list.
-
-**Recommend fixing the two ghosts as their own small PR ahead of the arc**, the
-way `unless` was landed ahead of Arc C: it is a live LSP defect that is only
-incidentally Arc A's, and the arc's audit will otherwise carry it as a red row
-for several PRs.
+`scroll`, `start`) were missing from the same list; **`push` and `replace` are now
+present**, leaving `process`, `pseudo-command`, `scroll`, `start`.
 
 ### Finding 6 — registration already mutates the parser's command set
 
@@ -340,8 +352,11 @@ step-1 audit rows so the diff is the review artifact:
    `_hyperscript` checkout — the Arc C step-2 oracle.
 2. **template-capabilities** (12 unclassified; latent). Also decide the
    `COMMAND_IMPLEMENTATIONS` second-list overlap.
-3. **`COMMAND_KEYWORDS`** (6 gaps) — assuming the two ghosts already landed
-   separately per Finding 5.
+3. **`COMMAND_KEYWORDS`** (**4** gaps — `process`, `pseudo-command`, `scroll`,
+   `start`; the two ghosts landed separately per Finding 5, and that rename
+   closed `push`/`replace`). The gaps are already an explicit `KEYWORD_GAPS`
+   allowlist in `lsp-metadata.test.ts` with a stale-entry check, so closing one
+   means deleting its line there — fold that gate into step 1's audit.
 4. **`packageInfo.commands`** as a derived value; fix the drifted "48/58/59"
    docstrings (`runtime/runtime.ts` has "48 commands" in **six** places, plus
    undercounting per-category group comments — e.g. "DOM Commands (11)" above 15
@@ -358,7 +373,7 @@ step-1 audit rows so the diff is the review artifact:
 
 | Step | Suites | Command |
 | ---- | ------ | ------- |
-| all | quick validation (baseline **7795**) | `npm run test:quick --prefix packages/core` |
+| all | quick validation (baseline **7800**; was 7795 before the Finding 5 fix) | `npm run test:quick --prefix packages/core` |
 | all | the reference gate | `npm run verify:reference --prefix packages/core` |
 | 1 | the new audit test itself | added in the step-1 PR |
 | 2, 3 | bundle size — the tree-shaking guard | `npm run bundle-size` (`--check`, ±5% vs `baseline.json`) |
@@ -443,3 +458,15 @@ was touched.
   (177 B vs 38,395 B). All run against `b69bc035` with a clean tree and reverted.
   Next action: the `pushUrl`/`replaceUrl` ghost fix as a standalone PR
   (Finding 5), then step 1.
+- 2026-07-28 — **Finding 5 ghost fix landed** (branch
+  `fix/lsp-metadata-url-command-ghosts`, off `d6e3ba18`). `COMMAND_KEYWORDS`'
+  `pushUrl`/`replaceUrl` → `push`/`replace`; new bidirectional gate
+  `packages/core/src/lsp-metadata.test.ts` (5 tests). Re-verified the ghost by
+  probe before touching anything (`push url "/x"` parses, `pushUrl "/x"` does
+  not; registry = 59, has `push`+`replace`, not `pushUrl`/`replaceUrl`), and
+  mutation-verified the new gate in both directions. Gates: core 7800 passing /
+  128 skipped / 300 files, `verify:reference` clean (59 = 59), `typecheck`
+  clean, `test:check` exit 0 across all packages, language-server 223 passing
+  against the rebuilt core dist. Two knock-on edits to this brief: step 4.3 is
+  now **4** gaps not 6, and the step baseline is 7800.
+  Next action: step 1 (the audit-as-gate).

--- a/packages/core/src/lsp-metadata.test.ts
+++ b/packages/core/src/lsp-metadata.test.ts
@@ -1,0 +1,97 @@
+/**
+ * COMMAND_KEYWORDS must name real commands — in BOTH directions.
+ *
+ * `COMMAND_KEYWORDS` advertised `pushUrl` and `replaceUrl`. Neither parses: the
+ * command is one `HistoryCommand` registered as `push` with a `replace` alias,
+ * and only `push url <url>` / `replace url <url>` are accepted. The list feeds
+ * `ALL_KEYWORDS` (below it in this module), which `language-server/src/server.ts`
+ * uses as its canonical keyword list — so the LSP offered two completions the
+ * engine rejects. Same class as the `persist`/`transfer`/`process-partials`
+ * ghosts that motivated `language-server/src/command-tiers.test.ts`, alive in a
+ * sibling list that had no gate.
+ *
+ * Unlike that test, this one checks the OMISSION direction too. A list gate that
+ * only computes `list.filter(isGhost)` is structurally blind to a real command
+ * being dropped from the list, which is the failure mode a list edit actually
+ * produces — measured, and the reason `docs-internal/HANDOFF-command-arch-manifest.md`
+ * exists. Both allowlists below are explicit and commented rather than snapshots,
+ * so a change has to be made deliberately.
+ *
+ * This file deliberately constructs NO Runtime: `command-adapter.ts`'s
+ * `register()` does `COMMANDS.add(name)`, so the imported Set grows from 59 to 60
+ * the moment one is built, and a later test in the same file would score against
+ * a different set than an earlier one.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { COMMAND_KEYWORDS, ALL_KEYWORDS } from './lsp-metadata';
+import { COMMANDS, CONTROL_FLOW_COMMANDS } from './parser/parser-constants';
+
+/** Everything the engine will execute by name, as seeded statically. */
+const engine = new Set<string>([...COMMANDS, ...CONTROL_FLOW_COMMANDS]);
+
+/**
+ * In `COMMAND_KEYWORDS` but not an executable command, legitimately.
+ *
+ * `else` is a block keyword — it continues an `if`, it is never dispatched as a
+ * command — so it is absent from `COMMANDS` by design while still being a
+ * keyword the LSP should complete.
+ */
+const NOT_A_COMMAND = new Set(['else']);
+
+/**
+ * Registered commands `COMMAND_KEYWORDS` does not yet advertise.
+ *
+ * Tracked as step 4.3 of the command-manifest arc
+ * (`docs-internal/HANDOFF-command-arch-manifest.md`); adding them is a docs +
+ * completions decision, not part of the ghost fix. Was six before the
+ * `pushUrl`/`replaceUrl` ghosts became `push`/`replace`.
+ */
+const KEYWORD_GAPS = new Set([
+  'process', // htmx-like: process partials in <content>
+  'scroll', // upstream _hyperscript 0.9.90 `scroll to <target>`
+  'start', // start view transition ... end
+  // 'pseudo-command' is not in the static COMMANDS seed either — it is added at
+  // registration time by command-adapter.ts, so it never reaches `engine` here.
+]);
+
+describe('lsp-metadata COMMAND_KEYWORDS', () => {
+  it('the engine sets loaded (guards the imports)', () => {
+    expect(engine.size).toBeGreaterThan(40);
+    expect(engine.has('toggle')).toBe(true);
+    expect(engine.has('push')).toBe(true);
+    expect(engine.has('replace')).toBe(true);
+  });
+
+  it('every keyword names something the engine knows', () => {
+    const ghosts = COMMAND_KEYWORDS.filter(k => !engine.has(k) && !NOT_A_COMMAND.has(k));
+    expect(
+      ghosts,
+      `advertised by COMMAND_KEYWORDS but unknown to the engine: ${ghosts.join(', ')}`
+    ).toEqual([]);
+  });
+
+  it('every engine command is advertised, except the tracked gaps', () => {
+    const advertised = new Set<string>(COMMAND_KEYWORDS);
+    const missing = [...engine].filter(c => !advertised.has(c) && !KEYWORD_GAPS.has(c));
+    expect(missing, `registered but absent from COMMAND_KEYWORDS: ${missing.join(', ')}`).toEqual(
+      []
+    );
+  });
+
+  it('the tracked gaps are still gaps (prune them when they close)', () => {
+    const advertised = new Set<string>(COMMAND_KEYWORDS);
+    const stale = [...KEYWORD_GAPS].filter(c => advertised.has(c));
+    expect(stale, `now advertised — remove from KEYWORD_GAPS: ${stale.join(', ')}`).toEqual([]);
+  });
+
+  it('advertises the history command under its parsing names', () => {
+    // `push url "/x"` and `replace url "/x"` parse; `pushUrl` / `replaceUrl` do not.
+    expect(COMMAND_KEYWORDS).toContain('push');
+    expect(COMMAND_KEYWORDS).toContain('replace');
+    expect(COMMAND_KEYWORDS as readonly string[]).not.toContain('pushUrl');
+    expect(COMMAND_KEYWORDS as readonly string[]).not.toContain('replaceUrl');
+    expect(ALL_KEYWORDS as readonly string[]).not.toContain('pushUrl');
+    expect(ALL_KEYWORDS as readonly string[]).not.toContain('replaceUrl');
+  });
+});

--- a/packages/core/src/lsp-metadata.ts
+++ b/packages/core/src/lsp-metadata.ts
@@ -51,8 +51,14 @@ export const COMMAND_KEYWORDS = [
 
   // Navigation Commands
   'go',
-  'pushUrl',
-  'replaceUrl',
+  // The registered command names are `push` and `replace` (one HistoryCommand,
+  // registered as 'push' with a 'replace' alias). The camelCase `pushUrl` /
+  // `replaceUrl` spellings that used to sit here were ghosts: the engine
+  // rejects them, only `push url <url>` / `replace url <url>` parse. This list
+  // feeds ALL_KEYWORDS, which the language server uses as its canonical keyword
+  // list, so the LSP was offering two completions nothing accepts.
+  'push',
+  'replace',
 
   // Control Flow Commands
   'if',


### PR DESCRIPTION
## The defect

`lsp-metadata.ts` `COMMAND_KEYWORDS` listed **`pushUrl`** and **`replaceUrl`**. Neither is a command.

There is one `HistoryCommand`, registered as `push` with a `replace` alias, and only `push url <url>` / `replace url <url>` parse. Verified by probe against the built runtime, with canonical controls:

```text
REJECTS   "pushUrl \"/x\""          # ghost
PARSES    "push url \"/x\""         # canonical control
REJECTS   "replaceUrl \"/x\""       # ghost
PARSES    "replace url \"/x\""      # canonical control
PARSES    "toggle .active on me"    # canonical control

registry size: 59 · has 'push': true · has 'replace': true
                    has 'pushUrl': false · has 'replaceUrl': false
```

The list feeds `ALL_KEYWORDS`, which `language-server/src/server.ts:1544` uses as its canonical keyword list — so the LSP was offering two completions the engine rejects. Same class as the `persist` / `transfer` / `process-partials` ghosts that motivated `command-tiers.test.ts`, alive in a sibling list that had **no gate**.

## Why rename, not delete

`push` and `replace` **are** registered commands. Deleting the two entries would have removed LSP completions for a real shipped command, then re-added them a few PRs later at the arc's step 4.3. The rename also closes two of the six known gaps in this list.

No duplicates are introduced — neither `push` nor `replace` appeared anywhere in `lsp-metadata.ts` before this change.

## The gate, and why it is bidirectional

Adds `packages/core/src/lsp-metadata.test.ts` (5 tests).

Every existing list gate in this repo computes `list.filter(isGhost)` and asserts `[]`. That is structurally blind to a real command being **dropped** from the list — which is the failure mode a list edit actually produces. Writing another one-directional ghost test here would have reproduced the exact defect the command-manifest brief documents, so this one checks both directions.

Mutation-verified:

| Mutation | Result |
| --- | --- |
| re-introduce `pushUrl` | 2 tests fail |
| drop `toggle` (omission direction) | 1 test fails — the direction `capability-ghosts` / `command-tiers` cannot see |
| no mutation | 5 pass |

The four remaining gaps (`process`, `pseudo-command`, `scroll`, `start`) are an explicit commented `KEYWORD_GAPS` allowlist with a stale-entry check, not a snapshot blob. The file deliberately constructs no `Runtime`, since `command-adapter.ts`'s `register()` does `COMMANDS.add(name)` and would grow the imported Set from 59 to 60 mid-file.

## Context

Pre-arc fix for **Finding 5** of the command-manifest arc (`docs-internal/HANDOFF-command-arch-manifest.md`), landed standalone the way `unless` landed ahead of Arc C — it is a live LSP defect only incidentally belonging to that arc.

Brief updated with the two knock-on effects: step 4.3 is now **4** gaps not 6, and the step baseline moves 7795 → 7800.

## Gates

- `test:quick --prefix packages/core` — **7800 passing / 128 skipped / 300 files** (was 7795 / 128 / 299; the delta is exactly the 5 new tests, so no pre-existing test moved)
- `verify:reference --prefix packages/core` — clean (59 commands = 59 factories)
- `typecheck --prefix packages/core` — clean
- `npm run test:check` — **exit 0** across all packages
- `npm test --prefix packages/language-server` — 223 passing against the rebuilt core dist
- `check:test-list` — OK (38 packages gated)
- oxlint + prettier — clean

Confirmed on the rebuilt dist that the consumer sees the fix: `ALL_KEYWORDS` contains `push`/`replace` and no longer contains `pushUrl`/`replaceUrl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)