### PR TITLE
feat(docs): single-source command docs — 43 of 59 → all 59, gated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -580,10 +580,18 @@ jobs:
       # of these were stale across all 24 languages. Their generators are now
       # prettier-idempotent, so a fresh run is byte-identical to the committed
       # file and these checks are exact.
+      # `docs:commands:check` joined them in Arc B step 4b. Its generator had the
+      # same two defects these had: it emitted unpadded markdown tables that the
+      # pre-commit hook then padded (so a fresh run showed a 252-line diff of pure
+      # column padding with identical content), and a `Generated: <ISO>` line that
+      # made any whole-file comparison fail on every run. Both are fixed, so this
+      # check is exact too. Coverage of the generator's command table is a separate
+      # gate — src/commands/__tests__/docs-coverage.test.ts, in the unit suite.
       - name: Check generated artifacts are in sync
         run: |
           npm run check:grammar --prefix packages/semantic
           npm run check:keywords --prefix packages/vite-plugin
+          npm run docs:commands:check --prefix packages/core
 
       - name: Verify reference data
         run: npm run verify:reference --prefix packages/core

--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -87,11 +87,11 @@ generators with `--check` CI gates, `typecheck:scripts`, and ghost tests.
 | ~~D — target-resolution consolidation~~ | **DONE** (#796/#797/#798) | ✅ + 36 new tests pinning the rung order and both selector shapes | [HANDOFF-command-arch-target-resolution.md](./HANDOFF-command-arch-target-resolution.md) — now a record, not a plan |
 | ~~C — output contract~~ | **DONE** (#801/#802/#803/#805/#806) | ✅ the per-command `it` audit, both execution paths, 45 of 59 commands | [HANDOFF-command-arch-output-contract.md](./HANDOFF-command-arch-output-contract.md) — now a record, not a plan |
 | ~~A — command manifest~~ | **DONE** (#811/#813/#814/#815/#817/#818/#819) | ✅ the 19-test bidirectional audit + the manifest's §7; classification debt is **0** | [HANDOFF-command-arch-manifest.md](./HANDOFF-command-arch-manifest.md) — now a record, not a plan |
-| B — metadata single-sourcing | types see metadata; docs generated | ✅ partial: typecheck:scripts, metadataOf() throws | [HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md) — brief written 2026-07-29, arc not started; it CORRECTS the arc's stated motivation |
+| ~~B — metadata single-sourcing~~ | **DONE** (#823/#824/#825/#826/#827/#828) | ✅ the 7-test docs-coverage gate + §9's compatibility coupling + the static/instance bridge invariant; `metadataOf()` deleted, its check now `TS2322` | [HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md) — now a record, not a plan |
 | E — generated static bundles | 4 executors → 1 template source | ✅ partial: bundle-size ±5% + ceilings, compat matrix, parser-template drift test | drift test becomes a generator |
 | F — schema-driven mappers | ~30 of 47 mappers deleted | ✅ semantic suite + ten-signal ratchet + R2 | mapper/`semantic-integration` switch duplication is data |
 
-## The arcs — remaining sequence B → E → F (A, C and D are done)
+## The arcs — remaining sequence E → F (A, B, C and D are done)
 
 ### Arc D — target-resolution consolidation — ✅ DONE 2026-07-28
 
@@ -262,7 +262,42 @@ derived values land. Gates already in place: `verify:reference`,
 `capability-ghosts.test.ts`, `command-tiers.test.ts`,
 `bundle-manifest-consistency.test.ts`.
 
-### Arc B — metadata single-sourcing (medium; verified mechanical)
+### Arc B — metadata single-sourcing — ✅ DONE 2026-07-29
+
+Landed as #823 (the brief), #824 (`commandMeta()` + the three undecorated
+classes), #825 (the `compatibility` coupling, before any values existed), #826
+(all 52 decorated classes migrated), #827 (`@meta` and `metadataOf()` deleted),
+and #828 (the docs generator, 43 → 59, with its coverage gate). Detail, per-step
+outcomes, and all findings live in
+[HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md).
+
+**The arc's goal is delivered**: decorator statics are type-visible —
+`ToggleCommand.metadata.category` narrows to `'dom'` where every read used to be
+`TS2339` — and the workarounds that invisibility forced (`metadataOf()`, the three
+dead getters, script typechecking staying off) are gone. The decorator module went
+257 → 179 lines while *gaining* `commandMeta`.
+
+Things later arcs should carry forward:
+
+- **The arc's own stated motivation was wrong, and measuring caught it.** `@meta`
+  already type-checked its 52 literals; the defects were the invisible *static* and
+  three literals checked by nothing. A plan's premise deserves the same scoring as
+  its rows.
+- **A gate never seen to fail is not known to work.** Step 2 landed a gate that was
+  vacuous over values and mutation-verified it anyway; step 3's oracle then reported
+  a false `0` because it iterated one side's keys only. Diff the UNION, and take
+  baselines from the MERGED PARENT commit — a mid-step snapshot made a pure deletion
+  look like 59 changed rows.
+- **Two structural facts the type system surfaced** that `defineProperty` had
+  hidden: base classes cannot declare `metadata` as a property if subclasses supply
+  a getter (18 errors, 9 subclasses), and a **shared implementation cannot carry two
+  `compatibility` values** — `ConditionalCommand` is both `if` (upstream) and
+  `unless` (extension), pinned in §9 derived from the shared groups.
+
+**The original plan paragraph is kept below for the record.**
+
+> **Superseded — this is what the plan said before the arc ran.**
+
 
 > **Read [HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md)
 > first — it CORRECTS this paragraph's stated motivation.** "Making metadata
@@ -370,6 +405,19 @@ not the core abstractions.
 
 ## Open, filed rather than folded in
 
+- **`command-adapter.ts` declares its own `CommandMetadata`, and the load-bearing
+  reader uses it.** `:54-60` defines a loose shape with an
+  `[extra: string]: unknown` index signature — which is the only reason
+  `impl.metadata?.name` at `:421` typechecks, since the canonical
+  `types/command-metadata.ts` interface has **no `name` field**. Narrowing the
+  adapter to the canonical type turns `:421` into a type error, and `readonly` vs
+  mutable arrays will bite as well. Contained to one file (the shadow type is
+  exported but imported by nobody). It is a **behavior** question — that fallback
+  is the only path for a V1 command carrying `metadata.name` — so it wants its own
+  change rather than a slot inside a refactor. Third instance of the
+  dual-type-definition pattern (see also `ASTNode`/`ExpressionMetadata`). Detail:
+  [HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md) § F-B1.
+
 - **`metadata.isBlocking` / `hasBody` publish false claims for ≥7 commands.**
   Neither field is authored anywhere — every value comes from `@meta`'s (now
   `commandMeta`'s) `?? false` default — and nothing in production reads them. But
@@ -405,6 +453,29 @@ not the core abstractions.
 
 ## History
 
+- **2026-07-29** — **Arc B step 4b landed, closing the arc.** The command-docs
+  generator now covers all **59** commands (was 43), and the gate F-B3 said did
+  not exist is `packages/core/src/commands/__tests__/docs-coverage.test.ts`: the
+  table must name exactly `COMMAND_NAMES` in the same order, carry no duplicates,
+  and match what the runtime registers — asked of the runtime directly, because the
+  point of the file is comparing a docs list to the CODE. The sixteen commands that
+  had been silently undocumented: `blur`, `breakpoint`, `clear`, `close`, `empty`,
+  `focus`, `morph`, `open`, `process`, `push`, `replace`, `reset`, `scroll`,
+  `select`, `start`, `swap`.
+  - **Both 4a blockers fixed and each now gated**: the generator formats with
+    prettier (regeneration is a no-op, not a re-flow) and emits no timestamp
+    (`--check` means "content drifted"). `npm run docs:commands{,:check}` added, the
+    check joined the existing "Check generated artifacts are in sync" CI step, and
+    failure was mutation-verified in both directions.
+  - **One planned item was already done, and measuring beat building it.** The plan
+    opened 4b with "completeness tests for `reference/index.ts` and
+    `lsp-metadata.ts` (cheap)" — **Arc A had already built both** (§2 and §5 of the
+    manifest audit, both directions). Rewriting them would have added a second
+    place to maintain and no new check; the non-duplication is recorded in the new
+    test file instead. That freed effort went into a **prose ratchet** guarding
+    what `commandMeta` structurally cannot: `''` is a perfectly good `string`, so
+    the type system will never object to an empty description while the generator
+    will happily publish it.
 - **2026-07-29** — **Arc B step 4a landed**: the dead surface step 3 created is
   deleted. `meta()`, `MetaConfig`, all three module-private symbols,
   `ClassWithSymbols` and the three dead exported getters are gone; `@command`

--- a/docs-internal/HANDOFF-command-arch-metadata.md
+++ b/docs-internal/HANDOFF-command-arch-metadata.md
@@ -648,12 +648,55 @@ this deletes it.
 the `--check` gate. Regenerating it in 4a would have shipped an artifact change
 with no gate to keep it honest.
 
-**Step 4b — the prose (NOT started).** Completeness tests for
-`reference/index.ts` and `lsp-metadata.ts` first (cheap), then
-`generate-command-docs.ts`'s 43-entry table replaced by the manifest plus a
-factory map (F-B3 — it is 16 commands short and gated by nothing), an npm script,
-and `--check` in CI, honouring both findings above. Also still open from F-B1:
-narrowing the adapter's shadow `CommandMetadata` and settling `:421`'s fate.
+**Step 4b — the prose — ✅ DONE.**
+
+- **The generator now covers all 59** (was 43). The 16 previously-undocumented
+  commands: `blur`, `breakpoint`, `clear`, `close`, `empty`, `focus`, `morph`,
+  `open`, `process`, `push`, `replace`, `reset`, `scroll`, `select`, `start`,
+  `swap`. The import block and table were regenerated from the manifest order, so
+  the file no longer holds a hand-curated subset.
+- **The gate F-B3 said did not exist:**
+  `src/commands/__tests__/docs-coverage.test.ts`, 7 tests. The table must name
+  exactly `COMMAND_NAMES` **in the same order**, carry no duplicate rows, and match
+  what the runtime actually registers (asked directly, not through the manifest —
+  the whole point is comparing a docs list to the *code*). Mutation-verified in
+  four directions: dropping `toggle` fails 2 tests, duplicating a row fails 3,
+  reintroducing the timestamp fails its guard, removing the `prettier.format` call
+  fails its guard.
+- **Both 4a blockers fixed, and each is now itself gated.** The generator formats
+  its output with prettier (so regenerating is a no-op, not a re-flow) and emits
+  **no timestamp** (so `--check` means "content drifted" and nothing else).
+  Idempotence verified by running it twice and getting an identical diffstat, and
+  `prettier --check` is clean on both artifacts — so the pre-commit hook will not
+  fight the gate.
+- **`npm run docs:commands` / `docs:commands:check`** added, and the check joins
+  the existing "Check generated artifacts are in sync" CI step, which already
+  carries exactly this reasoning for two other generators. `--check` failure
+  mutation-verified in both directions (perturbed artifact; dropped table row).
+- **`commands.json` and `REFERENCE.md` regenerated** — now 59 commands each, and
+  carrying the `compatibility` field the metadata gained in step 3.
+
+**One thing the plan asked for that was already done.** The queue named
+"completeness tests for `reference/index.ts` and `lsp-metadata.ts` first (cheap)"
+as 4b's opening move. **Arc A already built both** — the manifest audit's §2
+asserts `reference/index.ts` "documents exactly the registered set" and §5 gates
+`COMMAND_KEYWORDS`/`HOVER_DOCS` in both directions. Writing them again would have
+added a second place to maintain and no new check, so `docs-coverage.test.ts`
+records the non-duplication instead. Measured before writing — the same "score the
+rows already there" check that corrected this arc's premise in the brief.
+
+What 4b substituted for that freed effort: a **prose ratchet** on the metadata
+itself (non-empty description, ≥1 syntax form, ≥1 example, all 59 passing today).
+It guards the thing `commandMeta` structurally cannot — `''` is a perfectly good
+`string`, so the type system will never object to an empty description, while the
+generator will happily publish it.
+
+**Still open from F-B1, deliberately not folded in:** narrowing
+`command-adapter.ts`'s shadow `CommandMetadata` and settling `:421`'s name
+fallback. It is a behavior question (the fallback is the only path for a V1
+command carrying `metadata.name`, and the canonical type has no `name` field), not
+a docs one, so it does not belong in the same PR as a docs generator. Recorded in
+the queue.
 
 ## Gate couplings that must move in the same diff
 

--- a/packages/core/docs/commands/REFERENCE.md
+++ b/packages/core/docs/commands/REFERENCE.md
@@ -1,7 +1,7 @@
 # HyperFixi Command Reference
 
-> Auto-generated from command metadata
-> Generated: 2026-07-28T15:21:42.542Z
+> Auto-generated from command metadata by `npm run docs:commands`.
+> Do not edit by hand — `npm run docs:commands:check` fails on drift.
 
 ## Table of Contents
 
@@ -21,51 +21,67 @@
 
 ## Quick Reference
 
-| Command          | Category     | Description                                                                                |
-| ---------------- | ------------ | ------------------------------------------------------------------------------------------ |
-| `add`            | dom          | Add CSS classes, attributes, or styles to elements.                                        |
-| `append`         | content      | Add content to the end of a string, array, Set, or HTML element.                           |
-| `async`          | advanced     | Execute commands asynchronously without blocking.                                          |
-| `beep`           | utility      | Debug output for expressions with type information.                                        |
-| `break`          | control-flow | Exit from the current loop (repeat, for, while, until).                                    |
-| `call`           | execution    | Evaluate an expression and store the result in the it variable.                            |
-| `continue`       | control-flow | Skip to the next iteration of the current loop.                                            |
-| `copy`           | utility      | Copy text or element content to the clipboard.                                             |
-| `decrement`      | data         | Modify a variable or property by a specified amount (default: 1).                          |
-| `default`        | data         | Set a value only if it doesn't already exist.                                              |
-| `exit`           | control-flow | Immediately terminate execution of the current event handler or behavior.                  |
-| `fetch`          | async        | Make HTTP requests with lifecycle event support.                                           |
-| `get`            | data         | Evaluate an expression and store the result in it.                                         |
-| `go`             | navigation   | Navigation functionality including URL navigation, element scrolling, and browser history. |
-| `halt`           | control-flow | Stop command execution or prevent event defaults.                                          |
-| `hide`           | dom          | Hide elements by setting display to none.                                                  |
-| `if`             | control-flow | Conditional execution based on boolean expressions.                                        |
-| `increment`      | data         | Modify a variable or property by a specified amount (default: 1).                          |
-| `install`        | behaviors    | Install a behavior on an element with optional parameters.                                 |
-| `js`             | advanced     | Execute inline JavaScript code with access to hyperscript context.                         |
-| `log`            | utility      | Log values to the console.                                                                 |
-| `make`           | dom          | Create DOM elements or class instances.                                                    |
-| `measure`        | animation    | Measure DOM element dimensions, positions, and properties.                                 |
-| `pick`           | utility      | Select from a collection (first/last/random/range/regex match).                            |
-| `prepend`        | content      | Add content to the start of a string, array, Set, or HTML element.                         |
-| `pseudo-command` | execution    | Treat a method on an object as a top-level command.                                        |
-| `put`            | dom          | Insert content into elements or properties.                                                |
-| `remove`         | dom          | Remove CSS classes, attributes, styles, or elements from the DOM.                          |
-| `render`         | templates    | Render templates with @if, @else, and @repeat directives.                                  |
-| `repeat`         | control-flow | Iteration in hyperscript - for-in, counted, conditional, event-driven, and infinite loops. |
-| `return`         | control-flow | Return a value from a command sequence or function, terminating execution.                 |
-| `send`           | event        | Dispatch events on elements.                                                               |
-| `set`            | data         | Set values to variables, attributes, or properties.                                        |
-| `settle`         | animation    | Wait for CSS transitions and animations to complete.                                       |
-| `show`           | dom          | Show elements by restoring display property.                                               |
-| `take`           | animation    | Move classes, attributes, and properties from one element to another.                      |
-| `tell`           | utility      | Execute commands in the context of target elements.                                        |
-| `throw`          | control-flow | Throw an error with a specified message.                                                   |
-| `toggle`         | dom          | Toggle classes, attributes, or interactive elements.                                       |
-| `transition`     | animation    | Animate CSS properties using CSS transitions.                                              |
-| `trigger`        | event        | Dispatch events on elements.                                                               |
-| `unless`         | control-flow | Conditional execution based on boolean expressions.                                        |
-| `wait`           | async        | Wait for time delay, event, or race condition.                                             |
+| Command          | Category     | Description                                                                                  |
+| ---------------- | ------------ | -------------------------------------------------------------------------------------------- |
+| `add`            | dom          | Add CSS classes, attributes, or styles to elements.                                          |
+| `append`         | content      | Add content to the end of a string, array, Set, or HTML element.                             |
+| `async`          | advanced     | Execute commands asynchronously without blocking.                                            |
+| `beep`           | utility      | Debug output for expressions with type information.                                          |
+| `blur`           | execution    | Remove focus from an element (calls HTMLElement.                                             |
+| `break`          | control-flow | Exit from the current loop (repeat, for, while, until).                                      |
+| `breakpoint`     | utility      | Drop into the debugger (emits a debugger; statement).                                        |
+| `call`           | execution    | Evaluate an expression and store the result in the it variable.                              |
+| `clear`          | data         | Reset a variable to null or clear the value of a form field (<input>, <textarea>, <select>). |
+| `close`          | dom          | Close a dialog, details element, or popover.                                                 |
+| `continue`       | control-flow | Skip to the next iteration of the current loop.                                              |
+| `copy`           | utility      | Copy text or element content to the clipboard.                                               |
+| `decrement`      | data         | Modify a variable or property by a specified amount (default: 1).                            |
+| `default`        | data         | Set a value only if it doesn't already exist.                                                |
+| `empty`          | dom          | Remove all children from an element (sets innerHTML to empty).                               |
+| `exit`           | control-flow | Immediately terminate execution of the current event handler or behavior.                    |
+| `fetch`          | async        | Make HTTP requests with lifecycle event support.                                             |
+| `focus`          | execution    | Focus an element (calls HTMLElement.                                                         |
+| `get`            | data         | Evaluate an expression and store the result in it.                                           |
+| `go`             | navigation   | Navigation functionality including URL navigation, element scrolling, and browser history.   |
+| `halt`           | control-flow | Stop command execution or prevent event defaults.                                            |
+| `hide`           | dom          | Hide elements by setting display to none.                                                    |
+| `if`             | control-flow | Conditional execution based on boolean expressions.                                          |
+| `increment`      | data         | Modify a variable or property by a specified amount (default: 1).                            |
+| `install`        | behaviors    | Install a behavior on an element with optional parameters.                                   |
+| `js`             | advanced     | Execute inline JavaScript code with access to hyperscript context.                           |
+| `log`            | utility      | Log values to the console.                                                                   |
+| `make`           | dom          | Create DOM elements or class instances.                                                      |
+| `measure`        | animation    | Measure DOM element dimensions, positions, and properties.                                   |
+| `morph`          | dom          | Morph content into target elements (intelligent diffing, preserves state).                   |
+| `open`           | dom          | Open a dialog, details element, or popover.                                                  |
+| `pick`           | utility      | Select from a collection (first/last/random/range/regex match).                              |
+| `prepend`        | content      | Add content to the start of a string, array, Set, or HTML element.                           |
+| `process`        | dom          | Process <hx-partial> elements for multi-target swaps.                                        |
+| `pseudo-command` | execution    | Treat a method on an object as a top-level command.                                          |
+| `push`           | navigation   | Modify browser history URL without page reload.                                              |
+| `put`            | dom          | Insert content into elements or properties.                                                  |
+| `remove`         | dom          | Remove CSS classes, attributes, styles, or elements from the DOM.                            |
+| `render`         | templates    | Render templates with @if, @else, and @repeat directives.                                    |
+| `repeat`         | control-flow | Iteration in hyperscript - for-in, counted, conditional, event-driven, and infinite loops.   |
+| `replace`        | navigation   | Modify browser history URL without page reload.                                              |
+| `reset`          | dom          | Reset a <form> element to its default values (HTMLFormElement.                               |
+| `return`         | control-flow | Return a value from a command sequence or function, terminating execution.                   |
+| `scroll`         | navigation   | Scroll an element into view (upstream _hyperscript 0.                                        |
+| `select`         | dom          | Select the contents of a text field, or select the contents of a DOM element.                |
+| `send`           | event        | Dispatch events on elements.                                                                 |
+| `set`            | data         | Set values to variables, attributes, or properties.                                          |
+| `settle`         | animation    | Wait for CSS transitions and animations to complete.                                         |
+| `show`           | dom          | Show elements by restoring display property.                                                 |
+| `start`          | animation    | Wrap a block of commands in document.                                                        |
+| `swap`           | dom          | Swap content into target elements with intelligent morphing support.                         |
+| `take`           | animation    | Move classes, attributes, and properties from one element to another.                        |
+| `tell`           | utility      | Execute commands in the context of target elements.                                          |
+| `throw`          | control-flow | Throw an error with a specified message.                                                     |
+| `toggle`         | dom          | Toggle classes, attributes, or interactive elements.                                         |
+| `transition`     | animation    | Animate CSS properties using CSS transitions.                                                |
+| `trigger`        | event        | Dispatch events on elements.                                                                 |
+| `unless`         | control-flow | Conditional execution based on boolean expressions.                                          |
+| `wait`           | async        | Wait for time delay, event, or race condition.                                               |
 
 ## Animation Commands
 
@@ -134,6 +150,30 @@ settle for 3000
 ```
 
 **Side Effects:** timing
+
+---
+
+### start
+
+Wrap a block of commands in document.startViewTransition()
+
+**Syntax:**
+
+```hyperscript
+start view transition [using <type>] <body> end
+```
+
+**Examples:**
+
+```hyperscript
+start view transition add .highlight to me end
+```
+
+```hyperscript
+start view transition using "slide" then put result into #panel end
+```
+
+**Side Effects:** animation, dom-mutation
 
 ---
 
@@ -567,6 +607,46 @@ unless user.isLoggedIn showLoginForm
 
 ## Data Commands
 
+### clear
+
+Reset a variable to null or clear the value of a form field (<input>, <textarea>, <select>)
+
+**Syntax:**
+
+```hyperscript
+clear <var>
+```
+
+```hyperscript
+clear :var
+```
+
+```hyperscript
+clear <target>
+```
+
+**Examples:**
+
+```hyperscript
+clear :count
+```
+
+```hyperscript
+clear myVar
+```
+
+```hyperscript
+clear #search
+```
+
+```hyperscript
+clear <textarea/>
+```
+
+**Side Effects:** state-mutation, dom-mutation
+
+---
+
 ### decrement
 
 Modify a variable or property by a specified amount (default: 1)
@@ -757,6 +837,78 @@ add [@data-test="value"] to #element
 
 ---
 
+### close
+
+Close a dialog, details element, or popover
+
+**Syntax:**
+
+```hyperscript
+close
+```
+
+```hyperscript
+close <target>
+```
+
+**Examples:**
+
+```hyperscript
+close
+```
+
+```hyperscript
+close #myDialog
+```
+
+```hyperscript
+close #details
+```
+
+```hyperscript
+close #popup
+```
+
+**Side Effects:** dom-mutation
+
+---
+
+### empty
+
+Remove all children from an element (sets innerHTML to empty)
+
+**Syntax:**
+
+```hyperscript
+empty
+```
+
+```hyperscript
+empty <target>
+```
+
+```hyperscript
+empty the <target>
+```
+
+**Examples:**
+
+```hyperscript
+empty me
+```
+
+```hyperscript
+empty #list
+```
+
+```hyperscript
+empty .results
+```
+
+**Side Effects:** dom-mutation
+
+---
+
 ### hide
 
 Hide elements by setting display to none
@@ -814,6 +966,106 @@ make a URL from "/path/", "https://origin.example.com"
 ```
 
 **Side Effects:** dom-creation, data-mutation
+
+---
+
+### morph
+
+Morph content into target elements (intelligent diffing, preserves state)
+
+**Syntax:**
+
+```hyperscript
+morph <target> with <content>
+```
+
+```hyperscript
+morph over <target> with <content>
+```
+
+**Examples:**
+
+```hyperscript
+morph #target with it
+```
+
+```hyperscript
+morph over #modal with fetchedContent
+```
+
+**Side Effects:** dom-mutation
+
+---
+
+### open
+
+Open a dialog, details element, or popover
+
+**Syntax:**
+
+```hyperscript
+open [<target>]
+```
+
+```hyperscript
+open <dialog> as modal
+```
+
+```hyperscript
+open <dialog> as non-modal
+```
+
+**Examples:**
+
+```hyperscript
+open
+```
+
+```hyperscript
+open #myDialog
+```
+
+```hyperscript
+open #details
+```
+
+```hyperscript
+open #popup as non-modal
+```
+
+**Side Effects:** dom-mutation
+
+---
+
+### process
+
+Process <hx-partial> elements for multi-target swaps
+
+**Syntax:**
+
+```hyperscript
+process partials in <content>
+```
+
+```hyperscript
+process partials in <content> using view transition
+```
+
+**Examples:**
+
+```hyperscript
+process partials in it
+```
+
+```hyperscript
+process partials in fetchedHtml
+```
+
+```hyperscript
+process partials in it using view transition
+```
+
+**Side Effects:** dom-mutation
 
 ---
 
@@ -889,6 +1141,70 @@ remove closest .item
 
 ---
 
+### reset
+
+Reset a <form> element to its default values (HTMLFormElement.reset())
+
+**Syntax:**
+
+```hyperscript
+reset
+```
+
+```hyperscript
+reset <target>
+```
+
+**Examples:**
+
+```hyperscript
+reset
+```
+
+```hyperscript
+reset #myForm
+```
+
+```hyperscript
+reset <form/>
+```
+
+**Side Effects:** dom-mutation
+
+---
+
+### select
+
+Select the contents of a text field, or select the contents of a DOM element
+
+**Syntax:**
+
+```hyperscript
+select
+```
+
+```hyperscript
+select <target>
+```
+
+**Examples:**
+
+```hyperscript
+select #search
+```
+
+```hyperscript
+select <textarea/>
+```
+
+```hyperscript
+select me
+```
+
+**Side Effects:** focus, dom-mutation
+
+---
+
 ### show
 
 Show elements by restoring display property
@@ -915,6 +1231,58 @@ show .hidden
 
 ```hyperscript
 show <button/>
+```
+
+**Side Effects:** dom-mutation
+
+---
+
+### swap
+
+Swap content into target elements with intelligent morphing support
+
+**Syntax:**
+
+```hyperscript
+swap <target> with <content>
+```
+
+```hyperscript
+swap [strategy] of <target> with <content>
+```
+
+```hyperscript
+swap into <target> with <content>
+```
+
+```hyperscript
+swap over <target> with <content>
+```
+
+```hyperscript
+swap delete <target>
+```
+
+```hyperscript
+swap <target> with <content> using view transition
+```
+
+**Examples:**
+
+```hyperscript
+swap #target with it
+```
+
+```hyperscript
+swap innerHTML of #target with it
+```
+
+```hyperscript
+swap over #modal with fetchedContent
+```
+
+```hyperscript
+swap delete #notification
 ```
 
 **Side Effects:** dom-mutation
@@ -1081,6 +1449,130 @@ go to top of #header
 
 ---
 
+### push
+
+Modify browser history URL without page reload
+
+**Syntax:**
+
+```hyperscript
+push url <url>
+```
+
+```hyperscript
+push url <url> with title <title>
+```
+
+```hyperscript
+replace url <url>
+```
+
+```hyperscript
+replace url <url> with title <title>
+```
+
+**Examples:**
+
+```hyperscript
+push url "/page/2"
+```
+
+```hyperscript
+push url "/search" with title "Search Results"
+```
+
+```hyperscript
+replace url "/search?q=test"
+```
+
+```hyperscript
+replace url "/page" with title "Updated Page"
+```
+
+**Side Effects:** navigation
+
+---
+
+### replace
+
+Modify browser history URL without page reload
+
+**Syntax:**
+
+```hyperscript
+push url <url>
+```
+
+```hyperscript
+push url <url> with title <title>
+```
+
+```hyperscript
+replace url <url>
+```
+
+```hyperscript
+replace url <url> with title <title>
+```
+
+**Examples:**
+
+```hyperscript
+push url "/page/2"
+```
+
+```hyperscript
+push url "/search" with title "Search Results"
+```
+
+```hyperscript
+replace url "/search?q=test"
+```
+
+```hyperscript
+replace url "/page" with title "Updated Page"
+```
+
+**Side Effects:** navigation
+
+---
+
+### scroll
+
+Scroll an element into view (upstream _hyperscript 0.9.90)
+
+**Syntax:**
+
+```hyperscript
+scroll to <target>
+```
+
+```hyperscript
+scroll to top of <target>
+```
+
+```hyperscript
+scroll to <target> smoothly
+```
+
+**Examples:**
+
+```hyperscript
+scroll to #top
+```
+
+```hyperscript
+scroll to bottom of #chat
+```
+
+```hyperscript
+scroll to me smoothly
+```
+
+**Side Effects:** scrolling
+
+---
+
 ## Utility Commands
 
 ### beep
@@ -1116,6 +1608,30 @@ beep! me.id, me.className
 ```
 
 **Side Effects:** console-output, debugging
+
+---
+
+### breakpoint
+
+Drop into the debugger (emits a debugger; statement)
+
+**Syntax:**
+
+```hyperscript
+breakpoint
+```
+
+**Examples:**
+
+```hyperscript
+breakpoint
+```
+
+```hyperscript
+on click breakpoint
+```
+
+**Side Effects:** debugging
 
 ---
 
@@ -1433,6 +1949,42 @@ send myEvent(count: 42) to me
 
 ## Execution Commands
 
+### blur
+
+Remove focus from an element (calls HTMLElement.blur())
+
+**Syntax:**
+
+```hyperscript
+blur
+```
+
+```hyperscript
+blur <target>
+```
+
+```hyperscript
+blur on <target>
+```
+
+**Examples:**
+
+```hyperscript
+blur
+```
+
+```hyperscript
+blur #search
+```
+
+```hyperscript
+blur on <input/>
+```
+
+**Side Effects:** focus
+
+---
+
 ### call
 
 Evaluate an expression and store the result in the it variable
@@ -1458,6 +2010,42 @@ call element.focus()
 ```
 
 **Side Effects:** function-execution, context-mutation
+
+---
+
+### focus
+
+Focus an element (calls HTMLElement.focus())
+
+**Syntax:**
+
+```hyperscript
+focus
+```
+
+```hyperscript
+focus <target>
+```
+
+```hyperscript
+focus on <target>
+```
+
+**Examples:**
+
+```hyperscript
+focus
+```
+
+```hyperscript
+focus #search
+```
+
+```hyperscript
+focus on <input/>
+```
+
+**Side Effects:** focus
 
 ---
 

--- a/packages/core/docs/commands/commands.json
+++ b/packages/core/docs/commands/commands.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://hyperfixi.dev/schemas/commands.json",
   "version": "1.0.0",
-  "generatedAt": "2026-07-28T15:22:24.229Z",
   "categories": [
     "animation",
     "async",
@@ -68,6 +67,9 @@
   ],
   "commands": {
     "add": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
       "description": "Add CSS classes, attributes, or styles to elements",
       "syntax": ["add <classes|@attr|{styles}> [to <target>]"],
       "examples": [
@@ -76,87 +78,367 @@
         "add .highlighted to #modal",
         "add [@data-test=\"value\"] to #element"
       ],
-      "category": "dom",
       "sideEffects": ["dom-mutation"],
+      "category": "dom",
+      "compatibility": "standard"
+    },
+    "append": {
       "isBlocking": false,
       "hasBody": false,
-      "version": "1.0.0"
-    },
-    "remove": {
-      "description": "Remove CSS classes, attributes, styles, or elements from the DOM",
-      "syntax": ["remove <classes|@attr|*prop|element> [from <target>]"],
+      "version": "1.0.0",
+      "description": "Add content to the end of a string, array, Set, or HTML element",
+      "syntax": ["append <content>", "append <content> to <target>"],
       "examples": [
-        "remove .active from me",
-        "remove \"active selected\" from <button/>",
-        "remove .highlighted from #modal",
-        "remove me",
-        "remove closest .item"
+        "append \"Hello\"",
+        "append \"World\" to greeting",
+        "append item to myArray",
+        "append \"<p>New</p>\" to #content",
+        "append \" (edited)\" to #title's textContent"
       ],
-      "category": "dom",
-      "sideEffects": ["dom-mutation"],
+      "sideEffects": ["data-mutation", "dom-mutation"],
+      "category": "content",
+      "compatibility": "standard"
+    },
+    "async": {
       "isBlocking": false,
       "hasBody": false,
-      "version": "1.0.0"
-    },
-    "toggle": {
-      "description": "Toggle classes, attributes, or interactive elements",
-      "syntax": [
-        "toggle <class> [on <target>]",
-        "toggle @attr",
-        "toggle <element> [as modal]",
-        "toggle <expr> for <duration>"
-      ],
+      "version": "1.0.0",
+      "description": "Execute commands asynchronously without blocking",
+      "syntax": ["async <command> [<command> ...]"],
       "examples": [
-        "toggle .active on me",
-        "toggle @disabled",
-        "toggle #myDialog as modal",
-        "toggle .loading for 2s"
+        "async command1 command2",
+        "async fetchData processData",
+        "async animateIn showContent"
       ],
-      "category": "dom",
-      "sideEffects": ["dom-mutation"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
+      "sideEffects": ["async-execution"],
+      "category": "advanced",
+      "compatibility": "lokascript-extension"
     },
-    "show": {
-      "description": "Show elements by restoring display property",
-      "syntax": ["show [<target>]"],
-      "examples": ["show me", "show #modal", "show .hidden", "show <button/>"],
-      "category": "dom",
-      "sideEffects": ["dom-mutation"],
+    "beep": {
       "isBlocking": false,
       "hasBody": false,
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "description": "Debug output for expressions with type information",
+      "syntax": ["beep!", "beep! <expression>", "beep! <expression>, <expression>, ..."],
+      "examples": ["beep!", "beep! myValue", "beep! me.id, me.className"],
+      "sideEffects": ["console-output", "debugging"],
+      "category": "utility",
+      "compatibility": "lokascript-extension"
+    },
+    "blur": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Remove focus from an element (calls HTMLElement.blur())",
+      "syntax": ["blur", "blur <target>", "blur on <target>"],
+      "examples": ["blur", "blur #search", "blur on <input/>"],
+      "sideEffects": ["focus"],
+      "category": "execution",
+      "compatibility": "standard"
+    },
+    "break": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Exit from the current loop (repeat, for, while, until)",
+      "syntax": ["break"],
+      "examples": [
+        "break",
+        "if found then break",
+        "repeat for item in items { if item == target then break }"
+      ],
+      "sideEffects": ["control-flow"],
+      "category": "control-flow",
+      "compatibility": "standard"
+    },
+    "breakpoint": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Drop into the debugger (emits a debugger; statement)",
+      "syntax": ["breakpoint"],
+      "examples": ["breakpoint", "on click breakpoint"],
+      "sideEffects": ["debugging"],
+      "category": "utility",
+      "compatibility": "standard"
+    },
+    "call": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Evaluate an expression and store the result in the it variable",
+      "syntax": ["call <expression>"],
+      "examples": ["call myFunction()", "call fetch(\"/api/data\")", "call element.focus()"],
+      "sideEffects": ["function-execution", "context-mutation"],
+      "category": "execution",
+      "compatibility": "standard"
+    },
+    "clear": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Reset a variable to null or clear the value of a form field (<input>, <textarea>, <select>)",
+      "syntax": ["clear <var>", "clear :var", "clear <target>"],
+      "examples": ["clear :count", "clear myVar", "clear #search", "clear <textarea/>"],
+      "sideEffects": ["state-mutation", "dom-mutation"],
+      "category": "data",
+      "compatibility": "standard"
+    },
+    "close": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Close a dialog, details element, or popover",
+      "syntax": ["close", "close <target>"],
+      "examples": ["close", "close #myDialog", "close #details", "close #popup"],
+      "sideEffects": ["dom-mutation"],
+      "category": "dom",
+      "compatibility": "standard"
+    },
+    "continue": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Skip to the next iteration of the current loop",
+      "syntax": ["continue"],
+      "examples": [
+        "continue",
+        "if item.isInvalid then continue",
+        "repeat for item in items { if item.skip then continue; process item }"
+      ],
+      "sideEffects": ["control-flow"],
+      "category": "control-flow",
+      "compatibility": "standard"
+    },
+    "copy": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Copy text or element content to the clipboard",
+      "syntax": ["copy <source>", "copy <source> to clipboard"],
+      "examples": ["copy \"Hello World\"", "copy #code-snippet", "copy my textContent"],
+      "sideEffects": ["clipboard-write", "custom-events"],
+      "category": "utility",
+      "compatibility": "lokascript-extension"
+    },
+    "decrement": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Modify a variable or property by a specified amount (default: 1)",
+      "syntax": ["increment <target> [by <number>]", "decrement <target> [by <number>]"],
+      "examples": [
+        "increment counter",
+        "increment counter by 5",
+        "decrement counter",
+        "decrement counter by 5"
+      ],
+      "sideEffects": ["data-mutation", "context-modification"],
+      "aliases": ["decrement"],
+      "category": "data",
+      "compatibility": "standard"
+    },
+    "default": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Set a value only if it doesn't already exist",
+      "syntax": ["default <expression> to <expression>"],
+      "examples": [
+        "default myVar to \"fallback\"",
+        "default @data-theme to \"light\"",
+        "default my innerHTML to \"No content\""
+      ],
+      "sideEffects": ["data-mutation", "dom-mutation"],
+      "category": "data",
+      "compatibility": "standard"
+    },
+    "empty": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Remove all children from an element (sets innerHTML to empty)",
+      "syntax": ["empty", "empty <target>", "empty the <target>"],
+      "examples": ["empty me", "empty #list", "empty .results"],
+      "sideEffects": ["dom-mutation"],
+      "category": "dom",
+      "compatibility": "standard"
+    },
+    "exit": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Immediately terminate execution of the current event handler or behavior",
+      "syntax": ["exit"],
+      "examples": ["exit", "if no draggedItem exit", "on click if disabled exit"],
+      "sideEffects": ["control-flow"],
+      "category": "control-flow",
+      "compatibility": "standard"
+    },
+    "fetch": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Make HTTP requests with lifecycle event support",
+      "syntax": ["fetch <url>", "fetch <url> as <type>", "fetch <url> with <options>"],
+      "examples": [
+        "fetch \"/api/data\"",
+        "fetch \"/api/users\" as json",
+        "fetch \"/api/save\" with { method:\"POST\" }"
+      ],
+      "sideEffects": ["network", "event-dispatching"],
+      "category": "async",
+      "compatibility": "standard"
+    },
+    "focus": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Focus an element (calls HTMLElement.focus())",
+      "syntax": ["focus", "focus <target>", "focus on <target>"],
+      "examples": ["focus", "focus #search", "focus on <input/>"],
+      "sideEffects": ["focus"],
+      "category": "execution",
+      "compatibility": "standard"
+    },
+    "get": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Evaluate an expression and store the result in it",
+      "syntax": ["get <expression>"],
+      "examples": ["get #my-dialog", "get <button/>", "get me.parentElement"],
+      "sideEffects": ["context-mutation"],
+      "category": "data",
+      "compatibility": "standard"
+    },
+    "go": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Navigation functionality including URL navigation, element scrolling, and browser history",
+      "syntax": ["go back", "go to url <url> [in new window]", "go to [position] [of] <element>"],
+      "examples": ["go back", "go to url \"https://example.com\"", "go to top of #header"],
+      "sideEffects": ["navigation", "scrolling"],
+      "category": "navigation",
+      "compatibility": "standard"
+    },
+    "halt": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Stop command execution or prevent event defaults",
+      "syntax": ["halt", "halt the event"],
+      "examples": [
+        "halt",
+        "halt the event",
+        "if error then halt",
+        "on click halt the event then log \"clicked\""
+      ],
+      "sideEffects": ["control-flow", "event-prevention"],
+      "category": "control-flow",
+      "compatibility": "standard"
     },
     "hide": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
       "description": "Hide elements by setting display to none",
       "syntax": ["hide [<target>]"],
       "examples": ["hide me", "hide #modal", "hide .warnings", "hide <button/>"],
