### PR TITLE
feat(core): Arc A step 3 — migrate the four mechanical consumers

### DIFF
--- a/docs-internal/HANDOFF-command-arch-manifest.md
+++ b/docs-internal/HANDOFF-command-arch-manifest.md
@@ -7,9 +7,10 @@
 > (Arc C, complete) and [HANDOFF-command-arch-target-resolution.md](./HANDOFF-command-arch-target-resolution.md)
 > (Arc D, complete).
 >
-> **Status: STEPS 1–2 LANDED (the audit-as-gate, then the manifest). Next
-> action: step 3 (migrate the four mechanical consumers).** Baseline for step 3
-> is **7824** (step 2 added 10 manifest tests to the audit file).
+> **Status: STEPS 1–3 LANDED (the audit-as-gate, the manifest, then the four
+> mechanical consumers). Next action: step 4 (the decision-bearing consumers,
+> one PR each — start with 4.1, the live LSP false negative).** Baseline for
+> step 4 is **7827** (step 3 added 3 tests to the audit file).
 >
 > **This brief REVISES the queue doc's Arc A plan — specifically its migration
 > ORDER and its manifest SHAPE.** Three of the paragraph's claims were measured
@@ -17,10 +18,18 @@
 > [What changed](#what-changed-vs-the-queue-docs-plan) before following the
 > queue's wording.
 
-## Verified state (2026-07-28, main `b69bc035`, working tree clean)
+## Verified state (measured 2026-07-28 on `b69bc035`; re-stamped after step 3, `051dd47e`)
 
 Line refs will drift — re-verify by symbol (`grep -n`), not by number.
-Baseline for the arc: **7795 passing, 128 skipped, 298 files** (`npm run test:quick --prefix packages/core`).
+Baseline when the arc opened: **7795 passing, 128 skipped, 298 files**
+(`npm run test:quick --prefix packages/core`). Current: **7827 / 128 / 300**.
+
+> **Claims 1 and 2 below describe the PRE-step-3 code and are kept as the
+> record of what made those lists safe to migrate. Two of them no longer
+> describe the tree:** the 59 flat `registry.register(create<X>Command())` calls
+> are now one manifest loop (Claim 1), and `parser-constants.COMMANDS` is now
+> derived rather than merely agreeing (Claim 2's first row). Claims 3 and 4 and
+> Findings 5–10 are still live.
 
 ### What the registry actually holds
 
@@ -286,6 +295,45 @@ side holds — so a half-finished reconciliation fails rather than silently
 re-pointing the row. Reconciling the unions is a rename touching the LSP and the
 docs surface, so it is deferred out of the arc alongside Finding 7.
 
+### Finding 11 — the manifest's DATA payload does not tree-shake either (measured in step 3)
+
+Finding 9 ruled out a `factory` field because referencing a factory pins the
+implementation. The same hazard exists one level down, and step 3 hit it: a
+consumer that wants only the command NAMES cannot get them via
+`COMMAND_MANIFEST.map(e => e.name)`, because the `.map()` references the entries
+and every entry's `category` / `tier` / `upstreamOrExtension` / `multiword`
+survives into the bundle.
+
+Measured when `parser-constants.COMMANDS` was first derived that way. Deltas are
+against the same commit built without the change (the committed
+`baseline.json` has its own accumulated drift, so the gate's percentages are not
+the measurement):
+
+| Bundle | via `COMMAND_MANIFEST.map()` | via `COMMAND_NAMES` |
+| ------ | ---------------------------- | ------------------- |
+| `hyperfixi-hx.js` (68.5 KB raw) | **+4.8 KB (+7.5% — FAILS the ±5% gate)** | +0.0 KB |
+| `hyperfixi-minimal.js` | +4.9 KB | +0.0 KB |
+| `hyperfixi.js` / `hx-v4` | +5.2 KB | +5.2 KB |
+
+`hyperfixi-hx.js` is the sharp case: an 18 KB-gzip hybrid-parser bundle with no
+command registry at all, which reaches `parser-constants.ts` and would have
+carried the classification data for 59 commands it cannot execute. The fix is a
+second literal in `manifest.ts` — `COMMAND_NAMES` — asserted equal to
+`COMMAND_MANIFEST.map(e => e.name)` **as an ordered list**, so it is a shape
+split rather than a hand-maintained copy. The last row is the honest cost and is
+correct: only the bundles that construct `Runtime` carry the rich array, and
+they are the ones that need it.
+
+**Knock-on for step 4.** Both remaining consumers want the RICH entries, not the
+names: 4.1 needs `upstreamOrExtension`, 4.2 needs whatever field the capability
+partition lands in. Before pointing either at `COMMAND_MANIFEST`, check whether
+that consumer reaches a shipped browser bundle — `template-capabilities.ts` is
+imported by `bundle-generator/`, which is build-time, but
+`vite-plugin/src/generator.ts` reading it does not make it browser-side and this
+should be **measured, not assumed**. `npm run snapshot:bundle-size --prefix
+packages/core` is the instrument; the ±5% tolerance on the small bundles is
+tight enough that 4.8 KB fails it.
+
 ## What changed vs. the queue doc's plan
 
 The queue says: consumers migrate "lowest-risk first — template-capabilities
@@ -381,7 +429,7 @@ costs nothing. **The command name matters:** this brief previously said
 that ran it, saw it fail, and shrugged would skip the exact guard Finding 9
 makes this step exist to satisfy.
 
-### Step 3 — migrate the mechanical consumers
+### Step 3 — migrate the mechanical consumers — **DONE**
 
 The four already-agreeing lists (Claim 2), one PR:
 `parser-constants.COMMANDS` seed, `commands/index.ts`, the `reference/index.ts`
@@ -394,6 +442,26 @@ parser at construction.
 per-bundle factory imports. Manifest-*checked*, not manifest-driven, wherever
 shaking matters. `runtime/runtime.ts` is the exception — it already imports all
 59, so a manifest-driven registration loop there costs nothing.
+
+**As landed**, two of the four are driven and two are checked:
+
+| Consumer | Result |
+| -------- | ------ |
+| `parser-constants.COMMANDS` | **driven** — `new Set([...COMMAND_NAMES, 'for'])`; `for` is the one parser-only keyword |
+| `runtime.ts` registration | **driven** — one loop over the manifest; a private `COMMAND_FACTORIES` map supplies the factory per name |
+| `commands/index.ts` | **checked** — re-export statements cannot be generated without pinning all 59 |
+| `reference/index.ts` + `metadata.ts` counts | **checked** — the manifest is now `verify:reference`'s spine |
+
+The loop registers the **55** rows without `consolidationAliasOf`; the other
+four names arrive from their primary's `metadata.aliases`. The pre-step-3 block
+did call `createDecrementCommand()` and its three siblings, but those calls were
+**redundant, not load-bearing** — `createDecrementCommand` is
+`createFactory(NumericModifyCommand)`, the same class whose `name` is
+`'increment'`, so the call re-registered `increment` over the entry the previous
+line had just made. Verified by a before/after registry oracle: identical names,
+classes, `metadata.aliases`, categories, and shared-implementation pairs; the
+only differences are `getCommandNames()` enumeration order (now alphabetical)
+and the seed gaining `pseudo-command`.
 
 ### Step 4 — the decision-bearing consumers, one PR each
 
@@ -435,10 +503,18 @@ step-1 audit rows so the diff is the review artifact:
    closed `push`/`replace`). The gaps are already an explicit `KEYWORD_GAPS`
    allowlist in `lsp-metadata.test.ts` with a stale-entry check, so closing one
    means deleting its line there — fold that gate into step 1's audit.
-4. **`packageInfo.commands`** as a derived value; fix the drifted "48/58/59"
-   docstrings (`runtime/runtime.ts` has "48 commands" in **six** places, plus
-   undercounting per-category group comments — e.g. "DOM Commands (11)" above 15
-   registrations, "Phase 6-5 Commands (6)" above 7) as the derived values land.
+4. **`packageInfo.commands`** as a derived value. **Step-3 knock-on: the
+   `runtime/runtime.ts` half of the docstring fix is already done.** All six
+   "48 commands" mentions and every undercounting per-category group comment
+   ("DOM Commands (11)" above 15 registrations, "Phase 6-5 Commands (6)" above
+   7) were in or immediately around the registration block step 3 replaced, so
+   leaving them would have meant shipping stale prose beside freshly-written
+   code. What remains for 4.4 is the actual derivation: `metadata.ts`'s
+   `packageInfo.commands` and the full-runtime bundles' `commandCount` are still
+   hand-typed numbers, checked against the manifest by `verify:reference` (step
+   3) but not computed from it. Other files still carrying stale counts —
+   `compatibility/browser-bundle-modular.ts`, `parser/parser-interface.ts`,
+   `parser/full-parser.ts` — were untouched, being outside step 3's diff.
 
 ### Deferred out of the arc, deliberately
 
@@ -453,7 +529,7 @@ step-1 audit rows so the diff is the review artifact:
 
 | Step | Suites | Command |
 | ---- | ------ | ------- |
-| all | quick validation (baseline **7800**; was 7795 before the Finding 5 fix) | `npm run test:quick --prefix packages/core` |
+| all | quick validation (baseline **7827** after step 3; was 7824 after step 2, 7814 after step 1, 7800 after the Finding 5 fix, 7795 before it) | `npm run test:quick --prefix packages/core` |
 | all | the reference gate | `npm run verify:reference --prefix packages/core` |
 | 1 | the new audit test itself | added in the step-1 PR |
 | 2, 3 | bundle size — the tree-shaking guard | `npm run snapshot:bundle-size --prefix packages/core` (`--check`, ±5% vs `scripts/bundle-snapshots/baseline.json`) |
@@ -512,11 +588,15 @@ was touched.
 - **A `factory` field in the manifest defeats tree-shaking** (Finding 9,
   measured: 177 B → 38 KB at four commands). Guard with the bundle-size snapshot,
   not by inspection.
-- **Registration mutates `COMMANDS`** (Finding 6). A test that reads
-  `parser-constants.COMMANDS` *after* any test in the same file constructed a
-  Runtime sees 60, not 59. Read the list from source text, or assert before
-  construction — `capability-ghosts.test.ts` imports the live Set and is exposed
-  to this ordering.
+- **Registration mutates `COMMANDS`** (Finding 6). Still true after step 3, but
+  the symptom moved: the built-in 59 are now in the seed from the start, so a
+  Runtime construction no longer changes the count. What still mutates it is
+  registration of anything the manifest does not name — a plugin, a custom
+  bundle, a command a test registers. A test that reads
+  `parser-constants.COMMANDS` after such a registration sees the extra entries.
+  Read the list from source text, or snapshot it before — `capability-ghosts.test.ts`
+  imports the live Set and is exposed to this ordering, and the audit snapshots
+  `STATIC_SEED` before its own Runtime for the same reason.
 - `export { X } from './f'` creates **no local binding** — import then export
   when moving registration points.
 - tsup multi-entry `splitting: false` **forks singletons** — verify at dist
@@ -618,3 +698,53 @@ was touched.
   oxlint clean, and `npm run snapshot:bundle-size` — the Finding 9 guard — all
   10 bundles within tolerance.
   Next action: step 3 (the four mechanical consumers, one PR).
+- 2026-07-28 — **Step 3 landed** (branch `feat/command-manifest-consumers`, off
+  `051dd47e`): the four mechanical consumers migrated, two driven and two
+  checked — see the table in the step-3 section. `parser-constants.COMMANDS` is
+  `new Set([...COMMAND_NAMES, 'for'])`; `runtime.ts`'s 59 registration calls are
+  one loop over the manifest against a private 55-entry `COMMAND_FACTORIES` map;
+  `verify:reference` scores `commands/index.ts` AND `reference/index.ts` against
+  the manifest instead of against each other (they used to be compared pairwise,
+  so an omission shared by both passed clean).
+  **Behavior preserved, measured not assumed:** a before/after registry oracle
+  (name → class, `metadata.aliases`, category, shared-implementation groups)
+  came back identical. The only two differences are intended —
+  `getCommandNames()` enumeration order is now alphabetical rather than
+  registration order (consumers sort it or use it for an error string), and the
+  static parser seed gained `pseudo-command`, which is Finding 6's disagreement
+  closing by construction. It is unreachable as a token anyway (`-` is not an
+  identifier character), so nothing parses differently.
+  **One measured constraint the brief did not anticipate, recorded above as
+  Finding 11:** deriving the seed as `COMMAND_MANIFEST.map(e => e.name)` shipped
+  the whole rich array into `hyperfixi-hx.js` — +4.8 KB raw, **+7.5%, a real
+  failure of the ±5% bundle-size gate** on a bundle with no command registry at
+  all. Finding 9's hazard one level down. Fixed with a `COMMAND_NAMES` literal
+  asserted equal to the entries as an ORDERED list. Step 4's consumers want the
+  rich entries, so this must be re-measured there, not assumed.
+  Two knock-ons outside `packages/core`: `language-server`'s
+  `command-tiers.test.ts` read core's `COMMANDS` literal by regex and now reads
+  `COMMAND_NAMES` from the manifest (the better anchor — `COMMANDS` is the
+  parser's set and carries `for`, while the file's title claims to check what
+  the engine executes); and step 4.4's `runtime.ts` docstring half is already
+  done (see that step).
+  The §2 gate was mutation-verified in **11** directions, all caught: a deleted
+  manifest entry, a deleted `COMMAND_NAMES` row with entries intact, a reordered
+  `COMMAND_NAMES`, a removed `COMMAND_FACTORIES` entry, a miswired one
+  (`toggle: createAddCommand`), a stray `registry.register()` outside the loop,
+  `parser-constants` reverted to a hand-written literal that happens to match
+  today, a dropped `commands/index.ts` factory export, a renamed
+  `reference/index.ts` entry, a deleted `COMMANDS.add` in `command-adapter.ts`
+  (Finding 6's mechanism), and a manifest name the LSP tiers still advertise.
+  Gates: core **7827** passing / 128 skipped / 300 files; `verify:reference`
+  clean (59 = 59); `snapshot:bundle-size` all 10 within tolerance; parser +
+  runtime 1873 passing; language-server 223 passing; Playwright
+  `src/compatibility/` 1111 passed / 8 skipped; typecheck, prettier, oxlint
+  clean.
+  **Note for step 4 on what the gate can no longer see:** the registry is now
+  DERIVED from the manifest, so "manifest names == registry names" is close to a
+  tautology. Two assertions carry that weight instead and must not be softened
+  into derivations — the hardcoded 59-name list in audit §1, and the new
+  per-command factory-identity test (each factory builds a command that calls
+  itself what the manifest calls it, and each alias row resolves to its
+  primary's instance with the alias declared in its `metadata.aliases`).
+  Next action: step 4.1 (LSP tiers — 23 unclassified, the arc's one live defect).

--- a/packages/core/scripts/verify-reference-data.ts
+++ b/packages/core/scripts/verify-reference-data.ts
@@ -8,12 +8,31 @@
  * - Command availability follows proper subset chain (lite ⊂ lite-plus ⊂ hybrid ⊂ full)
  * - All commands in reference have matching exports
  *
+ * ## The manifest is the spine (Arc A step 3)
+ *
+ * This script used to compare two hand-maintained lists against EACH OTHER —
+ * `commands/index.ts`'s factory aliases and `reference/index.ts`'s command
+ * entries — plus a count in `metadata.ts`. Two lists agreeing tells you they
+ * agree; it does not tell you either is right, and an identical omission in
+ * both passed clean.
+ *
+ * All three are now scored against `commands/manifest.ts`, which is itself
+ * gated against the live registry in both directions by
+ * `runtime/__tests__/command-manifest-audit.test.ts`. So the chain terminates
+ * at what the engine actually executes instead of closing on itself.
+ *
+ * Importing the manifest is safe here despite the "parse source text to avoid
+ * DOM dependency issues" rule the rest of this file follows: every import in
+ * `manifest.ts` is `import type`, so it pulls in no runtime code at all.
+ *
  * Run: npm run verify:reference
  */
 
 import { existsSync, readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
+
+import { COMMAND_MANIFEST, toRegisteredName } from '../src/commands/manifest';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CORE_ROOT = resolve(__dirname, '..');
@@ -30,18 +49,18 @@ function parseCommandFactories(): string[] {
 
   // Only process the TREE-SHAKEABLE section (before BACKWARD-COMPATIBLE)
   const treeshakeableEnd = content.indexOf('// BACKWARD-COMPATIBLE');
-  const treeshakeableSection = treeshakeableEnd > 0 ? content.substring(0, treeshakeableEnd) : content;
+  const treeshakeableSection =
+    treeshakeableEnd > 0 ? content.substring(0, treeshakeableEnd) : content;
 
   // Match all: createXxxCommand as yyy patterns (handles multiple exports per line)
   const aliasPattern = /create(\w+)Command\s+as\s+(\w+)/g;
 
   let match;
   while ((match = aliasPattern.exec(treeshakeableSection)) !== null) {
-    // Normalize: if_ -> if, break_ -> break, async_ -> async, defaultCmd -> default
-    let alias = match[2].replace(/_$/, '').toLowerCase();
-    // Also normalize Cmd suffix: defaultcmd -> default, processpartialscmd -> processpartials
-    alias = alias.replace(/cmd$/, '');
-    factories.add(alias);
+    // Normalize the export alias to the name the registry dispatches on:
+    // if_ -> if, defaultCmd -> default, pushUrl -> push, pseudo -> pseudo-command.
+    // Shared with the audit test so the two cannot normalize differently.
+    factories.add(toRegisteredName(match[2]));
   }
 
   return Array.from(factories);
@@ -55,7 +74,8 @@ function parseReferenceCommands(): Record<string, { category: string; availabili
   const commands: Record<string, { category: string; availability: string }> = {};
 
   // Match command entries: name: { ... category: 'xxx', ... availability: 'yyy' ... }
-  const commandBlockRegex = /^\s+(\w+):\s*\{[^}]*category:\s*'([^']+)'[^}]*availability:\s*'([^']+)'/gm;
+  const commandBlockRegex =
+    /^\s+(\w+):\s*\{[^}]*category:\s*'([^']+)'[^}]*availability:\s*'([^']+)'/gm;
 
   let match;
   while ((match = commandBlockRegex.exec(content)) !== null) {
@@ -109,6 +129,10 @@ const refCommands = parseReferenceCommands();
 const bundleInfo = parseBundleInfo();
 const packageInfo = parsePackageInfo();
 
+/** The registry-of-record every list below is scored against. */
+const manifestNames = COMMAND_MANIFEST.map(entry => entry.name);
+const manifestCommands = new Set(manifestNames);
+
 // =============================================================================
 // VERIFICATION FUNCTIONS
 // =============================================================================
@@ -123,7 +147,13 @@ interface VerificationResult {
 
 const results: VerificationResult[] = [];
 
-function verify(name: string, passed: boolean, message: string, details?: string[], isWarning?: boolean) {
+function verify(
+  name: string,
+  passed: boolean,
+  message: string,
+  details?: string[],
+  isWarning?: boolean
+) {
   results.push({ name, passed, message, details, isWarning });
 }
 
@@ -131,36 +161,44 @@ function verify(name: string, passed: boolean, message: string, details?: string
 // 1. VERIFY COMMAND COUNT
 // =============================================================================
 
+/** Score `list` against the manifest in both directions. */
+function diffAgainstManifest(list: string[]): { missing: string[]; extra: string[] } {
+  const present = new Set(list);
+  return {
+    missing: manifestNames.filter(n => !present.has(n)),
+    extra: [...new Set(list)].filter(n => !manifestCommands.has(n)).sort(),
+  };
+}
+
 function verifyCommandCount() {
-  // Count commands in reference
   const refCommandNames = Object.keys(refCommands);
-
-  const factoryCount = factoryNames.length;
-  const refCount = refCommandNames.length;
-
-  // Get the expected count from packageInfo
-  const expectedCount = packageInfo.commands;
+  const refNormalized = refCommandNames.map(toRegisteredName);
 
   const details: string[] = [];
 
-  if (factoryCount !== expectedCount) {
-    details.push(`  Factory exports: ${factoryCount}, packageInfo.commands: ${expectedCount}`);
+  // The manifest is the spine: every list is scored against IT, not against
+  // whichever other list happens to sit next to it. An omission shared by two
+  // hand-maintained lists used to pass this check clean.
+  if (packageInfo.commands !== manifestNames.length) {
+    details.push(
+      `  packageInfo.commands: ${packageInfo.commands}, manifest: ${manifestNames.length}`
+    );
   }
 
-  if (refCount !== expectedCount) {
-    details.push(`  Reference commands: ${refCount}, packageInfo.commands: ${expectedCount}`);
+  const factories = diffAgainstManifest(factoryNames);
+  if (factories.missing.length > 0) {
+    details.push(`  Manifest commands with no factory export: ${factories.missing.join(', ')}`);
+  }
+  if (factories.extra.length > 0) {
+    details.push(`  Factory exports the manifest does not name: ${factories.extra.join(', ')}`);
   }
 
-  // Find factories without reference entries
-  const refLower = refCommandNames.map((n) => n.toLowerCase());
-  const missingInRef = factoryNames.filter((f) => !refLower.includes(f));
-  const extraInRef = refLower.filter((r) => !factoryNames.includes(r));
-
-  if (missingInRef.length > 0) {
-    details.push(`  Commands missing from reference: ${missingInRef.join(', ')}`);
+  const reference = diffAgainstManifest(refNormalized);
+  if (reference.missing.length > 0) {
+    details.push(`  Manifest commands missing from reference: ${reference.missing.join(', ')}`);
   }
-  if (extraInRef.length > 0) {
-    details.push(`  Extra commands in reference: ${extraInRef.join(', ')}`);
+  if (reference.extra.length > 0) {
+    details.push(`  Reference entries the manifest does not name: ${reference.extra.join(', ')}`);
   }
 
   const passed = details.length === 0;
@@ -168,8 +206,8 @@ function verifyCommandCount() {
     'Command Count',
     passed,
     passed
-      ? `✓ ${refCount} commands in reference match ${factoryCount} factories`
-      : `✗ Command count mismatch`,
+      ? `✓ ${manifestNames.length} manifest commands match ${factoryNames.length} factory exports and ${refCommandNames.length} reference entries`
+      : `✗ Command set mismatch against commands/manifest.ts`,
     details.length > 0 ? details : undefined
   );
 }
@@ -211,7 +249,7 @@ function verifyBundleFiles() {
     passed
       ? `✓ All ${bundleInfo.length} bundle files exist in dist/`
       : `⚠ ${missingBundles.length} bundle files missing (${foundBundles.length} found)`,
-    missingBundles.length > 0 ? missingBundles.map((b) => `  ${b}`) : undefined,
+    missingBundles.length > 0 ? missingBundles.map(b => `  ${b}`) : undefined,
     true // Mark as warning - don't fail CI for missing bundles
   );
 }
@@ -303,7 +341,7 @@ function verifyCategories() {
     'Valid Categories',
     passed,
     passed ? `✓ All commands have valid categories` : `✗ Invalid categories found`,
-    invalidCategories.length > 0 ? invalidCategories.map((c) => `  ${c}`) : undefined
+    invalidCategories.length > 0 ? invalidCategories.map(c => `  ${c}`) : undefined
   );
 }
 
@@ -327,7 +365,7 @@ function verifyAvailabilities() {
     'Valid Availabilities',
     passed,
     passed ? `✓ All commands have valid availabilities` : `✗ Invalid availabilities found`,
-    invalidAvailabilities.length > 0 ? invalidAvailabilities.map((a) => `  ${a}`) : undefined
+    invalidAvailabilities.length > 0 ? invalidAvailabilities.map(a => `  ${a}`) : undefined
   );
 }
 
@@ -374,7 +412,7 @@ function verifyBundleCommandCounts() {
   }
 
   // Verify browser (full) bundle has all commands
-  const browserBundle = bundleInfo.find((b) => b.id === 'browser');
+  const browserBundle = bundleInfo.find(b => b.id === 'browser');
   if (browserBundle && browserBundle.commandCount !== packageInfo.commands) {
     errors.push(
       `Browser bundle has ${browserBundle.commandCount} commands, expected ${packageInfo.commands}`
@@ -384,7 +422,7 @@ function verifyBundleCommandCounts() {
   // Derive, don't trust: compare each list-publishing bundle's advertised count
   // against the commands it actually ships.
   for (const [id, sourceFile] of Object.entries(BUNDLES_WITH_COMMAND_LISTS)) {
-    const bundle = bundleInfo.find((b) => b.id === id);
+    const bundle = bundleInfo.find(b => b.id === id);
     if (!bundle) continue;
     const actual = actualCommandCount(sourceFile);
     if (actual === null) {
@@ -400,9 +438,7 @@ function verifyBundleCommandCounts() {
   verify(
     'Bundle Command Counts',
     passed,
-    passed
-      ? `✓ Bundle command counts are reasonable`
-      : `✗ Bundle command count issues`,
+    passed ? `✓ Bundle command counts are reasonable` : `✗ Bundle command count issues`,
     errors.length > 0 ? errors : undefined
   );
 }

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -20,6 +20,29 @@
  *   { expressionEvaluator: createCoreExpressionEvaluator() }
  * );
  * ```
+ *
+ * ## Relationship to the command manifest (Arc A step 3)
+ *
+ * `commands/manifest.ts` is the registry-of-record for WHICH commands exist.
+ * This file is **manifest-checked, not manifest-driven**, and that is
+ * deliberate: these are `export … from` statements, and the only way to
+ * generate them from data is an object literal referencing all 59 factories —
+ * which pins every one of them and defeats tree-shaking for consumers that
+ * import a single command (Finding 9, measured at 177 B → 38 KB). Explicit
+ * re-exports are what make this file shakeable, so they stay explicit.
+ *
+ * The gate is `runtime/__tests__/command-manifest-audit.test.ts` §2, which
+ * parses the tree-shakeable section below and asserts its alias set equals the
+ * registry's in BOTH directions — an added command missing an export here
+ * fails, and so does an export naming a command that does not exist.
+ * `scripts/verify-reference-data.ts` scores the same section against the
+ * manifest.
+ *
+ * Four aliases below are spelled differently from the name the command
+ * registers under (`pushUrl` → `push`, `replaceUrl` → `replace`,
+ * `processPartialsCmd` → `process`, `pseudo` → `pseudo-command`). Both gates
+ * normalize through `COMMAND_LIST_SPELLINGS` in the manifest; the aliases are
+ * published API and so are not renamed to match.
  */
 
 // =============================================================================

--- a/packages/core/src/commands/manifest.ts
+++ b/packages/core/src/commands/manifest.ts
@@ -6,14 +6,30 @@
  * currently described in ~20 hand-maintained places; this file is the one that
  * the others will be migrated onto, one consumer per PR (steps 3 and 4).
  *
- * ## Status: consumed by nobody, deliberately
+ * ## Status: the four mechanical consumers are migrated (step 3)
  *
- * Nothing imports this module yet. That is the point of step 2 — the manifest
- * becomes real and gated before anything depends on it, so its arrival carries
- * zero behavioral risk. Its gate lives in
- * `runtime/__tests__/command-manifest-audit.test.ts` (§7), beside the step-1
- * audit whose registry derivation and allowlists it reuses rather than
- * re-deriving.
+ * Step 2 landed this file consumed by nobody, deliberately — the manifest
+ * became real and gated before anything depended on it, so its arrival carried
+ * zero behavioral risk. Step 3 then pointed the four lists that already agreed
+ * with it (the brief's Claim 2) at this array:
+ *
+ * | Consumer | Relationship | Where |
+ * | -------- | ------------ | ----- |
+ * | `parser/parser-constants.ts` `COMMANDS` | **driven** — the seed IS the manifest names + the parser-only `for` | `parser-constants.ts` |
+ * | `runtime/runtime.ts` registration | **driven** — one loop over the manifest, `COMMAND_FACTORIES` supplies the factory per name | `runtime.ts` |
+ * | `commands/index.ts` factory aliases | **checked** — re-export statements cannot be generated without pinning all 59 (Finding 9) | audit §2 |
+ * | `reference/index.ts` + `metadata.ts` counts | **checked** — the manifest is now `verify:reference`'s spine | `scripts/verify-reference-data.ts` |
+ *
+ * Finding 6 is honored by the first two rows together: the static parser seed
+ * and the registration-time `COMMANDS.add` were two halves of one mechanism,
+ * and the manifest now feeds both halves rather than the runtime patching the
+ * parser at construction time. `command-adapter.ts`'s `COMMANDS.add` stays —
+ * it is what teaches the parser about commands registered from OUTSIDE the
+ * manifest (plugins, tests, custom bundles), and the audit pins that.
+ *
+ * The gate lives in `runtime/__tests__/command-manifest-audit.test.ts` (§7),
+ * beside the step-1 audit whose registry derivation and allowlists it reuses
+ * rather than re-deriving.
  *
  * ## Data-only, and why that is load-bearing (Finding 9)
  *
@@ -30,11 +46,18 @@
  * At 59 commands a `factory` field would pull the entire command set into any
  * bundle that merely wants the name list — and the intended consumers
  * (`template-capabilities`, the bundle generator, the LSP tier lists) are
- * exactly the slim-bundle-facing ones. If a factory map is ever wanted it is a
- * separate module, imported only by `runtime/runtime.ts`, which already imports
- * all 59 anyway. Every import below is `import type`, so this module erases to
- * a single array literal. The guard is
+ * exactly the slim-bundle-facing ones. Every import below is `import type`, so
+ * this module erases to two plain data literals. The guard is
  * `npm run snapshot:bundle-size --prefix packages/core`, not inspection.
+ *
+ * Step 3's manifest-driven registration loop needs a name → factory map, and
+ * that map lives in `runtime/runtime.ts` rather than here for exactly this
+ * reason: `runtime.ts` already imports every command implementation, so the
+ * pinning it causes is already paid there and nowhere else.
+ * `parser-constants.ts` imports the manifest for its names and gets no
+ * factories with them — which is the whole point of the split: a names-only
+ * consumer must never pull the command implementations in behind them. The
+ * data payload has the same hazard one level down; see {@link COMMAND_NAMES}.
  *
  * ## Where each field's values come from
  *
@@ -150,11 +173,102 @@ export interface CommandManifestEntry {
 }
 
 /**
+ * Just the names, for consumers that want the command SET and none of the
+ * facts about it.
+ *
+ * ## Why this is a second literal and not `COMMAND_MANIFEST.map(e => e.name)`
+ *
+ * Same hazard as Finding 9's `factory` field, one level down: a `.map()` over
+ * the entries references the entries, so the whole rich array — `category`,
+ * `tier`, `upstreamOrExtension`, `multiword` for 59 commands — survives into
+ * any bundle that wanted a name list. Measured on `hyperfixi-hx.js` (18 KB
+ * gzipped, a hybrid-parser bundle with no command registry at all) when
+ * `parser-constants.ts` derived its `COMMANDS` seed that way in step 3:
+ *
+ * ```text
+ * names via COMMAND_MANIFEST.map()   raw 73.3 KB  (+7.5%, over the ±5% gate)
+ * names via COMMAND_NAMES            raw 69.1 KB  (+0.9%)
+ * ```
+ *
+ * The entries are shaken out entirely by the second form, because nothing in
+ * that bundle's graph mentions them.
+ *
+ * ## This is not a hand-maintained second copy
+ *
+ * The audit asserts the two are equal **as ordered lists**, so a command added
+ * to one and not the other fails the gate rather than drifting — which is the
+ * only property that matters. It is the same trade Finding 9 already forced for
+ * `commands/index.ts`: an explicit list, gated at tolerance 0, because
+ * generating it would pin what must stay shakeable.
+ */
+export const COMMAND_NAMES: readonly string[] = [
+  'add',
+  'append',
+  'async',
+  'beep',
+  'blur',
+  'break',
+  'breakpoint',
+  'call',
+  'clear',
+  'close',
+  'continue',
+  'copy',
+  'decrement',
+  'default',
+  'empty',
+  'exit',
+  'fetch',
+  'focus',
+  'get',
+  'go',
+  'halt',
+  'hide',
+  'if',
+  'increment',
+  'install',
+  'js',
+  'log',
+  'make',
+  'measure',
+  'morph',
+  'open',
+  'pick',
+  'prepend',
+  'process',
+  'pseudo-command',
+  'push',
+  'put',
+  'remove',
+  'render',
+  'repeat',
+  'replace',
+  'reset',
+  'return',
+  'scroll',
+  'select',
+  'send',
+  'set',
+  'settle',
+  'show',
+  'start',
+  'swap',
+  'take',
+  'tell',
+  'throw',
+  'toggle',
+  'transition',
+  'trigger',
+  'unless',
+  'wait',
+];
+
+/**
  * All 59 registered commands, in registry (sorted) order.
  *
- * Adding or removing a command means editing this array **and** the registry
- * list in the audit — the gate compares them as sets in both directions, so
- * neither can move alone.
+ * Adding or removing a command means editing this array, {@link COMMAND_NAMES}
+ * above, **and** the registry list in the audit — the gate compares all three
+ * in both directions, so none can move alone.
  */
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   { name: 'add', category: 'dom', tier: 'lite', upstreamOrExtension: 'upstream', multiword: true },
@@ -545,3 +659,42 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     multiword: false,
   },
 ];
+
+/**
+ * Four commands are SPELLED differently in the two published lists than the
+ * name they register under, mapped here (lowercased, `_`/`Cmd` suffixes already
+ * stripped) → the registered name.
+ *
+ * `commands/index.ts` exports `createPushUrlCommand as pushUrl` and
+ * `reference/index.ts` keys the same command `pushUrl`, but the registry
+ * dispatches it as `push` (the parsing name — `push url "/x"` parses,
+ * `pushUrl "/x"` does not; that gap was the Finding 5 ghost, #810). Both
+ * spellings are **public API** — the export alias is part of
+ * `@hyperfixi/core/commands` and the reference key is part of the docs surface
+ * — so they are normalized here rather than renamed.
+ *
+ * This map is exported because two step-3 consumers need the same
+ * normalization and a second copy would be the twenty-first hand-maintained
+ * place this arc exists to remove: the audit
+ * (`runtime/__tests__/command-manifest-audit.test.ts`) and
+ * `scripts/verify-reference-data.ts`. It is a separate export from
+ * `COMMAND_MANIFEST` so a names-only consumer shakes it out.
+ */
+export const COMMAND_LIST_SPELLINGS: Readonly<Record<string, string>> = {
+  processpartials: 'process',
+  pushurl: 'push',
+  replaceurl: 'replace',
+  pseudo: 'pseudo-command',
+};
+
+/**
+ * Normalize a name as `commands/index.ts` or `reference/index.ts` spells it to
+ * the name the registry dispatches on: strip the `_` suffix that keeps
+ * reserved words legal identifiers (`if_`, `break_`), strip the `Cmd` suffix
+ * that does the same for `default`/`processPartials`, lowercase, then apply
+ * {@link COMMAND_LIST_SPELLINGS}.
+ */
+export function toRegisteredName(listSpelling: string): string {
+  const lower = listSpelling.replace(/_$/, '').replace(/Cmd$/, '').toLowerCase();
+  return COMMAND_LIST_SPELLINGS[lower] ?? lower;
+}

--- a/packages/core/src/parser/parser-constants.ts
+++ b/packages/core/src/parser/parser-constants.ts
@@ -3,6 +3,8 @@
  * Centralized location for all keywords, commands, and magic strings used in parser
  */
 
+import { COMMAND_NAMES } from '../commands/manifest';
+
 /**
  * Core hyperscript keywords used in expressions and control flow
  */
@@ -88,71 +90,47 @@ export const COMMAND_TERMINATORS = [
 ] as const;
 
 /**
- * All hyperscript commands
+ * Every name the parser will accept in command position.
+ *
+ * ## Manifest-driven (Arc A step 3)
+ *
+ * The registered commands come from `commands/manifest.ts`, not from a hand-
+ * maintained copy of it. This was one of the four lists the manifest arc names
+ * as "already agreeing" (the brief's Claim 2), and it is now derived rather
+ * than merely agreeing.
+ *
+ * It imports `COMMAND_NAMES`, deliberately, and not `COMMAND_MANIFEST`. The
+ * parser wants the command SET; it has no use for each command's category,
+ * tier, or upstream classification, and referencing the rich array would ship
+ * all of it — measured at +4.8 KB raw in `hyperfixi-hx.js`, a hybrid-parser
+ * bundle with no command registry at all, which is enough to break the ±5%
+ * bundle-size gate on its own. See the note on `COMMAND_NAMES`.
+ *
+ * ## This Set is mutable at runtime, deliberately (Finding 6)
+ *
+ * `runtime/command-adapter.ts`'s `register()` calls `COMMANDS.add(name)` for
+ * every command AND every `metadata.aliases` entry, so the parser learns about
+ * commands the manifest never named — plugins, custom bundles, commands
+ * registered by a test. Before step 3 that mechanism was also load-bearing for
+ * a *manifest* command (`pseudo-command` was absent from the seed and only
+ * appeared once a Runtime existed, which made the standalone parser and the
+ * post-Runtime parser disagree). The manifest now feeds both halves, so
+ * registration only ever ADDS to what is already here for the built-in 59.
+ *
+ * Practical consequence for tests: a test that reads this Set after any other
+ * test in the same file constructed a Runtime sees whatever that Runtime
+ * registered. Snapshot it before construction if that matters.
  */
-export const COMMANDS = new Set([
-  'add',
-  'append',
-  'async',
-  'beep',
-  'blur',
-  'break',
-  'breakpoint',
-  'call',
-  'clear',
-  'close',
-  'continue',
-  'copy',
-  'decrement',
-  'default',
-  'empty',
-  'exit',
-  'fetch',
-  'focus',
+export const COMMANDS = new Set<string>([
+  ...COMMAND_NAMES,
+  // Parser-only, with no command implementation and so no manifest row: `for`
+  // is the loop KEYWORD (`for x in y`), accepted in command position and
+  // handled by `parseForCommand`, which builds the same node shape `repeat`'s
+  // `for` loop type produces. It is also in CONTROL_FLOW_COMMANDS below.
+  // `while` is deliberately NOT here: it is only ever reached inside `repeat`'s
+  // own syntax (`repeat while <cond>`, and as a repeat-block terminator), never
+  // in command position.
   'for',
-  'get',
-  'go',
-  'halt',
-  'hide',
-  'open',
-  'if',
-  'increment',
-  'install',
-  'js',
-  'log',
-  'make',
-  'measure',
-  'morph', // htmx-like: DOM morphing with state preservation
-  'pick',
-  'prepend',
-  'process', // htmx-like: process partials
-  'push', // htmx-like: push url to history
-  'put',
-  'remove',
-  'render',
-  'repeat',
-  'replace', // htmx-like: replace url in history
-  'reset',
-  'return',
-  'scroll', // scroll to <target> (upstream _hyperscript 0.9.90)
-  'select',
-  'send',
-  'set',
-  'settle',
-  'show',
-  // `start` is currently a parse-prefix for `start view transition <body> end`
-  // (upstream _hyperscript animations.js:298-372). The parser dispatches to a
-  // dedicated parseStartCommand to handle the multi-word form.
-  'start',
-  'swap', // htmx-like: DOM swapping with multiple strategies
-  'take',
-  'tell',
-  'throw',
-  'toggle',
-  'transition',
-  'trigger',
-  'unless',
-  'wait',
 ]);
 
 /**

--- a/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
+++ b/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
@@ -32,9 +32,21 @@
  * ## Ordering constraint (Finding 6)
  *
  * `command-adapter.ts`'s `register()` does `COMMANDS.add(name)`, so the parser's
- * static seed grows from 59 to 60 entries the moment a Runtime is constructed.
- * The seed snapshot below is taken BEFORE the Runtime that derives the registry,
- * and the mutation itself is pinned as a test — step 3 must account for it.
+ * command set is mutable and grows whenever anything is registered. The seed
+ * snapshot below is therefore still taken BEFORE the Runtime that derives the
+ * registry: a snapshot taken after would be measuring the runtime, not the
+ * seed. Step 3 made the seed manifest-derived, so the built-in 59 no longer
+ * arrive by mutation — but the mutation itself remains live for commands from
+ * outside the manifest, and §2 pins it on a synthetic command.
+ *
+ * ## What is still independent, post-step-3
+ *
+ * The registry is now DERIVED from the manifest (`runtime.ts` loops it), so
+ * "the manifest names equal the registry names" no longer compares two
+ * independently-authored lists. Two things carry that weight instead, and
+ * neither may be softened into a derivation: the hardcoded 59-name list in §1,
+ * and the per-command factory identity check in §2 (each factory builds a
+ * command that calls itself what the manifest calls it).
  *
  * ## Cross-package reads
  *
@@ -50,7 +62,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 import { COMMANDS, COMPOUND_COMMANDS } from '../../parser/parser-constants';
-import { COMMAND_MANIFEST } from '../../commands/manifest';
+import { COMMAND_MANIFEST, COMMAND_NAMES, toRegisteredName } from '../../commands/manifest';
 import {
   AVAILABLE_COMMANDS,
   AVAILABLE_BLOCKS,
@@ -88,23 +100,19 @@ function gapsIn(list: Iterable<string>): string[] {
 }
 
 /**
- * The four alias-name spellings. `commands/index.ts`, `reference/index.ts`, and
- * the `runtime.ts` registration block all spell four commands differently from
- * their registered names (`createPushUrlCommand` registers `push`, etc.). One
- * map, applied after lowercasing, normalizes all three lists.
+ * `commands/index.ts` and `reference/index.ts` spell four commands differently
+ * from their registered names (`createPushUrlCommand as pushUrl` registers
+ * `push`, etc.). Both spellings are published API, so they are normalized
+ * rather than renamed.
+ *
+ * The map lives in `commands/manifest.ts` as `COMMAND_LIST_SPELLINGS` rather
+ * than here, because `scripts/verify-reference-data.ts` needs the identical
+ * normalization and two copies of it would be one more hand-maintained place
+ * (step 3). A local copy previously also carried `startviewtransition` for the
+ * `runtime.ts` registration block; that block is now a manifest-driven loop
+ * keyed on registered names, so the entry has no reader left.
  */
-const SPELLINGS: Record<string, string> = {
-  processpartials: 'process',
-  pushurl: 'push',
-  replaceurl: 'replace',
-  pseudo: 'pseudo-command',
-  startviewtransition: 'start', // registration stem only; the export alias is already `start`
-};
-
-function normalize(name: string): string {
-  const lower = name.replace(/_$/, '').replace(/Cmd$/, '').toLowerCase();
-  return SPELLINGS[lower] ?? lower;
-}
+const normalize = toRegisteredName;
 
 // ===========================================================================
 // 1. The registry — the arc's source of truth
@@ -114,6 +122,12 @@ describe('the registry', () => {
   it('registers exactly the 59 documented commands', () => {
     // Adding or removing a command must edit this list deliberately, the same
     // way command-output-contract.test.ts demands a row per command.
+    //
+    // Since step 3 this is also the arc's LAST independently-authored copy of
+    // the command set — everything else is derived from or checked against the
+    // manifest, and the manifest is what this list holds to account. Do not
+    // replace it with `COMMAND_MANIFEST.map(e => e.name)`; that would make the
+    // whole file self-confirming.
     expect(REGISTRY).toEqual([
       'add',
       'append',
@@ -177,13 +191,30 @@ describe('the registry', () => {
     ]);
   });
 
-  it('registration mutates the parser static seed (Finding 6)', () => {
-    // The seed is a static list the parser uses standalone; registration then
-    // augments it (`COMMANDS.add` in command-adapter.ts). Step 3 must treat the
-    // seed and the registration-time add as two halves of one mechanism, not as
-    // an independent hand-maintained copy.
-    expect(STATIC_SEED.has('pseudo-command')).toBe(false);
-    expect(COMMANDS.has('pseudo-command')).toBe(true);
+  it('registration still teaches the parser about non-manifest commands (Finding 6)', () => {
+    // `command-adapter.ts`'s register() does `COMMANDS.add(name)`, so the
+    // parser's command set grows at runtime. Before step 3 this was measurable
+    // on a BUILT-IN: `pseudo-command` was absent from the static seed and
+    // appeared only once a Runtime existed, so the standalone parser and the
+    // post-Runtime parser disagreed about a shipped command. The manifest now
+    // feeds both halves (see the seed test below), so that particular symptom
+    // is gone — but the mechanism itself is still load-bearing for commands
+    // the manifest never names: plugins, custom bundles, commands a test
+    // registers. Pinned here on a synthetic command so it cannot be deleted as
+    // dead code.
+    const name = 'audit-synthetic-command';
+    expect(COMMANDS.has(name)).toBe(false);
+
+    const registry = new Runtime().getRegistry();
+    registry.register({ name, metadata: { name, aliases: ['audit-synthetic-alias'] } });
+
+    expect(COMMANDS.has(name)).toBe(true);
+    expect(COMMANDS.has('audit-synthetic-alias')).toBe(true);
+
+    // Leave the module-level Set as it was found — it is shared process state
+    // and later assertions in this file read it.
+    COMMANDS.delete(name);
+    COMMANDS.delete('audit-synthetic-alias');
   });
 });
 
@@ -192,12 +223,25 @@ describe('the registry', () => {
 // ===========================================================================
 
 describe('the four core lists agree with the registry', () => {
-  it('parser-constants COMMANDS: the static seed differs only by for / pseudo-command', () => {
-    // `for` is a control-flow keyword with no command implementation, extra in
-    // the seed by design; `pseudo-command` is added at registration time (see
-    // the Finding 6 test above). Neither is rot.
+  it('parser-constants COMMANDS: the static seed is the manifest plus `for`', () => {
+    // Step 3 made this DERIVED, not merely agreeing. The one remaining
+    // divergence is `for`: a control-flow keyword the parser accepts in command
+    // position (parseForCommand) with no command implementation and so no
+    // manifest row. `pseudo-command` used to be the gap in the other direction
+    // — the seed lacked it and only registration supplied it — and deriving the
+    // seed closed that by construction.
     expect(ghostsIn(STATIC_SEED)).toEqual(['for']);
-    expect(gapsIn(STATIC_SEED)).toEqual(['pseudo-command']);
+    expect(gapsIn(STATIC_SEED)).toEqual([]);
+    expect(STATIC_SEED.size).toBe(REGISTRY.length + 1);
+
+    // Derivation, asserted rather than assumed: reverting the seed to a
+    // hand-written copy that happens to match today would pass the two checks
+    // above, so pin the source text too. `COMMAND_NAMES` and not
+    // `COMMAND_MANIFEST` — see the manifest's note; the rich array would ship
+    // into every bundle that reaches the parser constants.
+    const source = readFileSync(resolve(DIR, '../../parser/parser-constants.ts'), 'utf-8');
+    expect(source).toMatch(/import \{ COMMAND_NAMES \} from '\.\.\/commands\/manifest'/);
+    expect(source).toMatch(/new Set<string>\(\[\s*\.\.\.COMMAND_NAMES,/);
   });
 
   it('commands/index.ts exports one tree-shakeable factory per registered command', () => {
@@ -217,18 +261,72 @@ describe('the four core lists agree with the registry', () => {
     expect([...documented].sort()).toEqual(REGISTRY);
   });
 
-  it('runtime.ts registers every command with a uniform factory call', () => {
+  it('runtime.ts has exactly one registration site, and it loops the manifest', () => {
+    // Claim 1 was "59 flat, perfectly uniform `register(createXCommand())`
+    // calls", which is what made the block step 3's most mechanical target.
+    // They are now one loop. Pinning the count at 1 is strictly stronger than
+    // pinning uniformity at 59: a hand-added registration outside the loop —
+    // the way a command would once again come to exist without a manifest row
+    // — fails here.
     const source = readFileSync(resolve(DIR, '../runtime.ts'), 'utf-8');
-    const uniform = [...source.matchAll(/registry\.register\(create(\w+)Command\(\)\);/g)].map(m =>
-      normalize(m[1])
-    );
-    const anyRegister = [...source.matchAll(/registry\.register\(/g)];
-    // Claim 1: all registration calls have the exact `register(createXCommand())`
-    // shape — no arguments, no conditionals. This uniformity is what makes the
-    // block step 3's most mechanical migration target.
-    expect(anyRegister.length).toBe(uniform.length);
-    expect(uniform.length).toBe(59);
-    expect([...uniform].sort()).toEqual(REGISTRY);
+    // Anchored at statement position so the prose in the file header, which
+    // quotes the old `registry.register(createXCommand())` shape, is not
+    // counted as a second site.
+    expect([...source.matchAll(/^\s*registry\.register\(/gm)]).toHaveLength(1);
+    expect(source).toMatch(/for \(const entry of COMMAND_MANIFEST\)/);
+  });
+
+  it('runtime.ts supplies a factory for every manifest command that needs one', () => {
+    // The COMMAND_FACTORIES map is module-private (exporting it would publish
+    // an internal and, worse, invite a slim bundle to import it — the map is
+    // Finding 9's whole hazard), so it is read from source text, the same way
+    // the LSP tier lists are.
+    const source = readFileSync(resolve(DIR, '../runtime.ts'), 'utf-8');
+    const block = source.match(/const COMMAND_FACTORIES[\s\S]*?= \{([\s\S]*?)\n\};/);
+    expect(block, 'the COMMAND_FACTORIES literal moved or changed shape').not.toBeNull();
+
+    // Keys are bare identifiers or quoted (`'pseudo-command'`), values are the
+    // factory identifier — never a call, since the map holds factories, not
+    // instances. A trailing `// + the \`send\` alias` note is allowed.
+    const keys = [
+      ...block![1].matchAll(/^\s{2}'?([\w-]+)'?:\s*create\w+Command,\s*(?:\/\/.*)?$/gm),
+    ].map(m => m[1]);
+
+    // 59 commands, 55 factories: the four consolidation-alias rows are
+    // registered from their primary's metadata.aliases, not from a factory of
+    // their own. Set equality both ways, so a factory for a command the
+    // manifest does not name fails just as loudly as a missing one.
+    const needsFactory = COMMAND_MANIFEST.filter(e => !e.consolidationAliasOf).map(e => e.name);
+    expect(needsFactory).toHaveLength(55);
+    expect([...keys].sort()).toEqual([...needsFactory].sort());
+  });
+
+  it('each factory builds a command that registers under its manifest name', () => {
+    // The check that keeps the loop honest. With registration manifest-driven,
+    // "the manifest names equal the registry names" is very nearly a tautology
+    // — this is not. A map entry pointing at the wrong factory (`toggle:
+    // createAddCommand`) would register `add` twice and leave `toggle` absent,
+    // and the identity below is what names the mistake instead of leaving it
+    // to the hardcoded 59-name list above to report as a bare diff.
+    const registered = new Runtime().getRegistry();
+    for (const entry of COMMAND_MANIFEST) {
+      const impl = registered.getImplementation(entry.name) as
+        { name: string; metadata?: { aliases?: string[] } } | undefined;
+      expect(impl, `${entry.name} has no implementation`).toBeDefined();
+
+      if (entry.consolidationAliasOf) {
+        // An alias row resolves to its PRIMARY's implementation, and that
+        // implementation is what declares the alias — i.e. the row exists
+        // because `command-adapter.ts` acted on `metadata.aliases`, not
+        // because something registered it directly.
+        expect(impl!.name.toLowerCase(), `${entry.name} primary`).toBe(entry.consolidationAliasOf);
+        expect(impl!.metadata?.aliases ?? [], `${entry.name} alias declaration`).toContain(
+          entry.name
+        );
+      } else {
+        expect(impl!.name.toLowerCase(), `${entry.name} self-name`).toBe(entry.name);
+      }
+    }
   });
 });
 
@@ -557,6 +655,17 @@ describe('the command manifest', () => {
 
   it('is sorted in registry order, so the diff of an added command is one line', () => {
     expect(COMMAND_MANIFEST.map(e => e.name)).toEqual(REGISTRY);
+  });
+
+  it('COMMAND_NAMES is the same list, in the same order', () => {
+    // The names are a second literal in the manifest module rather than
+    // `COMMAND_MANIFEST.map(e => e.name)`, because a `.map()` references the
+    // rich entries and drags all of them into names-only bundles (measured:
+    // +4.8 KB raw in hyperfixi-hx.js, past the ±5% size gate). Equality as
+    // ORDERED lists, not as sets, so the two cannot drift in either content or
+    // order — which is what makes the split a shape change rather than a
+    // second hand-maintained copy.
+    expect(COMMAND_NAMES).toEqual(COMMAND_MANIFEST.map(e => e.name));
   });
 
   it('carries no factory field, and no field the schema does not name (Finding 9)', () => {

--- a/packages/core/src/runtime/runtime.ts
+++ b/packages/core/src/runtime/runtime.ts
@@ -1,14 +1,32 @@
 /**
- * Hyperscript runtime entry point. Extends `RuntimeBase` with the
- * concrete command registry and the default set of 48 commands.
+ * Hyperscript runtime entry point. Extends `RuntimeBase` with the concrete
+ * command registry and the full command set.
+ *
+ * ## The command set is manifest-driven (Arc A step 3)
+ *
+ * The constructor no longer holds one `registry.register(createXCommand())`
+ * line per command. It loops `COMMAND_MANIFEST` and looks each name up in
+ * {@link COMMAND_FACTORIES} below, so `commands/manifest.ts` decides WHICH
+ * commands the default runtime has and this file only supplies HOW to build
+ * each one. Adding a command means adding a manifest row and a factory entry;
+ * omitting either is a startup error rather than a silent absence.
+ *
+ * This file is Finding 9's stated exception to "manifest-checked, not
+ * manifest-driven": a factory map defeats tree-shaking (measured, 177 B →
+ * 38 KB for a names-only consumer at four commands), but `runtime.ts` already
+ * imports every command implementation, so the pinning is already paid here.
+ * Slim bundles (`compatibility/browser-bundle-*.ts`) keep their explicit
+ * per-bundle imports and must NOT adopt this map.
  */
 
 import { RuntimeBase, type RuntimeBaseOptions } from './runtime-base';
 import { CommandRegistryV2 } from './command-adapter';
 import { createFullExpressionRegistry } from '../expressions/index';
+import { COMMAND_MANIFEST } from '../commands/manifest';
 
-// Import all 48 V2 commands
-// DOM Commands (11) - includes htmx-like swap/morph/process-partials and v0.9.90 `empty`
+// Every command factory the default runtime can build. Grouped by source
+// directory; the authoritative *set* is the manifest, not these groupings.
+// DOM Commands - includes htmx-like swap/morph/process-partials and v0.9.90 `empty`
 import { createHideCommand } from '../commands/dom/hide';
 import { createShowCommand } from '../commands/dom/show';
 import { createAddCommand } from '../commands/dom/add';
@@ -24,31 +42,28 @@ import { createResetCommand } from '../commands/dom/reset';
 import { createSwapCommand, createMorphCommand } from '../commands/dom/swap';
 import { createProcessPartialsCommand } from '../commands/dom/process-partials';
 
-// Async Commands (2)
+// Async Commands
 import { createWaitCommand } from '../commands/async/wait';
 import { createFetchCommand } from '../commands/async/fetch';
 
-// Data Commands (5) — + clear (v0.9.90)
+// Data Commands — + clear (v0.9.90)
 import { createSetCommand } from '../commands/data/set';
 import { createGetCommand } from '../commands/data/get';
 import { createIncrementCommand } from '../commands/data/increment';
-import { createDecrementCommand } from '../commands/data/decrement';
 import { createClearCommand } from '../commands/data/clear';
 
-// Utility Commands (1)
+// Utility Commands
 import { createLogCommand } from '../commands/utility/log';
 
-// Event Commands (2)
+// Event Commands
 import { createTriggerCommand } from '../commands/events/trigger';
-import { createSendCommand } from '../commands/events/send';
 
-// Navigation Commands (3) - includes htmx-like push/replace url
+// Navigation Commands - includes htmx-like push/replace url
 import { createGoCommand } from '../commands/navigation/go';
 import { createPushUrlCommand } from '../commands/navigation/push-url';
-import { createReplaceUrlCommand } from '../commands/navigation/replace-url';
 import { createScrollCommand } from '../commands/navigation/scroll-to';
 
-// Control Flow Commands (7)
+// Control Flow Commands
 import { createIfCommand } from '../commands/control-flow/if';
 import { createRepeatCommand } from '../commands/control-flow/repeat';
 import { createBreakCommand } from '../commands/control-flow/break';
@@ -56,47 +71,174 @@ import { createContinueCommand } from '../commands/control-flow/continue';
 import { createHaltCommand } from '../commands/control-flow/halt';
 import { createReturnCommand } from '../commands/control-flow/return';
 import { createExitCommand } from '../commands/control-flow/exit';
+import { createThrowCommand } from '../commands/control-flow/throw';
 
-// Execution Commands (3) - includes v0.9.90 focus/blur
+// Execution Commands - includes v0.9.90 focus/blur
 import { createCallCommand } from '../commands/execution/call';
 import { createFocusCommand } from '../commands/execution/focus';
 import { createBlurCommand } from '../commands/execution/blur';
+import { createPseudoCommand } from '../commands/execution/pseudo-command';
 
-// Content Commands (1)
+// Content Commands
 import { createAppendCommand } from '../commands/content/append';
 import { createPrependCommand } from '../commands/content/prepend';
 
-// Animation Commands - Phase 6-3 (3)
+// Animation Commands
 import { createTransitionCommand } from '../commands/animation/transition';
 import { createMeasureCommand } from '../commands/animation/measure';
 import { createSettleCommand } from '../commands/animation/settle';
 import { createStartViewTransitionCommand } from '../commands/animation/start-view-transition';
+import { createTakeCommand } from '../commands/animation/take';
 
-// Advanced Commands - Phase 6-4 (2)
+// Advanced Commands
 import { createJsCommand } from '../commands/advanced/js';
 import { createAsyncCommand } from '../commands/advanced/async';
 
-// Control Flow - Phase 6-4 (1)
-import { createUnlessCommand } from '../commands/control-flow/unless';
-
-// Data Commands - Phase 6-4 (1)
+// Data Commands
 import { createDefaultCommand } from '../commands/data/default';
 
-// Execution Commands - Phase 6-4 (1)
-import { createPseudoCommand } from '../commands/execution/pseudo-command';
-
-// Utility & Specialized - Phase 6-5 (6)
+// Utility & Specialized
 import { createTellCommand } from '../commands/utility/tell';
 import { createCopyCommand } from '../commands/utility/copy';
 import { createPickCommand } from '../commands/utility/pick';
-import { createThrowCommand } from '../commands/control-flow/throw';
 import { createBeepCommand } from '../commands/utility/beep';
 import { createBreakpointCommand } from '../commands/utility/breakpoint';
 import { createInstallCommand } from '../commands/behaviors/install';
 
-// Final Commands - Phase 6-6 (2)
-import { createTakeCommand } from '../commands/animation/take';
+// Template Commands
 import { createRenderCommand } from '../commands/templates/render';
+
+/**
+ * How to build each command the manifest names — the "HOW" half of the split
+ * described in the file header, where `commands/manifest.ts` owns the "WHICH".
+ *
+ * ## Keyed by REGISTERED name, and 55 keys for 59 commands
+ *
+ * Four manifest rows carry `consolidationAliasOf` and have no key here:
+ * `decrement`, `replace`, `send`, and `unless` are alternate names for
+ * `increment`, `push`, `trigger`, and `if`, backed by ONE implementation class
+ * each and registered from that implementation's `metadata.aliases` by
+ * `command-adapter.ts`. They are real, dispatchable command names — not
+ * cosmetic synonyms — so the alias mechanism is load-bearing: break it and
+ * four commands disappear.
+ *
+ * The pre-step-3 block did call `createDecrementCommand()` and its three
+ * siblings, but those calls were redundant rather than load-bearing:
+ * `createDecrementCommand` is `createFactory(NumericModifyCommand)`, the same
+ * class `createIncrementCommand` builds, whose `name` is `'increment'` — so
+ * the call re-registered `increment` (and re-added the `decrement` alias) over
+ * the entry the previous line had just made. Dropping them changes which
+ * instance backs the pair, not which names exist or how they behave.
+ *
+ * NOTE this map is the reason a `factory` field must never appear in the
+ * manifest itself (Finding 9). It lives here because `runtime.ts` is the one
+ * module that legitimately references every command implementation.
+ */
+const COMMAND_FACTORIES: Readonly<Record<string, () => unknown>> = {
+  // DOM
+  hide: createHideCommand,
+  show: createShowCommand,
+  add: createAddCommand,
+  remove: createRemoveCommand,
+  toggle: createToggleCommand,
+  put: createPutCommand,
+  make: createMakeCommand,
+  empty: createEmptyCommand,
+  open: createOpenCommand,
+  close: createCloseCommand,
+  select: createSelectCommand,
+  reset: createResetCommand,
+  swap: createSwapCommand,
+  morph: createMorphCommand,
+  process: createProcessPartialsCommand,
+
+  // Async
+  wait: createWaitCommand,
+  fetch: createFetchCommand,
+
+  // Data
+  set: createSetCommand,
+  get: createGetCommand,
+  increment: createIncrementCommand, // + the `decrement` alias
+  clear: createClearCommand,
+  default: createDefaultCommand,
+
+  // Events
+  trigger: createTriggerCommand, // + the `send` alias
+
+  // Navigation — includes htmx-like push/replace url and `scroll to`
+  // (upstream _hyperscript 0.9.90's replacement for `go to top of X`)
+  go: createGoCommand,
+  push: createPushUrlCommand, // + the `replace` alias
+  scroll: createScrollCommand,
+
+  // Control flow
+  if: createIfCommand, // + the `unless` alias
+  repeat: createRepeatCommand,
+  break: createBreakCommand,
+  continue: createContinueCommand,
+  halt: createHaltCommand,
+  return: createReturnCommand,
+  exit: createExitCommand,
+  throw: createThrowCommand,
+
+  // Execution
+  call: createCallCommand,
+  focus: createFocusCommand,
+  blur: createBlurCommand,
+  'pseudo-command': createPseudoCommand,
+
+  // Content
+  append: createAppendCommand,
+  prepend: createPrependCommand,
+
+  // Animation
+  transition: createTransitionCommand,
+  measure: createMeasureCommand,
+  settle: createSettleCommand,
+  start: createStartViewTransitionCommand,
+  take: createTakeCommand,
+
+  // Advanced
+  js: createJsCommand,
+  async: createAsyncCommand,
+
+  // Utility
+  log: createLogCommand,
+  tell: createTellCommand,
+  copy: createCopyCommand,
+  pick: createPickCommand,
+  beep: createBeepCommand,
+  breakpoint: createBreakpointCommand,
+
+  // Behaviors & templates
+  install: createInstallCommand,
+  render: createRenderCommand,
+};
+
+/**
+ * Register the manifest's command set into `registry`.
+ *
+ * Rows with `consolidationAliasOf` are skipped: their name is registered by
+ * their primary's `metadata.aliases`, so registering them here would only
+ * rebuild the same implementation under the same primary name. A manifest row
+ * with neither an alias target nor a factory is a wiring error, and throwing
+ * makes it a loud one at construction rather than an "unknown command" at the
+ * first parse that needs it.
+ */
+function registerManifestCommands(registry: CommandRegistryV2): void {
+  for (const entry of COMMAND_MANIFEST) {
+    if (entry.consolidationAliasOf) continue;
+    const factory = COMMAND_FACTORIES[entry.name];
+    if (!factory) {
+      throw new Error(
+        `Command manifest names '${entry.name}' but runtime.ts has no factory for it. ` +
+          `Add it to COMMAND_FACTORIES, or give the manifest row a consolidationAliasOf.`
+      );
+    }
+    registry.register(factory());
+  }
+}
 
 /**
  * Runtime options (backward compatible with V1 interface)
@@ -132,7 +274,9 @@ export interface RuntimeOptions {
   expressionPreload?: 'core' | 'common' | 'all' | 'none';
 
   /**
-   * Custom registry (optional - if not provided, creates default with 48 V2 commands)
+   * Custom registry (optional). If not provided, one is created and populated
+   * with every command `commands/manifest.ts` names. Supplying a registry
+   * bypasses the manifest entirely — the caller owns the command set.
    */
   registry?: CommandRegistryV2;
 
@@ -161,12 +305,14 @@ export interface RuntimeOptions {
 /**
  * Runtime - Clean V2 Implementation
  *
- * Production-ready runtime that extends RuntimeBase and registers all 48 V2 commands.
+ * Production-ready runtime that extends RuntimeBase and registers every command
+ * `commands/manifest.ts` names. The count is deliberately not repeated here —
+ * it was stated as "48" in six places in this file while the real figure was
+ * 59, which is the drift Arc A exists to end. Ask the manifest.
  *
  * Key features:
  * - 100% V2 architecture (zero V1 dependencies)
- * - All 48 user-facing commands registered
- * - Tree-shakeable design (224 KB bundle)
+ * - Manifest-driven command set (see the file header)
  * - Lazy expression loading support
  * - Backward compatible with V1 RuntimeOptions
  */
@@ -175,94 +321,9 @@ export class Runtime extends RuntimeBase {
     // Create or use provided registry
     const registry = options.registry || new CommandRegistryV2();
 
-    // If no custom registry provided, register all 48 V2 commands
+    // If no custom registry provided, register the manifest's command set
     if (!options.registry) {
-      // DOM Commands (11) - includes htmx-like swap/morph/process-partials and v0.9.90 `empty`
-      registry.register(createHideCommand());
-      registry.register(createShowCommand());
-      registry.register(createAddCommand());
-      registry.register(createRemoveCommand());
-      registry.register(createToggleCommand());
-      registry.register(createPutCommand());
-      registry.register(createMakeCommand());
-      registry.register(createEmptyCommand());
-      registry.register(createOpenCommand());
-      registry.register(createCloseCommand());
-      registry.register(createSelectCommand());
-      registry.register(createResetCommand());
-      registry.register(createSwapCommand());
-      registry.register(createMorphCommand());
-      registry.register(createProcessPartialsCommand());
-
-      // Async Commands (2)
-      registry.register(createWaitCommand());
-      registry.register(createFetchCommand());
-
-      // Data Commands (5) — + clear (v0.9.90)
-      registry.register(createSetCommand());
-      registry.register(createGetCommand());
-      registry.register(createIncrementCommand());
-      registry.register(createDecrementCommand());
-      registry.register(createClearCommand());
-
-      // Utility Commands (1)
-      registry.register(createLogCommand());
-
-      // Event Commands (2)
-      registry.register(createTriggerCommand());
-      registry.register(createSendCommand());
-
-      // Navigation Commands (4) - includes htmx-like push/replace url and
-      // `scroll to` (upstream _hyperscript 0.9.90 replacement for the
-      // deprecated `go to top of X` scroll form)
-      registry.register(createGoCommand());
-      registry.register(createPushUrlCommand());
-      registry.register(createReplaceUrlCommand());
-      registry.register(createScrollCommand());
-
-      // Control Flow Commands (7)
-      registry.register(createIfCommand());
-      registry.register(createRepeatCommand());
-      registry.register(createBreakCommand());
-      registry.register(createContinueCommand());
-      registry.register(createHaltCommand());
-      registry.register(createReturnCommand());
-      registry.register(createExitCommand());
-
-      // Phase 6-2 Commands (4)
-      registry.register(createCallCommand());
-      registry.register(createAppendCommand());
-      registry.register(createPrependCommand());
-
-      // v0.9.90 focus/blur (Phase 1 of deferred features plan)
-      registry.register(createFocusCommand());
-      registry.register(createBlurCommand());
-
-      // Phase 6-3 Commands (4)
-      registry.register(createTransitionCommand());
-      registry.register(createMeasureCommand());
-      registry.register(createSettleCommand());
-      registry.register(createStartViewTransitionCommand());
-
-      // Phase 6-4 Commands (5)
-      registry.register(createJsCommand());
-      registry.register(createAsyncCommand());
-      registry.register(createUnlessCommand());
-      registry.register(createDefaultCommand());
-      registry.register(createPseudoCommand());
-
-      // Phase 6-5 Commands (6)
-      registry.register(createTellCommand());
-      registry.register(createCopyCommand());
-      registry.register(createPickCommand());
-      registry.register(createThrowCommand());
-      registry.register(createBeepCommand());
-      registry.register(createBreakpointCommand());
-      registry.register(createInstallCommand());
-
-      // Phase 6-6 Commands (2)
-      registry.register(createTakeCommand());
-      registry.register(createRenderCommand());
+      registerManifestCommands(registry);
     }
 
     // Initialize RuntimeBase with the bundle-supplied ExpressionRegistry. If

--- a/packages/language-server/src/command-tiers.test.ts
+++ b/packages/language-server/src/command-tiers.test.ts
@@ -6,9 +6,18 @@
  * command is `process`). Nothing checked these lists against the engine, so the
  * LSP offered completions for commands the runtime rejects.
  *
- * Reads core's COMMANDS set from source rather than importing it: the tier
+ * Reads core's command set from source rather than importing it: the tier
  * lists are plain data and this keeps the check dependency-free (the same
  * approach as scripts/check-ci-build-order.cjs).
+ *
+ * The source is `commands/manifest.ts`, core's registry-of-record since Arc A.
+ * It used to be `parser-constants.ts`'s `COMMANDS` literal, which Arc A step 3
+ * turned into `new Set([...COMMAND_NAMES, 'for'])` — derived from the manifest,
+ * and so no longer a list of quoted names for a regex to read. Reading the
+ * manifest is the better anchor anyway: `COMMANDS` is the PARSER's set (it
+ * carries `for`, which has no implementation) while the manifest is what the
+ * engine registers and executes, which is what this file's title claims to
+ * check.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -18,24 +27,30 @@ import { fileURLToPath } from 'url';
 import { HYPERSCRIPT_COMMANDS, LOKASCRIPT_ONLY_COMMANDS } from './command-tiers';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
+const MANIFEST = path.resolve(here, '../../core/src/commands/manifest.ts');
 const PARSER_CONSTANTS = path.resolve(here, '../../core/src/parser/parser-constants.ts');
 
-function namesIn(source: string, constant: string): string[] {
-  const block = source.match(
-    new RegExp(`export const ${constant} = new Set\\(\\[([\\s\\S]*?)\\]\\)`)
-  );
-  if (!block) throw new Error(`Could not find ${constant} in ${PARSER_CONSTANTS}`);
-  return [...block[1].matchAll(/'([^']+)'/g)].map(m => m[1]);
+function namesIn(file: string, label: string, block: RegExp): string[] {
+  const source = fs.readFileSync(file, 'utf8');
+  const match = source.match(block);
+  if (!match) throw new Error(`Could not find ${label} in ${file}`);
+  return [...match[1].matchAll(/'([^']+)'/g)].map(m => m[1]);
 }
 
 /**
  * Everything the engine will execute by name. CONTROL_FLOW_COMMANDS is unioned
  * in because loop forms like `while` are control-flow keywords rather than
- * entries in COMMANDS, yet the tiers legitimately advertise them.
+ * registered commands, yet the tiers legitimately advertise them.
  */
 function coreCommands(): Set<string> {
-  const source = fs.readFileSync(PARSER_CONSTANTS, 'utf8');
-  return new Set([...namesIn(source, 'COMMANDS'), ...namesIn(source, 'CONTROL_FLOW_COMMANDS')]);
+  return new Set([
+    ...namesIn(MANIFEST, 'COMMAND_NAMES', /export const COMMAND_NAMES[^=]*=\s*\[([\s\S]*?)\n\];/),
+    ...namesIn(
+      PARSER_CONSTANTS,
+      'CONTROL_FLOW_COMMANDS',
+      /export const CONTROL_FLOW_COMMANDS = new Set\(\[([\s\S]*?)\]\)/
+    ),
+  ]);
 }
 
 /**


### PR DESCRIPTION
Arc A step 3 of the command-manifest arc. Brief:
[`docs-internal/HANDOFF-command-arch-manifest.md`](../blob/feat/command-manifest-consumers/docs-internal/HANDOFF-command-arch-manifest.md).
Follows #811 (the audit-as-gate) and #813 (the manifest, consumed by nobody).

## What moved

The four lists the brief's Claim 2 found **already agreeing** with the registry
now point at `commands/manifest.ts`. Two are driven, two are checked:

| Consumer | Result |
| -------- | ------ |
| `parser-constants.COMMANDS` | **driven** — `new Set([...COMMAND_NAMES, 'for'])` |
| `runtime.ts` registration | **driven** — one loop over the manifest, private `COMMAND_FACTORIES` map supplies the factory |
| `commands/index.ts` | **checked** — audit §2 |
| `reference/index.ts` + `metadata.ts` counts | **checked** — the manifest is now `verify:reference`'s spine |

`verify:reference` previously compared two hand-maintained lists against **each
other**; an omission shared by both passed clean. All three are now scored
against the manifest, which the audit gates against the live registry.

**Finding 6** is honored by the first two rows together: the static seed and the
registration-time `COMMANDS.add` were two halves of one mechanism, and the
manifest now feeds both rather than the runtime patching the parser at
construction. `command-adapter.ts`'s `COMMANDS.add` stays — it is what teaches
the parser about commands from *outside* the manifest, and the audit re-pins it
on a synthetic command now that no built-in arrives that way.

**Finding 9** is honored by what did *not* change: `commands/index.ts` keeps
explicit re-exports, and the factory map is private to `runtime.ts` — the one
module that already imports every implementation.

## Behavior preserved, measured

The loop registers the **55** rows without `consolidationAliasOf`; the other four
names arrive from their primary's `metadata.aliases`. The dropped
`createDecrementCommand()` and its three siblings were **redundant, not
load-bearing** — each is a factory for the same class its primary builds, whose
`name` is the primary's, so the call re-registered the primary over the entry the
previous line had just made.

A before/after registry oracle (name → class, `metadata.aliases`, category,
shared-implementation groups) came back **identical**. Two intended differences:
`getCommandNames()` enumeration order is now alphabetical (consumers sort it or
use it for an error string), and the seed gained `pseudo-command` — unreachable
as a token, since `-` is not an identifier character.

## Finding 11 — new, measured, and it broke a gate first

Deriving the seed as `COMMAND_MANIFEST.map(e => e.name)` shipped the whole rich
array into `hyperfixi-hx.js`: **+4.8 KB raw, +7.5%, a real failure of the ±5%
bundle-size gate** on an 18 KB-gzip hybrid-parser bundle with no command registry
at all. Finding 9's hazard one level down — a `.map()` references the entries and
pins every `category` / `tier` / `upstreamOrExtension` / `multiword`.

Fixed with a `COMMAND_NAMES` literal asserted equal to the entries **as an
ordered list**, so it is a shape split rather than a second hand-maintained copy.
Net cost is now +5.2 KB raw in `hyperfixi.js` and `hx-v4` only — the two bundles
that construct `Runtime` and need the data. **Step 4's consumers want the rich
entries, so this must be re-measured there, not assumed.**

## Knock-ons

- `language-server`'s `command-tiers.test.ts` read core's `COMMANDS` literal by
  regex; it now reads `COMMAND_NAMES`. Better anchor anyway — `COMMANDS` is the
  *parser's* set (it carries `for`) while that file checks what the engine
  executes.
- Step 4.4's `runtime.ts` docstring half is done: all six "48 commands" mentions
  and the undercounting group comments ("DOM Commands (11)" above 15
  registrations) were in the block this replaces.

## Mutation-verified, 11 directions, all caught

Deleted manifest entry · deleted `COMMAND_NAMES` row with entries intact ·
reordered `COMMAND_NAMES` · removed factory entry · miswired factory
(`toggle: createAddCommand`) · stray `registry.register()` outside the loop ·
`parser-constants` reverted to a hand-written literal that matches today ·
dropped `commands/index.ts` export · renamed `reference/index.ts` entry ·
deleted `COMMANDS.add` · a manifest name the LSP tiers still advertise.

**For reviewers:** the registry is now *derived* from the manifest, so "manifest
names == registry names" is near-tautological. The hardcoded 59-name list in
audit §1 and the new per-command factory-identity test carry that weight and must
not be softened into derivations.

## Gates

- core **7827** passing / 128 skipped / 300 files
- `verify:reference` clean (59 = 59, availability chain valid)
- `snapshot:bundle-size` — all 10 bundles within tolerance
- parser + runtime **1873** passing; language-server **223** passing
- Playwright `src/compatibility/` — **1111** passed / 8 skipped
- typecheck, prettier, oxlint clean

Next: step 4.1 (LSP tiers — 23 unclassified, the arc's one live defect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)