### PR TITLE
feat(core): Arc A step 4.4 — packageInfo.commands as a derived value

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,15 @@
 # docs/, CLAUDE.md) stays formatted.
 docs-internal/
 
+# Archived material: superseded phase/plan/summary docs kept for history, plus
+# retired workflows and scripts. Same prose-mangling risk as docs-internal/, and
+# nothing here is edited any more — so formatting them only drags unrelated
+# churn into whichever diff happens to touch them (52 of the 68 markdown files
+# that had drifted under the old floating prettier range lived in
+# packages/core/docs/archive/ alone). Live docs stay formatted; only /archive/
+# is exempt.
+**/archive/
+
 # Build outputs / generated / vendored — never formatted. Keeps the local
 # `format` / `format:check` scripts (prettier .) scoped to real source.
 **/dist/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,7 @@ As of 2026-01-23, all CI testing has been consolidated into a single `.github/wo
 | 0    | `changes`                 | ✓   | ✓                 | Path classifier (code / protocol / goclient)      |
 | 1    | `build`                   | ✓   | ✓                 | Build all packages once; gated on `code` paths    |
 | 2    | `export-validation`       | ✓   | —                 | Verify package.json exports resolve to dist       |
-| 3    | `lint-typecheck`          | ✓   | —                 | ESLint + TypeScript checks                        |
+| 3    | `lint-typecheck`          | ✓   | —                 | oxlint + TypeScript checks                        |
 | 4    | `unit-tests`              | ✓   | —                 | Vitest tests on Node 24                           |
 | 5    | `coverage`                | —   | main only         | Codecov upload (already gated to push+main)       |
 | 6    | `browser-tests`           | ✓   | —                 | Playwright; PR-only (slim post-merge)             |

--- a/docs-internal/HANDOFF-command-arch-manifest.md
+++ b/docs-internal/HANDOFF-command-arch-manifest.md
@@ -7,11 +7,23 @@
 > (Arc C, complete) and [HANDOFF-command-arch-target-resolution.md](./HANDOFF-command-arch-target-resolution.md)
 > (Arc D, complete).
 >
-> **Status: STEPS 1–3 AND 4.1–4.3 LANDED** (the audit-as-gate, the manifest, the
-> four mechanical consumers, then the three decision-bearing classifications).
-> **The arc's classification debt is ZERO** — §8's headline counts all read 0.
-> **Next action: step 4.4 (`packageInfo.commands` as a derived value), the arc's
-> last step.** Baseline after 4.3 is **7843** core / **227** language-server.
+> **Status: ARC A COMPLETE — steps 1–3 and 4.1–4.4 all landed** (the
+> audit-as-gate, the manifest, the four mechanical consumers, the three
+> decision-bearing classifications, and the derivation).
+> **The arc's classification debt is ZERO** — §8's headline counts all read 0,
+> and 4.4 correctly added no row to it.
+> Baseline after 4.4 is **7844** core / **227** language-server.
+>
+> **4.4 found three ADVERTISED COUNTS THAT WERE FALSE** (Finding 15), all in the
+> set nothing was checking: `minimal` 30→10, `standard` 35→25, and
+> `multilingual` **59→52** — the last claiming the full-registry number while
+> shipping seven fewer commands. The derivation itself was a two-line change;
+> the yield was entirely in the rows next to it.
+>
+> **Next action: none in this arc.** The recommended follow-on remains
+> **Finding 13** (14 unreachable capability case labels — the largest
+> user-visible stake). Finding 15 also leaves two named behavior questions for
+> their own PRs.
 >
 > **Step 4.2 also opened a new live defect it deliberately did NOT fix** — 14 of
 > the 38 advertised capability rows emit a case label the bundle parser can
@@ -507,6 +519,60 @@ wants its own decision):
   but it means the registry entry and the parse path disagree about what runs —
   Arc E (the executors) territory.
 
+### Finding 15 — three advertised bundle counts were FALSE, all in the ungated set (measured in step 4.4)
+
+Step 4.4's own subject — `packageInfo.commands` — was a two-line change and was
+never wrong. The yield was entirely in the counts beside it.
+
+`metadata.ts` advertises a `commandCount` per bundle. Before this step
+`verify:reference` checked exactly two of the nine against anything
+(`lite-plus`, `hybrid-complete`, via their own `commands: [...]` arrays). Both
+were correct. **Every remaining checkable one was wrong:**
+
+| Bundle | Advertised | Actual | How the actual was measured |
+| ------ | ---------- | ------ | --------------------------- |
+| `minimal` | 30 | **10** | its own `commands: [...]` array |
+| `standard` | 35 | **25** | its own `commands: [...]` array |
+| `multilingual` | 59 | **52** | the factory list it passes to `createTreeShakeableRuntime` |
+
+`multilingual` is the sharp one: 59 is the *full-registry* number, so the entry
+read as a full-runtime bundle. It is not. Missing vs the manifest are `morph`,
+`process`, `push`, `replace`, `scroll`, `start`, `swap` — measured by
+replicating `CommandRegistryV2.register()` over its factory list (52 factories →
+52 names; no phantoms in the other direction).
+
+The two that WERE gated were right and the three that were not were wrong, which
+is the whole finding: the numbers were pinned in one place (§6 pins each array's
+size) and advertised in another (`metadata.ts`), and **nothing compared the two**.
+Pinning one side and advertising the other is not a check.
+
+Verified honest and left alone:
+
+- `browser` — constructs `Runtime`; measured 59, no gaps and no extras.
+- `hybrid-hx-v4` / `hybrid-hx` — re-export `browser` / `hybrid-complete`
+  wholesale, so they inherit 59 / 24.
+- `lite` (8), and the `textshelf` bundles (10).
+
+**Two behavior questions deliberately NOT answered here**, since 4.4 is a
+derivation and neither is:
+
+1. **Should `multilingual` ship all 59?** It is the flagship multilingual bundle
+   and silently lacks seven commands. This step only stopped the number lying.
+2. **`minimal` registers 11 but advertises 10.** Its `createSendCommand` also
+   registers the consolidation alias `trigger`, so `trigger` works there and is
+   absent from the published array. The metadata count mirrors the *advertised*
+   array so the two stay comparable; correcting the array is a change to a
+   shipped bundle's public surface.
+
+**What moved so this cannot recur:** the bundle→source pairing now lives in one
+place (`compatibility/bundle-sources.ts`), read by both `verify:reference` and
+audit §6. The gate re-derives all nine counts (array, factory list, or
+re-export target); §6 gained the metadata↔array comparison that was missing.
+`verify:reference` also had to stop text-scraping `metadata.ts` — its
+`commandCount:\s*(\d+)` regex matches only literal digits, so the moment the
+full-runtime counts became derived expressions it would have silently skipped
+exactly the entries it most needed to see.
+
 ## What changed vs. the queue doc's plan
 
 The queue says: consumers migrate "lowest-risk first — template-capabilities
@@ -725,7 +791,20 @@ step-1 audit rows so the diff is the review artifact:
    claim in step 3's own notes.
    §5 of the audit no longer proxies this through registry membership: it probes
    the parser, using each keyword's `HOVER_DOCS` example as the snippet.
-4. **`packageInfo.commands`** as a derived value. **Step-3 knock-on: the
+4. **`packageInfo.commands`** as a derived value — **DONE** (see the status log
+   and Finding 15). The oracle was **the manifest itself** (`COMMAND_NAMES`),
+   which is what made this step's named work nearly free — and why the risk sat
+   elsewhere. `packageInfo.commands` and the two genuinely-full-runtime bundle
+   counts (`browser`, `hybrid-hx-v4`) now read `COMMAND_NAMES.length` via a
+   `FULL_RUNTIME_COMMAND_COUNT` constant; `COMMAND_NAMES` and **not**
+   `COMMAND_MANIFEST.map(...)`, per Finding 11. Measured clean: all 10 bundles
+   within tolerance, `hyperfixi-hx.js` +0.4%, and the built bundle verified
+   directly to contain no `metadata.ts` content and none of the manifest's
+   classification fields — `metadata.ts` turns out to be a leaf module that
+   nothing in `src/` imports.
+   **The three false counts Finding 15 records were fixed in the same PR**, and
+   the gate widened from 2 of 9 bundles to all 9.
+   **Step-3 knock-on: the
    `runtime/runtime.ts` half of the docstring fix is already done.** All six
    "48 commands" mentions and every undercounting per-category group comment
    ("DOM Commands (11)" above 15 registrations, "Phase 6-5 Commands (6)" above
@@ -1169,3 +1248,41 @@ was touched.
   than 60").
   Next action: step 4.4 (`packageInfo.commands` as a derived value) — the arc's
   last step.
+- 2026-07-29 — **step 4.4 landed; ARC A COMPLETE** (branch
+  `feat/manifest-derived-command-counts`, off `5425f26a`). Oracle: **the manifest
+  itself** (`COMMAND_NAMES`) — stated up front, and the reason the named work was
+  nearly free. `packageInfo.commands`, `browser.commandCount` and
+  `hybrid-hx-v4.commandCount` now derive from a `FULL_RUNTIME_COMMAND_COUNT =
+  COMMAND_NAMES.length` constant (**not** `COMMAND_MANIFEST.map()`, per
+  Finding 11), as does `ecosystem.core.description`, which had rotted to "43
+  commands".
+  **The yield was adjacent, exactly as the 4.1/4.2/4.3 pattern predicted:
+  three advertised bundle counts were FALSE** — `minimal` 30→10, `standard`
+  35→25, `multilingual` **59→52** (Finding 15). The two bundles the gate already
+  covered were both correct; every unchecked-and-checkable one was wrong.
+  `multilingual` claimed the full-registry number while missing `morph`,
+  `process`, `push`, `replace`, `scroll`, `start`, `swap`.
+  Also corrected eleven stale prose counts across eight files (`48 commands` in
+  the three named files, plus `41` ×5 in the multilingual/semantic-complete
+  bundles, `43+`, `40+`, `37`, `16`, `8`).
+  Structural: new `compatibility/bundle-sources.ts` holds the bundle→source
+  pairing once, read by both `verify:reference` and audit §6; the gate now
+  re-derives **all nine** counts (was two) across three arms — published array,
+  factory list, re-export target — each negative-tested to fail. `verify:reference`
+  stopped text-scraping `metadata.ts` (its `\d+` regexes cannot see a derived
+  expression). §6 gained the metadata↔array comparison whose absence was the
+  bug; §8 correctly gained no row. Core CLAUDE.md step 7 rewritten — the
+  full-runtime counts no longer need bumping by hand.
+  Deliberately NOT done, both behavior calls wanting their own PR: making
+  `multilingual` ship all 59, and adding the registered-but-unadvertised
+  `trigger` to `minimal`'s published array (it registers 11, advertises 10).
+  Gates: core **7844** passing / 128 skipped / 301 files (+1 = the new §6 test);
+  `verify:reference` clean; language-server **227**; `snapshot:bundle-size` all
+  10 within tolerance with `hyperfixi-hx.js` at +0.4%, plus a direct check that
+  the built bundle carries no `metadata.ts` content and none of the manifest's
+  classification fields; Playwright `src/compatibility/` **1111 passed / 8
+  skipped** with the same 10 known-local failures. **`test:check` was FULLY
+  GREEN** — the two failures the previous entry recorded did NOT reproduce,
+  confirming its own diagnosis that they were copied-`dist/` worktree artifacts:
+  this session ran in the main tree with freshly rebuilt dists.
+  Next action: none in this arc. Recommended follow-on is still **Finding 13**.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "lerna": "^9.0.3",
         "lint-staged": "^16.4.0",
         "oxlint": "^1.74.0",
-        "prettier": "^3.7.4",
+        "prettier": "3.9.5",
         "typescript": "^5.9.3"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint:domains": "for pkg in sql bdd behaviorspec flow jsx learn llm todo voice; do npm test --prefix packages/domain-$pkg -- --run lint || exit 1; done",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "format:check:src": "prettier --check \"packages/*/src/**/*.ts\"",
     "typecheck": "npm run typecheck --workspaces",
     "generate:language-assets": "npm run generate:language-assets --prefix packages/semantic",
     "clean": "npm run clean --workspaces && rm -rf node_modules",
@@ -77,7 +78,7 @@
     "lerna": "^9.0.3",
     "lint-staged": "^16.4.0",
     "oxlint": "^1.74.0",
-    "prettier": "^3.7.4",
+    "prettier": "3.9.5",
     "typescript": "^5.9.3"
   },
   "overrides": {

--- a/packages/aot-compiler/src/scanner/html-scanner.test.ts
+++ b/packages/aot-compiler/src/scanner/html-scanner.test.ts
@@ -122,7 +122,8 @@ describe('HTMLScanner', () => {
         attributeNames: ['hs', 'hyperscript'],
       });
 
-      const html = '<button hs="on click toggle .a">A</button><button hyperscript="toggle .b">B</button>';
+      const html =
+        '<button hs="on click toggle .a">A</button><button hyperscript="toggle .b">B</button>';
       const scripts = customScanner.extract(html, 'test.html');
 
       expect(scripts).toHaveLength(2);

--- a/packages/aot-compiler/src/scanner/html-scanner.ts
+++ b/packages/aot-compiler/src/scanner/html-scanner.ts
@@ -5,7 +5,12 @@
  * Supports _ attributes, data-hs attributes, and script tags.
  */
 
-import type { ExtractedScript, SourceLocation, ScannerOptions, ScanResult } from '../types/aot-types.js';
+import type {
+  ExtractedScript,
+  SourceLocation,
+  ScannerOptions,
+  ScanResult,
+} from '../types/aot-types.js';
 
 // =============================================================================
 // DEFAULT OPTIONS
@@ -27,10 +32,7 @@ const DEFAULT_OPTIONS: Required<ScannerOptions> = {
  */
 function createAttributeRegex(attrName: string): RegExp {
   const escaped = attrName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return new RegExp(
-    `${escaped}\\s*=\\s*(?:"([^"]*?)"|'([^']*?)'|([^\\s>]+))`,
-    'gi'
-  );
+  return new RegExp(`${escaped}\\s*=\\s*(?:"([^"]*?)"|'([^']*?)'|([^\\s>]+))`, 'gi');
 }
 
 /**
@@ -41,7 +43,8 @@ const ELEMENT_REGEX = /<([a-z][a-z0-9-]*)\s+([^>]*?)>/gi;
 /**
  * Match script tags with type="text/hyperscript".
  */