-      "category": "dom",
       "sideEffects": ["dom-mutation"],
+      "category": "dom",
+      "compatibility": "standard"
+    },
+    "if": {
       "isBlocking": false,
       "hasBody": false,
-      "version": "1.0.0"
-    },
-    "put": {
-      "description": "Insert content into elements or properties",
+      "version": "1.0.0",
+      "description": "Conditional execution based on boolean expressions",
       "syntax": [
-        "put <value> into <target>",
-        "put <value> before <target>",
-        "put <value> after <target>"
+        "if <condition> then <commands>",
+        "if <condition> then <commands> else <commands>",
+        "unless <condition> <commands>"
       ],
       "examples": [
-        "put \"Hello World\" into me",
-        "put <div>Content</div> before #target",
-        "put value into #elem's innerHTML"
+        "if x > 5 then add .active",
+        "if user.isAdmin then show #adminPanel else hide #adminPanel",
+        "unless user.isLoggedIn showLoginForm"
       ],
-      "category": "dom",
-      "sideEffects": ["dom-mutation"],
+      "sideEffects": ["conditional-execution"],
+      "aliases": ["unless"],
+      "category": "control-flow",
+      "compatibility": "standard"
+    },
+    "increment": {
       "isBlocking": false,
       "hasBody": false,
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "description": "Modify a variable or property by a specified amount (default: 1)",
+      "syntax": ["increment <target> [by <number>]", "decrement <target> [by <number>]"],
+      "examples": [
+        "increment counter",
+        "increment counter by 5",
+        "decrement counter",
+        "decrement counter by 5"
+      ],
+      "sideEffects": ["data-mutation", "context-modification"],
+      "aliases": ["decrement"],
+      "category": "data",
+      "compatibility": "standard"
+    },
+    "install": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Install a behavior on an element with optional parameters",
+      "syntax": [
+        "install <BehaviorName>",
+        "install <BehaviorName> on <element>",
+        "install <BehaviorName>(param: value)",
+        "install <BehaviorName>(param: value) on <element>"
+      ],
+      "examples": [
+        "install Removable",
+        "install Draggable on #box",
+        "install Tooltip(text: \"Help\", position: \"top\")",
+        "install Sortable(axis: \"y\") on .list",
+        "install MyBehavior(foo: 42) on the first <div/>"
+      ],
+      "category": "behaviors",
+      "compatibility": "standard",
+      "sideEffects": ["behavior-installation", "element-modification"]
+    },
+    "js": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Execute inline JavaScript code with access to hyperscript context",
+      "syntax": ["js <code> end", "js(param1, param2) <code> end"],
+      "examples": [
+        "js console.log(\"Hello\") end",
+        "js(x, y) return x + y end",
+        "js me.style.color = \"red\" end"
+      ],
+      "sideEffects": ["code-execution", "data-mutation"],
+      "category": "advanced",
+      "compatibility": "standard"
+    },
+    "log": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Log values to the console",
+      "syntax": ["log [<values...>]"],
+      "examples": ["log \"Hello World\"", "log me.value", "log x y z", "log \"Result:\" result"],
+      "sideEffects": ["console-output"],
+      "category": "utility",
+      "compatibility": "standard"
     },
     "make": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
       "description": "Create DOM elements or class instances",
       "syntax": [
         "make a <tag#id.class1.class2/>",
@@ -166,56 +448,14 @@
         "make an <a.navlink/> called linkElement",
         "make a URL from \"/path/\", \"https://origin.example.com\""
       ],
