### PR TITLE
refactor(bundles): one boot shell, seven copies → one gate (Arc E step 3)

### DIFF
--- a/docs-internal/HANDOFF-command-arch-bundles.md
+++ b/docs-internal/HANDOFF-command-arch-bundles.md
@@ -350,6 +350,125 @@ either style branch, dropping `via`, dropping `with`, and un-emitting
 green, so none is an incidental compile crash). The `getClassName` mutation
 names exactly the four `@attr` rows.
 
+## Step 3 — CLOSED: the shared boot shell, and the shells that were not counted
+
+The step's own premise was the first thing to fail re-measurement, in the way
+this arc keeps re-learning. The brief said four shells (hybrid-complete, lite,
+lite-plus, the generator). Measured: **seven emission sites across two
+packages** — the three handwritten bundles, core's
+`bundle-generator/generator.ts`, and **three more in `@hyperfixi/vite-plugin`**
+that no one had counted: `generator.ts`'s main shell, its separate
+empty-bundle shell, and `compiled-generator.ts`'s AOT shell. The union was
+taken by executing the modules and reading `Object.keys(api)`, not by reading
+source — a count-only or one-side diff would have missed three of the seven.
+
+### The measured union (this replaces the brief's step-3 sentence)
+
+| key | hybrid-complete | lite | lite-plus | core-gen | vite main | vite empty | vite compiled |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `version` `parse` `execute` `init` `process` `commands` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ (stubs) | partial |
+| `blocks` | ✓ (7) | — | — | conditional | conditional | — | — |
+| `run` `eval` `parserName` | — | — | — | ✓ | ✓ | ✓ | — |
+| `tokenize` `evaluate` | ✓ | — | — | — | — | — | — |
+| `addAliases` `addEventAliases` | ✓ | — | ✓ | — | — | — | — |
+| `window._hyperscript` | — | — | — | ✓ | ✓ | ✓ | ✓ |
+
+Two of the brief's step-3 claims were wrong: `addAliases`/`addEventAliases` are
+on lite-plus too (not hybrid-complete alone), and the `compiled-generator`
+shell has neither `parse` nor `execute` — `hyperfixi.execute(...)` is undefined
+on an AOT-compiled vite bundle while every other bundle has it. That last one
+is left filed, not fixed: it is a capability gap in the compile-mode runtime,
+not a shell divergence.
+
+### The decisions — the union was NOT unioned
+
+Scored per family, and the rule that fell out is worth carrying: **an extra
+survives where a consumer or gate witnesses it, and is removed where nothing
+does.** Unioning all fourteen keys into all seven shells would have put
+unrequested API into four shipped bundles and into every bundle the vite-plugin
+emits — the step-2 `getClassName` comment-trim trade, at larger scale.
+
+1. **hybrid-complete gains `run`/`eval`/`parserName`? DECLINED.** Nothing reads
+   them on a handwritten bundle, and `hyperfixi-hx.js` spreads
+   hybrid-complete's api wholesale (`browser-bundle-hybrid-hx.ts:171`), so any
+   addition is user-visible API on **two** shipped bundles. Scoring found the
+   inverse of what "dead code" would predict: `parserName` is NOT dead — it is
+   read by `examples/vite-plugin-test/main.js` and
+   `examples/vite-plugin-multilingual/main.js`, AND it is the regex anchor the
+   vite-plugin splices semantic api props after (`generator.ts:765`,
+   `/parserName: '(?:lite|hybrid)',/`). A rename there breaks the semantic
+   bundle path silently.
+2. **The emitted shell gains `tokenize`/`evaluate`/`addAliases`/
+   `addEventAliases`? DECLINED.** Bytes in EVERY generated bundle for API
+   nothing requests; `tokenize` would additionally force a parser-core import
+   into a path that is deliberately self-contained.
+3. **Does any hybrid bundle set `window._hyperscript`? NO — and the four that
+   did, stop.** This is the step's one behavior change. Measured against
+   `hyperscript.org@0.9.93`: `_hyperscript` is a **callable function**
+   (`_hyperscript('1 + 1')` → `2`) carrying `evaluate`, `processNode`,
+   `internals`, `config`, `addCommand`, `addFeature`. The bundle `api` is a
+   plain object with none of them. On a page loading both, last-write-wins; if
+   the generated bundle won, `_hyperscript(...)` threw "not a function",
+   `.evaluate` was undefined, and `parse`/`process` — the only overlapping
+   names — silently did something else. No shipped handwritten bundle ever did
+   this and **no test in either package asserted it**, which is why it survived
+   in four emitters. The convergence is toward the shipped bundles' behavior.
+4. **`eval` KEPT on generated bundles.** Redundant alias of `execute` with zero
+   consumers, but removing published API is a breaking change with no defect
+   behind it — unlike `_hyperscript`, which actively breaks a third party.
+
+### S3-a — the shared helper was measured, and the obvious design REJECTED
+
+The natural reading of "one helper" is a factory that takes an options object
+and returns the api. Built, measured, reverted: **+103 bytes gzip on
+`hyperfixi-hybrid-complete.js`, +63 on `hyperfixi-hx.js`.** Terser inlines the
+call but cannot collapse the two object literals or the property indirection
+through the options bag, and since every bundle is rolled up independently the
+indirection buys no sharing at runtime — it is pure overhead in four shipped
+bundles.
+
+What shipped instead shares only what is genuinely identical — the `[_]` scan
+loop (`createProcessElements`) and the global install (`installBundleGlobal`) —
+while each bundle keeps a flat api literal typed as `BundleShellApi<TAst>`.
+Final cost: hybrid-complete **+27 gz**, hx **+22 gz**, lite +33, lite-plus +34.
+The generalizable half: **the anti-drift property comes from the GATE, not from
+the indirection.** Once `bundle-shell.test.ts` pins the key sets, the factory
+was buying nothing the type and the test did not already buy, for 4× the bytes.
+
+### S3-b — a gate row that measured nothing, caught by mutation testing
+
+The first version asserted "a scan error is contained, not thrown" by feeding
+each shell gibberish. Mutation testing (replace the `catch` with `throw err`)
+left it **green**: neither the regex nor the hybrid parser throws
+*synchronously* on malformed source — they degrade and return a node, and the
+executor's rejection is an un-awaited promise. The row was exercising nothing.
+
+Replaced with five tests against `createProcessElements` directly, injecting a
+throwing parse and a throwing run. This is Finding 16's rule arriving from a
+new direction: it is not enough to assert a real effect, the input must be
+capable of PRODUCING the failure the assertion describes. **11 of 11 mutations
+now fail their intended test and nothing else** (verified individually, so none
+is an incidental compile crash).
+
+### Gate — step 3
+
+`compatibility/bundle-shell.test.ts` (37 tests) pins each shell's key set as
+**set equality, both directions** — an ADDED key fails too, which is what makes
+it a ratchet — plus what every core export is FOR (`execute` applies a DOM
+effect, `init` wires elements under a root, `process` IS `init`, `blocks`
+present iff the bundle has blocks) and what each witnessed extra is for
+(`addAliases` makes the alias actually execute). `vite-plugin/src/
+emitted-shell.test.ts` (4 tests) covers the three sites a core-side gate cannot
+see. Both sides assert the `_hyperscript` absence, since neither can see the
+other's emitters.
+
+### Measured cost — SHIPPED bundles only
+
+Only the four slim bundles moved; the six full bundles are untouched.
+`baseline.json` was updated **for those four entries only** — a blanket
+`--update` would have absorbed the +0.3–0.8% raw local-vs-recorded drift the
+full bundles already show into the committed numbers, blinding the gate to it.
+
 ## Finding 17, restated with the arc's numbers
 
 The shipped hybrid bundles PARSE 35 commands and EXECUTE 24. The 11 orphans —
