### PR TITLE
feat(core): Arc A step 2 — the command manifest, data-only and gated

### DIFF
--- a/docs-internal/HANDOFF-command-arch-manifest.md
+++ b/docs-internal/HANDOFF-command-arch-manifest.md
@@ -7,9 +7,9 @@
 > (Arc C, complete) and [HANDOFF-command-arch-target-resolution.md](./HANDOFF-command-arch-target-resolution.md)
 > (Arc D, complete).
 >
-> **Status: STEP 1 LANDED (the audit-as-gate). Next action: step 2 (the
-> manifest, data-only, consumed by nobody).** Baseline for step 2 is **7814**
-> (step 1 absorbed `lsp-metadata.test.ts`'s 5 tests and added 19).
+> **Status: STEPS 1–2 LANDED (the audit-as-gate, then the manifest). Next
+> action: step 3 (migrate the four mechanical consumers).** Baseline for step 3
+> is **7824** (step 2 added 10 manifest tests to the audit file).
 >
 > **This brief REVISES the queue doc's Arc A plan — specifically its migration
 > ORDER and its manifest SHAPE.** Three of the paragraph's claims were measured
@@ -260,6 +260,32 @@ factory map is wanted, it is a separate module imported only by
 `runtime/runtime.ts`, which already imports all 59 anyway (61 import lines, 58 of
 them per-command deep imports).
 
+### Finding 10 — `category` has two sources, and they disagree on 2 of 59 (measured in step 2)
+
+The step-1 knock-ons asked step 2 to measure this rather than assume it.
+Measured: **57 of 59 agree**. The two that do not are `send` and `trigger` —
+`'events'` in `reference/index.ts`, `'event'` in the `@command` decorator.
+
+It is not a typo. There are **two independent `CommandCategory` unions**, and
+they differ in exactly two members:
+
+```text
+reference/index.ts         …| 'events' |…              (no 'storage')
+types/command-metadata.ts  …| 'event'  | 'storage' |…
+```
+
+`'event'` is the only spelling the decorator union will accept, so
+`events/trigger.ts` could not have used `'events'` — each file is internally
+consistent and the two were simply never compared. Nothing in the repo compared
+them before the step-2 audit section.
+
+The manifest follows the **decorator/registry** union, because the manifest
+mirrors what the engine serves. The reference-side divergence is pinned in the
+audit as `CATEGORY_DOC_DISAGREEMENTS`, which also asserts *which* spelling each
+side holds — so a half-finished reconciliation fails rather than silently
+re-pointing the row. Reconciling the unions is a rename touching the LSP and the
+docs surface, so it is deferred out of the arc alongside Finding 7.
+
 ## What changed vs. the queue doc's plan
 
 The queue says: consumers migrate "lowest-risk first — template-capabilities
@@ -375,13 +401,35 @@ Each carries an explicit classification decision for its gaps, and each flips it
 step-1 audit rows so the diff is the review artifact:
 
 1. **LSP tiers** (23 unclassified; live false negative). Classify against a
-   `_hyperscript` checkout — the Arc C step-2 oracle.
+   `_hyperscript` checkout — the Arc C step-2 oracle. **Step-2 knock-on:** the
+   classification has a typed home already — `CommandMetadata` declares
+   `compatibility?: 'standard' | 'lokascript-extension' | 'experimental'` and
+   `@meta` forwards it, but **all 59 commands leave it unset** (measured). So
+   Finding 8's "recorded nowhere but the tier lists" is right, and the sharper
+   statement is that the slot exists and is vacant. Populating it as the
+   classification lands would let `upstreamOrExtension` become *derived* rather
+   than absorbed, and would put the fact on the implementation where the other
+   per-command metadata already lives. Whichever way it goes, the manifest's
+   `unknown` set and the audit's `TIER_UNCLASSIFIED` are asserted equal — both
+   move in the same diff or the gate fails.
 2. **template-capabilities** (**13** unclassified, not 12 — see the 2026-07-28
    step-1 status entry; latent). 10 rows have no classification at all
    (`CAPABILITY_UNCLASSIFIED` in the audit); `if`/`repeat`/`fetch` are
    classified only as blocks (`CAPABILITY_BLOCK_ONLY`) and need an explicit
    blocks-count-as-classified decision. Also decide the
    `COMMAND_IMPLEMENTATIONS` second-list overlap.
+   **Step-2 knock-on — do NOT derive these lists from the manifest's `tier`.**
+   The manifest's `tier` mirrors `reference/index.ts`'s `availability` (which
+   prebuilt bundle first ships a command; `verify:reference` already checks the
+   chain `lite(7) ⊂ lite-plus(17) ⊂ hybrid(31) ⊂ full(59)`). That is a
+   **different fact** from the capability lists ("can the generator emit it into
+   a lite bundle"). Measured under the natural mapping `full` ↔
+   full-runtime-only, they disagree on **16 of 59** rows: `beep`, `copy`, `js`,
+   `take`, `exit`, `halt`, `morph`, `return`, `throw`, `transition` are `full`
+   yet generator-available; `async`, `fetch`, `if`, `make`, `repeat`, `swap` are
+   `hybrid` yet absent from the capability lists entirely. Two facts, not one
+   fact stored twice — the manifest will need a second field for this, not a
+   reuse of `tier`.
 3. **`COMMAND_KEYWORDS`** (**4** gaps — `process`, `pseudo-command`, `scroll`,
    `start`; the two ghosts landed separately per Finding 5, and that rename
    closed `push`/`replace`). The gaps are already an explicit `KEYWORD_GAPS`
@@ -398,6 +446,8 @@ step-1 audit rows so the diff is the review artifact:
   own decision, like Arc D's element-list follow-up.
 - **The `COMMAND_ALIASES` duplication** — real, but not yet drifted; it should
   fold into the manifest only once Finding 7 is decided.
+- **The two `CommandCategory` unions** (found in step 2, see Finding 10). A
+  rename with LSP and docs reach; pinned by the audit meanwhile.
 
 ## Gates, per step
 
@@ -531,3 +581,40 @@ was touched.
   manifest's `unknown` set to `TIER_UNCLASSIFIED`, measure the two `category`
   sources (reference vs decorator) before choosing one, and
   `consolidationAliasOf` = the four `metadata.aliases` only.
+- 2026-07-28 — **Step 2 landed** (branch `feat/command-manifest`, off
+  `b83c26dc`): `packages/core/src/commands/manifest.ts`, 59 data-only entries
+  (`name`, `category`, `tier`, `upstreamOrExtension`, `consolidationAliasOf?`,
+  `multiword`), plus a 10-test §7 added to the step-1 audit file. **Imported by
+  nobody** — verified by grep across all packages, which is the step's whole
+  point. Every import in the manifest is `import type`, so it erases to one
+  array literal; there is no `factory` field and the audit asserts the entry
+  key set structurally, so Finding 9 is guarded by shape as well as by the
+  bundle-size snapshot.
+  Each field is a **checked mirror**, never a fresh copy: `category` vs the
+  registry's `metadata.category`, `tier` vs `reference/index.ts` `availability`,
+  `multiword` vs `COMPOUND_COMMANDS` (22, zero ghosts), `consolidationAliasOf`
+  vs *implementation identity* (the four shared instances — `decrement`→
+  `increment`, `replace`→`push`, `send`→`trigger`, `unless`→`if` — derived by
+  identity rather than by re-reading `metadata.aliases`, since sharing one
+  instance is what `command-adapter.ts` actually establishes), and
+  `upstreamOrExtension` vs the LSP tier lists. The knock-on coupling is in
+  place: the manifest's `unknown` set is asserted **equal** to the audit's
+  `TIER_UNCLASSIFIED`, so step 4.1 must move both in one diff.
+  The §7 gate was mutation-verified in 11 directions, all caught: dropping an
+  entry (the omission direction Claim 3 says the old gates are blind to — 6
+  failures), duplicating one, reordering one, a wrong `category`, a wrong
+  `tier`, a dropped `multiword`, a wrong alias target, a removed alias,
+  reintroducing a `factory` field, and classifying an `unknown` without touching
+  `TIER_UNCLASSIFIED`. (One self-correction found by the mutation run: a
+  duplicated entry **collapses** in a name-keyed Map, so the Map's size cannot
+  see it — the array-length assertion is what rules it out.)
+  Two measurements the brief asked for, both recorded above as **Finding 10**
+  (the two `CommandCategory` unions; 57/59 agree) and as step-4 knock-ons
+  (`metadata.compatibility` is a typed-but-empty slot on all 59 → step 4.1;
+  `tier` and the capability lists are two different facts disagreeing on 16/59
+  rows → step 4.2 must not derive one from the other).
+  Gates: core **7824** passing / 128 skipped / 300 files, `verify:reference`
+  clean (59 = 59, availability chain valid), `typecheck` clean, prettier +
+  oxlint clean, and `npm run snapshot:bundle-size` — the Finding 9 guard — all
+  10 bundles within tolerance.
+  Next action: step 3 (the four mechanical consumers, one PR).

--- a/packages/core/src/commands/manifest.ts
+++ b/packages/core/src/commands/manifest.ts
@@ -1,0 +1,547 @@
+/**
+ * The command manifest — Arc A's registry-of-record (step 2)
+ *
+ * Arc A of `docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md`; the brief is
+ * `docs-internal/HANDOFF-command-arch-manifest.md`. The command set is
+ * currently described in ~20 hand-maintained places; this file is the one that
+ * the others will be migrated onto, one consumer per PR (steps 3 and 4).
+ *
+ * ## Status: consumed by nobody, deliberately
+ *
+ * Nothing imports this module yet. That is the point of step 2 — the manifest
+ * becomes real and gated before anything depends on it, so its arrival carries
+ * zero behavioral risk. Its gate lives in
+ * `runtime/__tests__/command-manifest-audit.test.ts` (§7), beside the step-1
+ * audit whose registry derivation and allowlists it reuses rather than
+ * re-deriving.
+ *
+ * ## Data-only, and why that is load-bearing (Finding 9)
+ *
+ * There is deliberately **no `factory` field**. An object literal that
+ * references a command factory pins it, so nothing downstream can be shaken
+ * out. Measured with esbuild `--bundle --minify` over a four-command manifest
+ * whose consumer reads only the names:
+ *
+ * ```text
+ * data-only     ({name, category})           →     177 bytes
+ * factory-carrying ({name, category, factory}) →  38,395 bytes
+ * ```
+ *
+ * At 59 commands a `factory` field would pull the entire command set into any
+ * bundle that merely wants the name list — and the intended consumers
+ * (`template-capabilities`, the bundle generator, the LSP tier lists) are
+ * exactly the slim-bundle-facing ones. If a factory map is ever wanted it is a
+ * separate module, imported only by `runtime/runtime.ts`, which already imports
+ * all 59 anyway. Every import below is `import type`, so this module erases to
+ * a single array literal. The guard is
+ * `npm run snapshot:bundle-size --prefix packages/core`, not inspection.
+ *
+ * ## Where each field's values come from
+ *
+ * | Field | Source | Gate |
+ * | ----- | ------ | ---- |
+ * | `name` | `new Runtime().getRegistry().getCommandNames()` | set equality, both directions |
+ * | `category` | the implementation's `metadata.category` (what the registry serves) | exact, all 59 |
+ * | `tier` | `reference/index.ts`'s `availability` | exact, all 59 |
+ * | `upstreamOrExtension` | the LSP tier lists (`language-server/src/command-tiers.ts`) | `unknown` set === the audit's `TIER_UNCLASSIFIED` |
+ * | `consolidationAliasOf` | `metadata.aliases`, resolved by shared implementation identity | exact, the 4 pairs |
+ * | `multiword` | `parser-constants.COMPOUND_COMMANDS` | set equality |
+ *
+ * Every field is a **checked mirror** of a source that already exists, not a
+ * fresh hand-maintained copy — which is the whole point: a manifest that could
+ * drift from the registry would be the twenty-first place, not the fix.
+ *
+ * ## Two measurements taken while authoring this file
+ *
+ * **1. `category` has two sources, and they disagree on exactly 2 of 59.**
+ * `reference/index.ts` carries a `category:` per command (validated by
+ * `scripts/verify-reference-data.ts` against its own 13-name list), and the
+ * `@command({ category })` decorator statics carry another. Nothing compared
+ * them before now. Measured: 57 agree; `send` and `trigger` are `'events'` in
+ * the reference and `'event'` in the decorator. The root cause is not a typo —
+ * there are **two independent `CommandCategory` unions**, differing in two
+ * members:
+ *
+ * ```text
+ * reference/index.ts        …| 'events' |…            (no 'storage')
+ * types/command-metadata.ts …| 'event'  | 'storage' |…
+ * ```
+ *
+ * This manifest follows the **decorator/registry** union, because the manifest
+ * mirrors what the engine serves and `types/command-metadata.ts` is that
+ * union. The reference-side divergence is recorded and pinned in the audit
+ * (`CATEGORY_DOC_DISAGREEMENTS`) rather than silently resolved here —
+ * reconciling the two unions is a rename with LSP and docs reach, so it wants
+ * its own decision, like Finding 7's synonym aliases.
+ *
+ * **2. `upstreamOrExtension` has a typed slot that is empty (Finding 8,
+ * sharpened).** `CommandMetadata` already declares
+ * `compatibility?: 'standard' | 'lokascript-extension' | 'experimental'`, and
+ * the `@meta` decorator forwards it — but **all 59 commands leave it unset**.
+ * So the fact genuinely is recorded nowhere except the LSP tier lists, as the
+ * brief found; what is new is that the natural home for it already exists and
+ * is vacant. Step 4.1 classifies the 23 `unknown` rows against an upstream
+ * `_hyperscript` checkout; populating `metadata.compatibility` at the same time
+ * would let this field become derived rather than absorbed.
+ *
+ * ## Not in this file
+ *
+ * - **The eleven synonym aliases** (`flip`, `fire`, `goto`, …) in
+ *   `COMMAND_ALIASES`. `consolidationAliasOf` is Finding 7's *first* mechanism
+ *   only — the four `metadata.aliases` that back real command names the parser
+ *   accepts. The synonyms work in the slim bundles and are rejected by the full
+ *   parser; that divergence is a behavior change deferred out of the arc.
+ * - **The parse.** `multiword` records *that* a command has multi-word forms
+ *   (mirroring `COMPOUND_COMMANDS`); `MULTI_WORD_PATTERNS` and the command
+ *   parsers keep owning *how* they parse.
+ */
+
+import type { CommandCategory } from '../types/command-metadata';
+
+/**
+ * Which prebuilt browser bundle first ships a command, mirroring
+ * `reference/index.ts`'s `BundleAvailability`.
+ *
+ * NOTE this is **not** the same partition as
+ * `bundle-generator/template-capabilities.ts`'s
+ * `AVAILABLE_COMMANDS` / `FULL_RUNTIME_ONLY_COMMANDS`, and neither derives
+ * from the other. Under the natural mapping (`full` ↔ full-runtime-only) the
+ * two disagree on **16 of 59** rows — `beep`/`copy`/`js`/`take` are `full`
+ * here yet generator-available, while `async`/`fetch`/`make`/`swap` are
+ * `hybrid` here yet absent from the capability lists entirely. They answer
+ * different questions ("which shipped bundle has it" vs "can the generator
+ * emit it into a lite bundle"), so step 4.2 must treat them as two facts, not
+ * one fact stored twice.
+ */
+export type CommandTier = 'lite' | 'lite-plus' | 'hybrid' | 'full';
+
+/**
+ * Whether a command exists in upstream `_hyperscript` or is a LokaScript
+ * extension.
+ *
+ * `'unknown'` is not a placeholder for "we did not bother" — it is the 23-row
+ * classification debt the step-1 audit pins as `TIER_UNCLASSIFIED`, and the
+ * audit asserts these two sets are equal so step 4.1 has to move both together.
+ * This is the arc's one *live* defect: `detectLokascriptFeatures()` warns only
+ * for commands in `LOKASCRIPT_ONLY_COMMANDS`, so an extension missing from
+ * that list produces no compatibility warning at all.
+ */
+export type UpstreamOrExtension = 'upstream' | 'extension' | 'unknown';
+
+/** One command, as the manifest records it. Data only — see the file header. */
+export interface CommandManifestEntry {
+  /** The name the registry dispatches on, and the parser recognizes. */
+  readonly name: string;
+  /** `metadata.category` as the registry serves it (see measurement 1). */
+  readonly category: CommandCategory;
+  /** Earliest prebuilt bundle that ships it. */
+  readonly tier: CommandTier;
+  /** Upstream `_hyperscript`, LokaScript extension, or not yet classified. */
+  readonly upstreamOrExtension: UpstreamOrExtension;
+  /**
+   * For the four consolidated commands, the name of the implementation this
+   * one is an alias of. Both names are real, registered, and parse; they share
+   * one implementation instance via `metadata.aliases`
+   * (`runtime/command-adapter.ts`). Absent for the other 55.
+   */
+  readonly consolidationAliasOf?: string;
+  /** Has multi-word forms — mirrors `parser-constants.COMPOUND_COMMANDS`. */
+  readonly multiword: boolean;
+}
+
+/**
+ * All 59 registered commands, in registry (sorted) order.
+ *
+ * Adding or removing a command means editing this array **and** the registry
+ * list in the audit — the gate compares them as sets in both directions, so
+ * neither can move alone.
+ */
+export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
+  { name: 'add', category: 'dom', tier: 'lite', upstreamOrExtension: 'upstream', multiword: true },
+  {
+    name: 'append',
+    category: 'content',
+    tier: 'hybrid',
+    upstreamOrExtension: 'upstream',
+    multiword: false,
+  },
+  {
+    name: 'async',
+    category: 'advanced',
+    tier: 'hybrid',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'beep',
+    category: 'utility',
+    tier: 'full',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'blur',
+    category: 'execution',
+    tier: 'lite-plus',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'break',
+    category: 'control-flow',
+    tier: 'hybrid',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'breakpoint',
+    category: 'utility',
+    tier: 'full',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'call',
+    category: 'execution',
+    tier: 'hybrid',
+    upstreamOrExtension: 'upstream',
+    multiword: false,
+  },
+  {
+    name: 'clear',
+    category: 'data',
+    tier: 'full',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'close',
+    category: 'dom',
+    tier: 'full',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'continue',
+    category: 'control-flow',
+    tier: 'hybrid',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'copy',
+    category: 'utility',
+    tier: 'full',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'decrement',
+    category: 'data',
+    tier: 'lite-plus',
+    upstreamOrExtension: 'upstream',
+    consolidationAliasOf: 'increment',
+    multiword: false,
+  },
+  {
+    name: 'default',
+    category: 'data',
+    tier: 'full',
+    upstreamOrExtension: 'upstream',
+    multiword: false,
+  },
+  {
+    name: 'empty',
+    category: 'dom',
+    tier: 'lite-plus',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'exit',
+    category: 'control-flow',
+    tier: 'full',
+    upstreamOrExtension: 'upstream',
+    multiword: false,
+  },
+  {
+    name: 'fetch',
+    category: 'async',
+    tier: 'hybrid',
+    upstreamOrExtension: 'upstream',
+    multiword: false,
+  },
+  {
+    name: 'focus',
+    category: 'execution',
+    tier: 'lite-plus',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'get',
+    category: 'data',
+    tier: 'lite-plus',
+    upstreamOrExtension: 'upstream',
+    multiword: false,
+  },
+  {
+    name: 'go',
+    category: 'navigation',
+    tier: 'lite-plus',
+    upstreamOrExtension: 'upstream',
+    multiword: true,
+  },
+  {
+    name: 'halt',
+    category: 'control-flow',
+    tier: 'full',
+    upstreamOrExtension: 'upstream',
+    multiword: true,
+  },
+  { name: 'hide', category: 'dom', tier: 'lite', upstreamOrExtension: 'upstream', multiword: true },
+  {
+    name: 'if',
+    category: 'control-flow',
+    tier: 'hybrid',
+    upstreamOrExtension: 'upstream',
+    multiword: false,
+  },
+  {
+    name: 'increment',
+    category: 'data',
+    tier: 'lite-plus',
+    upstreamOrExtension: 'upstream',
+    multiword: false,
+  },
+  {
+    name: 'install',
+    category: 'behaviors',
+    tier: 'full',
+    upstreamOrExtension: 'extension',
+    multiword: false,
+  },
+  {
+    name: 'js',
+    category: 'advanced',
+    tier: 'full',
+    upstreamOrExtension: 'upstream',
+    multiword: true,
+  },
+  {
+    name: 'log',
+    category: 'utility',
+    tier: 'lite-plus',
+    upstreamOrExtension: 'upstream',
+    multiword: false,
+  },
+  {
+    name: 'make',
+    category: 'dom',
+    tier: 'hybrid',
+    upstreamOrExtension: 'extension',
+    multiword: false,
+  },
+  {
+    name: 'measure',
+    category: 'animation',
+    tier: 'full',
+    upstreamOrExtension: 'extension',
+    multiword: true,
+  },
+  {
+    name: 'morph',
+    category: 'dom',
+    tier: 'full',
+    upstreamOrExtension: 'extension',
+    multiword: true,
+  },
+  {
+    name: 'open',
+    category: 'dom',
+    tier: 'full',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'pick',
+    category: 'utility',
+    tier: 'full',
+    upstreamOrExtension: 'unknown',
+    multiword: true,
+  },
+  {
+    name: 'prepend',
+    category: 'content',
+    tier: 'hybrid',
+    upstreamOrExtension: 'extension',
+    multiword: false,
+  },
+  {
+    name: 'process',
+    category: 'dom',
+    tier: 'full',
+    upstreamOrExtension: 'extension',
+    multiword: true,
+  },
+  {
+    name: 'pseudo-command',
+    category: 'execution',
+    tier: 'full',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'push',
+    category: 'navigation',
+    tier: 'hybrid',
+    upstreamOrExtension: 'unknown',
+    multiword: true,
+  },
+  { name: 'put', category: 'dom', tier: 'lite', upstreamOrExtension: 'upstream', multiword: true },
+  {
+    name: 'remove',
+    category: 'dom',
+    tier: 'lite',
+    upstreamOrExtension: 'upstream',
+    multiword: true,
+  },
+  {
+    name: 'render',
+    category: 'templates',
+    tier: 'full',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'repeat',
+    category: 'control-flow',
+    tier: 'hybrid',
+    upstreamOrExtension: 'upstream',
+    multiword: false,
+  },
+  {
+    name: 'replace',
+    category: 'navigation',
+    tier: 'hybrid',
+    upstreamOrExtension: 'unknown',
+    consolidationAliasOf: 'push',
+    multiword: true,
+  },
+  {
+    name: 'reset',
+    category: 'dom',
+    tier: 'full',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'return',
+    category: 'control-flow',
+    tier: 'full',
+    upstreamOrExtension: 'upstream',
+    multiword: false,
+  },
+  {
+    name: 'scroll',
+    category: 'navigation',
+    tier: 'full',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'select',
+    category: 'dom',
+    tier: 'full',
+    upstreamOrExtension: 'unknown',
+    multiword: false,
+  },
+  {
+    name: 'send',
+    category: 'event',
+    tier: 'hybrid',
+    upstreamOrExtension: 'upstream',
+    consolidationAliasOf: 'trigger',
+    multiword: true,
+  },
+  { name: 'set', category: 'data', tier: 'lite', upstreamOrExtension: 'upstream', multiword: true },
+  {
+    name: 'settle',
+    category: 'animation',
+    tier: 'full',
+    upstreamOrExtension: 'extension',
+    multiword: false,
+  },
+  { name: 'show', category: 'dom', tier: 'lite', upstreamOrExtension: 'upstream', multiword: true },
+  {
+    name: 'start',
+    category: 'animation',
+    tier: 'full',
+    upstreamOrExtension: 'unknown',
+    multiword: true,
+  },
+  {
+    name: 'swap',
+    category: 'dom',
+    tier: 'hybrid',
+    upstreamOrExtension: 'unknown',
+    multiword: true,
+  },
+  {
+    name: 'take',
+    category: 'animation',
+    tier: 'full',
+    upstreamOrExtension: 'upstream',
+    multiword: true,
+  },
+  {
+    name: 'tell',
+    category: 'utility',
+    tier: 'full',
+    upstreamOrExtension: 'upstream',
+    multiword: true,
+  },
+  {
+    name: 'throw',
+    category: 'control-flow',
+    tier: 'full',
+    upstreamOrExtension: 'upstream',
+    multiword: false,
+  },
+  {
+    name: 'toggle',
+    category: 'dom',
+    tier: 'lite',
+    upstreamOrExtension: 'upstream',
+    multiword: true,
+  },
+  {
+    name: 'transition',
+    category: 'animation',
+    tier: 'full',
+    upstreamOrExtension: 'upstream',
+    multiword: false,
+  },
+  {
+    name: 'trigger',
+    category: 'event',
+    tier: 'lite-plus',
+    upstreamOrExtension: 'upstream',
+    multiword: true,
+  },
+  {
+    name: 'unless',
+    category: 'control-flow',
+    tier: 'full',
+    upstreamOrExtension: 'unknown',
+    consolidationAliasOf: 'if',
+    multiword: false,
+  },
+  {
+    name: 'wait',
+    category: 'async',
+    tier: 'lite-plus',
+    upstreamOrExtension: 'upstream',
+    multiword: false,
+  },
+];

--- a/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
+++ b/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
@@ -49,7 +49,8 @@ import { readFileSync, readdirSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
-import { COMMANDS } from '../../parser/parser-constants';
+import { COMMANDS, COMPOUND_COMMANDS } from '../../parser/parser-constants';
+import { COMMAND_MANIFEST } from '../../commands/manifest';
 import {
   AVAILABLE_COMMANDS,
   AVAILABLE_BLOCKS,
@@ -497,7 +498,183 @@ describe('the per-bundle commands arrays', () => {
 });
 
 // ===========================================================================
-// 7. The headline counts
+// 7. The manifest (commands/manifest.ts) — Arc A step 2
+// ===========================================================================
+
+/**
+ * The manifest is a **checked mirror**, never an independent copy: every field
+ * is asserted against the source it mirrors, so it cannot drift into being the
+ * twenty-first hand-maintained place. It lives here rather than beside
+ * `manifest.ts` because the coupling assertion below needs `TIER_UNCLASSIFIED`,
+ * and re-deriving the registry in a second file is the duplication this arc
+ * exists to remove.
+ */
+const MANIFEST_BY_NAME = new Map(COMMAND_MANIFEST.map(e => [e.name, e]));
+
+/**
+ * The only keys a manifest entry may carry. A `factory` field defeats
+ * tree-shaking (Finding 9: 177 B → 38,395 B for a names-only consumer at four
+ * commands), and this asserts the shape structurally so the bundle-size
+ * snapshot is a second line of defence rather than the only one.
+ */
+const ALLOWED_KEYS = new Set([
+  'name',
+  'category',
+  'tier',
+  'upstreamOrExtension',
+  'consolidationAliasOf',
+  'multiword',
+]);
+
+/**
+ * `send` and `trigger` are `'events'` in `reference/index.ts` and `'event'` in
+ * the `@command` decorator — the only two of 59 where the two category sources
+ * disagree, and not a typo: `reference/index.ts` and `types/command-metadata.ts`
+ * declare two independent `CommandCategory` unions that differ in exactly two
+ * members (`'events'` vs `'event'`, and `'storage'` present only in the latter).
+ * Nothing compared them before this audit.
+ *
+ * The manifest follows the decorator/registry union (it mirrors what the engine
+ * serves). Reconciling the two unions is a rename with LSP and docs reach, so
+ * it is pinned here rather than resolved inside a data-only step — the same
+ * treatment Finding 7's synonym aliases got.
+ */
+const CATEGORY_DOC_DISAGREEMENTS: Record<string, { reference: string; decorator: string }> = {
+  send: { reference: 'events', decorator: 'event' },
+  trigger: { reference: 'events', decorator: 'event' },
+};
+
+describe('the command manifest', () => {
+  it('names exactly the registered set, both directions', () => {
+    const names = COMMAND_MANIFEST.map(e => e.name);
+    expect(ghostsIn(names)).toEqual([]);
+    expect(gapsIn(names)).toEqual([]);
+    // A duplicated entry satisfies both checks above and COLLAPSES in the Map,
+    // so the Map's size cannot see it — the array length is what rules it out.
+    expect(COMMAND_MANIFEST.length).toBe(59);
+    expect(MANIFEST_BY_NAME.size).toBe(59);
+  });
+
+  it('is sorted in registry order, so the diff of an added command is one line', () => {
+    expect(COMMAND_MANIFEST.map(e => e.name)).toEqual(REGISTRY);
+  });
+
+  it('carries no factory field, and no field the schema does not name (Finding 9)', () => {
+    for (const entry of COMMAND_MANIFEST) {
+      const extra = Object.keys(entry).filter(k => !ALLOWED_KEYS.has(k));
+      expect(extra, `${entry.name} carries unexpected keys`).toEqual([]);
+    }
+    // The specific field the measurement rules out, named so a future edit that
+    // reintroduces it fails against the reason rather than a generic schema.
+    expect(COMMAND_MANIFEST.some(e => 'factory' in e)).toBe(false);
+  });
+
+  it('category mirrors what the registry serves', () => {
+    const registered = new Runtime().getRegistry();
+    for (const name of REGISTRY) {
+      const served = registered.getImplementation(name)?.metadata?.category;
+      expect(MANIFEST_BY_NAME.get(name)!.category, `${name} category`).toBe(served);
+    }
+  });
+
+  it('pins the 2 rows where the reference and decorator categories disagree', () => {
+    const disagreeing: string[] = [];
+    for (const [key, ref] of Object.entries(referenceCommands)) {
+      const name = normalize(key);
+      const manifest = MANIFEST_BY_NAME.get(name);
+      if (manifest && manifest.category !== (ref as { category: string }).category) {
+        disagreeing.push(name);
+      }
+    }
+    expect(disagreeing.sort()).toEqual(Object.keys(CATEGORY_DOC_DISAGREEMENTS).sort());
+    // Keeps the allowlist honest about WHICH spellings diverge, so a partial
+    // fix (one side renamed) fails instead of silently re-pointing the row.
+    for (const [name, { reference, decorator }] of Object.entries(CATEGORY_DOC_DISAGREEMENTS)) {
+      const ref = Object.entries(referenceCommands).find(([k]) => normalize(k) === name)![1];
+      expect((ref as { category: string }).category, `${name} reference category`).toBe(reference);
+      expect(MANIFEST_BY_NAME.get(name)!.category, `${name} manifest category`).toBe(decorator);
+    }
+  });
+
+  it('tier mirrors reference/index.ts availability', () => {
+    for (const [key, ref] of Object.entries(referenceCommands)) {
+      const name = normalize(key);
+      const availability = (ref as { availability: string }).availability;
+      expect(MANIFEST_BY_NAME.get(name)!.tier, `${name} tier`).toBe(availability);
+    }
+  });
+
+  it('multiword mirrors COMPOUND_COMMANDS', () => {
+    const manifestMultiword = COMMAND_MANIFEST.filter(e => e.multiword)
+      .map(e => e.name)
+      .sort();
+    expect(manifestMultiword).toEqual([...COMPOUND_COMMANDS].sort());
+    expect(manifestMultiword.length).toBe(22);
+  });
+
+  it('consolidationAliasOf names the 4 shared implementations, and only those', () => {
+    // Derived by implementation IDENTITY, not by re-reading metadata.aliases:
+    // two registered names backed by one instance IS the consolidation, and
+    // that is the property `command-adapter.ts` actually establishes.
+    const registered = new Runtime().getRegistry();
+    const byImpl = new Map<unknown, string[]>();
+    for (const name of REGISTRY) {
+      const impl = registered.getImplementation(name);
+      if (!byImpl.has(impl)) byImpl.set(impl, []);
+      byImpl.get(impl)!.push(name);
+    }
+
+    const expected: Record<string, string> = {};
+    for (const [impl, names] of byImpl) {
+      if (names.length === 1) continue;
+      const primary = (impl as { name: string }).name;
+      for (const name of names) if (name !== primary) expected[name] = primary;
+    }
+
+    const actual = Object.fromEntries(
+      COMMAND_MANIFEST.filter(e => e.consolidationAliasOf).map(e => [
+        e.name,
+        e.consolidationAliasOf!,
+      ])
+    );
+    expect(actual).toEqual(expected);
+    // Finding 7's FIRST mechanism only — four real command names sharing an
+    // implementation, NOT the eleven slim-bundle synonyms in COMMAND_ALIASES.
+    expect(actual).toEqual({
+      decrement: 'increment',
+      replace: 'push',
+      send: 'trigger',
+      unless: 'if',
+    });
+    // Every alias target is itself a manifest row, so the graph never dangles.
+    for (const target of Object.values(actual)) expect(MANIFEST_BY_NAME.has(target)).toBe(true);
+  });
+
+  it('upstreamOrExtension agrees with the LSP tier lists', () => {
+    for (const name of REGISTRY) {
+      const expected = HYPERSCRIPT_TIER.includes(name)
+        ? 'upstream'
+        : LOKASCRIPT_TIER.includes(name)
+          ? 'extension'
+          : 'unknown';
+      expect(MANIFEST_BY_NAME.get(name)!.upstreamOrExtension, `${name} tier`).toBe(expected);
+    }
+  });
+
+  it('the unknown set IS the audit TIER_UNCLASSIFIED set (step 4.1 moves both)', () => {
+    // The coupling that stops the two from drifting apart — which is the exact
+    // disease this arc exists to cure. Classifying a command in step 4.1 must
+    // delete its row HERE and in TIER_UNCLASSIFIED in the same diff, or this
+    // fails.
+    const unknown = COMMAND_MANIFEST.filter(e => e.upstreamOrExtension === 'unknown')
+      .map(e => e.name)
+      .sort();
+    expect(unknown).toEqual([...TIER_UNCLASSIFIED].sort());
+  });
+});
+
+// ===========================================================================
+// 8. The headline counts
 // ===========================================================================
 
 describe('the classification debt, counted', () => {


### PR DESCRIPTION
Step 2 of the command-manifest arc (`docs-internal/HANDOFF-command-arch-manifest.md`, authoritative for Arc A). Follows #811 (the audit-as-gate) and #812 (brief maintenance).

## What this adds

`packages/core/src/commands/manifest.ts` — 59 entries: `name`, `category`, `tier`, `upstreamOrExtension`, `consolidationAliasOf?`, `multiword`.

**Imported by nobody**, verified by grep across all packages. That is the step's point: the manifest becomes real and gated before anything depends on it, so its arrival carries zero behavioral risk.

## Data-only, per Finding 9

No `factory` field. An object literal referencing a factory pins it, so nothing downstream can be shaken out — measured with esbuild at four commands: **177 B** data-only vs **38,395 B** factory-carrying. The intended consumers (`template-capabilities`, the bundle generator, the LSP tiers) are exactly the slim-bundle-facing ones.

Every import is `import type`, so the module erases to a single array literal. The audit asserts the entry key set structurally too, so the shape is guarded independently of the bundle-size snapshot.

## Every field is a checked mirror

Never a fresh hand-maintained copy — a manifest that could drift from the registry would be the twenty-first place, not the fix.

| Field | Mirrors | 
| --- | --- |
| `name` | `getRegistry().getCommandNames()`, both directions |
| `category` | the implementation's `metadata.category` |
| `tier` | `reference/index.ts` `availability` |
| `upstreamOrExtension` | the LSP tier lists |
| `consolidationAliasOf` | implementation **identity** — the four shared instances |
| `multiword` | `COMPOUND_COMMANDS` (22, zero ghosts) |

`consolidationAliasOf` is derived by identity rather than by re-reading `metadata.aliases`, since two registered names backed by one instance is what `command-adapter.ts` actually establishes: `decrement`→`increment`, `replace`→`push`, `send`→`trigger`, `unless`→`if`. Finding 7's first mechanism only — not the eleven slim-bundle synonyms.

## The gate lives in step 1's audit file

Not a new file. The required coupling — the manifest's `unknown` set asserted **equal** to the audit's `TIER_UNCLASSIFIED`, so step 4.1 must move both in one diff — needs that set in scope, and re-deriving the registry elsewhere is the duplication this arc exists to remove.

Mutation-verified in **11 directions, all caught**, including the omission direction the pre-existing ghost tests are structurally blind to (dropping an entry fails 6 tests): drop / duplicate / reorder an entry, wrong `category`, wrong `tier`, dropped `multiword`, wrong alias target, removed alias, reintroduced `factory`, and classifying an `unknown` without touching `TIER_UNCLASSIFIED`.

The mutation run also corrected one of my own assertions: a duplicated entry **collapses** in a name-keyed Map, so the Map's size cannot see it — the array length is what rules it out.

## Two measurements the brief asked for rather than assumed

**`category` has two sources; they disagree on 2 of 59 (new Finding 10).** `send`/`trigger` are `'events'` in `reference/index.ts` and `'event'` in the decorator. Not a typo — two independent `CommandCategory` unions differing in exactly two members (`'events'`/`'event'`, and `'storage'` in one only), so each file is internally consistent and nothing ever compared them. The manifest follows the decorator/registry union; the divergence is pinned as `CATEGORY_DOC_DISAGREEMENTS`, which asserts *which* spelling each side holds so a half-finished rename fails loudly. Reconciling the unions reaches the LSP and docs — deferred out of the arc alongside Finding 7.

**Two step-4 knock-ons, recorded in the brief.** `tier` and the capability lists are different facts, disagreeing on 16 of 59 rows — step 4.2 must not derive one from the other. And `metadata.compatibility` is a typed-but-empty slot on all 59, sharpening Finding 8: the natural home for the upstream/extension fact already exists and is vacant, which step 4.1 could fill to make the field derived rather than absorbed.

## Gates

- `npm run test:quick --prefix packages/core` — **7824 passing** / 128 skipped / 300 files (7814 baseline + 10)
- `npm run verify:reference --prefix packages/core` — clean (59 = 59, availability chain valid)
- `npm run snapshot:bundle-size --prefix packages/core` — the Finding 9 guard; all 10 bundles within tolerance
- `typecheck`, prettier, oxlint — clean

`multilingual-validation` is not expected to fire: no command added or removed, no semantic surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)