### PR TITLE
fix(bundles): templates absorb the executor capabilities (Arc E step 2)

### DIFF
--- a/docs-internal/HANDOFF-command-arch-bundles.md
+++ b/docs-internal/HANDOFF-command-arch-bundles.md
@@ -139,12 +139,15 @@ capability-emission (generated bundles only).
 
 ### D2 — hybrid-complete richer than the templates (generation as-is would DROP these)
 
-| Row | hybrid-complete has | templates have |
-| --- | --- | --- |
-| `toggle`/`add`/`removeClass` | `@attr` attribute toggling (`toggle @disabled`) | classList only — `@disabled` becomes a bogus class name |
-| `increment`/`decrement` | style-prop branch (possessive `*opacity`) | no style branch |
-| `fetch` block | `via <METHOD>` + `with <options>` (FormData, RequestInit merge) | url + responseType only |
-| `removeClass` | sets `ctx.it` to targets | returns targets without setting `ctx.it` |
+**All four rows are now DECIDED — see § "Step 2 — CLOSED" for the reasoning and
+the measured before/after.** Three absorbed, one declined.
+
+| Row | hybrid-complete has | templates have | Step 2 |
+| --- | --- | --- | --- |
+| `toggle`/`add`/`removeClass` | `@attr` attribute toggling (`toggle @disabled`) | classList only — `@disabled` becomes a bogus class name | **absorbed** |
+| `increment`/`decrement` | style-prop branch (possessive `*opacity`) | no style branch | **absorbed** |
+| `fetch` block | `via <METHOD>` + `with <options>` (FormData, RequestInit merge) | url + responseType only | **absorbed** |
+| `removeClass` | sets `ctx.it` to targets | returns targets without setting `ctx.it` | **declined** — the template is the copy Arc C endorses |
 
 ### D3 — templates richer than hybrid-complete (generation closes real gaps)
 
@@ -167,6 +170,185 @@ not a silent side effect of choosing which copy the generator reads. The
 default posture: templates absorb D2 (superset), D3 stands as-is (templates
 already the better copy), D1 is fixed by generation itself once the templates
 are the source — but it should not WAIT for generation (step 1).
