### PR TITLE
fix(lsp): Arc A step 4.1 — classify every command against the upstream engine

### DIFF
--- a/docs-internal/HANDOFF-command-arch-manifest.md
+++ b/docs-internal/HANDOFF-command-arch-manifest.md
@@ -7,10 +7,10 @@
 > (Arc C, complete) and [HANDOFF-command-arch-target-resolution.md](./HANDOFF-command-arch-target-resolution.md)
 > (Arc D, complete).
 >
-> **Status: STEPS 1–3 LANDED (the audit-as-gate, the manifest, then the four
-> mechanical consumers). Next action: step 4 (the decision-bearing consumers,
-> one PR each — start with 4.1, the live LSP false negative).** Baseline for
-> step 4 is **7827** (step 3 added 3 tests to the audit file).
+> **Status: STEPS 1–3 AND 4.1 LANDED** (the audit-as-gate, the manifest, the
+> four mechanical consumers, then the LSP tier classification — the arc's one
+> live defect). **Next action: step 4.2 (template-capabilities, 13 rows,
+> latent).** Baseline after 4.1 is **7829** core / **227** language-server.
 >
 > **This brief REVISES the queue doc's Arc A plan — specifically its migration
 > ORDER and its manifest SHAPE.** Three of the paragraph's claims were measured
@@ -124,13 +124,20 @@ two separate PRs and not one:**
   size, not correctness. (Note the second escape hatch, `COMMAND_IMPLEMENTATIONS`
   keyed by name: a command can be "available" via a list the capability file does
   not know about. Two lists, one fact — the queue's own disease.)
-- **LSP tiers: a live false negative.** `detectLokascriptFeatures()` loops
-  `LOKASCRIPT_ONLY_COMMANDS` and warns "'X' command is a LokaScript extension".
-  A LokaScript-only command missing from that list produces **no warning**, so a
-  user writing code that will not run on original \_hyperscript is told nothing.
-  Several of the 23 (`empty`, `clear`, `open`, `close`, `select`, `reset`,
-  `swap`, `push`, `replace`, `focus`, `blur`, `copy`, `unless`) are extensions on
-  the Arc C upstream survey's reading.
+- **LSP tiers: a live false negative** — **FIXED in step 4.1.**
+  `detectLokascriptFeatures()` loops `LOKASCRIPT_ONLY_COMMANDS` and warns "'X'
+  command is a LokaScript extension"; `server.ts` renders that as a
+  `DiagnosticSeverity.Error`. A LokaScript-only command missing from that list
+  produced **no warning**, so a user writing code that will not run on original
+  \_hyperscript was told nothing.
+  > The sentence that followed here — "several of the 23 (`empty`, `clear`,
+  > `open`, `close`, `select`, `reset`, `swap`, `push`, `replace`, `focus`,
+  > `blur`, `copy`, `unless`) are extensions on the Arc C upstream survey's
+  > reading" — was a **guess, and mostly wrong**: measured against the engine,
+  > only `push`, `replace`, `copy` and `unless` of those thirteen are
+  > extensions. The other nine are upstream. Kept as written because it is the
+  > reason the step was specified as an oracle run rather than a reading. See
+  > Finding 12, which also records the false positives the same run exposed.
 
 ### Claim 4 — "verify:reference derives what it claims" — TRUE but far narrower than the queue implies
 
@@ -334,6 +341,48 @@ should be **measured, not assumed**. `npm run snapshot:bundle-size --prefix
 packages/core` is the instrument; the ±5% tolerance on the small bundles is
 tight enough that 4.8 KB fails it.
 
+### Finding 12 — the tier lists carried FALSE POSITIVES too, and the detector is a bare word match (measured in step 4.1)
+
+Claim 3 framed the tier lists as *incomplete* (23 unclassified). Running the
+oracle over the whole file rather than only the gaps found the mirror defect:
+**5 of the 7 entries in `LOKASCRIPT_ONLY_COMMANDS` were not extensions at
+all.** `make`, `measure`, `morph`, `settle` are upstream commands
+(`basic.js`, `dom.js`, `animations.js`), and `install` is an upstream *feature*
+(`install Foo` at element level is portable). Since `server.ts` renders every
+hit as a `DiagnosticSeverity.Error`, the LSP was flagging portable code as
+incompatible. Step 4.1 moved all five.
+
+Only 2 of the original 7 survived: `prepend` and `process`.
+
+**And the brief's own guess about the 23 was mostly wrong**, which is the case
+for keeping the oracle mandatory rather than reasoning from names. Claim 3 said
+`empty, clear, open, close, select, reset, swap, push, replace, focus, blur,
+copy, unless` "read as extensions"; measured, only `push`, `replace`, `copy` and
+`unless` are. The other nine are upstream.
+
+**The deferred half.** `detectLokascriptFeatures()` matches
+`new RegExp('\\b' + cmd + '\\b', 'i')` against raw source — no string-literal
+stripping, no command-position anchor, no guard against a preceding `.`. That
+was tolerable while the list held `prepend`/`morph`/`settle`; step 4.1 adds
+`push`, `copy`, `replace`, `unless`, `async`, `beep`, which are ordinary English
+and JS words. Measured after the change:
+
+| Portable code | Spurious flag |
+| ------------- | ------------- |
+| `call $items.push(1)` | `push` — a JS method call |
+| `set x to "copy me"` | `copy` — inside a string literal |
+| `put "replace" into #a` | `replace` — inside a string literal |
+| `log "x" unless $flag` | `unless` — the upstream TRAILING modifier is portable |
+| `beep! me` | `beep` — the upstream spelling; `\b` matches before `!` |
+
+This is pre-existing crudeness (it already fired on `process`), but step 4.1
+widens its reach, so it is recorded rather than shipped silently. **Not fixed
+here**: anchoring the scan to command position is a behavior change to the
+detector with its own tests, and folding it in would bury the 23 judgment calls
+that are this step's review artifact — the same treatment Findings 7 and 10 got.
+Mitigating factor: the scan runs only in `hyperscript`/`hyperscript-i18n` mode,
+which is opt-in. Recommended as the next LSP PR.
+
 ## What changed vs. the queue doc's plan
 
 The queue says: consumers migrate "lowest-risk first — template-capabilities
@@ -468,18 +517,24 @@ and the seed gaining `pseudo-command`.
 Each carries an explicit classification decision for its gaps, and each flips its
 step-1 audit rows so the diff is the review artifact:
 
-1. **LSP tiers** (23 unclassified; live false negative). Classify against a
-   `_hyperscript` checkout — the Arc C step-2 oracle. **Step-2 knock-on:** the
-   classification has a typed home already — `CommandMetadata` declares
+1. **LSP tiers** — **DONE** (see the status log). 23 unclassified rows became
+   17 upstream + 6 extension, and Finding 12's 5 false positives moved the
+   other way, so the lists are now a total partition of the registry: **51
+   upstream / 8 extension**. The oracle was `hyperscript.org@0.9.93` from this
+   repo's `node_modules` (the engine the R4 gate already loads), cross-checked
+   against a 0.9.91 checkout.
+   **The step-2 knock-on was decided NO:** `CommandMetadata` declares
    `compatibility?: 'standard' | 'lokascript-extension' | 'experimental'` and
