### PR TITLE
refactor(commands): migrate all 52 decorated classes to type-visible metadata

### DIFF
--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -368,6 +368,26 @@ curated-behaviors philosophy. Each proved itself under pressure in the very
 session that produced this queue. The problem is the hand-maintained periphery,
 not the core abstractions.
 
+## Open, filed rather than folded in
+
+- **`metadata.isBlocking` / `hasBody` publish false claims for ≥7 commands.**
+  Neither field is authored anywhere — every value comes from `@meta`'s (now
+  `commandMeta`'s) `?? false` default — and nothing in production reads them. But
+  they ARE published: `packages/core/docs/commands/commands.json` carries
+  `isBlocking: false`, `hasBody: false`, `version: '1.0.0'` on 40 of its 43
+  entries, with **zero variance**. So the shipped docs state that `wait`, `fetch`,
+  `settle` and `transition` do not block, and that `if`, `repeat` and `tell` take
+  no body. All false.
+  Arc B step 3 deliberately PRESERVED the boilerplate rather than fixing or
+  deleting it, to keep the migration a refactor (decision recorded in
+  [HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md)).
+  Authoring the two booleans truthfully is ~59 judgment calls with its own review
+  surface, and `version` is meaningless per-command — worth its own change.
+  Note there may be derivable sources: `COMPOUND_COMMANDS` and the parser's
+  `CommandNode.isBlocking` already encode part of this, so check before hand-
+  authoring 59 rows. Discovered by Arc B while measuring what should happen to
+  `@meta`'s defaults — the queue's "score the rows already there" lesson again.
+
 ## Risk register
 
 - `export { X } from './f'` creates **no local binding** — import then export
@@ -385,6 +405,35 @@ not the core abstractions.
 
 ## History
 
+- **2026-07-29** — **Arc B step 3 landed**: all 52 decorated classes migrated to
+  `static readonly metadata = commandMeta({…})` + `get metadata()`, `@meta`
+  removed from every call site, and `compatibility` populated on all 55 literals.
+  **The arc's goal is delivered**: `ToggleCommand.metadata` was `TS2339` and now
+  typechecks, with `.category` narrowing to `'dom'`. `@meta`, `MetaConfig`, the
+  `COMMAND_METADATA` symbol and `metadataOf()`'s reason for existing are all dead
+  — step 4 deletes them, kept separate from the migration diff.
+  - **The type system found 18 errors with one cause, invisible before.** The four
+    base classes declared `metadata` as a `declare readonly` PROPERTY, and a
+    subclass cannot override a property with an accessor (TS2611/TS4114) — nine
+    subclasses. The runtime `defineProperty` had simply shadowed the declaration.
+    Fixed by `abstract readonly metadata`, which is also the honest declaration.
+  - **A shared implementation cannot carry two `compatibility` values.**
+    `ConditionalCommand` is registered as both `if` (upstream) and `unless`
+    (extension) and both names resolve to the same instance. It carries
+    `'standard'`; `unless` is pinned in §9, **derived** from the shared groups
+    rather than hand-listed, so a future alias across the tier line fails loudly.
+  - **Two gate rows moved deliberately and were left as assertions, not deleted**:
+    step 1's "no defaults on the three" is INVERTED (the 52's byte-identity was
+    the larger preservation), and `COMPATIBILITY_UNSET` went from the whole
+    registry to empty — which step 2's gate forced into the same diff.
+  - Registry oracle diff was **exactly the predicted 3 rows**. Slim bundles
+    +0.0% (`hyperfixi-hx.js` byte-identical at 19019, headroom intact); full
+    bundles +0.1% gzip for the new field.
+  - **The verification instrument had the arc's own disease.** The first oracle
+    diff said "0 rows changed" and was wrong: it iterated only the BEFORE row's
+    keys, so an ADDED field was structurally invisible. Diff the union of both key
+    sets. A one-directional check that reads as green — the exact thing this queue
+    exists to catch, reproduced in the tool used to catch it.
 - **2026-07-29** — **Arc B step 2 landed**: the `compatibility` coupling, as §9 of
   the manifest audit (39 → 44 tests), while the expected state is still "unset on
   all 59" — so the gate is proven before it has values to bless.