+
+## Step 1 — CLOSED (#830 the gate + two fixes, #829 this brief)
+
+`compatibility/shipped-bundle-execution.test.ts` exists now (602 lines, 10
+tests, 43 surfaces) and is the INCUMBENT execution gate for the handwritten
+bundles — **extend it, never write a second one.** Its completeness test is a
+ratchet: a name added to a bundle's `commands`/`blocks` array without a surface
+FAILS. D1 (`take`) is fixed — hybrid-complete now passes the NODE, matching the
+template.
+
+The gate found **two defects beyond the one the brief predicted**, and both are
+recorded here because they lived only in #830's PR body and code comments until
+now — #829 merged AFTER #830, so this brief never received them. That is the
+exact rot this queue exists to fight.
+
+### S1-a — hybrid-complete's `case 'trigger':` (`:474`) is UNREACHABLE DEAD CODE
+
+The parser emits name `'send'` for all of `send`/`trigger`/`fire` —
+`parseSend(marker)` hardcodes `name: 'send'`. This is **Finding 13's mirror,
+inside the handwritten bundle**: the templates' `trigger` label was deleted for
+this reason and a comment left in its place (`templates.ts`, above `put`), while
+hybrid-complete's identical label survived.
+
+It was load-bearing when added (2026-07-20 audit — `trigger` really was a silent
+no-op then); Finding 13's parser work killed it silently. The sharp part:
+`bundle-manifest-consistency.test.ts:73-76` **PINS it with a source-text
+regex** — the *gate that locks the defect in* antipattern, now measured rather
+than hypothesized. Deleting the label by hand would fail that gate, so it comes
+out **structurally in step 4**, when the executor is generated and the manifest
+gate's source-text assumption is retired with it.
+
+### S1-b — `for x in #t.children` iterates ONCE for an N-element collection
+
+The coercion is `Array.isArray(items) ? items : items instanceof NodeList ?
+Array.from(items) : [items]`, and an **HTMLCollection satisfies neither arm**,
+so it is wrapped as a single item. Present in BOTH copies (hybrid-complete
+`:700`, the `for` template) — an agreement, not a divergence, so no D2/D3 row
+sees it.
+
+This is Arc D's deliberately-deferred array-like question
+(`toElementListFiltered` vs `toElementListStrict`: `put` filters a mixed array
+and gates on `instanceof NodeList`; `append`/`prepend` duck-type and accept an
+HTMLCollection). It is therefore a **behavior change, not a step-2 refactor**.
+The step-1 gate's `for` row deliberately uses a multi-match selector
+(`for x in .item`) and records the gap in its comment.
+
+### S1-c — `return` leaked its internal token out of the public API (fixed in #830)
+
+Unpredicted by the brief, and the reason the gate earned its keep twice in one
+sitting. `return` unwinds by throwing `{type:'return', value}`. **Three of four**
+sequence entry points caught it — the event-handler path, the init path, and the
+generated bundles' `executeAST` — but hybrid-complete's top-level sequence path
+did not, so `hyperfixi.execute('return 42')` rejected with a bare internal
+object (no `message`, not an `Error`) instead of resolving to `42`. Fixed at
+`browser-bundle-hybrid-complete.ts:803`.
+
+The generalizable shape: **a control-flow signal implemented as a throw needs a
+catch at EVERY entry point, and "three of four" is invisible to any gate that
+exercises one path.**
+
+## Step 2 — CLOSED: the templates are now the superset
+
+Three of the four D2 rows absorbed, one declined. Every row was measured in
+BOTH copies before anything was written (#792's rule, applied for the fourth
+time) — and that is what turned row 4 around.
+
+### The four decisions
+
+1. **`@attr` on `toggle`/`add`/`removeClass` — ABSORBED.** Measured before:
+   `toggle @disabled on #t` left the attribute untouched and added a class
+   literally named `disabled`; `remove @disabled` was a silent no-op. After: all
+   three match hybrid-complete exactly.
+2. **Style-prop `increment`/`decrement` — ABSORBED.** Measured before:
+   `increment #t's *opacity by 0.25` was a **silent no-op** — no error, no
+   effect, opacity unmoved — because the possessive fell through to the
+   textContent path where `toElementArray` of an evaluated style value yields no
+   elements. After: 0.5 → 0.75, matching hybrid-complete.
+3. **`fetch` `via`/`with` — ABSORBED.** Measured before: the template
+   destructured neither, so `fetch "/api" via POST with opts` issued a plain
+   **GET with no body and reported success**. That is a wrong request shape, not
+   a missing feature, which is what justifies the bytes.
+4. **`removeClass`'s `ctx.it` — DECLINED, and this is the row that inverted.**
+   The brief's default posture ("templates absorb D2") would have adopted
+   hybrid-complete's `ctx.it = targets`. Arc C's contract says the opposite:
+   `remove .active from #probe` leaves `it` at its initial value, pinned in
+   `runtime/__tests__/command-output-contract.test.ts`, under the rule *a
+   command sets `it` iff upstream sets `result` for it*. **The template was
+   already the correct copy.** Absorbing would have added a NEW divergence from
+   the canonical engine inside the arc meant to remove copies.
+   **Consequence for step 4:** generating hybrid-complete from the templates
+   REMOVES that assignment from the shipped bundle — a deliberate behavior
+   change that must be restated in step 4's PR body, not discovered there.
+
+### S2-a — the D2 table described case BODIES; two of three absorptions needed the SHELL
+
+The harvest's method was diffing `case` blocks, so it was structurally unable to
+see helper divergence. Two absorptions turned out to be **shell** changes, both
+in `bundle-generator/generator.ts`, and either one alone would have made its
+template a silent no-op:
+
+- `getClassName` sliced EVERY selector, so `@disabled` arrived as `disabled` and
+  the new `raw.startsWith('@')` branch could never fire. It now passes `@`
+  through unsliced, matching hybrid-complete's helper.
+- `getStyleProp` **was never emitted at all** — only `isStyleProp`/
+  `getStyleName`/`setStyleProp`. Now emitted behind a new `STYLE_READ_COMMANDS`
+  export (a strict subset of `STYLE_COMMANDS`: `set`/`put` only ever write), so
+  the very common `put`-only bundle does not carry a getter it never calls.
+
+Generalizable: **when a divergence table is built by diffing bodies, budget for
+the helpers those bodies call.** Step 3 (the shared boot shell) is where these
+helpers stop being a separate surface.
+
+### S2-b — both bundle executors diverge from Arc C's `it` contract on ≥5 more rows
+
+Found while scoring row 4. `toggle`, `add`, `put`, `append`/`prepend` and
+`transition` all self-assign `ctx.it` in BOTH bundle copies, where the canonical
+runtime sets nothing (`transition` deliberately, in Arc C's close-out). Because
+the two copies **agree**, no D2/D3 row sees it — the harvest's method is blind to
+a shared divergence from a third party.
+
+Deliberately NOT fixed here: it is a behavior change to generated bundles across
+five rows, and **no execution gate currently asserts `it` at all** (both gates
+assert DOM effects and return values). It wants its own decision, like S1-b.
+
+### S2-c — the `'js'` output format emits invalid JavaScript for 6 of 40 templates
+
+`stripTypes()` has no rule for the non-null assertion (`block.condition!`,
+`ctx.me.parentElement!` — `if`/`repeat`/`while`/`take`), for a bare `let x: any;`
+(`fetch`), or for `const promises: Promise[] = []` (`transition`). Verified
+byte-identical before and after step 2, so it is **pre-existing**, and
+**nothing requests `format: 'js'` today** — every consumer takes the `'ts'`
+default, which is why it has never surfaced.
+
+Step 2 deliberately did not add to it: the new fetch code writes
+`{} as RequestInit`, not `: RequestInit`, because `stripTypes` removes `as Type`
+casts but has no rule for a `const x: Type =` annotation. That reasoning is
+recorded in the template itself so the next editor does not "tidy" it back.
+
+### Measured cost — GENERATED bundles only
+
+The Oracle-3 claim was verified, not assumed: no shipped bundle entry imports
+`bundle-generator` (the `rollup.config.mjs` hit is a library subpath entry, not a
+size-gated browser bundle). Shipped sizes are unmoved; `hyperfixi-hx.js` does not
+budge, as required.
+
+| Generated config | before | after | delta |
+| --- | --- | --- | --- |
+| full 35 cmds + 5 blocks | 31740 raw / 7375 gz | 34105 / 7766 | **+2365 / +391** |
+| hybrid-complete-equivalent 24+5 | 25579 / 5951 | 27944 / 6345 | **+2365 / +394** |
+| typical vite bundle (5+1) | 14735 / 3742 | 15395 / 3875 | +660 / +133 |
+| `put` + `fetch` block only | 13738 / 3672 | 14458 / 3886 | +720 / +214 |
+
+Unminified generator output; the shipped rollup+terser pipeline lands lower.
+Note the `getClassName` `@` branch lands in EVERY generated bundle (it is an
+unconditional shell helper), which is why even a `put`-only bundle moves.
+Its explanatory comment was deliberately cut to one line for the same reason —
+emitted shell code is shipped bytes, and the rationale belongs in `templates.ts`
+and here, not in every user's bundle.
+
+**Step 4's budget is now tighter than Finding 17 measured it.** The orphan cost
+re-measures at **+1421 gz** (24+5 → 35+5 on the current templates), consistent
+with Finding 17's +1433 — but step 2 adds a further **~+390 gz** to the executor
+core that step 4 will generate. The `MAX_HYBRID` → 22000 recommendation still
+looks adequate against `hyperfixi-hx.js`'s 19003-baseline gzip, but step 4 must
+**re-measure rather than inherit** it.
+
+### Gate
+
+`capability-emission.test.ts` gained a `CAPABILITIES` list (7 rows) kept separate
+from `SURFACES`, whose one-row-per-advertised-command completeness ratchet
+depends on being exactly 1:1. `toggle` gets **both** directions, because a
+`toggle` that only ever removes passes an adding-only row. Each row also asserts
+the *bogus class did not appear* — the literal defect shape, not a proxy for it.
+
+Mutation-verified, 7 for 7: reverting the `getClassName` `@` branch, deleting
+either style branch, dropping `via`, dropping `with`, and un-emitting
+`getStyleProp` each fail **only** the new capability test (12 other tests stay
+green, so none is an incidental compile crash). The `getClassName` mutation
+names exactly the four `@attr` rows.
 
 ## Finding 17, restated with the arc's numbers
 

--- a/packages/core/src/bundle-generator/__tests__/capability-emission.test.ts
+++ b/packages/core/src/bundle-generator/__tests__/capability-emission.test.ts
@@ -224,6 +224,95 @@ const SURFACES: Record<string, Surface> = {
   },
 };
 
