### PR TITLE
test(commands): couple metadata.compatibility to the manifest, BEFORE any values

### DIFF
--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -385,6 +385,21 @@ not the core abstractions.
 
 ## History
 
+- **2026-07-29** — **Arc B step 2 landed**: the `compatibility` coupling, as §9 of
+  the manifest audit (39 → 44 tests), while the expected state is still "unset on
+  all 59" — so the gate is proven before it has values to bless.
+  - **A vacuous gate was mutation-verified instead of trusted**, and the three
+    outcomes are the design: a **wrong** value trips the projection, a
+    **correct** value trips *only* the row-moving allowlist (so step 3 cannot
+    populate silently — it must empty `COMPATIBILITY_UNSET` in the same diff),
+    and `'experimental'` trips its own guard. Re-partitioning `EXTENSIONS` fires
+    §3's existing 51/8 split as well, so the two sections are genuinely coupled.
+  - **Key-presence is not the same question as value.** `@meta` assigns
+    `compatibility` unconditionally, so 56 commands carry the key holding
+    `undefined` while the 3 `commandMeta` classes omit it entirely — a
+    `'compatibility' in md` check splits the registry 56/3 and reads as a
+    classification when it is an artifact of declaration style. Every §9 check
+    asks for the value.
 - **2026-07-29** — **Arc B step 1 landed**: `commandMeta()` plus the three
   undecorated classes (`install`, `pseudo-command`, `render`). Per-step detail in
   [HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md).

--- a/docs-internal/HANDOFF-command-arch-metadata.md
+++ b/docs-internal/HANDOFF-command-arch-metadata.md
@@ -464,12 +464,41 @@ or a decoration of one of these, fails loudly). Mutation-verified: deleting
 
 Registry oracle: **byte-identical** before and after.
 
-**Step 2 — the coupling for `compatibility`, before any values are copied.**
-Land the audit assertions and `COMPATIBILITY_EXPERIMENTAL` while the expected
-state is "unset on all 59", so the gate is proven to fail correctly *before* it
-has values to bless. Then populate the 59 values in step 3's mechanical sweep.
-Sequencing it this way is the lesson from Arc A step 1: the audit lands first and
-the migration ratchets it down.
+**Step 2 — the coupling for `compatibility`, before any values are copied — ✅ DONE.**
+Landed as §9 of `runtime/__tests__/command-manifest-audit.test.ts`, five tests,
+while the expected state is still "unset on all 59". The audit goes 39 → 44.
+
+Because the projection test is **vacuous over values today**, it was
+mutation-verified rather than trusted — and the three outcomes are the design,
+not an accident:
+
+| Mutation | What fired |
+| --- | --- |
+| `copy` (an extension) marked `'standard'` — **wrong side** | projection test **+** the allowlist test |
+| `copy` marked `'lokascript-extension'` — **correct** | **only** the allowlist test |
+| `copy` marked `'experimental'` | the experimental guard **+** the allowlist test |
+| a row added to `EXTENSIONS` (re-partitioning the registry) | §3's existing 51/8 split **+** two of §9's tests |
+
+The middle row is the one that matters: populating a value *correctly* is allowed
+by the projection but still fails the row-moving assertion, so **step 3 cannot
+populate silently** — it has to empty `COMPATIBILITY_UNSET` in the same diff.
+That is the `TIER_UNCLASSIFIED` discipline, and it now demonstrably works in both
+directions before there is anything to bless.
+
+`COMPATIBILITY_UNSET` is seeded as `new Set(REGISTRY)` rather than 59 literal
+names — it cannot be satisfied by accident either way: populating 58 of 59 and
+emptying the set fails (measured 1 ≠ 0), and populating 58 while leaving the set
+whole fails too (1 ≠ 59).
+
+**Finding — every check here must be value-based, never key-presence.**
+`'compatibility' in metadata` is measurably a *different question* from
+`metadata.compatibility === undefined`: `@meta` assigns the key unconditionally,
+so **56** commands carry it holding `undefined`, while the **3** `commandMeta`
+classes omit it entirely. A key-presence check therefore splits the registry 56/3
+and reads as a classification when it is an artifact of how each class declares
+its metadata. Pre-existing (step 1's registry oracle was byte-identical), and
+recorded in §9's docstring so the next reader does not re-introduce it. Step 3
+should expect this asymmetry to disappear as the 52 gain real values.
 
 **Step 3 — migrate the 52 decorated classes.** `static readonly metadata =
 commandMeta({…})` plus the `get metadata()` bridge, keeping `@command` for

--- a/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
+++ b/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
@@ -1003,3 +1003,143 @@ describe('the classification debt, counted', () => {
     expect(KEYWORD_NOT_ADVERTISED.size).toBe(1); // step 4.3 — DECIDED: pseudo-command
   });
 });
