### PR TITLE
feat(core): Arc A step 4.2 — classify every command against the generator

### DIFF
--- a/docs-internal/HANDOFF-command-arch-manifest.md
+++ b/docs-internal/HANDOFF-command-arch-manifest.md
@@ -7,10 +7,14 @@
 > (Arc C, complete) and [HANDOFF-command-arch-target-resolution.md](./HANDOFF-command-arch-target-resolution.md)
 > (Arc D, complete).
 >
-> **Status: STEPS 1–3 AND 4.1 LANDED** (the audit-as-gate, the manifest, the
-> four mechanical consumers, then the LSP tier classification — the arc's one
-> live defect). **Next action: step 4.2 (template-capabilities, 13 rows,
-> latent).** Baseline after 4.1 is **7829** core / **227** language-server.
+> **Status: STEPS 1–3, 4.1 AND 4.2 LANDED** (the audit-as-gate, the manifest,
+> the four mechanical consumers, the LSP tier classification, then the
+> capability lists). **Next action: step 4.3 (`COMMAND_KEYWORDS`, 4 gaps).**
+> Baseline after 4.2 is **7840** core / **227** language-server.
+>
+> **Step 4.2 also opened a new live defect it deliberately did NOT fix** — 14 of
+> the 38 advertised capability rows emit a case label the bundle parser can
+> never reach (Finding 13). Gated and pinned, remedy is a parser PR.
 >
 > **This brief REVISES the queue doc's Arc A plan — specifically its migration
 > ORDER and its manifest SHAPE.** Three of the paragraph's claims were measured
@@ -383,6 +387,60 @@ that are this step's review artifact — the same treatment Findings 7 and 10 go
 Mitigating factor: the scan runs only in `hyperscript`/`hyperscript-i18n` mode,
 which is opt-in. Recommended as the next LSP PR.
 
+### Finding 13 — the capability lists' incumbents are wrong in the OTHER direction: 14 of 38 advertised commands are unreachable (measured in step 4.2)
+
+Finding 12's shape, one step later, and the second consecutive time that
+scoring the ALREADY-CLASSIFIED rows found more than the gaps did.
+
+Claim 3 framed `template-capabilities` as **latent** — 13 unclassified rows
+costing bundle size, not correctness, because the generator falls back to the
+full runtime for anything it does not recognize. That is true of the gaps. It is
+**not** true of the incumbents. Membership in `AVAILABLE_COMMANDS` means the
+`case` label is EMITTED; nothing ever checked that the generated bundle's parser
+can REACH it. Measured against `parser/hybrid/parser-core.ts` — the parser
+`generateBundle()` points every bundle at — its `parseCommand()` dispatches a
+`cmdMap` of exactly **24** entries, and unknown input hits a fallback that
+advances one token and returns `null`. No throw, no warning, no node.
+
+So **24 of the 38 advertised commands are reachable and 14 are dead**, in two
+groups:
+
+| Cause | Rows |
+| ----- | ---- |
+| absent from `cmdMap` entirely | `copy`, `beep`, `push`, `push-url`, `replace`, `replace-url`, `break`, `continue`, `exit`, `throw`, `js`, `morph` |
+| parsed under a DIFFERENT name | `trigger` (→ `parseSend()`, emits `send`); `empty` (absent from parser-core, though present in the embedded template — see below) |
+
+`trigger` is the sharp case and the reason this is a correctness defect rather
+than a tidiness one. Measured end-to-end in jsdom: `generateBundle({commands:
+['trigger']})` returns **zero errors**, emits `case 'trigger':` and no `case
+'send':`, and `api.execute('trigger foo on #t')` leaves the listener
+**unfired**. The user wrote valid hyperscript, the toolchain reported success,
+and nothing happened. `vite-plugin`'s `getUnsupportedCommands()` cannot save
+them either — `isAvailableCommand('trigger')` is `true`, so the conservative
+full-runtime fallback never fires.
+
+`validation.test.ts` (lines ~103–143) pins twelve of the fourteen as available
+and NOT full-runtime-only, so the existing gate locks the defect in.
+
+**Deliberately not fixed in 4.2.** Reclassifying them full-runtime-only would
+make the gate honest but would DELETE a working feature — every one has a
+working template — and bump every project using `trigger`/`break`/`continue`
+from ~8 KB to the full runtime. The remedy that keeps the capability is a parser
+rule (or, for `trigger`, a `COMMAND_ALIASES` entry pointing it at the `send`
+template exactly as `push-url` points at `push`). That is a behavior change
+wanting its own decision — the treatment Findings 7, 10 and 12's deferred half
+got. Named, counted and pinned meanwhile in
+`bundle-generator/__tests__/capability-emission.test.ts`
+(`UNREACHABLE_CASE_LABELS`, tolerance 0 both directions).
+
+**A second drift the same run exposed.** Core's `generateBundle()` IMPORTS
+`parser/hybrid/parser-core`, but `vite-plugin/src/generator.ts` embeds
+`HYBRID_PARSER_TEMPLATE` instead — and the two `cmdMap`s are **not the same 24
+names**: the template has `empty` and lacks `halt`; parser-core has `halt` and
+lacks `empty`. So the reachable set depends on which generator you went through.
+`parser-template-drift.test.ts` compares the two on `catch`/`finally` only and
+is structurally unable to see this; §3 of the new gate pins it.
+
 ## What changed vs. the queue doc's plan
 
 The queue says: consumers migrate "lowest-risk first — template-capabilities
@@ -535,12 +593,46 @@ step-1 audit rows so the diff is the review artifact:
    second undiscussed decision inside an upstream-parity PR. Arc B loses
    nothing by waiting — it can now copy 59 *finished* values, which it could
    not have done while 23 read `'unknown'`.