+/**
+ * A capability of a command that already has a SURFACES row — a second syntax
+ * the same template must serve. Arc E step 2 absorbed four such capabilities
+ * from the handwritten hybrid-complete executor into the templates, and each
+ * one gets a row here so "the templates are the superset" is measured rather
+ * than asserted in a commit message.
+ *
+ * Kept as a separate list, not merged into SURFACES, because SURFACES is
+ * one-row-per-advertised-command and its completeness ratchet depends on that
+ * being exactly true.
+ */
+interface Capability extends Surface {
+  /** Unique file id for the generated bundle (SURFACES rows use the command). */
+  id: string;
+  /** The template the capability belongs to — what gets put in the bundle. */
+  command: string;
+}
+
+/** Requests the generated bundle issued, so a `via`/`with` row can inspect them. */
+const fetchCalls: Array<{ url: string; init: RequestInit | undefined }> = [];
+
+const ATTR_NOTE = 'the attribute form; before step 2 the @ was sliced off and applied as a class';
+
+const CAPABILITIES: Capability[] = [
+  // Both directions, because a `toggle` that only ever REMOVES passes the
+  // adding row and vice versa. Each also asserts no bogus class appeared —
+  // that was the literal shape of the defect, not just a proxy for it.
+  {
+    id: 'toggle_attr_off',
+    command: 'toggle',
+    code: 'toggle @disabled on #t',
+    setup: d => t(d).setAttribute('disabled', ''),
+    check: o => !t(o.doc).hasAttribute('disabled') && !t(o.doc).classList.contains('disabled'),
+  },
+  {
+    id: 'toggle_attr_on',
+    command: 'toggle',
+    code: 'toggle @disabled on #t',
+    check: o => t(o.doc).hasAttribute('disabled') && !t(o.doc).classList.contains('disabled'),
+  },
+  {
+    id: 'add_attr',
+    command: 'add',
+    code: 'add @hidden to #t',
+    check: o => t(o.doc).hasAttribute('hidden') && !t(o.doc).classList.contains('hidden'),
+  },
+  {
+    id: 'removeclass_attr',
+    command: 'removeClass',
+    code: 'remove @disabled from #t',
+    setup: d => t(d).setAttribute('disabled', ''),
+    check: o => !t(o.doc).hasAttribute('disabled'),
+  },
+  // The style-property branch. Asserted on the STYLE, and on textContent being
+  // untouched: the pre-step-2 fallback treated the possessive as an element
+  // reference, so a row that only checked "opacity is a number" would have been
+  // satisfied by the silent no-op that left it at its initial value.
+  {
+    id: 'increment_style',
+    command: 'increment',
+    code: "increment #t's *opacity by 0.25",
+    setup: d => (t(d).style.opacity = '0.5'),
+    check: o => t(o.doc).style.opacity === '0.75' && t(o.doc).textContent === 'seed',
+  },
+  {
+    id: 'decrement_style',
+    command: 'decrement',
+    code: "decrement #t's *opacity by 0.25",
+    setup: d => (t(d).style.opacity = '0.5'),
+    check: o => t(o.doc).style.opacity === '0.25' && t(o.doc).textContent === 'seed',
+  },
+  // `via`/`with`. The check inspects the REQUEST, not the response: the
+  // pre-step-2 template dropped both and issued a plain GET, which still
+  // resolved and still filled #t. A row asserting only the swapped-in body
+  // would have passed against the defect — the fallback-measuring trap the
+  // module header describes, here with the "fallback" being the wrong verb.
+  {
+    id: 'fetch_via_with',
+    command: 'put',
+    blocks: ['fetch'],
+    code: 'fetch "/api" via POST with window.__capFetchOpts as text then put it into #t end',
+    check: o =>
+      fetchCalls.length === 1 &&
+      fetchCalls[0].init?.method === 'POST' &&
+      (fetchCalls[0].init as { headers?: Record<string, string> }).headers?.['X-Cap'] === '1' &&
+      t(o.doc).innerHTML === 'FETCHED',
+  },
+];
+
 const win = (): Record<string, unknown> => globalThis as unknown as Record<string, unknown>;
 
 /**
@@ -234,9 +323,13 @@ const win = (): Record<string, unknown> => globalThis as unknown as Record<strin
  */
 const GEN_DIR = join(__dirname, '.generated');
 
