### PR TITLE
refactor(commands): delete the @meta decorator and metadataOf(), now dead

### DIFF
--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -405,6 +405,23 @@ not the core abstractions.
 
 ## History
 
+- **2026-07-29** — **Arc B step 4a landed**: the dead surface step 3 created is
+  deleted. `meta()`, `MetaConfig`, all three module-private symbols,
+  `ClassWithSymbols` and the three dead exported getters are gone; `@command`
+  reduces to **name-only** (with `meta()` deleted nothing read `COMMAND_CATEGORY`,
+  so `CommandConfig.category` would have been a parameter accepted on 52 call
+  sites that goes nowhere — worse than duplication, because it reads as
+  authoritative); and **`metadataOf()` is deleted with the type doing its job** —
+  the docs-generator table now *requires* `readonly metadata: CommandMetadata`, so
+  a class without it is **TS2322 at compile time** where it used to be a runtime
+  throw. That is the arc's thesis paying off in the exact place that motivated it.
+  - **Two findings about the generated artifact, both for 4b.** The generator is
+    **not prettier-idempotent** — it emits unpadded markdown tables, so a fresh run
+    produced a **252-line diff that was pure column padding** (content verified
+    identical; after `prettier --write` the whole diff collapsed to one line). And
+    the `Generated:` ISO timestamp is then the *only* remaining difference, so a
+    `--check` gate diffing the whole file would fail 100% of the time. 4b must fix
+    both or the gate is unusable and regenerations will read as rewrites.
 - **2026-07-29** — **Arc B step 3 landed**: all 52 decorated classes migrated to
   `static readonly metadata = commandMeta({…})` + `get metadata()`, `@meta`
   removed from every call site, and `compatibility` populated on all 55 literals.

--- a/docs-internal/HANDOFF-command-arch-metadata.md
+++ b/docs-internal/HANDOFF-command-arch-metadata.md
@@ -551,17 +551,39 @@ deleted** so they read as decisions:
   gate forced: populating a value correctly still failed the row-moving assertion
   until this set moved in the same diff.
 
-**Registry oracle diff — exactly the predicted 3 rows.** `install`,
-`pseudo-command`, `render`, on `hasBody`+`isBlocking` only. Registered count,
-distinct implementations, all four shared-implementation groups, and every alias
-identity: **identical**.
+**Registry oracle diff.** Two intended changes, and PR #826's description stated
+only the first — corrected here, since this file is the durable record:
 
-> **A caution earned the hard way in this step.** The first oracle diff reported
-> **0 rows changed** and was WRONG — it iterated only the *before* row's keys, so
-> a field that was **added** was structurally invisible. That is this arc's own
-> central disease (a one-directional check that reads as green) reproduced in the
-> verification instrument itself. Diff the **union** of both key sets. The
-> corrected diff found the 3 rows immediately.
+1. **3 rows on `hasBody`+`isBlocking`** — `install`, `pseudo-command`, `render`,
+   from `commandMeta` gaining the defaults. This was the predicted diff.
+2. **59 rows gaining `compatibility`** — the population itself, which is the whole
+   point of the step and is gated by §9. The #826 text said the diff was "exactly
+   the predicted 3 rows" because the oracle snapshot behind that sentence was
+   taken **before** the population ran, so it was measuring the migration alone.
+   The claim was true of what it measured and incomplete about the step.
+
+Registered count, distinct implementations, all four shared-implementation groups,
+and every alias identity: **identical**.
+
+> **Two cautions about the oracle itself, both earned here. The instrument needed
+> more debugging than the migration did.**
+>
+> **1. Diff the UNION of both key sets.** The first diff reported **0 rows
+> changed** and was WRONG: it iterated only the *before* row's keys, so a field
+> that was **added** was structurally invisible. That is this arc's own central
+> disease — a one-directional check that reads as green — reproduced inside the
+> instrument built to catch it. The corrected diff found the 3 rows immediately.
+>
+> **2. Take the baseline from the merged parent commit.** A snapshot is only a
+> baseline for the tree that produced it. Step 4a diffed against a step-3 snapshot
+> taken mid-step and showed **59** changed rows; against merged `main` the same
+> code showed **0**, which is the true answer for a pure deletion. A mid-step
+> baseline silently folds the earlier step's unfinished work into the later step's
+> diff.
+>
+> Note the two interact usefully: 4a's `0` is trustworthy *because* the same
+> instrument had just produced a non-zero result on a different comparison. A gate
+> that has never been seen to fail is not known to work.
 
 - Registry oracle diff is the behaviour-preservation instrument. Names, classes,
   aliases, categories, shared-implementation groups, and both metadata-presence
@@ -583,13 +605,55 @@ identity: **identical**.
   change**, because a class field is reachable differently from a
   `defineProperty` side effect and could defeat the shaking that keeps them out.
 
