### PR TITLE
fix(lsp): Arc A step 4.3 — classify every command against the parser

### DIFF
--- a/docs-internal/HANDOFF-command-arch-manifest.md
+++ b/docs-internal/HANDOFF-command-arch-manifest.md
@@ -7,10 +7,11 @@
 > (Arc C, complete) and [HANDOFF-command-arch-target-resolution.md](./HANDOFF-command-arch-target-resolution.md)
 > (Arc D, complete).
 >
-> **Status: STEPS 1–3, 4.1 AND 4.2 LANDED** (the audit-as-gate, the manifest,
-> the four mechanical consumers, the LSP tier classification, then the
-> capability lists). **Next action: step 4.3 (`COMMAND_KEYWORDS`, 4 gaps).**
-> Baseline after 4.2 is **7840** core / **227** language-server.
+> **Status: STEPS 1–3 AND 4.1–4.3 LANDED** (the audit-as-gate, the manifest, the
+> four mechanical consumers, then the three decision-bearing classifications).
+> **The arc's classification debt is ZERO** — §8's headline counts all read 0.
+> **Next action: step 4.4 (`packageInfo.commands` as a derived value), the arc's
+> last step.** Baseline after 4.3 is **7843** core / **227** language-server.
 >
 > **Step 4.2 also opened a new live defect it deliberately did NOT fix** — 14 of
 > the 38 advertised capability rows emit a case label the bundle parser can
@@ -441,6 +442,71 @@ lacks `empty`. So the reachable set depends on which generator you went through.
 `parser-template-drift.test.ts` compares the two on `catch`/`finally` only and
 is structurally unable to see this; §3 of the new gate pins it.
 
+### Finding 14 — `COMMAND_KEYWORDS`' incumbents are CLEAN, and the negative result is the point (measured in step 4.3)
+
+Steps 4.1 and 4.2 both found the already-classified rows wrong (5 of 7, then 14
+of 38), and step 4.3 was told to expect the same. It ran the same sweep and
+found the opposite: **all 58 pre-existing entries are live syntax.** Recorded
+because a negative result from a mandated check is evidence, and the next
+session should not re-run this sweep expecting a harvest.
+
+The sweep was not free, though — it found three defects one level down, in the
+same file, and a wrong claim in this brief:
+
+1. **The step-3 "unreachable" note is false.** It said `pseudo-command` is
+   "unreachable as a token (`-` is not an identifier character)". Measured: `-`
+   IS an identifier character. `pseudo-command` tokenizes as ONE identifier and
+   `on click pseudo-command` reaches a real command node. The conclusion
+   survives on different evidence — the node carries no `methodName`, because
+   `pseudo-command` is the name the parser EMITS for the method-call form
+   (`setAttribute('a','b') on me` yields it). So it is degenerate, not
+   unreachable, and it is excluded from `COMMAND_KEYWORDS` deliberately
+   (`KEYWORD_NOT_ADVERTISED`) rather than being a gap. **Step 4.3 is therefore 3
+   additions plus a reasoned exclusion, not 4 additions.**
+
+2. **Three of the 55 command hover examples were dead code** — the LSP showed
+   them to users and none reaches a command node: `repeat` (both forms written
+   without the closing `end`), `while` (written standalone, but `while` is a
+   MODIFIER on `repeat` and the bare form fails to parse), and `transition`
+   (`transition #box's opacity to 0 over 500ms` — the grammar is
+   `transition <property> to <value>`, where the property is a bare name or a
+   `*` style reference; the possessive target form yields nothing). Fixed in the
+   step-4.3 PR: same file, same defect class as Finding 5, evidence in hand —
+   the treatment Finding 12 got.
+
+3. **`push`/`replace` had no hover docs at all**, from #810's rename onward. So
+   the LSP advertised two keywords it could say nothing about. Added.
+
+**The methodological trap, and it is step 4.1's trap in a second engine.**
+`parse()` returning `success: true` does NOT mean the command exists:
+`on click zzznotacommand .x` parses "fine" and hands back an EMPTY command list.
+The probe must assert a real command node. This is exactly why the three dead
+examples were dead *silently*, and it is why the new gate walks the AST instead
+of reading `success`.
+
+**The gate that replaces the proxy.** `ghostsIn` checks registry membership,
+which is only a proxy for what this list promises — and it is weaker in both
+directions (`pseudo-command` is registered but not a keyword; `else`/`for`/
+`while` are keywords but not registered). §5 now probes the parser directly,
+using each keyword's own `HOVER_DOCS` example as the snippet. That choice is
+load-bearing: it is the text the LSP puts in front of the user, and it means
+there is no second hand-maintained probe table to drift — documenting a keyword
+IS probing it. A companion assertion requires every keyword to HAVE a doc, so
+the gate cannot go vacuously green by way of an undocumented entry.
+
+**Two defects found and deliberately NOT fixed** (out of the file, and each
+wants its own decision):
+
+- `tell <target> to <command>` **drops the `tell` wrapper**: `tell #modal to
+  show` parses to `[show]` alone, with no `tell` node, so the command would run
+  against the wrong target. The form without `to` is fine (`tell #modal show` →
+  `[tell, show]`). A parser defect for `docs-internal/PARSER_NEXT_STEPS.md`.
+- `increment`/`decrement` **desugar to a `set` command node** carrying a `+`
+  binary expression, so the registered `increment` implementation is never
+  reached from source. Legitimate as desugaring and not a defect on its face,
+  but it means the registry entry and the parse path disagree about what runs —
+  Arc E (the executors) territory.
+
 ## What changed vs. the queue doc's plan
 
 The queue says: consumers migrate "lowest-risk first — template-capabilities