-      "category": "dom",
       "sideEffects": ["dom-creation", "data-mutation"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "wait": {
-      "description": "Wait for time delay, event, or race condition",
-      "syntax": ["wait <time>", "wait for <event>", "wait for <event> or <condition>"],
-      "examples": [
-        "wait 2s",
-        "wait for click",
-        "wait for click or 1s",
-        "wait for mousemove(clientX, clientY)"
-      ],
-      "category": "async",
-      "sideEffects": ["time", "event-listening"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "fetch": {
-      "description": "Make HTTP requests with lifecycle event support",
-      "syntax": ["fetch <url>", "fetch <url> as <type>", "fetch <url> with <options>"],
-      "examples": [
-        "fetch \"/api/data\"",
-        "fetch \"/api/users\" as json",
-        "fetch \"/api/save\" with { method:\"POST\" }"
-      ],
-      "category": "async",
-      "sideEffects": ["network", "event-dispatching"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "transition": {
-      "description": "Animate CSS properties using CSS transitions",
-      "syntax": ["transition <property> to <value> [over <duration>] [with <timing>]"],
-      "examples": [
-        "transition opacity to 0.5",
-        "transition left to 100px over 500ms",
-        "transition background-color to red over 1s with ease-in-out"
-      ],
-      "category": "animation",
-      "sideEffects": ["style-change", "timing"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
+      "category": "dom",
+      "compatibility": "standard"
     },
     "measure": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
       "description": "Measure DOM element dimensions, positions, and properties",
       "syntax": ["measure", "measure <property>", "measure <target> <property>"],
       "examples": [
@@ -224,312 +464,36 @@
         "measure #element height",
         "measure x and set dragX"
       ],
-      "category": "animation",
       "sideEffects": ["data-mutation"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "settle": {
-      "description": "Wait for CSS transitions and animations to complete",
-      "syntax": ["settle [<target>] [for <timeout>]"],
-      "examples": ["settle", "settle #animated-element", "settle for 3000"],
       "category": "animation",
-      "sideEffects": ["timing"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
+      "compatibility": "standard"
     },
-    "take": {
-      "description": "Move classes, attributes, and properties from one element to another",
-      "syntax": [
-        "take <property> from <source>",
-        "take <property> from <source> and put it on <target>"
-      ],
-      "examples": [
-        "take class from <#source/>",
-        "take @data-value from <.source/> and put it on <#target/>"
-      ],
-      "category": "animation",
-      "sideEffects": ["dom-mutation", "property-transfer"],
+    "morph": {
       "isBlocking": false,
       "hasBody": false,
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "description": "Morph content into target elements (intelligent diffing, preserves state)",
+      "syntax": ["morph <target> with <content>", "morph over <target> with <content>"],
+      "examples": ["morph #target with it", "morph over #modal with fetchedContent"],
+      "sideEffects": ["dom-mutation"],
+      "category": "dom",
+      "compatibility": "standard"
     },
-    "if": {
-      "description": "Conditional execution based on boolean expressions",
-      "syntax": [
-        "if <condition> then <commands>",
-        "if <condition> then <commands> else <commands>",
-        "unless <condition> <commands>"
-      ],
-      "examples": [
-        "if x > 5 then add .active",
-        "if user.isAdmin then show #adminPanel else hide #adminPanel",
-        "unless user.isLoggedIn showLoginForm"
-      ],
-      "category": "control-flow",
-      "sideEffects": ["conditional-execution"],
-      "aliases": ["unless"],
+    "open": {
       "isBlocking": false,
       "hasBody": false,
-      "version": "1.0.0"
-    },
-    "repeat": {
-      "description": "Iteration in hyperscript - for-in, counted, conditional, event-driven, and infinite loops",
-      "syntax": [
-        "repeat for <var> in <collection> { <commands> }",
-        "repeat <count> times { <commands> }",
-        "repeat while <condition> { <commands> }",
-        "repeat until <condition> { <commands> }",
-        "repeat forever { <commands> }"
-      ],
-      "examples": ["repeat for item in items { log item }", "repeat 5 times { log \"hello\" }"],
-      "category": "control-flow",
-      "sideEffects": ["iteration", "conditional-execution"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "break": {
-      "description": "Exit from the current loop (repeat, for, while, until)",
-      "syntax": ["break"],
-      "examples": [
-        "break",
-        "if found then break",
-        "repeat for item in items { if item == target then break }"
-      ],
-      "category": "control-flow",
-      "sideEffects": ["control-flow"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "continue": {
-      "description": "Skip to the next iteration of the current loop",
-      "syntax": ["continue"],
-      "examples": [
-        "continue",
-        "if item.isInvalid then continue",
-        "repeat for item in items { if item.skip then continue; process item }"
-      ],
-      "category": "control-flow",
-      "sideEffects": ["control-flow"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "return": {
-      "description": "Return a value from a command sequence or function, terminating execution",
-      "syntax": ["return", "return <value>"],
-      "examples": ["return", "return 42", "return user.name", "if found then return result"],
-      "category": "control-flow",
-      "sideEffects": ["control-flow", "context-mutation"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "exit": {
-      "description": "Immediately terminate execution of the current event handler or behavior",
-      "syntax": ["exit"],
-      "examples": ["exit", "if no draggedItem exit", "on click if disabled exit"],
-      "category": "control-flow",
-      "sideEffects": ["control-flow"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "halt": {
-      "description": "Stop command execution or prevent event defaults",
-      "syntax": ["halt", "halt the event"],
-      "examples": [
-        "halt",
-        "halt the event",
-        "if error then halt",
-        "on click halt the event then log \"clicked\""
-      ],
-      "category": "control-flow",
-      "sideEffects": ["control-flow", "event-prevention"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "throw": {
-      "description": "Throw an error with a specified message",
-      "syntax": ["throw <message>"],
-      "examples": ["throw \"Invalid input\"", "if not valid then throw \"Validation failed\""],
-      "category": "control-flow",
-      "sideEffects": ["error-throwing", "execution-termination"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "unless": {
-      "description": "Conditional execution based on boolean expressions",
-      "syntax": [
-        "if <condition> then <commands>",
-        "if <condition> then <commands> else <commands>",
-        "unless <condition> <commands>"
-      ],
-      "examples": [
-        "if x > 5 then add .active",
-        "if user.isAdmin then show #adminPanel else hide #adminPanel",
-        "unless user.isLoggedIn showLoginForm"
-      ],
-      "category": "control-flow",
-      "sideEffects": ["conditional-execution"],
-      "aliases": ["unless"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "set": {
-      "description": "Set values to variables, attributes, or properties",
-      "syntax": ["set <target> to <value>"],
-      "examples": [
-        "set myVar to \"value\"",
-        "set @data-theme to \"dark\"",
-        "set my innerHTML to \"content\""
-      ],
-      "category": "data",
-      "sideEffects": ["state-mutation", "dom-mutation"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "get": {
-      "description": "Evaluate an expression and store the result in it",
-      "syntax": ["get <expression>"],
-      "examples": ["get #my-dialog", "get <button/>", "get me.parentElement"],
-      "category": "data",
-      "sideEffects": ["context-mutation"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "increment": {
-      "description": "Modify a variable or property by a specified amount (default: 1)",
-      "syntax": ["increment <target> [by <number>]", "decrement <target> [by <number>]"],
-      "examples": [
-        "increment counter",
-        "increment counter by 5",
-        "decrement counter",
-        "decrement counter by 5"
-      ],
-      "category": "data",
-      "sideEffects": ["data-mutation", "context-modification"],
-      "aliases": ["decrement"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "decrement": {
-      "description": "Modify a variable or property by a specified amount (default: 1)",
-      "syntax": ["increment <target> [by <number>]", "decrement <target> [by <number>]"],
-      "examples": [
-        "increment counter",
-        "increment counter by 5",
-        "decrement counter",
-        "decrement counter by 5"
-      ],
-      "category": "data",
-      "sideEffects": ["data-mutation", "context-modification"],
-      "aliases": ["decrement"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "default": {
-      "description": "Set a value only if it doesn't already exist",
-      "syntax": ["default <expression> to <expression>"],
-      "examples": [
-        "default myVar to \"fallback\"",
-        "default @data-theme to \"light\"",
-        "default my innerHTML to \"No content\""
-      ],
-      "category": "data",
-      "sideEffects": ["data-mutation", "dom-mutation"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "trigger": {
-      "description": "Dispatch events on elements",
-      "syntax": [
-        "trigger <event> on <target>",
-        "trigger <event>(<detail>) on <target>",
-        "send <event> to <target>",
-        "send <event>(<detail>) to <target>"
-      ],
-      "examples": [
-        "trigger click on #button",
-        "trigger customEvent on me",
-        "send dataEvent to #target",
-        "send myEvent(count: 42) to me"
-      ],
-      "category": "event",
-      "sideEffects": ["event-dispatch"],
-      "aliases": ["send"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "send": {
-      "description": "Dispatch events on elements",
-      "syntax": [
-        "trigger <event> on <target>",
-        "trigger <event>(<detail>) on <target>",
-        "send <event> to <target>",
-        "send <event>(<detail>) to <target>"
-      ],
-      "examples": [
-        "trigger click on #button",
-        "trigger customEvent on me",
-        "send dataEvent to #target",
-        "send myEvent(count: 42) to me"
-      ],
-      "category": "event",
-      "sideEffects": ["event-dispatch"],
-      "aliases": ["send"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "log": {
-      "description": "Log values to the console",
-      "syntax": ["log [<values...>]"],
-      "examples": ["log \"Hello World\"", "log me.value", "log x y z", "log \"Result:\" result"],
-      "category": "utility",
-      "sideEffects": ["console-output"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "beep": {
-      "description": "Debug output for expressions with type information",
-      "syntax": ["beep!", "beep! <expression>", "beep! <expression>, <expression>, ..."],
-      "examples": ["beep!", "beep! myValue", "beep! me.id, me.className"],
-      "category": "utility",
-      "sideEffects": ["console-output", "debugging"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "tell": {
-      "description": "Execute commands in the context of target elements",
-      "syntax": ["tell <target> <command> [<command> ...]"],
-      "examples": [
-        "tell #sidebar hide",
-        "tell .buttons add .disabled",
-        "tell closest <form/> submit"
-      ],
-      "category": "utility",
-      "sideEffects": ["context-switching", "command-execution"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "description": "Open a dialog, details element, or popover",
+      "syntax": ["open [<target>]", "open <dialog> as modal", "open <dialog> as non-modal"],
+      "examples": ["open", "open #myDialog", "open #details", "open #popup as non-modal"],
+      "sideEffects": ["dom-mutation"],
+      "category": "dom",
+      "compatibility": "standard"
     },
     "pick": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
       "description": "Select from a collection (first/last/random/range/regex match)",
       "syntax": [
         "pick first <count> of <expr>",
@@ -549,33 +513,48 @@
         "pick from colors",
         "pick \"red\", \"green\", \"blue\""
       ],
-      "category": "utility",
       "sideEffects": ["random-selection"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "copy": {
-      "description": "Copy text or element content to the clipboard",
-      "syntax": ["copy <source>", "copy <source> to clipboard"],
-      "examples": ["copy \"Hello World\"", "copy #code-snippet", "copy my textContent"],
       "category": "utility",
-      "sideEffects": ["clipboard-write", "custom-events"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
+      "compatibility": "standard"
     },
-    "call": {
-      "description": "Evaluate an expression and store the result in the it variable",
-      "syntax": ["call <expression>"],
-      "examples": ["call myFunction()", "call fetch(\"/api/data\")", "call element.focus()"],
-      "category": "execution",
-      "sideEffects": ["function-execution", "context-mutation"],
+    "prepend": {
       "isBlocking": false,
       "hasBody": false,
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "description": "Add content to the start of a string, array, Set, or HTML element",
+      "syntax": ["prepend <content>", "prepend <content> to <target>"],
+      "examples": [
+        "prepend \"Hello\"",
+        "prepend \"World\" to greeting",
+        "prepend item to myArray",
+        "prepend \"<p>First</p>\" to #content"
+      ],
+      "sideEffects": ["data-mutation", "dom-mutation"],
+      "category": "content",
+      "compatibility": "lokascript-extension"
+    },
+    "process": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Process <hx-partial> elements for multi-target swaps",
+      "syntax": [
+        "process partials in <content>",
+        "process partials in <content> using view transition"
+      ],
+      "examples": [
+        "process partials in it",
+        "process partials in fetchedHtml",
+        "process partials in it using view transition"
+      ],
+      "sideEffects": ["dom-mutation"],
+      "category": "dom",
+      "compatibility": "lokascript-extension"
     },
     "pseudo-command": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
       "description": "Treat a method on an object as a top-level command",
       "syntax": ["<method>(<args>) [(to|on|with|into|from|at)] <expression>"],
       "examples": [
@@ -585,78 +564,71 @@
         "foo() on me"
       ],
       "category": "execution",
+      "compatibility": "standard",
       "sideEffects": ["method-execution"]
     },
-    "js": {
-      "description": "Execute inline JavaScript code with access to hyperscript context",
-      "syntax": ["js <code> end", "js(param1, param2) <code> end"],
-      "examples": [
-        "js console.log(\"Hello\") end",
-        "js(x, y) return x + y end",
-        "js me.style.color = \"red\" end"
-      ],
-      "category": "advanced",
-      "sideEffects": ["code-execution", "data-mutation"],
+    "push": {
       "isBlocking": false,
       "hasBody": false,
-      "version": "1.0.0"
-    },
-    "async": {
-      "description": "Execute commands asynchronously without blocking",
-      "syntax": ["async <command> [<command> ...]"],
-      "examples": [
-        "async command1 command2",
-        "async fetchData processData",
-        "async animateIn showContent"
+      "version": "1.0.0",
+      "description": "Modify browser history URL without page reload",
+      "syntax": [
+        "push url <url>",
+        "push url <url> with title <title>",
+        "replace url <url>",
+        "replace url <url> with title <title>"
       ],
-      "category": "advanced",
-      "sideEffects": ["async-execution"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
-    },
-    "go": {
-      "description": "Navigation functionality including URL navigation, element scrolling, and browser history",
-      "syntax": ["go back", "go to url <url> [in new window]", "go to [position] [of] <element>"],
-      "examples": ["go back", "go to url \"https://example.com\"", "go to top of #header"],
+      "examples": [
+        "push url \"/page/2\"",
+        "push url \"/search\" with title \"Search Results\"",
+        "replace url \"/search?q=test\"",
+        "replace url \"/page\" with title \"Updated Page\""
+      ],
+      "sideEffects": ["navigation"],
+      "aliases": ["replace"],
       "category": "navigation",
-      "sideEffects": ["navigation", "scrolling"],
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0"
+      "compatibility": "lokascript-extension"
     },
-    "append": {
-      "description": "Add content to the end of a string, array, Set, or HTML element",
-      "syntax": ["append <content>", "append <content> to <target>"],
-      "examples": [
-        "append \"Hello\"",
-        "append \"World\" to greeting",
-        "append item to myArray",
-        "append \"<p>New</p>\" to #content",
-        "append \" (edited)\" to #title's textContent"
-      ],
-      "category": "content",
-      "sideEffects": ["data-mutation", "dom-mutation"],
+    "put": {
       "isBlocking": false,
       "hasBody": false,
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "description": "Insert content into elements or properties",
+      "syntax": [
+        "put <value> into <target>",
+        "put <value> before <target>",
+        "put <value> after <target>"
+      ],
+      "examples": [
+        "put \"Hello World\" into me",
+        "put <div>Content</div> before #target",
+        "put value into #elem's innerHTML"
+      ],
+      "sideEffects": ["dom-mutation"],
+      "category": "dom",
+      "compatibility": "standard"
     },
-    "prepend": {
-      "description": "Add content to the start of a string, array, Set, or HTML element",
-      "syntax": ["prepend <content>", "prepend <content> to <target>"],
-      "examples": [
-        "prepend \"Hello\"",
-        "prepend \"World\" to greeting",
-        "prepend item to myArray",
-        "prepend \"<p>First</p>\" to #content"
-      ],
-      "category": "content",
-      "sideEffects": ["data-mutation", "dom-mutation"],
+    "remove": {
       "isBlocking": false,
       "hasBody": false,
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "description": "Remove CSS classes, attributes, styles, or elements from the DOM",
+      "syntax": ["remove <classes|@attr|*prop|element> [from <target>]"],
+      "examples": [
+        "remove .active from me",
+        "remove \"active selected\" from <button/>",
+        "remove .highlighted from #modal",
+        "remove me",
+        "remove closest .item"
+      ],
+      "sideEffects": ["dom-mutation"],
+      "category": "dom",
+      "compatibility": "standard"
     },
     "render": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
       "description": "Render templates with @if, @else, and @repeat directives",
       "syntax": [
         "render <template>",
@@ -670,25 +642,324 @@
         "render template with (items: data)"
       ],
       "category": "templates",
+      "compatibility": "standard",
       "sideEffects": ["dom-creation", "template-execution"]
     },
-    "install": {
-      "description": "Install a behavior on an element with optional parameters",
+    "repeat": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Iteration in hyperscript - for-in, counted, conditional, event-driven, and infinite loops",
       "syntax": [
-        "install <BehaviorName>",
-        "install <BehaviorName> on <element>",
-        "install <BehaviorName>(param: value)",
-        "install <BehaviorName>(param: value) on <element>"
+        "repeat for <var> in <collection> { <commands> }",
+        "repeat <count> times { <commands> }",
+        "repeat while <condition> { <commands> }",
+        "repeat until <condition> { <commands> }",
+        "repeat forever { <commands> }"
+      ],
+      "examples": ["repeat for item in items { log item }", "repeat 5 times { log \"hello\" }"],
+      "sideEffects": ["iteration", "conditional-execution"],
+      "category": "control-flow",
+      "compatibility": "standard"
+    },
+    "replace": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Modify browser history URL without page reload",
+      "syntax": [
+        "push url <url>",
+        "push url <url> with title <title>",
+        "replace url <url>",
+        "replace url <url> with title <title>"
       ],
       "examples": [
-        "install Removable",
-        "install Draggable on #box",
-        "install Tooltip(text: \"Help\", position: \"top\")",
-        "install Sortable(axis: \"y\") on .list",
-        "install MyBehavior(foo: 42) on the first <div/>"
+        "push url \"/page/2\"",
+        "push url \"/search\" with title \"Search Results\"",
+        "replace url \"/search?q=test\"",
+        "replace url \"/page\" with title \"Updated Page\""
       ],
-      "category": "behaviors",
-      "sideEffects": ["behavior-installation", "element-modification"]
+      "sideEffects": ["navigation"],
+      "aliases": ["replace"],
+      "category": "navigation",
+      "compatibility": "lokascript-extension"
+    },
+    "reset": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Reset a <form> element to its default values (HTMLFormElement.reset())",
+      "syntax": ["reset", "reset <target>"],
+      "examples": ["reset", "reset #myForm", "reset <form/>"],
+      "sideEffects": ["dom-mutation"],
+      "category": "dom",
+      "compatibility": "standard"
+    },
+    "return": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Return a value from a command sequence or function, terminating execution",
+      "syntax": ["return", "return <value>"],
+      "examples": ["return", "return 42", "return user.name", "if found then return result"],
+      "sideEffects": ["control-flow", "context-mutation"],
+      "category": "control-flow",
+      "compatibility": "standard"
+    },
+    "scroll": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Scroll an element into view (upstream _hyperscript 0.9.90)",
+      "syntax": ["scroll to <target>", "scroll to top of <target>", "scroll to <target> smoothly"],
+      "examples": ["scroll to #top", "scroll to bottom of #chat", "scroll to me smoothly"],
+      "sideEffects": ["scrolling"],
+      "category": "navigation",
+      "compatibility": "standard"
+    },
+    "select": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Select the contents of a text field, or select the contents of a DOM element",
+      "syntax": ["select", "select <target>"],
+      "examples": ["select #search", "select <textarea/>", "select me"],
+      "sideEffects": ["focus", "dom-mutation"],
+      "category": "dom",
+      "compatibility": "standard"
+    },
+    "send": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Dispatch events on elements",
+      "syntax": [
+        "trigger <event> on <target>",
+        "trigger <event>(<detail>) on <target>",
+        "send <event> to <target>",
+        "send <event>(<detail>) to <target>"
+      ],
+      "examples": [
+        "trigger click on #button",
+        "trigger customEvent on me",
+        "send dataEvent to #target",
+        "send myEvent(count: 42) to me"
+      ],
+      "sideEffects": ["event-dispatch"],
+      "aliases": ["send"],
+      "category": "event",
+      "compatibility": "standard"
+    },
+    "set": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Set values to variables, attributes, or properties",
+      "syntax": ["set <target> to <value>"],
+      "examples": [
+        "set myVar to \"value\"",
+        "set @data-theme to \"dark\"",
+        "set my innerHTML to \"content\""
+      ],
+      "sideEffects": ["state-mutation", "dom-mutation"],
+      "category": "data",
+      "compatibility": "standard"
+    },
+    "settle": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Wait for CSS transitions and animations to complete",
+      "syntax": ["settle [<target>] [for <timeout>]"],
+      "examples": ["settle", "settle #animated-element", "settle for 3000"],
+      "sideEffects": ["timing"],
+      "category": "animation",
+      "compatibility": "standard"
+    },
+    "show": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Show elements by restoring display property",
+      "syntax": ["show [<target>]"],
+      "examples": ["show me", "show #modal", "show .hidden", "show <button/>"],
+      "sideEffects": ["dom-mutation"],
+      "category": "dom",
+      "compatibility": "standard"
+    },
+    "start": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Wrap a block of commands in document.startViewTransition()",
+      "syntax": ["start view transition [using <type>] <body> end"],
+      "examples": [
+        "start view transition add .highlight to me end",
+        "start view transition using \"slide\" then put result into #panel end"
+      ],
+      "sideEffects": ["animation", "dom-mutation"],
+      "category": "animation",
+      "compatibility": "standard"
+    },
+    "swap": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Swap content into target elements with intelligent morphing support",
+      "syntax": [
+        "swap <target> with <content>",
+        "swap [strategy] of <target> with <content>",
+        "swap into <target> with <content>",
+        "swap over <target> with <content>",
+        "swap delete <target>",
+        "swap <target> with <content> using view transition"
+      ],
+      "examples": [
+        "swap #target with it",
+        "swap innerHTML of #target with it",
+        "swap over #modal with fetchedContent",
+        "swap delete #notification"
+      ],
+      "sideEffects": ["dom-mutation"],
+      "category": "dom",
+      "compatibility": "standard"
+    },
+    "take": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Move classes, attributes, and properties from one element to another",
+      "syntax": [
+        "take <property> from <source>",
+        "take <property> from <source> and put it on <target>"
+      ],
+      "examples": [
+        "take class from <#source/>",
+        "take @data-value from <.source/> and put it on <#target/>"
+      ],
+      "sideEffects": ["dom-mutation", "property-transfer"],
+      "category": "animation",
+      "compatibility": "standard"
+    },
+    "tell": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Execute commands in the context of target elements",
+      "syntax": ["tell <target> <command> [<command> ...]"],
+      "examples": [
+        "tell #sidebar hide",
+        "tell .buttons add .disabled",
+        "tell closest <form/> submit"
+      ],
+      "sideEffects": ["context-switching", "command-execution"],
+      "category": "utility",
+      "compatibility": "standard"
+    },
+    "throw": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Throw an error with a specified message",
+      "syntax": ["throw <message>"],
+      "examples": ["throw \"Invalid input\"", "if not valid then throw \"Validation failed\""],
+      "sideEffects": ["error-throwing", "execution-termination"],
+      "category": "control-flow",
+      "compatibility": "standard"
+    },
+    "toggle": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Toggle classes, attributes, or interactive elements",
+      "syntax": [
+        "toggle <class> [on <target>]",
+        "toggle @attr",
+        "toggle <element> [as modal]",
+        "toggle <expr> for <duration>"
+      ],
+      "examples": [
+        "toggle .active on me",
+        "toggle @disabled",
+        "toggle #myDialog as modal",
+        "toggle .loading for 2s"
+      ],
+      "sideEffects": ["dom-mutation"],
+      "category": "dom",
+      "compatibility": "standard"
+    },
+    "transition": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Animate CSS properties using CSS transitions",
+      "syntax": ["transition <property> to <value> [over <duration>] [with <timing>]"],
+      "examples": [
+        "transition opacity to 0.5",
+        "transition left to 100px over 500ms",
+        "transition background-color to red over 1s with ease-in-out"
+      ],
+      "sideEffects": ["style-change", "timing"],
+      "category": "animation",
+      "compatibility": "standard"
+    },
+    "trigger": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Dispatch events on elements",
+      "syntax": [
+        "trigger <event> on <target>",
+        "trigger <event>(<detail>) on <target>",
+        "send <event> to <target>",
+        "send <event>(<detail>) to <target>"
+      ],
+      "examples": [
+        "trigger click on #button",
+        "trigger customEvent on me",
+        "send dataEvent to #target",
+        "send myEvent(count: 42) to me"
+      ],
+      "sideEffects": ["event-dispatch"],
+      "aliases": ["send"],
+      "category": "event",
+      "compatibility": "standard"
+    },
+    "unless": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Conditional execution based on boolean expressions",
+      "syntax": [
+        "if <condition> then <commands>",
+        "if <condition> then <commands> else <commands>",
+        "unless <condition> <commands>"
+      ],
+      "examples": [
+        "if x > 5 then add .active",
+        "if user.isAdmin then show #adminPanel else hide #adminPanel",
+        "unless user.isLoggedIn showLoginForm"
+      ],
+      "sideEffects": ["conditional-execution"],
+      "aliases": ["unless"],
+      "category": "control-flow",
+      "compatibility": "standard"
+    },
+    "wait": {
+      "isBlocking": false,
+      "hasBody": false,
+      "version": "1.0.0",
+      "description": "Wait for time delay, event, or race condition",
+      "syntax": ["wait <time>", "wait for <event>", "wait for <event> or <condition>"],
+      "examples": [
+        "wait 2s",
+        "wait for click",
+        "wait for click or 1s",
+        "wait for mousemove(clientX, clientY)"
+      ],
+      "sideEffects": ["time", "event-listening"],
+      "category": "async",
+      "compatibility": "standard"
     }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -226,6 +226,8 @@
     "size": "npm run size:analysis",
     "size:analysis": "echo 'Size Analysis:' && echo 'ES Module: '$(wc -c < dist/index.mjs)' bytes' && echo 'CJS Module: '$(wc -c < dist/index.js)' bytes' && echo 'Gzipped: '$(gzip -c dist/index.mjs | wc -c)' bytes'",
     "verify:reference": "tsx scripts/verify-reference-data.ts",
+    "docs:commands": "tsx scripts/generate-command-docs.ts && tsx scripts/generate-command-docs.ts --format json",
+    "docs:commands:check": "tsx scripts/generate-command-docs.ts --check && tsx scripts/generate-command-docs.ts --format json --check",
     "update:sizes": "tsx scripts/update-bundle-sizes.ts",
     "update:sizes:auto": "tsx scripts/update-bundle-sizes.ts --update"
   },

--- a/packages/core/scripts/generate-command-docs.ts
+++ b/packages/core/scripts/generate-command-docs.ts
@@ -14,6 +14,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import * as prettier from 'prettier';
 import {
   COMMAND_CATEGORIES,
   COMMAND_SIDE_EFFECTS,
@@ -22,61 +23,67 @@ import {
   type CommandMetadata,
 } from '../src/types/command-metadata';
 
-// Import all command classes
+// Import every command class, in registry order.
+//
+// The list is COMPLETE by gate, not by care: `docs-coverage.test.ts` asserts
+// the table below names exactly `COMMAND_NAMES`, both directions. Before Arc B
+// step 4b it held 43 of 59 and nothing compared it to anything, so sixteen
+// shipped commands were simply undocumented.
 import { AddCommand } from '../src/commands/dom/add';
-import { RemoveCommand } from '../src/commands/dom/remove';
-import { ToggleCommand } from '../src/commands/dom/toggle';
-import { ShowCommand } from '../src/commands/dom/show';
-import { HideCommand } from '../src/commands/dom/hide';
-import { PutCommand } from '../src/commands/dom/put';
-import { MakeCommand } from '../src/commands/dom/make';
-
-import { WaitCommand } from '../src/commands/async/wait';
-import { FetchCommand } from '../src/commands/async/fetch';
-
-import { TransitionCommand } from '../src/commands/animation/transition';
-import { MeasureCommand } from '../src/commands/animation/measure';
-import { SettleCommand } from '../src/commands/animation/settle';
-import { TakeCommand } from '../src/commands/animation/take';
-
-import { IfCommand } from '../src/commands/control-flow/if';
-import { RepeatCommand } from '../src/commands/control-flow/repeat';
-import { BreakCommand } from '../src/commands/control-flow/break';
-import { ContinueCommand } from '../src/commands/control-flow/continue';
-import { ReturnCommand } from '../src/commands/control-flow/return';
-import { ExitCommand } from '../src/commands/control-flow/exit';
-import { HaltCommand } from '../src/commands/control-flow/halt';
-import { ThrowCommand } from '../src/commands/control-flow/throw';
-import { UnlessCommand } from '../src/commands/control-flow/unless';
-
-import { SetCommand } from '../src/commands/data/set';
-import { GetCommand } from '../src/commands/data/get';
-import { IncrementCommand } from '../src/commands/data/increment';
-import { DecrementCommand } from '../src/commands/data/decrement';
-import { DefaultCommand } from '../src/commands/data/default';
-
-import { TriggerCommand } from '../src/commands/events/trigger';
-import { SendCommand } from '../src/commands/events/send';
-
-import { LogCommand } from '../src/commands/utility/log';
-import { BeepCommand } from '../src/commands/utility/beep';
-import { TellCommand } from '../src/commands/utility/tell';
-import { PickCommand } from '../src/commands/utility/pick';
-import { CopyCommand } from '../src/commands/utility/copy';
-
-import { CallCommand } from '../src/commands/execution/call';
-import { PseudoCommand } from '../src/commands/execution/pseudo-command';
-
-import { JsCommand } from '../src/commands/advanced/js';
-import { AsyncCommand } from '../src/commands/advanced/async';
-
-import { GoCommand } from '../src/commands/navigation/go';
-
 import { AppendCommand } from '../src/commands/content/append';
-import { PrependCommand } from '../src/commands/content/prepend';
-import { RenderCommand } from '../src/commands/templates/render';
-
+import { AsyncCommand } from '../src/commands/advanced/async';
+import { BeepCommand } from '../src/commands/utility/beep';
+import { BlurCommand } from '../src/commands/execution/blur';
+import { BreakCommand } from '../src/commands/control-flow/break';
+import { BreakpointCommand } from '../src/commands/utility/breakpoint';
+import { CallCommand } from '../src/commands/execution/call';
+import { ClearCommand } from '../src/commands/data/clear';
+import { CloseCommand } from '../src/commands/dom/close';
+import { ContinueCommand } from '../src/commands/control-flow/continue';
+import { CopyCommand } from '../src/commands/utility/copy';
+import { NumericModifyCommand } from '../src/commands/data/increment';
+import { DefaultCommand } from '../src/commands/data/default';
+import { EmptyCommand } from '../src/commands/dom/empty';
+import { ExitCommand } from '../src/commands/control-flow/exit';
+import { FetchCommand } from '../src/commands/async/fetch';
+import { FocusCommand } from '../src/commands/execution/focus';
+import { GetCommand } from '../src/commands/data/get';
+import { GoCommand } from '../src/commands/navigation/go';
+import { HaltCommand } from '../src/commands/control-flow/halt';
+import { HideCommand } from '../src/commands/dom/hide';
+import { ConditionalCommand } from '../src/commands/control-flow/if';
 import { InstallCommand } from '../src/commands/behaviors/install';
+import { JsCommand } from '../src/commands/advanced/js';
+import { LogCommand } from '../src/commands/utility/log';
+import { MakeCommand } from '../src/commands/dom/make';
+import { MeasureCommand } from '../src/commands/animation/measure';
+import { MorphCommand } from '../src/commands/dom/swap';
+import { OpenCommand } from '../src/commands/dom/open';
+import { PickCommand } from '../src/commands/utility/pick';
+import { PrependCommand } from '../src/commands/content/prepend';
+import { ProcessPartialsCommand } from '../src/commands/dom/process-partials';
+import { PseudoCommand } from '../src/commands/execution/pseudo-command';
+import { HistoryCommand } from '../src/commands/navigation/push-url';
+import { PutCommand } from '../src/commands/dom/put';
+import { RemoveCommand } from '../src/commands/dom/remove';
+import { RenderCommand } from '../src/commands/templates/render';
+import { RepeatCommand } from '../src/commands/control-flow/repeat';
+import { ResetCommand } from '../src/commands/dom/reset';
+import { ReturnCommand } from '../src/commands/control-flow/return';
+import { ScrollCommand } from '../src/commands/navigation/scroll-to';
+import { SelectCommand } from '../src/commands/dom/select';
+import { EventDispatchCommand } from '../src/commands/events/trigger';
+import { SetCommand } from '../src/commands/data/set';
+import { SettleCommand } from '../src/commands/animation/settle';
+import { ShowCommand } from '../src/commands/dom/show';
+import { StartViewTransitionCommand } from '../src/commands/animation/start-view-transition';
+import { SwapCommand } from '../src/commands/dom/swap';
+import { TakeCommand } from '../src/commands/animation/take';
+import { TellCommand } from '../src/commands/utility/tell';
+import { ThrowCommand } from '../src/commands/control-flow/throw';
+import { ToggleCommand } from '../src/commands/dom/toggle';
+import { TransitionCommand } from '../src/commands/animation/transition';
+import { WaitCommand } from '../src/commands/async/wait';
 
 // ============================================================================
 // Command Registry
@@ -105,72 +112,65 @@ interface CommandEntry {
 }
 
 const COMMANDS: CommandEntry[] = [
-  // DOM
   { name: 'add', class: AddCommand },
-  { name: 'remove', class: RemoveCommand },
-  { name: 'toggle', class: ToggleCommand },
-  { name: 'show', class: ShowCommand },
-  { name: 'hide', class: HideCommand },
-  { name: 'put', class: PutCommand },
-  { name: 'make', class: MakeCommand },
-
-  // Async
-  { name: 'wait', class: WaitCommand },
-  { name: 'fetch', class: FetchCommand },
-
-  // Animation
-  { name: 'transition', class: TransitionCommand },
-  { name: 'measure', class: MeasureCommand },
-  { name: 'settle', class: SettleCommand },
-  { name: 'take', class: TakeCommand },
-
-  // Control Flow
-  { name: 'if', class: IfCommand },
-  { name: 'repeat', class: RepeatCommand },
-  { name: 'break', class: BreakCommand },
-  { name: 'continue', class: ContinueCommand },
-  { name: 'return', class: ReturnCommand },
-  { name: 'exit', class: ExitCommand },
-  { name: 'halt', class: HaltCommand },
-  { name: 'throw', class: ThrowCommand },
-  { name: 'unless', class: UnlessCommand },
-
-  // Data
-  { name: 'set', class: SetCommand },
-  { name: 'get', class: GetCommand },
-  { name: 'increment', class: IncrementCommand },
-  { name: 'decrement', class: DecrementCommand },
-  { name: 'default', class: DefaultCommand },
-
-  // Events
-  { name: 'trigger', class: TriggerCommand },
-  { name: 'send', class: SendCommand },
-
-  // Utility
-  { name: 'log', class: LogCommand },
-  { name: 'beep', class: BeepCommand },
-  { name: 'tell', class: TellCommand },
-  { name: 'pick', class: PickCommand },
-  { name: 'copy', class: CopyCommand },
-
-  // Execution
-  { name: 'call', class: CallCommand },
-  { name: 'pseudo-command', class: PseudoCommand },
-
-  // Advanced
-  { name: 'js', class: JsCommand },
-  { name: 'async', class: AsyncCommand },
-
-  // Navigation
-  { name: 'go', class: GoCommand },
-
-  // Content
   { name: 'append', class: AppendCommand },
-  { name: 'prepend', class: PrependCommand },
-  { name: 'render', class: RenderCommand },
-
-  // Behaviors
+  { name: 'async', class: AsyncCommand },
+  { name: 'beep', class: BeepCommand },
+  { name: 'blur', class: BlurCommand },
+  { name: 'break', class: BreakCommand },
+  { name: 'breakpoint', class: BreakpointCommand },
+  { name: 'call', class: CallCommand },
+  { name: 'clear', class: ClearCommand },
+  { name: 'close', class: CloseCommand },
+  { name: 'continue', class: ContinueCommand },
+  { name: 'copy', class: CopyCommand },
+  { name: 'decrement', class: NumericModifyCommand },
+  { name: 'default', class: DefaultCommand },
+  { name: 'empty', class: EmptyCommand },
+  { name: 'exit', class: ExitCommand },
+  { name: 'fetch', class: FetchCommand },
+  { name: 'focus', class: FocusCommand },
+  { name: 'get', class: GetCommand },
+  { name: 'go', class: GoCommand },
+  { name: 'halt', class: HaltCommand },
+  { name: 'hide', class: HideCommand },
+  { name: 'if', class: ConditionalCommand },
+  { name: 'increment', class: NumericModifyCommand },
   { name: 'install', class: InstallCommand },
+  { name: 'js', class: JsCommand },
+  { name: 'log', class: LogCommand },
+  { name: 'make', class: MakeCommand },
+  { name: 'measure', class: MeasureCommand },
+  { name: 'morph', class: MorphCommand },
+  { name: 'open', class: OpenCommand },
+  { name: 'pick', class: PickCommand },
+  { name: 'prepend', class: PrependCommand },
+  { name: 'process', class: ProcessPartialsCommand },
+  { name: 'pseudo-command', class: PseudoCommand },
+  { name: 'push', class: HistoryCommand },
+  { name: 'put', class: PutCommand },
+  { name: 'remove', class: RemoveCommand },
+  { name: 'render', class: RenderCommand },
+  { name: 'repeat', class: RepeatCommand },
+  { name: 'replace', class: HistoryCommand },
+  { name: 'reset', class: ResetCommand },
+  { name: 'return', class: ReturnCommand },
+  { name: 'scroll', class: ScrollCommand },
+  { name: 'select', class: SelectCommand },
+  { name: 'send', class: EventDispatchCommand },
+  { name: 'set', class: SetCommand },
+  { name: 'settle', class: SettleCommand },
+  { name: 'show', class: ShowCommand },
+  { name: 'start', class: StartViewTransitionCommand },
+  { name: 'swap', class: SwapCommand },
+  { name: 'take', class: TakeCommand },
+  { name: 'tell', class: TellCommand },
+  { name: 'throw', class: ThrowCommand },
+  { name: 'toggle', class: ToggleCommand },
+  { name: 'transition', class: TransitionCommand },
+  { name: 'trigger', class: EventDispatchCommand },
+  { name: 'unless', class: ConditionalCommand },
+  { name: 'wait', class: WaitCommand },
 ];
 
 // ============================================================================
@@ -203,8 +203,8 @@ function generateMarkdown(commands: CommandEntry[]): string {
 
   lines.push('# HyperFixi Command Reference');
   lines.push('');
-  lines.push('> Auto-generated from command metadata');
-  lines.push(`> Generated: ${new Date().toISOString()}`);
+  lines.push('> Auto-generated from command metadata by `npm run docs:commands`.');
+  lines.push('> Do not edit by hand — `npm run docs:commands:check` fails on drift.');
   lines.push('');
 
   // Table of contents
@@ -363,7 +363,6 @@ function generateJSON(commands: CommandEntry[]): string {
   const output = {
     $schema: 'https://hyperfixi.dev/schemas/commands.json',
     version: '1.0.0',
-    generatedAt: new Date().toISOString(),
     categories: COMMAND_CATEGORIES,
     sideEffects: COMMAND_SIDE_EFFECTS,
     commands: Object.fromEntries(
@@ -398,6 +397,33 @@ if (format === 'json') {
 } else {
   content = generateMarkdown(COMMANDS);
   filename = 'REFERENCE.md';
+}
+
+// Run the emitted text through prettier with the repo's own config.
+//
+// Without this the generator is NOT idempotent: it emits unpadded markdown
+// tables, the pre-commit hook pads them, and the next run un-pads them again —
+// which produced a 252-line diff of pure column padding with identical content
+// (Arc B step 4a). A `--check` gate over a non-idempotent generator is unusable,
+// so this is a prerequisite for the gate below, not a tidiness pass.
+content = await prettier.format(content, {
+  ...(await prettier.resolveConfig(path.join(process.cwd(), filename))),
+  filepath: filename,
+});
+
+// `--check`: fail if the committed artifact differs from what we would write.
+// Deterministic by construction — the generator emits no timestamp, precisely
+// so that this comparison means "the content drifted" and nothing else.
+if (args.includes('--check')) {
+  const filePath = path.join(process.cwd(), outputDir, filename);
+  const onDisk = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : '';
+  if (onDisk !== content) {
+    console.error(`\u2717 ${filename} is out of date. Run: npm run docs:commands`);
+    if (!onDisk) console.error('  (the file does not exist)');
+    process.exit(1);
+  }
+  console.log(`\u2713 ${filename} is up to date (${COMMANDS.length} commands)`);
+  process.exit(0);
 }
 
 // Output

--- a/packages/core/src/commands/__tests__/docs-coverage.test.ts
+++ b/packages/core/src/commands/__tests__/docs-coverage.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The command-docs generator's coverage — Arc B step 4b.
+ *
+ * ## Why this file exists
+ *
+ * `scripts/generate-command-docs.ts` held a hand-maintained `COMMANDS` table of
+ * **43** entries against a **59**-command registry, and **nothing compared it to
+ * anything**: no npm script ran it, no CI step checked it, and the manifest audit
+ * could not see it because the generator lives in `scripts/`. So sixteen shipped
+ * commands — `blur`, `breakpoint`, `clear`, `close`, `empty`, `focus`, `morph`,
+ * `open`, `process`, `push`, `replace`, `reset`, `scroll`, `select`, `start`,
+ * `swap` — were simply undocumented, and would have stayed that way. That is the
+ * queue's founding disease verbatim: *a list that describes code, that nothing
+ * compares to the code.*
+ *
+ * The table is now complete, and this is the mechanism that keeps it so.
+ *
+ * ## Why it reads source TEXT rather than importing
+ *
+ * The generator is a CLI script with top-level side effects — importing it would
+ * write files during the test run. Reading its source is the same approach the
+ * manifest audit uses for the cross-package LSP tier lists, and it is why the
+ * table's formatting is pinned below: the extraction has to keep working.
+ *
+ * ## What is deliberately NOT duplicated here
+ *
+ * Arc A already gates the two lists the Arc B plan named as "cheap completeness
+ * tests" — `reference/index.ts` in the manifest audit's §2 ("documents exactly the
+ * registered set") and `lsp-metadata`'s `COMMAND_KEYWORDS`/`HOVER_DOCS` in §5,
+ * both directions. Re-asserting them here would add a second place to maintain
+ * without adding a check. Measured before writing, not assumed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { COMMAND_NAMES } from '../manifest';
+import { Runtime } from '../../runtime/runtime';
+
+const GENERATOR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../scripts/generate-command-docs.ts'
+);
+
+function generatorSource(): string {
+  return readFileSync(GENERATOR, 'utf8');
+}
+
+/** The `{ name: 'x', class: X }` rows of the generator's COMMANDS table, in order. */
+function tableNames(src: string): string[] {
+  const start = src.indexOf('const COMMANDS: CommandEntry[] = [');
+  expect(start, 'the COMMANDS table moved — fix this extraction').toBeGreaterThan(-1);
+  const end = src.indexOf('\n];', start);
+  const block = src.slice(start, end);
+  return [...block.matchAll(/\{ name: '([^']+)', class: \w+ \}/g)].map(m => m[1]);
+}
+
+describe('the command-docs generator covers the whole command set', () => {
+  it('names exactly COMMAND_NAMES, in the same order', () => {
+    // ORDERED equality, not set equality: the manifest is sorted in registry
+    // order so that adding a command is a one-line diff here too, and an ordered
+    // check keeps the two from drifting in arrangement as well as in content.
+    expect(tableNames(generatorSource())).toEqual([...COMMAND_NAMES]);
+  });
+
+  it('has no duplicate rows', () => {
+    // A duplicated row satisfies set-equality and collapses in a Map, so neither
+    // the check above nor the generator's own output would notice it; the row
+    // count is what rules it out.
+    const names = tableNames(generatorSource());
+    expect(names.length).toBe(new Set(names).size);
+  });
+
+  it('is the same set the engine actually registers', () => {
+    // COMMAND_NAMES is the manifest's own list, and the manifest audit holds it
+    // to the registry — but this file's whole point is that a docs list must be
+    // compared to the CODE, so it asks the runtime directly rather than trusting
+    // one hop of indirection.
+    const registered = [...new Runtime().getRegistry().getCommandNames()].sort();
+    expect([...tableNames(generatorSource())].sort()).toEqual(registered);
+  });
+
+  it('emits no timestamp, so `--check` means "content drifted"', () => {
+    // The gate is only usable because the output is deterministic. A
+    // `Generated: <ISO>` line made a whole-file `--check` fail on every run
+    // (measured in step 4a), so its absence is load-bearing, not cosmetic.
+    const src = generatorSource();
+    expect(src).not.toMatch(/Generated: \$\{new Date\(\)/);
+    expect(src).not.toMatch(/generatedAt: new Date\(\)/);
+  });
+
+  it('formats its output with prettier, so regenerating is a no-op', () => {
+    // Without this the generator emits unpadded markdown tables, the pre-commit
+    // hook pads them, and the next run un-pads them — a 252-line diff of pure
+    // column padding with identical content (measured in step 4a). A `--check`
+    // over a non-idempotent generator can never pass twice.
+    expect(generatorSource()).toMatch(/await prettier\.format\(/);
+  });
+});
+
+describe('every registered command carries publishable prose', () => {
+  // Passes today for all 59; it is a RATCHET, not a discovery. The metadata is
+  // now the single source for the generated docs, so an empty description here
+  // would ship an empty row there — and `commandMeta` cannot catch it, because
+  // `''` is a perfectly good `string`.
+  const rows = [
+    ...(
+      new Runtime().getRegistry() as unknown as {
+        implementations: Map<string, { metadata?: Record<string, unknown> }>;
+      }
+    ).implementations,
+  ];
+
+  it('has a non-empty description', () => {
+    const bad = rows
+      .filter(([, impl]) => !String(impl.metadata?.description ?? '').trim())
+      .map(([name]) => name);
+    expect(bad).toEqual([]);
+  });
+
+  it('has at least one syntax form and one example', () => {
+    const bad: string[] = [];
+    for (const [name, impl] of rows) {
+      const syntax = impl.metadata?.syntax;
+      const forms = Array.isArray(syntax) ? syntax : syntax ? [syntax] : [];
+      if (forms.length === 0) bad.push(`${name}: no syntax`);
+      if (!(impl.metadata?.examples as unknown[] | undefined)?.length) {
+        bad.push(`${name}: no examples`);
+      }
+    }
+    expect(bad).toEqual([]);
+  });
+});


### PR DESCRIPTION
Arc B step 4b, **closing the arc** (#823 brief · #824 · #825 · #826 · #827).

`scripts/generate-command-docs.ts` held a hand-maintained table of **43** entries against a **59**-command registry, and **nothing compared it to anything**: no npm script ran it, no CI step checked it, and the manifest audit couldn't see it because the generator lives in `scripts/`. Sixteen shipped commands were simply undocumented and would have stayed that way — the queue's founding disease verbatim, in the one place Arc A didn't sweep.

**Now documented:** `blur`, `breakpoint`, `clear`, `close`, `empty`, `focus`, `morph`, `open`, `process`, `push`, `replace`, `reset`, `scroll`, `select`, `start`, `swap`.

## The gate F-B3 said did not exist

`src/commands/__tests__/docs-coverage.test.ts`, 7 tests. The table must name exactly `COMMAND_NAMES` **in the same order**, carry no duplicate rows, and match what the runtime actually registers — asked of the runtime **directly** rather than through the manifest, because the point of the file is comparing a docs list to the *code*.

Mutation-verified four ways:

| Mutation | Result |
| --- | --- |
| drop `toggle` from the table | 2 tests fail |
| duplicate a row | 3 tests fail |
| reintroduce the `Generated:` timestamp | its guard fails |
| replace the `prettier.format` call | its guard fails |

It reads the generator's **source text** rather than importing it — the generator is a CLI script with top-level side effects, so importing would write files during the test run. Same approach the manifest audit uses for the cross-package tier lists.

## Both 4a blockers fixed, and each is now itself gated

- **The generator formats its output with prettier**, so regenerating is a **no-op** rather than a re-flow. Without it, it emitted unpadded markdown tables that the pre-commit hook then padded — a 252-line diff of pure column padding with identical content.
- **It emits no timestamp**, so `--check` means "the content drifted" and nothing else. A `Generated: <ISO>` line made a whole-file comparison fail **100%** of runs.

Idempotence verified by running twice for an identical diffstat; `prettier --check` clean on both artifacts; and confirmed post-commit that the pre-commit hook's prettier pass leaves them alone, so the hook won't fight the gate. `--check` failure mutation-verified in both directions.

## Wiring

`npm run docs:commands` and `docs:commands:check`. The check joins the existing **"Check generated artifacts are in sync"** CI step, which already carries exactly this reasoning for two other generators that had the same two defects. `REFERENCE.md` and `commands.json` regenerated — 59 commands each, now carrying the `compatibility` field the metadata gained in step 3.

## One planned item was already done, and measuring beat building it

The plan opened 4b with "completeness tests for `reference/index.ts` and `lsp-metadata.ts` (cheap)". **Arc A had already built both** — the manifest audit's §2 asserts `reference/index.ts` "documents exactly the registered set" and §5 gates `COMMAND_KEYWORDS`/`HOVER_DOCS` in both directions. Rewriting them would have added a second place to maintain and no new check, so the non-duplication is recorded in the new test file instead.

That freed effort went into a **prose ratchet** on the metadata itself (non-empty description, ≥1 syntax form, ≥1 example; all 59 pass today). It guards what `commandMeta` structurally *cannot*: `''` is a perfectly good `string`, so the type system will never object to an empty description while the generator will happily publish it.

## Verification

| Gate | Result |
| --- | --- |
| core `test:check` | **7629 → 7636** / 106 skipped / 298 files — the 7 new tests, nothing changed |
| `typecheck` / `typecheck:scripts` | 0 / 0 |
| `verify:reference` | pass |
| `docs:commands:check` | pass (and passes *after* the pre-commit hook runs) |
| `check:test-list` / `check:ci-build-order` | OK (38 packages gated) |
| prettier | clean |

## Still open, filed not folded in

F-B1: narrowing `command-adapter.ts`'s shadow `CommandMetadata` and settling `:421`'s name fallback. That's a **behavior** question — the fallback is the only path for a V1 command carrying `metadata.name`, and the canonical type has no `name` field — so it doesn't belong in a docs-generator PR. Filed in the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)