-2. **template-capabilities** (**13** unclassified, not 12 — see the 2026-07-28
-   step-1 status entry; latent). 10 rows have no classification at all
-   (`CAPABILITY_UNCLASSIFIED` in the audit); `if`/`repeat`/`fetch` are
-   classified only as blocks (`CAPABILITY_BLOCK_ONLY`) and need an explicit
-   blocks-count-as-classified decision. Also decide the
-   `COMMAND_IMPLEMENTATIONS` second-list overlap.
+2. **template-capabilities** — **DONE** (see the status log). The three
+   decisions, all measured against the generator rather than reasoned from
+   names:
+   - **The 10 unclassified rows → `FULL_RUNTIME_ONLY_COMMANDS`.** None has a
+     `COMMAND_IMPLEMENTATIONS` key, so `generateBundle()` rejects each as
+     `unknown-command`, and none is reachable in the generated parser.
+     Behavior-preserving for bundle SELECTION (`getUnsupportedCommands()`
+     already treated an unclassified name as unsupported via its second arm);
+     what changes is DETECTION — `vite-plugin/src/scanner.ts` builds its command
+     regex from both lists, so nine of them (`pseudo-command` is filtered by the
+     scanner's `/^[A-Za-z]+$/` guard) become scannable and now route to a tier
+     that runs them instead of being silently skipped in a lite bundle.
+   - **Blocks DO count as a classification, and the three must stay OUT of
+     `FULL_RUNTIME_ONLY_COMMANDS`.** `if`/`repeat`/`fetch` are commands in the
+     ENGINE and blocks in the GENERATOR — one name, two dispatch surfaces
+     (`BLOCK_IMPLEMENTATIONS`, not `COMMAND_IMPLEMENTATIONS`). Listing them as
+     full-runtime-only would force a full-runtime fallback for `if`/`repeat`/
+     `fetch` code that lite bundles execute correctly today, because
+     `getUnsupportedCommands()` consults that list first. Pinned as an assertion
+     in audit §4, not only as prose.
+   - **The `COMMAND_IMPLEMENTATIONS` overlap resolves in that map's favour.**
+     Measured: `AVAILABLE_COMMANDS` is *exactly* `Object.keys(COMMAND_IMPLEMENTATIONS)`
+     plus the two advertised aliases, and `AVAILABLE_BLOCKS` is exactly
+     `Object.keys(BLOCK_IMPLEMENTATIONS)`. The implementation maps are the fact;
+     the capability lists are a second copy of it. They are now **checked
+     mirrors** — set equality both directions in
+     `bundle-generator/__tests__/capability-emission.test.ts`. A consequence
+     worth knowing: `vite-plugin/src/generator.ts`'s second escape hatch
+     (`!isAvailableCommand(cmd) && !COMMAND_IMPLEMENTATIONS[cmd]`) is therefore
+     **measurably redundant** — the two clauses cover the same set.
+     They stay LITERALS rather than derivations: `Object.keys(COMMAND_IMPLEMENTATIONS)`
+     references `templates.ts` and would drag all 36 command source strings into
+     every consumer — Finding 9/11 one level down, the same shape split as
+     `COMMAND_NAMES` vs `COMMAND_MANIFEST`. Measured clean:
+     `hyperfixi-hx.js` moved +0.4%, all 10 bundles within tolerance.
+
+   **What the step also found, and did not fix: Finding 13** — 14 of the 38
+   advertised rows emit a case label the bundle parser can never reach. See that
+   finding for why the remedy is a parser PR, not a reclassification.
+
    **Step-2 knock-on — do NOT derive these lists from the manifest's `tier`.**
    The manifest's `tier` mirrors `reference/index.ts`'s `availability` (which
    prebuilt bundle first ships a command; `verify:reference` already checks the
@@ -579,12 +671,25 @@ step-1 audit rows so the diff is the review artifact:
   fold into the manifest only once Finding 7 is decided.
 - **The two `CommandCategory` unions** (found in step 2, see Finding 10). A
   rename with LSP and docs reach; pinned by the audit meanwhile.
+- **The 14 unreachable case labels** (found in step 4.2, see Finding 13) — the
+  arc's second live defect, and the one with the largest user-visible stake.
+  **Recommended as the next bundle-generator PR**, with the evidence already in
+  hand: the gate names all 14, splits them by cause, and the remedy differs per
+  group. `trigger` is a one-line `COMMAND_ALIASES` entry (→ `send`, exactly like
+  `push-url` → `push`) and is the cheapest real fix. `empty` and `halt` want the
+  two parser copies reconciled (they disagree on precisely those two). The
+  remaining twelve want `cmdMap` rules in
+  `parser/hybrid/parser-core.ts` **and** `parser-templates.ts` — their templates
+  already exist and work, so this restores capability rather than removing it.
+  Reclassifying them full-runtime-only is the wrong fix: it would make the lists
+  honest by deleting a working feature and bumping every `trigger`/`break`/
+  `continue` project to the full runtime.
 
 ## Gates, per step
 
 | Step | Suites | Command |
 | ---- | ------ | ------- |
-| all | quick validation (baseline **7829** after step 4.1; was 7827 after step 3, 7824 after step 2, 7814 after step 1, 7800 after the Finding 5 fix, 7795 before it) | `npm run test:quick --prefix packages/core` |
+| all | quick validation (baseline **7840** after step 4.2; was 7829 after 4.1, 7827 after step 3, 7824 after step 2, 7814 after step 1, 7800 after the Finding 5 fix, 7795 before it) | `npm run test:quick --prefix packages/core` |
 | all | the reference gate | `npm run verify:reference --prefix packages/core` |
 | 1 | the new audit test itself | added in the step-1 PR |
 | 2, 3 | bundle size — the tree-shaking guard | `npm run snapshot:bundle-size --prefix packages/core` (`--check`, ±5% vs `scripts/bundle-snapshots/baseline.json`) |
@@ -858,3 +963,64 @@ was touched.
   `src/compatibility/`; typecheck, prettier, oxlint clean.
   Next action: step 4.2 (template-capabilities — 13 rows, latent, costs bundle
   size not correctness).
+- 2026-07-28 — **Step 4.2 landed** (branch
+  `feat/command-capability-classification`, off `55afdb20`): the capability
+  lists now classify every registered command. `CAPABILITY_UNCLASSIFIED` is an
+  empty set the audit holds at zero; the ten rows moved into
+  `FULL_RUNTIME_ONLY_COMMANDS`, and the block-only three were RESOLVED as
+  classified-by-`AVAILABLE_BLOCKS` rather than merely tolerated — so §8's debt
+  went 17 → 4, all of it step 4.3's.
+  **The oracle was the generator itself**, as the step specified, and it was
+  run rather than reasoned: `generateBundle()` for each of the 59 registered
+  commands plus the two aliases, each emitted bundle written to disk, imported,
+  and executed against jsdom. `emit=Y` ⟺ `AVAILABLE_COMMANDS` held with **zero
+  exceptions across all 61 rows**, which is what makes the ten-row
+  classification mechanical rather than a judgment call. Deliberately NOT
+  upstream \_hyperscript — what upstream accepts is step 4.1's question.
+  **The 4.1 lesson paid off again, and harder: scoring the incumbents found a
+  live correctness defect the step was told was latent** (recorded above as
+  **Finding 13**). Membership in `AVAILABLE_COMMANDS` means the case label is
+  EMITTED; nothing had ever checked the generated parser can REACH it.
+  `parser-core.ts`'s `parseCommand()` dispatches a 24-entry `cmdMap` and skips
+  anything else silently, so **14 of the 38 advertised commands are dead
+  labels**. Measured end-to-end: a `trigger`-only bundle reports zero errors,
+  emits `case 'trigger':` and no `case 'send':`, and leaves the listener
+  unfired. `getUnsupportedCommands()` cannot save them because
+  `isAvailableCommand('trigger')` is `true`.
+  **The first probe run nearly missed it.** Nine of the fourteen scored "RUNS"
+  because their execution check was `() => true` — an empty command list throws
+  nothing. That is 4.1's `hs.parse()` trap in a new costume: *absence of an
+  error is not evidence of a command*. The parse-level probe, which asserts a
+  node named after the case label, is what exposed it.
+  **Not fixed here, deliberately.** Every one of the 14 has a working template,
+  so reclassifying them would delete a feature and bump every
+  `trigger`/`break`/`continue` project from ~8 KB to the full runtime; the
+  remedy that keeps the capability is a parser rule. Named, split by cause and
+  pinned at tolerance 0 in the new
+  `bundle-generator/__tests__/capability-emission.test.ts` (10 tests), and
+  written up as the recommended next PR under "Deferred out of the arc".
+  **A second drift the same run exposed:** core's `generateBundle()` imports
+  `parser/hybrid/parser-core` while `vite-plugin/src/generator.ts` embeds
+  `HYBRID_PARSER_TEMPLATE`, and the two `cmdMap`s differ — the template has
+  `empty` and lacks `halt`, parser-core the reverse. So the reachable set
+  depends on which generator you went through.
+  `parser-template-drift.test.ts` compares the two on `catch`/`finally` only and
+  is structurally unable to see it; §3 of the new gate pins it.
+  **`COMMAND_IMPLEMENTATIONS` overlap decided in that map's favour:**
+  `AVAILABLE_COMMANDS` is exactly its key set plus the two aliases, and
+  `AVAILABLE_BLOCKS` exactly `Object.keys(BLOCK_IMPLEMENTATIONS)` — now checked
+  mirrors, set equality both directions. Which also makes the vite-plugin's
+  second escape hatch (`!isAvailableCommand(cmd) && !COMMAND_IMPLEMENTATIONS[cmd]`)
+  measurably redundant. Kept as literals, not derivations, per Finding 9/11.
+  The new gate was mutation-verified in **7** directions, all caught: a dropped
+  `AVAILABLE_COMMANDS` entry, a phantom one, a removed `UNREACHABLE_CASE_LABELS`
+  row, a reachable command added to it, a full-runtime entry that has a
+  template, a dropped `FULL_RUNTIME_ONLY` row (audit gap direction), and `if`
+  moved into `FULL_RUNTIME_ONLY` (the block-only decision).
+  Gates: core **7840** passing / 128 skipped / 301 files; `verify:reference`
+  clean (59 = 59, availability chain valid); `snapshot:bundle-size` all 10
+  within tolerance (`hyperfixi-hx.js` +0.4% — the Finding 11 sharp case);
+  language-server **227** passing; vite-plugin **315** passing (the package
+  whose detection surface this changes); typecheck clean.
+  Next action: step 4.3 (`COMMAND_KEYWORDS` — 4 gaps: `process`,
+  `pseudo-command`, `scroll`, `start`).

--- a/packages/core/src/bundle-generator/__tests__/capability-emission.test.ts
+++ b/packages/core/src/bundle-generator/__tests__/capability-emission.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Can the generator actually emit what `template-capabilities.ts` advertises?
+ *
+ * `capability-ghosts.test.ts` asks whether each entry names a REAL command.
+ * Nothing asked the question this file exists for: whether a command listed as
+ * available can be emitted into a bundle and then reached by that bundle's
+ * parser. Arc A step 4.2 measured it and the answer was no for 14 of 38.
+ *
+ * The oracle is the generator itself — `templates.ts` (which case labels get
+ * emitted), `parser/hybrid/parser-core.ts` (the parser `generateBundle()`
+ * points every bundle at), and `parser-templates.ts`'s `HYBRID_PARSER_TEMPLATE`
+ * (the copy the vite-plugin embeds instead). Deliberately NOT upstream
+ * _hyperscript: what upstream accepts is a different question, answered by the
+ * LSP tier lists (step 4.1).
+ *
+ * See `docs-internal/HANDOFF-command-arch-manifest.md`, Finding 13.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  AVAILABLE_COMMANDS,
+  AVAILABLE_BLOCKS,
+  FULL_RUNTIME_ONLY_COMMANDS,
+  COMMAND_ALIASES,
+  resolveCommandKey,
+} from '../template-capabilities';
+import { COMMAND_IMPLEMENTATIONS, BLOCK_IMPLEMENTATIONS } from '../templates';
+import { HYBRID_PARSER_TEMPLATE } from '../parser-templates';
+import { HybridParser } from '../../parser/hybrid/parser-core';
+
+// ===========================================================================
+// 1. The lists mirror the implementation maps, both directions
+// ===========================================================================
+
+describe('the capability lists mirror the generator implementation maps', () => {
+  it('AVAILABLE_COMMANDS is exactly the template keys plus the advertised aliases', () => {
+    // The equality that makes AVAILABLE_COMMANDS a checked mirror rather than a
+    // third hand-maintained copy of the same fact. Set equality both ways: an
+    // advertised name with no template is a phantom capability, and a template
+    // nobody advertises is dead weight the scanner never routes to.
+    const expected = [...Object.keys(COMMAND_IMPLEMENTATIONS), ...Object.keys(COMMAND_ALIASES)];
+    expect([...AVAILABLE_COMMANDS].sort()).toEqual(expected.sort());
+  });
+
+  it('AVAILABLE_BLOCKS is exactly the block template keys', () => {
+    expect([...AVAILABLE_BLOCKS].sort()).toEqual(Object.keys(BLOCK_IMPLEMENTATIONS).sort());
+  });
+
+  it('nothing full-runtime-only has a template — that is what the label means', () => {
+    const emittable = FULL_RUNTIME_ONLY_COMMANDS.filter(
+      name => COMMAND_IMPLEMENTATIONS[resolveCommandKey(name)]
+    );
+    expect(emittable).toEqual([]);
+  });
+
+  it('every advertised alias resolves to a real template key', () => {
+    for (const [advertised, key] of Object.entries(COMMAND_ALIASES)) {
+      expect(COMMAND_IMPLEMENTATIONS[key], `${advertised} → ${key}`).toBeDefined();
+    }
+  });
+});
+
+// ===========================================================================
+// 2. Reachability: is the emitted case label ever executed?
+// ===========================================================================
+
+/**
+ * A representative surface per advertised command. These are the probes step
+ * 4.2 ran; they are recorded rather than reduced to a boolean so the next
+ * reader re-verifies instead of trusting.
+ */
+const SURFACES: Record<string, string[]> = {
+  toggle: ['toggle .x on #t'],
+  add: ['add .x to #t'],
+  remove: ['remove me', 'remove #t'],
+  removeClass: ['remove .x from #t'],
+  show: ['show #t'],
+  hide: ['hide #t'],
+  put: ['put "hi" into #t'],
+  append: ['append "hi" to #t'],
+  prepend: ['prepend "hi" to #t'],
+  take: ['take .x from .p'],
+  empty: ['empty #t', 'empty me', 'on click empty #t'],
+  set: ['set :v to 1'],
+  get: ['get "v"'],
+  increment: ['increment :v'],
+  decrement: ['decrement :v'],
+  wait: ['wait 1ms'],
+  transition: ["transition #t's opacity to 0.5"],
+  send: ['send foo to #t'],
+  trigger: ['trigger foo on #t'],
+  log: ['log "hi"'],
+  call: ['call foo()'],
+  copy: ['copy "hi"', 'copy #t', 'on click copy "x"'],
+  beep: ['beep "x"', 'beep! me', 'beep'],
+  go: ['go to url "/x"'],
+  push: ['push url "/p"', 'push "/p"'],
+  'push-url': ['push url "/p"', 'push-url "/p"'],
+  replace: ['replace url "/r"', 'replace "/r"'],
+  'replace-url': ['replace url "/r"', 'replace-url "/r"'],
+  focus: ['focus #t'],
+  blur: ['blur #t'],
+  return: ['return 1'],
+  break: ['break', 'repeat 3 times break end'],
+  continue: ['continue', 'repeat 3 times continue end'],
+  halt: ['halt'],
+  exit: ['exit', 'on click exit'],
+  throw: ['throw "e"', 'on click throw "e"'],
+  js: ['js return 1 end'],
+  morph: ['morph #t to "<p></p>"', 'morph me to "<p></p>"'],
+};
+
+/**
+ * Advertised commands whose emitted `case` label the bundle parser can NEVER
+ * reach. Requesting one produces a bundle that carries its implementation as
+ * dead code while the user's source silently no-ops — the parser's unknown-command
+ * fallback advances one token and returns null (`parser-core.ts`, end of
+ * `parseCommand()`), so there is no error either.
+ *
+ * Two distinct causes, both measured:
+ *
+ *  - NOT IN THE PARSER'S `cmdMap` at all (12): `copy`, `beep`, `push`,
+ *    `push-url`, `replace`, `replace-url`, `break`, `continue`, `exit`,
+ *    `throw`, `js`, `morph`. `parseCommand()` has 24 entries; these are not
+ *    among them.
+ *  - PARSED UNDER ANOTHER NAME (2): `trigger` is mapped to `parseSend()`, which
+ *    emits a node named `send`; `empty` is absent from `parser-core.ts` (though
+ *    present in the embedded template — see §3).
+ *
+ * NOT fixed by reclassifying them full-runtime-only. Every one has a working
+ * template, so the remedy that keeps the capability is a parser rule (or, for
+ * `trigger`, a `COMMAND_ALIASES` entry pointing it at the `send` template the
+ * way `push-url` points at `push`). Reclassification would delete a working
+ * feature and bump every project using `trigger`/`break`/`continue` from ~8 KB
+ * to the full runtime. That trade is a behavior change wanting its own PR —
+ * the treatment Findings 7, 10 and 12's deferred half got.
+ *
+ * Tolerance 0 in both directions: a NEW dead label is a regression, and a name
+ * that becomes reachable must be deleted from this list in the same change.
+ */
+const UNREACHABLE_CASE_LABELS = new Set([
+  'beep',
+  'break',
+  'continue',
+  'copy',
+  'empty',
+  'exit',
+  'js',
+  'morph',
+  'push',
+  'push-url',
+  'replace',
+  'replace-url',
+  'throw',
+  'trigger',
+]);
+
+/** Every command-node name anywhere in a parse tree. */
+const commandNamesIn = (node: unknown, acc: string[] = []): string[] => {
+  if (!node || typeof node !== 'object') return acc;
+  const n = node as { type?: string; name?: string };
+  if (n.type === 'command' && typeof n.name === 'string') acc.push(n.name);
+  for (const value of Object.values(node as Record<string, unknown>)) {
+    if (Array.isArray(value)) value.forEach(item => commandNamesIn(item, acc));
+    else if (value && typeof value === 'object') commandNamesIn(value, acc);
+  }
+  return acc;
+};
+
+/** Can the bundle parser produce a node named `key` for any listed surface? */
+const isReachable = (advertised: string): boolean => {
+  const key = resolveCommandKey(advertised);
+  return (SURFACES[advertised] ?? []).some(code => {
+    try {
+      return commandNamesIn(new HybridParser(code).parse()).includes(key);
+    } catch {
+      return false;
+    }
+  });
+};
+
+describe('every advertised command can be reached by the bundle parser', () => {
+  it('has a probe surface for every advertised command', () => {
+    // Guards the gate itself: a command added to AVAILABLE_COMMANDS without a
+    // surface here would otherwise score as unreachable for the wrong reason.
+    expect(AVAILABLE_COMMANDS.filter(name => !SURFACES[name])).toEqual([]);
+  });
+
+  it('the unreachable set is exactly the documented allowlist', () => {
+    const unreachable = AVAILABLE_COMMANDS.filter(name => !isReachable(name));
+    expect(unreachable.sort()).toEqual([...UNREACHABLE_CASE_LABELS].sort());
+  });
+
+  it('24 of 38 advertised commands are reachable', () => {
+    // A count as well as a list, so a change has to move a number too — the
+    // discipline the audit's §8 headline counts use.
+    expect(AVAILABLE_COMMANDS.length).toBe(38);
+    expect(UNREACHABLE_CASE_LABELS.size).toBe(14);
+  });
+
+  it('trigger parses, but as send — so a trigger-only bundle dispatches nothing', () => {
+    // The sharpest of the 14, and the reason this is a correctness defect and
+    // not a tidiness one: the user's code is valid and the generator reports no
+    // error, yet the emitted bundle carries `case 'trigger'` and the parser
+    // hands it a node named `send`.
+    expect(commandNamesIn(new HybridParser('trigger foo on #t').parse())).toEqual(['send']);
+    expect(COMMAND_IMPLEMENTATIONS.trigger).toContain("case 'trigger'");
+    expect(COMMAND_IMPLEMENTATIONS.trigger).not.toContain("case 'send'");
+  });
+
+  it('an unknown command is skipped silently, which is why this is invisible', () => {
+    // The mechanism behind all 14. No throw, no warning, no node.
+    expect(commandNamesIn(new HybridParser('copy "hi"').parse())).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// 3. The two bundle parsers do not agree on their command set
+// ===========================================================================
+
+/** The `cmdMap` keys of the embedded template, read from its source text. */
+const templateCommandKeys = (): string[] => {
+  const block = HYBRID_PARSER_TEMPLATE.match(/const cmdMap = \{([\s\S]*?)\n {4}\};/);
+  if (!block) return [];
+  return [...block[1].matchAll(/^\s{6}([A-Za-z_][\w]*):/gm)].map(m => m[1]);
+};
+
+describe('parser-core and the embedded parser template classify the same commands', () => {
+  it('differ on exactly empty and halt', () => {
+    // `generateBundle()` in core imports `parser/hybrid/parser-core`, but the
+    // vite-plugin's own generator embeds HYBRID_PARSER_TEMPLATE instead, so the
+    // two paths have different reachable sets. Measured: the template handles
+    // `empty` and parser-core does not; parser-core handles `halt` and the
+    // template does not. `parser-template-drift.test.ts` compares the two on
+    // catch/finally only and cannot see this.
+    const inTemplate = new Set(templateCommandKeys());
+    expect(inTemplate.size, 'cmdMap regex found nothing — the template shape changed').toBe(24);
+
+    expect(inTemplate.has('empty')).toBe(true);
+    expect(isReachable('empty')).toBe(false); // parser-core lacks it
+
+    expect(inTemplate.has('halt')).toBe(false);
+    expect(isReachable('halt')).toBe(true); // parser-core has it
+  });
+});

--- a/packages/core/src/bundle-generator/template-capabilities.ts
+++ b/packages/core/src/bundle-generator/template-capabilities.ts
@@ -3,11 +3,56 @@
  *
  * Documents which commands and blocks are available in generated lite bundles
  * versus those that require the full runtime.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT "AVAILABLE" MEANS HERE, AND WHERE THE FACT ACTUALLY LIVES
+ * (Arc A step 4.2 — `docs-internal/HANDOFF-command-arch-manifest.md`)
+ * ---------------------------------------------------------------------------
+ *
+ * These lists answer ONE question: *can the bundle generator emit this command
+ * into a lite bundle?* That is deliberately NOT the same question as the
+ * command manifest's `tier` (`commands/manifest.ts`), which mirrors
+ * `reference/index.ts`'s `availability` — "which prebuilt bundle first ships
+ * it". Measured under the natural mapping the two facts disagree on 16 of 59
+ * rows, so neither may be derived from the other.
+ *
+ * The generator's emission fact is `COMMAND_IMPLEMENTATIONS` in `./templates.ts`
+ * (a `Record<name, caseSource>`): `generateBundle()` filters on it, and a name
+ * with no key is rejected as `unknown-command`. `AVAILABLE_COMMANDS` below is a
+ * **checked mirror** of its key set plus the two advertised aliases — not a
+ * third hand-maintained copy. `capability-emission.test.ts` asserts the
+ * equality in both directions, so the two cannot drift.
+ *
+ * It stays a literal rather than `Object.keys(COMMAND_IMPLEMENTATIONS)` for the
+ * reason recorded as Finding 9/11 in the brief: a derivation references
+ * `templates.ts`, dragging all 36 command source strings into every consumer of
+ * this module. Same shape-split as `COMMAND_NAMES` vs `COMMAND_MANIFEST`.
+ *
+ * **Blocks count as a classification.** `if`, `repeat` and `fetch` are
+ * registered commands that appear in neither list below; they are classified by
+ * `AVAILABLE_BLOCKS`, and the generator dispatches them through
+ * `BLOCK_IMPLEMENTATIONS`, not `COMMAND_IMPLEMENTATIONS`. They must NOT be
+ * added to `FULL_RUNTIME_ONLY_COMMANDS`: `vite-plugin`'s `getUnsupportedCommands`
+ * checks that list first, so listing them would force a full-runtime fallback
+ * for `if`/`repeat`/`fetch` code that lite bundles execute correctly today.
+ *
+ * **Known open defect (step 4.2 follow-up).** Membership here means the case
+ * label is EMITTED, not that the generated parser ever reaches it. 14 of the
+ * entries below are unreachable — the parser produces no node for them, or
+ * produces one under a different name — so the emitted `case` is dead code and
+ * the user's source silently no-ops. They are named, counted and pinned in
+ * `capability-emission.test.ts` (`UNREACHABLE_CASE_LABELS`). They are NOT
+ * reclassified here: every one has a working template, so the correct remedy is
+ * a parser rule that restores the capability, not a reclassification that
+ * removes it and bumps those projects to the full runtime.
  */
 
 /**
  * Commands available in generated lite bundles.
  * These have simplified implementations that cover common use cases.
+ *
+ * Exactly `Object.keys(COMMAND_IMPLEMENTATIONS)` plus `push-url`/`replace-url`
+ * (see COMMAND_ALIASES below) — gated, both directions.
  */
 export const AVAILABLE_COMMANDS = [
   // DOM manipulation
@@ -62,6 +107,10 @@ export const AVAILABLE_COMMANDS = [
 
 /**
  * Blocks available in generated lite bundles.
+ *
+ * Exactly `Object.keys(BLOCK_IMPLEMENTATIONS)` — gated, both directions. Three
+ * of these (`if`, `repeat`, `fetch`) are also registered commands; this list is
+ * their classification (see the module header).
  */
 export const AVAILABLE_BLOCKS = ['if', 'repeat', 'for', 'while', 'fetch'] as const;
 
@@ -69,6 +118,11 @@ export const AVAILABLE_BLOCKS = ['if', 'repeat', 'for', 'while', 'fetch'] as con
  * Commands NOT available in lite bundles (require full runtime).
  * These either have complex implementations or depend on features
  * not included in lite bundles.
+ *
+ * Invariant, gated: no entry here has a `COMMAND_IMPLEMENTATIONS` key. Being
+ * listed routes the vite-plugin's bundle selection to the full runtime, which
+ * is the conservative and correct default for anything the generator cannot
+ * emit.
  */
 export const FULL_RUNTIME_ONLY_COMMANDS = [
   // Advanced execution
@@ -89,6 +143,36 @@ export const FULL_RUNTIME_ONLY_COMMANDS = [
   'measure',
   // Behaviors (requires registry)
   'install',
+
+  // -------------------------------------------------------------------------
+  // Classified by Arc A step 4.2. These ten were in NEITHER list — registered
+  // commands the capability file had no opinion about, against a doc comment
+  // that claims a partition. Measured against the generator (the oracle for
+  // this file): none has a `COMMAND_IMPLEMENTATIONS` key, so `generateBundle()`
+  // rejects each as `unknown-command`, and none is reachable in the generated
+  // parser. Full-runtime-only is therefore the accurate classification, not a
+  // conservative guess.
+  //
+  // Behavior-preserving for bundle selection — `getUnsupportedCommands()`
+  // already treated an unclassified name as unsupported via its
+  // `!isAvailableCommand && !COMMAND_IMPLEMENTATIONS[cmd]` arm. What DOES
+  // change is detection: `vite-plugin/src/scanner.ts` builds its command regex
+  // from both lists, so these nine (`pseudo-command` is filtered out by the
+  // scanner's `/^[A-Za-z]+$/` guard) become scannable. That is the improvement
+  // the scanner's own comment asks for — previously their use went undetected
+  // and got a lite bundle that silently no-opped them; now it routes to a tier
+  // that runs them.
+  // -------------------------------------------------------------------------
+  'breakpoint', // debugger integration — needs the full runtime's debug hooks
+  'clear', // storage/DOM clear
+  'close', // dialog/details close
+  'open', // dialog/details open
+  'pseudo-command', // method-call-as-command; needs full expression evaluation
+  'render', // template rendering — needs the template registry
+  'reset', // form reset
+  'scroll', // scroll to target
+  'select', // selection API
+  'start', // start view transition … end
 ] as const;
 
 /**

--- a/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
+++ b/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
@@ -473,36 +473,42 @@ const CAPABILITY_NOT_COMMANDS = new Set(['removeClass', 'push-url', 'replace-url
 
 /**
  * Registered commands in NEITHER capability list, but present in
- * AVAILABLE_BLOCKS — classified as blocks rather than commands. Whether that
- * satisfies the file's partition ("available in generated lite bundles versus
- * … the full runtime") is step 4.2's decision to make explicit.
+ * AVAILABLE_BLOCKS — classified as blocks rather than commands.
+ *
+ * **Step 4.2 decided this DOES satisfy the file's partition, and that these
+ * three must stay out of `FULL_RUNTIME_ONLY_COMMANDS`.** The generator
+ * dispatches them through `BLOCK_IMPLEMENTATIONS`, not
+ * `COMMAND_IMPLEMENTATIONS`, and lite bundles execute them correctly today;
+ * `vite-plugin`'s `getUnsupportedCommands()` checks the full-runtime list
+ * first, so listing them there would force a full-runtime fallback for working
+ * `if`/`repeat`/`fetch` code. The reason they look unclassified is that they
+ * are commands in the ENGINE and blocks in the GENERATOR — one name, two
+ * dispatch surfaces.
  */
 const CAPABILITY_BLOCK_ONLY = new Set(['fetch', 'if', 'repeat']);
 
 /**
  * Registered commands with NO classification anywhere in the capability file.
- * Latent rather than live: `vite-plugin/src/generator.ts` treats an
- * unclassified command as unsupported and falls back to the full runtime, so
- * these cost bundle size, not correctness. All fixed by step 4.2 (which must
- * also decide the COMMAND_IMPLEMENTATIONS second-list overlap).
  *
- * NOTE: the brief's Claim 3 table says 12 gaps for this file. Measured, it is
- * 13 = these 10 + the 3 block-only rows above — the table counted `if` as
+ * **Emptied by step 4.2** — all ten moved into `FULL_RUNTIME_ONLY_COMMANDS`.
+ * Measured against the generator (this file's oracle): none has a
+ * `COMMAND_IMPLEMENTATIONS` key, so `generateBundle()` rejects each as
+ * `unknown-command`, and none is reachable in the generated parser.
+ * Behavior-preserving for bundle selection, and it makes them scannable so
+ * their use routes to a tier that runs them.
+ *
+ * NOTE: the brief's Claim 3 table says 12 gaps for this file. Measured, it was
+ * 13 = those 10 + the 3 block-only rows above — the table counted `if` as
  * classified, but `if` appears in neither command list, exactly like `repeat`
  * and `fetch` which it did count.
+ *
+ * The mirror defect the same oracle run exposed — 14 of the 38 ADVERTISED
+ * commands emit a case label the bundle parser can never reach — is gated
+ * separately in `bundle-generator/__tests__/capability-emission.test.ts`
+ * (`UNREACHABLE_CASE_LABELS`), because its remedy is a parser rule rather than
+ * a reclassification. See Finding 13 in the brief.
  */
-const CAPABILITY_UNCLASSIFIED = new Set([
-  'breakpoint',
-  'clear',
-  'close',
-  'open',
-  'pseudo-command',
-  'render',
-  'reset',
-  'scroll',
-  'select',
-  'start',
-]);
+const CAPABILITY_UNCLASSIFIED = new Set<string>([]);
 
 describe('the capability lists', () => {
   it('every capability entry is a registered command or an allowlisted generator name', () => {
@@ -518,10 +524,12 @@ describe('the capability lists', () => {
     expect(REGISTERED.has(resolveCommandKey('replace-url'))).toBe(true);
   });
 
-  it('13 registered commands are outside the command partition (step 4.2)', () => {
+  it('only the 3 block-only rows are outside the command partition (step 4.2)', () => {
+    // Was 13 before step 4.2 (10 unclassified + these 3).
     expect(gapsIn([...AVAILABLE_COMMANDS, ...FULL_RUNTIME_ONLY_COMMANDS])).toEqual(
       [...CAPABILITY_BLOCK_ONLY, ...CAPABILITY_UNCLASSIFIED].sort()
     );
+    expect(CAPABILITY_UNCLASSIFIED.size, 'a command lost its classification').toBe(0);
   });
 
   it('the block-only rows really are classified as blocks', () => {
@@ -529,6 +537,16 @@ describe('the capability lists', () => {
     // AVAILABLE_BLOCKS it must move to CAPABILITY_UNCLASSIFIED, not linger.
     for (const name of CAPABILITY_BLOCK_ONLY) {
       expect(AVAILABLE_BLOCKS, `${name} left AVAILABLE_BLOCKS`).toContain(name);
+    }
+  });
+
+  it('the block-only rows are NOT full-runtime-only (step 4.2 decision)', () => {
+    // The decision, pinned as an assertion rather than only as prose: adding
+    // one of these to FULL_RUNTIME_ONLY_COMMANDS would bump every project using
+    // an `if` block to the full runtime, because getUnsupportedCommands()
+    // consults that list before anything else.
+    for (const name of CAPABILITY_BLOCK_ONLY) {
+      expect(FULL_RUNTIME_ONLY_COMMANDS as readonly string[]).not.toContain(name);
     }
   });
 });
@@ -835,7 +853,7 @@ describe('the command manifest', () => {
 // ===========================================================================
 
 describe('the classification debt, counted', () => {
-  it('17 rows await deliberate classification (steps 4.2–4.3)', () => {
+  it('4 rows await deliberate classification (step 4.3)', () => {
     // The numbers the arc exists to burn down. A step that classifies a
     // command flips its allowlist row AND moves the count here, so the diff
     // shows both the decision and its scope. Do not adjust a count without
@@ -843,9 +861,13 @@ describe('the classification debt, counted', () => {
     //
     // Step 4.1 took this from 40 to 17: the LSP tier lists are now a total
     // partition of the registry (51 upstream / 8 extension), asserted in §3.
+    // Step 4.2 took it from 17 to 4 by classifying the ten unclassified
+    // capability rows as full-runtime-only and RESOLVING the block-only three
+    // as classified-by-AVAILABLE_BLOCKS rather than unclassified, so they no
+    // longer count as debt (they are still pinned in §4, both directions).
     expect(TIER_UNCLASSIFIED.size).toBe(0); // step 4.1 — DONE, was 23
-    expect(CAPABILITY_UNCLASSIFIED.size).toBe(10); // step 4.2 — latent, costs bundle size
-    expect(CAPABILITY_BLOCK_ONLY.size).toBe(3); // step 4.2 — decide blocks-as-classification
+    expect(CAPABILITY_UNCLASSIFIED.size).toBe(0); // step 4.2 — DONE, was 10
+    expect(CAPABILITY_BLOCK_ONLY.size).toBe(3); // step 4.2 — DECIDED: blocks classify
     expect(KEYWORD_GAPS.size).toBe(4); // step 4.3 — missing LSP completions
   });
 });


### PR DESCRIPTION
Arc A step 4.2 of the command-manifest arc. Brief: `docs-internal/HANDOFF-command-arch-manifest.md` (authoritative for the arc).

`bundle-generator/template-capabilities.ts` claims a partition — "available in generated lite bundles versus those that require the full runtime" — but had no opinion about 13 of the 59 registered commands.

## The oracle

The generator itself, run rather than reasoned: `generateBundle()` for all 59 registered commands plus the two advertised aliases, each emitted bundle written to disk, imported, and executed against jsdom. `emit=Y` matched `AVAILABLE_COMMANDS` with **zero exceptions across all 61 rows**, which is what makes the classification mechanical rather than a judgment call.

Deliberately *not* upstream _hyperscript — what upstream accepts is step 4.1's question.

## The three decisions

**1. The 10 unclassified rows → `FULL_RUNTIME_ONLY_COMMANDS`.** None has a `COMMAND_IMPLEMENTATIONS` key, so `generateBundle()` rejects each as `unknown-command`, and none is reachable in the generated parser. Behavior-preserving for bundle *selection* (`getUnsupportedCommands()` already treated an unclassified name as unsupported via its second arm). What changes is *detection*: `vite-plugin/src/scanner.ts` builds its command regex from both lists, so nine of them become scannable and route to a tier that runs them instead of being silently skipped in a lite bundle — the improvement that file's own comment asks for.

**2. Blocks DO count as a classification, and `if`/`repeat`/`fetch` stay OUT of `FULL_RUNTIME_ONLY_COMMANDS`.** They are commands in the *engine* and blocks in the *generator* — one name, two dispatch surfaces (`BLOCK_IMPLEMENTATIONS`, not `COMMAND_IMPLEMENTATIONS`). Listing them as full-runtime-only would force a full-runtime fallback for `if`/`repeat`/`fetch` code that lite bundles execute correctly today, because `getUnsupportedCommands()` consults that list first. Pinned as an assertion, not only as prose.

**3. The `COMMAND_IMPLEMENTATIONS` overlap resolves in that map's favour.** Measured: `AVAILABLE_COMMANDS` is *exactly* its key set plus the two aliases, and `AVAILABLE_BLOCKS` is exactly `Object.keys(BLOCK_IMPLEMENTATIONS)`. The implementation maps are the fact; the capability lists were a second copy. They are now **checked mirrors** (set equality, both directions). A consequence worth knowing: the vite-plugin's second escape hatch `!isAvailableCommand(cmd) && !COMMAND_IMPLEMENTATIONS[cmd]` is therefore **measurably redundant**.

They stay literals rather than derivations — `Object.keys(COMMAND_IMPLEMENTATIONS)` references `templates.ts` and would drag all 36 command source strings into every consumer (Findings 9/11 one level down). Measured clean: `hyperfixi-hx.js` +0.4%, all 10 bundles within tolerance.

## What scoring the incumbents found — Finding 13

Step 4.1's lesson paid off again, harder. **The step was told it was latent; it isn't.**

Membership in `AVAILABLE_COMMANDS` means the case label is EMITTED. Nothing had ever checked that the generated bundle's parser can REACH it. `parser-core.ts`'s `parseCommand()` dispatches a **24-entry** `cmdMap` and skips anything else silently (advance one token, return `null` — no throw, no warning, no node). So **14 of the 38 advertised commands are dead labels**:

| Cause | Rows |
| ----- | ---- |
| absent from `cmdMap` | `copy` `beep` `push` `push-url` `replace` `replace-url` `break` `continue` `exit` `throw` `js` `morph` |
| parsed under another name | `trigger` (→ emits `send`), `empty` |

Measured end-to-end: `generateBundle({commands: ['trigger']})` returns **zero errors**, emits `case 'trigger':` and no `case 'send':`, and `api.execute('trigger foo on #t')` leaves the listener **unfired**. Valid hyperscript, successful toolchain, nothing happens. `getUnsupportedCommands()` can't save it — `isAvailableCommand('trigger')` is `true`.

> The first probe run nearly missed this: nine of the fourteen scored "RUNS" because their check was `() => true`, and an empty command list throws nothing. That is 4.1's `hs.parse()` trap in a new costume — *absence of an error is not evidence of a command*. The parse-level probe, which asserts a node named after the case label, is what exposed it.

**Not fixed here, deliberately.** Every one has a working template, so reclassifying them would make the lists honest by *deleting a working feature* and bumping every `trigger`/`break`/`continue` project from ~8 KB to the full runtime. The remedy that keeps the capability is a parser rule (for `trigger`, a one-line `COMMAND_ALIASES` entry → `send`, exactly like `push-url` → `push`). A behavior change wanting its own decision — the treatment Findings 7, 10 and 12's deferred half got. Named, split by cause, pinned at tolerance 0, and written up as the recommended next PR.

**A second drift the same run exposed:** core's `generateBundle()` imports `parser/hybrid/parser-core` while `vite-plugin/src/generator.ts` embeds `HYBRID_PARSER_TEMPLATE` — and the two `cmdMap`s differ (the template has `empty` and lacks `halt`; parser-core the reverse). The reachable set depends on which generator you went through. `parser-template-drift.test.ts` compares them on `catch`/`finally` only and is structurally unable to see this.

## Gate couplings moved in this diff

- Audit §4: `CAPABILITY_UNCLASSIFIED` → empty; the 13-row test becomes 3 (block-only); new assertion that block-only rows are NOT full-runtime-only.
- Audit §8 headline counts: 17 → **4** (all step 4.3's).
- New `bundle-generator/__tests__/capability-emission.test.ts`, 10 tests.

No manifest field was added, so §7's `ALLOWED_KEYS` is untouched — and per the step-2 knock-on these lists are **not** derived from the manifest's `tier` (two different facts, disagreeing on 16 of 59 rows).

Mutation-verified in **7** directions, all caught: dropped `AVAILABLE_COMMANDS` entry, phantom entry, removed `UNREACHABLE_CASE_LABELS` row, reachable command added to it, full-runtime entry that has a template, dropped `FULL_RUNTIME_ONLY` row, and `if` moved into `FULL_RUNTIME_ONLY`.

## Gates

- core **7840** passing / 128 skipped / 301 files (was 7829/128/300)
- `verify:reference` clean (59 = 59, availability chain valid)
- `snapshot:bundle-size` — all 10 bundles within tolerance; `hyperfixi-hx.js` +0.4%
- language-server **227** passing; vite-plugin **315** passing (the package whose detection surface this changes)
- `test:check` exit 0 across all packages
- Playwright `src/compatibility/` — 1111 passed / 8 skipped, plus the 10 pre-existing local-environment failures the brief documents (`behaviors-demo`, `i18n-htmx`, `swap-debug`); the bundle-compatibility matrix passes **92/92** on its own
- typecheck, prettier, oxlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)