@@ -645,11 +711,20 @@ step-1 audit rows so the diff is the review artifact:
    `hybrid` yet absent from the capability lists entirely. Two facts, not one
    fact stored twice — the manifest will need a second field for this, not a
    reuse of `tier`.
-3. **`COMMAND_KEYWORDS`** (**4** gaps — `process`, `pseudo-command`, `scroll`,
-   `start`; the two ghosts landed separately per Finding 5, and that rename
-   closed `push`/`replace`). The gaps are already an explicit `KEYWORD_GAPS`
-   allowlist in `lsp-metadata.test.ts` with a stale-entry check, so closing one
-   means deleting its line there — fold that gate into step 1's audit.
+3. **`COMMAND_KEYWORDS`** — **DONE** (see the status log). The 4 gaps resolved
+   as **3 additions** (`process`, `scroll`, `start` — each probed live against
+   the parser) **plus one reasoned exclusion**: `pseudo-command` is the name the
+   parser EMITS for the method-call form, not a token any user writes, so it
+   moved to a new `KEYWORD_NOT_ADVERTISED` allowlist rather than into the list.
+   `KEYWORD_GAPS` is now empty and stays empty — a registered command belongs
+   there only while somebody is actively deciding.
+   **The oracle was the hyperfixi parser** (not the published engine, which was
+   4.1's question, nor the generator, which was 4.2's): does `<keyword> …` reach
+   a real command node? Per Finding 14 the 58 incumbents all passed, but the
+   sweep found three dead hover examples, two undocumented keywords, and a wrong
+   claim in step 3's own notes.
+   §5 of the audit no longer proxies this through registry membership: it probes
+   the parser, using each keyword's `HOVER_DOCS` example as the snippet.
 4. **`packageInfo.commands`** as a derived value. **Step-3 knock-on: the
    `runtime/runtime.ts` half of the docstring fix is already done.** All six
    "48 commands" mentions and every undercounting per-category group comment
@@ -689,7 +764,7 @@ step-1 audit rows so the diff is the review artifact:
 
 | Step | Suites | Command |
 | ---- | ------ | ------- |
-| all | quick validation (baseline **7840** after step 4.2; was 7829 after 4.1, 7827 after step 3, 7824 after step 2, 7814 after step 1, 7800 after the Finding 5 fix, 7795 before it) | `npm run test:quick --prefix packages/core` |
+| all | quick validation (baseline **7843** after step 4.3; was 7840 after 4.2, 7829 after 4.1, 7827 after step 3, 7824 after step 2, 7814 after step 1, 7800 after the Finding 5 fix, 7795 before it) | `npm run test:quick --prefix packages/core` |
 | all | the reference gate | `npm run verify:reference --prefix packages/core` |
 | 1 | the new audit test itself | added in the step-1 PR |
 | 2, 3 | bundle size — the tree-shaking guard | `npm run snapshot:bundle-size --prefix packages/core` (`--check`, ±5% vs `scripts/bundle-snapshots/baseline.json`) |
