### PR TITLE
feat(commands): add commandMeta() and type-check the three undecorated statics

### DIFF
--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -385,6 +385,26 @@ not the core abstractions.
 
 ## History
 
+- **2026-07-29** — **Arc B step 1 landed**: `commandMeta()` plus the three
+  undecorated classes (`install`, `pseudo-command`, `render`). Per-step detail in
+  [HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md).
+  - **The brief's predicted defects did not exist.** It expected the conversion to
+    surface real problems in three literals nothing had ever checked; typecheck was
+    clean on the first run. The *unchecked* state was measured and real; the
+    *broken* state was an assumption. Worth recording — a failed prediction is
+    cheap here and expensive one arc later.
+  - **The new gate was mutation-verified rather than assumed**, at the real call
+    sites: a bad `category` → TS2820, a nonsense `sideEffects` entry → TS2820, a
+    misspelled field → TS2561. And the *runtime* gate too — deleting
+    `RenderCommand`'s `get metadata()` fails 3 of the new file's 10 tests.
+  - **Two decisions step 3 must not inherit by omission.** `commandMeta` is pure
+    identity and fills **no** defaults (so the three classes' `undefined`
+    `isBlocking`/`hasBody` did not silently become `false`) — but the 52 decorated
+    classes *do* get those defaults from `@meta`, so step 3 has to choose
+    deliberately. And `category` belongs **in** the literal, because a static whose
+    type omits it cannot serve `metadata.category`, which the audit's §7 reads.
+  - Core 7610 → **7620** with every increment a new test and none changed;
+    registry oracle **byte-identical**; all ten bundles **+0.0%**.
 - **2026-07-29** — **Arc B brief written**
   ([HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md)), arc
   not started. Measured against main `973ee1c5`.

--- a/docs-internal/HANDOFF-command-arch-metadata.md
+++ b/docs-internal/HANDOFF-command-arch-metadata.md
@@ -416,13 +416,53 @@ columns are 59/59 today; they must still be 59/59 after every step.
 
 **Step 0 (this PR).** The brief. Docs-only.
 
-**Step 1 — `commandMeta()` + the three undecorated classes.** Add the helper with
-the verified signature. Convert `install`, `pseudo-command`, `render` from
-`as const` to `commandMeta({…})`. Small, self-contained, and it is the only step
-where "tsc rejects a mis-shaped literal" is a genuinely new gate — so it is where
-the type oracle gets mutation-verified in the PR body (typo a field, show the
-error, revert). Expect this step to surface real defects in those three literals,
-since nothing has ever checked them.
+**Step 1 — `commandMeta()` + the three undecorated classes — ✅ DONE.**
+`commandMeta` lives in `commands/decorators/index.ts` (that module's imports are
+all type-only, so it carries zero runtime weight and adds no module edge — every
+command file already imports from it). `install`, `pseudo-command` and `render`
+are converted from `as const` to `commandMeta({…})`.
+
+**The predicted defects did not exist.** This brief expected the conversion to
+surface real problems in three literals nothing had ever checked; typecheck came
+back clean on the first run. All three were already valid. Recorded because a
+prediction that fails is worth as much as one that lands — the *unchecked* state
+was real and measured, the *broken* state was an assumption.
+
+The gate is real, not vacuous. Mutation-verified at the real call sites, each
+reverted after:
+
+| Mutation in `install.ts` | Result |
+| --- | --- |
+| `category: 'behaviorz'` | `TS2820: not assignable to type 'CommandCategory'. Did you mean "behaviors"?` |
+| `sideEffects: ['behavior-instalation', …]` | `TS2820: not assignable to type 'CommandSideEffect'` |
+| `descriptio:` | `TS2561: … does not exist in type 'CommandMetaInput'` |
+
+Two decisions settled here, both load-bearing for step 3:
+
+- **`commandMeta` is pure identity — it fills NO defaults.** `@meta` defaults
+  `isBlocking`/`hasBody` to `false` and stamps `version: '1.0.0'`; the three
+  converted classes carried none of those fields, so filling them would have
+  flipped `undefined → false` on three commands as a side effect of a refactor.
+  A test pins their absence. **Step 3 has to decide this deliberately for the 52**,
+  because those *do* currently get the defaults from `@meta` — either `@meta`
+  keeps stamping them, or the literals become explicit. Do not let it happen by
+  omission.
+- **`category` belongs IN the literal.** `CommandMetaInput` requires it, because a
+  static whose *type* omits `category` cannot serve `metadata.category` — which
+  is exactly what the manifest audit's §7 reads. Consequence for step 3: the 52
+  decorated literals gain a `category:` line each, and `@command` keeps owning
+  `name`. Mechanical and diff-visible, which is the point.
+
+Gate added: `commands/decorators/__tests__/command-meta.test.ts`, 10 tests. It
+deliberately does **not** unit-test `commandMeta`'s runtime behaviour (it returns
+its argument; the gate is `typecheck`). What it pins is the **bridge invariant**
+step 3 depends on — every registered command serves the *same object* through its
+static and its instance, both are defined, and the set of commands with an *own*
+`name` property is exactly the three converted classes (so a fourth conversion,
+or a decoration of one of these, fails loudly). Mutation-verified: deleting
+`RenderCommand`'s `get metadata()` fails 3 of the 10.
+
+Registry oracle: **byte-identical** before and after.
 
 **Step 2 — the coupling for `compatibility`, before any values are copied.**
 Land the audit assertions and `COMPATIBILITY_EXPERIMENTAL` while the expected