-const runInBundle = async (name: string, surface: Surface): Promise<Outcome> => {
+const runInBundle = async (
+  name: string,
+  surface: Surface,
+  fileId: string = name
+): Promise<Outcome> => {
   const gen = generateBundle({
-    name: `Cap${name.replace(/-/g, '')}`,
+    name: `Cap${fileId.replace(/-/g, '')}`,
     commands: [name, ...(surface.also ?? [])],
     blocks: surface.blocks ?? [],
     autoInit: false,
@@ -244,7 +337,7 @@ const runInBundle = async (name: string, surface: Surface): Promise<Outcome> => 
   });
   expect(gen.errors, `generateBundle rejected the advertised command '${name}'`).toEqual([]);
 
-  const file = join(GEN_DIR, `${name.replace(/-/g, '_')}.ts`);
+  const file = join(GEN_DIR, `${fileId.replace(/-/g, '_')}.ts`);
   writeFileSync(file, gen.code);
 
   document.body.innerHTML =
@@ -255,6 +348,12 @@ const runInBundle = async (name: string, surface: Surface): Promise<Outcome> => 
   );
   clipboardWrites.length = 0;
   consoleLines.length = 0;
+  fetchCalls.length = 0;
+  win().__capFetchOpts = { headers: { 'X-Cap': '1' } };
+  win().fetch = async (url: string, init?: RequestInit) => {
+    fetchCalls.push({ url: String(url), init });
+    return new Response('FETCHED', { status: 200 });
+  };
   win().__capJs = undefined;
   win().__capCall_ran = false;
   win().__capCall = () => (win().__capCall_ran = true);
@@ -309,6 +408,24 @@ describe('every advertised command runs in a generated bundle', () => {
     // closed (plus `take`, which the parse-level oracle could not see at all).
     expect(dead).toEqual([]);
     expect(AVAILABLE_COMMANDS.length).toBe(38);
+  }, 60000);
+
+  it('every capability absorbed from hybrid-complete runs (Arc E step 2)', async () => {
+    // The templates are now claimed to be the SUPERSET of the two AST
+    // executors. This is the claim, measured. Each row failed against the
+    // pre-step-2 templates and passed against hybrid-complete — the divergence
+    // was measured in both copies before any of it was written, because #792
+    // established that the canonical copy is sometimes the broken one.
+    const dead: string[] = [];
+    for (const cap of CAPABILITIES) {
+      const outcome = await runInBundle(cap.command, cap, cap.id);
+      if (!cap.check(outcome)) {
+        dead.push(
+          `${cap.id}${outcome.error ? ` (threw: ${String(outcome.error.message).slice(0, 60)})` : ''}`
+        );
+      }
+    }
+    expect(dead).toEqual([]);
   }, 60000);
 
   it('a trigger-only bundle now dispatches on the named target', async () => {

--- a/packages/core/src/bundle-generator/generator.ts
+++ b/packages/core/src/bundle-generator/generator.ts
@@ -10,6 +10,7 @@ import {
   COMMAND_IMPLEMENTATIONS,
   BLOCK_IMPLEMENTATIONS,
   STYLE_COMMANDS,
+  STYLE_READ_COMMANDS,
   ELEMENT_ARRAY_COMMANDS,
   MORPH_COMMANDS,
   getCommandImplementations,
@@ -40,6 +41,7 @@ export function generateBundleCode(config: GeneratorOptions): string {
   } = config;
 
   const needsStyleHelpers = commands.some(cmd => STYLE_COMMANDS.includes(cmd));
+  const needsStyleReadHelper = commands.some(cmd => STYLE_READ_COMMANDS.includes(cmd));
   const needsElementArrayHelper = commands.some(cmd => ELEMENT_ARRAY_COMMANDS.includes(cmd));
   // MORPH_COMMANDS has been exported since the template was written but was
   // never read here, so the `morph` template's `morphlexMorph`/`morphlexMorphInner`
@@ -288,7 +290,15 @@ const setStyleProp = (el: Element, prop: string, value: any): boolean => {
   (el as HTMLElement).style.setProperty(getStyleName(prop), String(value));
   return true;
 };
+${
+  needsStyleReadHelper
+    ? `const getStyleProp = (el: Element, prop: string): string | undefined => {
+  if (!isStyleProp(prop)) return undefined;
+  return getComputedStyle(el as HTMLElement).getPropertyValue(getStyleName(prop));
+};
 `
+    : ''
+}`
     : ''
 }
 
@@ -317,7 +327,11 @@ async function executeCommand(cmd: CommandNode, ctx: Context): Promise<any> {
 
   const getClassName = (node: any): string => {
     if (!node) return '';
-    if (node.type === 'selector') return node.value.slice(1);
+    if (node.type === 'selector') {
+      // \`@attr\` passes through unsliced; .class / #id lose their prefix.
+      if (node.value.startsWith('@')) return node.value;
+      return node.value.slice(1);
+    }
     if (node.type === 'string' || node.type === 'literal') {
       const val = node.value;
       return typeof val === 'string' && val.startsWith('.') ? val.slice(1) : String(val);

--- a/packages/core/src/bundle-generator/templates.ts
+++ b/packages/core/src/bundle-generator/templates.ts
@@ -37,20 +37,40 @@ function stripTypes(code: string, format: CodeFormat): string {
  * Each command is a complete case block for the executeCommand switch.
  */
 const COMMAND_IMPLEMENTATIONS_TS: Record<string, string> = {
+  // The three class commands share an ATTRIBUTE form (`toggle @disabled`,
+  // `add @hidden`, `remove @disabled`), absorbed from the handwritten
+  // hybrid-complete executor in Arc E step 2. The shell's `getClassName` passes
+  // an `@`-prefixed selector through UNSLICED precisely so this branch can tell
+  // the two apart; without it `@disabled` was sliced to `disabled` and applied
+  // as a bogus CLASS NAME, leaving the attribute untouched (measured, all three
+  // rows). Gated by the `@attr` surfaces in capability-emission.test.ts.
   toggle: `
     case 'toggle': {
-      const className = getClassName(cmd.args[0]) || String(await evaluate(cmd.args[0], ctx));
+      const raw = getClassName(cmd.args[0]) || String(await evaluate(cmd.args[0], ctx));
       const targets = await getTarget();
-      for (const el of targets) el.classList.toggle(className);
+      if (raw.startsWith('@')) {
+        const attr = raw.slice(1);
+        for (const el of targets) {
+          if (el.hasAttribute(attr)) el.removeAttribute(attr);
+          else el.setAttribute(attr, '');
+        }
+      } else {
+        for (const el of targets) el.classList.toggle(raw);
+      }
       ctx.it = targets.length === 1 ? targets[0] : targets;
       return ctx.it;
     }`,
 
   add: `
     case 'add': {
-      const className = getClassName(cmd.args[0]) || String(await evaluate(cmd.args[0], ctx));
+      const raw = getClassName(cmd.args[0]) || String(await evaluate(cmd.args[0], ctx));
       const targets = await getTarget();
-      for (const el of targets) el.classList.add(className);
+      if (raw.startsWith('@')) {
+        const attr = raw.slice(1);
+        for (const el of targets) el.setAttribute(attr, '');
+      } else {
+        for (const el of targets) el.classList.add(raw);
+      }
       ctx.it = targets.length === 1 ? targets[0] : targets;
       return ctx.it;
     }`,
@@ -62,11 +82,25 @@ const COMMAND_IMPLEMENTATIONS_TS: Record<string, string> = {
       return null;
     }`,
 
+  // NOTE — the `ctx.it` half of this row was DECIDED AGAINST absorption.
+  // hybrid-complete sets `ctx.it = targets` here; this template does not, and
+  // that is the copy Arc C's contract endorses: `remove .active from #probe`
+  // leaves `it` at its initial value in the canonical runtime, pinned by
+  // `runtime/__tests__/command-output-contract.test.ts` ("a command sets `it`
+  // iff upstream sets `result` for it"). Absorbing it would have added a NEW
+  // divergence from the canonical engine in the arc meant to remove copies.
+  // Step 4's generation therefore REMOVES that assignment from the shipped
+  // bundle — a deliberate behavior change, to be restated in that PR body.
   removeClass: `
     case 'removeClass': {
-      const className = getClassName(cmd.args[0]) || String(await evaluate(cmd.args[0], ctx));
+      const raw = getClassName(cmd.args[0]) || String(await evaluate(cmd.args[0], ctx));
       const targets = await getTarget();
-      for (const el of targets) el.classList.remove(className);
+      if (raw.startsWith('@')) {
+        const attr = raw.slice(1);
+        for (const el of targets) el.removeAttribute(attr);
+      } else {
+        for (const el of targets) el.classList.remove(raw);
+      }
       return targets;
     }`,
 
@@ -315,6 +349,11 @@ const COMMAND_IMPLEMENTATIONS_TS: Record<string, string> = {
       return ctx.me;
     }`,
 
+  // The possessive STYLE-PROPERTY branch below (`increment #t's *opacity`) is
+  // absorbed from hybrid-complete in Arc E step 2. Without it the possessive
+  // fell through to the textContent path, where `toElementArray` of an
+  // evaluated style value yields no elements — so the command was a SILENT
+  // NO-OP: no error, no effect, opacity unmoved (measured on both rows).
   increment: `
     case 'increment': {
       const target = cmd.args[0];
@@ -328,6 +367,18 @@ const COMMAND_IMPLEMENTATIONS_TS: Record<string, string> = {
         map.set(varName, newVal);
         ctx.it = newVal;
         return newVal;
+      }
+
+      if (target.type === 'possessive' && isStyleProp(target.property)) {
+        const obj = await evaluate(target.object, ctx);
+        const elements = toElementArray(obj);
+        for (const el of elements) {
+          const current = parseFloat(getStyleProp(el, target.property) || '0') || 0;
+          const newVal = current + amount;
+          setStyleProp(el, target.property, newVal);
+          ctx.it = newVal;
+        }
+        return ctx.it;
       }
 
       const elements = toElementArray(await evaluate(target, ctx));
@@ -353,6 +404,18 @@ const COMMAND_IMPLEMENTATIONS_TS: Record<string, string> = {
         map.set(varName, newVal);
         ctx.it = newVal;
         return newVal;
+      }
+
+      if (target.type === 'possessive' && isStyleProp(target.property)) {
+        const obj = await evaluate(target.object, ctx);
+        const elements = toElementArray(obj);
+        for (const el of elements) {
+          const current = parseFloat(getStyleProp(el, target.property) || '0') || 0;
+          const newVal = current - amount;
+          setStyleProp(el, target.property, newVal);
+          ctx.it = newVal;
+        }
+        return ctx.it;
       }
 
       const elements = toElementArray(await evaluate(target, ctx));
@@ -663,12 +726,38 @@ const BLOCK_IMPLEMENTATIONS_TS: Record<string, string> = {
       return null;
     }`,
 
+  // \`via <METHOD>\` and \`with <options>\` are absorbed from hybrid-complete in
+  // Arc E step 2. The parser has always emitted \`method\`/\`options\` on the
+  // fetchConfig node; this template destructured neither, so a generated bundle
+  // DROPPED them silently — \`fetch "/api" via POST with body\` issued a plain
+  // GET with no body and reported success. Not a missing feature so much as a
+  // wrong request shape, which is why it is worth the bytes.
+  //
+  // \`{} as RequestInit\` rather than \`: RequestInit\` deliberately: stripTypes()
+  // removes \` as Type\` casts but has no rule for a \`const x: Type =\`
+  // annotation, so the annotated form would emit invalid JS in 'js' format.
   fetch: `
     case 'fetch': {
-      const { url, responseType } = block.condition as any;
+      const { url, responseType, options, method } = block.condition as any;
       try {
         const urlVal = await evaluate(url, ctx);
-        const response = await fetch(String(urlVal));
+        const fetchInit = {} as RequestInit;
+
+        if (method) {
+          const methodVal = await evaluate(method, ctx);
+          fetchInit.method = String(methodVal).toUpperCase();
+        }
+
+        if (options) {
+          const optionsVal = await evaluate(options, ctx);
+          if (optionsVal instanceof FormData) {
+            fetchInit.body = optionsVal;
+          } else if (optionsVal && typeof optionsVal === 'object' && !(optionsVal instanceof Element)) {
+            Object.assign(fetchInit, optionsVal);
+          }
+        }
+
+        const response = await fetch(String(urlVal), fetchInit);
         if (!response.ok) throw new Error(\`HTTP \${response.status}\`);
 
         const resType = await evaluate(responseType, ctx);
@@ -699,6 +788,16 @@ const BLOCK_IMPLEMENTATIONS_TS: Record<string, string> = {
  * Commands that require style property helpers (isStyleProp, setStyleProp)
  */
 export const STYLE_COMMANDS = ['set', 'put', 'increment', 'decrement'];
+
+/**
+ * Commands that additionally READ a style property back (`getStyleProp`).
+ *
+ * A strict subset of STYLE_COMMANDS: `set`/`put` only ever write, while
+ * increment/decrement must read the current value to add to it. Kept separate
+ * so the two write-only commands — `put` in particular, which is in nearly
+ * every generated bundle — do not carry a getter they never call.
+ */
+export const STYLE_READ_COMMANDS = ['increment', 'decrement'];
 
 /**
  * Commands that require toElementArray helper


### PR DESCRIPTION
Arc E **step 2 of 5**. Step 1 is closed (#830 the gate + two fixes, #829 the brief). Reconciles the D2 divergences between the two AST executors into `bundle-generator/templates.ts` as the superset, so step 4's generation is a refactor rather than a silent behavior flip.

Brief: `docs-internal/HANDOFF-command-arch-bundles.md` § "The harvest" (D2) and § "Step 2 — CLOSED".

## The four D2 decisions

The brief's rule: every D2/D3 row is a **decision**, not a side effect of choosing which copy the generator reads. Each was measured in **both** copies before anything was written — #792's lesson applied for the fourth time, and it is what turned row 4 around.

| Row | Decision | Measured BEFORE (generated bundle) |
| --- | --- | --- |
| `@attr` on `toggle`/`add`/`removeClass` | **absorbed** | `toggle @disabled on #t` left the attribute untouched and added a class literally named `disabled`; `remove @disabled` a silent no-op |
| style-prop `increment`/`decrement` | **absorbed** | `increment #t's *opacity by 0.25` was a **silent no-op** — no error, no effect, opacity unmoved |
| `fetch` `via`/`with` | **absorbed** | template destructured neither, so `fetch "/api" via POST with opts` issued a plain **GET with no body** and reported success |
| `removeClass`'s `ctx.it` | **declined** | see below |

**Row 4 inverted the brief's default posture.** "Templates absorb D2" would have adopted hybrid-complete's `ctx.it = targets`. Arc C's contract says the opposite: `remove .active from #probe` leaves `it` at its initial value, pinned in `runtime/__tests__/command-output-contract.test.ts` under *a command sets `it` iff upstream sets `result` for it*. **The template was already the correct copy** — absorbing would have added a NEW divergence from the canonical engine inside the arc meant to remove copies.

> **Carried to step 4:** generating hybrid-complete from the templates therefore **removes** that assignment from the shipped bundle. A deliberate behavior change, to be restated in that PR body rather than discovered there.

## The named harvest paid — the D2 table described case BODIES, not the shell

Two of three absorptions turned out to need `generator.ts`, and either one alone would have left its template a silent no-op:

- `getClassName` sliced **every** selector, so `@disabled` arrived as `disabled` and the new `raw.startsWith('@')` branch could never fire.
- `getStyleProp` **was never emitted at all** — only `isStyleProp`/`getStyleName`/`setStyleProp`. Now emitted behind a new `STYLE_READ_COMMANDS` export, a strict subset of `STYLE_COMMANDS` (`set`/`put` only ever write), so the very common `put`-only bundle does not carry a getter it never calls.

Generalizable: **when a divergence table is built by diffing bodies, budget for the helpers those bodies call.**

## The three oracles

**(1) Execution — both instruments moved, as required.** `capability-emission.test.ts` (generated bundles) gains a `CAPABILITIES` list, 7 rows, one per absorbed capability. Kept **separate** from `SURFACES`, whose completeness ratchet depends on being exactly one row per advertised command. `toggle` gets **both** directions, because a `toggle` that only ever removes passes an adding-only row; every row also asserts the *bogus class did not appear* — the literal defect shape, not a proxy. `shipped-bundle-execution.test.ts` (handwritten bundles) is **untouched and still green**: absorbing a capability into the templates must not change what the shipped bundle does in this step.

Mutation-verified **7/7** — reverting the `getClassName` `@` branch, deleting either style branch, dropping `via`, dropping `with`, un-emitting `getStyleProp`. Each fails **only** the new capability test while the other 12 stay green, so none is an incidental compile crash; the `getClassName` mutation names exactly the four `@attr` rows.

**(2) The cmdMap-equality spec** (capability-emission §4, 35 = 35) — untouched, still green. It remains the spec step 5's generator must satisfy.

**(3) Bundle size — the claim was verified, not assumed.** No shipped bundle entry imports `bundle-generator` (the `rollup.config.mjs` hit is a library subpath entry, not a size-gated browser bundle). Empirically: `hyperfixi-hx.js` gzip **+0.0%**, `hyperfixi-hybrid-complete.js` gzip **−0.0%**, all bundles within tolerance. Generated-only delta:

| Generated config | before | after | delta |
| --- | --- | --- | --- |
| full 35 cmds + 5 blocks | 31740 raw / 7375 gz | 34105 / 7766 | **+2365 / +391** |
| hybrid-complete-equivalent 24+5 | 25579 / 5951 | 27944 / 6345 | **+2365 / +394** |
| typical vite bundle (5+1) | 14735 / 3742 | 15395 / 3875 | +660 / +133 |
| `put` + `fetch` block only | 13738 / 3672 | 14458 / 3886 | +720 / +214 |

`MAX_HYBRID`, `baseline.json --update` and the 24→35 advertised-count ripple all remain **step 4's** budget, untouched here. But step 4 is now **tighter** than Finding 17 measured: the orphan cost re-measures at +1421 gz, consistent with Finding 17's +1433, and step 2 adds a further ~+390 gz to the executor core step 4 will generate. The 22000 recommendation still looks adequate — step 4 must **re-measure rather than inherit** it.

## Brief updated with findings that lived only in code comments

Step 1's findings never reached the brief (#829 merged after #830). Now recorded, plus two new ones:

- **S1-a** hybrid-complete's `case 'trigger':` is unreachable dead code — the parser emits `send` for all of send/trigger/fire. `bundle-manifest-consistency.test.ts:73-76` **pins it with a source-text regex**: the *gate that locks the defect in* antipattern, now measured. Removed structurally by step 4, not by hand.
- **S1-b** `for x in #t.children` iterates **once** for an N-element collection (an HTMLCollection satisfies neither coercion arm). Arc D's deferred array-like question — a behavior change, not a step-2 refactor.
- **S1-c** `return` leaked its internal `{type:'return'}` token out of the public API; three of four sequence entry points caught it, one didn't.
- **S2-b (new)** Both bundle executors diverge from Arc C's `it` contract on **≥5 further rows** (`toggle`, `add`, `put`, `append`/`prepend`, `transition`). They **agree with each other**, so no D2/D3 row sees it — the harvest's method is blind to a shared divergence from a third party. Not fixed here: **no execution gate asserts `it` at all**.
- **S2-c (new)** The `'js'` output format emits **invalid JavaScript for 6 of 40 templates** (`stripTypes` has no rule for `!` non-null assertions, a bare `let x: any;`, or `const promises: Promise[] = []`). Verified byte-identical before/after, so pre-existing — and **nothing requests `format: 'js'` today**. Step 2 deliberately did not add to it: the new fetch code writes `{} as RequestInit`, not `: RequestInit`, with that reasoning recorded in the template so the next editor does not "tidy" it back.

## Gates

All from the merged parent `a002419f`, exit status captured before any pipe.

| Gate | Result |
| --- | --- |
| `test:quick` (core) | **7647** passed / 106 skipped / 299 files (baseline 7646 — +1 is the new row) |
| `typecheck` (core) | clean |
| `verify:reference` | pass |
| `docs:commands:check` | pass (59 commands) |
| `snapshot:bundle-size` | all within tolerance; hx **+0.0%** |
| `npm test` language-server | **227** |
| `npm run test:check` | pass (vite-plugin **315**) |
| `playwright src/compatibility/` | **1102 passed / 8 skipped / 10 failed** — the known-local set (behaviors-demo, i18n-htmx, swap-debug), green in CI |

Prettier 3.9.5 run by hand; `--check` clean and idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