@@ -398,16 +517,16 @@ capability-emission row. Affects GENERATED bundle sizes only (vite-plugin
 users) — snapshot the delta in the PR body. After this step the templates are
 the undisputed best copy of every row they carry.
 
-**Step 3 — shared boot-shell helper.** The queue says the shells "differ only
-in their commands/blocks arrays and alias-registration identity" — measured,
-they also differ in: `tokenize`/`evaluate` exports and `addAliases`/
-`addEventAliases` (hybrid-complete has them; the generator's emitted shell
-does not), `run`/`eval`/`parserName` and the `window._hyperscript` global
-(generator has them; the handwritten shells do not). Decide the union surface
-once, in one helper consumed by the generator and both handwritten families
-(lite/lite-plus join here). `hyperfixi-hx.js` imports hybrid-complete's
-default export (`browser-bundle-hybrid-hx.ts:35`) — its API surface is a
-consumer to keep green.
+**Step 3 — shared boot-shell helper. CLOSED — see § "Step 3 — CLOSED" above
+for the measured union, the four decisions, and the two findings.** The
+paragraph that stood here undercounted the shells (four; there are **seven**,
+three of them in `@hyperfixi/vite-plugin`) and misattributed
+`addAliases`/`addEventAliases` to hybrid-complete alone. Outcome in one line:
+the union was deliberately NOT unioned — extras stay where a consumer or gate
+witnesses them — the shared helper covers only the `[_]` scan loop and the
+global install (the api-building factory was measured at +103 gz and
+rejected), and `window._hyperscript` is gone from all four emitters that
+claimed it.
 
 **Step 4 — generate the hybrid-complete executor core; commit output with a
 `--check` drift guard.** `generateBundleCode()` already emits the whole file

--- a/packages/core/scripts/bundle-snapshots/baseline.json
+++ b/packages/core/scripts/bundle-snapshots/baseline.json
@@ -4,7 +4,7 @@
   "generated": "2026-07-29",
   "commit": "09010f5c",
   "tolerance_percent": 5,
-  "notes": "Updated 2026-07-29 (#821): every full bundle DROPPED ~29.1 KB raw / ~6 KB gzip — a near-constant across minimal, standard, classic, classic-i18n, browser and hx-v4 — when the dead src/expressions/*/impl/ classes were deleted. They were unreachable at runtime (the registry objects in each category's index.ts are what execute) but were kept alive in the payload by trailing 'Re-export implementations for tests' lines, which made them public API surface that tree-shaking could not drop. The four slim bundles (lite, lite-plus, hybrid-complete, hybrid-hx) are unchanged, since they never pull in the expression registry. Both directions of this gate matter: it uses Math.abs, so a size IMPROVEMENT this large trips it too and must be recorded here. Previously updated 2026-07-20 (pre-release audit): added the four slim bundles, which had NO size-regression coverage, and refreshed all sizes post-#736. Runs in the CI bundle-size job. Run `node scripts/bundle-size-snapshot.mjs --check` after changes; failures (±5% drift) point to tree-shaking or duplication regressions. Regenerate with --update after an INTENTIONAL size change; the numbers here are macOS-local and read ~1 KB (0.3%) below CI Linux zlib on the full bundles, well inside the tolerance. metadata.ts, by contrast, must carry the CI numbers.",
+  "notes": "Updated 2026-07-30 (Arc E step 3, shared boot shell): ONLY the four slim bundles were re-baselined, because only they changed — they now import the shared `[_]` scanner and global installer from `compatibility/bundle-shell.ts` instead of each inlining their own. gzip deltas: lite +33 (+1.7%), lite-plus +34 (+1.3%), hybrid-complete +27 (+0.3%), hx +22 (+0.1%); raw deltas are +15 to +54. The gzip cost exceeds the raw cost on the two smallest bundles because the shared arrow-function form compresses slightly worse than the inline for-loop it replaced. A factory that also BUILT the api object was measured and rejected at +103 gz on hybrid-complete / +63 on hx — see the header of bundle-shell.ts. The six full bundles were deliberately NOT re-baselined: this change does not touch them, and a blanket --update would have absorbed the +0.3-0.8% raw local-vs-recorded drift they already show into the committed numbers, blinding the gate to it. Updated 2026-07-29 (#821): every full bundle DROPPED ~29.1 KB raw / ~6 KB gzip — a near-constant across minimal, standard, classic, classic-i18n, browser and hx-v4 — when the dead src/expressions/*/impl/ classes were deleted. They were unreachable at runtime (the registry objects in each category's index.ts are what execute) but were kept alive in the payload by trailing 'Re-export implementations for tests' lines, which made them public API surface that tree-shaking could not drop. The four slim bundles (lite, lite-plus, hybrid-complete, hybrid-hx) are unchanged, since they never pull in the expression registry. Both directions of this gate matter: it uses Math.abs, so a size IMPROVEMENT this large trips it too and must be recorded here. Previously updated 2026-07-20 (pre-release audit): added the four slim bundles, which had NO size-regression coverage, and refreshed all sizes post-#736. Runs in the CI bundle-size job. Run `node scripts/bundle-size-snapshot.mjs --check` after changes; failures (±5% drift) point to tree-shaking or duplication regressions. Regenerate with --update after an INTENTIONAL size change; the numbers here are macOS-local and read ~1 KB (0.3%) below CI Linux zlib on the full bundles, well inside the tolerance. metadata.ts, by contrast, must carry the CI numbers.",
   "bundles": {
     "hyperfixi-minimal.js": {
       "config": "rollup.browser-minimal.config.mjs",
@@ -52,29 +52,29 @@
       "config": "rollup.browser-lite.config.mjs",
       "entry": "src/compatibility/browser-bundle-lite.ts",
       "evaluator_strategy": "inline regex mini-parser (no AST evaluator)",
-      "raw_bytes": 5294,
-      "gzip_bytes": 1967
+      "raw_bytes": 5309,
+      "gzip_bytes": 2000
     },
     "hyperfixi-lite-plus.js": {
       "config": "rollup.browser-lite-plus.config.mjs",
       "entry": "src/compatibility/browser-bundle-lite-plus.ts",
       "evaluator_strategy": "inline regex mini-parser (no AST evaluator)",
-      "raw_bytes": 8298,
-      "gzip_bytes": 2658
+      "raw_bytes": 8313,
+      "gzip_bytes": 2692
     },
     "hyperfixi-hybrid-complete.js": {
       "config": "rollup.browser-hybrid-complete.config.mjs",
       "entry": "src/compatibility/browser-bundle-hybrid-complete.ts",
       "evaluator_strategy": "HybridParser + inline executeCommand switch",
-      "raw_bytes": 33227,
-      "gzip_bytes": 8382
+      "raw_bytes": 33279,
+      "gzip_bytes": 8409
     },
     "hyperfixi-hx.js": {
       "config": "rollup.browser-hybrid-hx.config.mjs",
       "entry": "src/compatibility/browser-bundle-hybrid-hx.ts",
       "evaluator_strategy": "hybrid-complete runtime + htmx/fixi attribute layer",
-      "raw_bytes": 72173,
-      "gzip_bytes": 19003
+      "raw_bytes": 72227,
+      "gzip_bytes": 19025
     }
   }
 }

