### PR TITLE
docs(command-arch): brief Arc B (metadata single-sourcing) from fresh measurement

### DIFF
--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -87,7 +87,7 @@ generators with `--check` CI gates, `typecheck:scripts`, and ghost tests.
 | ~~D — target-resolution consolidation~~ | **DONE** (#796/#797/#798) | ✅ + 36 new tests pinning the rung order and both selector shapes | [HANDOFF-command-arch-target-resolution.md](./HANDOFF-command-arch-target-resolution.md) — now a record, not a plan |
 | ~~C — output contract~~ | **DONE** (#801/#802/#803/#805/#806) | ✅ the per-command `it` audit, both execution paths, 45 of 59 commands | [HANDOFF-command-arch-output-contract.md](./HANDOFF-command-arch-output-contract.md) — now a record, not a plan |
 | ~~A — command manifest~~ | **DONE** (#811/#813/#814/#815/#817/#818/#819) | ✅ the 19-test bidirectional audit + the manifest's §7; classification debt is **0** | [HANDOFF-command-arch-manifest.md](./HANDOFF-command-arch-manifest.md) — now a record, not a plan |
-| B — metadata single-sourcing | types see metadata; docs generated | ✅ partial: typecheck:scripts, metadataOf() throws | decorator statics invisible to TS remain the root cause |
+| B — metadata single-sourcing | types see metadata; docs generated | ✅ partial: typecheck:scripts, metadataOf() throws | [HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md) — brief written 2026-07-29, arc not started; it CORRECTS the arc's stated motivation |
 | E — generated static bundles | 4 executors → 1 template source | ✅ partial: bundle-size ±5% + ceilings, compat matrix, parser-template drift test | drift test becomes a generator |
 | F — schema-driven mappers | ~30 of 47 mappers deleted | ✅ semantic suite + ten-signal ratchet + R2 | mapper/`semantic-integration` switch duplication is data |
 
@@ -264,6 +264,23 @@ derived values land. Gates already in place: `verify:reference`,
 
 ### Arc B — metadata single-sourcing (medium; verified mechanical)
 
+> **Read [HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md)
+> first — it CORRECTS this paragraph's stated motivation.** "Making metadata
+> visible to the type system" is right; the implied corollary that tsc does not
+> currently reject a mis-shaped metadata literal is **false for 52 of 55
+> implementations** (`meta(config: MetaConfig)` types its parameter, so a typoed
+> field is already `TS2561` — mutation-verified with a misspelled field name).
+> The static really is invisible
+> (`TS2339`, also mutation-verified), and that — plus **three undecorated classes
+> whose metadata is checked by nothing at all** — is the arc's actual payoff.
+> The brief also settles the `compatibility` domain mismatch, records the
+> verified `commandMeta()` signature, and adds four findings: a **second
+> `CommandMetadata` interface** in `command-adapter.ts` that the load-bearing
+> reader uses, a third `CommandCategory` union, `generate-command-docs.ts` as a
+> **21st hand-maintained list that is 16 commands short and gated by nothing**,
+> and **16 dead `metadata.examples` across 12 commands** (a different set from
+> Arc C's five, because it is a different oracle).
+
 Replace `@meta`'s runtime `defineProperty` statics with
 `static readonly metadata = commandMeta({...})`, making metadata visible to the
 type system (the invisibility is why `scripts/` typechecking stayed off for six
@@ -368,6 +385,53 @@ not the core abstractions.
 
 ## History
 
+- **2026-07-29** — **Arc B brief written**
+  ([HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md)), arc
+  not started. Measured against main `973ee1c5`.
+  - **The arc's own premise failed the queue's five-times-paid lesson.** "Score
+    the rows already there" applies to motivations too: `@meta(config: MetaConfig)`
+    types its parameter, so the 52 decorated literals are **already** checked
+    (`TS2561` on a misspelled field, mutation-verified). What is actually broken is
+    narrower and different — the **static** is invisible (`TS2339`), and the
+    **three undecorated classes** (`install`, `pseudo-command`, `render`) are
+    checked by nothing at all (a bogus `category` *and* a bogus `sideEffects` entry
+    both accepted). Selling step 1 on "tsc will now reject bad metadata" would have
+    built a gate that mostly existed.
+  - **The target shape already exists in-tree, three times** — those same three
+    classes are written as `static readonly metadata = {…} as const` plus a
+    `get metadata()` bridge, which is the proposed end state including the
+    mechanism that keeps `command-adapter.ts:440` working. A working reference
+    implementation, not a design sketch. Their `as const` is exactly why they are
+    unchecked, which is what `commandMeta()` fixes; its signature is verified in
+    the brief (`<const T extends MetaInput>` — keeps literal types, catches typos,
+    bad categories, and bad side-effects).
+  - **Two `CommandMetadata` interfaces**, and the load-bearing reader uses the
+    loose one: `command-adapter.ts:54-60` declares its own with an
+    `[extra: string]: unknown` index signature, which is the only reason
+    `impl.metadata?.name` typechecks — the canonical type has **no `name` field**.
+    Narrowing it turns :421 into a type error, and `readonly` vs mutable arrays
+    will bite. Contained to one file (exported, imported by nobody). Third
+    instance of the dual-type-definition pattern.
+  - **`generate-command-docs.ts` is a 21st hand-maintained list: 43 entries
+    against a 59-command registry, gated by nothing** — no npm script, no CI
+    step, no audit coupling, 16 commands missing. #793 fixed drift of the
+    *output* (`commands.json` matches the table); nothing checks the *input*.
+    The one instance Arc A did not sweep, because the generator is invisible to
+    `verify:reference`.
+  - **A named harvest, non-empty as predicted: 16 dead `metadata.examples`
+    across 12 commands** — and a *different* set from Arc C's five, because it is
+    a different oracle (raw string at parse level vs adapted snippet at
+    execution). Splits cleanly into examples authored in syntax the language never
+    had (the brace-block `repeat … { … }` in three commands; an `unless` example
+    on `if`) and real parser gaps to file (`toggle .loading for 2s`,
+    `wait for click or 1s` — both upstream syntax, check the published engine
+    first). Also: `increment`/`decrement` examples parse to a `set` node, so a
+    future "example reaches its own command" gate must allowlist that row.
+  - **`compatibility`'s domain mismatch is decided in the brief**, not left to
+    the arc: `upstream → 'standard'`, `extension → 'lokascript-extension'`,
+    `'experimental'` kept as an allowlisted third state at size 0, coupled via
+    the `TIER_UNCLASSIFIED`-equality trick against the audit's existing
+    `EXTENSIONS` set and `TIER_COUNTS`.
 - **2026-07-29** — **Arc A CLOSED**, and its recommended follow-on (Finding 13,
   the 14 unreachable capability case labels) closed with it. Both records are in
   [HANDOFF-command-arch-manifest.md](./HANDOFF-command-arch-manifest.md); the

--- a/docs-internal/HANDOFF-command-arch-metadata.md
+++ b/docs-internal/HANDOFF-command-arch-metadata.md
@@ -1,0 +1,543 @@
+# Handoff: Arc B — metadata single-sourcing
+
+> **Status: brief written 2026-07-29, arc NOT started.** Every figure below was
+> measured against main `973ee1c5` for this document; nothing is inherited from
+> the queue paragraph. Companion to
+> [COMMAND_ARCHITECTURE_NEXT_STEPS.md](./COMMAND_ARCHITECTURE_NEXT_STEPS.md)
+> § Arc B, which stays pointer-only. Prior art for the decorator toolchain:
+> [HANDOFF_vitest-oxc-decorators.md](./HANDOFF_vitest-oxc-decorators.md).
+>
+> **Read § "The premise, corrected" before writing any code.** The arc's stated
+> motivation — "tsc rejecting a mis-shaped metadata literal is the point" — is
+> **already true for 52 of 55 implementations**, mutation-verified. The arc still
+> has real value, but it is not the value the queue paragraph claims, and
+> mis-stating it would send step 1 after a gate that already exists.
+
+## The two oracles, settled up front
+
+Neither is a parse. State them in every step's PR body.
+
+**Oracle 1 — the type system.** `tsc --noEmit -p packages/core/tsconfig.json`.
+Mutation-verified in both directions (§ "The premise, corrected"), so the arc
+knows exactly which mis-shapes it newly catches and which were already caught.
+
+**Oracle 2 — the registry oracle**, for behavior preservation. A dump of every
+fact the decorator statics feed into registration: registered names, constructor
+identity, name source (own vs prototype), instance-vs-static metadata presence,
+category, aliases, compatibility, `isBlocking`/`hasBody`, syntax shape/count,
+example count, adapter name, shared-implementation groups, and alias→instance
+identity. **Diff the JSON before and after each step.** Script and baseline in
+§ "Oracle 2: the registry oracle".
+
+Finding 16's rule carries verbatim: a green suite is not evidence the statics
+moved correctly. 52 of 55 implementations are reached only through
+`impl.metadata`, and the suite passes with that read intact but wrong.
+
+## The premise, corrected
+
+Four mutation probes, run against main `973ee1c5` (temporary file under
+`packages/core/src/`, `npx tsc --noEmit -p tsconfig.json`, reverted after):
+
+| Probe | Expectation from the queue paragraph | Measured |
+| --- | --- | --- |
+| Read a decorated class's static: `ToggleCommand.metadata.description` | invisible | **`TS2339: Property 'metadata' does not exist on type 'typeof ToggleCommand'`** — confirmed |
+| Typo a field inside `@meta({ descriptionn: … })` | silently accepted | **`TS2561: … 'descriptionn' does not exist in type 'MetaConfig'`** — **already caught** |
+| Read an undecorated class's static: `InstallCommand.metadata.description` | n/a | **no error** — it is a real class field |
+| Bogus `category` **and** bogus `sideEffects` in an undecorated `static readonly metadata = {…} as const` | n/a | **no error at all** — completely unchecked |
+
+So the honest statement of what Arc B buys:
+
+1. **The static becomes visible.** `@meta` installs it with
+   `Object.defineProperty`, and a class decorator that returns the original class
+   cannot widen its type — the root cause, already written down verbatim in
+   `scripts/generate-command-docs.ts:84-93`. This is why `metadataOf()` exists and
+   why `scripts/` typechecking stayed off for six months. **This is the real prize.**
+2. **The three undecorated classes get checked for the first time.**
+   `install`, `pseudo-command`, `render` use a bare
+   `static readonly metadata = {…} as const` with **no contextual type**, so an
+   invalid category and a nonsense side-effect are both accepted today (probe 4).
+   These three are the only rows where "tsc rejects a mis-shaped literal" is a
+   *new* gate.
+3. **The 48 `declare readonly metadata: CommandMetadata` assertions stop being
+   lies.** `declare` asserts a shape the compiler never verifies; the decorator
+   fills it at runtime. Visible-but-unverified is not the same as checked.
+
+What Arc B does **not** buy: type-checking of the 52 decorated literals.
+`meta(config: MetaConfig)` types its parameter, so object-literal freshness
+already catches typos and bad enum values there. Do not sell step 1 on that.
+
+This is the arc's own premise failing the lesson the queue records five times
+over — **score the rows already there**. It is recorded here rather than quietly
+fixed because the next arc will be tempted by the same shortcut.
+
+## The target shape already exists in-tree, three times
+
+`install.ts:66-99`, `pseudo-command.ts:63-90`, `render.ts:61-88` are **not**
+decorated. Each is already written in the end-state shape the arc proposes,
+*including the instance bridge that keeps `command-adapter.ts:440` working*:
+
+```ts
+export class InstallCommand {
+  readonly name = 'install';                    // own property, not prototype
+  static readonly metadata = { … } as const;    // the static, type-VISIBLE
+  get metadata() { return InstallCommand.metadata; }   // the instance bridge
+}
+```
+
+This is a working reference implementation, not a design sketch. Two things to
+take from it:
+
+- **The instance bridge is a `get metadata()` returning the static.** The queue
+  offered "instance field/getter, or point both adapter sites at
+  `impl.constructor.metadata`". The getter is already proven in-tree on 3 of 59
+  registered commands, needs no adapter change, and is what makes hybrid
+  migration states safe. **Prefer it.** Re-pointing the adapter is a second,
+  optional change that should not ride along with the mechanical migration.
+- **`as const` is the wrong half of the job** and is precisely why these three
+  are unchecked. It preserves literal types and validates nothing.
+  `commandMeta()` must do both.
+
+### `commandMeta()` — signature verified
+
+`commandMeta()` does not exist yet; Arc B creates it. This signature was probed
+against the real `CommandMetadata` and does everything required:
+
+```ts
+type MetaInput = Omit<CommandMetadata, 'version'> & { version?: string };
+
+export function commandMeta<const T extends MetaInput>(m: T): T {
+  return m;
+}
+```
+
+Measured behaviour (same probe run, all four cases in one file):
+
+| Case | Result |
+| --- | --- |
+| Valid literal, then `const x: 'a' = ok.syntax[0]` | **no error** — `const T` preserves literal types, so nothing `as const` gave up is lost |
+| `descriptionn:` typo | `TS2561` ✓ |
+| `category: 'not-a-category'` | `TS2322: not assignable to type 'CommandCategory'` ✓ |
+| `sideEffects: ['nonsense']` | `TS2322: not assignable to type 'CommandSideEffect'` ✓ |
+
+The `const` type parameter is load-bearing: without it the literal widens to
+`string[]` and the arc trades checking for inference instead of getting both.
+
+## Census — measured, not inherited
+
+| Fact | Value |
+| --- | --- |
+| Registered command names | **59** |
+| Distinct implementation classes | **55** |
+| — decorated (`@command` + `@meta`) | **52** |
+| — undecorated (`static readonly metadata`) | **3** (install, pseudo-command, render) |
+| Shared-implementation groups | **4** |
+| Alias keywords from `metadata.aliases` | **4** (`unless`, `trigger`, `replace`, `decrement`) |
+| `name` from prototype (`@command` defineProperty) | 56 rows |
+| `name` from an own property | 3 rows (the undecorated classes) |
+| Rows with `metadata.compatibility` set | **0 of 59** |
+| Files declaring `declare readonly metadata` | 48 |
+| Files declaring `declare readonly name` | 48 |
+| Total `metadata.examples` strings across 59 rows | **202** |
+
+Counting note: `grep -rl '@command('` returns 53 files, two of which are false
+positives — `validation/command-pattern-validator.ts` and
+`commands/decorators/index.ts` both mention the decorators in **docstrings**.
+Match `^@command(` at line start, or count constructors from the registry.
+
+The four shared-implementation groups:
+
+| Class | Registered as |
+| --- | --- |
+| `ConditionalCommand` | `if`, `unless` |
+| `EventDispatchCommand` | `send`, `trigger` |
+| `HistoryCommand` | `push`, `replace` |
+| `NumericModifyCommand` | `decrement`, `increment` |
+
+## Anchors — re-verified 2026-07-29, by symbol
+
+`packages/core/src/commands/decorators/index.ts`:
+
+| Symbol | Line | What it does |
+| --- | --- | --- |
+| `COMMAND_NAME` / `COMMAND_CATEGORY` / `COMMAND_METADATA` | 65-67 | module-private symbols; **zero external readers** (re-verified) |
+| `defineProperty(target.prototype, 'name', …)` | 114 | prototype `name`, `writable: false` |
+| `defineProperty(target, 'metadata', …)` | 184 | the static, `configurable: false` |
+| `defineProperty(target.prototype, 'metadata', {get})` | 192 | the instance getter, `configurable: false` |
+| `getCommandName` / `getCommandCategory` / `getCommandMetadata` | 212 / 222 / 232 | **dead exported getters** — re-verified zero readers repo-wide |
+
+`packages/core/src/runtime/command-adapter.ts`:
+
+| Line | Read | Status |
+| --- | --- | --- |
+| 212 | `this.impl.metadata?.name` | name fallback, cosmetic getter |
+| 217-220 | `syntax` / `description` / `examples` | the cosmetic projection |
+| **421** | `impl.name \|\| impl.metadata?.name` | name fallback at registration |
+| **440** | `impl.metadata?.aliases` | **LOAD-BEARING** — dropping it silently un-registers `unless`, `trigger`, `replace`, `decrement` |
+
+`compatibility?` is declared at `types/command-metadata.ts:305`, unset on all 59.
+
+## New findings this measurement produced
+
+### F-B1 — there are TWO `CommandMetadata` interfaces, and the load-bearing reader uses the loose one
+
+`command-adapter.ts:54-60` declares its **own** `CommandMetadata`:
+
+```ts
+export interface CommandMetadata {
+  description?: string;
+  examples?: string[];          // MUTABLE — the real one is readonly
+  syntax?: string | string[];   // MUTABLE
+  aliases?: string[];           // MUTABLE
+  [extra: string]: unknown;     // <- swallows everything
+}
+```
+
+Consequences the arc must plan around:
+
+- **`impl.metadata?.name` typechecks only because of the index signature.** The
+  real `CommandMetadata` has **no `name` field** (checked). So :421's fallback
+  reads a property the canonical type does not declare — and narrowing the
+  adapter to the real type turns that line into a type error. That is the type
+  system biting correctly; decide whether the fallback survives (it is the only
+  path for a V1 command carrying `metadata.name`) before the compiler forces it.
+- **`readonly` vs mutable will bite.** The canonical type's arrays are `readonly`;
+  the adapter's are not. `readonly string[]` is not assignable to `string[]`.
+- The adapter's copy is **exported but imported by nobody** (verified), so
+  narrowing it is contained to one file — no cross-package ripple.
+
+This is a third instance of the dual-type-definition pattern already recorded for
+`ASTNode`/`ExpressionMetadata`. Do not attempt a global consolidation inside Arc
+B; note it and keep the blast radius at one file.
+
+### F-B2 — a third `CommandCategory` union
+
+The manifest audit already pins two (`types/command-metadata.ts` vs
+`reference/index.ts`, differing on `'event'`/`'events'` and `'storage'` —
+`command-manifest-audit.test.ts:815-826`). Relevant to Arc B because
+`commandMeta()` forces a choice of which union the literals are checked against.
+**Use the `types/command-metadata.ts` union** — it is what the decorator and
+registry already serve, and what the manifest mirrors. Do not reconcile the
+unions here; that is a rename with LSP and docs reach, deliberately pinned.
+
+### F-B3 — `generate-command-docs.ts` is a 21st hand-maintained list, 16 short, gated by nothing
+
+The prose half of the arc is in worse shape than the queue says.
+
+| Fact | Value |
+| --- | --- |
+| Entries in the generator's `COMMANDS` table | **43** |
+| Registered commands missing from it | **16** |
+| Ghosts in it | 0 |
+| `commands.json` entries | 43 — in sync with the generator |
+| npm script that runs it | **none** |
+| CI step that runs or `--check`s it | **none** |
+| Manifest-audit coupling | **none** |
+
+The 16 missing: `blur`, `breakpoint`, `clear`, `close`, `empty`, `focus`,
+`morph`, `open`, `process`, `push`, `replace`, `reset`, `scroll`, `select`,
+`start`, `swap`.
+
+Precise statement of the defect: #793 fixed **drift of the output** (`commands.json`
+was regenerated and matches the table), but nothing checks the **input**. So
+`docs/commands/commands.json` documents 43 of 59 commands and always will. This
+is the exact shape the queue's opening paragraph describes — *a list that
+describes code, that nothing compares to the code* — and it is the one instance
+Arc A did not sweep, because the generator is invisible to `verify:reference`.
+
+Because the entries are `{ name, class }` pairs, making the static type-visible
+is what lets this table be **replaced by the manifest plus a factory map** rather
+than re-typed. Sequence it accordingly (step 4).
+
+### F-B4 — the harvest: 16 dead `metadata.examples` across 12 commands
+
+Probed all 202 example strings against the real parser, asserting **at least one
+real command node** — `success: true` is not evidence (4.1 / 4.3 / Finding 14;
+reuse `commandNodesIn()` from `command-manifest-audit.test.ts:626`).
+
+**16 examples reach no command node, across 12 commands.** This is a
+*different* set from the five Arc C recorded, because it is a *different oracle*:
+Arc C adapted each snippet to a fixture and ran it to **execution**; this probes
+the **raw example string** at parse level. Only `process` and `pseudo-command`
+appear in both. Arc C's other three (`async`, `default`, `take`) parse cleanly
+standalone — their failures are execution-level only.
+
+| Command | Dead example | Parser says |
+| --- | --- | --- |
+| `pseudo-command` | all 4 (`foo() on me`, `setAttribute("foo","bar") on me`, `reload() the location of the window`, `getElementById("d1") from the document`) | `Unexpected token: on/the/from (missing operator between values?)` |
+| `repeat` | both (`repeat for item in items { log item }`, `repeat 5 times { log "hello" }`) | `Expected "end" to close repeat block` |
+| `break` | `repeat for item in items { if item == target then break }` | same |
+| `continue` | `repeat for item in items { if item.skip then continue; process item }` | same |
+| `if` | `unless user.isLoggedIn showLoginForm` | `Expected command after if condition in single-line form` |
+| `unless` | same string (shared `ConditionalCommand`) | same |
+| `toggle` | `toggle .loading for 2s` | `Expected variable name after "for"` |
+| `wait` | `wait for click or 1s` | `Expected event name after "for"` |
+| `settle` | `settle for 3000` | `Expected variable name after "for"` |
+| `tell` | `tell closest <form/> submit` | `tell command requires at least one command after the target` |
+| `start` | `start view transition using "slide" then put result into #panel end` | `Expected "end" to close repeat block` |
+| `process` | `process partials in it using view transition` | `Transition command requires a CSS property` |
+
+### F-B4a — the harvest, triaged against the upstream engine
+
+The split was **not** left for the arc. All 16 were run on the real
+`hyperscript.org` engine (`node_modules/hyperscript.org/dist/_hyperscript.esm.js`
+via `hs.parse(src).errors`, the loader at
+`packages/testing-framework/src/multilingual/canonical-validity.ts:70-82`) —
+4.1's oracle, and the only one that can tell a bad example from a missing
+feature. Candidate corrected forms were then re-probed against hyperfixi's own
+parser. Both result sets are below, so step 3 has concrete edits rather than a
+triage task.
+
+**Real parser gaps — upstream ACCEPTS, hyperfixi rejects. File, do not fix here.**
+
+| Example | Upstream | hyperfixi |
+| --- | --- | --- |
+| `toggle .loading for 2s` | **accepts** | `Expected variable name after "for"` |
+| `wait for click or 1s` | **accepts** | `Expected event name after "for"` |
+
+Both are documented upstream syntax on shipped, documented commands. Filed in
+[PARSER_NEXT_STEPS.md](./PARSER_NEXT_STEPS.md).
+
+**Bad example text — upstream rejects them too. Fix in the same file (Finding 12
+treatment).** Corrected forms verified to reach real command nodes:
+
+| Command | Dead example | Verified replacement | Parses to |
+| --- | --- | --- | --- |
+| `repeat` | `repeat 5 times { log "hello" }` | `repeat 5 times log "hello" end` | `repeat, log` |
+| `repeat` | `repeat for item in items { log item }` | `repeat for item in items log item end` | `repeat, log` |
+| `break` | `repeat … { if item == target then break }` | `repeat for item in items if item == target then break end end` | `repeat, if, break` |
+| `continue` | `repeat … { if item.skip then continue; … }` | same shape as `break` above | — |
+| `settle` | `settle for 3000` | `settle` (upstream accepts bare `settle`) | `settle` |
+| `pseudo-command` | all 4 | re-author against the real grammar | — |
+
+`pseudo-command`'s four are the clearest case: **upstream rejects all four
+identically** (`Unexpected Token : on` / `the` / `from`), so they are not a
+hyperfixi defect at all — the examples are not valid top-level syntax in either
+engine, which independently corroborates Arc C's "no top-level form parses".
+
+The brace-block `repeat … { … }` form is a syntax **neither engine has ever
+had** — upstream says `Expected 'end' but found '{'`, hyperfixi says
+`Expected "end" to close repeat block`. Four examples authored in an invented
+syntax, one of them duplicated through a shared class.
+
+**Needs its own decision — the upstream oracle cannot arbitrate.** These sit on
+LokaScript extensions (`unless`, `process`, `start`) or a non-upstream form, so
+upstream's rejection carries no information:
+
+| Row | Finding |
+| --- | --- |
+| `if` + `unless` (one shared string) | Upstream rejects `unless user.isLoggedIn showLoginForm` **and** the `then` form — upstream has `unless` only as a *trailing statement modifier*, which is exactly why the audit lists it in `EXTENSIONS`. hyperfixi accepts `unless user.isLoggedIn then showLoginForm end` (`unless`). The example is misplaced as much as malformed: it is an **`unless` example living on the `if` row**, via the shared `ConditionalCommand`. Splitting per-name metadata is a shape question, not an example fix. |
+| `start` | `start view transition using "slide" end` parses (`start`); the failing example's `then put result into #panel end` tail is what breaks. Trim the tail, or establish whether the `then` form should work. |
+| `process` | `process partials in it` parses (`process`); the `using view transition` tail breaks it, and it fails with **`Transition command requires a CSS property`** — the tail is being routed into another command. Routing bug, not a syntax gap. |
+| `tell` | `tell #modal show end` parses (`tell, show`), but `tell closest <form/> submit end` still fails with `tell command requires at least one command after the target` — `submit` is a method, not a command, so this wants the pseudo-command path. Related to the already-filed `tell`-wrapper defect; needs its own triage. |
+
+Two secondary observations from the same probe, worth recording so a future gate
+does not trip on them:
+
+- **`increment`/`decrement` examples parse to a `set` command node**, all four,
+  both rows. The parser desugars them. A gate asserting "an example reaches its
+  own command" must allow this row explicitly, or it will read as a defect.
+- **`beep` parses to a node named `beep!`** — registered name and parse-node name
+  differ by the bang. (`EXTENSIONS` in the audit already notes upstream spells it
+  `beep!`.)
+- **An error position is being reported past the end of the input**: three rows
+  report `column 78` for strings 37 and 69 characters long. Cosmetic, but it is a
+  stale/leaked position and it made triage slower. Note it in
+  `PARSER_NEXT_STEPS.md`; do not chase it inside this arc.
+
+## The `compatibility` decision — decided here, so the arc does not have to
+
+Arc A left `compatibility` unset on all 59 deliberately, so Arc B could copy 59
+**finished** values. The domains do not line up, and that is now a decision:
+
+| Manifest (`upstreamOrExtension`) | Decorator union (`compatibility`) |
+| --- | --- |
+| `upstream` — **51 rows** | `'standard'` |
+| `extension` — **8 rows** | `'lokascript-extension'` |
+| — *(no counterpart)* | `'experimental'` |
+
+**Decision: map `upstream → 'standard'`, `extension → 'lokascript-extension'`,
+and keep `'experimental'` in the union as an allowlisted third state that no
+command occupies today.**
+
+Rationale: dropping `'experimental'` narrows an exported public type for no
+present benefit, and the state is genuinely meaningful for a future command. The
+risk of keeping it is that it becomes an escape hatch from the coupling — which is
+what the coupling mechanism has to prevent.
+
+**Couple it with the `TIER_UNCLASSIFIED`-equality trick**, in
+`runtime/__tests__/command-manifest-audit.test.ts`, which already holds the two
+halves this needs (`EXTENSIONS`, a named 8-entry set, and `TIER_COUNTS =
+{ upstream: 51, extension: 8 }`):
+
+- Assert, for all 59 registered commands, that `metadata.compatibility` equals
+  the projection of `EXTENSIONS` membership. Set equality both directions, not
+  filter-and-assert-empty.
+- Hold an explicit `COMPATIBILITY_EXPERIMENTAL = new Set<string>([])` at size 0.
+  A command marked `'experimental'` then fails the projection **and** has to be
+  added here with a reason in the same diff — the same discipline that made the
+  23 tier rows reviewable.
+- Keep asserting the counts. A count alone lets two rows swap sides; a list alone
+  lets a row leave silently. The audit already learned this.
+
+The eight extensions, for the record: `async`, `beep`, `copy`, `prepend`,
+`process`, `push`, `replace`, `unless`.
+
+## Oracle 2: the registry oracle
+
+Run before and after every step; diff the JSON. From `packages/core`, with a
+scratch file outside the package (do not leave it in `src/` — it would be
+typechecked and collected):
+
+```ts
+import { Runtime } from './src/runtime/runtime';
+const registry: any = new Runtime().getRegistry();
+const names: string[] = [...registry.getCommandNames()].sort();
+const impls: Map<string, any> = registry.implementations;
+// per name: ctor.name, name source (own vs proto), instance metadata present,
+// static metadata present, category, aliases, compatibility, isBlocking,
+// hasBody, syntax kind+count, example count, adapter name
+// then: shared-implementation groups, and alias -> same-instance identity
+```
+
+Baseline recorded 2026-07-29 on `973ee1c5`:
+
+- 59 registered / 55 distinct implementations / 4 shared groups (table above)
+- **every** alias resolves to the *same instance* as its primary (`same=true`
+  for all 8 pairs, counting both directions of each shared row)
+- name source: 56 prototype, 3 own
+- instance metadata present: **59/59**; static metadata present: **59/59**
+- `compatibility`: `undefined` on all 59
+
+That last row is the one to watch hardest: the migration's whole risk is a class
+whose static moves but whose instance read silently returns `undefined`. Both
+columns are 59/59 today; they must still be 59/59 after every step.
+
+## Steps — one PR each, merged before the next
+
+**Step 0 (this PR).** The brief. Docs-only.
+
+**Step 1 — `commandMeta()` + the three undecorated classes.** Add the helper with
+the verified signature. Convert `install`, `pseudo-command`, `render` from
+`as const` to `commandMeta({…})`. Small, self-contained, and it is the only step
+where "tsc rejects a mis-shaped literal" is a genuinely new gate — so it is where
+the type oracle gets mutation-verified in the PR body (typo a field, show the
+error, revert). Expect this step to surface real defects in those three literals,
+since nothing has ever checked them.
+
+**Step 2 — the coupling for `compatibility`, before any values are copied.**
+Land the audit assertions and `COMPATIBILITY_EXPERIMENTAL` while the expected
+state is "unset on all 59", so the gate is proven to fail correctly *before* it
+has values to bless. Then populate the 59 values in step 3's mechanical sweep.
+Sequencing it this way is the lesson from Arc A step 1: the audit lands first and
+the migration ratchets it down.
+
+**Step 3 — migrate the 52 decorated classes.** `static readonly metadata =
+commandMeta({…})` plus the `get metadata()` bridge, keeping `@command` for
+name/category or folding category into the literal (decide in step 1 and record
+it). Populate `compatibility` here, against step 2's live gate.
+
+- Registry oracle diff is the behaviour-preservation instrument. Names, classes,
+  aliases, categories, shared-implementation groups, and both metadata-presence
+  columns.
+- The **factory-identity test** must stay a direct assertion — each factory's
+  command calls itself what the manifest calls it, and each alias resolves to the
+  primary instance. **Do not soften it into a derivation.** It carries weight the
+  manifest-vs-registry equality no longer can, precisely because both sides would
+  then read from the same statics.
+- Probe every class's `syntax:` and `examples:` while touching it; apply the
+  F-B4 split.
+- `configurable: false` means a hybrid state is fine but re-decoration is
+  impossible. Never leave a class both decorated and statically assigned.
+- **Measure the bundle, do not assume.** Metadata text **does** ship: ~25.3 KB
+  raw of `description`/`syntax`/`examples` literals across 433 matches in
+  `dist/hyperfixi.js`. The slim bundles are clean (no metadata strings in
+  `hyperfixi-hx.js`, `-hybrid-complete.js`, `-minimal.js`, `-standard.js`), which
+  is what protects the thin hybrid headroom — **verify that still holds after the
+  change**, because a class field is reachable differently from a
+  `defineProperty` side effect and could defeat the shaking that keeps them out.
+
+**Step 4 — retire the workarounds, then the prose.** With the static visible:
+delete `metadataOf()`; delete the three dead exported getters; consider narrowing
+the adapter's shadow `CommandMetadata` (F-B1, and settle :421's fate). Then the
+prose half — completeness tests for `reference/index.ts` and `lsp-metadata.ts`
+first (cheap), then `generate-command-docs.ts`'s 43-entry table replaced by the
+manifest plus a factory map (F-B3), an npm script, and `--check` in CI on the
+idempotent-generator pattern from #793.
+
+## Gate couplings that must move in the same diff
+
+- `runtime/__tests__/command-manifest-audit.test.ts` **§7** asserts manifest
+  `category` against `getImplementation(name)?.metadata?.category` — an
+  **instance** read. It moves if the read path changes.
+- The **factory-identity test** — keep it a direct assertion (above).
+- `validation/command-pattern-validator.ts` reads `instance.metadata` and checks
+  for `description`/`syntax`/`examples`/`category` presence plus a
+  `sideEffects` + `examples.length >= 2` quality tier (`:80-107`, `:176-207`).
+- The cosmetic projection at `command-adapter.ts:212-221`.
+- If `compatibility` gets populated: the audit's tier-coupling assertions
+  (`EXTENSIONS`, `TIER_COUNTS`, `TIER_UNCLASSIFIED`).
+
+## Gates and measured baselines
+
+Run from the repo root unless noted. **Baselines measured 2026-07-29 on
+`973ee1c5`**, macOS, after `npm run build --prefix packages/core`.
+
+| Gate | Baseline |
+| --- | --- |
+| `npm run typecheck --prefix packages/core` | clean (**this arc's first oracle**) |
+| `npm run test:check --prefix packages/core` | **295 passed / 1 skipped (296 files); 7610 passed / 106 skipped (7716)** |
+| `npm test --prefix packages/core` | identical to the above — cross-checked |
+| `npm run verify:reference --prefix packages/core` | run before pushing |
+| `npm run snapshot:bundle-size --prefix packages/core` | all 10 bundles **+0.0%**, "all bundles within tolerance" |
+| `npm test --prefix packages/language-server` | **227 passed (5 files)** ✓ matches the cited figure |
+| `npm test --prefix packages/vite-plugin` | **315 passed (11 files)** ✓ matches the cited figure |
+| `npm run test:check` (all packages) | fully green in the main tree |
+| `cd packages/core && npx playwright test src/compatibility/` | ~1111 passed / 8 skipped; 10 known-local failures (behaviors-demo, i18n-htmx, swap-debug) are a local artifact, green in CI |
+
+> **The core baseline is 7610 / 106 / 296, not the 7847 / 128 / 301 carried into
+> this session.** Verified two independent ways (`test:check` and `npm test`, same
+> numbers), and the gap is **not** silent collection loss: 300 `*.test.ts` files
+> exist under `src/`, 295 collect, 1 is skipped (`performance/command-benchmarks.test.ts`),
+> and the remainder are named in `vitest.config.ts`'s `exclude` block. Use the
+> measured figure. If a later run reads 7847, something changed that this brief
+> cannot see — find out what before treating it as the baseline.
+
+Bundle ceilings (CI, `.github/workflows/ci.yml:1160-1161`): `MAX_LITE=4000`,
+`MAX_HYBRID=20000`. `hyperfixi-hx.js` measures **19019 bytes gzip** — **981 bytes
+of headroom**. Metadata strings do not currently reach that bundle; keep it that
+way.
+
+## Notes carried in, verified or corrected
+
+- `capability-emission.test.ts` now **executes** generated bundles; it writes a
+  `.generated` dir under `bundle-generator/__tests__/` during runs
+  (`:235`, `:287`) and self-cleans. Confirmed.
+- Prettier is pinned **3.9.5** at the root (installed: 3.9.5); no CI format gate,
+  so run `format:check:src` by hand. Note `packages/core` still declares
+  `prettier: ^3.0.0` rather than the pin — cosmetic, not this arc's business.
+- The bundle-size baseline was re-measured 2026-07-29 (#820) and reads +0.0%
+  across all ten bundles here. Confirmed.
+- The tree is at **`973ee1c5`**, two commits ahead of the `f2511a97` cited at
+  session start (`d3a86631` #821 and `973ee1c5` #822 landed after).
+
+## One flag examined, and NOT acted on
+
+The claim that `multilingual` sits at 1.6% of `update:sizes`' 2% band **does not
+reproduce here.** A fresh `npm run update:sizes --prefix packages/core` reports
+`multilingual` at **✓** (no drift), and the largest drift of any bundle is
+**0.3%** (`hybrid-hx-v4` and `browser`; `standard` 0.1%). So there is no measured
+case for relaxing the band, and relaxing a gate on an unreproduced number is the
+wrong trade.
+
+Two things that *are* true and worth keeping in view:
+
+- The step **is** blocking CI — `.github/workflows/ci.yml:1104-1105`. The root
+  `CLAUDE.md` does describe it as a gate ("fails only when metadata is stale
+  enough to mislead", plus the instruction to take numbers from the CI job log),
+  so the "documented as run by hand" premise does not hold up against the text.
+- **Gzip is platform-dependent and CI is the authority.** A local macOS run reads
+  ~2 KB lower on the full bundles than CI's Linux zlib, so a bundle can sit near
+  the band on CI while reading ✓ locally. **If the 1.6% figure came from a CI job
+  log, that is the number that matters** — recheck it there before dismissing
+  this, and if it holds, the fix is a band change argued from the CI measurement,
+  in its own PR, not folded into Arc B.

--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -28,6 +28,7 @@ ones, because the gate *is* the tracking mechanism.
 | **`tell` never consumes a terminating `end`** | medium — no real `tell … end` block form; upstream requires one | **none** | comment at `packages/core/src/parser/command-parsers/utility-commands.ts` (the `ELSE`/`END` break in `parseTellCommand`) |
 | **`tell <target> to <command>` drops the `tell` wrapper** | medium — **silent wrong target** on the form users actually write | **none** | see the measured table below; found by Arc A step 4.3 (Finding 14 in [HANDOFF-command-arch-manifest.md](./HANDOFF-command-arch-manifest.md)), re-verified 2026-07-29 |
 | **`set <idref> to <value>` / js property-path args no-op** | medium — silent no-effect on shipped pages | ✅ execution-gate allowlist entries | families 1/6 in [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md) |
+| **`for <duration>` tail rejected on `toggle` / `wait`** | medium — two upstream-valid forms on shipped, documented commands; both are the command's OWN documented example | **none** | see the measured table below; found by the Arc B examples sweep ([HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md) § F-B4a) |
 | `and` is not a command separator anywhere | low — consistent everywhere, so no surprise | ✅ 2 `KNOWN GAP` tests | `packages/core/src/parser/__tests__/then-as-separator.test.ts` |
 | `sortable-list.html` recovers with errors | low — one shipped example | ✅ allowlist ratchet | `packages/testing-framework/baselines/shipped-sources-validity.json` |
 
@@ -79,6 +80,37 @@ Not fixed by Arc A, deliberately: it is a behavior change to the parser with its
 own tests, and folding it into a classification step would have buried that
 step's review artifact.
 
+### `for <duration>` on `toggle` / `wait` — the measured shape
+
+Measured 2026-07-29. Each source was parsed on hyperfixi and on the real
+`hyperscript.org` engine (`hs.parse(src).errors`, the loader at
+`packages/testing-framework/src/multilingual/canonical-validity.ts:70-82`).
+**Upstream accepts both; hyperfixi rejects both.** Each is the command's own
+`metadata.examples` entry, so the shipped documentation advertises a form the
+shipped parser refuses:
+
+| Source | Upstream | hyperfixi |
+| ------ | -------- | --------- |
+| `toggle .loading for 2s` | accepts | `Expected variable name after "for"` |
+| `wait for click or 1s` | accepts | `Expected event name after "for"` |
+
+Both errors read as a `for`-tail being parsed as the start of a loop/event
+construct rather than as a duration modifier, but the two commands take different
+paths, so treat them as one family with two fixes and confirm they share a cause
+before assuming they do.
+
+Two adjacent diagnostics found in the same sweep, both cosmetic and neither
+worth its own arc — fold them into whichever change touches this area:
+
+- **An error position is reported past the end of the input.** Three of the
+  sweep's rows report `column 78` for source strings 37 and 69 characters long.
+- **`start` reports a `repeat` error.** `start view transition` (no terminator)
+  fails with `Expected "end" to close repeat block`; `start view transition using
+  "slide" end` parses. The message names the wrong construct, which cost real
+  triage time. The same wrong-construct routing shows on `process partials in it
+  using view transition`, which fails with `Transition command requires a CSS
+  property`.
+
 ## Notes
 
 **The `examples/**` execution gap is CLOSED** (2026-07-27): the shipped-examples
@@ -107,6 +139,15 @@ regression episode that motivates it:
 
 ## History
 
+- **2026-07-29** — two entries added from the Arc B examples sweep: the
+  `for <duration>` family above, and the diagnostics beside it. Found by probing
+  all 202 `metadata.examples` strings against the parser and then triaging the
+  16 failures on the upstream engine — the same oracle discipline as R4. Only 2
+  of the 16 were parser gaps; 10 were examples authored in syntax **neither**
+  engine has ever accepted (notably a brace-block `repeat … { … }` form in four
+  places), which is a docs defect and is being fixed in the arc's own diff, not
+  here. Triage table:
+  [HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md) § F-B4a.
 - **2026-07-27** — event filters enforced: `on keydown[key=='Escape']` ran on
   ANY key because the runtime never read `EventHandlerNode.condition` (parsed,
   typed, documented, never consumed). The gate's first finding, fixed the same


### PR DESCRIPTION
Step 0 of Arc B — the handoff brief, written the way C/D/A were: measure first, then plan. **Docs-only**; no source or gate changes. Doc-only diffs skip the npm stack via the `changes` path gate, so the required checks will report "skipped".

## The brief corrects the arc's stated motivation

The queue paragraph implies tsc does not currently reject a mis-shaped metadata literal. **That is false for 52 of 55 implementations** — `meta(config: MetaConfig)` types its parameter, so a misspelled field is already `TS2561`. Mutation-verified in both directions:

| Probe | Measured |
| --- | --- |
| `ToggleCommand.metadata.description` (decorated static) | `TS2339: Property 'metadata' does not exist` — invisible, confirmed |
| Misspelled field in `@meta({ … })` | `TS2561` — **already caught** |
| Bogus `category` **and** bogus `sideEffects` in an undecorated `static readonly metadata = {…} as const` | **no error at all** — completely unchecked |

So the real payoff is narrower and different: the **static becomes visible** (the root cause of `metadataOf()` and of scripts-typechecking staying off), the **three undecorated classes** get checked for the first time, and the 48 `declare readonly metadata` assertions stop being unverified. Selling step 1 on "tsc will now reject bad metadata" would have built a gate that mostly existed — the queue's five-times-paid *score the rows already there* lesson, applied to the arc's own premise.

## Both oracles settled, with baselines

**Type system**, mutation-verified above. **Registry oracle** for behavior preservation, baseline recorded: 59 registered / 55 distinct implementations / 4 shared-implementation groups / 4 alias keywords (`unless`, `trigger`, `replace`, `decrement`) / metadata presence **59-of-59 on both** the static and instance columns / `compatibility` unset on all 59.

## Findings

- **The target shape already exists in-tree, three times.** `install`, `pseudo-command`, `render` are already `static readonly metadata` + a `get metadata()` bridge — the proposed end state *including* the mechanism that keeps `command-adapter.ts:440` working. A reference implementation, not a sketch. Their `as const` is exactly why they are unchecked.
- **`commandMeta()`'s signature is verified, not proposed.** `<const T extends MetaInput>` keeps literal types while catching typos, bad categories and bad side-effects — all four cases probed.
- **Two `CommandMetadata` interfaces**, and the load-bearing reader uses the loose one. `command-adapter.ts` declares its own with an `[extra: string]: unknown` index signature, which is the only reason `impl.metadata?.name` typechecks — the canonical type has **no `name` field**. Narrowing it turns `:421` into a type error.
- **`generate-command-docs.ts` is a 21st hand-maintained list:** 43 entries against a 59-command registry, 16 missing, gated by nothing (no npm script, no CI step, no audit coupling). #793 fixed drift of the *output*; nothing checks the input.
- **`compatibility`'s domain mismatch is decided here**, not left to the arc: `upstream → 'standard'`, `extension → 'lokascript-extension'`, `'experimental'` kept as an allowlisted third state at size 0, coupled via the `TIER_UNCLASSIFIED`-equality trick against the audit's existing `EXTENSIONS` set and `TIER_COUNTS`.

## The harvest — triaged, not filed as candidates

Probed all **202** `metadata.examples` strings asserting a real command node (`success: true` is not evidence). **16 dead across 12 commands** — a different set from Arc C's five, because it is a different oracle (raw string at parse level vs adapted snippet at execution). Then triaged every one on the real `hyperscript.org` engine:

- **2 are real parser gaps** — `toggle .loading for 2s` and `wait for click or 1s`. Upstream accepts both, hyperfixi rejects both, and each is the command's *own documented example*. Filed in `PARSER_NEXT_STEPS.md` with two adjacent diagnostics (an error position past end-of-input; `start` reporting a `repeat` error).
- **10 are examples authored in syntax neither engine has ever accepted** — notably a brace-block `repeat … { … }` form in four places. Verified replacements recorded for step 3.
- **4 need a decision the upstream oracle cannot arbitrate** (they sit on LokaScript extensions).

Also recorded so a future gate does not trip on them: `increment`/`decrement` examples parse to a `set` node, and `beep` parses to a node named `beep!`.

## Two figures corrected, each measured twice

- **Core baseline is 7610 passed / 106 skipped / 296 files**, not 7847 / 128 / 301. Cross-checked via `test:check` and `npm test`. The gap is **not** silent collection loss: 300 test files exist under `src/`, 295 collect, 1 is skipped, the rest are named in `vitest.config.ts`'s `exclude` block. `language-server` (227) and `vite-plugin` (315) match as cited.
- **The `multilingual` / `update:sizes` band report does not reproduce.** `multilingual` reads clean; the largest drift of any bundle is 0.3%. **No band change made** — relaxing a gate on an unreproduced number is the wrong trade. Recorded with the reason it might still be real (gzip is platform-dependent and CI is the authority) and what would settle it.

## Verification

| Gate | Result |
| --- | --- |
| `prettier --check` on all three docs | clean |
| Diff scope | docs-only, 3 files, 1 commit |
| Baselines re-measured for the brief | core 7610/106/296 · language-server 227 · vite-plugin 315 · `snapshot:bundle-size` all 10 bundles +0.0% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)