-   `@meta` forwards it, but **all 59 commands leave it unset** (measured). So
-   Finding 8's "recorded nowhere but the tier lists" is right, and the sharper
-   statement is that the slot exists and is vacant. Populating it as the
-   classification lands would let `upstreamOrExtension` become *derived* rather
-   than absorbed, and would put the fact on the implementation where the other
-   per-command metadata already lives. Whichever way it goes, the manifest's
-   `unknown` set and the audit's `TIER_UNCLASSIFIED` are asserted equal — both
-   move in the same diff or the gate fails.
+   `@meta` forwards it, but all 59 commands still leave it unset, and
+   `upstreamOrExtension` stays *absorbed* from the tier lists rather than
+   derived from the implementations. Reasons, recorded in `manifest.ts`: the
+   decorator statics are Arc B by this brief's own non-goals; 23 judgment calls
+   are reviewable as one annotated table and not as a one-line change across 59
+   files; and the two domains do not line up (`'experimental'` has no
+   counterpart here, `'unknown'` none there), so populating it would force a
+   second undiscussed decision inside an upstream-parity PR. Arc B loses
+   nothing by waiting — it can now copy 59 *finished* values, which it could
+   not have done while 23 read `'unknown'`.
 2. **template-capabilities** (**13** unclassified, not 12 — see the 2026-07-28
    step-1 status entry; latent). 10 rows have no classification at all
    (`CAPABILITY_UNCLASSIFIED` in the audit); `if`/`repeat`/`fetch` are
@@ -529,7 +584,7 @@ step-1 audit rows so the diff is the review artifact:
 
 | Step | Suites | Command |
 | ---- | ------ | ------- |
-| all | quick validation (baseline **7827** after step 3; was 7824 after step 2, 7814 after step 1, 7800 after the Finding 5 fix, 7795 before it) | `npm run test:quick --prefix packages/core` |
+| all | quick validation (baseline **7829** after step 4.1; was 7827 after step 3, 7824 after step 2, 7814 after step 1, 7800 after the Finding 5 fix, 7795 before it) | `npm run test:quick --prefix packages/core` |
 | all | the reference gate | `npm run verify:reference --prefix packages/core` |
 | 1 | the new audit test itself | added in the step-1 PR |
 | 2, 3 | bundle size — the tree-shaking guard | `npm run snapshot:bundle-size --prefix packages/core` (`--check`, ±5% vs `scripts/bundle-snapshots/baseline.json`) |