+
+// ===========================================================================
+// 9. metadata.compatibility (Arc B step 2) — the coupling, landed BEFORE values
+// ===========================================================================
+
+/**
+ * `metadata.compatibility` is UNSET on all 59 registered commands, deliberately:
+ * Arc A step 4.1 declined to populate it so Arc B could copy 59 *finished*
+ * values instead of 23 `'unknown'`s. This section is the coupling that makes
+ * that copy reviewable, and it lands **before** the values do — so the gate is
+ * proven to fail correctly while there is still nothing for it to bless. A gate
+ * written after the migration can only confirm what the migration decided.
+ *
+ * ## The domain mismatch, and the decision
+ *
+ * The two vocabularies do not line up:
+ *
+ * | manifest `upstreamOrExtension` | decorator `compatibility` |
+ * | ------------------------------ | ------------------------- |
+ * | `upstream` (51 rows)           | `'standard'`              |
+ * | `extension` (8 rows)           | `'lokascript-extension'`  |
+ * | *(no counterpart)*             | `'experimental'`          |
+ *
+ * DECIDED: project `upstream → 'standard'`, `extension → 'lokascript-extension'`,
+ * and keep `'experimental'` as a third state that no command occupies. Dropping
+ * it would narrow an exported public type for no present benefit; keeping it
+ * unguarded would make it an escape hatch from this coupling. So it is
+ * allowlisted at size 0 — a command marked `'experimental'` fails the projection
+ * AND has to be named below with a reason, in the same diff. That is the
+ * `TIER_UNCLASSIFIED` discipline: a judgment call is only reviewable if making
+ * it moves a row and a count.
+ *
+ * ## Why every check here is value-based, never key-presence
+ *
+ * `'compatibility' in metadata` is measurably NOT the same question as
+ * `metadata.compatibility === undefined`. `@meta` assigns the key
+ * unconditionally (`compatibility: config.compatibility`), so 56 commands carry
+ * the key holding `undefined`, while the three `commandMeta` classes
+ * (`install`, `pseudo-command`, `render`) omit it entirely. A key-presence check
+ * therefore splits the registry 56/3 and reads as a classification when it is
+ * an artifact of how each class declares its metadata. Every assertion below
+ * asks for the VALUE.
+ */
+
+/**
+ * Registered commands with no `compatibility` value. Currently the whole
+ * registry, which is the state Arc A deliberately left.
+ *
+ * Step 3 replaces this with the rows it could not classify — expected `[]`. It
+ * cannot be satisfied by accident in either direction: populating 58 of 59 and
+ * emptying this set fails (measured 1 ≠ 0), and populating 58 while leaving this
+ * as the whole registry fails too (measured 1 ≠ 59).
+ */
+const COMPATIBILITY_UNSET = new Set<string>(REGISTRY);
+
+/**
+ * Commands deliberately marked `'experimental'`. Empty, and it must stay empty
+ * unless someone writes down why a command has a compatibility state the
+ * manifest cannot express.
+ */
+const COMPATIBILITY_EXPERIMENTAL = new Set<string>([]);
+
+/** The projection this arc commits to: manifest tier → decorator vocabulary. */
+function expectedCompatibility(name: string): 'standard' | 'lokascript-extension' {
+  return EXTENSIONS.has(name) ? 'lokascript-extension' : 'standard';
+}
+
+/** Read through the INSTANCE, the same path `command-adapter.ts` uses. */
+function servedCompatibility(): Map<string, unknown> {
+  const registered = new Runtime().getRegistry();
+  return new Map(
+    REGISTRY.map(name => [
+      name,
+      (registered.getImplementation(name) as { metadata?: { compatibility?: unknown } } | undefined)
+        ?.metadata?.compatibility,
+    ])
+  );
+}
+
+describe('metadata.compatibility', () => {
+  it('every populated row matches the manifest projection', () => {
+    // THE live gate. Vacuous over values today (all 59 unset) and deliberately
+    // so — mutation-verified when it landed by setting one command's
+    // compatibility to the wrong side and watching this fail. Step 3 populates
+    // into a gate that already works rather than one written to fit its output.
+    const wrong: string[] = [];
+    for (const [name, served] of servedCompatibility()) {
+      if (served === undefined) continue; // unset rows are governed below
+      if (served === 'experimental') continue; // governed by its own test
+      if (served !== expectedCompatibility(name)) {
+        wrong.push(`${name}: ${String(served)} (manifest projects ${expectedCompatibility(name)})`);
+      }
+    }
+    expect(wrong).toEqual([]);
+  });
+
+  it('the unset rows are exactly the allowlist, both directions', () => {
+    const unset = [...servedCompatibility()]
+      .filter(([, served]) => served === undefined)
+      .map(([name]) => name)
+      .sort();
+    expect(unset).toEqual([...COMPATIBILITY_UNSET].sort());
+  });
+
+  it("only allowlisted commands may be 'experimental'", () => {
+    // The escape-hatch guard. `'experimental'` has no manifest counterpart, so
+    // the projection test above cannot judge it — this is what stops it being
+    // used to route around the projection.
+    const experimental = [...servedCompatibility()]
+      .filter(([, served]) => served === 'experimental')
+      .map(([name]) => name)
+      .sort();
+    expect(experimental).toEqual([...COMPATIBILITY_EXPERIMENTAL].sort());
+    expect(COMPATIBILITY_EXPERIMENTAL.size, 'an experimental row needs a written reason').toBe(0);
+  });
+
+  it('the projection is total and splits 51 / 8, matching §3', () => {
+    // Ties this section to the count §3 already enforces, so the projection
+    // cannot quietly re-partition the registry. If EXTENSIONS gains or loses a
+    // row, this fails here as well as there.
+    const tally = { standard: 0, 'lokascript-extension': 0 };
+    for (const name of REGISTRY) tally[expectedCompatibility(name)]++;
+    expect(tally).toEqual({
+      standard: TIER_COUNTS.upstream,
+      'lokascript-extension': TIER_COUNTS.extension,
+    });
+    expect(tally.standard + tally['lokascript-extension']).toBe(REGISTRY.length);
+  });
+
+  it('agrees with the manifest row-by-row, not just in aggregate', () => {
+    // A count can be satisfied by two rows swapping sides. This cannot.
+    for (const name of REGISTRY) {
+      const manifestSide = MANIFEST_BY_NAME.get(name)!.upstreamOrExtension;
+      const projected = expectedCompatibility(name);
+      expect(projected, `${name} projection vs manifest`).toBe(
+        manifestSide === 'upstream' ? 'standard' : 'lokascript-extension'
+      );
+    }
+  });
+});