--- a/docs-internal/HANDOFF-command-arch-metadata.md
+++ b/docs-internal/HANDOFF-command-arch-metadata.md
@@ -500,10 +500,68 @@ its metadata. Pre-existing (step 1's registry oracle was byte-identical), and
 recorded in §9's docstring so the next reader does not re-introduce it. Step 3
 should expect this asymmetry to disappear as the 52 gain real values.
 
-**Step 3 — migrate the 52 decorated classes.** `static readonly metadata =
-commandMeta({…})` plus the `get metadata()` bridge, keeping `@command` for
-name/category or folding category into the literal (decide in step 1 and record
-it). Populate `compatibility` here, against step 2's live gate.
+**Step 3 — migrate the 52 decorated classes — ✅ DONE.** All 52 moved to
+`static readonly metadata = commandMeta({…})` + `get metadata()`, `@meta` removed
+from every call site, `category` folded into the literal, and `compatibility`
+populated on all **55** literals against step 2's live gate.
+
+**The arc's goal is delivered and proven.** `ToggleCommand.metadata.description`
+was `TS2339` before this step and now typechecks, with
+`ToggleCommand.metadata.category` narrowing to the literal `'dom'`.
+
+**`@meta` is now completely dead** — zero call sites, zero importers. So are
+`MetaConfig` and the `COMMAND_METADATA` symbol, and `metadataOf()`'s reason for
+existing is gone. Step 4 removes them; step 3 deliberately does not, to keep the
+migration diff separable from the deletion diff.
+
+The shape was uniform enough to script: all 51 files matched a single canonical
+layout (`@meta({…})` → `@command({name, category})` → `class X`), with `swap.ts`
+(two decorated classes) the only structural exception.
+
+**Two things the type system caught that `defineProperty` had hidden:**
+
+- **18 errors, one cause** — the four base classes (`ContentInsertionCommand`,
+  `ControlFlowSignalBase`, `DOMModificationBase`, `VisibilityCommandBase`)
+  declared `metadata` as a `declare readonly` **property**, and a subclass may not
+  override a property with an accessor (`TS2611`, plus `TS4114` wanting
+  `override`). Nine subclasses. Fixed by making the base member
+  `abstract readonly metadata: CommandMetadata` — which is also the honest
+  declaration, since the unchecked `declare` was itself the shape this arc exists
+  to remove. Invisible before, because the runtime `defineProperty` simply
+  shadowed the declaration.
+- **A shared implementation cannot carry two `compatibility` values.**
+  `ConditionalCommand` is registered as both `if` (upstream → `'standard'`) and
+  `unless` (extension → `'lokascript-extension'`), and both names resolve to the
+  same instance — which is precisely how `command-adapter.ts:440` registers the
+  alias. The class carries `'standard'` (matching `if`, the primary and upstream
+  name) and `unless` is pinned in §9's `COMPATIBILITY_ALIAS_DIVERGENCE`. Checked
+  **derived, not hand-listed**: of the four shared groups only this one straddles
+  the tier line, so a future consolidated alias across it fails loudly. Splitting
+  metadata per registered name would fix it and is architectural — pinned, the way
+  Arc A pinned the two category unions.
+
+**Two gate rows MOVED deliberately, and are left as assertions rather than
+deleted** so they read as decisions:
+
+- Step 1's test asserting the three converted classes carry **no**
+  `isBlocking`/`hasBody`/`version` is **inverted** — they now carry them, because
+  `commandMeta` fills `@meta`'s defaults, which is what keeps the *fifty-two*
+  byte-identical. The larger preservation won.
+- `COMPATIBILITY_UNSET` goes from the whole registry to **empty**, which step 2's
+  gate forced: populating a value correctly still failed the row-moving assertion
+  until this set moved in the same diff.
+
+**Registry oracle diff — exactly the predicted 3 rows.** `install`,
+`pseudo-command`, `render`, on `hasBody`+`isBlocking` only. Registered count,
+distinct implementations, all four shared-implementation groups, and every alias
+identity: **identical**.
+
+> **A caution earned the hard way in this step.** The first oracle diff reported
+> **0 rows changed** and was WRONG — it iterated only the *before* row's keys, so
+> a field that was **added** was structurally invisible. That is this arc's own
+> central disease (a one-directional check that reads as green) reproduced in the
+> verification instrument itself. Diff the **union** of both key sets. The
+> corrected diff found the 3 rows immediately.
 
 - Registry oracle diff is the behaviour-preservation instrument. Names, classes,
   aliases, categories, shared-implementation groups, and both metadata-presence

--- a/packages/core/src/commands/advanced/async.ts
+++ b/packages/core/src/commands/advanced/async.ts
@@ -12,8 +12,8 @@ import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -47,20 +47,26 @@ export interface AsyncCommandOutput {
  * Before: 233 lines
  * After: ~150 lines (36% reduction)
  */
-@meta({
-  description: 'Execute commands asynchronously without blocking',
-  syntax: ['async <command> [<command> ...]'],
-  examples: [
-    'async command1 command2',
-    'async fetchData processData',
-    'async animateIn showContent',
-  ],
-  sideEffects: ['async-execution'],
-})
 @command({ name: 'async', category: 'advanced' })
 export class AsyncCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Execute commands asynchronously without blocking',
+    syntax: ['async <command> [<command> ...]'],
+    examples: [
+      'async command1 command2',
+      'async fetchData processData',
+      'async animateIn showContent',
+    ],
+    sideEffects: ['async-execution'],
+    category: 'advanced',
+    compatibility: 'lokascript-extension',
+  });
+
+  get metadata() {
+    return AsyncCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/advanced/js.ts
+++ b/packages/core/src/commands/advanced/js.ts
@@ -13,8 +13,8 @@ import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -40,20 +40,26 @@ export interface JsCommandOutput {
  * Before: 241 lines
  * After: ~160 lines (34% reduction)
  */
-@meta({
-  description: 'Execute inline JavaScript code with access to hyperscript context',
-  syntax: ['js <code> end', 'js(param1, param2) <code> end'],
-  examples: [
-    'js console.log("Hello") end',
-    'js(x, y) return x + y end',
-    'js me.style.color = "red" end',
-  ],
-  sideEffects: ['code-execution', 'data-mutation'],
-})
 @command({ name: 'js', category: 'advanced' })
 export class JsCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Execute inline JavaScript code with access to hyperscript context',
+    syntax: ['js <code> end', 'js(param1, param2) <code> end'],
+    examples: [
+      'js console.log("Hello") end',
+      'js(x, y) return x + y end',
+      'js me.style.color = "red" end',
+    ],
+    sideEffects: ['code-execution', 'data-mutation'],
+    category: 'advanced',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return JsCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/animation/measure.ts
+++ b/packages/core/src/commands/animation/measure.ts
@@ -16,8 +16,8 @@ import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { isHTMLElement } from '../../utils/element-check';
 import { resolveElement } from '../helpers/element-resolution';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -45,16 +45,22 @@ export interface MeasureCommandOutput {
  * Before: 376 lines
  * After: ~180 lines (52% reduction)
  */
-@meta({
-  description: 'Measure DOM element dimensions, positions, and properties',
-  syntax: ['measure', 'measure <property>', 'measure <target> <property>'],
-  examples: ['measure', 'measure width', 'measure #element height', 'measure x and set dragX'],
-  sideEffects: ['data-mutation'],
-})
 @command({ name: 'measure', category: 'animation' })
 export class MeasureCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Measure DOM element dimensions, positions, and properties',
+    syntax: ['measure', 'measure <property>', 'measure <target> <property>'],
+    examples: ['measure', 'measure width', 'measure #element height', 'measure x and set dragX'],
+    sideEffects: ['data-mutation'],
+    category: 'animation',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return MeasureCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/animation/settle.ts
+++ b/packages/core/src/commands/animation/settle.ts
@@ -22,8 +22,8 @@ import {
 } from '../helpers/duration-parsing';
 import { waitForAnimationComplete } from '../helpers/event-waiting';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -53,16 +53,22 @@ export interface SettleCommandOutput {
  * Before: 191 lines
  * After: ~120 lines (37% reduction)
  */
-@meta({
-  description: 'Wait for CSS transitions and animations to complete',
-  syntax: 'settle [<target>] [for <timeout>]',
-  examples: ['settle', 'settle #animated-element', 'settle for 3000'],
-  sideEffects: ['timing'],
-})
 @command({ name: 'settle', category: 'animation' })
 export class SettleCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Wait for CSS transitions and animations to complete',
+    syntax: 'settle [<target>] [for <timeout>]',
+    examples: ['settle', 'settle #animated-element', 'settle for 3000'],
+    sideEffects: ['timing'],
+    category: 'animation',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return SettleCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/animation/start-view-transition.ts
+++ b/packages/core/src/commands/animation/start-view-transition.ts
@@ -28,8 +28,8 @@ import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { withViewTransition, isViewTransitionsSupported } from '../../lib/view-transitions';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -49,19 +49,25 @@ export interface StartViewTransitionOutput {
   commandsExecuted: number;
 }
 
-@meta({
-  description: 'Wrap a block of commands in document.startViewTransition()',
-  syntax: ['start view transition [using <type>] <body> end'],
-  examples: [
-    'start view transition add .highlight to me end',
-    'start view transition using "slide" then put result into #panel end',
-  ],
-  sideEffects: ['animation', 'dom-mutation'],
-})
 @command({ name: 'start', category: 'animation' })
 export class StartViewTransitionCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Wrap a block of commands in document.startViewTransition()',
+    syntax: ['start view transition [using <type>] <body> end'],
+    examples: [
+      'start view transition add .highlight to me end',
+      'start view transition using "slide" then put result into #panel end',
+    ],
+    sideEffects: ['animation', 'dom-mutation'],
+    category: 'animation',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return StartViewTransitionCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/animation/take.ts
+++ b/packages/core/src/commands/animation/take.ts
@@ -14,8 +14,8 @@ import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { resolveElement } from '../helpers/element-resolution';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -39,19 +39,28 @@ export interface TakeCommandOutput {
  * Before: 406 lines
  * After: ~180 lines (56% reduction)
  */
-@meta({
-  description: 'Move classes, attributes, and properties from one element to another',
-  syntax: ['take <property> from <source>', 'take <property> from <source> and put it on <target>'],
-  examples: [
-    'take class from <#source/>',
-    'take @data-value from <.source/> and put it on <#target/>',
-  ],
-  sideEffects: ['dom-mutation', 'property-transfer'],
-})
 @command({ name: 'take', category: 'animation' })
 export class TakeCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Move classes, attributes, and properties from one element to another',
+    syntax: [
+      'take <property> from <source>',
+      'take <property> from <source> and put it on <target>',
+    ],
+    examples: [
+      'take class from <#source/>',
+      'take @data-value from <.source/> and put it on <#target/>',
+    ],
+    sideEffects: ['dom-mutation', 'property-transfer'],
+    category: 'animation',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return TakeCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/animation/transition.ts
+++ b/packages/core/src/commands/animation/transition.ts
@@ -18,8 +18,8 @@ import { resolveElement } from '../helpers/element-resolution';
 import { parseDuration, camelToKebab } from '../helpers/duration-parsing';
 import { waitForTransitionEnd } from '../helpers/event-waiting';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -54,20 +54,26 @@ export interface TransitionCommandOutput {
  * Before: 250 lines
  * After: ~130 lines (48% reduction)
  */
-@meta({
-  description: 'Animate CSS properties using CSS transitions',
-  syntax: 'transition <property> to <value> [over <duration>] [with <timing>]',
-  examples: [
-    'transition opacity to 0.5',
-    'transition left to 100px over 500ms',
-    'transition background-color to red over 1s with ease-in-out',
-  ],
-  sideEffects: ['style-change', 'timing'],
-})
 @command({ name: 'transition', category: 'animation' })
 export class TransitionCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Animate CSS properties using CSS transitions',
+    syntax: 'transition <property> to <value> [over <duration>] [with <timing>]',
+    examples: [
+      'transition opacity to 0.5',
+      'transition left to 100px over 500ms',
+      'transition background-color to red over 1s with ease-in-out',
+    ],
+    sideEffects: ['style-change', 'timing'],
+    category: 'animation',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return TransitionCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/async/fetch.ts
+++ b/packages/core/src/commands/async/fetch.ts
@@ -15,8 +15,8 @@ import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { isHTMLElement } from '../../utils/element-check';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -150,20 +150,26 @@ export interface FetchCommandOutput {
  * Before: 640 lines
  * After: ~250 lines (61% reduction)
  */
-@meta({
-  description: 'Make HTTP requests with lifecycle event support',
-  syntax: ['fetch <url>', 'fetch <url> as <type>', 'fetch <url> with <options>'],
-  examples: [
-    'fetch "/api/data"',
-    'fetch "/api/users" as json',
-    'fetch "/api/save" with { method:"POST" }',
-  ],
-  sideEffects: ['network', 'event-dispatching'],
-})
 @command({ name: 'fetch', category: 'async' })
 export class FetchCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Make HTTP requests with lifecycle event support',
+    syntax: ['fetch <url>', 'fetch <url> as <type>', 'fetch <url> with <options>'],
+    examples: [
+      'fetch "/api/data"',
+      'fetch "/api/users" as json',
+      'fetch "/api/save" with { method:"POST" }',
+    ],
+    sideEffects: ['network', 'event-dispatching'],
+    category: 'async',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return FetchCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/async/wait.ts
+++ b/packages/core/src/commands/async/wait.ts
@@ -16,8 +16,8 @@ import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { parseDurationStrict } from '../helpers/duration-parsing';
 import { waitForTime, waitForEvent } from '../helpers/event-waiting';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -51,21 +51,27 @@ export interface WaitCommandOutput {
  * Before: 650 lines
  * After: ~280 lines (57% reduction)
  */
-@meta({
-  description: 'Wait for time delay, event, or race condition',
-  syntax: ['wait <time>', 'wait for <event>', 'wait for <event> or <condition>'],
-  examples: [
-    'wait 2s',
-    'wait for click',
-    'wait for click or 1s',
-    'wait for mousemove(clientX, clientY)',
-  ],
-  sideEffects: ['time', 'event-listening'],
-})
 @command({ name: 'wait', category: 'async' })
 export class WaitCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Wait for time delay, event, or race condition',
+    syntax: ['wait <time>', 'wait for <event>', 'wait for <event> or <condition>'],
+    examples: [
+      'wait 2s',
+      'wait for click',
+      'wait for click or 1s',
+      'wait for mousemove(clientX, clientY)',
+    ],
+    sideEffects: ['time', 'event-listening'],
+    category: 'async',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return WaitCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/behaviors/install.ts
+++ b/packages/core/src/commands/behaviors/install.ts
@@ -89,6 +89,7 @@ export class InstallCommand {
       'install MyBehavior(foo: 42) on the first <div/>',
     ],
     category: 'behaviors',
+    compatibility: 'standard',
     sideEffects: ['behavior-installation', 'element-modification'],
   });
 

--- a/packages/core/src/commands/content/append.ts
+++ b/packages/core/src/commands/content/append.ts
@@ -16,27 +16,33 @@ import {
   type InsertionCommandInput,
   type InsertionCommandOutput,
 } from './insertion-base';
-import { command, meta, createFactory, type CommandMetadata } from '../decorators';
+import { commandMeta, command, createFactory, type CommandMetadata } from '../decorators';
 
 export type AppendCommandInput = InsertionCommandInput;
 export type AppendCommandOutput = InsertionCommandOutput;
 
-@meta({
-  description: 'Add content to the end of a string, array, Set, or HTML element',
-  syntax: ['append <content>', 'append <content> to <target>'],
-  examples: [
-    'append "Hello"',
-    'append "World" to greeting',
-    'append item to myArray',
-    'append "<p>New</p>" to #content',
-    'append " (edited)" to #title\'s textContent',
-  ],
-  sideEffects: ['data-mutation', 'dom-mutation'],
-})
 @command({ name: 'append', category: 'content' })
 export class AppendCommand extends ContentInsertionCommand {
+  static readonly metadata = commandMeta({
+    description: 'Add content to the end of a string, array, Set, or HTML element',
+    syntax: ['append <content>', 'append <content> to <target>'],
+    examples: [
+      'append "Hello"',
+      'append "World" to greeting',
+      'append item to myArray',
+      'append "<p>New</p>" to #content',
+      'append " (edited)" to #title\'s textContent',
+    ],
+    sideEffects: ['data-mutation', 'dom-mutation'],
+    category: 'content',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return AppendCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   constructor() {
     super('append');

--- a/packages/core/src/commands/content/insertion-base.ts
+++ b/packages/core/src/commands/content/insertion-base.ts
@@ -101,7 +101,15 @@ function toInsertionInput(target: WriteTarget, content: unknown): InsertionComma
 
 export abstract class ContentInsertionCommand implements DecoratedCommand {
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
+  /**
+   * Each concrete subclass supplies this via `static readonly metadata =
+   * commandMeta({…})` plus an instance getter (Arc B step 3). Declared
+   * `abstract` rather than `declare readonly`: a `declare`d PROPERTY cannot be
+   * overridden by an accessor (TS2611), and the unchecked `declare` was itself
+   * the shape Arc B exists to remove — it asserted a type the compiler never
+   * verified.
+   */
+  abstract readonly metadata: CommandMetadata;
 
   protected constructor(protected readonly position: InsertionPosition) {}
 

--- a/packages/core/src/commands/content/prepend.ts
+++ b/packages/core/src/commands/content/prepend.ts
@@ -19,26 +19,32 @@ import {
   type InsertionCommandInput,
   type InsertionCommandOutput,
 } from './insertion-base';
-import { command, meta, createFactory, type CommandMetadata } from '../decorators';
+import { commandMeta, command, createFactory, type CommandMetadata } from '../decorators';
 
 export type PrependCommandInput = InsertionCommandInput;
 export type PrependCommandOutput = InsertionCommandOutput;
 
-@meta({
-  description: 'Add content to the start of a string, array, Set, or HTML element',
-  syntax: ['prepend <content>', 'prepend <content> to <target>'],
-  examples: [
-    'prepend "Hello"',
-    'prepend "World" to greeting',
-    'prepend item to myArray',
-    'prepend "<p>First</p>" to #content',
-  ],
-  sideEffects: ['data-mutation', 'dom-mutation'],
-})
 @command({ name: 'prepend', category: 'content' })
 export class PrependCommand extends ContentInsertionCommand {
+  static readonly metadata = commandMeta({
+    description: 'Add content to the start of a string, array, Set, or HTML element',
+    syntax: ['prepend <content>', 'prepend <content> to <target>'],
+    examples: [
+      'prepend "Hello"',
+      'prepend "World" to greeting',
+      'prepend item to myArray',
+      'prepend "<p>First</p>" to #content',
+    ],
+    sideEffects: ['data-mutation', 'dom-mutation'],
+    category: 'content',
+    compatibility: 'lokascript-extension',
+  });
+
+  get metadata() {
+    return PrependCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   constructor() {
     super('prepend');

--- a/packages/core/src/commands/control-flow/break.ts
+++ b/packages/core/src/commands/control-flow/break.ts
@@ -7,7 +7,7 @@
  * Syntax: break
  */
 
-import { command, meta, createFactory } from '../decorators';
+import { commandMeta, command, createFactory } from '../decorators';
 import { ControlFlowSignalBase } from './signal-base';
 
 // Re-export for backward compatibility
@@ -20,18 +20,25 @@ export interface BreakCommandOutput {
 /**
  * BreakCommand - Exits from the current loop
  */
-@meta({
-  description: 'Exit from the current loop (repeat, for, while, until)',
-  syntax: ['break'],
-  examples: [
-    'break',
-    'if found then break',
-    'repeat for item in items { if item == target then break }',
-  ],
-  sideEffects: ['control-flow'],
-})
 @command({ name: 'break', category: 'control-flow' })
 export class BreakCommand extends ControlFlowSignalBase {
+  static readonly metadata = commandMeta({
+    description: 'Exit from the current loop (repeat, for, while, until)',
+    syntax: ['break'],
+    examples: [
+      'break',
+      'if found then break',
+      'repeat for item in items { if item == target then break }',
+    ],
+    sideEffects: ['control-flow'],
+    category: 'control-flow',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return BreakCommand.metadata;
+  }
+
   protected readonly signalType = 'break' as const;
   protected readonly errorMessage = 'BREAK_LOOP';
   protected readonly errorFlag = 'isBreak';

--- a/packages/core/src/commands/control-flow/continue.ts
+++ b/packages/core/src/commands/control-flow/continue.ts
@@ -7,7 +7,7 @@
  * Syntax: continue
  */
 
-import { command, meta, createFactory } from '../decorators';
+import { commandMeta, command, createFactory } from '../decorators';
 import { ControlFlowSignalBase } from './signal-base';
 
 // Re-export for backward compatibility
@@ -20,18 +20,25 @@ export interface ContinueCommandOutput {
 /**
  * ContinueCommand - Skips to next loop iteration
  */
-@meta({
-  description: 'Skip to the next iteration of the current loop',
-  syntax: ['continue'],
-  examples: [
-    'continue',
-    'if item.isInvalid then continue',
-    'repeat for item in items { if item.skip then continue; process item }',
-  ],
-  sideEffects: ['control-flow'],
-})
 @command({ name: 'continue', category: 'control-flow' })
 export class ContinueCommand extends ControlFlowSignalBase {
+  static readonly metadata = commandMeta({
+    description: 'Skip to the next iteration of the current loop',
+    syntax: ['continue'],
+    examples: [
+      'continue',
+      'if item.isInvalid then continue',
+      'repeat for item in items { if item.skip then continue; process item }',
+    ],
+    sideEffects: ['control-flow'],
+    category: 'control-flow',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return ContinueCommand.metadata;
+  }
+
   protected readonly signalType = 'continue' as const;
   protected readonly errorMessage = 'CONTINUE_LOOP';
   protected readonly errorFlag = 'isContinue';

--- a/packages/core/src/commands/control-flow/exit.ts
+++ b/packages/core/src/commands/control-flow/exit.ts
@@ -8,7 +8,7 @@
  *   exit
  */
 
-import { command, meta, createFactory } from '../decorators';
+import { commandMeta, command, createFactory } from '../decorators';
 import { ControlFlowSignalBase } from './signal-base';
 
 /**
@@ -27,14 +27,21 @@ export interface ExitCommandOutput {
 /**
  * ExitCommand - Exits from event handler
  */
-@meta({
-  description: 'Immediately terminate execution of the current event handler or behavior',
-  syntax: ['exit'],
-  examples: ['exit', 'if no draggedItem exit', 'on click if disabled exit'],
-  sideEffects: ['control-flow'],
-})
 @command({ name: 'exit', category: 'control-flow' })
 export class ExitCommand extends ControlFlowSignalBase {
+  static readonly metadata = commandMeta({
+    description: 'Immediately terminate execution of the current event handler or behavior',
+    syntax: ['exit'],
+    examples: ['exit', 'if no draggedItem exit', 'on click if disabled exit'],
+    sideEffects: ['control-flow'],
+    category: 'control-flow',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return ExitCommand.metadata;
+  }
+
   protected readonly signalType = 'exit' as const;
   protected readonly errorMessage = 'EXIT_COMMAND';
   protected readonly errorFlag = 'isExit';

--- a/packages/core/src/commands/control-flow/halt.ts
+++ b/packages/core/src/commands/control-flow/halt.ts
@@ -13,8 +13,8 @@ import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -42,21 +42,27 @@ export interface HaltCommandOutput {
  * Before: 216 lines
  * After: ~100 lines (54% reduction)
  */
-@meta({
-  description: 'Stop command execution or prevent event defaults',
-  syntax: ['halt', 'halt the event'],
-  examples: [
-    'halt',
-    'halt the event',
-    'if error then halt',
-    'on click halt the event then log "clicked"',
-  ],
-  sideEffects: ['control-flow', 'event-prevention'],
-})
 @command({ name: 'halt', category: 'control-flow' })
 export class HaltCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Stop command execution or prevent event defaults',
+    syntax: ['halt', 'halt the event'],
+    examples: [
+      'halt',
+      'halt the event',
+      'if error then halt',
+      'on click halt the event then log "clicked"',
+    ],
+    sideEffects: ['control-flow', 'event-prevention'],
+    category: 'control-flow',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return HaltCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/control-flow/if.ts
+++ b/packages/core/src/commands/control-flow/if.ts
@@ -15,8 +15,8 @@ import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { evaluateCondition } from '../helpers/condition-helpers';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -67,25 +67,31 @@ export interface IfCommandOutput extends ConditionalCommandOutput {}
  * - 'if' mode: executes then-branch when condition is TRUE
  * - 'unless' mode: executes then-branch when condition is FALSE
  */
-@meta({
-  description: 'Conditional execution based on boolean expressions',
-  syntax: [
-    'if <condition> then <commands>',
-    'if <condition> then <commands> else <commands>',
-    'unless <condition> <commands>',
-  ],
-  examples: [
-    'if x > 5 then add .active',
-    'if user.isAdmin then show #adminPanel else hide #adminPanel',
-    'unless user.isLoggedIn showLoginForm',
-  ],
-  sideEffects: ['conditional-execution'],
-  aliases: ['unless'],
-})
 @command({ name: 'if', category: 'control-flow' })
 export class ConditionalCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Conditional execution based on boolean expressions',
+    syntax: [
+      'if <condition> then <commands>',
+      'if <condition> then <commands> else <commands>',
+      'unless <condition> <commands>',
+    ],
+    examples: [
+      'if x > 5 then add .active',
+      'if user.isAdmin then show #adminPanel else hide #adminPanel',
+      'unless user.isLoggedIn showLoginForm',
+    ],
+    sideEffects: ['conditional-execution'],
+    aliases: ['unless'],
+    category: 'control-flow',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return ConditionalCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode>; commandName?: string },

--- a/packages/core/src/commands/control-flow/repeat.ts
+++ b/packages/core/src/commands/control-flow/repeat.ts
@@ -18,8 +18,8 @@ import { evaluateCondition } from '../helpers/condition-helpers';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -64,23 +64,29 @@ export interface RepeatCommandOutput {
   interrupted?: boolean;
 }
 
-@meta({
-  description:
-    'Iteration in hyperscript - for-in, counted, conditional, event-driven, and infinite loops',
-  syntax: [
-    'repeat for <var> in <collection> { <commands> }',
-    'repeat <count> times { <commands> }',
-    'repeat while <condition> { <commands> }',
-    'repeat until <condition> { <commands> }',
-    'repeat forever { <commands> }',
-  ],
-  examples: ['repeat for item in items { log item }', 'repeat 5 times { log "hello" }'],
-  sideEffects: ['iteration', 'conditional-execution'],
-})
 @command({ name: 'repeat', category: 'control-flow' })
 export class RepeatCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description:
+      'Iteration in hyperscript - for-in, counted, conditional, event-driven, and infinite loops',
+    syntax: [
+      'repeat for <var> in <collection> { <commands> }',
+      'repeat <count> times { <commands> }',
+      'repeat while <condition> { <commands> }',
+      'repeat until <condition> { <commands> }',
+      'repeat forever { <commands> }',
+    ],
+    examples: ['repeat for item in items { log item }', 'repeat 5 times { log "hello" }'],
+    sideEffects: ['iteration', 'conditional-execution'],
+    category: 'control-flow',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return RepeatCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/control-flow/return.ts
+++ b/packages/core/src/commands/control-flow/return.ts
@@ -13,8 +13,8 @@ import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -41,16 +41,22 @@ export interface ReturnCommandOutput {
  * Before: 152 lines
  * After: ~65 lines (57% reduction)
  */
-@meta({
-  description: 'Return a value from a command sequence or function, terminating execution',
-  syntax: ['return', 'return <value>'],
-  examples: ['return', 'return 42', 'return user.name', 'if found then return result'],
-  sideEffects: ['control-flow', 'context-mutation'],
-})
 @command({ name: 'return', category: 'control-flow' })
 export class ReturnCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Return a value from a command sequence or function, terminating execution',
+    syntax: ['return', 'return <value>'],
+    examples: ['return', 'return 42', 'return user.name', 'if found then return result'],
+    sideEffects: ['control-flow', 'context-mutation'],
+    category: 'control-flow',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return ReturnCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/control-flow/signal-base.ts
+++ b/packages/core/src/commands/control-flow/signal-base.ts
@@ -31,7 +31,15 @@ export interface SignalCommandOutput {
  */
 export abstract class ControlFlowSignalBase implements DecoratedCommand {
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
+  /**
+   * Each concrete subclass supplies this via `static readonly metadata =
+   * commandMeta({…})` plus an instance getter (Arc B step 3). Declared
+   * `abstract` rather than `declare readonly`: a `declare`d PROPERTY cannot be
+   * overridden by an accessor (TS2611), and the unchecked `declare` was itself
+   * the shape Arc B exists to remove — it asserted a type the compiler never
+   * verified.
+   */
+  abstract readonly metadata: CommandMetadata;
 
   /** Subclasses must define their signal type */
   protected abstract readonly signalType: SignalType;

--- a/packages/core/src/commands/control-flow/throw.ts
+++ b/packages/core/src/commands/control-flow/throw.ts
@@ -12,8 +12,8 @@ import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -39,16 +39,22 @@ export interface ThrowCommandOutput {
  * Before: 143 lines
  * After: ~60 lines (58% reduction)
  */
-@meta({
-  description: 'Throw an error with a specified message',
-  syntax: ['throw <message>'],
-  examples: ['throw "Invalid input"', 'if not valid then throw "Validation failed"'],
-  sideEffects: ['error-throwing', 'execution-termination'],
-})
 @command({ name: 'throw', category: 'control-flow' })
 export class ThrowCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Throw an error with a specified message',
+    syntax: ['throw <message>'],
+    examples: ['throw "Invalid input"', 'if not valid then throw "Validation failed"'],
+    sideEffects: ['error-throwing', 'execution-termination'],
+    category: 'control-flow',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return ThrowCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/data/clear.ts
+++ b/packages/core/src/commands/data/clear.ts
@@ -26,8 +26,8 @@ import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { isHTMLElement } from '../../utils/element-check';
 import { resolveTargetsFromArgs } from '../helpers/element-resolution';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -43,17 +43,23 @@ function isFormFieldElement(
   return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
 }
 
-@meta({
-  description:
-    'Reset a variable to null or clear the value of a form field (<input>, <textarea>, <select>)',
-  syntax: ['clear <var>', 'clear :var', 'clear <target>'],
-  examples: ['clear :count', 'clear myVar', 'clear #search', 'clear <textarea/>'],
-  sideEffects: ['state-mutation', 'dom-mutation'],
-})
 @command({ name: 'clear', category: 'data' })
 export class ClearCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description:
+      'Reset a variable to null or clear the value of a form field (<input>, <textarea>, <select>)',
+    syntax: ['clear <var>', 'clear :var', 'clear <target>'],
+    examples: ['clear :count', 'clear myVar', 'clear #search', 'clear <textarea/>'],
+    sideEffects: ['state-mutation', 'dom-mutation'],
+    category: 'data',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return ClearCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/data/default.ts
+++ b/packages/core/src/commands/data/default.ts
@@ -24,8 +24,8 @@ import {
   isEmpty,
 } from '../helpers/element-property-access';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -52,20 +52,26 @@ export interface DefaultCommandOutput {
   targetType: 'variable' | 'attribute' | 'property' | 'element';
 }
 
-@meta({
-  description: "Set a value only if it doesn't already exist",
-  syntax: ['default <expression> to <expression>'],
-  examples: [
-    'default myVar to "fallback"',
-    'default @data-theme to "light"',
-    'default my innerHTML to "No content"',
-  ],
-  sideEffects: ['data-mutation', 'dom-mutation'],
-})
 @command({ name: 'default', category: 'data' })
 export class DefaultCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: "Set a value only if it doesn't already exist",
+    syntax: ['default <expression> to <expression>'],
+    examples: [
+      'default myVar to "fallback"',
+      'default @data-theme to "light"',
+      'default my innerHTML to "No content"',
+    ],
+    sideEffects: ['data-mutation', 'dom-mutation'],
+    category: 'data',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return DefaultCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/data/get.ts
+++ b/packages/core/src/commands/data/get.ts
@@ -13,8 +13,8 @@ import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -40,16 +40,22 @@ export interface GetCommandOutput {
  * Before: 160 lines
  * After: ~65 lines (59% reduction)
  */
-@meta({
-  description: 'Evaluate an expression and store the result in it',
-  syntax: 'get <expression>',
-  examples: ['get #my-dialog', 'get <button/>', 'get me.parentElement'],
-  sideEffects: ['context-mutation'],
-})
 @command({ name: 'get', category: 'data' })
 export class GetCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Evaluate an expression and store the result in it',
+    syntax: 'get <expression>',
+    examples: ['get #my-dialog', 'get <button/>', 'get me.parentElement'],
+    sideEffects: ['context-mutation'],
+    category: 'data',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return GetCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/data/increment.ts
+++ b/packages/core/src/commands/data/increment.ts
@@ -14,8 +14,8 @@
 import type { TypedExecutionContext } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -49,22 +49,28 @@ export type { NumericTargetInput as DecrementCommandInput };
  * Consolidates IncrementCommand and DecrementCommand into single implementation.
  * Registered under both 'increment' and 'decrement' names via aliases.
  */
-@meta({
-  description: 'Modify a variable or property by a specified amount (default: 1)',
-  syntax: ['increment <target> [by <number>]', 'decrement <target> [by <number>]'],
-  examples: [
-    'increment counter',
-    'increment counter by 5',
-    'decrement counter',
-    'decrement counter by 5',
-  ],
-  sideEffects: ['data-mutation', 'context-modification'],
-  aliases: ['decrement'],
-})
 @command({ name: 'increment', category: 'data' })
 export class NumericModifyCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Modify a variable or property by a specified amount (default: 1)',
+    syntax: ['increment <target> [by <number>]', 'decrement <target> [by <number>]'],
+    examples: [
+      'increment counter',
+      'increment counter by 5',
+      'decrement counter',
+      'decrement counter by 5',
+    ],
+    sideEffects: ['data-mutation', 'context-modification'],
+    aliases: ['decrement'],
+    category: 'data',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return NumericModifyCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   /**
    * Parse raw AST input into structured input object

--- a/packages/core/src/commands/data/set.ts
+++ b/packages/core/src/commands/data/set.ts
@@ -31,8 +31,8 @@ import {
 } from '../helpers/property-target';
 import { resolveWriteTarget, type WriteTarget } from '../helpers/write-target';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -94,16 +94,26 @@ function toSetInput(target: WriteTarget, value: unknown): SetCommandInput {
   }
 }
 
-@meta({
-  description: 'Set values to variables, attributes, or properties',
-  syntax: ['set <target> to <value>'],
-  examples: ['set myVar to "value"', 'set @data-theme to "dark"', 'set my innerHTML to "content"'],
-  sideEffects: ['state-mutation', 'dom-mutation'],
-})
 @command({ name: 'set', category: 'data' })
 export class SetCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Set values to variables, attributes, or properties',
+    syntax: ['set <target> to <value>'],
+    examples: [
+      'set myVar to "value"',
+      'set @data-theme to "dark"',
+      'set my innerHTML to "content"',
+    ],
+    sideEffects: ['state-mutation', 'dom-mutation'],
+    category: 'data',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return SetCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/decorators/__tests__/command-meta.test.ts
+++ b/packages/core/src/commands/decorators/__tests__/command-meta.test.ts
@@ -93,16 +93,33 @@ describe('the classes converted to commandMeta() in step 1', () => {
     }
   );
 
-  it.each(CONVERTED)('$name declares no defaults commandMeta did not fill', ({ cls }) => {
-    // `commandMeta` is deliberately identity — it does NOT fill @meta's
-    // `isBlocking`/`hasBody`/`version` defaults. These three carried no such
-    // fields before the conversion, so they must carry none after it: that is
-    // what makes step 1 a shape-preserving change rather than a silent
-    // undefined-to-false flip on three commands.
+  it.each(CONVERTED)('$name now carries the three defaults (step 3 MOVED this row)', ({ cls }) => {
+    // INVERTED in step 3, deliberately, and left as an explicit assertion
+    // rather than deleted so the change reads as a moved row.
+    //
+    // Step 1 shipped `commandMeta` as pure identity and asserted these three
+    // fields were ABSENT here, because that was shape-preserving for the three
+    // classes it converted. Step 3 chose the other way — `commandMeta` fills
+    // `isBlocking`/`hasBody`/`version` exactly as `@meta` did — because that is
+    // what keeps the FIFTY-TWO classes it migrated byte-identical, which is the
+    // larger preservation. The cost is these three gaining the fields, and this
+    // assertion is that cost, written down.
+    //
+    // The values are boilerplate and two of them are false for other commands
+    // (`wait`/`fetch` do block, `if`/`repeat` do take bodies). Authoring them
+    // truthfully is a separate, filed item — do NOT quietly fix it here.
     const md = cls.metadata as Record<string, unknown>;
-    expect('isBlocking' in md).toBe(false);
-    expect('hasBody' in md).toBe(false);
-    expect('version' in md).toBe(false);
+    expect(md.isBlocking).toBe(false);
+    expect(md.hasBody).toBe(false);
+    expect(md.version).toBe('1.0.0');
+  });
+
+  it.each(CONVERTED)('$name carries a compatibility value (step 3)', ({ cls }) => {
+    // None of the three is a LokaScript extension, so all three project to
+    // 'standard'. The projection itself is gated in the manifest audit's §9;
+    // this only pins that step 3 did not skip the classes it had already
+    // touched in step 1.
+    expect((cls.metadata as Record<string, unknown>).compatibility).toBe('standard');
   });
 
   it('is exactly the set of registered commands whose name is an OWN property', () => {

--- a/packages/core/src/commands/decorators/index.ts
+++ b/packages/core/src/commands/decorators/index.ts
@@ -249,14 +249,30 @@ export type CommandMetaInput = Omit<CommandMetadata, 'version'> & {
  * excess-property and enum checking fire. Drop `const` and the arc trades
  * inference for checking instead of getting both.
  *
- * Returns its argument unchanged — deliberately identity, with **no default
- * filling**, so a migrated class's runtime shape is byte-for-byte what it was.
- * `@meta`'s `isBlocking`/`hasBody`/`version` defaults are its own behavior;
- * folding them in here would silently change `undefined` to `false` on the
- * classes this migrates.
+ * ## The defaults, and why they are here
+ *
+ * Fills `isBlocking`/`hasBody`/`version` exactly as `@meta` did, so the 52
+ * classes step 3 migrated keep byte-identical metadata. Step 1 shipped this as a
+ * pure identity function and said the choice had to be made deliberately in step
+ * 3 rather than by omission; this is that decision. The cost is that the three
+ * `commandMeta` classes migrated in step 1 (`install`, `pseudo-command`,
+ * `render`) now GAIN the three fields — a change their tests assert explicitly,
+ * so it shows up as a moved row rather than as drift.
+ *
+ * Spread order is load-bearing: the defaults come first, so a literal that
+ * states `isBlocking: true` wins and still narrows to `true`.
+ *
+ * **These three fields are unauthored and unread.** No command literal sets
+ * them, nothing in production reads them, and every one of the 40 rows in the
+ * shipped `docs/commands/commands.json` therefore says `isBlocking: false`,
+ * `hasBody: false`, `version: '1.0.0'` — which is FALSE for `wait`, `fetch`,
+ * `settle`, `transition` (they block) and for `if`, `repeat`, `tell` (they take
+ * bodies). Preserving them here is deliberately a refactor-preserving choice,
+ * not an endorsement; authoring them truthfully is filed as its own item in
+ * `docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md`.
  */
-export function commandMeta<const T extends CommandMetaInput>(metadata: T): T {
-  return metadata;
+export function commandMeta<const T extends CommandMetaInput>(metadata: T) {
+  return { isBlocking: false, hasBody: false, version: '1.0.0', ...metadata };
 }
 
 // ============================================================================

--- a/packages/core/src/commands/dom/add.ts
+++ b/packages/core/src/commands/dom/add.ts
@@ -22,7 +22,7 @@ import {
   batchSetStyles,
 } from '../helpers/batch-dom-operations';
 import { resolveDynamicClasses } from '../helpers/class-manipulation';
-import { command, meta, createFactory } from '../decorators';
+import { commandMeta, command, createFactory } from '../decorators';
 import { DOMModificationBase } from './dom-modification-base';
 
 /**
@@ -50,19 +50,26 @@ export type AddCommandInput =
 /**
  * AddCommand - Adds classes, attributes, or styles to elements
  */
-@meta({
-  description: 'Add CSS classes, attributes, or styles to elements',
-  syntax: 'add <classes|@attr|{styles}> [to <target>]',
-  examples: [
-    'add .active to me',
-    'add "active selected" to <button/>',
-    'add .highlighted to #modal',
-    'add [@data-test="value"] to #element',
-  ],
-  sideEffects: ['dom-mutation'],
-})
 @command({ name: 'add', category: 'dom' })
 export class AddCommand extends DOMModificationBase {
+  static readonly metadata = commandMeta({
+    description: 'Add CSS classes, attributes, or styles to elements',
+    syntax: 'add <classes|@attr|{styles}> [to <target>]',
+    examples: [
+      'add .active to me',
+      'add "active selected" to <button/>',
+      'add .highlighted to #modal',
+      'add [@data-test="value"] to #element',
+    ],
+    sideEffects: ['dom-mutation'],
+    category: 'dom',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return AddCommand.metadata;
+  }
+
   protected readonly mode = 'add' as const;
   protected readonly preposition = 'to';
 

--- a/packages/core/src/commands/dom/close.ts
+++ b/packages/core/src/commands/dom/close.ts
@@ -29,8 +29,8 @@ import {
   resolveSmartElementTargets,
 } from '../helpers/smart-element';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -44,16 +44,22 @@ function isPopoverElement(el: HTMLElement): boolean {
   return el.hasAttribute('popover');
 }
 
-@meta({
-  description: 'Close a dialog, details element, or popover',
-  syntax: ['close', 'close <target>'],
-  examples: ['close', 'close #myDialog', 'close #details', 'close #popup'],
-  sideEffects: ['dom-mutation'],
-})
 @command({ name: 'close', category: 'dom' })
 export class CloseCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Close a dialog, details element, or popover',
+    syntax: ['close', 'close <target>'],
+    examples: ['close', 'close #myDialog', 'close #details', 'close #popup'],
+    sideEffects: ['dom-mutation'],
+    category: 'dom',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return CloseCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/dom/dom-modification-base.ts
+++ b/packages/core/src/commands/dom/dom-modification-base.ts
@@ -57,7 +57,15 @@ export interface RawCommandInput {
  */
 export abstract class DOMModificationBase implements DecoratedCommand {
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
+  /**
+   * Each concrete subclass supplies this via `static readonly metadata =
+   * commandMeta({…})` plus an instance getter (Arc B step 3). Declared
+   * `abstract` rather than `declare readonly`: a `declare`d PROPERTY cannot be
+   * overridden by an accessor (TS2611), and the unchecked `declare` was itself
+   * the shape Arc B exists to remove — it asserted a type the compiler never
+   * verified.
+   */
+  abstract readonly metadata: CommandMetadata;
 
   /** Subclasses define their mode */
   protected abstract readonly mode: DOMModificationMode;

--- a/packages/core/src/commands/dom/empty.ts
+++ b/packages/core/src/commands/dom/empty.ts
@@ -19,8 +19,8 @@ import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { isHTMLElement } from '../../utils/element-check';
 import { resolveTargetsFromArgs } from '../helpers/element-resolution';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -30,16 +30,22 @@ export interface EmptyCommandInput {
   targets: HTMLElement[];
 }
 
-@meta({
-  description: 'Remove all children from an element (sets innerHTML to empty)',
-  syntax: ['empty', 'empty <target>', 'empty the <target>'],
-  examples: ['empty me', 'empty #list', 'empty .results'],
-  sideEffects: ['dom-mutation'],
-})
 @command({ name: 'empty', category: 'dom' })
 export class EmptyCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Remove all children from an element (sets innerHTML to empty)',
+    syntax: ['empty', 'empty <target>', 'empty the <target>'],
+    examples: ['empty me', 'empty #list', 'empty .results'],
+    sideEffects: ['dom-mutation'],
+    category: 'dom',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return EmptyCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/dom/hide.ts
+++ b/packages/core/src/commands/dom/hide.ts
@@ -10,7 +10,7 @@
  */
 
 import type { TypedExecutionContext } from '../../types/core';
-import { command, meta, createFactory } from '../decorators';
+import { commandMeta, command, createFactory } from '../decorators';
 import { isHTMLElement } from '../../utils/element-check';
 import { VisibilityCommandBase, type VisibilityCommandInput } from './visibility-base';
 import type { VisibilityInput } from '../helpers/visibility-target-parser';
@@ -21,14 +21,21 @@ export type HideCommandInput = VisibilityInput;
 /**
  * HideCommand - Hides elements
  */
-@meta({
-  description: 'Hide elements by setting display to none',
-  syntax: 'hide [<target>]',
-  examples: ['hide me', 'hide #modal', 'hide .warnings', 'hide <button/>'],
-  sideEffects: ['dom-mutation'],
-})
 @command({ name: 'hide', category: 'dom' })
 export class HideCommand extends VisibilityCommandBase {
+  static readonly metadata = commandMeta({
+    description: 'Hide elements by setting display to none',
+    syntax: 'hide [<target>]',
+    examples: ['hide me', 'hide #modal', 'hide .warnings', 'hide <button/>'],
+    sideEffects: ['dom-mutation'],
+    category: 'dom',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return HideCommand.metadata;
+  }
+
   protected readonly mode = 'hide' as const;
 
   async execute(input: VisibilityCommandInput, _context: TypedExecutionContext): Promise<void> {

--- a/packages/core/src/commands/dom/make.ts
+++ b/packages/core/src/commands/dom/make.ts
@@ -15,8 +15,8 @@ import { isHTMLElement } from '../../utils/element-check';
 import { setVariableValue } from '../helpers/variable-access';
 import { evaluateExpressionFromSource } from '../../parser/runtime';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -178,19 +178,28 @@ async function resolveVariableName(
   return typeof value === 'string' ? value : undefined;
 }
 
-@meta({
-  description: 'Create DOM elements or class instances',
-  syntax: ['make a <tag#id.class1.class2/>', 'make a <ClassName> from <args> called <identifier>'],
-  examples: [
-    'make an <a.navlink/> called linkElement',
-    'make a URL from "/path/", "https://origin.example.com"',
-  ],
-  sideEffects: ['dom-creation', 'data-mutation'],
-})
 @command({ name: 'make', category: 'dom' })
 export class MakeCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Create DOM elements or class instances',
+    syntax: [
+      'make a <tag#id.class1.class2/>',
+      'make a <ClassName> from <args> called <identifier>',
+    ],
+    examples: [
+      'make an <a.navlink/> called linkElement',
+      'make a URL from "/path/", "https://origin.example.com"',
+    ],
+    sideEffects: ['dom-creation', 'data-mutation'],
+    category: 'dom',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return MakeCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ASTNode> },

--- a/packages/core/src/commands/dom/open.ts
+++ b/packages/core/src/commands/dom/open.ts
@@ -31,8 +31,8 @@ import {
   resolveSmartElementTargets,
 } from '../helpers/smart-element';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -79,16 +79,22 @@ function isPopoverElement(el: HTMLElement): boolean {
   return el.hasAttribute('popover');
 }
 
-@meta({
-  description: 'Open a dialog, details element, or popover',
-  syntax: ['open [<target>]', 'open <dialog> as modal', 'open <dialog> as non-modal'],
-  examples: ['open', 'open #myDialog', 'open #details', 'open #popup as non-modal'],
-  sideEffects: ['dom-mutation'],
-})
 @command({ name: 'open', category: 'dom' })
 export class OpenCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Open a dialog, details element, or popover',
+    syntax: ['open [<target>]', 'open <dialog> as modal', 'open <dialog> as non-modal'],
+    examples: ['open', 'open #myDialog', 'open #details', 'open #popup as non-modal'],
+    sideEffects: ['dom-mutation'],
+    category: 'dom',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return OpenCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/dom/process-partials.ts
+++ b/packages/core/src/commands/dom/process-partials.ts
@@ -18,8 +18,8 @@ import { isHTMLElement } from '../../utils/element-check';
 import { debug } from '../../utils/debug';
 import type { SwapStrategy } from './swap';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -209,20 +209,29 @@ export function processPartials(html: string, morphOptions?: MorphOptions): Proc
  * Before: ~130 lines (builder pattern section)
  * After: ~100 lines (decorator pattern)
  */
-@meta({
-  description: 'Process <hx-partial> elements for multi-target swaps',
-  syntax: ['process partials in <content>', 'process partials in <content> using view transition'],
-  examples: [
-    'process partials in it',
-    'process partials in fetchedHtml',
-    'process partials in it using view transition',
-  ],
-  sideEffects: ['dom-mutation'],
-})
 @command({ name: 'process', category: 'dom' })
 export class ProcessPartialsCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Process <hx-partial> elements for multi-target swaps',
+    syntax: [
+      'process partials in <content>',
+      'process partials in <content> using view transition',
+    ],
+    examples: [
+      'process partials in it',
+      'process partials in fetchedHtml',
+      'process partials in it using view transition',
+    ],
+    sideEffects: ['dom-mutation'],
+    category: 'dom',
+    compatibility: 'lokascript-extension',
+  });
+
+  get metadata() {
+    return ProcessPartialsCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/dom/put.ts
+++ b/packages/core/src/commands/dom/put.ts
@@ -28,8 +28,8 @@ import {
 } from '../helpers/dom-mutation';
 import { queryTargetElements, toElementListFiltered } from '../helpers/target-elements';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -56,24 +56,30 @@ export interface PutCommandInput {
  * Before: 562 lines
  * After: ~250 lines (56% reduction)
  */
-@meta({
-  description: 'Insert content into elements or properties',
-  syntax: [
-    'put <value> into <target>',
-    'put <value> before <target>',
-    'put <value> after <target>',
-  ],
-  examples: [
-    'put "Hello World" into me',
-    'put <div>Content</div> before #target',
-    "put value into #elem's innerHTML",
-  ],
-  sideEffects: ['dom-mutation'],
-})
 @command({ name: 'put', category: 'dom' })
 export class PutCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Insert content into elements or properties',
+    syntax: [
+      'put <value> into <target>',
+      'put <value> before <target>',
+      'put <value> after <target>',
+    ],
+    examples: [
+      'put "Hello World" into me',
+      'put <div>Content</div> before #target',
+      "put value into #elem's innerHTML",
+    ],
+    sideEffects: ['dom-mutation'],
+    category: 'dom',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return PutCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/dom/remove.ts
+++ b/packages/core/src/commands/dom/remove.ts
@@ -24,7 +24,7 @@ import {
   batchRemoveStyles,
 } from '../helpers/batch-dom-operations';
 import { resolveDynamicClasses } from '../helpers/class-manipulation';
-import { command, meta, createFactory } from '../decorators';
+import { commandMeta, command, createFactory } from '../decorators';
 import { DOMModificationBase } from './dom-modification-base';
 
 /**
@@ -55,20 +55,27 @@ export type RemoveCommandInput =
 /**
  * RemoveCommand - Removes classes, attributes, styles, or elements
  */
-@meta({
-  description: 'Remove CSS classes, attributes, styles, or elements from the DOM',
-  syntax: 'remove <classes|@attr|*prop|element> [from <target>]',
-  examples: [
-    'remove .active from me',
-    'remove "active selected" from <button/>',
-    'remove .highlighted from #modal',
-    'remove me',
-    'remove closest .item',
-  ],
-  sideEffects: ['dom-mutation'],
-})
 @command({ name: 'remove', category: 'dom' })
 export class RemoveCommand extends DOMModificationBase {
+  static readonly metadata = commandMeta({
+    description: 'Remove CSS classes, attributes, styles, or elements from the DOM',
+    syntax: 'remove <classes|@attr|*prop|element> [from <target>]',
+    examples: [
+      'remove .active from me',
+      'remove "active selected" from <button/>',
+      'remove .highlighted from #modal',
+      'remove me',
+      'remove closest .item',
+    ],
+    sideEffects: ['dom-mutation'],
+    category: 'dom',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return RemoveCommand.metadata;
+  }
+
   protected readonly mode = 'remove' as const;
   protected readonly preposition = 'from';
 

--- a/packages/core/src/commands/dom/reset.ts
+++ b/packages/core/src/commands/dom/reset.ts
@@ -18,8 +18,8 @@ import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { isHTMLElement } from '../../utils/element-check';
 import { resolveTargetsFromArgs } from '../helpers/element-resolution';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -33,16 +33,22 @@ function isFormElement(el: HTMLElement): el is HTMLFormElement {
   return el.tagName === 'FORM';
 }
 
-@meta({
-  description: 'Reset a <form> element to its default values (HTMLFormElement.reset())',
-  syntax: ['reset', 'reset <target>'],
-  examples: ['reset', 'reset #myForm', 'reset <form/>'],
-  sideEffects: ['dom-mutation'],
-})
 @command({ name: 'reset', category: 'dom' })
 export class ResetCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Reset a <form> element to its default values (HTMLFormElement.reset())',
+    syntax: ['reset', 'reset <target>'],
+    examples: ['reset', 'reset #myForm', 'reset <form/>'],
+    sideEffects: ['dom-mutation'],
+    category: 'dom',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return ResetCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/dom/select.ts
+++ b/packages/core/src/commands/dom/select.ts
@@ -21,8 +21,8 @@ import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { isHTMLElement } from '../../utils/element-check';
 import { resolveTargetsFromArgs } from '../helpers/element-resolution';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -37,16 +37,22 @@ function isTextFieldElement(el: HTMLElement): el is HTMLInputElement | HTMLTextA
   return tag === 'INPUT' || tag === 'TEXTAREA';
 }
 
-@meta({
-  description: 'Select the contents of a text field, or select the contents of a DOM element',
-  syntax: ['select', 'select <target>'],
-  examples: ['select #search', 'select <textarea/>', 'select me'],
-  sideEffects: ['focus', 'dom-mutation'],
-})
 @command({ name: 'select', category: 'dom' })
 export class SelectCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Select the contents of a text field, or select the contents of a DOM element',
+    syntax: ['select', 'select <target>'],
+    examples: ['select #search', 'select <textarea/>', 'select me'],
+    sideEffects: ['focus', 'dom-mutation'],
+    category: 'dom',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return SelectCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/dom/show.ts
+++ b/packages/core/src/commands/dom/show.ts
@@ -10,7 +10,7 @@
  */
 
 import type { TypedExecutionContext } from '../../types/core';
-import { command, meta, createFactory } from '../decorators';
+import { commandMeta, command, createFactory } from '../decorators';
 import { isHTMLElement } from '../../utils/element-check';
 import { VisibilityCommandBase, type VisibilityCommandInput } from './visibility-base';
 
@@ -22,14 +22,21 @@ export interface ShowCommandInput extends VisibilityCommandInput {
 /**
  * ShowCommand - Restores element visibility
  */
-@meta({
-  description: 'Show elements by restoring display property',
-  syntax: 'show [<target>]',
-  examples: ['show me', 'show #modal', 'show .hidden', 'show <button/>'],
-  sideEffects: ['dom-mutation'],
-})
 @command({ name: 'show', category: 'dom' })
 export class ShowCommand extends VisibilityCommandBase {
+  static readonly metadata = commandMeta({
+    description: 'Show elements by restoring display property',
+    syntax: 'show [<target>]',
+    examples: ['show me', 'show #modal', 'show .hidden', 'show <button/>'],
+    sideEffects: ['dom-mutation'],
+    category: 'dom',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return ShowCommand.metadata;
+  }
+
   protected readonly mode = 'show' as const;
 
   async execute(input: VisibilityCommandInput, _context: TypedExecutionContext): Promise<void> {

--- a/packages/core/src/commands/dom/swap.ts
+++ b/packages/core/src/commands/dom/swap.ts
@@ -30,8 +30,8 @@ import {
 import type { MorphOptions } from '../../lib/morph-adapter';
 import { isHTMLElement } from '../../utils/element-check';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -95,28 +95,34 @@ async function resolveTargets(
  * Before: ~210 lines (builder pattern section)
  * After: ~200 lines (decorator pattern)
  */
-@meta({
-  description: 'Swap content into target elements with intelligent morphing support',
-  syntax: [
-    'swap <target> with <content>',
-    'swap [strategy] of <target> with <content>',
-    'swap into <target> with <content>',
-    'swap over <target> with <content>',
-    'swap delete <target>',
-    'swap <target> with <content> using view transition',
-  ],
-  examples: [
-    'swap #target with it',
-    'swap innerHTML of #target with it',
-    'swap over #modal with fetchedContent',
-    'swap delete #notification',
-  ],
-  sideEffects: ['dom-mutation'],
-})
 @command({ name: 'swap', category: 'dom' })
 export class SwapCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Swap content into target elements with intelligent morphing support',
+    syntax: [
+      'swap <target> with <content>',
+      'swap [strategy] of <target> with <content>',
+      'swap into <target> with <content>',
+      'swap over <target> with <content>',
+      'swap delete <target>',
+      'swap <target> with <content> using view transition',
+    ],
+    examples: [
+      'swap #target with it',
+      'swap innerHTML of #target with it',
+      'swap over #modal with fetchedContent',
+      'swap delete #notification',
+    ],
+    sideEffects: ['dom-mutation'],
+    category: 'dom',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return SwapCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },
@@ -359,16 +365,22 @@ export class SwapCommand implements DecoratedCommand {
  * Before: ~90 lines (builder pattern section)
  * After: ~80 lines (decorator pattern)
  */
-@meta({
-  description: 'Morph content into target elements (intelligent diffing, preserves state)',
-  syntax: ['morph <target> with <content>', 'morph over <target> with <content>'],
-  examples: ['morph #target with it', 'morph over #modal with fetchedContent'],
-  sideEffects: ['dom-mutation'],
-})
 @command({ name: 'morph', category: 'dom' })
 export class MorphCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Morph content into target elements (intelligent diffing, preserves state)',
+    syntax: ['morph <target> with <content>', 'morph over <target> with <content>'],
+    examples: ['morph #target with it', 'morph over #modal with fetchedContent'],
+    sideEffects: ['dom-mutation'],
+    category: 'dom',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return MorphCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/dom/toggle.ts
+++ b/packages/core/src/commands/dom/toggle.ts
@@ -45,8 +45,8 @@ import {
   type PropertyTarget,
 } from '../helpers/property-target';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -176,26 +176,32 @@ function detectExpressionType(
   return { type: 'class', expression: '' };
 }
 
-@meta({
-  description: 'Toggle classes, attributes, or interactive elements',
-  syntax: [
-    'toggle <class> [on <target>]',
-    'toggle @attr',
-    'toggle <element> [as modal]',
-    'toggle <expr> for <duration>',
-  ],
-  examples: [
-    'toggle .active on me',
-    'toggle @disabled',
-    'toggle #myDialog as modal',
-    'toggle .loading for 2s',
-  ],
-  sideEffects: ['dom-mutation'],
-})
 @command({ name: 'toggle', category: 'dom' })
 export class ToggleCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Toggle classes, attributes, or interactive elements',
+    syntax: [
+      'toggle <class> [on <target>]',
+      'toggle @attr',
+      'toggle <element> [as modal]',
+      'toggle <expr> for <duration>',
+    ],
+    examples: [
+      'toggle .active on me',
+      'toggle @disabled',
+      'toggle #myDialog as modal',
+      'toggle .loading for 2s',
+    ],
+    sideEffects: ['dom-mutation'],
+    category: 'dom',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return ToggleCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/dom/visibility-base.ts
+++ b/packages/core/src/commands/dom/visibility-base.ts
@@ -32,7 +32,15 @@ export interface VisibilityCommandInput extends VisibilityInput {
  */
 export abstract class VisibilityCommandBase implements DecoratedCommand {
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
+  /**
+   * Each concrete subclass supplies this via `static readonly metadata =
+   * commandMeta({…})` plus an instance getter (Arc B step 3). Declared
+   * `abstract` rather than `declare readonly`: a `declare`d PROPERTY cannot be
+   * overridden by an accessor (TS2611), and the unchecked `declare` was itself
+   * the shape Arc B exists to remove — it asserted a type the compiler never
+   * verified.
+   */
+  abstract readonly metadata: CommandMetadata;
 
   /** Subclasses must define this to identify their mode */
   protected abstract readonly mode: VisibilityMode;

--- a/packages/core/src/commands/events/trigger.ts
+++ b/packages/core/src/commands/events/trigger.ts
@@ -18,8 +18,8 @@ import { isHTMLElement } from '../../utils/element-check';
 import { createCustomEvent, parseEventValue } from '../helpers/event-helpers';
 import type { EventOptions } from '../helpers/event-helpers';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -54,27 +54,33 @@ export type SendCommandInput = Omit<EventDispatchInput, 'mode'>;
  * Consolidates TriggerCommand and SendCommand into single implementation.
  * Registered under both 'trigger' and 'send' names via aliases.
  */
-@meta({
-  description: 'Dispatch events on elements',
-  syntax: [
-    'trigger <event> on <target>',
-    'trigger <event>(<detail>) on <target>',
-    'send <event> to <target>',
-    'send <event>(<detail>) to <target>',
-  ],
-  examples: [
-    'trigger click on #button',
-    'trigger customEvent on me',
-    'send dataEvent to #target',
-    'send myEvent(count: 42) to me',
-  ],
-  sideEffects: ['event-dispatch'],
-  aliases: ['send'],
-})
 @command({ name: 'trigger', category: 'event' })
 export class EventDispatchCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Dispatch events on elements',
+    syntax: [
+      'trigger <event> on <target>',
+      'trigger <event>(<detail>) on <target>',
+      'send <event> to <target>',
+      'send <event>(<detail>) to <target>',
+    ],
+    examples: [
+      'trigger click on #button',
+      'trigger customEvent on me',
+      'send dataEvent to #target',
+      'send myEvent(count: 42) to me',
+    ],
+    sideEffects: ['event-dispatch'],
+    aliases: ['send'],
+    category: 'event',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return EventDispatchCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode>; commandName?: string },

--- a/packages/core/src/commands/execution/blur.ts
+++ b/packages/core/src/commands/execution/blur.ts
@@ -19,8 +19,8 @@ import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { isHTMLElement } from '../../utils/element-check';
 import { resolveTargetsFromArgs } from '../helpers/element-resolution';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -30,16 +30,22 @@ export interface BlurCommandInput {
   targets: HTMLElement[];
 }
 
-@meta({
-  description: 'Remove focus from an element (calls HTMLElement.blur())',
-  syntax: ['blur', 'blur <target>', 'blur on <target>'],
-  examples: ['blur', 'blur #search', 'blur on <input/>'],
-  sideEffects: ['focus'],
-})
 @command({ name: 'blur', category: 'execution' })
 export class BlurCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Remove focus from an element (calls HTMLElement.blur())',
+    syntax: ['blur', 'blur <target>', 'blur on <target>'],
+    examples: ['blur', 'blur #search', 'blur on <input/>'],
+    sideEffects: ['focus'],
+    category: 'execution',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return BlurCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/execution/call.ts
+++ b/packages/core/src/commands/execution/call.ts
@@ -12,8 +12,8 @@ import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import { evaluateAST } from '../../parser/runtime';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -41,16 +41,22 @@ export interface CallCommandOutput {
  * Before: 238 lines
  * After: ~85 lines (64% reduction)
  */
-@meta({
-  description: 'Evaluate an expression and store the result in the it variable',
-  syntax: ['call <expression>'],
-  examples: ['call myFunction()', 'call fetch("/api/data")', 'call element.focus()'],
-  sideEffects: ['function-execution', 'context-mutation'],
-})
 @command({ name: 'call', category: 'execution' })
 export class CallCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Evaluate an expression and store the result in the it variable',
+    syntax: ['call <expression>'],
+    examples: ['call myFunction()', 'call fetch("/api/data")', 'call element.focus()'],
+    sideEffects: ['function-execution', 'context-mutation'],
+    category: 'execution',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return CallCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/execution/focus.ts
+++ b/packages/core/src/commands/execution/focus.ts
@@ -19,8 +19,8 @@ import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { isHTMLElement } from '../../utils/element-check';
 import { resolveTargetsFromArgs } from '../helpers/element-resolution';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -30,16 +30,22 @@ export interface FocusCommandInput {
   targets: HTMLElement[];
 }
 
-@meta({
-  description: 'Focus an element (calls HTMLElement.focus())',
-  syntax: ['focus', 'focus <target>', 'focus on <target>'],
-  examples: ['focus', 'focus #search', 'focus on <input/>'],
-  sideEffects: ['focus'],
-})
 @command({ name: 'focus', category: 'execution' })
 export class FocusCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Focus an element (calls HTMLElement.focus())',
+    syntax: ['focus', 'focus <target>', 'focus on <target>'],
+    examples: ['focus', 'focus #search', 'focus on <input/>'],
+    sideEffects: ['focus'],
+    category: 'execution',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return FocusCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/execution/pseudo-command.ts
+++ b/packages/core/src/commands/execution/pseudo-command.ts
@@ -80,6 +80,7 @@ export class PseudoCommand {
       'foo() on me',
     ],
     category: 'execution',
+    compatibility: 'standard',
     sideEffects: ['method-execution'],
   });
 

--- a/packages/core/src/commands/navigation/go.ts
+++ b/packages/core/src/commands/navigation/go.ts
@@ -15,8 +15,8 @@ import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { isHTMLElement } from '../../utils/element-check';
 import { getVariableValue } from '../helpers/variable-access';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -43,17 +43,23 @@ export interface GoCommandOutput {
  * Before: 682 lines
  * After: ~350 lines (49% reduction)
  */
-@meta({
-  description:
-    'Navigation functionality including URL navigation, element scrolling, and browser history',
-  syntax: ['go back', 'go to url <url> [in new window]', 'go to [position] [of] <element>'],
-  examples: ['go back', 'go to url "https://example.com"', 'go to top of #header'],
-  sideEffects: ['navigation', 'scrolling'],
-})
 @command({ name: 'go', category: 'navigation' })
 export class GoCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description:
+      'Navigation functionality including URL navigation, element scrolling, and browser history',
+    syntax: ['go back', 'go to url <url> [in new window]', 'go to [position] [of] <element>'],
+    examples: ['go back', 'go to url "https://example.com"', 'go to top of #header'],
+    sideEffects: ['navigation', 'scrolling'],
+    category: 'navigation',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return GoCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/navigation/push-url.ts
+++ b/packages/core/src/commands/navigation/push-url.ts
@@ -15,8 +15,8 @@ import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -51,27 +51,33 @@ export interface HistoryCommandOutput {
  * Consolidates PushUrlCommand and ReplaceUrlCommand into single implementation.
  * Registered under both 'push' and 'replace' names via aliases.
  */
-@meta({
-  description: 'Modify browser history URL without page reload',
-  syntax: [
-    'push url <url>',
-    'push url <url> with title <title>',
-    'replace url <url>',
-    'replace url <url> with title <title>',
-  ],
-  examples: [
-    'push url "/page/2"',
-    'push url "/search" with title "Search Results"',
-    'replace url "/search?q=test"',
-    'replace url "/page" with title "Updated Page"',
-  ],
-  sideEffects: ['navigation'],
-  aliases: ['replace'],
-})
 @command({ name: 'push', category: 'navigation' })
 export class HistoryCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Modify browser history URL without page reload',
+    syntax: [
+      'push url <url>',
+      'push url <url> with title <title>',
+      'replace url <url>',
+      'replace url <url> with title <title>',
+    ],
+    examples: [
+      'push url "/page/2"',
+      'push url "/search" with title "Search Results"',
+      'replace url "/search?q=test"',
+      'replace url "/page" with title "Updated Page"',
+    ],
+    sideEffects: ['navigation'],
+    aliases: ['replace'],
+    category: 'navigation',
+    compatibility: 'lokascript-extension',
+  });
+
+  get metadata() {
+    return HistoryCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode>; commandName?: string },

--- a/packages/core/src/commands/navigation/scroll-to.ts
+++ b/packages/core/src/commands/navigation/scroll-to.ts
@@ -16,8 +16,8 @@ import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { isHTMLElement } from '../../utils/element-check';
 import { getVariableValue } from '../helpers/variable-access';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -33,16 +33,22 @@ export interface ScrollCommandOutput {
   smooth: boolean;
 }
 
-@meta({
-  description: 'Scroll an element into view (upstream _hyperscript 0.9.90)',
-  syntax: ['scroll to <target>', 'scroll to top of <target>', 'scroll to <target> smoothly'],
-  examples: ['scroll to #top', 'scroll to bottom of #chat', 'scroll to me smoothly'],
-  sideEffects: ['scrolling'],
-})
 @command({ name: 'scroll', category: 'navigation' })
 export class ScrollCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Scroll an element into view (upstream _hyperscript 0.9.90)',
+    syntax: ['scroll to <target>', 'scroll to top of <target>', 'scroll to <target> smoothly'],
+    examples: ['scroll to #top', 'scroll to bottom of #chat', 'scroll to me smoothly'],
+    sideEffects: ['scrolling'],
+    category: 'navigation',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return ScrollCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/templates/render.ts
+++ b/packages/core/src/commands/templates/render.ts
@@ -82,6 +82,7 @@ export class RenderCommand {
       'render template with (items: data)',
     ],
     category: 'templates',
+    compatibility: 'standard',
     sideEffects: ['dom-creation', 'template-execution'],
   });
 

--- a/packages/core/src/commands/utility/beep.ts
+++ b/packages/core/src/commands/utility/beep.ts
@@ -19,8 +19,8 @@ import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { isHTMLElement } from '../../utils/element-check';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -48,16 +48,22 @@ export interface BeepCommandOutput {
  * Before: 279 lines
  * After: ~130 lines (53% reduction)
  */
-@meta({
-  description: 'Debug output for expressions with type information',
-  syntax: ['beep!', 'beep! <expression>', 'beep! <expression>, <expression>, ...'],
-  examples: ['beep!', 'beep! myValue', 'beep! me.id, me.className'],
-  sideEffects: ['console-output', 'debugging'],
-})
 @command({ name: 'beep', category: 'utility' })
 export class BeepCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Debug output for expressions with type information',
+    syntax: ['beep!', 'beep! <expression>', 'beep! <expression>, <expression>, ...'],
+    examples: ['beep!', 'beep! myValue', 'beep! me.id, me.className'],
+    sideEffects: ['console-output', 'debugging'],
+    category: 'utility',
+    compatibility: 'lokascript-extension',
+  });
+
+  get metadata() {
+    return BeepCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/utility/breakpoint.ts
+++ b/packages/core/src/commands/utility/breakpoint.ts
@@ -16,8 +16,8 @@ import type {
 } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -28,16 +28,22 @@ export interface BreakpointCommandInput {
   _tag?: 'breakpoint';
 }
 
-@meta({
-  description: 'Drop into the debugger (emits a debugger; statement)',
-  syntax: ['breakpoint'],
-  examples: ['breakpoint', 'on click breakpoint'],
-  sideEffects: ['debugging'],
-})
 @command({ name: 'breakpoint', category: 'utility' })
 export class BreakpointCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Drop into the debugger (emits a debugger; statement)',
+    syntax: ['breakpoint'],
+    examples: ['breakpoint', 'on click breakpoint'],
+    sideEffects: ['debugging'],
+    category: 'utility',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return BreakpointCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     _raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/utility/copy.ts
+++ b/packages/core/src/commands/utility/copy.ts
@@ -15,8 +15,8 @@ import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { isHTMLElement } from '../../utils/element-check';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -46,16 +46,22 @@ export interface CopyCommandOutput {
  * Before: 312 lines
  * After: ~140 lines (55% reduction)
  */
-@meta({
-  description: 'Copy text or element content to the clipboard',
-  syntax: ['copy <source>', 'copy <source> to clipboard'],
-  examples: ['copy "Hello World"', 'copy #code-snippet', 'copy my textContent'],
-  sideEffects: ['clipboard-write', 'custom-events'],
-})
 @command({ name: 'copy', category: 'utility' })
 export class CopyCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Copy text or element content to the clipboard',
+    syntax: ['copy <source>', 'copy <source> to clipboard'],
+    examples: ['copy "Hello World"', 'copy #code-snippet', 'copy my textContent'],
+    sideEffects: ['clipboard-write', 'custom-events'],
+    category: 'utility',
+    compatibility: 'lokascript-extension',
+  });
+
+  get metadata() {
+    return CopyCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/utility/log.ts
+++ b/packages/core/src/commands/utility/log.ts
@@ -14,8 +14,8 @@ import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -42,16 +42,22 @@ export interface LogCommandOutput {
  * Before: 192 lines
  * After: ~70 lines (64% reduction)
  */
-@meta({
-  description: 'Log values to the console',
-  syntax: 'log [<values...>]',
-  examples: ['log "Hello World"', 'log me.value', 'log x y z', 'log "Result:" result'],
-  sideEffects: ['console-output'],
-})
 @command({ name: 'log', category: 'utility' })
 export class LogCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Log values to the console',
+    syntax: 'log [<values...>]',
+    examples: ['log "Hello World"', 'log me.value', 'log x y z', 'log "Result:" result'],
+    sideEffects: ['console-output'],
+    category: 'utility',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return LogCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/utility/pick.ts
+++ b/packages/core/src/commands/utility/pick.ts
@@ -21,8 +21,8 @@ import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -57,32 +57,38 @@ export interface PickCommandOutput {
   variant: PickCommandInput['variant'];
 }
 
-@meta({
-  description: 'Select from a collection (first/last/random/range/regex match)',
-  syntax: [
-    'pick first <count> of <expr>',
-    'pick last <count> of <expr>',
-    'pick random [<count>] of <expr>',
-    'pick items <i> to <j> of <expr>',
-    'pick match of <regex> from <expr>',
-    'pick from <array>',
-    'pick <item1>, <item2>, ...',
-  ],
-  examples: [
-    'pick first 3 of items',
-    'pick last 2 of items',
-    'pick random 2 of items',
-    'pick items 1 to 3 of items',
-    'pick match of "[0-9]+" from text',
-    'pick from colors',
-    'pick "red", "green", "blue"',
-  ],
-  sideEffects: ['random-selection'],
-})
 @command({ name: 'pick', category: 'utility' })
 export class PickCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Select from a collection (first/last/random/range/regex match)',
+    syntax: [
+      'pick first <count> of <expr>',
+      'pick last <count> of <expr>',
+      'pick random [<count>] of <expr>',
+      'pick items <i> to <j> of <expr>',
+      'pick match of <regex> from <expr>',
+      'pick from <array>',
+      'pick <item1>, <item2>, ...',
+    ],
+    examples: [
+      'pick first 3 of items',
+      'pick last 2 of items',
+      'pick random 2 of items',
+      'pick items 1 to 3 of items',
+      'pick match of "[0-9]+" from text',
+      'pick from colors',
+      'pick "red", "green", "blue"',
+    ],
+    sideEffects: ['random-selection'],
+    category: 'utility',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return PickCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/commands/utility/tell.ts
+++ b/packages/core/src/commands/utility/tell.ts
@@ -13,8 +13,8 @@ import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { resolveElements } from '../helpers/element-resolution';
 import {
+  commandMeta,
   command,
-  meta,
   createFactory,
   type DecoratedCommand,
   type CommandMetadata,
@@ -43,16 +43,22 @@ export interface TellCommandOutput {
  * Before: 204 lines
  * After: ~90 lines (56% reduction)
  */
-@meta({
-  description: 'Execute commands in the context of target elements',
-  syntax: ['tell <target> <command> [<command> ...]'],
-  examples: ['tell #sidebar hide', 'tell .buttons add .disabled', 'tell closest <form/> submit'],
-  sideEffects: ['context-switching', 'command-execution'],
-})
 @command({ name: 'tell', category: 'utility' })
 export class TellCommand implements DecoratedCommand {
+  static readonly metadata = commandMeta({
+    description: 'Execute commands in the context of target elements',
+    syntax: ['tell <target> <command> [<command> ...]'],
+    examples: ['tell #sidebar hide', 'tell .buttons add .disabled', 'tell closest <form/> submit'],
+    sideEffects: ['context-switching', 'command-execution'],
+    category: 'utility',
+    compatibility: 'standard',
+  });
+
+  get metadata() {
+    return TellCommand.metadata;
+  }
+
   declare readonly name: string;
-  declare readonly metadata: CommandMetadata;
 
   async parseInput(
     raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },

--- a/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
+++ b/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
@@ -1056,7 +1056,30 @@ describe('the classification debt, counted', () => {
  * emptying this set fails (measured 1 ≠ 0), and populating 58 while leaving this
  * as the whole registry fails too (measured 1 ≠ 59).
  */
-const COMPATIBILITY_UNSET = new Set<string>(REGISTRY);
+const COMPATIBILITY_UNSET = new Set<string>([]);
+
+/**
+ * Names whose served `compatibility` cannot match their own manifest side,
+ * because a SHARED implementation cannot carry two values.
+ *
+ * `unless` is the only such row in the registry, and it is structural rather
+ * than an oversight: `ConditionalCommand` is registered as both `if`
+ * (upstream → `'standard'`) and `unless` (extension → `'lokascript-extension'`),
+ * and both names resolve to the SAME instance — which is exactly how
+ * `command-adapter.ts:440` registers the alias in the first place. One object,
+ * one `compatibility`. The class carries `'standard'`, matching `if`: the
+ * primary registered name, and the upstream one.
+ *
+ * Checked against the shared groups rather than hand-listed: of the four groups,
+ * only this one straddles the upstream/extension line (`send`/`trigger` are both
+ * upstream, `push`/`replace` both extension, `decrement`/`increment` both
+ * upstream). Splitting metadata per registered name would fix it and is an
+ * architectural change, so it is pinned here the way Arc A pinned the
+ * two-category-unions disagreement rather than resolved inside a mechanical step.
+ */
+const COMPATIBILITY_ALIAS_DIVERGENCE: Record<string, { served: string; ownSide: string }> = {
+  unless: { served: 'standard', ownSide: 'lokascript-extension' },
+};
 
 /**
  * Commands deliberately marked `'experimental'`. Empty, and it must stay empty
@@ -1092,11 +1115,43 @@ describe('metadata.compatibility', () => {
     for (const [name, served] of servedCompatibility()) {
       if (served === undefined) continue; // unset rows are governed below
       if (served === 'experimental') continue; // governed by its own test
+      if (name in COMPATIBILITY_ALIAS_DIVERGENCE) continue; // shared impl, governed below
       if (served !== expectedCompatibility(name)) {
         wrong.push(`${name}: ${String(served)} (manifest projects ${expectedCompatibility(name)})`);
       }
     }
     expect(wrong).toEqual([]);
+  });
+
+  it('the alias divergences are exactly the shared groups that straddle the tier line', () => {
+    // Derived, not hand-listed: any OTHER shared implementation whose names
+    // disagree on tier would appear here and fail, so adding a consolidated
+    // alias across the line cannot pass unnoticed.
+    const straddling: string[] = [];
+    const byCtor = new Map<string, string[]>();
+    const registered = new Runtime().getRegistry();
+    for (const name of REGISTRY) {
+      const ctor = (registered.getImplementation(name) as object | undefined)?.constructor?.name;
+      if (!ctor) continue;
+      byCtor.set(ctor, [...(byCtor.get(ctor) ?? []), name]);
+    }
+    for (const names of byCtor.values()) {
+      if (names.length < 2) continue;
+      const sides = new Set(names.map(n => expectedCompatibility(n)));
+      if (sides.size > 1) {
+        // every name in the group except the one the class actually matches
+        for (const n of names) {
+          const served = servedCompatibility().get(n);
+          if (served !== expectedCompatibility(n)) straddling.push(n);
+        }
+      }
+    }
+    expect(straddling.sort()).toEqual(Object.keys(COMPATIBILITY_ALIAS_DIVERGENCE).sort());
+    // And the allowlist stays honest about WHICH way each row diverges.
+    for (const [name, { served, ownSide }] of Object.entries(COMPATIBILITY_ALIAS_DIVERGENCE)) {
+      expect(servedCompatibility().get(name), `${name} served`).toBe(served);
+      expect(expectedCompatibility(name), `${name} own side`).toBe(ownSide);
+    }
   });
 
   it('the unset rows are exactly the allowlist, both directions', () => {


### PR DESCRIPTION
Arc B step 3 (brief #823, step 1 #824, step 2 #825) — **the step where the arc's goal lands.**

All 52 decorated classes move from `@meta({…})` to `static readonly metadata = commandMeta({…})` + a `get metadata()` bridge, `category` folds into the literal, and `compatibility` is populated on all 55 literals against step 2's live gate.

## The goal, proven

`ToggleCommand.metadata.description` was **`TS2339`** before this commit and now typechecks, with `.category` narrowing to the literal `'dom'`. That invisibility was the root cause of `metadataOf()` and of script typechecking staying off for six months.

**`@meta` is now completely dead** — zero call sites, zero importers — as are `MetaConfig` and the `COMMAND_METADATA` symbol. Step 4 deletes them plus `metadataOf()`; keeping the deletion out of this diff keeps the migration reviewable.

Scriptable because the shape was uniform: all 51 files matched one canonical layout, with `swap.ts` (two decorated classes) the only structural exception.

## Two things the type system caught that `defineProperty` had hidden

**1. 18 errors, one cause.** The four base classes declared `metadata` as a `declare readonly` **property**, and a subclass may not override a property with an accessor (`TS2611`, plus `TS4114` wanting `override`) — nine subclasses. Fixed with `abstract readonly metadata: CommandMetadata`, which is also the honest declaration: the unchecked `declare` was itself the shape this arc exists to remove. Invisible before, because the runtime `defineProperty` simply shadowed it.

**2. A shared implementation cannot carry two `compatibility` values.** `ConditionalCommand` is registered as both `if` (upstream → `'standard'`) and `unless` (extension → `'lokascript-extension'`), and both resolve to the **same instance** — precisely how `command-adapter.ts:440` registers the alias. The class carries `'standard'` (matching `if`, the primary and upstream name); `unless` is pinned in §9's `COMPATIBILITY_ALIAS_DIVERGENCE`. The pin is **derived** from the shared groups, not hand-listed: of the four groups only this one straddles the tier line, so a future consolidated alias across it fails loudly. Splitting metadata per registered name is architectural — pinned, the way Arc A pinned the two category unions.

## Two gate rows moved deliberately, left as assertions rather than deleted

- Step 1 asserted the three `commandMeta` classes carry **no** `isBlocking`/`hasBody`/`version`. **Inverted** here: `commandMeta` now fills `@meta`'s defaults, because that keeps the **52** byte-identical — the larger preservation. The three gaining the fields is the cost, written down.
- `COMPATIBILITY_UNSET` goes from the whole registry to **empty** — which step 2's gate forced: populating a value correctly still failed the row-moving assertion until this set moved in the same diff.

## Verification

| Gate | Result |
| --- | --- |
| **Registry oracle diff** | **exactly the predicted 3 rows** (`install`, `pseudo-command`, `render`) on `hasBody`+`isBlocking` only. Registered count, distinct implementations, all four shared-implementation groups, every alias identity: **identical** |
| `typecheck` / `typecheck:scripts` | 0 / 0 |
| `verify:reference` | pass |
| core `test:check` | **7625 → 7629** / 106 skipped / 297 files |
| full-repo `test:check` | green (39 packages) |
| `language-server` | 227 |
| `snapshot:bundle-size` | within tolerance — slim bundles **+0.0%**, `hyperfixi-hx.js` **byte-identical at 19019** gzip (the ~980 B `MAX_HYBRID` headroom intact); full bundles +0.1% gzip for the new field |
| Playwright `src/compatibility/` | 1102 passed / 8 skipped / 10 failed — the identical known-local set, unchanged from step 1 |

## A caution worth more than the refactor

The **first** registry-oracle diff reported "0 rows changed" and was **wrong**: it iterated only the *before* row's keys, so a field that was **added** was structurally invisible. That is this arc's own central disease — a one-directional check that reads as green — reproduced inside the instrument built to catch it. Diff the **union** of both key sets. Recorded in the brief and the queue history.

## Filed, not folded in

`metadata.isBlocking`/`hasBody` publish **false claims for ≥7 commands**: `commands.json` states `wait`/`fetch` don't block and `if`/`repeat` take no body, on 40 rows with zero variance. Preserved deliberately to keep this a refactor. The queue entry notes `COMPOUND_COMMANDS` and the parser's `CommandNode.isBlocking` may already encode part of the truth, so whoever takes it shouldn't hand-author 59 rows first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)