-**Step 4 — retire the workarounds, then the prose.** With the static visible:
-delete `metadataOf()`; delete the three dead exported getters; consider narrowing
-the adapter's shadow `CommandMetadata` (F-B1, and settle :421's fate). Then the
-prose half — completeness tests for `reference/index.ts` and `lsp-metadata.ts`
-first (cheap), then `generate-command-docs.ts`'s 43-entry table replaced by the
-manifest plus a factory map (F-B3), an npm script, and `--check` in CI on the
-idempotent-generator pattern from #793.
+**Step 4 splits**, following Arc A's own 4.1–4.4 precedent: the deletions are
+mechanical and verifiable, the prose half is a different kind of work.
+
+**Step 4a — retire the dead surface — ✅ DONE.** Step 3 made all of this dead;
+this deletes it.
+
+- `meta()`, `MetaConfig`, all three module-private symbols (`COMMAND_NAME`,
+  `COMMAND_CATEGORY`, `COMMAND_METADATA`), `ClassWithSymbols`, and the three dead
+  exported getters — gone.
+- **`@command` reduces to name-only.** With `meta()` deleted, nothing read
+  `COMMAND_CATEGORY`, so `CommandConfig.category` would have been a parameter
+  accepted on 52 call sites that goes nowhere — worse than duplication, because it
+  reads as authoritative. Removed from the interface and from every call site;
+  `@command`'s only job is now the prototype `name` it advertises. The category
+  lives in the class's own literal, where §7 already gates it against the manifest.
+- **`metadataOf()` deleted, and the type now does its job.** `CommandClass` in
+  `scripts/generate-command-docs.ts` became
+  `(abstract new (...args: never[]) => object) & { readonly metadata: CommandMetadata }`,
+  so the table simply *requires* the static. Mutation-verified: adding a class with
+  no metadata is now **`TS2322` at compile time** where it used to be a runtime
+  throw. That is the arc's thesis paying off in the exact place that motivated it.
+
+**Two findings for 4b, both about the generated artifact:**
+
+1. **The generator is not prettier-idempotent.** It emits unpadded markdown
+   tables; the committed `REFERENCE.md` is prettier-formatted, so a fresh run
+   produces a **252-line diff that is pure column padding**. Content was verified
+   identical — after `prettier --write` the entire diff collapsed to one line.
+   This is the exact failure mode #793 fixed elsewhere and the reason
+   "prettier-idempotent generators" is in the design principles. **4b must make the
+   generator emit prettier-formatted output**, or every regeneration will look like
+   a rewrite and reviewers will stop reading it.
+2. **The `Generated:` timestamp defeats a naive `--check` gate.** After padding is
+   accounted for, the *only* remaining diff is
+   `> Generated: <ISO timestamp>` — which changes on every run. A `--check` that
+   diffs the whole file would fail 100% of the time. 4b must either drop the
+   timestamp or exclude it from the comparison.
+
+`commands.json` was deliberately NOT regenerated here: it still lacks the
+`compatibility` field the metadata now carries, which is 4b's business along with
+the `--check` gate. Regenerating it in 4a would have shipped an artifact change
+with no gate to keep it honest.
+
+**Step 4b — the prose (NOT started).** Completeness tests for
+`reference/index.ts` and `lsp-metadata.ts` first (cheap), then
+`generate-command-docs.ts`'s 43-entry table replaced by the manifest plus a
+factory map (F-B3 — it is 16 commands short and gated by nothing), an npm script,
+and `--check` in CI, honouring both findings above. Also still open from F-B1:
+narrowing the adapter's shadow `CommandMetadata` and settling `:421`'s fate.
 
 ## Gate couplings that must move in the same diff
 

--- a/packages/core/scripts/generate-command-docs.ts
+++ b/packages/core/scripts/generate-command-docs.ts
@@ -83,31 +83,25 @@ import { InstallCommand } from '../src/commands/behaviors/install';
 // ============================================================================
 
 /**
- * A `@command`/`@meta`-decorated command class.
+ * A command class carrying its metadata as a type-visible static.
  *
- * `@meta` attaches `metadata` as a STATIC property at runtime, via
- * `Object.defineProperty` (see commands/decorators/index.ts). A class decorator
- * that returns the original class cannot widen its type, so TypeScript never
- * sees that static — which is why this table cannot be typed as
- * `{ metadata: CommandMetadata }` directly. `metadataOf()` is the single place
- * that asserts the runtime contract, and it checks rather than assumes.
+ * Arc B step 3 replaced `@meta`'s runtime `Object.defineProperty` with
+ * `static readonly metadata = commandMeta({...})`, so TypeScript now SEES the
+ * static and this table can simply require it. Before that it could not: a class
+ * decorator returning the original class cannot widen its type, so every read was
+ * `TS2339` and a runtime `metadataOf()` assertion stood in for the type — which is
+ * also why script typechecking stayed off for six months. Both are gone.
+ *
+ * `metadata.category` is the class's own declared category; there is no second
+ * copy on `@command` to disagree with it any more.
  */