-const SCRIPT_TAG_REGEX = /<script\s+[^>]*type\s*=\s*["']text\/hyperscript["'][^>]*>([\s\S]*?)<\/script>/gi;
+const SCRIPT_TAG_REGEX =
+  /<script\s+[^>]*type\s*=\s*["']text\/hyperscript["'][^>]*>([\s\S]*?)<\/script>/gi;
 
 /**
  * Extract id attribute from element.
@@ -457,7 +460,10 @@ export async function scanFiles(
 /**
  * Create a scanner for the appropriate file type.
  */
-export function createScanner(filename: string, options?: ScannerOptions): HTMLScanner | JSXScanner {
+export function createScanner(
+  filename: string,
+  options?: ScannerOptions
+): HTMLScanner | JSXScanner {
   if (filename.endsWith('.vue')) {
     return new VueScanner(options);
   }

--- a/packages/compilation-service/src/operations/types.ts
+++ b/packages/compilation-service/src/operations/types.ts
@@ -13,9 +13,7 @@
 
 /** A reference to the target of an operation */
 export type TargetRef =
-  | { kind: 'self' }
-  | { kind: 'selector'; value: string }
-  | { kind: 'variable'; value: string };
+  { kind: 'self' } | { kind: 'selector'; value: string } | { kind: 'variable'; value: string };
 
 // =============================================================================
 // Abstract Operations

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -97,11 +97,16 @@ export const createIncrementCommand = createFactory(IncrementCommand);
 4. Add parser support in `src/parser/command-parsers/{category}-commands.ts` only if the command needs non-generic parsing — simple commands use the default identifier-plus-args path
 5. For lite/hybrid bundle coverage, add cases to `src/bundle-generator/templates.ts`, `parser-templates.ts`, and `template-capabilities.ts`
 6. Add reference/LSP entries in `src/reference/index.ts` and `src/lsp-metadata.ts`
-7. Bump the counts in `src/metadata.ts` — `packageInfo.commands` plus the
-   `commandCount` of each full-runtime bundle (`browser`, `hybrid-hx-v4`,
-   `multilingual`). The `verify:reference` CI gate fails otherwise; it also
-   derives the list-publishing bundles' counts from their own `commands: [...]`
-   arrays, so those stay honest on their own.
+7. **No longer needed for the full-runtime counts** — `packageInfo.commands` and
+   the `commandCount` of `browser` / `hybrid-hx-v4` are derived from the
+   manifest (`COMMAND_NAMES.length`) as of Arc A step 4.4, so adding a command
+   updates them automatically. What you DO still update is any bundle you added
+   the command to: each non-full bundle carries its own measured count, and
+   `verify:reference` re-derives every one of them from the bundle source via
+   `compatibility/bundle-sources.ts` (its `commands: [...]` array, its
+   `createTreeShakeableRuntime` factory list, or the bundle it re-exports).
+   Note `multilingual` is NOT a full-runtime bundle despite once claiming 59 —
+   it hand-picks 52.
 8. Write tests in `src/commands/{category}/__tests__/{name}.test.ts`
 9. If the command should be available multilingually, sync `packages/semantic/`:
    - Add the action to the `ActionType` union in `packages/semantic/src/types.ts`

--- a/packages/core/scripts/verify-reference-data.ts
+++ b/packages/core/scripts/verify-reference-data.ts
@@ -33,6 +33,20 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 import { COMMAND_MANIFEST, toRegisteredName } from '../src/commands/manifest';
+// Imported rather than text-scraped for the same reason as the manifest above:
+// `metadata.ts` is pure data with no DOM reach. It has to be imported now —
+// step 4.4 made the full-runtime counts DERIVED expressions
+// (`FULL_RUNTIME_COMMAND_COUNT`), and the regexes this file used to scrape them
+// with (`commandCount:\s*(\d+)`) match only literal digits, so they silently
+// skipped exactly the entries the gate most needs to see.
+import { bundleInfo, packageInfo } from '../src/metadata';
+// The bundle→source pairing lives in one place so this gate and the audit test
+// cannot disagree about which file backs which bundle.
+import {
+  BUNDLES_WITH_COMMAND_LISTS,
+  BUNDLES_WITH_FACTORY_LISTS,
+  BUNDLES_INHERITING,
+} from '../src/compatibility/bundle-sources';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CORE_ROOT = resolve(__dirname, '..');
@@ -88,37 +102,8 @@ function parseReferenceCommands(): Record<string, { category: string; availabili
   return commands;
 }
 
-function parseBundleInfo(): Array<{ id: string; filename: string; commandCount: number }> {
-  const metaPath = resolve(CORE_ROOT, 'src/metadata.ts');
-  const content = readFileSync(metaPath, 'utf-8');
-
-  const bundles: Array<{ id: string; filename: string; commandCount: number }> = [];
-
-  // Match bundle entries
-  const bundleRegex = /id:\s*'([^']+)'[^}]*filename:\s*'([^']+)'[^}]*commandCount:\s*(\d+)/g;
-
-  let match;
-  while ((match = bundleRegex.exec(content)) !== null) {
-    bundles.push({
-      id: match[1],
-      filename: match[2],
-      commandCount: parseInt(match[3], 10),
-    });
-  }
-
-  return bundles;
-}
-
-function parsePackageInfo(): { commands: number } {
-  const metaPath = resolve(CORE_ROOT, 'src/metadata.ts');
-  const content = readFileSync(metaPath, 'utf-8');
-
-  // Match: commands: 43
-  const match = content.match(/commands:\s*(\d+)/);
-  return {
-    commands: match ? parseInt(match[1], 10) : 0,
-  };
-}
+// `parseBundleInfo` / `parsePackageInfo` were deleted in step 4.4 — see the
+// `metadata` import above. The values now come from the module itself.
 
 // =============================================================================
 // PARSE DATA
@@ -126,8 +111,6 @@ function parsePackageInfo(): { commands: number } {
 
 const factoryNames = parseCommandFactories();
 const refCommands = parseReferenceCommands();
-const bundleInfo = parseBundleInfo();
-const packageInfo = parsePackageInfo();
 
 /** The registry-of-record every list below is scored against. */
 const manifestNames = COMMAND_MANIFEST.map(entry => entry.name);
@@ -374,17 +357,22 @@ function verifyAvailabilities() {
 // =============================================================================
 
 /**
- * Bundles that publish their own `commands: [...]` array. Their metadata
- * commandCount is checked against that array rather than trusted: lite-plus and
- * the two hybrids were stale by 4-5 commands each for months, because nothing
- * compared the advertised number to the real list. (The full-runtime bundles
- * have no such array — they register everything the default runtime does, so
- * their count is checked against packageInfo.commands instead.)
+ * Every bundle's advertised commandCount is re-derived from its own source
+ * rather than trusted — the pairing lives in `compatibility/bundle-sources.ts`.
+ * lite-plus and the two hybrids were stale by 4-5 commands each for months
+ * because nothing compared the advertised number to the real list; step 4.4
+ * widened the same idea to the rest and caught three more (`minimal` 30→10,
+ * `standard` 35→25, `multilingual` 59→52).
  */
-const BUNDLES_WITH_COMMAND_LISTS: Record<string, string> = {
-  'lite-plus': 'browser-bundle-lite-plus.ts',
-  'hybrid-complete': 'browser-bundle-hybrid-complete.ts',
-};
+
+/** Count `createXCommand()` calls in a bundle's tree-shakeable runtime list. */
+function actualFactoryCount(sourceFile: string): number | null {
+  const bundlePath = resolve(__dirname, '../src/compatibility', sourceFile);
+  if (!existsSync(bundlePath)) return null;
+  const source = readFileSync(bundlePath, 'utf-8');
+  const calls = source.match(/^\s+create[A-Za-z0-9]*Command\(\),?$/gm);
+  return calls ? new Set(calls.map(c => c.trim())).size : null;
+}
 
 /** Count entries in a bundle source's `commands: [ ... ]` array. */
 function actualCommandCount(sourceFile: string): number | null {
@@ -430,6 +418,32 @@ function verifyBundleCommandCounts() {
     } else if (actual !== bundle.commandCount) {
       errors.push(
         `${id} advertises ${bundle.commandCount} commands but ${sourceFile} ships ${actual}`
+      );
+    }
+  }
+
+  // Same, for the bundles that hand-pick factories without publishing an array.
+  for (const [id, sourceFile] of Object.entries(BUNDLES_WITH_FACTORY_LISTS)) {
+    const bundle = bundleInfo.find(b => b.id === id);
+    if (!bundle) continue;
+    const actual = actualFactoryCount(sourceFile);
+    if (actual === null) {
+      errors.push(`${id}: could not read the factory list from ${sourceFile}`);
+    } else if (actual !== bundle.commandCount) {
+      errors.push(
+        `${id} advertises ${bundle.commandCount} commands but ${sourceFile} registers ${actual}`
+      );
+    }
+  }
+
+  // And the bundles that re-export another bundle wholesale.
+  for (const [id, inheritsFrom] of Object.entries(BUNDLES_INHERITING)) {
+    const bundle = bundleInfo.find(b => b.id === id);
+    const parent = bundleInfo.find(b => b.id === inheritsFrom);
+    if (!bundle || !parent) continue;
+    if (bundle.commandCount !== parent.commandCount) {
+      errors.push(
+        `${id} re-exports ${inheritsFrom} but advertises ${bundle.commandCount} vs its ${parent.commandCount}`
       );
     }
   }

--- a/packages/core/src/__test-utils__/parser-context-mock.ts
+++ b/packages/core/src/__test-utils__/parser-context-mock.ts
@@ -208,14 +208,12 @@ export function createMockParserContext(
     parseCommandListUntilEnd: vi.fn(() => []),
 
     // Position
-    getPosition: vi.fn(
-      (): Position => ({
-        start: currentPosition,
-        end: currentPosition,
-        line: 1,
-        column: currentPosition,
-      })
-    ),
+    getPosition: vi.fn((): Position => ({
+      start: currentPosition,
+      end: currentPosition,
+      line: 1,
+      column: currentPosition,
+    })),
 
     // Error handling
     addError: vi.fn(),

--- a/packages/core/src/ast-utils/interchange/from-core.ts
+++ b/packages/core/src/ast-utils/interchange/from-core.ts
@@ -142,13 +142,7 @@ export function fromCoreAST(node: CoreNode): InterchangeNode {
       return {
         type: 'positional',
         position: node.position as
-          | 'first'
-          | 'last'
-          | 'next'
-          | 'previous'
-          | 'closest'
-          | 'parent'
-          | 'random',
+          'first' | 'last' | 'next' | 'previous' | 'closest' | 'parent' | 'random',
         ...(node.target ? { target: fromCoreAST(node.target as CoreNode) } : {}),
         ...pos(node),
       };
@@ -156,13 +150,7 @@ export function fromCoreAST(node: CoreNode): InterchangeNode {
       return {
         type: 'positional',
         position: node.operator as
-          | 'first'
-          | 'last'
-          | 'next'
-          | 'previous'
-          | 'closest'
-          | 'parent'
-          | 'random',
+          'first' | 'last' | 'next' | 'previous' | 'closest' | 'parent' | 'random',
         ...(node.argument ? { target: fromCoreAST(node.argument as CoreNode) } : {}),
         ...pos(node),
       };

--- a/packages/core/src/commands/animation/start-view-transition.ts
+++ b/packages/core/src/commands/animation/start-view-transition.ts
@@ -84,8 +84,7 @@ export class StartViewTransitionCommand implements DecoratedCommand {
     context: TypedExecutionContext
   ): Promise<StartViewTransitionOutput> {
     const runtimeExecute = context.locals.get('_runtimeExecute') as
-      | ((cmd: unknown, ctx: TypedExecutionContext) => Promise<unknown>)
-      | undefined;
+      ((cmd: unknown, ctx: TypedExecutionContext) => Promise<unknown>) | undefined;
 
     let commandsExecuted = 0;
 

--- a/packages/core/src/commands/control-flow/repeat.ts
+++ b/packages/core/src/commands/control-flow/repeat.ts
@@ -335,8 +335,7 @@ export class RepeatCommand implements DecoratedCommand {
     ) {
       const block = commands as { commands?: unknown[] };
       const runtimeExecute = context.locals.get('_runtimeExecute') as
-        | ((cmd: unknown, ctx: TypedExecutionContext) => Promise<unknown>)
-        | undefined;
+        ((cmd: unknown, ctx: TypedExecutionContext) => Promise<unknown>) | undefined;
       if (!runtimeExecute) throw new Error('Runtime execute function not available');
       let lastResult: unknown;
       if (block.commands) {

--- a/packages/core/src/commands/data/clear.ts
+++ b/packages/core/src/commands/data/clear.ts
@@ -34,8 +34,7 @@ import {
 } from '../decorators';
 
 export type ClearCommandInput =
-  | { type: 'variable'; name: string }
-  | { type: 'form-fields'; targets: HTMLElement[] };
+  { type: 'variable'; name: string } | { type: 'form-fields'; targets: HTMLElement[] };
 
 function isFormFieldElement(
   el: HTMLElement

--- a/packages/core/src/commands/execution/call.ts
+++ b/packages/core/src/commands/execution/call.ts
@@ -75,8 +75,7 @@ export class CallCommand implements DecoratedCommand {
     // canonical `evaluateAST` — the bundle's registry is already threaded
     // through `context.registry`.
     const mockEvaluator = context.locals?.get('__evaluator') as
-      | { evaluate(node: ASTNode, ctx: ExecutionContext): unknown }
-      | undefined;
+      { evaluate(node: ASTNode, ctx: ExecutionContext): unknown } | undefined;
     const expression = mockEvaluator
       ? await mockEvaluator.evaluate(expressionNode, context)
       : await evaluateAST(expressionNode, context);

--- a/packages/core/src/commands/helpers/dom-mutation.ts
+++ b/packages/core/src/commands/helpers/dom-mutation.ts
@@ -17,11 +17,7 @@ import { isHTMLElement } from '../../utils/element-check';
  * Note: We use a custom type name to avoid conflict with the DOM InsertPosition type
  */
 export type ContentInsertPosition =
-  | 'beforebegin'
-  | 'afterbegin'
-  | 'beforeend'
-  | 'afterend'
-  | 'replace';
+  'beforebegin' | 'afterbegin' | 'beforeend' | 'afterend' | 'replace';
 
 /**
  * Semantic position names mapped to InsertPosition

--- a/packages/core/src/commands/helpers/element-property-access.ts
+++ b/packages/core/src/commands/helpers/element-property-access.ts
@@ -156,12 +156,10 @@ export function setElementProperty(element: HTMLElement, property: string, value
   try {
     (element as unknown as Record<string, unknown>)[property] = value;
   } catch (error) {
-    if (
-      !(
-        error instanceof TypeError &&
-        (error.message.includes('only a getter') || error.message.includes('read only'))
-      )
-    ) {
+    if (!(
+      error instanceof TypeError &&
+      (error.message.includes('only a getter') || error.message.includes('read only'))
+    )) {
       throw new Error(
         `Cannot set property '${property}': ${error instanceof Error ? error.message : 'Unknown error'}`
       );

--- a/packages/core/src/commands/helpers/event-waiting.ts
+++ b/packages/core/src/commands/helpers/event-waiting.ts
@@ -224,8 +224,7 @@ export function waitForAnimationComplete(
  * Wait condition for racing
  */
 export type WaitCondition =
-  | { type: 'time'; ms: number }
-  | { type: 'event'; target: EventTarget; eventName: string };
+  { type: 'time'; ms: number } | { type: 'event'; target: EventTarget; eventName: string };
 
 /**
  * Result of a race between conditions

--- a/packages/core/src/commands/helpers/selector-type-detection.ts
+++ b/packages/core/src/commands/helpers/selector-type-detection.ts
@@ -16,12 +16,7 @@ import type { ASTNode, ExecutionContext } from '../../types/base-types';
  * Types of selectors recognized by HyperFixi commands
  */
 export type SelectorType =
-  | 'class'
-  | 'attribute'
-  | 'css-property'
-  | 'element'
-  | 'identifier'
-  | 'unknown';
+  'class' | 'attribute' | 'css-property' | 'element' | 'identifier' | 'unknown';
 
 /**
  * Smart element types that have special toggle behavior
@@ -324,12 +319,7 @@ export function isBareSmartElementNode(node: ASTNode): boolean {
  * Used by toggle, add, remove commands to determine what operation to perform
  */
 export type CommandInputType =
-  | 'classes'
-  | 'attribute'
-  | 'css-property'
-  | 'element'
-  | 'styles'
-  | 'unknown';
+  'classes' | 'attribute' | 'css-property' | 'element' | 'styles' | 'unknown';
 
 /**
  * Result of parsing a command's first argument

--- a/packages/core/src/commands/utility/tell.ts
+++ b/packages/core/src/commands/utility/tell.ts
@@ -82,8 +82,7 @@ export class TellCommand implements DecoratedCommand {
 
     // Get runtime execute function for AST command nodes (same pattern as RepeatCommand)
     const runtimeExecute = context.locals.get('_runtimeExecute') as
-      | ((cmd: unknown, ctx: TypedExecutionContext) => Promise<unknown>)
-      | undefined;
+      ((cmd: unknown, ctx: TypedExecutionContext) => Promise<unknown>) | undefined;
 
     const commandResults: any[] = [];
 

--- a/packages/core/src/compatibility/browser-bundle-classic-i18n.ts
+++ b/packages/core/src/compatibility/browser-bundle-classic-i18n.ts
@@ -1,7 +1,7 @@
 /**
  * HyperFixi Classic Browser Bundle with i18n Support
  *
- * Combines the classic _hyperscript runtime (37 commands) with full
+ * Combines the classic _hyperscript runtime (43 commands) with full
  * internationalization support including:
  * - 12 language keyword providers (es, ja, fr, de, ar, ko, zh, tr, id, pt, qu, sw)
  * - Automatic browser locale detection

--- a/packages/core/src/compatibility/browser-bundle-minimal-v2.ts
+++ b/packages/core/src/compatibility/browser-bundle-minimal-v2.ts
@@ -4,7 +4,8 @@
  * This bundle uses true tree-shaking by importing:
  * - createTreeShakeableRuntime (zero module-level command imports)
  * - createCoreExpressionEvaluator (only 3 expression categories)
- * - Only the 8 commands needed for minimal functionality
+ * - Only the 10 commands needed for minimal functionality (11 register: createSendCommand
+ *   also registers its `trigger` alias)
  *
  * Commands included (10 minimal):
  * - add, remove, toggle (DOM manipulation)

--- a/packages/core/src/compatibility/browser-bundle-modular.ts
+++ b/packages/core/src/compatibility/browser-bundle-modular.ts
@@ -69,10 +69,10 @@ import {
 // Option A: Regex parser (~5 KB) - 8 commands, simple syntax only
 // import { regexParser as parser } from '../parser/regex-parser';
 
-// Option B: Hybrid parser (~7 KB) - 21+ commands, ~85% coverage
+// Option B: Hybrid parser (~7 KB) - 24 commands, ~85% coverage
 import { hybridParser as parser } from '../parser/hybrid-parser';
 
-// Option C: Full parser (~180 KB) - 48 commands, 100% coverage
+// Option C: Full parser (~180 KB) - all 59 commands, 100% coverage
 // import { fullParser as parser } from '../parser/full-parser';
 
 // =============================================================================

--- a/packages/core/src/compatibility/browser-bundle-multilingual.ts
+++ b/packages/core/src/compatibility/browser-bundle-multilingual.ts
@@ -36,7 +36,9 @@ import { createFullExpressionRegistry } from '../expressions/index';
 import { createContext, ensureContext } from '../core/context';
 import type { ASTNode } from '../types/base-types';
 
-// Import ALL V2 commands (41 commands total)
+// Import the 52 commands this bundle ships (was labelled 41; the label had
+// drifted). Authoritative count: metadata.ts `bundleInfo`, gated by
+// verify:reference against the factory list below.
 // DOM Commands (7)
 import { createHideCommand } from '../commands/dom/hide';
 import { createShowCommand } from '../commands/dom/show';
@@ -214,7 +216,8 @@ const SUPPORTED_LANGUAGES = [
   'sw',
 ] as const;
 
-// Create runtime with ALL 41 commands
+// Create runtime with 52 commands — NOT the full 59. Absent vs the manifest:
+// morph, process, push, replace, scroll, start, swap.
 const runtime = createTreeShakeableRuntime(
   [
     // DOM (7)

--- a/packages/core/src/compatibility/browser-bundle-semantic-complete.ts
+++ b/packages/core/src/compatibility/browser-bundle-semantic-complete.ts
@@ -6,7 +6,7 @@
  *
  * This bundle provides:
  *   - Full semantic parsing (13 languages)
- *   - All 41 commands
+ *   - 52 commands (not the full 59)
  *   - Translation between languages
  *   - Direct semantic->AST->execute path
  *
@@ -39,7 +39,8 @@ import { createFullExpressionRegistry } from '../expressions/index';
 import { createContext, ensureContext } from '../core/context';
 import type { ASTNode } from '../types/base-types';
 
-// Import ALL V2 commands (41 commands total)
+// Import the 52 commands this bundle ships (was labelled 41; the label had
+// drifted).
 // DOM Commands (7)
 import { createHideCommand } from '../commands/dom/hide';
 import { createShowCommand } from '../commands/dom/show';
@@ -214,7 +215,8 @@ const SUPPORTED_LANGUAGES = [
   'sw',
 ] as const;
 
-// Create runtime with ALL 41 commands
+// Create runtime with 52 commands — NOT the full 59. Absent vs the manifest:
+// morph, process, push, replace, scroll, start, swap.
 const runtime = createTreeShakeableRuntime(
   [
     // DOM (7)

--- a/packages/core/src/compatibility/browser-bundle-standard-v2.ts
+++ b/packages/core/src/compatibility/browser-bundle-standard-v2.ts
@@ -4,7 +4,7 @@
  * This bundle uses true tree-shaking by importing:
  * - createTreeShakeableRuntime (zero module-level command imports)
  * - createCommonExpressionEvaluator (5 expression categories)
- * - Only the 16 commands needed for standard functionality
+ * - Only the 25 commands needed for standard functionality
  *
  * Commands included (25 standard):
  * - DOM: add, remove, toggle, show, hide, put, make, empty, open, close, select, reset (12)

--- a/packages/core/src/compatibility/browser-bundle.ts
+++ b/packages/core/src/compatibility/browser-bundle.ts
@@ -1,11 +1,11 @@
 /**
  * HyperFixi Full Browser Bundle
- * Includes ALL commands and features (40+ commands)
+ * Includes ALL commands and features (all 59 — this bundle constructs Runtime)
  *
  * This is the complete bundle for maximum compatibility.
  * For smaller bundle sizes, consider:
- * - hyperfixi-minimal.js (~50-60KB gzipped, 8 commands, core expressions)
- * - hyperfixi-standard.js (~100-110KB gzipped, 20 commands, core+common expressions)
+ * - hyperfixi-minimal.js (~50-60KB gzipped, 10 commands, core expressions)
+ * - hyperfixi-standard.js (~100-110KB gzipped, 25 commands, core+common expressions)
  *
  * Phase 2 optimization notes:
  * - When using createRuntime(), specify expressionPreload option:

--- a/packages/core/src/compatibility/bundle-sources.ts
+++ b/packages/core/src/compatibility/bundle-sources.ts
@@ -1,0 +1,55 @@
+/**
+ * Which source file backs each `metadata.ts` bundle entry, and how that file
+ * declares its command set.
+ *
+ * ## Why this exists
+ *
+ * `metadata.ts` advertises a `commandCount` per bundle. Until Arc A step 4.4
+ * only two of those numbers were checked against anything, and all three of the
+ * unchecked-and-checkable ones were wrong: `minimal` said 30 against an array of
+ * 10, `standard` said 35 against 25, and `multilingual` said 59 — the
+ * full-registry number — while registering 52.
+ *
+ * The count and the file that determines it were declared in different places,
+ * so nothing could compare them. This module is the one place the pairing
+ * lives; `scripts/verify-reference-data.ts` and
+ * `runtime/__tests__/command-manifest-audit.test.ts` both read it, so the gate
+ * and the audit cannot disagree about which file backs which bundle.
+ *
+ * Data only — no imports, so it costs nothing to reach from anywhere.
+ */
+
+/**
+ * Bundles that publish their own `commands: [...]` array. The array is the
+ * fact; the metadata count mirrors it.
+ */
+export const BUNDLES_WITH_COMMAND_LISTS: Readonly<Record<string, string>> = {
+  lite: 'browser-bundle-lite.ts',
+  'lite-plus': 'browser-bundle-lite-plus.ts',
+  'hybrid-complete': 'browser-bundle-hybrid-complete.ts',
+  minimal: 'browser-bundle-minimal-v2.ts',
+  standard: 'browser-bundle-standard-v2.ts',
+};
+
+/**
+ * Bundles that hand-pick commands through `createTreeShakeableRuntime([...])`
+ * without publishing an array. The factory calls are the fact.
+ *
+ * Note `minimal` REGISTERS one more name than it advertises — its
+ * `createSendCommand` also registers the consolidation alias `trigger`. The
+ * metadata count mirrors the advertised array, so the two stay comparable;
+ * whether the array should also list `trigger` is a behavior question left to
+ * its own PR.
+ */
+export const BUNDLES_WITH_FACTORY_LISTS: Readonly<Record<string, string>> = {
+  multilingual: 'browser-bundle-multilingual.ts',
+};
+
+/**
+ * Bundles that re-export another bundle wholesale, so their count must equal
+ * that bundle's rather than being stated again.
+ */
+export const BUNDLES_INHERITING: Readonly<Record<string, string>> = {
+  'hybrid-hx': 'hybrid-complete',
+  'hybrid-hx-v4': 'browser',
+};

--- a/packages/core/src/experimental/binary-tree/types.ts
+++ b/packages/core/src/experimental/binary-tree/types.ts
@@ -89,9 +89,7 @@ export type SerializablePrimitive = null | undefined | boolean | number | string
 
 /** Supported value types for serialization */
 export type SerializableValue =
-  | SerializablePrimitive
-  | SerializableValue[]
-  | { [key: string]: SerializableValue };
+  SerializablePrimitive | SerializableValue[] | { [key: string]: SerializableValue };
 
 // =============================================================================
 // Internal Types

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -16,6 +16,25 @@
  * ```
  */
 
+import { COMMAND_NAMES } from './commands/manifest';
+
+/**
+ * The number of commands the default runtime registers — derived, never typed.
+ *
+ * Sourced from `COMMAND_NAMES` and **not** `COMMAND_MANIFEST.map(...)`: a
+ * `.map()` over the entries references the entries, dragging every command's
+ * `category`/`tier`/`upstreamOrExtension`/`multiword` into any bundle that
+ * reaches this module (Finding 11 in the arc brief — that shape cost
+ * `hyperfixi-hx.js` +4.8 KB / +7.5% and failed the ±5% size gate in step 3).
+ * `COMMAND_NAMES` is a flat string list, and the audit asserts the two are
+ * equal as ordered lists, so this cannot drift from the manifest.
+ *
+ * Only bundles that register the WHOLE registry may use this. Bundles that
+ * hand-pick commands carry their own measured count — see the note on
+ * `commandCount` below.
+ */
+const FULL_RUNTIME_COMMAND_COUNT = COMMAND_NAMES.length;
+
 // =============================================================================
 // PACKAGE INFO
 // =============================================================================
@@ -31,7 +50,7 @@ export const packageInfo = {
   description: 'Modern hyperscript engine with fixi/htmx integration',
   compatibility: '~85% official _hyperscript',
   languages: 24,
-  commands: 59,
+  commands: FULL_RUNTIME_COMMAND_COUNT,
   repository: 'https://github.com/codetalcott/hyperfixi',
   documentation: 'https://github.com/codetalcott/hyperfixi/tree/main/packages/core#readme',
 } as const;
@@ -51,7 +70,20 @@ export interface BundleInfo {
   gzipSize: string;
   /** Raw size (approximate) */
   rawSize: string;
-  /** Number of commands included */
+  /**
+   * Number of commands the bundle actually registers.
+   *
+   * Bundles that register the whole registry (`browser`, `hybrid-hx-v4`) use
+   * `FULL_RUNTIME_COMMAND_COUNT` so they track the manifest automatically.
+   * Every other bundle hand-picks its commands, so its count is a measured
+   * literal — and `verify:reference` re-derives each one from the bundle
+   * source rather than trusting it.
+   *
+   * Widening that check in step 4.4 found three that were wrong, all in the
+   * ungated set: `minimal` 30→10, `standard` 35→25, `multilingual` 59→52.
+   * The two bundles that were already gated (`lite-plus`, `hybrid-complete`)
+   * were both correct — the errors were exactly where nothing was looking.
+   */
   commandCount: number;
   /** Parser type used */
   parser: 'regex' | 'hybrid' | 'full';
@@ -151,7 +183,8 @@ export const bundleInfo: BundleInfo[] = [
     filename: 'hyperfixi-hx-v4.js',
     gzipSize: '323.7 KB',
     rawSize: '1507 KB',
-    commandCount: 59,
+    // Re-exports `browser-bundle.ts`, so it inherits the full registry.
+    commandCount: FULL_RUNTIME_COMMAND_COUNT,
     parser: 'full',
     hasBlocks: true,
     hasEventModifiers: true,
@@ -168,7 +201,13 @@ export const bundleInfo: BundleInfo[] = [
     filename: 'hyperfixi-minimal.js',
     gzipSize: '76.6 KB',
     rawSize: '315 KB',
-    commandCount: 30,
+    // Was 30, ungated and wrong by 20. `browser-bundle-minimal-v2.ts`
+    // advertises 10 in its own `commands: [...]` array, which is what this
+    // mirrors. Note it REGISTERS 11: `createSendCommand` also registers the
+    // consolidation alias `trigger`, so `trigger` works there but is not
+    // advertised. Left as-is deliberately — changing a shipped bundle's
+    // advertised surface is a behavior call, not part of a derivation step.
+    commandCount: 10,
     parser: 'full',
     hasBlocks: true,
     hasEventModifiers: true,
@@ -185,7 +224,9 @@ export const bundleInfo: BundleInfo[] = [
     filename: 'hyperfixi-standard.js',
     gzipSize: '83.1 KB',
     rawSize: '343 KB',
-    commandCount: 35,
+    // Was 35, ungated and wrong by 10. `browser-bundle-standard-v2.ts`
+    // registers 25, matching its own published `commands: [...]` array exactly.
+    commandCount: 25,
     parser: 'full',
     hasBlocks: true,
     hasEventModifiers: true,
@@ -202,7 +243,9 @@ export const bundleInfo: BundleInfo[] = [
     filename: 'hyperfixi.js',
     gzipSize: '312.2 KB',
     rawSize: '1470 KB',
-    commandCount: 59,
+    // Constructs `Runtime`, which seeds the whole registry (measured: 59, no
+    // gaps and no extras vs the manifest).
+    commandCount: FULL_RUNTIME_COMMAND_COUNT,
     parser: 'full',
     hasBlocks: true,
     hasEventModifiers: true,
@@ -219,7 +262,12 @@ export const bundleInfo: BundleInfo[] = [
     filename: 'hyperfixi-multilingual.js',
     gzipSize: '97.5 KB',
     rawSize: '403 KB',
-    commandCount: 59,
+    // NOT a full-runtime bundle, despite the old 59. It hand-picks 52 via
+    // `createTreeShakeableRuntime`; missing vs the manifest are `morph`,
+    // `process`, `push`, `replace`, `scroll`, `start`, `swap`. Whether it
+    // SHOULD ship all 59 is a behavior question, deliberately left to its own
+    // PR — this step only stops the number from lying.
+    commandCount: 52,
     parser: 'full',
     hasBlocks: true,
     hasEventModifiers: true,
@@ -431,7 +479,7 @@ export function compareBundles(bundleIds: string[]): Record<string, BundleInfo> 
 export const ecosystem = {
   core: {
     name: '@hyperfixi/core',
-    description: 'Main runtime, parser, 43 commands',
+    description: `Main runtime, parser, ${FULL_RUNTIME_COMMAND_COUNT} commands`,
     npm: 'https://www.npmjs.com/package/@hyperfixi/core',
   },
   semantic: {

--- a/packages/core/src/parser/command-parsers/dom-commands.ts
+++ b/packages/core/src/parser/command-parsers/dom-commands.ts
@@ -99,8 +99,7 @@ export function parseToggleCommand(ctx: ParserContext, identifierNode: Identifie
     // comes back as a single binary `and` expression. Split it back into the
     // flat `classA, and, classB` shape the toggle command's parseInput expects.
     const firstArg = parseOneArgument(ctx, [KEYWORDS.AND]) as
-      | (ASTNode & { type?: string; operator?: string; left?: ASTNode; right?: ASTNode })
-      | undefined;
+      (ASTNode & { type?: string; operator?: string; left?: ASTNode; right?: ASTNode }) | undefined;
     if (firstArg && firstArg.type === 'binaryExpression' && firstArg.operator === 'and') {
       if (firstArg.left) args.push(firstArg.left);
       args.push(ctx.createIdentifier('and'));

--- a/packages/core/src/parser/full-parser.ts
+++ b/packages/core/src/parser/full-parser.ts
@@ -1,8 +1,9 @@
 /**
  * Full Parser - Complete Hyperscript Parser with 100% Coverage
  *
- * This is the largest parser (~180KB) but supports all 48 commands
- * and 100% of the official _hyperscript syntax.
+ * This is the largest parser (~180KB) but supports all 59 commands
+ * (the manifest's `COMMAND_NAMES`) and 100% of the official _hyperscript
+ * syntax. The previous `48` predated eleven commands.
  *
  * Use this parser when you need full hyperscript compatibility.
  * For smaller bundles, consider hybridParser or regexParser.

--- a/packages/core/src/parser/parser-interface.ts
+++ b/packages/core/src/parser/parser-interface.ts
@@ -5,8 +5,14 @@
  * Different parsers have different capabilities and bundle sizes:
  *
  * - **regexParser**: ~5KB, 8 commands, simple syntax only
- * - **hybridParser**: ~7KB, 21+ commands, ~85% hyperscript coverage
- * - **fullParser**: ~180KB, 48 commands, 100% hyperscript coverage
+ * - **hybridParser**: ~7KB, 24 commands, ~85% hyperscript coverage
+ * - **fullParser**: ~180KB, all 59 commands, 100% hyperscript coverage
+ *
+ * The counts track the bundles these parsers ship in — `lite`,
+ * `hybrid-complete`, and the full-runtime bundles respectively. Authoritative
+ * values live in `metadata.ts`'s `bundleInfo`, which `verify:reference`
+ * re-derives from each bundle's source; the full count is the manifest's
+ * (`COMMAND_NAMES`). The `48` here was stale by eleven commands.
  *
  * @example
  * ```typescript

--- a/packages/core/src/parser/semantic-integration.ts
+++ b/packages/core/src/parser/semantic-integration.ts
@@ -23,11 +23,7 @@ import {
  * Semantic value types that can be captured from patterns.
  */
 export type SemanticValueType =
-  | 'literal'
-  | 'selector'
-  | 'reference'
-  | 'property-path'
-  | 'expression';
+  'literal' | 'selector' | 'reference' | 'property-path' | 'expression';
 
 /**
  * A semantic value from pattern matching.

--- a/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
+++ b/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
@@ -70,6 +70,8 @@ import {
   resolveCommandKey,
 } from '../../bundle-generator/template-capabilities';
 import { COMMAND_KEYWORDS, ALL_KEYWORDS, HOVER_DOCS } from '../../lsp-metadata';
+import { bundleInfo } from '../../metadata';
+import { BUNDLES_WITH_COMMAND_LISTS } from '../../compatibility/bundle-sources';
 import { commands as referenceCommands } from '../../reference/index';
 import { parse } from '../../parser/parser';
 
@@ -744,6 +746,30 @@ describe('the per-bundle commands arrays', () => {
     const counts = Object.fromEntries(Object.entries(arrays).map(([f, n]) => [f, n.length]));
     expect(counts).toEqual(BUNDLE_COMMAND_COUNTS);
   });
+
+  /**
+   * The link whose ABSENCE was the bug. §6 pinned each array's size and
+   * `metadata.ts` advertised a `commandCount`, but the two were never compared,
+   * so `minimal` sat at 30 against an array of 10 and `standard` at 35 against
+   * 25 — both for as long as the entries have existed. Pinning one side and
+   * advertising the other is not a check; only the comparison is.
+   *
+   * Scoped to the array-publishing bundles: `verify:reference` covers the
+   * factory-list and re-export arms with the same `bundle-sources.ts` pairing.
+   */
+  it('metadata commandCount matches the array each bundle actually publishes', () => {
+    const mismatches: string[] = [];
+    for (const [id, sourceFile] of Object.entries(BUNDLES_WITH_COMMAND_LISTS)) {
+      const advertised = bundleInfo.find(b => b.id === id)?.commandCount;
+      const actual = arrays[sourceFile]?.length;
+      if (advertised === undefined || actual === undefined) {
+        mismatches.push(`${id}: no metadata entry or no array in ${sourceFile}`);
+      } else if (advertised !== actual) {
+        mismatches.push(`${id}: metadata says ${advertised}, ${sourceFile} publishes ${actual}`);
+      }
+    }
+    expect(mismatches).toEqual([]);
+  });
 });
 
 // ===========================================================================
@@ -941,8 +967,11 @@ describe('the command manifest', () => {
 // ===========================================================================
 
 describe('the classification debt, counted', () => {
-  // Zero CLASSIFICATION debt; step 4.4 (deriving `packageInfo.commands`) is a
-  // derivation, not a classification, and is not counted here.
+  // Zero CLASSIFICATION debt. Step 4.4 (deriving `packageInfo.commands`) has
+  // now LANDED and correctly added no row here: it is a derivation, not a
+  // classification. Arc A is complete — every count below stays at its decided
+  // value, and the counts 4.4 governs are gated in §6 and by verify:reference
+  // rather than tracked as debt.
   it('0 rows await deliberate classification (4.1, 4.2, 4.3 all landed)', () => {
     // The numbers the arc exists to burn down. A step that classifies a
     // command flips its allowlist row AND moves the count here, so the diff

--- a/packages/core/src/types/command-metadata.ts
+++ b/packages/core/src/types/command-metadata.ts
@@ -5,7 +5,7 @@
  * single source of truth for all command metadata.
  *
  * Benefits:
- * - Consistent metadata format across all 43+ commands
+ * - Consistent metadata format across all 59 commands
  * - Better documentation generation
  * - IDE tooling support
  * - Validation improvements

--- a/packages/domain-flow/src/types.ts
+++ b/packages/domain-flow/src/types.ts
@@ -8,15 +8,7 @@
  */
 
 export type FlowAction =
-  | 'fetch'
-  | 'poll'
-  | 'stream'
-  | 'submit'
-  | 'transform'
-  | 'enter'
-  | 'follow'
-  | 'perform'
-  | 'capture';
+  'fetch' | 'poll' | 'stream' | 'submit' | 'transform' | 'enter' | 'follow' | 'perform' | 'capture';
 
 /**
  * Structured data flow specification.

--- a/packages/framework/src/core/pattern-matching/pattern-matcher.ts
+++ b/packages/framework/src/core/pattern-matching/pattern-matcher.ts
@@ -1560,8 +1560,7 @@ export class PatternMatcher {
       }
 
       const metadata = token.metadata as
-        | { modifierName: string; value?: number | string }
-        | undefined;
+        { modifierName: string; value?: number | string } | undefined;
       if (!metadata) {
         break;
       }

--- a/packages/framework/src/feedback/types.ts
+++ b/packages/framework/src/feedback/types.ts
@@ -60,11 +60,7 @@ export interface FeedbackDiagnostic {
  * Machine-actionable fix type for LLM retry logic.
  */
 export type FixType =
-  | 'missing_role'
-  | 'invalid_type'
-  | 'unknown_command'
-  | 'unknown_role'
-  | 'syntax_error';
+  'missing_role' | 'invalid_type' | 'unknown_command' | 'unknown_role' | 'syntax_error';
 
 // =============================================================================
 // Confidence-Aware Disambiguation (Level 2)

--- a/packages/framework/src/ir/from-interchange.ts
+++ b/packages/framework/src/ir/from-interchange.ts
@@ -167,8 +167,7 @@ function convertIf(node: INode): SemanticNode {
   let elseBranch: SemanticNode[] | undefined;
 
   const elseIfBranches = node.elseIfBranches as
-    | ReadonlyArray<{ condition: INode; body: INode[] }>
-    | undefined;
+    ReadonlyArray<{ condition: INode; body: INode[] }> | undefined;
 
   if (elseIfBranches && elseIfBranches.length > 0) {
     // Chain else-if branches as nested conditionals

--- a/packages/intent/src/types.ts
+++ b/packages/intent/src/types.ts
@@ -30,12 +30,7 @@ export type SemanticRole = string;
 // =============================================================================
 
 export type SemanticValue =
-  | LiteralValue
-  | SelectorValue
-  | ReferenceValue
-  | PropertyPathValue
-  | ExpressionValue
-  | FlagValue;
+  LiteralValue | SelectorValue | ReferenceValue | PropertyPathValue | ExpressionValue | FlagValue;
 
 /** Expected value types for role tokens. */
 export type ExpectedType = SemanticValue['type'];

--- a/packages/intercept/src/types.ts
+++ b/packages/intercept/src/types.ts
@@ -26,11 +26,7 @@ export interface ExecutionContext {
 
 /** The five cache strategies upstream ships. */
 export type Strategy =
-  | 'cache-first'
-  | 'network-first'
-  | 'stale-while-revalidate'
-  | 'network-only'
-  | 'cache-only';
+  'cache-first' | 'network-first' | 'stale-while-revalidate' | 'network-only' | 'cache-only';
 
 /** Runtime config posted to the service worker as `hs:intercept:config`. */
 export interface InterceptConfig {

--- a/packages/language-server/src/symbol-table.ts
+++ b/packages/language-server/src/symbol-table.ts
@@ -16,12 +16,7 @@ import { escapeRegExp } from './utils.js';
 // =============================================================================
 
 export type SymbolKind =
-  | 'behavior'
-  | 'function'
-  | 'variable'
-  | 'event'
-  | 'caretVar'
-  | 'componentAttr';
+  'behavior' | 'function' | 'variable' | 'event' | 'caretVar' | 'componentAttr';
 
 export interface SymbolLocation {
   /** Line in the overall document (0-based). */

--- a/packages/mcp-multilingual-intent/src/siren.ts
+++ b/packages/mcp-multilingual-intent/src/siren.ts
@@ -11,14 +11,7 @@
  */
 
 export type SirenFieldType =
-  | 'text'
-  | 'number'
-  | 'hidden'
-  | 'email'
-  | 'url'
-  | 'search'
-  | 'tel'
-  | 'password';
+  'text' | 'number' | 'hidden' | 'email' | 'url' | 'search' | 'tel' | 'password';
 
 export interface SirenField {
   name: string;

--- a/packages/mcp-server/src/tools/routes.ts
+++ b/packages/mcp-server/src/tools/routes.ts
@@ -143,11 +143,7 @@ async function generateServerRoutes(args: Record<string, unknown>): Promise<Tool
 
   const html = getString(args, 'html');
   const framework = getString(args, 'framework', 'express') as
-    | 'express'
-    | 'hono'
-    | 'openapi'
-    | 'django'
-    | 'fastapi';
+    'express' | 'hono' | 'openapi' | 'django' | 'fastapi';
   const typescript = getBoolean(args, 'typescript', true);
   const filename = getString(args, 'filename', 'input.html');
 

--- a/packages/patterns-reference/src/api/language-docs.ts
+++ b/packages/patterns-reference/src/api/language-docs.ts
@@ -172,8 +172,7 @@ export async function getCommandByName(
   const db = getDatabase({ ...options, readonly: true });
 
   const row = db.prepare('SELECT * FROM commands WHERE LOWER(name) = LOWER(?)').get(name) as
-    | CommandRow
-    | undefined;
+    CommandRow | undefined;
 
   return row ? mapCommand(row) : null;
 }
@@ -224,8 +223,7 @@ export async function getExpressionByName(
   const db = getDatabase({ ...options, readonly: true });
 
   const row = db.prepare('SELECT * FROM expressions WHERE LOWER(name) = LOWER(?)').get(name) as
-    | ExpressionRow
-    | undefined;
+    ExpressionRow | undefined;
 
   if (!row) return null;
 
@@ -312,8 +310,7 @@ export async function getKeywordByName(
   const db = getDatabase({ ...options, readonly: true });
 
   const row = db.prepare('SELECT * FROM keywords WHERE LOWER(name) = LOWER(?)').get(name) as
-    | KeywordRow
-    | undefined;
+    KeywordRow | undefined;
 
   return row ? mapKeyword(row) : null;
 }
@@ -343,8 +340,7 @@ export async function getFeatureByName(
   const db = getDatabase({ ...options, readonly: true });
 
   const row = db.prepare('SELECT * FROM features WHERE LOWER(name) = LOWER(?)').get(name) as
-    | FeatureRow
-    | undefined;
+    FeatureRow | undefined;
 
   return row ? mapFeature(row) : null;
 }

--- a/packages/patterns-reference/src/types/index.ts
+++ b/packages/patterns-reference/src/types/index.ts
@@ -367,11 +367,7 @@ export interface SpecialSymbol {
  * Element type for searching across language elements.
  */
 export type LanguageElementType =
-  | 'command'
-  | 'expression'
-  | 'keyword'
-  | 'feature'
-  | 'special_symbol';
+  'command' | 'expression' | 'keyword' | 'feature' | 'special_symbol';
 
 /**
  * A language element (union of all documentation types).

--- a/packages/semantic/src/ast-builder/expression-parser/types.ts
+++ b/packages/semantic/src/ast-builder/expression-parser/types.ts
@@ -31,13 +31,7 @@ export interface LiteralNode extends ExpressionNode {
   readonly value: string | number | boolean | null | undefined;
   readonly raw?: string | undefined;
   readonly dataType?:
-    | 'string'
-    | 'number'
-    | 'boolean'
-    | 'null'
-    | 'undefined'
-    | 'duration'
-    | undefined;
+    'string' | 'number' | 'boolean' | 'null' | 'undefined' | 'duration' | undefined;
 }
 
 export interface TemplateLiteralNode extends ExpressionNode {
@@ -63,17 +57,7 @@ export interface SelectorNode extends ExpressionNode {
 // =============================================================================
 
 export type ContextType =
-  | 'me'
-  | 'you'
-  | 'it'
-  | 'its'
-  | 'my'
-  | 'your'
-  | 'result'
-  | 'event'
-  | 'target'
-  | 'body'
-  | 'detail';
+  'me' | 'you' | 'it' | 'its' | 'my' | 'your' | 'result' | 'event' | 'target' | 'body' | 'detail';
 
 export interface ContextReferenceNode extends ExpressionNode {
   readonly type: 'contextReference' | 'symbol';

--- a/packages/semantic/src/generators/profiles/types.ts
+++ b/packages/semantic/src/generators/profiles/types.ts
@@ -22,15 +22,7 @@ export type MarkingStrategy = 'preposition' | 'postposition' | 'particle' | 'cas
  * to handle mixed-script input (e.g., Arabic verb + CSS property name).
  */
 export type ScriptType =
-  | 'latin'
-  | 'cyrillic'
-  | 'arabic'
-  | 'cjk'
-  | 'devanagari'
-  | 'hangul'
-  | 'bengali'
-  | 'thai'
-  | 'hebrew';
+  'latin' | 'cyrillic' | 'arabic' | 'cjk' | 'devanagari' | 'hangul' | 'bengali' | 'thai' | 'hebrew';
 
 /**
  * A grammatical marker (preposition, particle, etc.) for a semantic role.

--- a/packages/semantic/src/generators/schema-validator.ts
+++ b/packages/semantic/src/generators/schema-validator.ts
@@ -503,9 +503,7 @@ export function validateRoleValues(
  * Collision type indicating how the keyword overlap occurs.
  */
 export type KeywordCollisionType =
-  | 'primary-primary'
-  | 'primary-alternative'
-  | 'alternative-alternative';
+  'primary-primary' | 'primary-alternative' | 'alternative-alternative';
 
 /**
  * A keyword collision between two or more commands in a language profile.

--- a/packages/semantic/src/interchange/from-semantic.ts
+++ b/packages/semantic/src/interchange/from-semantic.ts
@@ -131,13 +131,7 @@ export function fromSemanticAST(node: SemanticASTNode): InterchangeNode {
       return {
         type: 'positional',
         position: node.position as
-          | 'first'
-          | 'last'
-          | 'next'
-          | 'previous'
-          | 'closest'
-          | 'parent'
-          | 'random',
+          'first' | 'last' | 'next' | 'previous' | 'closest' | 'parent' | 'random',
         ...(node.target ? { target: fromSemanticAST(node.target as SemanticASTNode) } : {}),
         ...pos(node),
       };
@@ -145,13 +139,7 @@ export function fromSemanticAST(node: SemanticASTNode): InterchangeNode {
       return {
         type: 'positional',
         position: node.operator as
-          | 'first'
-          | 'last'
-          | 'next'
-          | 'previous'
-          | 'closest'
-          | 'parent'
-          | 'random',
+          'first' | 'last' | 'next' | 'previous' | 'closest' | 'parent' | 'random',
         ...(node.argument ? { target: fromSemanticAST(node.argument as SemanticASTNode) } : {}),
         ...pos(node),
       };

--- a/packages/testing-framework/src/multilingual/orchestrator.ts
+++ b/packages/testing-framework/src/multilingual/orchestrator.ts
@@ -155,8 +155,7 @@ export class TestOrchestrator {
       // Report regression if enabled
       if (this.config.regression) {
         const regressionReporter = this.reporters.find(r => r instanceof RegressionReporter) as
-          | RegressionReporter
-          | undefined;
+          RegressionReporter | undefined;
 
         if (regressionReporter?.hasBaseline()) {
           const regressionResults = regressionReporter.getRegressionResults();
@@ -471,8 +470,7 @@ export class TestOrchestrator {
    */
   getRegressionReporter(): RegressionReporter | undefined {
     return this.reporters.find(r => r instanceof RegressionReporter) as
-      | RegressionReporter
-      | undefined;
+      RegressionReporter | undefined;
   }
 }
 

--- a/packages/types-browser/src/semantic-api.ts
+++ b/packages/types-browser/src/semantic-api.ts
@@ -3,19 +3,7 @@
  */
 
 export type SupportedLanguage =
-  | 'en'
-  | 'ja'
-  | 'ar'
-  | 'es'
-  | 'ko'
-  | 'tr'
-  | 'zh'
-  | 'pt'
-  | 'fr'
-  | 'de'
-  | 'id'
-  | 'qu'
-  | 'sw';
+  'en' | 'ja' | 'ar' | 'es' | 'ko' | 'tr' | 'zh' | 'pt' | 'fr' | 'de' | 'id' | 'qu' | 'sw';
 
 /**
  * HyperFixi semantic parser API exposed on window.HyperFixiSemantic


### PR DESCRIPTION
**Arc A's last step.** Closes the command-manifest arc.

`packageInfo.commands`, `browser.commandCount` and `hybrid-hx-v4.commandCount` now read a `FULL_RUNTIME_COMMAND_COUNT = COMMAND_NAMES.length` constant instead of a hand-typed `59` — as does `ecosystem.core.description`, which had rotted to "43 commands".

`COMMAND_NAMES`, **not** `COMMAND_MANIFEST.map(...)`, per Finding 11. Measured rather than assumed: all 10 bundles within tolerance, `hyperfixi-hx.js` **+0.4%**, plus a direct check that the built bundle contains no `metadata.ts` content and none of the manifest's classification fields (`upstreamOrExtension`, `consolidationAliasOf`) — zero occurrences of any. `metadata.ts` turns out to be a leaf module nothing in `src/` imports.

## Three advertised counts were FALSE (Finding 15)

The derivation was two lines and was never wrong. The yield was next to it, as in 4.1/4.2/4.3. `verify:reference` checked **2 of 9** bundle counts; both were correct, and **every unchecked-and-checkable one was wrong**:

| Bundle | Advertised | Actual | Measured from |
| --- | --- | --- | --- |
| `minimal` | 30 | **10** | its own `commands: [...]` array |
| `standard` | 35 | **25** | its own `commands: [...]` array |
| `multilingual` | 59 | **52** | its `createTreeShakeableRuntime` factory list |

`multilingual` is the sharp one: 59 is the *full-registry* number, so the entry read as a full-runtime bundle. It is not — `morph`, `process`, `push`, `replace`, `scroll`, `start`, `swap` are absent. Measured by replicating `CommandRegistryV2.register()` over its factory list (52 factories → 52 names; no phantoms the other way).

The counts were pinned in one place (audit §6 pins each array's size) and advertised in another (`metadata.ts`), and **nothing compared the two**.

Verified honest and left alone: `browser` (constructs `Runtime`; 59, no gaps or extras), `hybrid-hx-v4` / `hybrid-hx` (re-export wholesale), `lite` (8), textshelf (10).

## Structural

- new `compatibility/bundle-sources.ts` — the bundle→source pairing in **one** place, read by both `verify:reference` and audit §6, so they cannot disagree
- the gate re-derives **all nine** counts (was two) across three arms — published array, factory list, re-export target. **Each arm negative-tested to fail.**
- `verify:reference` stopped text-scraping `metadata.ts`: its `commandCount:\s*(\d+)` regexes match literal digits only, so the moment the full-runtime counts became derived expressions it would have silently skipped exactly the entries it most needed to see
- audit §6 gained the metadata↔array comparison whose absence was the bug; **§8 correctly gained no row** (4.4 is a derivation, not a classification)
- eleven stale prose counts fixed across eight files (`48` in the three named files, `41` ×5 in the multilingual/semantic-complete bundles, plus `43+`, `40+`, `37`, `16`, `8`)
- core CLAUDE.md step 7 rewritten — full-runtime counts no longer need hand-bumping

## Deliberately not done

Both behavior calls wanting their own PR: making `multilingual` ship all 59, and adding the registered-but-unadvertised `trigger` to `minimal`'s published array (registers 11, advertises 10).

## Gates

- core **7844** passing / 128 skipped / 301 files (+1 = the new §6 test)
- `verify:reference` clean · language-server **227** · typecheck clean · oxlint 0 errors
- `snapshot:bundle-size` all 10 within tolerance
- Playwright `src/compatibility/` **1111 passed / 8 skipped**, with the 10 known-local failures (behaviors-demo, i18n-htmx, swap-debug — green in CI)
- **`test:check` fully green** — the two failures the 4.3 status-log entry recorded did *not* reproduce, confirming its own diagnosis that they were copied-`dist/` worktree artifacts; this session ran in the main tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also folded in: `chore(lint): pin prettier exactly and clear the resulting format drift`

Second, **independent** commit (`76078fa5`) — carried here rather than as its own PR to avoid a separate CI + merge cycle. **Zero file overlap** with the Arc A commit, so the two review cleanly apart.

The `prettier` devDependency was a floating `^3.7.4` resolving to 3.9.5. Prettier changed how it breaks TypeScript union types between those versions, so 34 files under `packages/*/src/` read as unformatted despite having been formatted correctly when committed. Every changed line is union-member placement (`| A | B` → `A | B`) — identical TypeScript; 178 of the 202 removed lines start with `|`.

- pins `prettier` to **3.9.5** exactly, so the target stops moving
- reformats the 34 affected src files (formatting only, no semantic change)
- adds a `format:check:src` script — **not wired to CI**, run by hand
- ignores `**/archive/` (85 tracked files across three archive dirs). 52 of the 68 drifted markdown files were archived phase/plan/summary docs nobody edits, and prettier's markdown normalization is the same hazard that already put `docs-internal/` in that file.
- corrects the CI table's `lint-typecheck` row, which still said "ESLint" (the repo moved to oxlint in #687)

**No CI gate deliberately.** The exact pin removes this drift's cause; a gate would only guard hook bypass, and blocking a PR over union-pipe placement costs more than that is worth. Repo-wide `prettier --check .` still differs on ~477 files (examples/, experiments/, protocol/, apps/, HTML, tests outside `src/`), none of which the hook formats either.

Re-verified on the combined branch: pin and lockfile agree at 3.9.5, `format:check:src` clean, `verify:reference` clean, typecheck clean, core **7844 / 128 / 301** unchanged.