@@ -872,8 +947,13 @@ was touched.
   `getCommandNames()` enumeration order is now alphabetical rather than
   registration order (consumers sort it or use it for an error string), and the
   static parser seed gained `pseudo-command`, which is Finding 6's disagreement
-  closing by construction. It is unreachable as a token anyway (`-` is not an
-  identifier character), so nothing parses differently.
+  closing by construction. ~~It is unreachable as a token anyway (`-` is not an
+  identifier character), so nothing parses differently.~~ **That parenthetical
+  is wrong and step 4.3 measured it wrong**: `-` IS an identifier character, so
+  `pseudo-command` tokenizes as a single identifier and `on click
+  pseudo-command` reaches a real command node. The conclusion it was supporting
+  still holds, but for a different reason — the node carries no `methodName`,
+  so it is degenerate rather than unreachable. See Finding 14.
   **One measured constraint the brief did not anticipate, recorded above as
   Finding 11:** deriving the seed as `COMMAND_MANIFEST.map(e => e.name)` shipped
   the whole rich array into `hyperfixi-hx.js` — +4.8 KB raw, **+7.5%, a real
@@ -1024,3 +1104,68 @@ was touched.
   whose detection surface this changes); typecheck clean.
   Next action: step 4.3 (`COMMAND_KEYWORDS` — 4 gaps: `process`,
   `pseudo-command`, `scroll`, `start`).