-type CommandClass = abstract new (...args: never[]) => object;
+type CommandClass = (abstract new (...args: never[]) => object) & {
+  readonly metadata: CommandMetadata;
+};
 
 interface CommandEntry {
   name: string;
   class: CommandClass;
-}
-
-/** Read a decorated class's static metadata, failing loudly if @meta is absent. */
-function metadataOf(entry: CommandEntry): CommandMetadata {
-  const metadata = (entry.class as unknown as { metadata?: CommandMetadata }).metadata;
-  if (!metadata) {
-    throw new Error(
-      `Command '${entry.name}' has no static metadata — is the @meta decorator applied to ${entry.class.name}?`
-    );
-  }
-  return metadata;
 }
 
 const COMMANDS: CommandEntry[] = [
@@ -217,7 +211,7 @@ function generateMarkdown(commands: CommandEntry[]): string {
   lines.push('## Table of Contents');
   lines.push('');
   for (const category of COMMAND_CATEGORIES) {
-    const categoryCommands = commands.filter((c) => metadataOf(c).category === category);
+    const categoryCommands = commands.filter(c => c.class.metadata.category === category);
     if (categoryCommands.length === 0) continue;
     lines.push(`- [${CATEGORY_NAMES[category]} Commands](#${category}-commands)`);
   }
@@ -229,7 +223,7 @@ function generateMarkdown(commands: CommandEntry[]): string {
   lines.push('| Command | Category | Description |');
   lines.push('|---------|----------|-------------|');
   for (const cmd of commands.sort((a, b) => a.name.localeCompare(b.name))) {
-    const meta = metadataOf(cmd);
+    const meta = cmd.class.metadata;
     const desc = meta.description.split('.')[0] + '.'; // First sentence
     lines.push(`| \`${cmd.name}\` | ${meta.category} | ${desc} |`);
   }
@@ -237,14 +231,14 @@ function generateMarkdown(commands: CommandEntry[]): string {
 
   // Commands by category
   for (const category of COMMAND_CATEGORIES) {
-    const categoryCommands = commands.filter((c) => metadataOf(c).category === category);
+    const categoryCommands = commands.filter(c => c.class.metadata.category === category);
     if (categoryCommands.length === 0) continue;
 
     lines.push(`## ${CATEGORY_NAMES[category]} Commands`);
     lines.push('');
 
     for (const cmd of categoryCommands.sort((a, b) => a.name.localeCompare(b.name))) {
-      const meta = metadataOf(cmd);
+      const meta = cmd.class.metadata;
 
       lines.push(`### ${cmd.name}`);
       lines.push('');
@@ -373,11 +367,11 @@ function generateJSON(commands: CommandEntry[]): string {
     categories: COMMAND_CATEGORIES,
     sideEffects: COMMAND_SIDE_EFFECTS,
     commands: Object.fromEntries(
-      commands.map((cmd) => [
+      commands.map(cmd => [
         cmd.name,
         {
-          ...metadataOf(cmd),
-          syntax: getSyntaxArray(metadataOf(cmd)),
+          ...cmd.class.metadata,
+          syntax: getSyntaxArray(cmd.class.metadata),
         },
       ])
     ),
@@ -390,12 +384,8 @@ function generateJSON(commands: CommandEntry[]): string {
 // ============================================================================
 
 const args = process.argv.slice(2);
-const format = args.includes('--format')
-  ? args[args.indexOf('--format') + 1]
-  : 'markdown';
-const outputDir = args.includes('--output')
-  ? args[args.indexOf('--output') + 1]
-  : 'docs/commands';
+const format = args.includes('--format') ? args[args.indexOf('--format') + 1] : 'markdown';
+const outputDir = args.includes('--output') ? args[args.indexOf('--output') + 1] : 'docs/commands';
 const toStdout = args.includes('--stdout');
 
 // Generate content
@@ -423,5 +413,5 @@ if (toStdout) {
   console.log(`✓ Generated ${filePath}`);
   console.log(`  Format: ${format}`);
   console.log(`  Commands: ${COMMANDS.length}`);
-  console.log(`  Categories: ${new Set(COMMANDS.map((c) => metadataOf(c).category)).size}`);
+  console.log(`  Categories: ${new Set(COMMANDS.map(c => c.class.metadata.category)).size}`);
 }

--- a/packages/core/src/commands/advanced/async.ts
+++ b/packages/core/src/commands/advanced/async.ts
@@ -47,7 +47,7 @@ export interface AsyncCommandOutput {
  * Before: 233 lines
  * After: ~150 lines (36% reduction)
  */
-@command({ name: 'async', category: 'advanced' })
+@command({ name: 'async' })
 export class AsyncCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Execute commands asynchronously without blocking',

--- a/packages/core/src/commands/advanced/js.ts
+++ b/packages/core/src/commands/advanced/js.ts
@@ -40,7 +40,7 @@ export interface JsCommandOutput {
  * Before: 241 lines
  * After: ~160 lines (34% reduction)
  */
-@command({ name: 'js', category: 'advanced' })
+@command({ name: 'js' })
 export class JsCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Execute inline JavaScript code with access to hyperscript context',

--- a/packages/core/src/commands/animation/measure.ts
+++ b/packages/core/src/commands/animation/measure.ts
@@ -45,7 +45,7 @@ export interface MeasureCommandOutput {
  * Before: 376 lines
  * After: ~180 lines (52% reduction)
  */
-@command({ name: 'measure', category: 'animation' })
+@command({ name: 'measure' })
 export class MeasureCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Measure DOM element dimensions, positions, and properties',

--- a/packages/core/src/commands/animation/settle.ts
+++ b/packages/core/src/commands/animation/settle.ts
@@ -53,7 +53,7 @@ export interface SettleCommandOutput {
  * Before: 191 lines
  * After: ~120 lines (37% reduction)
  */
-@command({ name: 'settle', category: 'animation' })
+@command({ name: 'settle' })
 export class SettleCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Wait for CSS transitions and animations to complete',

--- a/packages/core/src/commands/animation/start-view-transition.ts
+++ b/packages/core/src/commands/animation/start-view-transition.ts
@@ -49,7 +49,7 @@ export interface StartViewTransitionOutput {
   commandsExecuted: number;
 }
 
-@command({ name: 'start', category: 'animation' })
+@command({ name: 'start' })
 export class StartViewTransitionCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Wrap a block of commands in document.startViewTransition()',

--- a/packages/core/src/commands/animation/take.ts
+++ b/packages/core/src/commands/animation/take.ts
@@ -39,7 +39,7 @@ export interface TakeCommandOutput {
  * Before: 406 lines
  * After: ~180 lines (56% reduction)
  */
-@command({ name: 'take', category: 'animation' })
+@command({ name: 'take' })
 export class TakeCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Move classes, attributes, and properties from one element to another',

--- a/packages/core/src/commands/animation/transition.ts
+++ b/packages/core/src/commands/animation/transition.ts
@@ -54,7 +54,7 @@ export interface TransitionCommandOutput {
  * Before: 250 lines
  * After: ~130 lines (48% reduction)
  */
-@command({ name: 'transition', category: 'animation' })
+@command({ name: 'transition' })
 export class TransitionCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Animate CSS properties using CSS transitions',

--- a/packages/core/src/commands/async/fetch.ts
+++ b/packages/core/src/commands/async/fetch.ts
@@ -150,7 +150,7 @@ export interface FetchCommandOutput {
  * Before: 640 lines
  * After: ~250 lines (61% reduction)
  */
-@command({ name: 'fetch', category: 'async' })
+@command({ name: 'fetch' })
 export class FetchCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Make HTTP requests with lifecycle event support',

--- a/packages/core/src/commands/async/wait.ts
+++ b/packages/core/src/commands/async/wait.ts
@@ -51,7 +51,7 @@ export interface WaitCommandOutput {
  * Before: 650 lines
  * After: ~280 lines (57% reduction)
  */
-@command({ name: 'wait', category: 'async' })
+@command({ name: 'wait' })
 export class WaitCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Wait for time delay, event, or race condition',

--- a/packages/core/src/commands/content/append.ts
+++ b/packages/core/src/commands/content/append.ts
@@ -21,7 +21,7 @@ import { commandMeta, command, createFactory, type CommandMetadata } from '../de
 export type AppendCommandInput = InsertionCommandInput;
 export type AppendCommandOutput = InsertionCommandOutput;
 
-@command({ name: 'append', category: 'content' })
+@command({ name: 'append' })
 export class AppendCommand extends ContentInsertionCommand {
   static readonly metadata = commandMeta({
     description: 'Add content to the end of a string, array, Set, or HTML element',

--- a/packages/core/src/commands/content/prepend.ts
+++ b/packages/core/src/commands/content/prepend.ts
@@ -24,7 +24,7 @@ import { commandMeta, command, createFactory, type CommandMetadata } from '../de
 export type PrependCommandInput = InsertionCommandInput;
 export type PrependCommandOutput = InsertionCommandOutput;
 
-@command({ name: 'prepend', category: 'content' })
+@command({ name: 'prepend' })
 export class PrependCommand extends ContentInsertionCommand {
   static readonly metadata = commandMeta({
     description: 'Add content to the start of a string, array, Set, or HTML element',

--- a/packages/core/src/commands/control-flow/break.ts
+++ b/packages/core/src/commands/control-flow/break.ts
@@ -20,7 +20,7 @@ export interface BreakCommandOutput {
 /**
  * BreakCommand - Exits from the current loop
  */
-@command({ name: 'break', category: 'control-flow' })
+@command({ name: 'break' })
 export class BreakCommand extends ControlFlowSignalBase {
   static readonly metadata = commandMeta({
     description: 'Exit from the current loop (repeat, for, while, until)',

--- a/packages/core/src/commands/control-flow/continue.ts
+++ b/packages/core/src/commands/control-flow/continue.ts
@@ -20,7 +20,7 @@ export interface ContinueCommandOutput {
 /**
  * ContinueCommand - Skips to next loop iteration
  */
-@command({ name: 'continue', category: 'control-flow' })
+@command({ name: 'continue' })
 export class ContinueCommand extends ControlFlowSignalBase {
   static readonly metadata = commandMeta({
     description: 'Skip to the next iteration of the current loop',

--- a/packages/core/src/commands/control-flow/exit.ts
+++ b/packages/core/src/commands/control-flow/exit.ts
@@ -27,7 +27,7 @@ export interface ExitCommandOutput {
 /**
  * ExitCommand - Exits from event handler
  */
-@command({ name: 'exit', category: 'control-flow' })
+@command({ name: 'exit' })
 export class ExitCommand extends ControlFlowSignalBase {
   static readonly metadata = commandMeta({
     description: 'Immediately terminate execution of the current event handler or behavior',

--- a/packages/core/src/commands/control-flow/halt.ts
+++ b/packages/core/src/commands/control-flow/halt.ts
@@ -42,7 +42,7 @@ export interface HaltCommandOutput {
  * Before: 216 lines
  * After: ~100 lines (54% reduction)
  */
-@command({ name: 'halt', category: 'control-flow' })
+@command({ name: 'halt' })
 export class HaltCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Stop command execution or prevent event defaults',

--- a/packages/core/src/commands/control-flow/if.ts
+++ b/packages/core/src/commands/control-flow/if.ts
@@ -67,7 +67,7 @@ export interface IfCommandOutput extends ConditionalCommandOutput {}
  * - 'if' mode: executes then-branch when condition is TRUE
  * - 'unless' mode: executes then-branch when condition is FALSE
  */
-@command({ name: 'if', category: 'control-flow' })
+@command({ name: 'if' })
 export class ConditionalCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Conditional execution based on boolean expressions',

--- a/packages/core/src/commands/control-flow/repeat.ts
+++ b/packages/core/src/commands/control-flow/repeat.ts
@@ -64,7 +64,7 @@ export interface RepeatCommandOutput {
   interrupted?: boolean;
 }
 
-@command({ name: 'repeat', category: 'control-flow' })
+@command({ name: 'repeat' })
 export class RepeatCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description:

--- a/packages/core/src/commands/control-flow/return.ts
+++ b/packages/core/src/commands/control-flow/return.ts
@@ -41,7 +41,7 @@ export interface ReturnCommandOutput {
  * Before: 152 lines
  * After: ~65 lines (57% reduction)
  */
-@command({ name: 'return', category: 'control-flow' })
+@command({ name: 'return' })
 export class ReturnCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Return a value from a command sequence or function, terminating execution',

--- a/packages/core/src/commands/control-flow/throw.ts
+++ b/packages/core/src/commands/control-flow/throw.ts
@@ -39,7 +39,7 @@ export interface ThrowCommandOutput {
  * Before: 143 lines
  * After: ~60 lines (58% reduction)
  */
-@command({ name: 'throw', category: 'control-flow' })
+@command({ name: 'throw' })
 export class ThrowCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Throw an error with a specified message',

--- a/packages/core/src/commands/data/clear.ts
+++ b/packages/core/src/commands/data/clear.ts
@@ -43,7 +43,7 @@ function isFormFieldElement(
   return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
 }
 
-@command({ name: 'clear', category: 'data' })
+@command({ name: 'clear' })
 export class ClearCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description:

--- a/packages/core/src/commands/data/default.ts
+++ b/packages/core/src/commands/data/default.ts
@@ -52,7 +52,7 @@ export interface DefaultCommandOutput {
   targetType: 'variable' | 'attribute' | 'property' | 'element';
 }
 
-@command({ name: 'default', category: 'data' })
+@command({ name: 'default' })
 export class DefaultCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: "Set a value only if it doesn't already exist",

--- a/packages/core/src/commands/data/get.ts
+++ b/packages/core/src/commands/data/get.ts
@@ -40,7 +40,7 @@ export interface GetCommandOutput {
  * Before: 160 lines
  * After: ~65 lines (59% reduction)
  */
-@command({ name: 'get', category: 'data' })
+@command({ name: 'get' })
 export class GetCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Evaluate an expression and store the result in it',

--- a/packages/core/src/commands/data/increment.ts
+++ b/packages/core/src/commands/data/increment.ts
@@ -49,7 +49,7 @@ export type { NumericTargetInput as DecrementCommandInput };
  * Consolidates IncrementCommand and DecrementCommand into single implementation.
  * Registered under both 'increment' and 'decrement' names via aliases.
  */
-@command({ name: 'increment', category: 'data' })
+@command({ name: 'increment' })
 export class NumericModifyCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Modify a variable or property by a specified amount (default: 1)',

--- a/packages/core/src/commands/data/set.ts
+++ b/packages/core/src/commands/data/set.ts
@@ -94,7 +94,7 @@ function toSetInput(target: WriteTarget, value: unknown): SetCommandInput {
   }
 }
 
-@command({ name: 'set', category: 'data' })
+@command({ name: 'set' })
 export class SetCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Set values to variables, attributes, or properties',

--- a/packages/core/src/commands/decorators/index.ts
+++ b/packages/core/src/commands/decorators/index.ts
@@ -9,7 +9,7 @@
  *
  * @example
  * ```typescript
- * @command({ name: 'increment', category: 'data' })
+ * @command({ name: 'increment' })
  * @meta({
  *   description: 'Increment a variable',
  *   syntax: 'increment <target>',
@@ -37,34 +37,7 @@ import type {
 export interface CommandConfig {
   /** Command name as used in hyperscript */
   name: string;
-  /** Command category */
-  category: CommandCategory;
 }
-
-/**
- * Simplified metadata for the @meta decorator (excludes category which is in @command)
- */
-export interface MetaConfig {
-  description: string;
-  syntax: string | readonly string[];
-  examples: readonly string[];
-  sideEffects?: readonly CommandSideEffect[];
-  deprecated?: boolean;
-  deprecationMessage?: string;
-  aliases?: readonly string[];
-  relatedCommands?: readonly string[];
-  isBlocking?: boolean;
-  hasBody?: boolean;
-  /** @see CommandMetadata.compatibility */
-  compatibility?: 'standard' | 'lokascript-extension' | 'experimental';
-}
-
-/**
- * Symbol keys for storing decorator data
- */
-const COMMAND_NAME = Symbol('command:name');
-const COMMAND_CATEGORY = Symbol('command:category');
-const COMMAND_METADATA = Symbol('command:metadata');
 
 /**
  * Interface for decorated command classes
@@ -73,15 +46,6 @@ export interface DecoratedCommand {
   readonly name: string;
   readonly metadata: CommandMetadata;
 }
-
-/**
- * Type for class constructors with symbol properties
- */
-type ClassWithSymbols = {
-  [COMMAND_NAME]?: string;
-  [COMMAND_CATEGORY]?: CommandCategory;
-  [COMMAND_METADATA]?: CommandMetadata;
-};
 
 // ============================================================================
 // @command Decorator
@@ -96,7 +60,7 @@ type ClassWithSymbols = {
  *
  * @example
  * ```typescript
- * @command({ name: 'increment', category: 'data' })
+ * @command({ name: 'increment' })
  * class IncrementCommand { ... }
  * ```
  */
@@ -105,96 +69,11 @@ export function command(config: CommandConfig) {
     target: T,
     context: ClassDecoratorContext
   ): T | void {
-    // Store config on class for later use
-    const targetWithSymbols = target as T & ClassWithSymbols;
-    targetWithSymbols[COMMAND_NAME] = config.name;
-    targetWithSymbols[COMMAND_CATEGORY] = config.category;
-
     // Add name property to prototype
     Object.defineProperty(target.prototype, 'name', {
       value: config.name,
       writable: false,
       enumerable: true,
-    });
-
-    // Return undefined to keep original class (mutated)
-    return;
-  };
-}
-
-// ============================================================================
-// @meta Decorator
-// ============================================================================
-
-/**
- * Class decorator that sets command metadata.
- *
- * Adds:
- * - static `metadata` property
- * - instance `metadata` getter
- *
- * Must be used after @command to access category.
- *
- * @example
- * ```typescript
- * @command({ name: 'increment', category: 'data' })
- * @meta({
- *   description: 'Increment a variable or property',
- *   syntax: 'increment <target> [by <amount>]',
- *   examples: ['increment counter', 'increment counter by 5'],
- * })
- * class IncrementCommand { ... }
- * ```
- */
-export function meta(config: MetaConfig) {
-  return function <T extends new (...args: unknown[]) => object>(
-    target: T,
-    context: ClassDecoratorContext
-  ): T | void {
-    // Build full metadata (category comes from @command decorator)
-    const targetWithSymbols = target as T & ClassWithSymbols;
-    const category = targetWithSymbols[COMMAND_CATEGORY];
-
-    if (!category) {
-      throw new Error(
-        `@meta decorator requires @command decorator to be applied first on ${target.name}`
-      );
-    }
-
-    const fullMetadata: CommandMetadata = {
-      description: config.description,
-      syntax: config.syntax,
-      examples: config.examples,
-      category,
-      sideEffects: config.sideEffects,
-      deprecated: config.deprecated,
-      deprecationMessage: config.deprecationMessage,
-      aliases: config.aliases,
-      relatedCommands: config.relatedCommands,
-      isBlocking: config.isBlocking ?? false,
-      hasBody: config.hasBody ?? false,
-      version: '1.0.0',
-      compatibility: config.compatibility,
-    };
-
-    // Store on class
-    targetWithSymbols[COMMAND_METADATA] = fullMetadata;
-
-    // Add static metadata property
-    Object.defineProperty(target, 'metadata', {
-      value: fullMetadata,
-      writable: false,
-      enumerable: true,
-      configurable: false,
-    });
-
-    // Add instance metadata getter via prototype
-    Object.defineProperty(target.prototype, 'metadata', {
-      get() {
-        return fullMetadata;
-      },
-      enumerable: true,
-      configurable: false,
     });
 
     // Return undefined to keep original class (mutated)
@@ -231,10 +110,11 @@ export type CommandMetaInput = Omit<CommandMetadata, 'version'> & {
  * `@meta` installs `metadata` with `Object.defineProperty`, and a class
  * decorator that returns the original class cannot widen its type — so
  * TypeScript never sees the static. That invisibility (not a lack of
- * validation) is the defect: `meta(config: MetaConfig)` already type-checks
- * the literal passed to it, but `SomeCommand.metadata` is `TS2339` at every
- * read, which is why `scripts/generate-command-docs.ts` needs a runtime
+ * validation) was the defect: the now-deleted `@meta` decorator DID type-check
+ * the literal passed to it, but `SomeCommand.metadata` was `TS2339` at every
+ * read — which is why `scripts/generate-command-docs.ts` needed a runtime
  * `metadataOf()` assertion and why script typechecking stayed off for months.
+ * Both are gone as of Arc B step 4.
  *
  * The classes this replaces used a bare `as const`, which has the mirror-image
  * problem: the static is visible but validated by **nothing**. Measured before
@@ -280,41 +160,11 @@ export function commandMeta<const T extends CommandMetaInput>(metadata: T) {
 // ============================================================================
 
 /**
- * Get command name from a decorated class
- */
-export function getCommandName<T extends new (...args: unknown[]) => object>(
-  target: T
-): string | undefined {
-  const targetWithSymbols = target as T & ClassWithSymbols;
-  return targetWithSymbols[COMMAND_NAME];
-}
-
-/**
- * Get command category from a decorated class
- */
-export function getCommandCategory<T extends new (...args: unknown[]) => object>(
-  target: T
-): CommandCategory | undefined {
-  const targetWithSymbols = target as T & ClassWithSymbols;
-  return targetWithSymbols[COMMAND_CATEGORY];
-}
-
-/**
- * Get command metadata from a decorated class
- */
-export function getCommandMetadata<T extends new (...args: unknown[]) => object>(
-  target: T
-): CommandMetadata | undefined {
-  const targetWithSymbols = target as T & ClassWithSymbols;
-  return targetWithSymbols[COMMAND_METADATA];
-}
-
-/**
  * Create a factory function for a command class
  *
  * @example
  * ```typescript
- * @command({ name: 'increment', category: 'data' })
+ * @command({ name: 'increment' })
  * @meta({ ... })
  * class IncrementCommand { ... }
  *

--- a/packages/core/src/commands/dom/add.ts
+++ b/packages/core/src/commands/dom/add.ts
@@ -50,7 +50,7 @@ export type AddCommandInput =
 /**
  * AddCommand - Adds classes, attributes, or styles to elements
  */
-@command({ name: 'add', category: 'dom' })
+@command({ name: 'add' })
 export class AddCommand extends DOMModificationBase {
   static readonly metadata = commandMeta({
     description: 'Add CSS classes, attributes, or styles to elements',

--- a/packages/core/src/commands/dom/close.ts
+++ b/packages/core/src/commands/dom/close.ts
@@ -44,7 +44,7 @@ function isPopoverElement(el: HTMLElement): boolean {
   return el.hasAttribute('popover');
 }
 
-@command({ name: 'close', category: 'dom' })
+@command({ name: 'close' })
 export class CloseCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Close a dialog, details element, or popover',

--- a/packages/core/src/commands/dom/empty.ts
+++ b/packages/core/src/commands/dom/empty.ts
@@ -30,7 +30,7 @@ export interface EmptyCommandInput {
   targets: HTMLElement[];
 }
 
-@command({ name: 'empty', category: 'dom' })
+@command({ name: 'empty' })
 export class EmptyCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Remove all children from an element (sets innerHTML to empty)',

--- a/packages/core/src/commands/dom/hide.ts
+++ b/packages/core/src/commands/dom/hide.ts
@@ -21,7 +21,7 @@ export type HideCommandInput = VisibilityInput;
 /**
  * HideCommand - Hides elements
  */
-@command({ name: 'hide', category: 'dom' })
+@command({ name: 'hide' })
 export class HideCommand extends VisibilityCommandBase {
   static readonly metadata = commandMeta({
     description: 'Hide elements by setting display to none',

--- a/packages/core/src/commands/dom/make.ts
+++ b/packages/core/src/commands/dom/make.ts
@@ -178,7 +178,7 @@ async function resolveVariableName(
   return typeof value === 'string' ? value : undefined;
 }
 
-@command({ name: 'make', category: 'dom' })
+@command({ name: 'make' })
 export class MakeCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Create DOM elements or class instances',

--- a/packages/core/src/commands/dom/open.ts
+++ b/packages/core/src/commands/dom/open.ts
@@ -79,7 +79,7 @@ function isPopoverElement(el: HTMLElement): boolean {
   return el.hasAttribute('popover');
 }
 
-@command({ name: 'open', category: 'dom' })
+@command({ name: 'open' })
 export class OpenCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Open a dialog, details element, or popover',

--- a/packages/core/src/commands/dom/process-partials.ts
+++ b/packages/core/src/commands/dom/process-partials.ts
@@ -209,7 +209,7 @@ export function processPartials(html: string, morphOptions?: MorphOptions): Proc
  * Before: ~130 lines (builder pattern section)
  * After: ~100 lines (decorator pattern)
  */
-@command({ name: 'process', category: 'dom' })
+@command({ name: 'process' })
 export class ProcessPartialsCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Process <hx-partial> elements for multi-target swaps',

--- a/packages/core/src/commands/dom/put.ts
+++ b/packages/core/src/commands/dom/put.ts
@@ -56,7 +56,7 @@ export interface PutCommandInput {
  * Before: 562 lines
  * After: ~250 lines (56% reduction)
  */
-@command({ name: 'put', category: 'dom' })
+@command({ name: 'put' })
 export class PutCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Insert content into elements or properties',

--- a/packages/core/src/commands/dom/remove.ts
+++ b/packages/core/src/commands/dom/remove.ts
@@ -55,7 +55,7 @@ export type RemoveCommandInput =
 /**
  * RemoveCommand - Removes classes, attributes, styles, or elements
  */
-@command({ name: 'remove', category: 'dom' })
+@command({ name: 'remove' })
 export class RemoveCommand extends DOMModificationBase {
   static readonly metadata = commandMeta({
     description: 'Remove CSS classes, attributes, styles, or elements from the DOM',

--- a/packages/core/src/commands/dom/reset.ts
+++ b/packages/core/src/commands/dom/reset.ts
@@ -33,7 +33,7 @@ function isFormElement(el: HTMLElement): el is HTMLFormElement {
   return el.tagName === 'FORM';
 }
 
-@command({ name: 'reset', category: 'dom' })
+@command({ name: 'reset' })
 export class ResetCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Reset a <form> element to its default values (HTMLFormElement.reset())',

--- a/packages/core/src/commands/dom/select.ts
+++ b/packages/core/src/commands/dom/select.ts
@@ -37,7 +37,7 @@ function isTextFieldElement(el: HTMLElement): el is HTMLInputElement | HTMLTextA
   return tag === 'INPUT' || tag === 'TEXTAREA';
 }
 
-@command({ name: 'select', category: 'dom' })
+@command({ name: 'select' })
 export class SelectCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Select the contents of a text field, or select the contents of a DOM element',

--- a/packages/core/src/commands/dom/show.ts
+++ b/packages/core/src/commands/dom/show.ts
@@ -22,7 +22,7 @@ export interface ShowCommandInput extends VisibilityCommandInput {
 /**
  * ShowCommand - Restores element visibility
  */
-@command({ name: 'show', category: 'dom' })
+@command({ name: 'show' })
 export class ShowCommand extends VisibilityCommandBase {
   static readonly metadata = commandMeta({
     description: 'Show elements by restoring display property',

--- a/packages/core/src/commands/dom/swap.ts
+++ b/packages/core/src/commands/dom/swap.ts
@@ -95,7 +95,7 @@ async function resolveTargets(
  * Before: ~210 lines (builder pattern section)
  * After: ~200 lines (decorator pattern)
  */
-@command({ name: 'swap', category: 'dom' })
+@command({ name: 'swap' })
 export class SwapCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Swap content into target elements with intelligent morphing support',
@@ -365,7 +365,7 @@ export class SwapCommand implements DecoratedCommand {
  * Before: ~90 lines (builder pattern section)
  * After: ~80 lines (decorator pattern)
  */
-@command({ name: 'morph', category: 'dom' })
+@command({ name: 'morph' })
 export class MorphCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Morph content into target elements (intelligent diffing, preserves state)',

--- a/packages/core/src/commands/dom/toggle.ts
+++ b/packages/core/src/commands/dom/toggle.ts
@@ -176,7 +176,7 @@ function detectExpressionType(
   return { type: 'class', expression: '' };
 }
 
-@command({ name: 'toggle', category: 'dom' })
+@command({ name: 'toggle' })
 export class ToggleCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Toggle classes, attributes, or interactive elements',

--- a/packages/core/src/commands/events/trigger.ts
+++ b/packages/core/src/commands/events/trigger.ts
@@ -54,7 +54,7 @@ export type SendCommandInput = Omit<EventDispatchInput, 'mode'>;
  * Consolidates TriggerCommand and SendCommand into single implementation.
  * Registered under both 'trigger' and 'send' names via aliases.
  */
-@command({ name: 'trigger', category: 'event' })
+@command({ name: 'trigger' })
 export class EventDispatchCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Dispatch events on elements',

--- a/packages/core/src/commands/execution/blur.ts
+++ b/packages/core/src/commands/execution/blur.ts
@@ -30,7 +30,7 @@ export interface BlurCommandInput {
   targets: HTMLElement[];
 }
 
-@command({ name: 'blur', category: 'execution' })
+@command({ name: 'blur' })
 export class BlurCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Remove focus from an element (calls HTMLElement.blur())',

--- a/packages/core/src/commands/execution/call.ts
+++ b/packages/core/src/commands/execution/call.ts
@@ -41,7 +41,7 @@ export interface CallCommandOutput {
  * Before: 238 lines
  * After: ~85 lines (64% reduction)
  */
-@command({ name: 'call', category: 'execution' })
+@command({ name: 'call' })
 export class CallCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Evaluate an expression and store the result in the it variable',

--- a/packages/core/src/commands/execution/focus.ts
+++ b/packages/core/src/commands/execution/focus.ts
@@ -30,7 +30,7 @@ export interface FocusCommandInput {
   targets: HTMLElement[];
 }
 
-@command({ name: 'focus', category: 'execution' })
+@command({ name: 'focus' })
 export class FocusCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Focus an element (calls HTMLElement.focus())',

--- a/packages/core/src/commands/navigation/go.ts
+++ b/packages/core/src/commands/navigation/go.ts
@@ -43,7 +43,7 @@ export interface GoCommandOutput {
  * Before: 682 lines
  * After: ~350 lines (49% reduction)
  */
-@command({ name: 'go', category: 'navigation' })
+@command({ name: 'go' })
 export class GoCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description:

--- a/packages/core/src/commands/navigation/push-url.ts
+++ b/packages/core/src/commands/navigation/push-url.ts
@@ -51,7 +51,7 @@ export interface HistoryCommandOutput {
  * Consolidates PushUrlCommand and ReplaceUrlCommand into single implementation.
  * Registered under both 'push' and 'replace' names via aliases.
  */
-@command({ name: 'push', category: 'navigation' })
+@command({ name: 'push' })
 export class HistoryCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Modify browser history URL without page reload',

--- a/packages/core/src/commands/navigation/scroll-to.ts
+++ b/packages/core/src/commands/navigation/scroll-to.ts
@@ -33,7 +33,7 @@ export interface ScrollCommandOutput {
   smooth: boolean;
 }
 
-@command({ name: 'scroll', category: 'navigation' })
+@command({ name: 'scroll' })
 export class ScrollCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Scroll an element into view (upstream _hyperscript 0.9.90)',

--- a/packages/core/src/commands/utility/beep.ts
+++ b/packages/core/src/commands/utility/beep.ts
@@ -48,7 +48,7 @@ export interface BeepCommandOutput {
  * Before: 279 lines
  * After: ~130 lines (53% reduction)
  */
-@command({ name: 'beep', category: 'utility' })
+@command({ name: 'beep' })
 export class BeepCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Debug output for expressions with type information',

--- a/packages/core/src/commands/utility/breakpoint.ts
+++ b/packages/core/src/commands/utility/breakpoint.ts
@@ -28,7 +28,7 @@ export interface BreakpointCommandInput {
   _tag?: 'breakpoint';
 }
 
-@command({ name: 'breakpoint', category: 'utility' })
+@command({ name: 'breakpoint' })
 export class BreakpointCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Drop into the debugger (emits a debugger; statement)',

--- a/packages/core/src/commands/utility/copy.ts
+++ b/packages/core/src/commands/utility/copy.ts
@@ -46,7 +46,7 @@ export interface CopyCommandOutput {
  * Before: 312 lines
  * After: ~140 lines (55% reduction)
  */
-@command({ name: 'copy', category: 'utility' })
+@command({ name: 'copy' })
 export class CopyCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Copy text or element content to the clipboard',

--- a/packages/core/src/commands/utility/log.ts
+++ b/packages/core/src/commands/utility/log.ts
@@ -42,7 +42,7 @@ export interface LogCommandOutput {
  * Before: 192 lines
  * After: ~70 lines (64% reduction)
  */
-@command({ name: 'log', category: 'utility' })
+@command({ name: 'log' })
 export class LogCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Log values to the console',

--- a/packages/core/src/commands/utility/pick.ts
+++ b/packages/core/src/commands/utility/pick.ts
@@ -57,7 +57,7 @@ export interface PickCommandOutput {
   variant: PickCommandInput['variant'];
 }
 
-@command({ name: 'pick', category: 'utility' })
+@command({ name: 'pick' })
 export class PickCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Select from a collection (first/last/random/range/regex match)',

--- a/packages/core/src/commands/utility/tell.ts
+++ b/packages/core/src/commands/utility/tell.ts
@@ -43,7 +43,7 @@ export interface TellCommandOutput {
  * Before: 204 lines
  * After: ~90 lines (56% reduction)
  */
-@command({ name: 'tell', category: 'utility' })
+@command({ name: 'tell' })
 export class TellCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Execute commands in the context of target elements',


### PR DESCRIPTION
Arc B step 4a (brief #823 · steps #824, #825, #826). Step 3 made all of this unreachable; this removes it.

**Deleted:** `meta()`, `MetaConfig`, the three module-private symbols (`COMMAND_NAME`, `COMMAND_CATEGORY`, `COMMAND_METADATA`), `ClassWithSymbols`, and the three exported getters that were already dead *before* the arc started (zero readers repo-wide). The decorator module goes **257 → 179 lines** despite having *gained* `commandMeta` and its docstring.

## `@command` reduces to name-only

With `meta()` gone nothing read `COMMAND_CATEGORY`, so `CommandConfig.category` would have been a parameter accepted at 52 call sites that goes nowhere — **worse than duplication**, because a declared-and-ignored field reads as authoritative. Removed from the interface and every call site. `@command`'s only job is now the prototype `name` it advertises; the category lives in the class's own `commandMeta({…})` literal, where §7 already gates it against the manifest.

## `metadataOf()` deleted, with the *type* doing its job

`CommandClass` in `scripts/generate-command-docs.ts` is now `(abstract new (...args: never[]) => object) & { readonly metadata: CommandMetadata }`, so the table simply **requires** the static. Mutation-verified: adding a class with no metadata is **`TS2322` at compile time** where it used to be a runtime throw.

That function existed *only* because the static was invisible — this is the arc's thesis paying off in the exact place that motivated it.

## Two findings for 4b, both about the generated artifact

1. **The generator is not prettier-idempotent.** It emits unpadded markdown tables while the committed `REFERENCE.md` is prettier-formatted, so a fresh run produced a **252-line diff that was pure column padding**. Content verified identical — after `prettier --write` the entire diff collapsed to one line. Reverted as noise.
2. **That one remaining line is `> Generated: <ISO timestamp>`**, which changes every run — so a `--check` gate diffing the whole file would fail **100% of the time**.

4b must fix both or the gate is unusable and every regeneration reads as a rewrite. `commands.json` was deliberately **not** regenerated here: it still lacks the `compatibility` field the metadata now carries, and shipping an artifact change with no gate to keep it honest is how it drifted in the first place.

## Corrects the step-3 record

PR #826 said its registry-oracle diff was "exactly the predicted 3 rows." True of what it measured, **incomplete about the step**: the snapshot behind that sentence was taken *before* `compatibility` was populated, so it saw the migration alone. Step 3's full diff was 3 rows on `hasBody`/`isBlocking` **plus** 59 rows gaining `compatibility` — both intended, the latter gated by §9. Corrected in the brief, which is the durable record.

Two cautions about the oracle are now recorded there, because **the instrument needed more debugging than the migration did**:

- **Diff the union of both key sets.** A one-directional diff made an *added* field invisible and reported a false `0`.
- **Take the baseline from the merged parent commit.** 4a showed **59** changed rows against a mid-step snapshot and **0** against `main`.

They interact usefully: 4a's `0` is trustworthy *because* the same instrument had just produced a non-zero result. A gate never seen to fail is not known to work.

## Verification

| Gate | Result |
| --- | --- |
| core `test:check` | **7629 / 106 skipped / 297 files — unchanged**, as a pure deletion should be |
| full-repo `test:check` | green (real exit status) |
| `typecheck` / `typecheck:scripts` | 0 / 0 |
| `verify:reference` | pass |
| **Registry oracle vs merged `main`** | **0 rows changed**; shared groups and alias identity identical |
| `snapshot:bundle-size` | all bundles **+0.0%**; `hyperfixi-hx.js` byte-identical at 19019 gzip |

🤖 Generated with [Claude Code](https://claude.com/claude-code)