--- a/packages/core/src/commands/behaviors/install.ts
+++ b/packages/core/src/commands/behaviors/install.ts
@@ -31,6 +31,7 @@ import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { isHTMLElement } from '../../utils/element-check';
+import { commandMeta } from '../decorators';
 
 /**
  * Typed input for InstallCommand
@@ -72,7 +73,7 @@ export class InstallCommand {
   /**
    * Command metadata for documentation and tooling
    */
-  static readonly metadata = {
+  static readonly metadata = commandMeta({
     description: 'Install a behavior on an element with optional parameters',
     syntax: [
       'install <BehaviorName>',
@@ -89,7 +90,7 @@ export class InstallCommand {
     ],
     category: 'behaviors',
     sideEffects: ['behavior-installation', 'element-modification'],
-  } as const;
+  });
 
   /**
    * Instance accessor for metadata (backward compatibility)

--- a/packages/core/src/commands/decorators/__tests__/command-meta.test.ts
+++ b/packages/core/src/commands/decorators/__tests__/command-meta.test.ts
@@ -1,0 +1,121 @@
+/**
+ * `commandMeta()` and the static/instance metadata bridge — Arc B step 1.
+ *
+ * ## What this file is FOR, and what it deliberately cannot do
+ *
+ * `commandMeta()`'s whole job is compile-time. Its runtime behaviour is
+ * `return metadata` — there is nothing to unit-test about that, and a test
+ * asserting "it returns its argument" would be theatre. **The gate for
+ * `commandMeta` is `npm run typecheck`**, mutation-verified at the real call
+ * sites when it landed (an invalid `category` → TS2820, a nonsense
+ * `sideEffects` entry → TS2820, a misspelled field → TS2561). Read those as the
+ * gate; do not add a runtime test that pretends to cover them.
+ *
+ * What IS testable, and is the reason this file exists, is the **bridge
+ * invariant** the migration depends on: every registered command serves the
+ * same metadata through its static and through its instance. Arc B step 3
+ * migrates 52 more classes onto exactly this shape, and
+ * `runtime/command-adapter.ts` reads the INSTANCE side — `:440`'s alias read is
+ * load-bearing, and dropping it silently un-registers `unless`, `trigger`,
+ * `replace` and `decrement`. So a class whose static moves while its instance
+ * read goes `undefined` is the migration's central risk, and it is invisible to
+ * every other suite: nothing else compares the two.
+ *
+ * These assertions are written over the whole registry rather than over the
+ * three converted classes, so they keep holding as step 3 lands and fail the
+ * moment a migrated class loses its instance bridge.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Runtime } from '../../../runtime/runtime';
+import { InstallCommand } from '../../behaviors/install';
+import { PseudoCommand } from '../../execution/pseudo-command';
+import { RenderCommand } from '../../templates/render';
+
+/** The three classes converted in step 1 — undecorated, `commandMeta`-checked. */
+const CONVERTED = [
+  { name: 'install', cls: InstallCommand, category: 'behaviors' },
+  { name: 'pseudo-command', cls: PseudoCommand, category: 'execution' },
+  { name: 'render', cls: RenderCommand, category: 'templates' },
+] as const;
+
+function registryImplementations(): Map<string, { metadata?: unknown; name?: string }> {
+  const registry = new Runtime().getRegistry() as unknown as {
+    implementations: Map<string, { metadata?: unknown; name?: string }>;
+  };
+  return registry.implementations;
+}
+
+describe('the static/instance metadata bridge', () => {
+  it('serves the SAME OBJECT through the static and the instance, for every registered command', () => {
+    // Identity, not deep equality: two structurally-equal copies would mean a
+    // consumer mutating one sees a stale other, and it would also hide a
+    // migration that rebuilt the object per-instance (a real perf regression at
+    // 59 commands). `@meta` and `commandMeta` both satisfy identity today.
+    const mismatched: string[] = [];
+    for (const [name, impl] of registryImplementations()) {
+      const fromStatic = (impl.constructor as unknown as { metadata?: unknown }).metadata;
+      if (impl.metadata !== fromStatic) mismatched.push(name);
+    }
+    expect(mismatched).toEqual([]);
+  });
+
+  it('exposes a defined instance `metadata` for every registered command', () => {
+    // The specific failure the migration risks: the static moves, the instance
+    // read silently returns undefined, and `command-adapter.ts:440` stops
+    // finding aliases. Asserted separately from identity above because
+    // `undefined === undefined` would satisfy that check.
+    const missing = [...registryImplementations()]
+      .filter(([, impl]) => impl.metadata == null)
+      .map(([name]) => name);
+    expect(missing).toEqual([]);
+  });
+
+  it('exposes a defined static `metadata` for every registered command', () => {
+    const missing = [...registryImplementations()]
+      .filter(
+        ([, impl]) => (impl.constructor as unknown as { metadata?: unknown }).metadata == null
+      )
+      .map(([name]) => name);
+    expect(missing).toEqual([]);
+  });
+});
+
+describe('the classes converted to commandMeta() in step 1', () => {
+  it.each(CONVERTED)(
+    '$name keeps its static, its bridge, and its category',
+    ({ cls, category }) => {
+      expect(cls.metadata).toBeDefined();
+      expect(cls.metadata.category).toBe(category);
+      // The instance getter returns the static itself, which is what lets the
+      // adapter keep reading `impl.metadata` unchanged.
+      expect(new cls().metadata).toBe(cls.metadata);
+    }
+  );
+
+  it.each(CONVERTED)('$name declares no defaults commandMeta did not fill', ({ cls }) => {
+    // `commandMeta` is deliberately identity — it does NOT fill @meta's
+    // `isBlocking`/`hasBody`/`version` defaults. These three carried no such
+    // fields before the conversion, so they must carry none after it: that is
+    // what makes step 1 a shape-preserving change rather than a silent
+    // undefined-to-false flip on three commands.
+    const md = cls.metadata as Record<string, unknown>;
+    expect('isBlocking' in md).toBe(false);
+    expect('hasBody' in md).toBe(false);
+    expect('version' in md).toBe(false);
+  });
+
+  it('is exactly the set of registered commands whose name is an OWN property', () => {
+    // Ties the list above to a structural fact instead of a hand-maintained
+    // count: `@command` installs `name` on the PROTOTYPE, while these three
+    // declare a class field. So "undecorated" is observable, and this fails if
+    // a fourth class is converted (or one of these is decorated) without the
+    // list being updated. As step 3 migrates the other 52 it must NOT change
+    // this — those keep `@command` and its prototype `name`.
+    const ownName = [...registryImplementations()]
+      .filter(([, impl]) => Object.prototype.hasOwnProperty.call(impl, 'name'))
+      .map(([name]) => name)
+      .sort();
+    expect(ownName).toEqual(CONVERTED.map(c => c.name).sort());
+  });
+});

--- a/packages/core/src/commands/decorators/index.ts
+++ b/packages/core/src/commands/decorators/index.ts
@@ -203,6 +203,63 @@ export function meta(config: MetaConfig) {
 }
 
 // ============================================================================
+// commandMeta — type-visible metadata (Arc B)
+// ============================================================================
+
+/**
+ * Input accepted by {@link commandMeta}: `CommandMetadata` with `version`
+ * optional, since it is a published constant rather than something an author
+ * chooses per command.
+ */
+export type CommandMetaInput = Omit<CommandMetadata, 'version'> & {
+  readonly version?: string;
+};
+
+/**
+ * Declare a command's metadata as a **type-visible** static.
+ *
+ * ```ts
+ * export class InstallCommand {
+ *   readonly name = 'install';
+ *   static readonly metadata = commandMeta({ … });
+ *   get metadata() { return InstallCommand.metadata; }
+ * }
+ * ```
+ *
+ * ## Why this exists, precisely
+ *
+ * `@meta` installs `metadata` with `Object.defineProperty`, and a class
+ * decorator that returns the original class cannot widen its type — so
+ * TypeScript never sees the static. That invisibility (not a lack of
+ * validation) is the defect: `meta(config: MetaConfig)` already type-checks
+ * the literal passed to it, but `SomeCommand.metadata` is `TS2339` at every
+ * read, which is why `scripts/generate-command-docs.ts` needs a runtime
+ * `metadataOf()` assertion and why script typechecking stayed off for months.
+ *
+ * The classes this replaces used a bare `as const`, which has the mirror-image
+ * problem: the static is visible but validated by **nothing**. Measured before
+ * this helper existed — an invalid `category` and a nonsense `sideEffects`
+ * entry both compiled clean.
+ *
+ * ## Why the `const` type parameter is load-bearing
+ *
+ * `<const T>` preserves the literal types `as const` gave (so
+ * `metadata.syntax[0]` stays a literal, not `string`), while
+ * `extends CommandMetaInput` supplies the contextual type that makes
+ * excess-property and enum checking fire. Drop `const` and the arc trades
+ * inference for checking instead of getting both.
+ *
+ * Returns its argument unchanged — deliberately identity, with **no default
+ * filling**, so a migrated class's runtime shape is byte-for-byte what it was.
+ * `@meta`'s `isBlocking`/`hasBody`/`version` defaults are its own behavior;
+ * folding them in here would silently change `undefined` to `false` on the
+ * classes this migrates.
+ */
+export function commandMeta<const T extends CommandMetaInput>(metadata: T): T {
+  return metadata;
+}
+
+// ============================================================================
 // Helper Functions
 // ============================================================================
 

--- a/packages/core/src/commands/execution/pseudo-command.ts
+++ b/packages/core/src/commands/execution/pseudo-command.ts
@@ -27,6 +27,7 @@
 import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
+import { commandMeta } from '../decorators';
 
 /**
  * Typed input for PseudoCommand
@@ -69,7 +70,7 @@ export class PseudoCommand {
   /**
    * Command metadata for documentation and tooling
    */
-  static readonly metadata = {
+  static readonly metadata = commandMeta({
     description: 'Treat a method on an object as a top-level command',
     syntax: ['<method>(<args>) [(to|on|with|into|from|at)] <expression>'],
     examples: [
@@ -80,7 +81,7 @@ export class PseudoCommand {
     ],
     category: 'execution',
     sideEffects: ['method-execution'],
-  } as const;
+  });
 
   /**
    * Instance accessor for metadata (backward compatibility)

--- a/packages/core/src/commands/templates/render.ts
+++ b/packages/core/src/commands/templates/render.ts
@@ -29,6 +29,7 @@ import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { debug } from '../../utils/debug';
+import { commandMeta } from '../decorators';
 
 /**
  * Typed input for RenderCommand
@@ -67,7 +68,7 @@ export class RenderCommand {
   /**
    * Command metadata for documentation and tooling
    */
-  static readonly metadata = {
+  static readonly metadata = commandMeta({
     description: 'Render templates with @if, @else, and @repeat directives',
     syntax: [
       'render <template>',
@@ -82,7 +83,7 @@ export class RenderCommand {
     ],
     category: 'templates',
     sideEffects: ['dom-creation', 'template-execution'],
-  } as const;
+  });
 
   /**
    * Instance accessor for metadata (backward compatibility)


### PR DESCRIPTION
Arc B step 1 (step 0 = the brief, #823). Adds `commandMeta()` and converts the three commands that were already using the arc's target shape but validated by nothing: `install`, `pseudo-command`, `render`.

## Why these three, and only these three

They were written as `static readonly metadata = {…} as const` with **no contextual type**, so their metadata was checked by nothing — before this change an invalid `category` *and* a nonsense `sideEffects` entry both compiled clean (measured). They are the only rows in the command set where "tsc rejects a mis-shaped metadata literal" is a genuinely **new** gate.

The other 52 are already checked: `meta(config: MetaConfig)` types its parameter. What *they* lack is **visibility** of the static (`TS2339` at every read) — the root cause of `metadataOf()` and of script typechecking staying off. That's step 3/4, not this PR.

## The brief's prediction failed, and that's recorded

The brief expected this conversion to surface real defects in three never-checked literals. **It did not** — typecheck was clean on the first run; all three were already valid. Kept in the handoff because the *unchecked* state was measured and real while the *broken* state was an assumption.

## So the gate was mutation-verified, not assumed

At the real call sites, each reverted:

| Mutation in `install.ts` | Result |
| --- | --- |
| `category: 'behaviorz'` | `TS2820` — "Did you mean `behaviors`?" |
| `sideEffects: ['behavior-instalation', …]` | `TS2820` |
| `descriptio:` | `TS2561` — not in `CommandMetaInput` |

And the runtime gate: deleting `RenderCommand`'s `get metadata()` fails **3 of the new file's 10** tests.

## Placement and signature

`commandMeta` lives in `commands/decorators/index.ts` — that module's imports are all type-only, so it carries **zero runtime weight** and adds no module edge (every command file already imports from it), and it is **not re-exported from the package index**, so there's no public API change. Confirmed absent from the built bundle (inlined away).

`<const T extends CommandMetaInput>` is load-bearing: `const` preserves the literal types `as const` gave, while the constraint supplies the contextual type that makes excess-property and enum checking fire. Without `const` the arc trades inference for checking instead of getting both.

## Two decisions step 3 must not inherit by omission

- **`commandMeta` is pure identity — it fills no defaults.** `@meta` defaults `isBlocking`/`hasBody` to `false` and stamps `version`; these three carried none of those fields, so filling them would have flipped `undefined → false` on three commands as a side effect of a refactor. A test pins their absence. The 52 decorated classes **do** get those defaults, so step 3 has to choose deliberately.
- **`category` belongs in the literal**, because a static whose *type* omits it cannot serve `metadata.category` — which the manifest audit's §7 reads. Consequence: step 3 adds a `category:` line to 52 literals.

## The new gate

`commands/decorators/__tests__/command-meta.test.ts`, 10 tests. It deliberately does **not** unit-test `commandMeta`'s runtime behavior — it returns its argument, and the gate for that is `typecheck`; a runtime test there would be theatre. What it pins is the **static/instance bridge invariant** that step 3 depends on and that nothing else in the repo compares: every registered command serves the *same object* through its static and its instance, both are defined, and the set of commands with an *own* `name` property is exactly these three (so a fourth conversion, or a decoration of one of these, fails loudly).

## Verification

| Gate | Result |
| --- | --- |
| `typecheck` | clean |
| core `test:check` | **7610 → 7620** / 106 skipped / 297 files — every increment a **new** test, none changed |
| full-repo `test:check` | 37 packages, zero failures (real exit status, not a piped one) |
| `verify:reference` | ✅ `lite(7) ⊂ lite-plus(17) ⊂ hybrid(31) ⊂ full(59)` |
| `snapshot:bundle-size` | all 10 bundles **+0.0%**; `hyperfixi-hx.js` unchanged at **19019 B** gzip, so the ~980 B `MAX_HYBRID` headroom is untouched |
| `language-server` | 227 |
| Playwright `src/compatibility/` | 1102 passed / 8 skipped / **10 failed — exactly the known-local set** (behaviors-demo, i18n-htmx, swap-debug), no new failures |
| **Registry oracle** | **byte-identical** before and after — names, ctors, name source, static+instance metadata presence, category, aliases, shared-implementation groups, alias identity |

🤖 Generated with [Claude Code](https://claude.com/claude-code)