+- 2026-07-29 — **Step 4.3 landed** (branch `fix/lsp-command-keywords-coverage`,
+  off `8c12cab5`): `COMMAND_KEYWORDS` is now a **total partition** of the
+  registry — 61 entries, every registered command either advertised or excluded
+  with a reason, and `KEYWORD_GAPS` empty. **§8's headline counts are all zero:
+  the arc's classification debt is gone.**
+  **The oracle was the hyperfixi parser**, and stating it mattered: 4.1 asked
+  the published upstream engine and 4.2 asked the bundle generator, but this
+  list's promise is that the token PARSES. Probe: does `on click <snippet>`
+  reach a real command node?
+  **The 4 gaps resolved 3 + 1, not 4.** `process`, `scroll` and `start` are live
+  syntax and were added (with hover docs). `pseudo-command` was NOT: it is the
+  name the parser EMITS for the method-call form — `setAttribute('a','b') on me`
+  yields a node called `pseudo-command` — so no user ever types it. It moved to
+  a new `KEYWORD_NOT_ADVERTISED` allowlist. **This also corrected step 3's own
+  note**, which said the token was "unreachable (`-` is not an identifier
+  character)": `-` IS an identifier character, the token tokenizes as one
+  identifier and does reach a command node, just a degenerate one with no
+  `methodName`. Right conclusion, wrong evidence; the strikethrough is in step
+  3's section and the detail is Finding 14.
+  **The incumbent sweep came back CLEAN — all 58 live** (Finding 14). Worth
+  recording as a negative result: 4.1 found 5 of 7 wrong and 4.2 found 14 of 38
+  dead, and a session reading only those two would expect a harvest here. The
+  sweep still paid for itself one level down, in the same file: **three of the
+  55 command hover examples were dead code** the LSP showed users — `repeat`
+  (both forms missing the closing `end`), `while` (written standalone, but it is
+  a MODIFIER on `repeat`), `transition` (the possessive `#box's opacity` target
+  form, which yields no command node) — and **`push`/`replace` had no hover docs
+  at all** since #810's rename. All fixed here: same file, same defect class as
+  Finding 5, evidence in hand — Finding 12's treatment.
+  **Step 4.1's methodological trap is live in this engine too:** `parse()`
+  returning `success: true` does NOT mean the command exists. `on click
+  zzznotacommand .x` parses "fine" with an EMPTY command list. That is precisely
+  why the three dead examples were dead *silently*, and why the new gate walks
+  the AST rather than reading `success`.
+  **The gate replaces a proxy with the real question.** `ghostsIn` checks
+  registry membership, which is weaker in both directions (`pseudo-command` is
+  registered but is not a keyword; `else`/`for`/`while` are keywords but are not
+  registered). §5 now probes the parser, using each keyword's own `HOVER_DOCS`
+  example as the snippet — the text the LSP actually shows, so there is no
+  second probe table to drift, and documenting a keyword IS probing it. A
+  companion assertion requires every keyword to have a doc, so an undocumented
+  entry cannot make the gate vacuously green.
+  Mutation-verified in **6** directions, all caught: each of the three restored
+  dead examples, advertising `pseudo-command`, **dropping `scroll`** (the
+  omission direction the ghost tests are structurally blind to), removing a
+  hover doc (the probe-corpus hole), and silently re-widening `KEYWORD_GAPS`.
+  **Two defects found and deliberately NOT fixed**, both outside this file and
+  each wanting its own decision (Finding 14): `tell <target> to <command>` drops
+  the `tell` wrapper (`tell #modal to show` → `[show]`, so it would run against
+  the wrong target — one for `PARSER_NEXT_STEPS.md`), and `increment`/
+  `decrement` desugar to a `set` node so the registered implementation is never
+  reached from source (Arc E territory).
+  Gates: core **7843** passing / 128 skipped / 301 files; `verify:reference`
+  clean (59 = 59, availability chain valid); language-server **227** passing
+  against the rebuilt core dist; typecheck, prettier, oxlint clean;
+  `snapshot:bundle-size` all 10 within tolerance; Playwright `src/compatibility/`
+  1110 passed / 9 skipped with the 10 known-local failures (behaviors-demo,
+  i18n-htmx, swap-debug — green in CI). `test:check` has two failures,
+  **both reproduced with this diff stashed at `8c12cab5`** and both artifacts of
+  a worktree whose non-core `dist/` trees were copied rather than rebuilt:
+  behaviors (2 files fail to collect, 134 tests still pass) and
+  testing-framework (`shipped-examples-execution`, "expected 52 to be greater
+  than 60").
+  Next action: step 4.4 (`packageInfo.commands` as a derived value) — the arc's
+  last step.

--- a/packages/core/src/lsp-metadata.ts
+++ b/packages/core/src/lsp-metadata.ts
@@ -16,6 +16,32 @@
 
 /**
  * All command keywords in LokaScript
+ *
+ * ## The contract, and the oracle that checks it (Arc A step 4.3)
+ *
+ * Every entry is a token the **hyperfixi parser** accepts at command position.
+ * That is a different question from "names a registered command", which is all
+ * anything checked before 2026-07-29 — and the weaker one: `pseudo-command` is
+ * registered yet is not a keyword anybody writes (see below). The audit,
+ * `packages/core/src/runtime/__tests__/command-manifest-audit.test.ts` §5, now
+ * probes the parser directly, using each entry's `HOVER_DOCS` example as the
+ * snippet. That is deliberately the same text the LSP shows the user: the
+ * defect this list has actually shipped (`pushUrl` / `replaceUrl`, #810) was
+ * advertising a spelling the engine rejects, and an example that does not parse
+ * is the same defect one level down.
+ *
+ * All 58 pre-existing entries were probed in step 4.3 and every one is live
+ * syntax — unlike the sibling lists step 4.1 and 4.2 scored, which were wrong
+ * on 5 of 7 and 14 of 38 rows respectively.
+ *
+ * `pseudo-command` is registered but deliberately **absent**. It is the name
+ * the parser EMITS for the method-call-as-command form — `setAttribute('a','b')
+ * on me` yields a node named `pseudo-command` — not a token a user ever types.
+ * The bare token does reach a command node (`-` IS an identifier character, so
+ * it tokenizes as one identifier; the step-3 note claiming it is "unreachable
+ * as a token" was measured false in step 4.3), but only a degenerate one
+ * carrying no `methodName`. Advertising it would offer a completion that parses
+ * and then does nothing.
  */
 export const COMMAND_KEYWORDS = [
   // DOM Commands
@@ -39,6 +65,10 @@ export const COMMAND_KEYWORDS = [
   'prepend',
   'take',
   'render',
+  // Added in step 4.3. Probed: `scroll to #section` and `process partials in
+  // result` each reach a real command node.
+  'scroll',
+  'process',
 
   // Async Commands
   'wait',
@@ -92,6 +122,9 @@ export const COMMAND_KEYWORDS = [
   // Animation Commands
   'transition',
   'measure',
+  // Added in step 4.3. Probed: `start view transition end` reaches a real
+  // command node. The bare token does not — `start` always opens a block.
+  'start',
 
   // Data Commands
   'increment',
@@ -374,6 +407,18 @@ export const HOVER_DOCS: Record<string, HoverDoc> = {
     example: 'render #template with {name: "World"}',
     category: 'command',
   },
+  scroll: {
+    title: 'scroll',
+    description: 'Scrolls an element into view.',
+    example: 'scroll to #section\nscroll to the top of me',
+    category: 'command',
+  },
+  process: {
+    title: 'process',
+    description: 'Processes hyperscript/partials in freshly-inserted content.',
+    example: 'process partials in result',
+    category: 'command',
+  },
 
   // Async Commands
   wait: {
@@ -416,6 +461,22 @@ export const HOVER_DOCS: Record<string, HoverDoc> = {
     example: 'go to url /home\ngo to #section\ngo back',
     category: 'command',
   },
+  // `push` and `replace` replaced the `pushUrl` / `replaceUrl` ghosts in #810
+  // but arrived without hover docs; added in step 4.3. The examples carry the
+  // `url` keyword because that is the form that parses — `pushUrl "/x"` was
+  // exactly the spelling the engine rejects.
+  push: {
+    title: 'push',
+    description: 'Pushes a URL onto the browser history stack.',
+    example: 'push url "/page/2"',
+    category: 'command',
+  },
+  replace: {
+    title: 'replace',
+    description: 'Replaces the current browser history entry.',
+    example: 'replace url "/page/2"',
+    category: 'command',
+  },
 
   // Control Flow Commands
   if: {
@@ -439,7 +500,11 @@ export const HOVER_DOCS: Record<string, HoverDoc> = {
   repeat: {
     title: 'repeat',
     description: 'Loops a specified number of times or over items.',
-    example: 'repeat 5 times log "hello"\nrepeat for item in items',
+    // Both forms need the closing `end`. Without it the parser yields NO
+    // command node at all rather than an error, so the previous example —
+    // `repeat 5 times log "hello"` with no `end` — was dead code the LSP
+    // showed on hover (found by the step-4.3 parse probe).
+    example: 'repeat 5 times\n  log "hello"\nend\nrepeat for item in items\n  log item\nend',
     category: 'command',
   },
   for: {
@@ -450,8 +515,11 @@ export const HOVER_DOCS: Record<string, HoverDoc> = {
   },
   while: {
     title: 'while',
-    description: 'Loops while condition is true.',
-    example: 'while :count < 10\n  increment :count\nend',
+    description: 'Loops while a condition holds. Used as `repeat while <cond>`.',
+    // `while` is a MODIFIER on `repeat`, not a standalone construct: bare
+    // `while :count < 10 … end` fails to parse outright. The previous example
+    // was exactly that dead form (found by the step-4.3 parse probe).
+    example: 'repeat while :count < 10\n  increment :count\nend',
     category: 'command',
   },
   break: {
@@ -565,13 +633,25 @@ export const HOVER_DOCS: Record<string, HoverDoc> = {
   transition: {
     title: 'transition',
     description: 'Applies CSS transition.',
-    example: "transition #box's opacity to 0 over 500ms",
+    // The grammar is `transition <property> to <value> [over <duration>]`,
+    // where the property is a bare name or a `*`-sigil style reference. The
+    // possessive target form the previous example used —
+    // `transition #box's opacity to 0 over 500ms` — parses to NO command node
+    // at all (found by the step-4.3 parse probe); to transition another
+    // element, use `tell`.
+    example: "transition *opacity to 0 over 500ms\ntransition *background-color to 'red' over 2s",
     category: 'command',
   },
   measure: {
     title: 'measure',
     description: 'Measures element dimensions.',
     example: 'measure #box then log result.width',
+    category: 'command',
+  },
+  start: {
+    title: 'start',
+    description: 'Starts a View Transition around a block of commands.',
+    example: 'start view transition\n  add .expanded to #panel\nend',
     category: 'command',
   },
 

--- a/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
+++ b/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
@@ -69,8 +69,9 @@ import {
   FULL_RUNTIME_ONLY_COMMANDS,
   resolveCommandKey,
 } from '../../bundle-generator/template-capabilities';
-import { COMMAND_KEYWORDS, ALL_KEYWORDS } from '../../lsp-metadata';
+import { COMMAND_KEYWORDS, ALL_KEYWORDS, HOVER_DOCS } from '../../lsp-metadata';
 import { commands as referenceCommands } from '../../reference/index';
+import { parse } from '../../parser/parser';
 
 /** Finding 6: snapshot the static parser seed BEFORE any Runtime exists. */
 const STATIC_SEED = new Set<string>(COMMANDS);
@@ -563,25 +564,112 @@ describe('the capability lists', () => {
 const KEYWORD_NOT_COMMANDS = new Set(['else', 'for', 'while']);
 
 /**
- * Registered commands COMMAND_KEYWORDS does not yet advertise, so the LSP
- * offers no completion for them. Was six before the Finding 5 ghost fix
- * renamed `pushUrl`/`replaceUrl` to `push`/`replace` (#810). Adding these is a
- * docs + completions decision — step 4.3.
+ * Registered commands COMMAND_KEYWORDS does not advertise, so the LSP offers
+ * no completion for them. Was six before the Finding 5 ghost fix renamed
+ * `pushUrl`/`replaceUrl` to `push`/`replace` (#810), then four, and step 4.3
+ * closed the last three (`process`, `scroll`, `start` — each probed live
+ * against the parser). **Now empty, and it stays empty**: a registered command
+ * belongs here only while somebody is actively deciding, and the two settled
+ * outcomes have their own homes — advertised (in the list) or permanently
+ * excluded (`KEYWORD_NOT_ADVERTISED` below, which requires a reason).
  */
-const KEYWORD_GAPS = new Set([
-  'process', // htmx-like: process partials in <content>
-  'pseudo-command', // method-call-as-command; absent from the static seed too (Finding 6)
-  'scroll', // upstream _hyperscript 0.9.90 `scroll to <target>`
-  'start', // start view transition ... end
-]);
+const KEYWORD_GAPS = new Set<string>([]);
+
+/**
+ * Registered commands deliberately kept OUT of COMMAND_KEYWORDS. Not debt —
+ * each row is a decision, and the reason has to survive next to it.
+ *
+ * `pseudo-command` is the name the parser EMITS for the method-call-as-command
+ * form: `setAttribute('a','b') on me` yields a node named `pseudo-command`. No
+ * user writes that token. It is not unreachable — step 3's note said it was
+ * ("`-` is not an identifier character"), and step 4.3 measured that FALSE: `-`
+ * is an identifier character, `pseudo-command` tokenizes as one identifier and
+ * reaches a command node. But the node it reaches carries no `methodName`, so
+ * advertising the token would offer a completion that parses and then does
+ * nothing — a subtler form of the `pushUrl` defect, not a fix for it.
+ */
+const KEYWORD_NOT_ADVERTISED = new Set(['pseudo-command']);
+
+/**
+ * The parse oracle for §5 — the question nothing asked before step 4.3.
+ *
+ * `ghostsIn` checks registry membership, which is only a PROXY for what this
+ * list promises: that the token parses. The proxy is weaker in BOTH directions.
+ * `pseudo-command` is registered yet is not a keyword anybody writes, and a
+ * name could parse without being registered (`else`, `for`, `while` do exactly
+ * that). So the entries are probed against the real parser here.
+ *
+ * The snippet is each keyword's own `HOVER_DOCS` example, deliberately — it is
+ * the text the LSP puts in front of the user, so a dead example is the shipped
+ * defect (`pushUrl`, #810) one level down. It also means there is no second
+ * hand-maintained probe table to drift: documenting a keyword IS probing it.
+ *
+ * A keyword passes when its example reaches at least one real command node.
+ * `success` alone is NOT sufficient and must never be substituted: an
+ * unrecognized word makes the command-list parser stop cleanly and hand back an
+ * EMPTY command list with `success: true` — `on click zzznotacommand .x` parses
+ * "fine". This is the same trap step 4.1 hit on the upstream engine, and it is
+ * live here too. It is what made three hover examples dead code in silence.
+ */
+function commandNodesIn(source: string): string[] {
+  const result = parse(source);
+  const found: string[] = [];
+  const seen = new Set<unknown>();
+  const walk = (node: unknown, depth = 0): void => {
+    if (!node || typeof node !== 'object' || depth > 25 || seen.has(node)) return;
+    seen.add(node);
+    if (Array.isArray(node)) {
+      node.forEach(child => walk(child, depth + 1));
+      return;
+    }
+    const rec = node as Record<string, unknown>;
+    if (rec.type === 'command' && typeof rec.name === 'string') found.push(rec.name);
+    for (const key of Object.keys(rec)) if (key !== 'tokens') walk(rec[key], depth + 1);
+  };
+  walk((result as { node?: unknown }).node);
+  return found;
+}
 
 describe('COMMAND_KEYWORDS', () => {
   it('every keyword names a registered command or an allowlisted block keyword', () => {
     expect(ghostsIn(COMMAND_KEYWORDS)).toEqual([...KEYWORD_NOT_COMMANDS].sort());
   });
 
-  it('4 registered commands are not advertised (step 4.3)', () => {
-    expect(gapsIn(COMMAND_KEYWORDS)).toEqual([...KEYWORD_GAPS].sort());
+  it('every registered command is advertised, or excluded with a reason (step 4.3)', () => {
+    expect(gapsIn(COMMAND_KEYWORDS)).toEqual([...KEYWORD_NOT_ADVERTISED].sort());
+    expect([...KEYWORD_GAPS]).toEqual([]);
+  });
+
+  it('every keyword is documented — the probe corpus has no holes', () => {
+    // Guards the gate below from going vacuously green: an undocumented
+    // keyword has no example, so it would otherwise be silently unprobed.
+    // `push`/`replace` sat undocumented from #810 until step 4.3.
+    expect(COMMAND_KEYWORDS.filter(kw => !HOVER_DOCS[kw])).toEqual([]);
+  });
+
+  it('every keyword PARSES — its own hover example reaches a command node', () => {
+    // The check `ghostsIn` cannot make. Mutation-verified: restoring any of the
+    // three examples step 4.3 fixed (`repeat` without `end`, standalone
+    // `while`, `transition #box's opacity`) fails here, and all three were
+    // SILENT before this test existed.
+    const dead = COMMAND_KEYWORDS.filter(kw => {
+      const example = HOVER_DOCS[kw]?.example;
+      if (!example) return false; // covered by the test above
+      return commandNodesIn(`on click ${example.replace(/\n/g, '\n  ')}`).length === 0;
+    });
+    expect(dead).toEqual([]);
+  });
+
+  it('the excluded rows are excluded for the stated reason, not by accident', () => {
+    for (const name of KEYWORD_NOT_ADVERTISED) {
+      expect(REGISTERED.has(name)).toBe(true); // still registered
+      expect(COMMAND_KEYWORDS as readonly string[]).not.toContain(name);
+    }
+    // `pseudo-command` is reachable as a token — step 3's "unreachable"
+    // note was measured false — but only as a degenerate node. Both halves
+    // are pinned so a future reader re-checks rather than trusting either.
+    expect(commandNodesIn('on click pseudo-command')).toContain('pseudo-command');
+    expect(commandNodesIn('on click setAttribute("a","b") on me')).toContain('pseudo-command');
   });
 
   it('advertises the history command under its parsing names', () => {
@@ -853,7 +941,9 @@ describe('the command manifest', () => {
 // ===========================================================================
 
 describe('the classification debt, counted', () => {
-  it('4 rows await deliberate classification (step 4.3)', () => {
+  // Zero CLASSIFICATION debt; step 4.4 (deriving `packageInfo.commands`) is a
+  // derivation, not a classification, and is not counted here.
+  it('0 rows await deliberate classification (4.1, 4.2, 4.3 all landed)', () => {
     // The numbers the arc exists to burn down. A step that classifies a
     // command flips its allowlist row AND moves the count here, so the diff
     // shows both the decision and its scope. Do not adjust a count without
@@ -865,9 +955,13 @@ describe('the classification debt, counted', () => {
     // capability rows as full-runtime-only and RESOLVING the block-only three
     // as classified-by-AVAILABLE_BLOCKS rather than unclassified, so they no
     // longer count as debt (they are still pinned in §4, both directions).
+    // Step 4.3 took it to ZERO: `process`/`scroll`/`start` are advertised, and
+    // `pseudo-command` moved to KEYWORD_NOT_ADVERTISED — a decision with a
+    // reason, not an open row.
     expect(TIER_UNCLASSIFIED.size).toBe(0); // step 4.1 — DONE, was 23
     expect(CAPABILITY_UNCLASSIFIED.size).toBe(0); // step 4.2 — DONE, was 10
     expect(CAPABILITY_BLOCK_ONLY.size).toBe(3); // step 4.2 — DECIDED: blocks classify
-    expect(KEYWORD_GAPS.size).toBe(4); // step 4.3 — missing LSP completions
+    expect(KEYWORD_GAPS.size).toBe(0); // step 4.3 — DONE, was 4
+    expect(KEYWORD_NOT_ADVERTISED.size).toBe(1); // step 4.3 — DECIDED: pseudo-command
   });
 });


### PR DESCRIPTION
Arc A step 4.3 of the command-manifest arc. Brief: `docs-internal/HANDOFF-command-arch-manifest.md`.

`COMMAND_KEYWORDS` is now a **total partition** of the registry — every registered command is either advertised or excluded with a reason — and the audit's §8 headline counts all read **0**. The arc's classification debt is gone.

## The oracle, stated

Not the published upstream engine (4.1's question), not the bundle generator (4.2's). This list's promise is that the token **parses**, so the probe is: does `on click <snippet>` reach a real command node?

## The 4 gaps resolved 3 + 1, not 4

`process`, `scroll` and `start` are live syntax and were added, with hover docs. `pseudo-command` was **not**: it is the name the parser *emits* for the method-call form — `setAttribute('a','b') on me` yields a node called `pseudo-command` — so no user ever types it. It moved to a new `KEYWORD_NOT_ADVERTISED` allowlist.

That also corrects **step 3's own note**, which said the token was "unreachable (`-` is not an identifier character)". Measured: `-` *is* an identifier character; `pseudo-command` tokenizes as one identifier and does reach a command node, just a degenerate one with no `methodName`. Right conclusion, wrong evidence.

## Scoring the incumbents — a clean result, and what it still bought

All **58** pre-existing entries are live, unlike the 5-of-7 and 14-of-38 the sibling steps found. Recorded as a negative result (Finding 14) so the next session doesn't re-run it expecting a harvest. The sweep still paid for itself one level down, in the same file:

- **Three of the 55 command hover examples were dead code** the LSP showed users: `repeat` (both forms missing the closing `end`), `while` (written standalone, but it is a *modifier* on `repeat`), `transition` (the possessive `#box's opacity` target form).
- **`push`/`replace` had no hover docs at all** since the #810 rename.

## Step 4.1's trap, live in this engine too

`parse()` returning `success: true` does **not** mean the command exists — `on click zzznotacommand .x` parses "fine" with an empty command list. That is exactly why those three examples were dead *silently*, and why the gate walks the AST instead of reading `success`.

## The gate

§5 now probes the parser instead of proxying through registry membership, which is weaker in both directions (`pseudo-command` is registered but is not a keyword; `else`/`for`/`while` are keywords but are not registered). The snippet is each keyword's own `HOVER_DOCS` example — the text the LSP actually shows — so there is no second probe table to drift: documenting a keyword *is* probing it. A companion assertion requires every keyword to have a doc, so an undocumented entry cannot make the gate vacuously green.

Mutation-verified in **6** directions, all caught: each of the three restored dead examples, advertising `pseudo-command`, **dropping `scroll`** (the omission direction the ghost tests are structurally blind to), removing a hover doc, and silently re-widening `KEYWORD_GAPS`.

## Found and deliberately NOT fixed

Both outside this file, each wanting its own decision (recorded in Finding 14):

- `tell <target> to <command>` **drops the `tell` wrapper** — `tell #modal to show` parses to `[show]` alone, so it would run against the wrong target. One for `PARSER_NEXT_STEPS.md`.
- `increment`/`decrement` **desugar to a `set` node**, so the registered implementation is never reached from source. Arc E territory.

## Gates

- core **7843** passing / 128 skipped / 301 files (was 7840)
- `verify:reference` clean (59 = 59, availability chain valid)
- language-server **227** passing against the rebuilt core dist
- `snapshot:bundle-size` — all 10 bundles within tolerance
- typecheck, prettier, oxlint clean
- Playwright `src/compatibility/` 1110 passed / 9 skipped, with the 10 known-local failures (behaviors-demo, i18n-htmx, swap-debug) that pass in CI

`test:check` has two failures, **both reproduced with this diff stashed at `8c12cab5`**: behaviors (2 files fail to collect; 134 tests still pass) and testing-framework (`shipped-examples-execution`, "expected 52 to be greater than 60"). Both are artifacts of a worktree whose non-core `dist/` trees were copied rather than rebuilt.

Next: step 4.4 (`packageInfo.commands` as a derived value) — the arc's last step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)