### PR DESCRIPTION
Arc B step 2 (step 0 = brief #823, step 1 = #824). Adds **§9** to the manifest audit: the coupling that makes step 3's 59-value copy reviewable — landed while `compatibility` is still unset on all 59, because **a gate written after a migration can only confirm what the migration decided.**

## The domain mismatch, decided

| manifest `upstreamOrExtension` | decorator `compatibility` |
| --- | --- |
| `upstream` (51) | `'standard'` |
| `extension` (8) | `'lokascript-extension'` |
| *(no counterpart)* | `'experimental'` |

**Decided:** project `upstream → 'standard'`, `extension → 'lokascript-extension'`, and keep `'experimental'` as a third state no command occupies. Dropping it narrows an exported public type for no present benefit; leaving it unguarded makes it an escape hatch from the projection. So it's allowlisted at size 0 — marking a command `'experimental'` fails the projection **and** must be named with a reason, in the same diff.

## The gate is vacuous over values today — so it was mutation-verified

Trusting a gate that has nothing to judge is the exact mistake this arc keeps finding elsewhere. Four mutations, each reverted. The three outcomes are the design, not luck:

| Mutation | What fired |
| --- | --- |
| `copy` (an extension) → `'standard'` — **wrong side** | projection **+** allowlist |
| `copy` → `'lokascript-extension'` — **correct** | **only** the allowlist |
| `copy` → `'experimental'` | experimental guard **+** allowlist |
| a row added to `EXTENSIONS` | §3's existing 51/8 split **+** two of §9's tests |

**The middle row is load-bearing:** populating a value *correctly* is allowed by the projection but still fails the row-moving assertion — so **step 3 cannot populate silently**, it must empty `COMPATIBILITY_UNSET` in the same diff. The last row shows §9 and §3 are genuinely coupled, not two counts that can drift apart.

`COMPATIBILITY_UNSET` is seeded `new Set(REGISTRY)` rather than 59 literal names, and still can't be satisfied by accident either way: populating 58 of 59 and emptying the set fails (measured 1 ≠ 0); populating 58 while leaving the set whole fails too (1 ≠ 59).

## Finding: key-presence is not the same question as value

`'compatibility' in metadata` and `metadata.compatibility === undefined` give **different answers** here. `@meta` assigns the key unconditionally, so **56** commands carry it holding `undefined`, while the **3** `commandMeta` classes omit it entirely. A key-presence check therefore splits the registry 56/3 and reads as a classification when it's an artifact of declaration style.

Every §9 check asks for the **value**, and the docstring records why so it isn't reintroduced. Pre-existing (step 1's registry oracle was byte-identical); it should disappear as step 3 gives the 52 real values.

The read goes through the **instance** (`getImplementation(name)?.metadata?.compatibility`) — the same path `command-adapter.ts` uses and that §7 reads `category` through, so the gate exercises the production read rather than a convenient one.

## Verification

| Gate | Result |
| --- | --- |
| core `test:check` | **7620 → 7625** / 106 skipped / 297 files — the 5 new tests, nothing changed; audit file 39 → 44 |
| `typecheck` | clean |
| prettier | clean |
| `snapshot:bundle-size` | **not run, deliberately** — the diff is one test file plus two docs, so no shipped byte can move |

🤖 Generated with [Claude Code](https://claude.com/claude-code)