@@ -748,3 +803,58 @@ was touched.
   itself what the manifest calls it, and each alias row resolves to its
   primary's instance with the alias declared in its `metadata.aliases`).
   Next action: step 4.1 (LSP tiers — 23 unclassified, the arc's one live defect).
+- 2026-07-28 — **Step 4.1 landed** (branch
+  `fix/lsp-command-tiers-classification`, off `4246469c`): the LSP tier lists
+  are now a **total partition** of the registry — **51 upstream / 8 extension**,
+  zero unclassified — and `TIER_UNCLASSIFIED` is an empty set the audit holds
+  at zero.
+  **The oracle changed, and it is better than the brief specified.** Step 4.1
+  was told to classify against "an upstream `_hyperscript` checkout"; the
+  stronger instrument was already in the repo — `hyperscript.org@0.9.93` in
+  `node_modules`, the *published* engine that
+  `testing-framework/src/multilingual/canonical-validity.ts` loads for the R4
+  gate. Versioned, reproducible in CI, and not a personal fork. Every row was
+  probed on it and cross-checked against a `bigskysoftware/_hyperscript` 0.9.91
+  checkout; **the two agree on every command**. The per-command probe and its
+  result are recorded inline in `command-tiers.ts`, so the next reader
+  re-verifies rather than trusts.
+  **One methodological trap, worth not re-discovering:** `hs.parse(...)`
+  returning no errors does NOT mean the command exists. A *feature* keyword
+  makes the command-list parser stop cleanly and hand back an EMPTY command
+  list — `on click install Foo` parses without error and contains nothing. The
+  probe must assert a real command node. Checking `errors` alone classified
+  `install` as an upstream command; it is an upstream *feature*.
+  **The 23 split 17 upstream / 6 extension**, and the brief's guess at them was
+  mostly wrong (Claim 3 named 13 as likely extensions; 4 are). Extensions:
+  `async`, `beep`, `copy`, `push`, `replace`, `unless`. Two carry a nuance
+  recorded in the file: upstream spells beep `beep!` (bare `beep` is ours, and
+  hyperfixi accepts both), and upstream has `unless` only as a TRAILING
+  statement modifier, so the leading block form is the addition.
+  **Scope note — Finding 12, the mirror defect.** The same oracle run scored
+  the rows that were already classified and found **5 of the 7**
+  `LOKASCRIPT_ONLY_COMMANDS` entries were not extensions: `make`, `measure`,
+  `morph`, `settle` are upstream commands and `install` is an upstream feature.
+  Because `server.ts` renders each hit as a `DiagnosticSeverity.Error`, the LSP
+  was erroring on portable code. Fixed in the same PR rather than deferred —
+  same file, same function, same defect class, evidence already in hand — but
+  kept as a separate commit and a separate test so it can be reverted without
+  unpicking the 23.
+  **Deferred, deliberately:** the detector's bare `\b<cmd>\b` scan. Adding
+  `push`/`copy`/`replace`/`unless` widens a pre-existing false-positive surface
+  (measured table in Finding 12 — `call $items.push(1)` now flags). Anchoring
+  the scan to command position is a behavior change wanting its own PR and its
+  own tests, and folding it in would bury this step's review artifact.
+  **The step-2 knock-on was decided NO** — `metadata.compatibility` stays
+  unset and `upstreamOrExtension` stays absorbed; the reasoning is in
+  `manifest.ts` and in step 4.1's section above.
+  Two gate hardenings the classification forced: the audit's `stringsIn` now
+  strips line comments before extracting quoted names (the tier lists carry
+  per-row prose, and an apostrophe in it paired across lines into a phantom
+  name), and the tier-list block regex is anchored on `] as const;` instead of
+  the first `]`.
+  Gates: core **7829** passing / 128 skipped / 300 files; language-server
+  **227** passing (was 223); `verify:reference` clean (59 = 59, availability
+  chain valid); `test:check` clean across all packages; Playwright
+  `src/compatibility/`; typecheck, prettier, oxlint clean.
+  Next action: step 4.2 (template-capabilities — 13 rows, latent, costs bundle
+  size not correctness).

--- a/packages/core/src/commands/manifest.ts
+++ b/packages/core/src/commands/manifest.ts
@@ -66,7 +66,7 @@
  * | `name` | `new Runtime().getRegistry().getCommandNames()` | set equality, both directions |
  * | `category` | the implementation's `metadata.category` (what the registry serves) | exact, all 59 |
  * | `tier` | `reference/index.ts`'s `availability` | exact, all 59 |
- * | `upstreamOrExtension` | the LSP tier lists (`language-server/src/command-tiers.ts`) | `unknown` set === the audit's `TIER_UNCLASSIFIED` |
+ * | `upstreamOrExtension` | the LSP tier lists (`language-server/src/command-tiers.ts`) | per-command equality, all 59; plus `unknown` set === the audit's `TIER_UNCLASSIFIED` (both empty since step 4.1) |
  * | `consolidationAliasOf` | `metadata.aliases`, resolved by shared implementation identity | exact, the 4 pairs |
  * | `multiword` | `parser-constants.COMPOUND_COMMANDS` | set equality |
  *
@@ -103,9 +103,27 @@
  * the `@meta` decorator forwards it — but **all 59 commands leave it unset**.
  * So the fact genuinely is recorded nowhere except the LSP tier lists, as the
  * brief found; what is new is that the natural home for it already exists and
- * is vacant. Step 4.1 classifies the 23 `unknown` rows against an upstream
- * `_hyperscript` checkout; populating `metadata.compatibility` at the same time
- * would let this field become derived rather than absorbed.
+ * is vacant.
+ *
+ * **Step 4.1 decided NOT to populate it, deliberately.** The classification
+ * stays absorbed from the tier lists and mirrored here under assertion. Three
+ * reasons, in order of weight:
+ *
+ * 1. Arc A's non-goals fence the decorator statics off as **Arc B** ("the
+ *    manifest is a sibling of `metadata`, not a replacement"). Populating
+ *    `compatibility` is that arc's work, not this one's.
+ * 2. The review artifact. Step 4.1 is 23 per-command judgment calls; they are
+ *    reviewable as one annotated table in one file, and unreviewable as a
+ *    one-line decorator change spread over 59 implementation files.
+ * 3. The domains do not line up. `compatibility` offers `'experimental'`,
+ *    which has no counterpart here, and this field offers `'unknown'`, which
+ *    has none there. Populating it would force a second, undiscussed decision
+ *    about what `'experimental'` means inside a PR about upstream parity.
+ *
+ * Nothing is lost by waiting: the classification is now **complete**, so Arc B
+ * can invert the direction (registry-derived rather than tier-list-absorbed)
+ * by copying 59 finished values, which it could not have done while 23 of them
+ * read `'unknown'`.
  *
  * ## Not in this file
  *
@@ -142,12 +160,23 @@ export type CommandTier = 'lite' | 'lite-plus' | 'hybrid' | 'full';
  * Whether a command exists in upstream `_hyperscript` or is a LokaScript
  * extension.
  *
- * `'unknown'` is not a placeholder for "we did not bother" — it is the 23-row
- * classification debt the step-1 audit pins as `TIER_UNCLASSIFIED`, and the
- * audit asserts these two sets are equal so step 4.1 has to move both together.
- * This is the arc's one *live* defect: `detectLokascriptFeatures()` warns only
- * for commands in `LOKASCRIPT_ONLY_COMMANDS`, so an extension missing from
- * that list produces no compatibility warning at all.
+ * **`'unknown'` is now unused — step 4.1 classified all 59 (51 upstream, 8
+ * extension).** It is kept in the union rather than deleted so the audit can go
+ * on asserting the empty-set coupling described below; a row that reappears as
+ * `'unknown'` fails the gate rather than being unrepresentable, which keeps the
+ * failure message about the classification instead of about a type.
+ *
+ * It was a 23-row classification debt, pinned by the step-1 audit as
+ * `TIER_UNCLASSIFIED`, and the audit asserts the manifest's `'unknown'` set and
+ * that set are **equal** — so step 4.1 had to empty both in one diff. That debt
+ * was the arc's one *live* defect: `detectLokascriptFeatures()` scans only
+ * `LOKASCRIPT_ONLY_COMMANDS` and `language-server/src/server.ts` turns each hit
+ * into a `DiagnosticSeverity.Error`, so an extension missing from that list
+ * produced no diagnostic at all.
+ *
+ * The values are measured against the published original engine, not recalled;
+ * `language-server/src/command-tiers.ts` carries the per-command probe and the
+ * oracle version, and is the source this field mirrors.
  */
 export type UpstreamOrExtension = 'upstream' | 'extension' | 'unknown';
 
@@ -283,35 +312,35 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'async',
     category: 'advanced',
     tier: 'hybrid',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'extension',
     multiword: false,
   },
   {
     name: 'beep',
     category: 'utility',
     tier: 'full',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'extension',
     multiword: false,
   },
   {
     name: 'blur',
     category: 'execution',
     tier: 'lite-plus',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   {
     name: 'break',
     category: 'control-flow',
     tier: 'hybrid',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   {
     name: 'breakpoint',
     category: 'utility',
     tier: 'full',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   {
@@ -325,28 +354,28 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'clear',
     category: 'data',
     tier: 'full',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   {
     name: 'close',
     category: 'dom',
     tier: 'full',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   {
     name: 'continue',
     category: 'control-flow',
     tier: 'hybrid',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   {
     name: 'copy',
     category: 'utility',
     tier: 'full',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'extension',
     multiword: false,
   },
   {
@@ -368,7 +397,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'empty',
     category: 'dom',
     tier: 'lite-plus',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   {
@@ -389,7 +418,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'focus',
     category: 'execution',
     tier: 'lite-plus',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   {
@@ -432,7 +461,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'install',
     category: 'behaviors',
     tier: 'full',
-    upstreamOrExtension: 'extension',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   {
@@ -453,35 +482,35 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'make',
     category: 'dom',
     tier: 'hybrid',
-    upstreamOrExtension: 'extension',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   {
     name: 'measure',
     category: 'animation',
     tier: 'full',
-    upstreamOrExtension: 'extension',
+    upstreamOrExtension: 'upstream',
     multiword: true,
   },
   {
     name: 'morph',
     category: 'dom',
     tier: 'full',
-    upstreamOrExtension: 'extension',
+    upstreamOrExtension: 'upstream',
     multiword: true,
   },
   {
     name: 'open',
     category: 'dom',
     tier: 'full',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   {
     name: 'pick',
     category: 'utility',
     tier: 'full',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: true,
   },
   {
@@ -502,14 +531,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'pseudo-command',
     category: 'execution',
     tier: 'full',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   {
     name: 'push',
     category: 'navigation',
     tier: 'hybrid',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'extension',
     multiword: true,
   },
   { name: 'put', category: 'dom', tier: 'lite', upstreamOrExtension: 'upstream', multiword: true },
@@ -524,7 +553,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'render',
     category: 'templates',
     tier: 'full',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   {
@@ -538,7 +567,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'replace',
     category: 'navigation',
     tier: 'hybrid',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'extension',
     consolidationAliasOf: 'push',
     multiword: true,
   },
@@ -546,7 +575,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'reset',
     category: 'dom',
     tier: 'full',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   {
@@ -560,14 +589,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'scroll',
     category: 'navigation',
     tier: 'full',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   {
     name: 'select',
     category: 'dom',
     tier: 'full',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   {
@@ -583,7 +612,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'settle',
     category: 'animation',
     tier: 'full',
-    upstreamOrExtension: 'extension',
+    upstreamOrExtension: 'upstream',
     multiword: false,
   },
   { name: 'show', category: 'dom', tier: 'lite', upstreamOrExtension: 'upstream', multiword: true },
@@ -591,14 +620,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'start',
     category: 'animation',
     tier: 'full',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: true,
   },
   {
     name: 'swap',
     category: 'dom',
     tier: 'hybrid',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'upstream',
     multiword: true,
   },
   {
@@ -647,7 +676,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     name: 'unless',
     category: 'control-flow',
     tier: 'full',
-    upstreamOrExtension: 'unknown',
+    upstreamOrExtension: 'extension',
     consolidationAliasOf: 'if',
     multiword: false,
   },

--- a/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
+++ b/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
@@ -83,9 +83,18 @@ const REGISTERED = new Set(REGISTRY);
 
 const DIR = dirname(fileURLToPath(import.meta.url));
 
-/** Extract the single-quoted string literals from a source-text block. */
+/**
+ * Extract the single-quoted string literals from a source-text block.
+ *
+ * Line comments are stripped FIRST. The lists this reads are annotated data —
+ * step 4.1 put the upstream-parity probe for each command in a trailing `//`
+ * comment — and prose contains apostrophes, which would otherwise pair up
+ * across lines and yield a multi-line "name" that no registry has. Command
+ * names never contain `//`, so removing it to end-of-line cannot eat one.
+ */
 function stringsIn(block: string): string[] {
-  return (block.match(/'[^']+'/g) ?? []).map(s => s.slice(1, -1));
+  const code = block.replace(/\/\/[^\n]*/g, '');
+  return (code.match(/'[^'\n]+'/g) ?? []).map(s => s.slice(1, -1));
 }
 
 /** Entries of `list` the registry does not have, sorted. */
@@ -338,10 +347,22 @@ const tiersSource = readFileSync(
   resolve(DIR, '../../../../language-server/src/command-tiers.ts'),
   'utf-8'
 );
-const HYPERSCRIPT_TIER = stringsIn(tiersSource.match(/HYPERSCRIPT_COMMANDS = \[([\s\S]*?)\]/)![1]);
-const LOKASCRIPT_TIER = stringsIn(
-  tiersSource.match(/LOKASCRIPT_ONLY_COMMANDS = \[([\s\S]*?)\]/)![1]
-);
+/**
+ * Anchored on the closing `] as const;` rather than the first `]`. The old
+ * non-greedy `\]` stopped at whatever bracket came first, so a `]` inside one
+ * of the annotation comments step 4.1 added would silently truncate the list
+ * and turn every command below it into a phantom gap.
+ */
+function tierList(name: string): string[] {
+  const block = tiersSource.match(new RegExp(`${name} = \\[([\\s\\S]*?)\\n\\] as const;`));
+  // Module scope, so a plain throw rather than expect(): a collection-time
+  // failure here must name the cause, not surface as "expect outside test".
+  if (!block) throw new Error(`${name} literal moved or changed shape in command-tiers.ts`);
+  return stringsIn(block[1]);
+}
+
+const HYPERSCRIPT_TIER = tierList('HYPERSCRIPT_COMMANDS');
+const LOKASCRIPT_TIER = tierList('LOKASCRIPT_ONLY_COMMANDS');
 
 /**
  * In the tier lists but not registered commands, legitimately: the seven
@@ -361,42 +382,48 @@ const TIER_NOT_COMMANDS = new Set([
 ]);
 
 /**
- * Registered commands in NEITHER tier list — unclassified against a file whose
- * own doc comment defines a partition ("which features are hyperscript … [or]
- * LokaScript extensions"). This is the arc's LIVE defect:
- * `detectLokascriptFeatures()` warns only for commands in
- * `LOKASCRIPT_ONLY_COMMANDS`, so a LokaScript-only command missing here
- * produces NO compatibility warning. Several of these (`empty`, `clear`,
- * `open`, `close`, `select`, `reset`, `swap`, `push`, `replace`, `focus`,
- * `blur`, `copy`, `unless`) read as extensions on the Arc C upstream survey.
+ * Registered commands in NEITHER tier list — **empty since step 4.1**, and the
+ * assertion below keeps it that way.
  *
- * Every entry is fixed by step 4.1 — a per-command classification against the
- * upstream _hyperscript checkout, not a mechanical migration.
+ * It held 23 names. That was the arc's one LIVE defect rather than a latent
+ * one: `detectLokascriptFeatures()` scans only `LOKASCRIPT_ONLY_COMMANDS`, and
+ * `language-server/src/server.ts` turns each hit into a
+ * `DiagnosticSeverity.Error`, so an unclassified extension produced NO
+ * diagnostic — a user writing non-portable code was told nothing.
+ *
+ * Step 4.1 classified all 23 against the published original engine
+ * (`hyperscript.org@0.9.93` from this repo's node_modules, cross-checked
+ * against an 0.9.91 checkout): **17 upstream, 6 extension**. The per-command
+ * probe that decided each row is recorded beside it in `command-tiers.ts`.
+ *
+ * Worth keeping as a named empty set rather than deleting: a command added
+ * later without a tier row lands here, and the failure message says
+ * "unclassified" instead of reporting a bare set difference.
  */
-const TIER_UNCLASSIFIED = new Set([
+const TIER_UNCLASSIFIED = new Set<string>([]);
+
+/**
+ * The classification, counted. Step 4.1's judgment calls are only reviewable
+ * if a later change has to move a number as well as a row — the same
+ * discipline as §8's headline counts. 51 + 8 = the 59 registered commands.
+ */
+const TIER_COUNTS = { upstream: 51, extension: 8 };
+
+/**
+ * The eight extensions, named. A count alone would let two rows swap sides
+ * unnoticed, and this list is what `detectLokascriptFeatures()` raises editor
+ * ERRORS from, so moving a command into or out of it is a user-visible change
+ * that should never be incidental to another edit.
+ */
+const EXTENSIONS = new Set([
   'async',
-  'beep',
-  'blur',
-  'break',
-  'breakpoint',
-  'clear',
-  'close',
-  'continue',
+  'beep', // upstream spells it `beep!`; the bare spelling is ours
   'copy',
-  'empty',
-  'focus',
-  'open',
-  'pick',
-  'pseudo-command',
+  'prepend',
+  'process',
   'push',
-  'render',
   'replace',
-  'reset',
-  'scroll',
-  'select',
-  'start',
-  'swap',
-  'unless',
+  'unless', // upstream has `unless` only as a TRAILING statement modifier
 ]);
 
 describe('the LSP tier lists', () => {
@@ -408,10 +435,28 @@ describe('the LSP tier lists', () => {
     );
   });
 
-  it('23 registered commands are unclassified — the live false negative (step 4.1)', () => {
+  it('classifies every registered command — the partition is total (step 4.1)', () => {
     expect(gapsIn([...HYPERSCRIPT_TIER, ...LOKASCRIPT_TIER])).toEqual(
       [...TIER_UNCLASSIFIED].sort()
     );
+    expect(TIER_UNCLASSIFIED.size, 'a command lost its classification').toBe(0);
+  });
+
+  it('the two tiers split the registry 51 / 8', () => {
+    const upstream = HYPERSCRIPT_TIER.filter(name => REGISTERED.has(name));
+    const extension = LOKASCRIPT_TIER.filter(name => REGISTERED.has(name));
+    expect(extension.sort()).toEqual([...EXTENSIONS].sort());
+    expect({ upstream: upstream.length, extension: extension.length }).toEqual(TIER_COUNTS);
+    expect(upstream.length + extension.length).toBe(REGISTRY.length);
+  });
+
+  it('the tiers stay disjoint', () => {
+    // command-tiers.test.ts asserts this too, but from inside the
+    // language-server package. Repeated here because §7 derives the manifest's
+    // upstreamOrExtension from these lists with `HYPERSCRIPT_TIER` winning:
+    // a name in both would silently classify as upstream.
+    const upstream = new Set(HYPERSCRIPT_TIER);
+    expect(LOKASCRIPT_TIER.filter(name => upstream.has(name))).toEqual([]);
   });
 });
 
@@ -770,15 +815,18 @@ describe('the command manifest', () => {
     }
   });
 
-  it('the unknown set IS the audit TIER_UNCLASSIFIED set (step 4.1 moves both)', () => {
+  it('the unknown set IS the audit TIER_UNCLASSIFIED set (both empty since 4.1)', () => {
     // The coupling that stops the two from drifting apart — which is the exact
-    // disease this arc exists to cure. Classifying a command in step 4.1 must
-    // delete its row HERE and in TIER_UNCLASSIFIED in the same diff, or this
-    // fails.
+    // disease this arc exists to cure. It did its job in step 4.1: classifying
+    // the 23 required deleting each row HERE and in TIER_UNCLASSIFIED in one
+    // diff. Both sides are now empty, so on its own this is a weak assertion —
+    // the load is carried by the per-command equality test above and by §3's
+    // 51/8 split, which a re-classification cannot satisfy by accident.
     const unknown = COMMAND_MANIFEST.filter(e => e.upstreamOrExtension === 'unknown')
       .map(e => e.name)
       .sort();
     expect(unknown).toEqual([...TIER_UNCLASSIFIED].sort());
+    expect(unknown).toEqual([]);
   });
 });
 
@@ -787,12 +835,15 @@ describe('the command manifest', () => {
 // ===========================================================================
 
 describe('the classification debt, counted', () => {
-  it('40 rows await deliberate classification (steps 4.1–4.3)', () => {
+  it('17 rows await deliberate classification (steps 4.2–4.3)', () => {
     // The numbers the arc exists to burn down. A step that classifies a
     // command flips its allowlist row AND moves the count here, so the diff
     // shows both the decision and its scope. Do not adjust a count without
     // moving the rows that justify it.
-    expect(TIER_UNCLASSIFIED.size).toBe(23); // step 4.1 — live LSP false negative
+    //
+    // Step 4.1 took this from 40 to 17: the LSP tier lists are now a total
+    // partition of the registry (51 upstream / 8 extension), asserted in §3.
+    expect(TIER_UNCLASSIFIED.size).toBe(0); // step 4.1 — DONE, was 23
     expect(CAPABILITY_UNCLASSIFIED.size).toBe(10); // step 4.2 — latent, costs bundle size
     expect(CAPABILITY_BLOCK_ONLY.size).toBe(3); // step 4.2 — decide blocks-as-classification
     expect(KEYWORD_GAPS.size).toBe(4); // step 4.3 — missing LSP completions

--- a/packages/language-server-hyperscript/README.md
+++ b/packages/language-server-hyperscript/README.md
@@ -40,8 +40,8 @@ Use the `@hyperscript-tools/vscode` extension instead — it bundles this server
 
 This is a thin wrapper around `@lokascript/language-server` that defaults to `hyperscript` mode. In this mode:
 
-- Only \_hyperscript-compatible commands are suggested (31 commands)
-- LokaScript extensions (make, settle, measure, etc.) are flagged as errors
+- Only \_hyperscript-compatible commands are suggested (51 of the engine's 59, plus the `for`/`while` loop keywords and the 7 feature definitions)
+- LokaScript extensions (`prepend`, `process`, `copy`, `push`/`replace`, `async`, `unless`, bare `beep`) are flagged as errors — the full list is `LOKASCRIPT_ONLY_COMMANDS` in `@lokascript/language-server`, where each entry records the probe against the published `hyperscript.org` engine that classified it
 - LokaScript syntax patterns (dot notation, optional chaining) produce warnings
 - No multilingual features are exposed
 

--- a/packages/language-server/src/command-tiers.ts
+++ b/packages/language-server/src/command-tiers.ts
@@ -5,6 +5,44 @@
  * This module defines which features are:
  * - hyperscript: Available in original _hyperscript (and LokaScript)
  * - lokascript: LokaScript extensions (not compatible with original _hyperscript)
+ *
+ * ## These lists are a partition, and it is now complete (Arc A step 4.1)
+ *
+ * Every registered command sits in exactly one of the two lists. Before
+ * 2026-07-28 **23 of the engine's 59 commands were in neither**, which was not
+ * a cosmetic gap: `detectLokascriptFeatures()` below scans only
+ * `LOKASCRIPT_ONLY_COMMANDS`, and `server.ts` turns each hit into a
+ * `DiagnosticSeverity.Error`. An unclassified extension therefore produced
+ * **no diagnostic at all** — a user writing code that cannot run on original
+ * _hyperscript was told nothing. The audit that pins the partition in both
+ * directions is `packages/core/src/runtime/__tests__/command-manifest-audit.test.ts`;
+ * the arc brief is `docs-internal/HANDOFF-command-arch-manifest.md`.
+ *
+ * ## The oracle, and how to re-run it
+ *
+ * Classification is measured, not remembered. The oracle is the **published**
+ * original engine, `hyperscript.org` from this repo's own `node_modules` (the
+ * same one `packages/testing-framework/src/multilingual/canonical-validity.ts`
+ * loads for the R4 gate). Verified 2026-07-28 against **0.9.93**, and
+ * cross-checked against a `bigskysoftware/_hyperscript` **0.9.91** checkout —
+ * the two agree on every row below.
+ *
+ * The package blocks subpath imports, so resolve it and import the prebuilt
+ * ESM sibling by file URL — the same dance `canonical-validity.ts` does:
+ *
+ * ```js
+ * const dir = path.dirname(createRequire(import.meta.url).resolve('hyperscript.org'));
+ * const hs = (await import(pathToFileURL(path.join(dir, '_hyperscript.esm.js')).href)).default;
+ * const el = hs.parse(`on click ${snippet}`);
+ * ```
+ *
+ * A command counts as upstream only when that parse yields a **real command
+ * node** — walk `el.features[0].start` and require something other than
+ * `EmptyCommandListCommand`/`ImplicitReturn`. Checking `el.errors` alone is not
+ * enough and produces a false "upstream": a *feature* keyword makes the
+ * command-list parser stop cleanly and hand back an EMPTY command list with no
+ * error at all. `install` is exactly that case, and it is why its row below
+ * carries the caveat it does.
  */
 
 /**
@@ -45,6 +83,53 @@ export const HYPERSCRIPT_COMMANDS = [
   'wait',
   'while',
 
+  // Upstream commands this list omitted until Arc A step 4.1. Each was probed
+  // on hyperscript.org@0.9.93 in the form shown and produced the command node
+  // named beside it; none of them is a LokaScript invention.
+  'blur', //           `blur #a`                        → BlurCommand
+  'break', //          `repeat 3 times break end`       → controlflow.js BreakCommand
+  'breakpoint', //     `breakpoint`                     → BreakpointCommand (core debug.js)
+  'clear', //          `clear #a`                       → EmptyCommand — upstream spells the
+  'empty', //          `empty #a`                         pair as ONE command with two keywords
+  'close', //          `close #a`                       → CloseCommand
+  'continue', //       `repeat 3 times continue end`    → controlflow.js ContinueCommand
+  'focus', //          `focus #a`                       → FocusCommand
+  'open', //           `open #a`                        → OpenCommand
+  'pick', //           `pick items 1 to 3 from "hello"` → PickCommand
+  'render', //         `render #tpl`                    → RenderCommand
+  'reset', //          `reset #a`                       → ResetCommand
+  'scroll', //         `scroll to #a`                   → ScrollCommand
+  'select', //         `select #a`                      → SelectCommand
+  'start', //          `start view transition end`      → ViewTransitionCommand
+  'swap', //           `swap $a with $b`                → SwapCommand. The htmx-style
+  //                     `swap <content> into <target>` form is an EXTENSION of this same
+  //                     command, not a different one — `commands/dom/swap.ts` implements the
+  //                     upstream value-swap variant explicitly, under a `variant` discriminator.
+
+  // Never written by a user: `pseudo-command` is the internal registry name for
+  // method-call-as-command (`foo() on #a`), and `-` is not an identifier
+  // character, so no source text can contain the token. Listed so the
+  // partition is total. The mechanism is upstream — the probe above yields
+  // PseudoCommand from `parsetree/commands/pseudoCommand.js`, which the core
+  // `_hyperscript.js` bundle registers.
+  'pseudo-command',
+
+  // Moved OUT of LOKASCRIPT_ONLY_COMMANDS by the same 4.1 oracle run. Each was
+  // asserted to be a LokaScript extension and each parses on stock
+  // hyperscript.org@0.9.93, so the LSP was raising a spurious *error*
+  // diagnostic on portable code — the same defect as the omissions above, with
+  // the sign flipped.
+  'make', //     `make a <div/>`             → MakeCommand      (basic.js)
+  'measure', //  `measure #a`                → MeasureCommand   (dom.js)
+  'morph', //    `morph #a to "<p>x</p>"`    → MorphCommand     (dom.js)
+  'settle', //   `settle`                    → SettleCommand    (animations.js)
+  // `install` is upstream at the position it is actually written — `_="install
+  // Foo"` parses as InstallFeature. It is a FEATURE upstream and a registered
+  // command here, so `on click install Foo` works only in LokaScript. The
+  // lists are keyed by name and cannot express "upstream in feature position
+  // only"; classified by the canonical usage, which is portable.
+  'install',
+
   // Definitions
   'behavior',
   'def',
@@ -58,17 +143,34 @@ export const HYPERSCRIPT_COMMANDS = [
 /**
  * Commands that are LokaScript extensions.
  * These do NOT work in original _hyperscript.
+ *
+ * Each row records the probe that placed it here: the snippet, and how
+ * hyperscript.org@0.9.93 rejected it.
  */
 export const LOKASCRIPT_ONLY_COMMANDS = [
   // Upstream _hyperscript has no `prepend`; it offers only
   // `put <content> at the start of <target>`.
-  'prepend',
-  'make',
-  'settle',
-  'measure',
-  'morph',
-  'install',
-  'process',
+  'prepend', // `prepend "x" to #a`      → Unexpected Token : prepend
+  'process', // `process "<p>x</p>"`     → Unexpected Token : process
+
+  // Added by Arc A step 4.1 — the omissions that produced NO diagnostic.
+  'async', //   `async do log "x" end`   → Unexpected Token : async
+  'copy', //    `copy "x"`               → Unexpected Token : copy
+  'push', //    `push url "/x"`          → Unexpected Token : push
+  'replace', // `replace url "/x"`       → Unexpected Token : replace
+
+  // Upstream spells this command `beep!`, with the bang as part of the token:
+  // `beep! me` parses (BeepCommand), `beep me` does not. hyperfixi registers it
+  // as `beep` and accepts both spellings, so the portable spelling is `beep!`
+  // and the bare one is the extension. Classified by the registered name,
+  // which is what these lists key on.
+  'beep', //    `beep me`                → Unexpected Token : beep
+
+  // Upstream has `unless` only as a TRAILING statement modifier
+  // (`log "x" unless true` → UnlessStatementModifier, kernel.js
+  // parseIndirectStatement). The registered `unless` COMMAND — the leading
+  // block form, an alias of `if` — is the LokaScript addition.
+  'unless', //  `unless true log "x" end` → Unexpected Token : unless
 ] as const;
 
 /**

--- a/packages/language-server/src/server.test.ts
+++ b/packages/language-server/src/server.test.ts
@@ -1781,12 +1781,51 @@ describe('Command Tiers', () => {
     });
 
     it('classifies lokascript extensions as lokascript-only', () => {
-      expect(isLokascriptOnlyCommand('make')).toBe(true);
-      expect(isLokascriptOnlyCommand('settle')).toBe(true);
-      expect(isLokascriptOnlyCommand('measure')).toBe(true);
-      expect(isLokascriptOnlyCommand('morph')).toBe(true);
+      // Every name here was rejected by hyperscript.org@0.9.93 — the probe is
+      // recorded per-row in command-tiers.ts. `make`/`settle`/`measure`/
+      // `morph`/`install` used to be asserted here and are NOT extensions; Arc
+      // A step 4.1 measured them and moved them (see the test below).
       expect(isLokascriptOnlyCommand('prepend')).toBe(true);
-      expect(isLokascriptOnlyCommand('install')).toBe(true);
+      expect(isLokascriptOnlyCommand('process')).toBe(true);
+      expect(isLokascriptOnlyCommand('async')).toBe(true);
+      expect(isLokascriptOnlyCommand('copy')).toBe(true);
+      expect(isLokascriptOnlyCommand('push')).toBe(true);
+      expect(isLokascriptOnlyCommand('replace')).toBe(true);
+      expect(isLokascriptOnlyCommand('beep')).toBe(true);
+      expect(isLokascriptOnlyCommand('unless')).toBe(true);
+    });
+
+    it('classifies upstream commands this list once called extensions', () => {
+      // The false-POSITIVE half of step 4.1. These five sat in
+      // LOKASCRIPT_ONLY_COMMANDS, so the LSP raised a DiagnosticSeverity.Error
+      // on portable code. All five parse on stock hyperscript.org@0.9.93.
+      for (const cmd of ['make', 'settle', 'measure', 'morph', 'install']) {
+        expect(isHyperscriptCommand(cmd), `${cmd} is upstream`).toBe(true);
+        expect(isLokascriptOnlyCommand(cmd), `${cmd} is not an extension`).toBe(false);
+      }
+    });
+
+    it('classifies the commands step 4.1 added to the upstream tier', () => {
+      // The false-NEGATIVE half: these were in NEITHER list, so nothing
+      // classified them at all.
+      for (const cmd of [
+        'blur',
+        'clear',
+        'empty',
+        'focus',
+        'open',
+        'close',
+        'pick',
+        'render',
+        'reset',
+        'scroll',
+        'select',
+        'start',
+        'swap',
+        'breakpoint',
+      ]) {
+        expect(isHyperscriptCommand(cmd), `${cmd} is upstream`).toBe(true);
+      }
     });
 
     it('does not classify hyperscript commands as lokascript-only', () => {
@@ -1796,16 +1835,16 @@ describe('Command Tiers', () => {
     });
 
     it('does not classify lokascript commands as hyperscript', () => {
-      expect(isHyperscriptCommand('morph')).toBe(false);
+      expect(isHyperscriptCommand('prepend')).toBe(false);
       expect(isHyperscriptCommand('persist')).toBe(false);
-      expect(isHyperscriptCommand('settle')).toBe(false);
+      expect(isHyperscriptCommand('process')).toBe(false);
     });
 
     it('handles case insensitivity', () => {
       expect(isHyperscriptCommand('Toggle')).toBe(true);
       expect(isHyperscriptCommand('TOGGLE')).toBe(true);
-      expect(isLokascriptOnlyCommand('Morph')).toBe(true);
-      expect(isLokascriptOnlyCommand('MORPH')).toBe(true);
+      expect(isLokascriptOnlyCommand('Prepend')).toBe(true);
+      expect(isLokascriptOnlyCommand('PREPEND')).toBe(true);
     });
   });
 
@@ -1813,16 +1852,16 @@ describe('Command Tiers', () => {
     it('returns only hyperscript commands in hyperscript mode', () => {
       const commands = getCommandsForMode('hyperscript');
       expect(commands).toEqual(HYPERSCRIPT_COMMANDS);
-      expect(commands).not.toContain('morph');
       expect(commands).not.toContain('prepend');
+      expect(commands).not.toContain('unless');
     });
 
     it('returns all commands in lokascript mode', () => {
       const commands = getCommandsForMode('lokascript');
       expect(commands).toEqual(ALL_COMMANDS);
       expect(commands).toContain('toggle');
-      expect(commands).toContain('morph');
       expect(commands).toContain('prepend');
+      expect(commands).toContain('unless');
     });
 
     it('lokascript mode includes all hyperscript commands', () => {
@@ -1858,17 +1897,45 @@ describe('Command Tiers', () => {
 describe('LokaScript Feature Detection', () => {
   describe('detectLokascriptFeatures', () => {
     it('detects lokascript-only commands', () => {
-      const features = detectLokascriptFeatures('morph #target to "<div>new</div>"');
+      const features = detectLokascriptFeatures('prepend "<li>x</li>" to #list');
       expect(features).toHaveLength(1);
       expect(features[0].feature).toBe('command');
-      expect(features[0].description).toContain("'morph'");
+      expect(features[0].description).toContain("'prepend'");
       expect(features[0].description).toContain('LokaScript extension');
     });
 
     it('detects multiple lokascript-only commands', () => {
-      const features = detectLokascriptFeatures('make a div then settle then morph it');
+      const features = detectLokascriptFeatures('prepend "x" to #a then copy it then beep');
       const commandFeatures = features.filter(f => f.feature === 'command');
       expect(commandFeatures.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('stays silent on upstream commands it used to flag (step 4.1)', () => {
+      // The regression this half of step 4.1 fixes: every one of these parses
+      // on stock hyperscript.org, and each produced an editor ERROR reading
+      // "'X' command is a LokaScript extension (not compatible with
+      // _hyperscript)". Measured, not assumed — see command-tiers.ts.
+      const portable = 'make a <div/> then settle then morph #a to "<p>x</p>" then measure #b';
+      expect(detectLokascriptFeatures(portable).filter(f => f.feature === 'command')).toEqual([]);
+      expect(detectLokascriptFeatures('install Draggable')).toEqual([]);
+    });
+
+    it('now warns on the extensions that were classified nowhere (step 4.1)', () => {
+      // The other half: these were in NEITHER tier list, so detection returned
+      // nothing at all and non-portable code shipped unflagged.
+      for (const [code, cmd] of [
+        ['async do log "x" end', 'async'],
+        ['copy "text"', 'copy'],
+        ['push url "/next"', 'push'],
+        ['replace url "/next"', 'replace'],
+        ['unless $x is empty log "y" end', 'unless'],
+      ] as const) {
+        const commands = detectLokascriptFeatures(code).filter(f => f.feature === 'command');
+        expect(
+          commands.map(f => f.pattern),
+          code
+        ).toContain(cmd);
+      }
     });
 
     it('detects dot notation syntax', () => {
@@ -1938,7 +2005,7 @@ describe('LokaScript Feature Detection', () => {
     it('detects multiple feature types in one code block', () => {
       const code = `on input.debounce(300)
         set val to my.value as Int
-        morph #preview to val`;
+        prepend val to #preview`;
       const features = detectLokascriptFeatures(code);
 
       expect(features.some(f => f.pattern === 'debounce')).toBe(true);
@@ -1951,8 +2018,11 @@ describe('LokaScript Feature Detection', () => {
 
 describe('Mode-Specific Behavior', () => {
   describe('hyperscript mode constraints', () => {
-    it('should flag morph command in hyperscript mode', () => {
-      const features = detectLokascriptFeatures('morph #target to html');
+    it('should flag prepend command in hyperscript mode', () => {
+      // Was `morph`, which step 4.1 measured to be upstream (it parses on
+      // stock hyperscript.org) and moved to HYPERSCRIPT_COMMANDS. `prepend` is
+      // a real extension: upstream offers only `put <x> at the start of <y>`.
+      const features = detectLokascriptFeatures('prepend "<li>x</li>" to #list');
       expect(features.length).toBeGreaterThan(0);
       // detectLokascriptFeatures returns the base description
       // The server adds "(not compatible with _hyperscript)" when reporting
@@ -2055,7 +2125,7 @@ describe('Server Mode Types', () => {
       // Both should flag LokaScript-only features
       // Both should use hyperscript branding
       // Only hyperscript-i18n enables multilingual
-      const features = detectLokascriptFeatures('morph #target');
+      const features = detectLokascriptFeatures('prepend "x" to #target');
       expect(features.length).toBeGreaterThan(0); // Flagged in both modes
     });
 
@@ -2067,8 +2137,8 @@ describe('Server Mode Types', () => {
       const lokascriptCommands = getCommandsForMode('lokascript');
 
       // hyperscript-i18n would use hyperscript command set
-      expect(hyperscriptCommands).not.toContain('morph');
-      expect(lokascriptCommands).toContain('morph');
+      expect(hyperscriptCommands).not.toContain('prepend');
+      expect(lokascriptCommands).toContain('prepend');
     });
   });
 });


### PR DESCRIPTION
Arc A step 4.1 of the command-manifest arc. Brief: `docs-internal/HANDOFF-command-arch-manifest.md` (authoritative; updated here). Follows #814.

The LSP tier lists are now a **total partition** of the registry — **51 upstream / 8 extension, zero unclassified**.

## The defect

23 of the engine's 59 commands were in **neither** tier list. That was the arc's one *live* defect, not a latent one: `detectLokascriptFeatures()` scans only `LOKASCRIPT_ONLY_COMMANDS`, and `server.ts` renders every hit as a **`DiagnosticSeverity.Error`**. An unclassified extension therefore produced *no diagnostic at all*, so a user writing code that cannot run on original _hyperscript was told nothing.

## The oracle

The brief said "an upstream `_hyperscript` checkout". A better instrument was already in the repo: **`hyperscript.org@0.9.93`** in `node_modules` — the *published* engine that `canonical-validity.ts` loads for the R4 gate. Versioned, reproducible in CI, not a personal fork. Cross-checked against a `bigskysoftware/_hyperscript` **0.9.91** checkout; **the two agree on every row**. Each command's probe and its result are recorded inline in `command-tiers.ts`.

**One methodological trap worth not re-discovering.** `hs.parse(...)` returning no errors is *not* evidence the command exists. A **feature** keyword makes the command-list parser stop cleanly and hand back an EMPTY command list, with no error:

```
on click install Foo   →  parses, chain = [EmptyCommandListCommand, ImplicitReturn]
install Foo            →  parses as _InstallFeature
```

Checking `errors` alone classified `install` as an upstream *command*. It is an upstream *feature*. The probe asserts a real command node.

## The 23: 17 upstream, 6 extension

**Upstream** (each probed, node named in the file): `blur` `break` `breakpoint` `clear` `empty` `close` `continue` `focus` `open` `pick` `render` `reset` `scroll` `select` `start` `swap` `pseudo-command`

**Extension**: `async` `beep` `copy` `push` `replace` `unless`

Two carry a nuance recorded in the file rather than smoothed over:
- upstream spells beep **`beep!`** — `beep! me` parses, `beep me` does not. hyperfixi registers `beep` and accepts both, so the portable spelling is the banged one and the bare one is ours.
- upstream has **`unless` only as a trailing statement modifier** (`log "x" unless true`). The registered `unless` *command* — the leading block form, an alias of `if` — is the addition.

`pseudo-command` is unreachable as source text (`-` is not an identifier character); listed so the partition is total, and classified upstream because the construct it names (`foo() on #a`) works upstream.

**The brief's guess was mostly wrong**, which is the case for making the oracle mandatory. Claim 3 named 13 commands as likely extensions; **4** are. The other nine are upstream.

## Scope note — the mirror defect (Finding 12)

The same oracle run scored the rows that were *already* classified, and **5 of the 7 `LOKASCRIPT_ONLY_COMMANDS` entries were not extensions**: `make`, `measure`, `morph`, `settle` are upstream commands, and `install` is an upstream feature. The LSP was raising an editor **Error** on portable code. Only `prepend` and `process` survived.

Fixed here rather than deferred — same file, same function, same defect class, evidence already in hand, and leaving it would mean knowingly shipping a list I had just measured to be false. **It is isolated for review**: the moved rows are their own commented block in `command-tiers.ts`, and the assertions are their own named tests (`classifies upstream commands this list once called extensions`, `stays silent on upstream commands it used to flag`). Say the word and I'll split it out.

## The step-2 knock-on: decided **no**

`metadata.compatibility` stays unset; `upstreamOrExtension` stays absorbed from the tier lists and mirrored in the manifest under assertion. Reasoning recorded in `manifest.ts`:

1. Arc A's own non-goals fence the decorator statics off as **Arc B**.
2. Review artifact: 23 judgment calls are reviewable as one annotated table in one file, and unreviewable as a one-line decorator change across 59 implementation files.
3. The domains don't line up — `compatibility` has `'experimental'` with no counterpart here, this field has `'unknown'` with none there. Populating it would force a second, undiscussed decision inside an upstream-parity PR.

Arc B loses nothing by waiting: it can now copy **59 finished values**, which it could not have done while 23 read `'unknown'`.

## Deferred, recorded, not hidden (Finding 12, second half)

`detectLokascriptFeatures()` matches a bare `\b<cmd>\b` against raw source — no string-literal stripping, no command-position anchor, no guard against a preceding `.`. Adding `push`/`copy`/`replace`/`unless` widens a pre-existing false-positive surface. **Measured after this change:**

| Portable code | Spurious flag |
| ------------- | ------------- |
| `call $items.push(1)` | `push` — a JS method call |
| `set x to "copy me"` | `copy` — inside a string literal |
| `put "replace" into #a` | `replace` — inside a string literal |
| `log "x" unless $flag` | `unless` — the upstream trailing modifier is portable |
| `beep! me` | `beep` — the upstream spelling; `\b` matches before `!` |

Not fixed here: anchoring the scan to command position is a behavior change wanting its own PR and its own tests, and folding it in would bury this step's review artifact — the treatment Findings 7 and 10 already got. Mitigating: the scan runs only in `hyperscript`/`hyperscript-i18n` mode, which is opt-in. **Recommended as the next LSP PR.**

## Gate hardenings the annotations forced

- the audit's `stringsIn` now strips line comments before extracting quoted names — the tier lists carry per-row prose, and an apostrophe in it paired across lines into a phantom "name";
- the tier-list block regex is anchored on `] as const;` instead of the first `]`, so a bracket in an annotation can't silently truncate the list.

Both are mutation-verified to stay green under exactly those inputs.

## Couplings — both moved in this diff

- manifest `upstreamOrExtension === 'unknown'` set **===** audit `TIER_UNCLASSIFIED` → both now empty;
- headline count `23` → `0`, with the rows that justify it. §8 total went 40 → 17 (4.2 and 4.3 remain).

Neither of the step-3 constraints was touched: no rich-entry consumer was pointed at `COMMAND_MANIFEST` (only data values changed), and audit §1's hardcoded 59-name list and the per-command factory-identity test are untouched.

## Mutation verification (8 directions, all as intended)

**Caught:** a dropped upstream row · a cross-tier move with the manifest untouched · a manifest row changed alone · an `'unknown'` reintroduced · a name in both tiers · a real extension reclassified as upstream.
**Correctly stayed green:** a `]` inside an annotation comment · an apostrophe inside an annotation comment.

## Gates

- core **7829** passing / 128 skipped / 300 files (was 7827; +2 audit tests)
- language-server **227** passing (was 223)
- `verify:reference` clean (59 = 59, availability chain valid)
- `test:check` exit **0** across all packages
- `snapshot:bundle-size` — all 10 within tolerance, `hyperfixi-hx.js` +0.4% (Finding 11's hazard did not reappear)
- typecheck, prettier, oxlint clean
- Playwright `src/compatibility/` — 1111 passed / 8 skipped, **10 pre-existing local failures** (`behaviors-demo`, `i18n-htmx`, `swap-debug`). Verified identical with this change stashed; nothing at runtime reads `upstreamOrExtension`, and none of the three specs references the tiers or the manifest.

Next: step 4.2 (template-capabilities — 13 rows, latent, costs bundle size not correctness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