--- a/packages/core/src/bundle-generator/generator.ts
+++ b/packages/core/src/bundle-generator/generator.ts
@@ -485,6 +485,13 @@ function processElements(root: Element | Document = document): void {
 // =============================================================================
 // PUBLIC API
 // =============================================================================
+// Shape mirrors \`compatibility/bundle-shell.ts\` (BundleShellApi). The two are
+// separate copies on purpose — a generated bundle is self-contained and must
+// not import from @hyperfixi/core — so \`bundle-shell.test.ts\` asserts the
+// emitted key set matches the handwritten one, the way Oracle 2 pins the two
+// cmdMaps. \`run\`/\`eval\`/\`parserName\` are generated-only extras; see the
+// witnessed-extras table in bundle-shell.ts for why they stay here and are not
+// added to the shipped handwritten bundles.
 
 const api = {
   version: '1.0.0-${name.toLowerCase().replace(/\s+/g, '-')}',
@@ -520,7 +527,6 @@ ${
     ? `
 if (typeof window !== 'undefined') {
   (window as any).${globalName} = api;
-  (window as any)._hyperscript = api;
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => processElements());

--- a/packages/core/src/compatibility/browser-bundle-hybrid-complete.ts
+++ b/packages/core/src/compatibility/browser-bundle-hybrid-complete.ts
@@ -29,6 +29,15 @@ import { HybridParser } from '../parser/hybrid/parser-core';
 import { tokenize } from '../parser/hybrid/tokenizer';
 import type { ASTNode, CommandNode, BlockNode, EventNode } from '../parser/hybrid/ast-types';
 import { addCommandAliases, addEventAliases } from '../parser/hybrid/aliases';
+import { createProcessElements, installBundleGlobal, type BundleShellApi } from './bundle-shell';
+
+/** The extras hybrid-complete adds above the shared core surface. */
+interface HybridCompleteExtras {
+  addAliases: typeof addCommandAliases;
+  addEventAliases: typeof addEventAliases;
+  tokenize: typeof tokenize;
+  evaluate: typeof evaluate;
+}
 
 // =============================================================================
 // RUNTIME (stays inline - specific to this bundle)
@@ -895,49 +904,31 @@ async function executeAST(ast: ASTNode, me: Element, event?: Event): Promise<any
 // DOM PROCESSOR
 // =============================================================================
 
-function processElement(el: Element): void {
-  const code = el.getAttribute('_');
-  if (!code) return;
+const parseCode = (code: string): ASTNode => new HybridParser(code).parse();
 
-  try {
-    const parser = new HybridParser(code);
-    const ast = parser.parse();
-    executeAST(ast, el);
-  } catch (err) {
-    console.error('HyperFixi Hybrid Complete error:', err, 'Code:', code);
-  }
-}
-
-function processElements(root: Element | Document = document): void {
-  const elements = root.querySelectorAll('[_]');
-  elements.forEach(processElement);
-}
+const processElements = createProcessElements(parseCode, executeAST, 'Hybrid Complete');
 
 // =============================================================================
-// PUBLIC API
+// PUBLIC API — shape shared via `bundle-shell.ts`, keys pinned by its gate
 // =============================================================================
 
-const api = {
+const api: BundleShellApi<ASTNode> & HybridCompleteExtras = {
   version: '1.0.0-hybrid-complete',
 
-  parse(code: string): ASTNode {
-    const parser = new HybridParser(code);
-    return parser.parse();
-  },
+  parse: parseCode,
 
-  async execute(code: string, element?: Element): Promise<any> {
-    const me = element || document.body;
-    const parser = new HybridParser(code);
-    const ast = parser.parse();
-    return executeAST(ast, me);
+  async execute(code: string, element?: Element): Promise<unknown> {
+    return executeAST(parseCode(code), element || document.body);
   },
 
   init: processElements,
   process: processElements,
 
+  // Witnessed extras, not shell core: `addAliases` is pinned by
+  // `browser-tests/hybrid-complete.spec.ts`, and `tokenize`/`evaluate` mirror
+  // the full bundle's surface. See the table in `bundle-shell.ts`.
   addAliases: addCommandAliases,
-  addEventAliases: addEventAliases,
-
+  addEventAliases,
   tokenize,
   evaluate,
 
@@ -975,14 +966,6 @@ const api = {
 // AUTO-INITIALIZE
 // =============================================================================
 
-if (typeof window !== 'undefined') {
-  (window as any).hyperfixi = api;
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => processElements());
-  } else {
-    processElements();
-  }
-}
+installBundleGlobal(api, processElements);
 
 export default api;

--- a/packages/core/src/compatibility/browser-bundle-lite-plus.ts
+++ b/packages/core/src/compatibility/browser-bundle-lite-plus.ts
@@ -20,6 +20,14 @@
  * Extensible via keyword aliases for internationalization.
  */
 
+import { createProcessElements, installBundleGlobal, type BundleShellApi } from './bundle-shell';
+
+/** The extras lite-plus adds above the shared core surface. */
+interface LitePlusExtras {
+  addAliases: (aliases: Record<string, string>) => void;
+  addEventAliases: (aliases: Record<string, string>) => void;
+}
+
 // ============== KEYWORD ALIASES ==============
 // Pattern for extending to other languages.
 // To add Spanish: import { SPANISH_ALIASES } from './aliases/es';
@@ -697,49 +705,23 @@ async function executeParsed(
 
 // ============== DOM PROCESSOR ==============
 
-function processElements(root: Element | Document = document): void {
-  const elements = root.querySelectorAll('[_]');
-
-  for (const el of elements) {
-    const code = el.getAttribute('_');
-    if (code) {
-      try {
-        const parsed = parseLite(code);
-        executeParsed(parsed, el);
-      } catch (err) {
-        console.error('HyperFixi Lite+ error:', err, 'Code:', code);
-      }
-    }
-  }
-}
+/** Scans `[_]` and runs each element's code. Shared with every other bundle. */
+const processElements = createProcessElements(parseLite, executeParsed, 'Lite+');
 
 // ============== PUBLIC API ==============
 
-const api = {
+// Shape shared via `bundle-shell.ts`; keys pinned by its gate. Lite+ carries
+// the core surface plus alias registration — a witnessed extra it shares with
+// hybrid-complete. It advertises no `blocks`: its regex executor has none.
+const api: BundleShellApi<LiteEventHandler | LiteCommand[]> & LitePlusExtras = {
   version: '1.0.0-lite-plus',
 
-  /**
-   * Parse hyperscript code
-   */
   parse: parseLite,
 
-  /**
-   * Execute hyperscript code on an element
-   */
-  execute: async (code: string, element?: Element) => {
-    const me = element || document.body;
-    const parsed = parseLite(code);
-    return executeParsed(parsed, me);
-  },
+  execute: async (code: string, element?: Element) =>
+    executeParsed(parseLite(code), element || document.body),
 
-  /**
-   * Process all _="" attributes
-   */
   init: processElements,
-
-  /**
-   * Process _="" attributes in a root
-   */
   process: processElements,
 
   /**
@@ -791,14 +773,6 @@ const api = {
 };
 
 // Auto-initialize
-if (typeof window !== 'undefined') {
-  (window as any).hyperfixi = api;
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => processElements());
-  } else {
-    processElements();
-  }
-}
+installBundleGlobal(api, processElements);
 
 export default api;

--- a/packages/core/src/compatibility/browser-bundle-lite.ts
+++ b/packages/core/src/compatibility/browser-bundle-lite.ts
@@ -15,6 +15,8 @@
  * - wait (async timing)
  */
 
+import { createProcessElements, installBundleGlobal, type BundleShellApi } from './bundle-shell';
+
 // ============== LITE PARSER ==============
 // Regex-based parser for minimal bundle size
 
@@ -470,69 +472,29 @@ function evaluateCondition(expr: string, me: Element, locals: Map<string, any>):
 
 // ============== DOM PROCESSOR ==============
 
-/**
- * Process all elements with _="" attributes
- */
-function processElements(root: Element | Document = document): void {
-  const elements = root.querySelectorAll('[_]');
-
-  for (const el of elements) {
-    const code = el.getAttribute('_');
-    if (code) {
-      try {
-        const parsed = parseLite(code);
-        executeParsed(parsed, el);
-      } catch (err) {
-        console.error('HyperFixi Lite error:', err, 'Code:', code);
-      }
-    }
-  }
-}
+/** Scans `[_]` and runs each element's code. Shared with every other bundle. */
+const processElements = createProcessElements(parseLite, executeParsed, 'Lite');
 
 // ============== PUBLIC API ==============
 
-const api = {
+// Shape shared via `bundle-shell.ts`; keys pinned by its gate. Lite carries the
+// core surface and nothing else — no `blocks` (it executes none) and no
+// alias registration (unlike lite-plus, which advertises i18n aliases).
+const api: BundleShellApi<LiteEventHandler | LiteCommand[]> = {
   version: '1.0.0-lite',
 
-  /**
-   * Parse hyperscript code (returns internal representation)
-   */
   parse: parseLite,
 
-  /**
-   * Execute hyperscript code on an element
-   */
-  execute: async (code: string, element?: Element) => {
-    const me = element || document.body;
-    const parsed = parseLite(code);
-    return executeParsed(parsed, me);
-  },
+  execute: async (code: string, element?: Element) =>
+    executeParsed(parseLite(code), element || document.body),
 
-  /**
-   * Process all _="" attributes in the document
-   */
   init: processElements,
-
-  /**
-   * Process _="" attributes in a specific root
-   */
   process: processElements,
 
-  /**
-   * Available commands in this lite bundle
-   */
   commands: ['add', 'remove', 'toggle', 'put', 'set', 'log', 'send', 'wait'],
 };
 
 // Auto-initialize
-if (typeof window !== 'undefined') {
-  (window as any).hyperfixi = api;
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => processElements());
-  } else {
-    processElements();
-  }
-}
+installBundleGlobal(api, processElements);
 
 export default api;

--- a/packages/core/src/compatibility/browser-tests/bundle-compatibility.spec.ts
+++ b/packages/core/src/compatibility/browser-tests/bundle-compatibility.spec.ts
@@ -19,7 +19,7 @@ const BASE_URL = process.env.BASE_URL ?? 'http://127.0.0.1:3000';
 const BUNDLES = {
   lite: {
     file: 'hyperfixi-lite.js',
-    size: '1.9 KB',
+    size: '2.0 KB',
     features: {
       toggle: true,
       addClass: true,

--- a/packages/core/src/compatibility/bundle-shell.test.ts
+++ b/packages/core/src/compatibility/bundle-shell.test.ts
@@ -1,0 +1,423 @@
+// @vitest-environment jsdom
+/**
+ * Do the bundle SHELLS agree on what a HyperFixi bundle's public API is?
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS EXISTS (Arc E step 3 — `docs-internal/HANDOFF-command-arch-bundles.md`)
+ * ---------------------------------------------------------------------------
+ *
+ * The same boot shell — the `[_]` scan, the `api` literal, the `window.<global>`
+ * install — is written out SEVEN times across two packages. Nothing compared
+ * them, so they drifted into four different public APIs along lines no user
+ * could predict, and one of the divergences (`window._hyperscript`) actively
+ * broke an unrelated library. `bundle-shell.ts` shares the logic that is
+ * genuinely identical; THIS FILE is what stops the surfaces diverging again,
+ * and it is the reason the shared helper does not need to build the api object
+ * itself (measured at +103 bytes gzip on hybrid-complete — see bundle-shell.ts).
+ *
+ * Two rules carried from the arc, which is why the assertions look stricter
+ * than "the key exists":
+ *
+ *   - ASSERT WHAT AN EXPORT IS FOR. `expect(typeof api.run).toBe('function')`
+ *     measures nothing — a shell exporting `run: () => {}` passes it. Every
+ *     export below is exercised for its actual effect.
+ *   - DIFF THE UNION, BOTH DIRECTIONS. The key-set assertions are set
+ *     EQUALITY, not `toContain`. A one-side-only check is blind to additions,
+ *     which is exactly how `run`/`eval`/`parserName` appeared in generated
+ *     bundles without anyone deciding they should.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import hybridComplete from './browser-bundle-hybrid-complete';
+import lite from './browser-bundle-lite';
+import litePlus from './browser-bundle-lite-plus';
+import { SHELL_CORE_KEYS, createProcessElements } from './bundle-shell';
+import { generateBundleCode } from '../bundle-generator/generator';
+
+// ===========================================================================
+// The declared surface of every shipped shell
+// ===========================================================================
+
+/**
+ * Extras each bundle carries ABOVE the core surface, and the consumer that
+ * justifies each one. Adding a key to a shipped shell without adding it here
+ * FAILS — that is the ratchet.
+ */
+const SHIPPED_SHELLS = [
+  {
+    name: 'hybrid-complete',
+    api: hybridComplete as unknown as Record<string, unknown>,
+    hasBlocks: true,
+    // addAliases: pinned by browser-tests/hybrid-complete.spec.ts.
+    // tokenize/evaluate: mirror the full bundle's surface.
+    extras: ['addAliases', 'addEventAliases', 'tokenize', 'evaluate'],
+  },
+  {
+    name: 'lite',
+    api: lite as unknown as Record<string, unknown>,
+    hasBlocks: false,
+    extras: [],
+  },
+  {
+    name: 'lite-plus',
+    api: litePlus as unknown as Record<string, unknown>,
+    hasBlocks: false,
+    extras: ['addAliases', 'addEventAliases'],
+  },
+] as const;
+
+/**
+ * Extras the GENERATED shell carries. Separate from the shipped list because
+ * generated bundles are a different consumer set:
+ *   - `parserName` is read by `examples/vite-plugin-test/main.js` and
+ *     `examples/vite-plugin-multilingual/main.js`, and is the regex anchor
+ *     `@hyperfixi/vite-plugin`'s generator splices semantic api props after.
+ *   - `run` mirrors the full bundle's `run`; `eval` is a redundant alias kept
+ *     only because dropping published API is a breaking change with no defect
+ *     behind it.
+ * None of the three is added to the shipped shells: nothing requests them
+ * there, and emitted shell code is shipped bytes.
+ */
+const GENERATED_EXTRAS = ['run', 'eval', 'parserName'];
+
+let container: HTMLElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  container.remove();
+});
+
+/** Let the shells' un-awaited async executors settle. */
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+/** Parse the `const api = {...}` literal out of generated source. */
+function emittedApiKeys(source: string): string[] {
+  const start = source.indexOf('const api = {');
+  expect(start, 'generated source must declare `const api = {`').toBeGreaterThan(-1);
+  const body = source.slice(start, source.indexOf('};', start));
+  return Array.from(body.matchAll(/^\s{2}(?:async\s+)?([A-Za-z_$][\w$]*)\s*[:(]/gm)).map(m => m[1]);
+}
+
+// ===========================================================================
+// 1. The key sets — set equality, both directions
+// ===========================================================================
+
+describe('shell surface', () => {
+  for (const shell of SHIPPED_SHELLS) {
+    it(`${shell.name} exposes exactly its declared surface`, () => {
+      const expected = [
+        ...SHELL_CORE_KEYS,
+        ...(shell.hasBlocks ? ['blocks'] : []),
+        ...shell.extras,
+      ].sort();
+
+      expect(Object.keys(shell.api).sort()).toEqual(expected);
+    });
+  }
+
+  it('the generated shell matches the handwritten core, plus its declared extras', () => {
+    const keys = emittedApiKeys(
+      generateBundleCode({ name: 'Drift', commands: ['toggle'], blocks: ['if'] } as never)
+    );
+
+    // Oracle-2 shape: two independent copies, one equality assertion. If the
+    // handwritten core gains a key and the emitter does not (or vice versa),
+    // this fails rather than shipping two different public APIs.
+    expect(keys.sort()).toEqual([...SHELL_CORE_KEYS, 'blocks', ...GENERATED_EXTRAS].sort());
+  });
+
+  it('the generated shell omits `blocks` when the bundle has none', () => {
+    // The one principled divergence: a bundle advertises `blocks` iff it can
+    // execute them. lite/lite-plus omit the key for the same reason.
+    const keys = emittedApiKeys(
+      generateBundleCode({ name: 'NoBlocks', commands: ['toggle'] } as never)
+    );
+
+    expect(keys).not.toContain('blocks');
+    expect(keys.sort()).toEqual([...SHELL_CORE_KEYS, ...GENERATED_EXTRAS].sort());
+  });
+});
+
+// ===========================================================================
+// 2. `window._hyperscript` — the absence is the assertion
+// ===========================================================================
+
+describe('the _hyperscript global', () => {
+  it('is not claimed by any shipped bundle', () => {
+    // All three shells have been imported (and auto-installed) by this point.
+    expect((window as unknown as Record<string, unknown>).hyperfixi).toBeDefined();
+    expect((window as unknown as Record<string, unknown>)._hyperscript).toBeUndefined();
+  });
+
+  it('is not claimed by a generated bundle', () => {
+    const source = generateBundleCode({
+      name: 'Global',
+      commands: ['toggle'],
+      blocks: ['if'],
+    } as never);
+
+    // Real `_hyperscript` (hyperscript.org) is a CALLABLE function carrying
+    // `evaluate`, `processNode`, `internals`, `config`, `addCommand`… The
+    // bundle api is a plain object with none of them, so a page loading both
+    // got whichever won the race — and if the bundle won, `_hyperscript(...)`
+    // threw "not a function" while the overlapping `parse`/`process` names
+    // silently did something else. Generated bundles claimed this global for
+    // as long as the generator has existed; nothing ever asserted it.
+    expect(source).toContain('.hyperfixi = api');
+    expect(source).not.toContain('_hyperscript');
+  });
+});
+
+// ===========================================================================
+// 3. What each core export is FOR
+// ===========================================================================
+
+describe('core surface behavior', () => {
+  for (const shell of SHIPPED_SHELLS) {
+    describe(shell.name, () => {
+      const api = shell.api as {
+        version: string;
+        parse: (code: string) => unknown;
+        execute: (code: string, el?: Element) => Promise<unknown>;
+        init: (root?: Element | Document) => void;
+        process: (root?: Element | Document) => void;
+        commands: string[];
+        blocks?: string[];
+      };
+
+      it('version identifies the bundle', () => {
+        expect(api.version).toMatch(/^\d+\.\d+\.\d+-/);
+      });
+
+      it('execute applies a real DOM effect', async () => {
+        const me = document.createElement('div');
+        container.appendChild(me);
+
+        await api.execute('add .applied to me', me);
+
+        expect(me.classList.contains('applied')).toBe(true);
+      });
+
+      it('parse produces something the bundle can actually run', () => {
+        // Not `toBeTruthy()` on the parse result — that passes for a parser
+        // returning a useless object. The witness is that `execute`, which
+        // routes through this same parse, produced the effect above.
+        const parsed = api.parse('add .x to me');
+
+        expect(parsed).toBeTruthy();
+        expect(typeof parsed).toBe('object');
+      });
+
+      it('init wires elements found under the given root', async () => {
+        const el = document.createElement('div');
+        el.setAttribute('_', 'add .wired to me');
+        container.appendChild(el);
+
+        api.init(container);
+        await flush();
+
+        expect(el.classList.contains('wired')).toBe(true);
+      });
+
+      it('process is the same scanner as init', () => {
+        // Both names have always pointed at one function; a shell that
+        // diverged them would break every htmx-afterSettle integration.
+        expect(api.process).toBe(api.init);
+      });
+
+      it('commands advertises a non-empty name list', () => {
+        expect(Array.isArray(api.commands)).toBe(true);
+        expect(api.commands.length).toBeGreaterThan(0);
+        expect(api.commands.every(c => typeof c === 'string' && c.length > 0)).toBe(true);
+      });
+
+      it(`blocks is ${shell.hasBlocks ? 'advertised' : 'absent'}`, () => {
+        expect('blocks' in api).toBe(shell.hasBlocks);
+      });
+    });
+  }
+});
+
+// ===========================================================================
+// 3b. The shared scanner itself
+// ===========================================================================
+//
+// These exercise `createProcessElements` directly rather than through a
+// bundle, because the containment they assert is not reachable from a shell's
+// public API: neither the regex nor the hybrid parser throws SYNCHRONOUSLY on
+// malformed source — they degrade and return a node. An earlier version of
+// this file asserted "a scan error is contained" by feeding each shell
+// gibberish, and mutation-testing showed the assertion was VACUOUS: deleting
+// the try/catch outright left it green, because the catch never ran.
+
+describe('createProcessElements (the shared scanner)', () => {
+  it('contains a parser throw and labels it with the bundle name', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const el = document.createElement('div');
+    el.setAttribute('_', 'anything');
+    container.appendChild(el);
+
+    const scan = createProcessElements(
+      () => {
+        throw new Error('parse boom');
+      },
+      () => undefined,
+      'Probe'
+    );
+
+    expect(() => scan(container)).not.toThrow();
+    expect(spy).toHaveBeenCalledWith(
+      'HyperFixi Probe error:',
+      expect.any(Error),
+      'Code:',
+      'anything'
+    );
+    spy.mockRestore();
+  });
+
+  it('contains an executor throw', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const el = document.createElement('div');
+    el.setAttribute('_', 'code');
+    container.appendChild(el);
+
+    const scan = createProcessElements(
+      (code: string) => code,
+      () => {
+        throw new Error('run boom');
+      },
+      'Probe'
+    );
+
+    expect(() => scan(container)).not.toThrow();
+    expect(spy).toHaveBeenCalledOnce();
+    spy.mockRestore();
+  });
+
+  it('one element failing does not stop the scan', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const bad = document.createElement('div');
+    bad.setAttribute('_', 'bad');
+    const good = document.createElement('div');
+    good.setAttribute('_', 'good');
+    container.append(bad, good);
+
+    const seen: string[] = [];
+    const scan = createProcessElements(
+      (code: string) => {
+        if (code === 'bad') throw new Error('boom');
+        return code;
+      },
+      (ast: string) => {
+        seen.push(ast);
+      },
+      'Probe'
+    );
+
+    scan(container);
+
+    expect(seen).toEqual(['good']);
+    spy.mockRestore();
+  });
+
+  it('scans only within the given root', () => {
+    const outside = document.createElement('div');
+    outside.setAttribute('_', 'outside');
+    document.body.appendChild(outside);
+    const inside = document.createElement('div');
+    inside.setAttribute('_', 'inside');
+    container.appendChild(inside);
+
+    const seen: string[] = [];
+    const scan = createProcessElements(
+      (code: string) => code,
+      (ast: string) => {
+        seen.push(ast);
+      },
+      'Probe'
+    );
+
+    scan(container);
+
+    expect(seen).toEqual(['inside']);
+    outside.remove();
+  });
+
+  it('ignores an element whose _ attribute is empty', () => {
+    const el = document.createElement('div');
+    el.setAttribute('_', '');
+    container.appendChild(el);
+
+    const seen: string[] = [];
+    const scan = createProcessElements(
+      (code: string) => {
+        seen.push(code);
+        return code;
+      },
+      () => undefined,
+      'Probe'
+    );
+
+    scan(container);
+
+    expect(seen).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// 4. What each EXTRA is for — the reason it survived the union decision
+// ===========================================================================
+
+describe('witnessed extras', () => {
+  it('hybrid-complete: addAliases makes the alias actually execute', async () => {
+    const api = hybridComplete as unknown as {
+      addAliases: (a: Record<string, string>) => void;
+      execute: (code: string, el?: Element) => Promise<unknown>;
+    };
+    const me = document.createElement('div');
+    container.appendChild(me);
+
+    api.addAliases({ basculer: 'toggle' });
+    await api.execute('basculer .fr on me', me);
+
+    expect(me.classList.contains('fr')).toBe(true);
+  });
+
+  it('lite-plus: addAliases makes the alias actually execute', async () => {
+    const api = litePlus as unknown as {
+      addAliases: (a: Record<string, string>) => void;
+      execute: (code: string, el?: Element) => Promise<unknown>;
+    };
+    const me = document.createElement('div');
+    container.appendChild(me);
+
+    api.addAliases({ agregar: 'add' });
+    await api.execute('agregar .es to me', me);
+
+    expect(me.classList.contains('es')).toBe(true);
+  });
+
+  it('hybrid-complete: tokenize returns tokens for real source', () => {
+    const api = hybridComplete as unknown as { tokenize: (code: string) => unknown[] };
+
+    const tokens = api.tokenize('toggle .active');
+
+    expect(Array.isArray(tokens)).toBe(true);
+    expect(tokens.length).toBeGreaterThan(1);
+  });
+
+  it('hybrid-complete: evaluate resolves a node against a context', async () => {
+    const api = hybridComplete as unknown as {
+      evaluate: (node: unknown, ctx: unknown) => Promise<unknown>;
+    };
+    const me = document.createElement('div');
+
+    const value = await api.evaluate({ type: 'literal', value: 42 }, { me, locals: new Map() });
+
+    expect(value).toBe(42);
+  });
+});

--- a/packages/core/src/compatibility/bundle-shell.ts
+++ b/packages/core/src/compatibility/bundle-shell.ts
@@ -1,0 +1,166 @@
+/**
+ * The shared boot shell — one definition of what a HyperFixi bundle's public
+ * API *is*, for every bundle that has one.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY (Arc E step 3 — `docs-internal/HANDOFF-command-arch-bundles.md`)
+ * ---------------------------------------------------------------------------
+ *
+ * Before this module, the same ~40 lines — `processElements`, the `api` object
+ * literal, and the `window.<global> = api` + DOMContentLoaded block — were
+ * written out SEVEN times: three handwritten TypeScript bundles
+ * (hybrid-complete, lite, lite-plus), core's `bundle-generator/generator.ts`,
+ * and three separate emission sites in `@hyperfixi/vite-plugin`
+ * (`generator.ts`'s main and empty-bundle shells, `compiled-generator.ts`).
+ * The brief predicted four. Counting only the copies you already know about is
+ * how the divergences below survived.
+ *
+ * They had drifted into four different public APIs, and NOT along any line a
+ * user could predict:
+ *
+ *   - `run`/`eval`/`parserName` existed ONLY in generated bundles.
+ *   - `tokenize`/`evaluate` existed ONLY in hybrid-complete.
+ *   - `addAliases`/`addEventAliases` existed in hybrid-complete and lite-plus
+ *     but not lite.
+ *   - `blocks` existed only where a bundle had blocks — the one divergence
+ *     that was actually principled.
+ *   - Every GENERATED bundle claimed `window._hyperscript`; no shipped
+ *     handwritten bundle did. See § THE `_hyperscript` DECISION below.
+ *
+ * ---------------------------------------------------------------------------
+ * THE RULE this module encodes
+ * ---------------------------------------------------------------------------
+ *
+ * A bundle's API is a CORE surface (`SHELL_CORE_KEYS` — every bundle with a
+ * shell has all six) plus `blocks` iff it executes blocks, plus `extras` that
+ * a specific bundle declares. Divergence above the core is legitimate only
+ * when a consumer or a gate witnesses it; it was measured, not assumed:
+ *
+ *   | extra              | kept on            | witnessed by                        |
+ *   | ------------------ | ------------------ | ----------------------------------- |
+ *   | addAliases         | hybrid-complete,   | `browser-tests/hybrid-complete.spec` |
+ *   |                    | lite-plus          | ("addAliases function works")       |
+ *   | addEventAliases    | same two           | i18n pair of the above              |
+ *   | tokenize, evaluate | hybrid-complete    | house-consistent with the full      |
+ *   |                    |                    | bundle, which exports both          |
+ *   | run, eval          | generated          | `run` mirrors the full bundle;      |
+ *   |                    |                    | `eval` is a redundant alias, kept   |
+ *   |                    |                    | only because removing published API |
+ *   |                    |                    | is a breaking change with no defect |
+ *   |                    |                    | behind it                           |
+ *   | parserName         | generated          | `examples/vite-plugin-test/main.js` |
+ *   |                    |                    | and `-multilingual/main.js` read it |
+ *
+ * Nothing was added to a shell that did not already have it. Unioning every
+ * key into every shell would have put unrequested API into four shipped
+ * bundles and into every bundle the vite-plugin emits — the same trade the
+ * `getClassName` comment-trim was decided on in step 2, where emitted shell
+ * code is shipped bytes.
+ *
+ * ---------------------------------------------------------------------------
+ * THE `_hyperscript` DECISION — the one behavior change here
+ * ---------------------------------------------------------------------------
+ *
+ * Every generated bundle assigned `window._hyperscript = api`, squatting the
+ * global of the library HyperFixi is compatible WITH. Measured against the
+ * real thing (`hyperscript.org@0.9.93`), the shapes are incompatible:
+ * `_hyperscript` is a callable function (`_hyperscript('1 + 1')` → `2`)
+ * carrying `evaluate`, `processNode`, `internals`, `config`, `addCommand`,
+ * `addFeature`, and more. The bundle `api` is a plain object with none of
+ * them. On a page loading both, last-write-wins, and if the generated bundle
+ * won then `_hyperscript(...)` threw "not a function", `.evaluate` was
+ * undefined, and `.parse`/`.process` — the only overlapping names — silently
+ * did something ELSE.
+ *
+ * No shipped handwritten bundle ever did this, and no test anywhere asserted
+ * it, so nothing was watching. The shells converge on NOT doing it; the
+ * absence is now pinned by `bundle-shell.test.ts`.
+ */
+
+/**
+ * The six keys every shell has. The drift gate asserts both the runtime shell
+ * and the emitted twin carry exactly these, so the two cannot diverge silently.
+ */
+export const SHELL_CORE_KEYS = [
+  'version',
+  'parse',
+  'execute',
+  'init',
+  'process',
+  'commands',
+] as const;
+
+/**
+ * The core surface every shell carries, typed. Generic over the bundle's AST
+ * so `api.parse` keeps its real return type — erasing it to
+ * `Record<string, unknown>` would break every consumer, including
+ * `hyperfixi-hx.js`, which spreads hybrid-complete's api wholesale.
+ *
+ * Bundles declare their api as a flat object literal satisfying this type
+ * rather than receiving one from a factory. That is deliberate, and MEASURED:
+ * a factory taking an options object and re-emitting it as an api object costs
+ * **+103 bytes gzip on `hyperfixi-hybrid-complete.js` and +63 on
+ * `hyperfixi-hx.js`** — terser inlines the call but cannot collapse the two
+ * object literals or the property indirection through the options bag. Since
+ * every bundle is rolled up independently, that indirection buys no sharing at
+ * runtime; it is pure overhead in four shipped bundles.
+ *
+ * What actually prevents the shells from drifting is `bundle-shell.test.ts`,
+ * which pins each shell's key set and the absence of `window._hyperscript` —
+ * not the indirection. So the helpers below share the logic that is genuinely
+ * identical (the `[_]` scan loop and the global install) and the type pins the
+ * shape, at zero byte cost.
+ */
+export interface BundleShellApi<TAst> {
+  version: string;
+  parse: (code: string) => TAst;
+  execute: (code: string, element?: Element) => Promise<unknown>;
+  init: (root?: Element | Document) => void;
+  process: (root?: Element | Document) => void;
+  commands: string[];
+  blocks?: string[];
+}
+
+/**
+ * Build the `[_]` document scanner every bundle runs.
+ *
+ * Identical in all seven shells apart from the console label, which is why it
+ * is shared and the api literal is not.
+ */
+export function createProcessElements<TAst>(
+  parse: (code: string) => TAst,
+  run: (ast: TAst, me: Element) => unknown,
+  errorLabel: string
+): (root?: Element | Document) => void {
+  return (root: Element | Document = document): void => {
+    root.querySelectorAll('[_]').forEach(el => {
+      const code = el.getAttribute('_');
+      if (!code) return;
+      try {
+        run(parse(code), el);
+      } catch (err) {
+        console.error(`HyperFixi ${errorLabel} error:`, err, 'Code:', code);
+      }
+    });
+  };
+}
+
+/**
+ * Publish the api on `window` and schedule the initial document scan.
+ *
+ * Deliberately assigns ONE global. See § THE `_hyperscript` DECISION.
+ */
+export function installBundleGlobal(
+  api: unknown,
+  processElements: (root?: Element | Document) => void,
+  globalName = 'hyperfixi'
+): void {
+  if (typeof window === 'undefined') return;
+  (window as any)[globalName] = api;
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => processElements());
+  } else {
+    processElements();
+  }
+}

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -113,7 +113,7 @@ export const bundleInfo: BundleInfo[] = [
     id: 'lite',
     name: 'Lite',
     filename: 'hyperfixi-lite.js',
-    gzipSize: '1.9 KB',
+    gzipSize: '2.0 KB',
     rawSize: '5 KB',
     commandCount: 8,
     parser: 'regex',

--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -637,7 +637,7 @@ export const bundles: BundleRef[] = [
   {
     name: 'lite',
     file: 'lokascript-lite.js',
-    size: '1.9 KB',
+    size: '2.0 KB',
     commandCount: 8,
     hasBlocks: false,
     hasEventModifiers: false,

--- a/packages/vite-plugin/src/compiled-generator.ts
+++ b/packages/vite-plugin/src/compiled-generator.ts
@@ -129,7 +129,6 @@ const api={
 
 if(typeof window!=='undefined'){
   window.${globalName}=api;
-  window._hyperscript=api;
   document.readyState==='loading'
     ?document.addEventListener('DOMContentLoaded',()=>init())
     :init();

--- a/packages/vite-plugin/src/emitted-shell.test.ts
+++ b/packages/vite-plugin/src/emitted-shell.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Does a bundle this plugin emits claim a global it has no right to?
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS EXISTS (Arc E step 3 — `docs-internal/HANDOFF-command-arch-bundles.md`)
+ * ---------------------------------------------------------------------------
+ *
+ * The boot shell is emitted from THREE sites in this package — `generator.ts`'s
+ * main shell and its empty-bundle shell, plus `compiled-generator.ts` — on top
+ * of the handwritten shells and the emitter in `@hyperfixi/core`. All of them
+ * assigned `window._hyperscript = api`, squatting the global belonging to the
+ * library HyperFixi is compatible WITH.
+ *
+ * Measured against `hyperscript.org@0.9.93`: `_hyperscript` is a CALLABLE
+ * function (`_hyperscript('1 + 1')` → `2`) carrying `evaluate`, `processNode`,
+ * `internals`, `config`, `addCommand`, `addFeature`. The emitted `api` is a
+ * plain object with none of them, so on a page loading both, last-write-wins —
+ * and when the generated bundle won, `_hyperscript(...)` threw "not a
+ * function", `.evaluate` was undefined, and `parse`/`process` (the only
+ * overlapping names) silently did something else entirely.
+ *
+ * No test in either package asserted this global, which is precisely why it
+ * survived in four emitters. The core-side twin of this file is
+ * `packages/core/src/compatibility/bundle-shell.test.ts`; a gate in core cannot
+ * see these three sites, so the assertion lives on both sides.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Generator } from './generator';
+import { generateCompiledBundle } from './compiled-generator';
+import type { CompiledHandler } from './compiler';
+
+function createUsage(commands: string[], blocks: string[] = []) {
+  return {
+    commands: new Set(commands),
+    blocks: new Set(blocks),
+    positional: false,
+    detectedLanguages: new Set<string>(),
+    htmx: {
+      hasHtmxAttributes: false,
+      hasFixiAttributes: false,
+      httpMethods: new Set<string>(),
+      swapStrategies: new Set<string>(),
+      onHandlers: [] as string[],
+      triggerModifiers: new Set<string>(),
+    },
+  };
+}
+
+const handler: CompiledHandler = {
+  id: 'h0',
+  event: 'click',
+  modifiers: {},
+  code: '/* noop */',
+  needsEvaluator: false,
+  original: 'on click log "hi"',
+};
+
+describe('emitted shells do not claim window._hyperscript', () => {
+  const generator = new Generator({ debug: false });
+
+  it('main shell (hybrid parser) installs only its own global', () => {
+    const code = generator.generate(createUsage(['toggle'], ['if']) as never, {});
+
+    expect(code).toContain('window.hyperfixi = api');
+    expect(code).not.toContain('_hyperscript');
+  });
+
+  it('main shell (lite parser) installs only its own global', () => {
+    const code = generator.generate(createUsage(['toggle']) as never, {});
+
+    expect(code).toContain('window.hyperfixi = api');
+    expect(code).not.toContain('_hyperscript');
+  });
+
+  it('empty bundle installs only its own global', () => {
+    const code = generator.generate(createUsage([]) as never, {});
+
+    // The empty shell is a distinct emission site with its own api literal —
+    // it is why "fix the generator" was three edits in this package, not one.
+    expect(code).toContain('LokaScript Empty Bundle');
+    expect(code).not.toContain('_hyperscript');
+  });
+
+  it('compiled (AOT) bundle installs only its own global', () => {
+    const code = generateCompiledBundle({
+      handlers: [handler],
+      needsLocals: false,
+      needsGlobals: false,
+    });
+
+    expect(code).toContain('window.hyperfixi=api');
+    expect(code).not.toContain('_hyperscript');
+  });
+});

--- a/packages/vite-plugin/src/generator.ts
+++ b/packages/vite-plugin/src/generator.ts
@@ -540,7 +540,6 @@ ${
     ? `
 if (typeof window !== 'undefined') {
   window.${globalName} = api;
-  window._hyperscript = api;
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => processElements());
@@ -837,7 +836,6 @@ const api = {
 
 if (typeof window !== 'undefined') {
   (window).${globalName} = api;
-  (window)._hyperscript = api;
 }
 
 export default api;


### PR DESCRIPTION
Arc E step 3 of the command-architecture roadmap. Steps 1 (#830/#829) and 2 (#831) are closed; this branches from the #831 merge commit `088ba163` and every baseline below was re-measured there.

## The premise failed re-measurement first

The brief said **four** shells. Measured — by executing the modules and reading `Object.keys(api)`, not by reading source — there are **seven emission sites across two packages**:

| # | Site | Notes |
| --- | --- | --- |
| 1–3 | `browser-bundle-{hybrid-complete,lite,lite-plus}.ts` | handwritten |
| 4 | `core/src/bundle-generator/generator.ts` | emitted, imports parser-core |
| 5 | `vite-plugin/src/generator.ts` main shell | emitted, embeds its parser |
| 6 | `vite-plugin/src/generator.ts` empty-bundle shell | separate api literal |
| 7 | `vite-plugin/src/compiled-generator.ts` | AOT shell |

A count-only or one-side diff would have missed three of seven — the standing lesson, paid again. Two further brief claims were wrong: `addAliases`/`addEventAliases` are on lite-plus too, and the compiled shell has neither `parse` nor `execute` (filed, not fixed — a compile-mode capability gap, not a shell divergence).

### The measured union

| key | hybrid-complete | lite | lite-plus | core-gen | vite main | vite empty | vite compiled |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `version` `parse` `execute` `init` `process` `commands` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ (stubs) | partial |
| `blocks` | ✓ (7) | — | — | conditional | conditional | — | — |
| `run` `eval` `parserName` | — | — | — | ✓ | ✓ | ✓ | — |
| `tokenize` `evaluate` | ✓ | — | — | — | — | — | — |
| `addAliases` `addEventAliases` | ✓ | — | ✓ | — | — | — | — |
| `window._hyperscript` | — | — | — | ✓ | ✓ | ✓ | ✓ |

## The decisions — the union was NOT unioned

Rule that fell out, decided per family: **an extra survives where a consumer or gate witnesses it, and is removed where nothing does.** Unioning all fourteen keys into all seven shells would have put unrequested API into four shipped bundles and every vite-emitted bundle — step 2's `getClassName` comment-trim trade at larger scale.

1. **hybrid-complete gains `run`/`eval`/`parserName`? DECLINED.** `hyperfixi-hx.js` **spreads** hybrid-complete's api (`browser-bundle-hybrid-hx.ts:171`), so any addition is user-visible API on two shipped bundles. Scoring inverted the guess: `parserName` is **not dead** — `examples/vite-plugin-test/main.js` and `examples/vite-plugin-multilingual/main.js` read it, and it is the regex anchor the vite-plugin splices semantic api props after (`generator.ts:765`, `/parserName: '(?:lite|hybrid)',/`). Renaming it would break the semantic bundle path silently.
2. **Emitted shell gains `tokenize`/`evaluate`/`addAliases`/`addEventAliases`? DECLINED.** Bytes in every generated bundle for API nothing requests; `tokenize` would force a parser-core import into a deliberately self-contained path.
3. **Does any hybrid bundle set `window._hyperscript`? NO — and the four that did, stop.** The one behavior change here. Measured against `hyperscript.org@0.9.93`: `_hyperscript` is a **callable function** (`_hyperscript('1 + 1')` → `2`) carrying `evaluate`, `processNode`, `internals`, `config`, `addCommand`, `addFeature`. The bundle `api` is a plain object with none of them. On a page loading both, last-write-wins; when the generated bundle won, `_hyperscript(...)` threw "not a function", `.evaluate` was undefined, and `parse`/`process` — the only overlapping names — silently did something else. No shipped handwritten bundle ever did this and **no test in either package asserted it**, which is how it survived in four emitters.
4. **`eval` KEPT on generated bundles.** Redundant alias with zero consumers, but removing published API is a breaking change with no defect behind it — unlike `_hyperscript`, which actively breaks a third party.

## S3-a — the obvious design was built, measured, and rejected

A factory taking an options object and returning the api costs **+103 bytes gzip on hybrid-complete, +63 on hx**: terser inlines the call but cannot collapse the two object literals or the property indirection through the options bag, and since every bundle is rolled up independently the indirection buys no runtime sharing.

What ships shares only what is genuinely identical — the `[_]` scan loop (`createProcessElements`) and the global install (`installBundleGlobal`) — with each bundle keeping a flat api literal typed `BundleShellApi<TAst>`. Final cost **+27 gz** (hybrid-complete) / **+22** (hx). The generalizable half: **the anti-drift property comes from the gate, not the indirection.**

## S3-b — a vacuous row in this PR's own gate, caught by mutation testing

The first version asserted "a scan error is contained" by feeding each shell gibberish. Replacing the `catch` with `throw err` left it **green** — neither parser throws *synchronously* on malformed source; they degrade and return a node. Replaced with five tests against `createProcessElements` directly, injecting a throwing parse and run. Finding 16's rule from a new direction: it is not enough to assert a real effect — the input must be capable of producing the failure the assertion describes.

## Three oracles

1. **EXECUTION** — `shipped-bundle-execution.test.ts` and `capability-emission.test.ts` green **unchanged**; no shell acquired a new surface, so neither needed a new row. `hyperfixi-hx.js`'s reads of hybrid-complete (`.execute`, `.process`, `...spread`) all still resolve.
2. **cmdMap equality (35 = 35)** — untouched.
3. **Bundle size** — only the four slim bundles moved: hybrid-complete +27 gz, hx +22, lite +33, lite-plus +34 (raw +15…+54); gzip exceeds raw on the two smallest because the shared arrow form compresses slightly worse than the inline loop it replaced. hx **19025** vs `MAX_HYBRID` 20000. `baseline.json` updated for **those four entries only** — a blanket `--update` would have absorbed the +0.3–0.8% raw local-vs-recorded drift the six full bundles already show, blinding the gate to it.

## Verification

- Mutation-verified **11 for 11**, each failing its intended test and nothing else (checked individually, so none is an incidental compile crash): re-add `_hyperscript` to the core emitter and to each of the three vite sites; add a stray key to hybrid-complete; drop `blocks`; diverge `process` from `init`; neuter `addAliases`; rethrow from the scanner; wrong console label; ignore the scan root; run empty `_` attributes; drop `run` from the emitted api; emit `blocks` unconditionally.
- Key-set assertions are **set equality, both directions** — an added key fails too.
- Every export is asserted for what it is FOR (`execute` applies a DOM effect, `init` wires elements under a root, `process` IS `init`, `addAliases` makes the alias actually execute), never `typeof x === 'function'`.

**Gates:** core `test:quick` 7684 passed / 106 skipped / 300 files (7647/106/299 baseline + 37 new); vite-plugin 319 (315 + 4); language-server 227; `verify:reference`, `typecheck` (both packages), `docs:commands:check`, `check:test-list`, `snapshot:bundle-size --check`, `test:check` all green; Playwright `src/compatibility/` 1102 passed / 8 skipped / 10 failed — the known-local set (behaviors-demo ×4, i18n-htmx ×4, swap-debug ×2), green in CI.

## Not taken here

S2-b (both executors self-assign `ctx.it` on ≥5 rows) is untouched in either direction — no shell change went near result plumbing. S2-c (`stripTypes` invalid for 6 of 40 templates in `'js'` format) not added to. Step 4's budget is unspent: the ceiling raise, the 24→35 advertised-count ripple, the dead `trigger` label, and removing `removeClass`'s `ctx.it` all remain step 4's, and its `MAX_HYBRID` recommendation still wants re-measuring rather than inheriting.

Findings landed in `docs-internal/HANDOFF-command-arch-bundles.md` **with this PR**, not as debt — § "Step 3 — CLOSED", plus the stale step-3 paragraph corrected in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
