### PR TITLE
fix(tests): index instead of `Array.prototype.at`, unblocking the majors bump

### DIFF
--- a/packages/core/src/features/eventsource-coverage.test.ts
+++ b/packages/core/src/features/eventsource-coverage.test.ts
@@ -145,7 +145,7 @@ describe('eventsource feature — supplementary coverage', () => {
         url: 'https://api.example.com/events',
         withCredentials: false,
       });
-      const es = MockES.instances.at(-1)!;
+      const es = MockES.instances[MockES.instances.length - 1]!;
 
       es.triggerOpen();
       await Promise.resolve();
@@ -164,7 +164,7 @@ describe('eventsource feature — supplementary coverage', () => {
           url: 'https://api.example.com/events',
           withCredentials: false,
         });
-        const es = MockES.instances.at(-1)!;
+        const es = MockES.instances[MockES.instances.length - 1]!;
         es.triggerError();
         await Promise.resolve();
         // Error handler ran and (attempted) reconnection was scheduled but not run.

--- a/packages/core/src/features/sockets-coverage.test.ts
+++ b/packages/core/src/features/sockets-coverage.test.ts
@@ -191,7 +191,7 @@ describe('sockets feature — supplementary coverage', () => {
     it('handles open, message, error and close events', async () => {
       const connected = await out.connection.connect(socketConfig());
       expect(connected).toBe(true);
-      const ws = MockWS.instances.at(-1)!;
+      const ws = MockWS.instances[MockWS.instances.length - 1]!;
 
       // open -> connected
       ws.triggerOpen();
@@ -211,7 +211,7 @@ describe('sockets feature — supplementary coverage', () => {
 
     it('reports connection info and state after connecting', async () => {
       await out.connection.connect(socketConfig());
-      MockWS.instances.at(-1)!.triggerOpen();
+      MockWS.instances[MockWS.instances.length - 1]!.triggerOpen();
       await Promise.resolve();
       const info = out.connection.getConnectionInfo();
       expect(info).toBeDefined();


### PR DESCRIPTION
Unblocks the **first** gate on Dependabot #773 (majors group), red on 5 consecutive runs since 2026-07-28. Predates the CI split (#833) and is not caused by it.

## Cause

`@types/node` 20 leaked ES2022 lib declarations into the compilation; `@types/node` 26 stops. Core's `tsconfig.json` declares `lib: ["ES2020", "DOM", "DOM.Iterable"]` **deliberately** — it is a promise about the runtime the shipped bundles support — so the fix is to stop using `.at()`, not to raise `lib`.

## Scope — four sites, not one

The kickoff for this change named a single line (`sockets-coverage.test.ts:214`). CI on #773 reports **four** TS2550s, all in tests:

```
src/features/eventsource-coverage.test.ts(148,35)
src/features/eventsource-coverage.test.ts(167,37)
src/features/sockets-coverage.test.ts(194,35)
src/features/sockets-coverage.test.ts(214,24)
```

All four are fixed here. `.at(` appears in no non-test source under `packages/*/src` (verified by ripgrep across `packages/`, `scripts/`, `tools/`), so nothing shipped changes.

`arr.at(-1)` and `arr[arr.length - 1]` agree on both branches that matter: identical for a non-empty array, `undefined` for an empty one. The existing `!` assertion is unchanged either way.

## Verification

- `npm run typecheck --prefix packages/core` — exit 0
- `vitest run src/features/sockets-coverage.test.ts src/features/eventsource-coverage.test.ts` — 2 files, 23 tests passed
- `oxlint` on both files — exit 0

## What this does NOT do

#773 bumps 13 majors. Typecheck was only the first gate; the group also carries **jsdom 26→30** (core's vitest environment), **zod 3→4** (mcp-server), **express 4→5** (server-bridge), **better-sqlite3 13** (patterns-reference, native), and **lint-staged 17** (pre-commit). Those are untriaged — after this lands, `@dependabot rebase` on #773 and triage whatever CI reports next. Splitting the group via ignore rules is the owner's call.

#698 (TypeScript 6.0.3) is separate: its TS5101 `baseUrl` is injected by the toolchain (no repo tsconfig declares it — tsup / rollup-plugin-dts), a real migration, not folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)