### PR TITLE
feat(bundles): generate the hybrid-complete executor core (Arc E step 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -741,11 +741,20 @@ jobs:
       # made any whole-file comparison fail on every run. Both are fixed, so this
       # check is exact too. Coverage of the generator's command table is a separate
       # gate — src/commands/__tests__/docs-coverage.test.ts, in the unit suite.
+      # `generate:bundles:check` joined in Arc E step 4. It regenerates the
+      # executor-core regions of the committed browser bundles from
+      # `bundle-generator/templates.ts` and fails if the result differs — the
+      # drift guard that lets hybrid-complete's `executeCommand` switch stop
+      # being a hand-maintained second copy of the templates. Same
+      # prettier-idempotency requirement as the three above: the generator
+      # formats with the pinned prettier before writing, so a fresh run is
+      # byte-identical to the committed file.
       - name: Check generated artifacts are in sync
         run: |
           npm run check:grammar --prefix packages/semantic
           npm run check:keywords --prefix packages/vite-plugin
           npm run docs:commands:check --prefix packages/core
+          npm run generate:bundles:check --prefix packages/core
 
       - name: Verify reference data
         run: npm run verify:reference --prefix packages/core
@@ -1413,7 +1422,16 @@ jobs:
           # real ~299 KB gz bundle. The browser/hx-v4 ceilings exist to catch
           # RE-duplication (the #616 double core+semantic class).
           MAX_LITE=4000           # 4 KB   (actual ~2 KB)
-          MAX_HYBRID=20000        # 20 KB  (hybrid-hx actual ~18.5 KB gz)
+          # Raised 20000 → 24000 in Arc E step 4, which closed Finding 17: the
+          # hybrid bundles used to PARSE 35 commands and EXECUTE 24, and adding
+          # the missing eleven cost hybrid-complete +2969 B gz / hx +2977 B gz
+          # (measured, not estimated). 2057 of that is `morphlex`, pulled in by
+          # the `morph` case — 69% of the increase for 1 of 13 commands, kept
+          # deliberately so no advertised command is a no-op.
+          # hx measured 21960 B gz locally, so 22000 would have failed on the
+          # first run; 24000 restores roughly the ~2 KB of headroom the old
+          # ceiling had. Mirrored in ci.yml and pre-publish-check.yml.
+          MAX_HYBRID=24000        # 24 KB  (hybrid-hx actual ~22.0 KB gz)
           MAX_BROWSER=340000      # 340 KB (hyperfixi.js actual ~299 KB gz post-dedupe)
           MAX_HXV4=350000         # 350 KB (hyperfixi-hx-v4.js actual ~311 KB gz post-dedupe)
 

--- a/.github/workflows/pre-publish-check.yml
+++ b/.github/workflows/pre-publish-check.yml
@@ -336,7 +336,16 @@ jobs:
           # ceilings exist specifically to catch RE-duplication (any change
           # that re-inlines a second core/semantic blows straight past them).
           MAX_LITE=4000           # 4 KB   (actual ~2 KB)
-          MAX_HYBRID=20000        # 20 KB  (hybrid-hx actual ~18.5 KB gz)
+          # Raised 20000 → 24000 in Arc E step 4, which closed Finding 17: the
+          # hybrid bundles used to PARSE 35 commands and EXECUTE 24, and adding
+          # the missing eleven cost hybrid-complete +2969 B gz / hx +2977 B gz
+          # (measured, not estimated). 2057 of that is `morphlex`, pulled in by
+          # the `morph` case — 69% of the increase for 1 of 13 commands, kept
+          # deliberately so no advertised command is a no-op.
+          # hx measured 21960 B gz locally, so 22000 would have failed on the
+          # first run; 24000 restores roughly the ~2 KB of headroom the old
+          # ceiling had. Mirrored in ci.yml and pre-publish-check.yml.
+          MAX_HYBRID=24000        # 24 KB  (hybrid-hx actual ~22.0 KB gz)
           MAX_BROWSER=340000      # 340 KB (hyperfixi.js actual ~299 KB gz post-dedupe)
           MAX_HXV4=350000         # 350 KB (hyperfixi-hx-v4.js actual ~311 KB gz post-dedupe)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **HyperFixi** is a complete \_hyperscript ecosystem with server-side compilation, multi-language i18n (24 languages including SOV/VSO grammar transformation), semantic-first multilingual parsing, and comprehensive developer tooling. Engine packages are published under `@hyperfixi/*`, multilingual packages under `@lokascript/*`.
 
 - **14,000+ tests** passing across all suites (core ~7000, semantic ~6500, i18n ~900, plus per-package suites)
-- **~310 KB** full browser bundle (gzipped); slim bundles from **1.9 KB** (lite) to **18 KB** (hybrid-hx) — sizes re-measured 2026-07-24 (post-dedupe; the 2.7.x ~534 KB figure was a duplicate core+semantic copy, since removed — growth from ~299 is semantic-content growth from the July pick/vocab arcs plus the 2.9.0 `markerLegacy` data, single-copy verified). **Gzip sizes are platform-dependent** — `metadata.ts` carries the values CI measures (Linux zlib); a local macOS `update:sizes` reads ~2 KB lower on the full bundles. `update:sizes` tolerates ±2% drift and fails only when metadata is stale enough to mislead; the size-**regression** gate is `scripts/bundle-size-snapshot.mjs --check` (±5% vs `baseline.json`), and CI also enforces absolute ceilings. Never run `update:sizes:auto` locally and commit the result — `dist/` is untracked, so your tree may hold another branch's build; take the numbers from the CI job log.
+- **~310 KB** full browser bundle (gzipped); slim bundles from **1.9 KB** (lite) to **21.5 KB** (hybrid-hx) — sizes re-measured 2026-07-24 (post-dedupe; the 2.7.x ~534 KB figure was a duplicate core+semantic copy, since removed — growth from ~299 is semantic-content growth from the July pick/vocab arcs plus the 2.9.0 `markerLegacy` data, single-copy verified). **Gzip sizes are platform-dependent** — `metadata.ts` carries the values CI measures (Linux zlib); a local macOS `update:sizes` reads ~2 KB lower on the full bundles. `update:sizes` tolerates ±2% drift and fails only when metadata is stale enough to mislead; the size-**regression** gate is `scripts/bundle-size-snapshot.mjs --check` (±5% vs `baseline.json`), and CI also enforces absolute ceilings. Never run `update:sizes:auto` locally and commit the result — `dist/` is untracked, so your tree may hold another branch's build; take the numbers from the CI job log.
 - **\_hyperscript compatible** — tested via gallery examples, bundle compatibility matrix, and command/expression browser tests (Playwright)
 
 ## Monorepo Structure
@@ -637,7 +637,7 @@ The bundle compatibility test suite automatically tests all 7 bundles against ga
 
 - Location: `packages/core/src/compatibility/browser-tests/bundle-compatibility.spec.ts`
 - Tests: Toggle, show/hide, input mirroring, counter, modals, fetch, tabs, blocks, event modifiers
-- Bundles: lite (1.9 KB), lite-plus (2.6 KB), hybrid-complete (8.2 KB), hybrid-hx (18.6 KB), hybrid-hx-v4 (~321 KB), minimal (71.5 KB), standard (78 KB), browser (~309 KB)
+- Bundles: lite (1.9 KB), lite-plus (2.6 KB), hybrid-complete (11.1 KB), hybrid-hx (21.5 KB), hybrid-hx-v4 (~321 KB), minimal (71.5 KB), standard (78 KB), browser (~309 KB)
 - Prints ASCII compatibility matrix showing feature support across all bundles
 
 ### Using Behaviors (Browser)
@@ -859,8 +859,8 @@ Quick selection (sizes gzipped):
 | ------------------------------ | --------- | ------------------------------------------------------------------------------------------ |
 | via `@hyperfixi/vite-plugin`   | minimal   | **Default for Vite projects** — scans usage, emits the right bundle                        |
 | `hyperfixi-lite.js`            | 1.9 KB    | Tiny static page (8 commands, regex parser)                                                |
-| `hyperfixi-hybrid-complete.js` | 8.2 KB    | Pure hyperscript, ~85% coverage (AST parser, blocks, modifiers)                            |
-| `hyperfixi-hx.js`              | 18 KB     | + htmx v1/v2 attributes (`hx-get` etc.); no reactivity/streaming                           |
+| `hyperfixi-hybrid-complete.js` | 11.1 KB   | Pure hyperscript, ~85% coverage (AST parser, blocks, modifiers)                            |
+| `hyperfixi-hx.js`              | 21.5 KB   | + htmx v1/v2 attributes (`hx-get` etc.); no reactivity/streaming                           |
 | `hyperfixi-hx-v4.js`           | ~321 KB   | `hx-live`, `bind`, `when`, SSE, WebSocket — full runtime + reactivity                      |
 | `hyperfixi.js`                 | ~309 KB   | Full bundle with parser (`window.hyperfixi`); reactivity + realtime plugins pre-installed  |
 | `hyperfixi-multilingual.js`    | 93 KB     | Multilingual, parser-free (pair with a semantic bundle)                                    |

--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -337,6 +337,23 @@ plus `--check` pattern), and `generate-command-docs --check` in CI so
 
 ### Arc E — generated static bundles (medium-large)
 
+> **Steps 1-4 CLOSED (#830, #831, #832, #833-adjacent, and the step-4 PR).**
+> Finding 17 is shut: `browser-bundle-hybrid-complete.ts`'s `executeCommand` and
+> `executeBlock` switch bodies are GENERATED from `bundle-generator/templates.ts`
+> by `packages/core/scripts/generate-bundles.ts` and guarded by
+> `generate:bundles:check` in CI. The bundle executes all 38 advertised names,
+> not 24. **Step 5 (generate `HYBRID_PARSER_TEMPLATE` from `parser-core.ts`) is
+> the remaining step** — its spec is unchanged and now stronger, since
+> `executor-core.ts` demonstrates the shared-emitter shape it should follow.
+> Three things a step-5 starter needs that this paragraph predates: the size
+> figures below are stale (hx is now **21997 gz against `MAX_HYBRID=24000`**,
+> raised deliberately in step 4 — `morphlex`, pulled in by the `morph` case, is
+> +2057 of that); the executor generation covers the CASE BODIES ONLY, because
+> every other runtime region was measured to diverge between the two copies; and
+> the parser's EMITTED-name set is not `cmdMap`'s key set (`waitFor` and
+> `removeClass` are emitted and are not keys), which is the check that found the
+> one real gap in step 2's "templates are the superset" claim.
+>
 > **Brief written 2026-07-29 —
 > [HANDOFF-command-arch-bundles.md](./HANDOFF-command-arch-bundles.md).**
 > It re-measured this paragraph and two of its claims did not survive: there are

--- a/docs-internal/HANDOFF-command-arch-bundles.md
+++ b/docs-internal/HANDOFF-command-arch-bundles.md
@@ -469,6 +469,159 @@ Only the four slim bundles moved; the six full bundles are untouched.
 `--update` would have absorbed the +0.3–0.8% raw local-vs-recorded drift the
 full bundles already show into the committed numbers, blinding the gate to it.
 
+## Step 4 — CLOSED: the executor core is generated, and Finding 17 is shut
+
+`browser-bundle-hybrid-complete.ts`'s `executeCommand` and `executeBlock` switch
+bodies are now emitted from `bundle-generator/templates.ts` by
+`packages/core/scripts/generate-bundles.ts`, committed, and guarded by
+`generate:bundles:check` in CI's "Check generated artifacts are in sync" step.
+The bundle EXECUTES all 38 advertised names, not 24.
+
+### The step's own premise failed re-measurement, again
+
+The brief's step-4 paragraph says to "point `generateBundleCode()` at the
+reconciled templates + shared shell and commit the output". Measured, that would
+have been a behavior change across the ENTIRE runtime, not a refactor:
+
+| region | hybrid-complete | emitted | identical? |
+| --- | --- | --- | --- |
+| `evaluate` | 86 L (`unary`/`object`/`array`/`valuesOf`, `collectFormValues`) | 71 L | NO |
+| `evaluateBinary` | 68 L | 39 L | NO |
+| `evaluatePositional` | present | conditional | NO |
+| `executeSequence` / `executeAST` | 11 L / 100 L | 21 L / 60 L | NO |
+| `Context` | has `globals`, is `export`ed | neither | NO |
+
+Step 2 reconciled the command and block CASE BODIES. It did not reconcile — and
+never claimed to reconcile — the surrounding runtime. So the region generated
+here is **only the case bodies**, spliced between `#region generated:` markers
+INSIDE each switch. The switch, its `default:` arm, the helper closures, the
+whole evaluator and the shell stay handwritten.
+
+That also settles the design question the kickoff posed (parameterize the shell
+emission, or generate the executor core only): **(b), the executor core only**.
+Parameterizing the emitter to produce both api shapes would have built a
+generalized emitter for exactly one consumer — S3-a's rejected indirection at a
+different level — against a surface that is gated as set equality in both
+directions and spread wholesale by `hyperfixi-hx.js`. Narrowing the region is
+also what keeps the emitter parameterless: the two `default:` arms warn with
+different text and the two bundles scope their helpers differently, and none of
+that has to be modelled.
+
+The shared emitter is `bundle-generator/executor-core.ts`
+(`emitCommandCases`/`emitBlockCases`), called by BOTH `generateBundleCode()` and
+the script. Without that, the arc would have replaced a duplicated executor with
+a duplicated emitter — the alias-dedupe rule is exactly the kind of thing that
+drifts.
+
+### S4-a — the templates were NOT the superset: `waitFor` was missing
+
+Step 2 concluded "the templates are the undisputed best copy of every row they
+carry." Measured against the parser, they were not, and generating from them
+as-is would have broken `wait for <event>` in the shipped bundle.
+
+The reason no existing check could see it is precise and worth carrying: every
+list gate compares against **`cmdMap`'s keys**. `cmdMap` has 35 keys and the
+templates have 35 case labels and the two agree — but `cmdMap`'s keys are the
+wrong question. What an executor must switch on is the set of names the parser
+**EMITS**, and those differ:
+
+| set | size | notes |
+| --- | --- | --- |
+| `cmdMap` keys | 35 | includes `trigger`; excludes `removeClass`, `waitFor` |
+| parser-emitted `name:` literals | 28 | includes `removeClass`, `waitFor`; excludes `trigger` |
+| template case labels (before) | 35 | included `removeClass`; **missing `waitFor`** |
+
+`parseWait` returns `{ name: 'waitFor' }` for `wait for <event>`. Confirmed by
+execution, not by reading: a generated bundle carrying `wait` fell to `default:`,
+warned once, and **resolved immediately** — so every command after
+`wait for click` in a handler ran without waiting. `hybrid-complete` had the case
+and was correct. Same class as the `morph` free identifier and the `take`
+DOMException: invisible to a parse-level or key-set check, visible only to
+execution.
+
+Fixed by absorbing the second label into the `wait` template, with two gates: a
+`SECONDARY_LABEL_SURFACES` entry so §3's label-reachability check stays at
+tolerance 0 (rather than allowlisting the label), and an execution row asserting
+the thing the command is FOR — that it had NOT resolved before the event and had
+after. A row that merely awaited the promise passes against the broken template,
+which is how this survived.
+
+### S4-b — `ctx.target` in the `js` template: templates are never typechecked
+
+Generation surfaced a type error that had been latent for the life of the
+template: `target: ctx.target || ctx.me`, where no `Context` in ANY bundle
+declares a `target` field and no executor assigns one. The left operand was
+always `undefined`, so the value was always `ctx.me` — harmless, and a hard
+error the moment the template landed in a file that is actually compiled.
+
+The generalizable half: **generated bundles are written, imported and executed,
+but never `tsc`'d.** `capability-emission.test.ts` writes them to
+`__tests__/.generated/` and removes them before AND after the run, so `typecheck`
+never sees them. Execution coverage does not imply type coverage, and this arc
+now has one instance of each blind spot finding the other.
+
+### S4-c — the advertised array became the generation INPUT
+
+`commands: [...]` is what the script reads and emits from. This is what makes
+Finding 17 unrepeatable rather than merely fixed: "advertised but not executed"
+stops being a state the file can be in. Two gates hold the other half —
+`shipped-bundle-execution.test.ts` pins the array as set-equal to
+`AVAILABLE_COMMANDS` in both directions (a dropped name would silently DELETE a
+working command on the next generation), and asserts every advertised name
+resolves to a real template.
+
+38 names, 35 case groups: `trigger`, `push-url` and `replace-url` fold into the
+templates they alias. `removeClass` is in the array despite being a parser NODE
+name no user types — it needs a case, so it needs to be there.
+
+### S4-d — the size estimate excluded the largest cost
+
+The arc's pre-measurement was **+1433 B gz**, taken on `generateBundle()`'s
+output. That output is TypeScript SOURCE TEXT, in which
+`import { morph } from 'morphlex'` is one line — so the estimate structurally
+excluded the library that line pulls in. Built and measured instead:
+
+| bundle | before | +12 cmds (no `morph`) | +13 cmds (with `morph`) |
+| --- | --- | --- | --- |
+| `hyperfixi-hybrid-complete.js` | 8409 | 9317 (+10.9%) | **11376 (+35.3%)** |
+| `hyperfixi-hx.js` | 19025 | 19888 (+4.8%) | **21997 (+15.6%)** |
+
+`morphlex` alone is **+2057 gz** — 69% of the increase for 1 of 13 commands.
+Including it was a deliberate call by the owner: no advertised command may be a
+no-op. `MAX_HYBRID` therefore moved 20000 → **24000** (ci.yml AND
+pre-publish-check.yml); the arc's recommended 22000 predates this measurement and
+would have failed on the first run at hx's 21997. `baseline.json` was updated for
+those two entries ONLY, per step 3's precedent.
+
+### S4-e — two gates transformed, neither dropped
+
+- `bundle-manifest-consistency.test.ts` pinned `case 'trigger':\n case 'send': {`
+  by source regex. That label was measured UNREACHABLE (the parser emits a `send`
+  node for both spellings) and generation removed it structurally, so the pin was
+  asserting the presence of code that could not run — it would have blocked the
+  fix it was written to protect. Replaced with the structural claim (`trigger`
+  resolves to a template that IS emitted) plus the execution row that already
+  covers the dispatch. Its advertised-command check also had to resolve through
+  the GENERATOR's alias map, not the parser's: `trigger` is a VALUE in one and a
+  KEY in the other, and conflating them made a correct file look broken.
+- `command-manifest-audit.test.ts`'s ghost check assumed a bundle's `commands`
+  array and the registry are one vocabulary. Since the array is now the
+  generation input they are two: `push-url`/`replace-url` are advertised alias
+  spellings (the registry's own aliases are the unhyphenated
+  `pushurl`/`replaceurl`), and `removeClass` is a parser node name. It resolves
+  through `resolveCommandKey` first, with `removeClass` as one named exception —
+  the same exception, for the same reason, that capability-emission already
+  carries.
+
+### Gate — step 4
+
+Core `test:quick` **7687 / 106 / 300** (from 7684; +1 waitFor execution row, +2
+advertised-list rows). All 14 new execution rows mutation-verified by deleting
+each generated case: every one fails its OWN row and nothing else (`push` and
+`replace` also fail their alias rows, correctly — the aliases resolve to those
+templates). The advertised-array gate mutation-verified in both directions.
+`generate:bundles:check` is idempotent under the pinned prettier.
+
 ## Finding 17, restated with the arc's numbers
 
 The shipped hybrid bundles PARSE 35 commands and EXECUTE 24. The 11 orphans —
@@ -529,7 +682,14 @@ rejected), and `window._hyperscript` is gone from all four emitters that
 claimed it.
 
 **Step 4 — generate the hybrid-complete executor core; commit output with a
-`--check` drift guard.** `generateBundleCode()` already emits the whole file
+`--check` drift guard. CLOSED — see § "Step 4 — CLOSED" above for the design
+decision (executor core only, NOT the shell or the runtime), the `waitFor` gap
+that made the templates not-yet-a-superset, and the measured size carry.** The
+paragraph below is the plan as written; two of its assumptions did not survive
+measurement — `generateBundleCode()` emits a whole-file shape whose every
+runtime region diverges from hybrid-complete's, and the +1433 gz estimate was
+taken on source text and so excluded `morphlex` entirely (the real figure is
++2967, of which 2057 is that one library). `generateBundleCode()` already emits the whole file
 shape (parser import via `parserImportPath`, runtime, shell, autoInit) — this
 step points it at the reconciled templates + shared shell and commits the
 output as the `browser-bundle-hybrid-complete.ts` entry (script under

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,7 +68,7 @@ packages/
 | hyperfixi-lite.js            | 1.9 KB      | Minimal (8 commands, regex parser)          |
 | hyperfixi-lite-plus.js       | 2.6 KB      | More commands + i18n aliases                |
 | hyperfixi-hybrid-complete.js | 7.7 KB      | **Recommended** (~85% hyperscript coverage) |
-| hyperfixi-hx.js              | 18 KB       | hybrid-complete + htmx/fixi support         |
+| hyperfixi-hx.js              | 21.5 KB     | hybrid-complete + htmx/fixi support         |
 | hyperfixi-minimal.js         | 76 KB       | Full parser + 30 commands                   |
 | hyperfixi.js                 | ~299 KB     | Everything + reactivity/realtime plugins    |
 

--- a/docs/BROWSER_BUNDLES.md
+++ b/docs/BROWSER_BUNDLES.md
@@ -11,8 +11,8 @@ Decision tree for the most common cases:
 
 1. **Using `@hyperfixi/vite-plugin`?** Don't pick a bundle by hand — the plugin scans your project and emits the right one (minimal handcrafted when possible, falls back to `hx-v4` when it spots htmx v4 features). See [vite plugin README](../packages/vite-plugin/README.md).
 2. **Need `hx-live`, `bind`, `when`, SSE, or WebSocket?** Use `hyperfixi-hx-v4.js` (~322 KB gz). Single script tag, everything auto-installed. The size cost buys correctness — the slim runtime can't satisfy these features (its `set` doesn't fire `notifyGlobalWrite`, the slim parser doesn't know reactive features, and SSE/WS modules aren't wired).
-3. **Need only htmx v1/v2 attributes (`hx-get`/`hx-post`/etc.)?** Use `hyperfixi-hx.js` (~18 KB gz). Includes htmx-compat + the slim hybrid runtime for `_=` attributes. No reactivity, no streaming.
-4. **Pure hyperscript (`_=` attributes), ~85% feature coverage, smallest realistic size?** Use `hyperfixi-hybrid-complete.js` (~8.2 KB gz). Full AST parser, expressions, event modifiers, block commands (`if`, `for`, `repeat`, `while`, `fetch`).
+3. **Need only htmx v1/v2 attributes (`hx-get`/`hx-post`/etc.)?** Use `hyperfixi-hx.js` (~21.5 KB gz). Includes htmx-compat + the slim hybrid runtime for `_=` attributes. No reactivity, no streaming.
+4. **Pure hyperscript (`_=` attributes), ~85% feature coverage, smallest realistic size?** Use `hyperfixi-hybrid-complete.js` (~11.1 KB gz). Full AST parser, expressions, event modifiers, block commands (`if`, `for`, `repeat`, `while`, `fetch`).
 5. **Tiny static page (toggle / show / hide / put / set)?** Use `hyperfixi-lite.js` (~1.9 KB gz). Regex parser, 8 commands. Drops to `hyperfixi-lite-plus.js` (~2.6 KB gz) if you need a few more commands + i18n aliases.
 6. **Authoring in multiple languages (Japanese, Korean, Arabic, etc.) or need the full semantic parser at runtime?** Use `hyperfixi.js` (full bundle, ~310 KB gz) or `hyperfixi-multilingual.js` (~93 KB, parser-free i18n via the semantic bundle loaded separately).
 
@@ -37,8 +37,8 @@ For projects prioritizing bundle size over features:
 | ------------------------------ | ----------- | --------- | ------------------------------------------------------------- |
 | `hyperfixi-lite.js`            | 1.9 KB      | 8         | Regex parser, basic commands                                  |
 | `hyperfixi-lite-plus.js`       | 2.6 KB      | 14        | Regex parser, more commands, i18n aliases                     |
-| `hyperfixi-hybrid-complete.js` | 8.2 KB      | 21+blocks | Full AST parser, expressions, event modifiers                 |
-| `hyperfixi-hx.js`              | 18 KB       | 21+blocks | hybrid-complete + htmx/fixi attribute support                 |
+| `hyperfixi-hybrid-complete.js` | 11.1 KB     | 38+blocks | Full AST parser, expressions, event modifiers                 |
+| `hyperfixi-hx.js`              | 21.5 KB     | 38+blocks | hybrid-complete + htmx/fixi attribute support                 |
 | `hyperfixi-hx-v4.js`           | ~322 KB     | 40+blocks | Full runtime + htmx-compat + reactivity (hx-live, bind, when) |
 
 **Hybrid Complete** (~85% hyperscript coverage) is recommended - it supports:
@@ -117,7 +117,7 @@ When `@hyperfixi/reactivity` is installed, the htmx-compat layer recognizes the 
 
 The expression re-runs only when its tracked dependencies actually change (not on every DOM mutation, which is the upstream htmx v4 approach). If reactivity isn't installed, the element is skipped with a clear console error pointing to the install command.
 
-**Easiest path: use the `hyperfixi-hx-v4.js` bundle.** It ships the full runtime + `@hyperfixi/reactivity` auto-installed + the htmx-compat layer in a single script tag. Larger than `hyperfixi-hx.js` (~322 KB vs 18 KB gzipped) but no manual plugin wiring required. For size-tuned production builds, use `@hyperfixi/vite-plugin` instead.
+**Easiest path: use the `hyperfixi-hx-v4.js` bundle.** It ships the full runtime + `@hyperfixi/reactivity` auto-installed + the htmx-compat layer in a single script tag. Larger than `hyperfixi-hx.js` (~322 KB vs 21.5 KB gzipped) but no manual plugin wiring required. For size-tuned production builds, use `@hyperfixi/vite-plugin` instead.
 
 ```html
 <script src="hyperfixi-hx-v4.js"></script>

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -149,8 +149,8 @@ See [docs/API.md](docs/API.md) for complete documentation.
 | Bundle                         | Size (gzip) | Use Case                                          |
 | ------------------------------ | ----------- | ------------------------------------------------- |
 | `hyperfixi-lite.js`            | 1.9 KB      | Minimal (8 commands, regex parser)                |
-| `hyperfixi-hybrid-complete.js` | 8.2 KB      | Recommended (~85% coverage)                       |
-| `hyperfixi-hx.js`              | 18 KB       | hybrid-complete + htmx/fixi v1/v2 attributes      |
+| `hyperfixi-hybrid-complete.js` | 11.1 KB     | Recommended (~85% coverage)                       |
+| `hyperfixi-hx.js`              | 21.5 KB     | hybrid-complete + htmx/fixi v1/v2 attributes      |
 | `hyperfixi-hx-v4.js`           | ~321 KB     | Full runtime + htmx-compat + reactivity (hx-live) |
 | `hyperfixi.js`                 | ~309 KB     | Everything + bundled reactivity/realtime plugins  |
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -228,6 +228,8 @@
     "verify:reference": "tsx scripts/verify-reference-data.ts",
     "docs:commands": "tsx scripts/generate-command-docs.ts && tsx scripts/generate-command-docs.ts --format json",
     "docs:commands:check": "tsx scripts/generate-command-docs.ts --check && tsx scripts/generate-command-docs.ts --format json --check",
+    "generate:bundles": "tsx scripts/generate-bundles.ts",
+    "generate:bundles:check": "tsx scripts/generate-bundles.ts --check",
     "update:sizes": "tsx scripts/update-bundle-sizes.ts",
     "update:sizes:auto": "tsx scripts/update-bundle-sizes.ts --update"
   },

--- a/packages/core/scripts/bundle-snapshots/baseline.json
+++ b/packages/core/scripts/bundle-snapshots/baseline.json
@@ -1,10 +1,10 @@
 {
   "$schema": "./baseline.schema.json",
   "purpose": "Tree-shaking + bundle-size baseline for the evaluator consolidation arc (parser/runtime.ts canonical + ExpressionRegistry).",
-  "generated": "2026-07-29",
-  "commit": "09010f5c",
+  "generated": "2026-07-30",
+  "commit": "fc17d2c0",
   "tolerance_percent": 5,
-  "notes": "Updated 2026-07-30 (Arc E step 3, shared boot shell): ONLY the four slim bundles were re-baselined, because only they changed — they now import the shared `[_]` scanner and global installer from `compatibility/bundle-shell.ts` instead of each inlining their own. gzip deltas: lite +33 (+1.7%), lite-plus +34 (+1.3%), hybrid-complete +27 (+0.3%), hx +22 (+0.1%); raw deltas are +15 to +54. The gzip cost exceeds the raw cost on the two smallest bundles because the shared arrow-function form compresses slightly worse than the inline for-loop it replaced. A factory that also BUILT the api object was measured and rejected at +103 gz on hybrid-complete / +63 on hx — see the header of bundle-shell.ts. The six full bundles were deliberately NOT re-baselined: this change does not touch them, and a blanket --update would have absorbed the +0.3-0.8% raw local-vs-recorded drift they already show into the committed numbers, blinding the gate to it. Updated 2026-07-29 (#821): every full bundle DROPPED ~29.1 KB raw / ~6 KB gzip — a near-constant across minimal, standard, classic, classic-i18n, browser and hx-v4 — when the dead src/expressions/*/impl/ classes were deleted. They were unreachable at runtime (the registry objects in each category's index.ts are what execute) but were kept alive in the payload by trailing 'Re-export implementations for tests' lines, which made them public API surface that tree-shaking could not drop. The four slim bundles (lite, lite-plus, hybrid-complete, hybrid-hx) are unchanged, since they never pull in the expression registry. Both directions of this gate matter: it uses Math.abs, so a size IMPROVEMENT this large trips it too and must be recorded here. Previously updated 2026-07-20 (pre-release audit): added the four slim bundles, which had NO size-regression coverage, and refreshed all sizes post-#736. Runs in the CI bundle-size job. Run `node scripts/bundle-size-snapshot.mjs --check` after changes; failures (±5% drift) point to tree-shaking or duplication regressions. Regenerate with --update after an INTENTIONAL size change; the numbers here are macOS-local and read ~1 KB (0.3%) below CI Linux zlib on the full bundles, well inside the tolerance. metadata.ts, by contrast, must carry the CI numbers.",
+  "notes": "Updated 2026-07-30 (Arc E step 4, generated executor core): ONLY hybrid-complete and hx were re-baselined, because only they changed. This closes Finding 17 \u2014 both bundles PARSED 35 commands and EXECUTED 24, so the eleven orphans (beep break continue copy empty exit js morph push replace throw) plus removeClass and the two url aliases reached `default:` -> `Unknown command` while their parser rules shipped as dead weight. Measured deltas: hybrid-complete raw +10811 (+32.5%) / gzip +2967 (+35.3%); hx raw +10863 (+15.0%) / gzip +2972 (+15.6%). 2057 gz of that is `morphlex`, bundled by the `morph` case \u2014 69% of the increase for 1 of 13 commands, and the reason the arc's pre-measurement (+1421 gz) was low: it was taken on the generator's SOURCE TEXT, where the morphlex import is one line rather than a library. Including morph was a deliberate call: no advertised command may be a no-op. CI's absolute ceiling moved 20000 -> 24000 in the same change (ci.yml + pre-publish-check.yml); 22000 would have failed immediately at hx's measured 21997. The eight other bundles were deliberately NOT re-baselined \u2014 this change cannot reach them (they share no executor with the hybrid family), and a blanket --update would have absorbed the +0.3-0.8% raw local-vs-recorded drift they already show into the committed numbers, blinding the gate to it. Updated 2026-07-30 (Arc E step 3, shared boot shell): ONLY the four slim bundles were re-baselined, because only they changed \u2014 they now import the shared `[_]` scanner and global installer from `compatibility/bundle-shell.ts` instead of each inlining their own. gzip deltas: lite +33 (+1.7%), lite-plus +34 (+1.3%), hybrid-complete +27 (+0.3%), hx +22 (+0.1%); raw deltas are +15 to +54. The gzip cost exceeds the raw cost on the two smallest bundles because the shared arrow-function form compresses slightly worse than the inline for-loop it replaced. A factory that also BUILT the api object was measured and rejected at +103 gz on hybrid-complete / +63 on hx \u2014 see the header of bundle-shell.ts. The six full bundles were deliberately NOT re-baselined: this change does not touch them, and a blanket --update would have absorbed the +0.3-0.8% raw local-vs-recorded drift they already show into the committed numbers, blinding the gate to it. Updated 2026-07-29 (#821): every full bundle DROPPED ~29.1 KB raw / ~6 KB gzip \u2014 a near-constant across minimal, standard, classic, classic-i18n, browser and hx-v4 \u2014 when the dead src/expressions/*/impl/ classes were deleted. They were unreachable at runtime (the registry objects in each category's index.ts are what execute) but were kept alive in the payload by trailing 'Re-export implementations for tests' lines, which made them public API surface that tree-shaking could not drop. The four slim bundles (lite, lite-plus, hybrid-complete, hybrid-hx) are unchanged, since they never pull in the expression registry. Both directions of this gate matter: it uses Math.abs, so a size IMPROVEMENT this large trips it too and must be recorded here. Previously updated 2026-07-20 (pre-release audit): added the four slim bundles, which had NO size-regression coverage, and refreshed all sizes post-#736. Runs in the CI bundle-size job. Run `node scripts/bundle-size-snapshot.mjs --check` after changes; failures (\u00b15% drift) point to tree-shaking or duplication regressions. Regenerate with --update after an INTENTIONAL size change; the numbers here are macOS-local and read ~1 KB (0.3%) below CI Linux zlib on the full bundles, well inside the tolerance. metadata.ts, by contrast, must carry the CI numbers.",
   "bundles": {
     "hyperfixi-minimal.js": {
       "config": "rollup.browser-minimal.config.mjs",
@@ -37,7 +37,7 @@
     "hyperfixi.js": {
       "config": "rollup.browser.config.mjs",
       "entry": "src/compatibility/browser-bundle.ts",
-      "evaluator_strategy": "kitchen-sink Runtime → constructs full ExpressionRegistry (7 categories) + parser/runtime.ts canonical evaluator",
+      "evaluator_strategy": "kitchen-sink Runtime \u2192 constructs full ExpressionRegistry (7 categories) + parser/runtime.ts canonical evaluator",
       "raw_bytes": 1487392,
       "gzip_bytes": 315478
     },
@@ -65,16 +65,16 @@
     "hyperfixi-hybrid-complete.js": {
       "config": "rollup.browser-hybrid-complete.config.mjs",
       "entry": "src/compatibility/browser-bundle-hybrid-complete.ts",
-      "evaluator_strategy": "HybridParser + inline executeCommand switch",
-      "raw_bytes": 33279,
-      "gzip_bytes": 8409
+      "evaluator_strategy": "HybridParser + GENERATED executeCommand/executeBlock switches (scripts/generate-bundles.ts)",
+      "raw_bytes": 44090,
+      "gzip_bytes": 11376
     },
     "hyperfixi-hx.js": {
       "config": "rollup.browser-hybrid-hx.config.mjs",
       "entry": "src/compatibility/browser-bundle-hybrid-hx.ts",
       "evaluator_strategy": "hybrid-complete runtime + htmx/fixi attribute layer",
-      "raw_bytes": 72227,
-      "gzip_bytes": 19025
+      "raw_bytes": 83090,
+      "gzip_bytes": 21997
     }
   }
 }

--- a/packages/core/scripts/generate-bundles.ts
+++ b/packages/core/scripts/generate-bundles.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env tsx
+/**
+ * Generate the committed bundles' executor cores from `bundle-generator/templates.ts`.
+ *
+ *   npm run generate:bundles         # rewrite the generated regions in place
+ *   npm run generate:bundles:check   # fail if the committed output is stale
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT THIS CLOSES (Finding 17)
+ * ---------------------------------------------------------------------------
+ *
+ * `hyperfixi-hybrid-complete.js` and `hyperfixi-hx.js` PARSED 35 commands and
+ * EXECUTED 24. The other eleven — beep, break, continue, copy, empty, exit, js,
+ * morph, push, replace, throw — reached the parser, produced a node, and fell to
+ * `default:` → `Unknown command`. The parser rules for them shipped as dead
+ * weight in every one of those bundles.
+ *
+ * The two rejected fixes are recorded in
+ * `docs-internal/HANDOFF-command-arch-manifest.md` § Finding 17: split the
+ * parser, or hand-add eleven cases. The second is a FIFTH hand-maintained copy
+ * of the executor, which is the thing Arc E exists to delete.
+ *
+ * ---------------------------------------------------------------------------
+ * THE INPUT IS THE BUNDLE'S OWN ADVERTISED LIST — deliberately
+ * ---------------------------------------------------------------------------
+ *
+ * The command set is read from the target's `commands: [...]` array rather than
+ * declared here. That is what makes Finding 17 unrepeatable rather than merely
+ * fixed: "advertised but not executed" stops being a state the file can be in.
+ * Add a name to the array, run this script, and the case body arrives from the
+ * templates. Nothing can advertise a command it does not execute, because the
+ * advertisement IS the generation input.
+ *
+ * `blocks: [...]` is passed the same way and filtered by the emitter. Its `else`
+ * and `unless` entries name SYNTAX, not dispatch types — the parser folds both
+ * into an `if` node — so they correctly contribute no case.
+ *
+ * ---------------------------------------------------------------------------
+ * ONLY THE CASE BODIES ARE GENERATED
+ * ---------------------------------------------------------------------------
+ *
+ * The region markers sit INSIDE each `switch`. The switch itself, its `default:`
+ * arm, the helper closures and every other runtime region stay handwritten,
+ * because the two runtimes were measured to differ in all of them (see
+ * `executor-core.ts`). This is also why the shell is untouched: the emitted and
+ * handwritten api surfaces differ BY DESIGN and are gated as set equality in
+ * both directions (`compatibility/bundle-shell.test.ts`,
+ * `vite-plugin/src/emitted-shell.test.ts`), and `hyperfixi-hx.js` spreads
+ * hybrid-complete's api, so any shell change is user-visible on two shipped
+ * bundles.
+ *
+ * ---------------------------------------------------------------------------
+ * PRETTIER-IDEMPOTENT OR THE `--check` IS UNUSABLE
+ * ---------------------------------------------------------------------------
+ *
+ * Output is formatted with the repo's pinned prettier before it is written, so
+ * `generate → format` is a fixed point. Without that the pre-commit formatter
+ * rewrites the file the generator just wrote and `--check` reports drift on a
+ * clean tree. #828 fixed exactly this for the docs generator.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative } from 'node:path';
+import * as prettier from 'prettier';
+import { emitCommandCases, emitBlockCases } from '../src/bundle-generator/executor-core';
+
+/** Package root (`packages/core`); target paths are relative to it. */
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+interface Target {
+  /** Repo-relative path of the file whose regions are generated. */
+  file: string;
+  /** Human label used in failure output. */
+  label: string;
+}
+
+const TARGETS: Target[] = [
+  {
+    file: 'src/compatibility/browser-bundle-hybrid-complete.ts',
+    label: 'hybrid-complete',
+  },
+];
+
+const BEGIN = (id: string) => `// #region generated:${id}`;
+const END = (id: string) => `// #endregion generated:${id}`;
+
+/** Read a `name: [ 'a', 'b' ]` string-array literal out of source text. */
+function readStringArray(source: string, name: string, label: string): string[] {
+  const match = source.match(new RegExp(`\\n\\s*${name}: \\[([^\\]]*)\\]`));
+  if (!match) throw new Error(`${label}: no \`${name}: [...]\` array found`);
+  return [...match[1].matchAll(/'([^']+)'/g)].map(m => m[1]);
+}
+
+/**
+ * Replace the body between `// #region generated:<id>` and its `#endregion`.
+ * Markers are preserved; everything between them is replaced wholesale.
+ */
+function spliceRegion(source: string, id: string, body: string, label: string): string {
+  const begin = source.indexOf(BEGIN(id));
+  const endMarker = source.indexOf(END(id));
+  if (begin < 0 || endMarker < 0 || endMarker < begin) {
+    throw new Error(`${label}: missing or inverted markers for region '${id}'`);
+  }
+  const afterBegin = source.indexOf('\n', begin) + 1;
+  // Snap to the start of the `#endregion` LINE so the marker keeps its indent;
+  // `indexOf` lands on the `//`, which would otherwise be spliced flush-left.
+  const end = source.lastIndexOf('\n', endMarker) + 1;
+  return source.slice(0, afterBegin) + body.replace(/\s*$/, '') + '\n' + source.slice(end);
+}
+
+async function generateOne(target: Target): Promise<{ path: string; next: string; prev: string }> {
+  const path = join(ROOT, target.file);
+  const prev = readFileSync(path, 'utf8');
+
+  const commands = readStringArray(prev, 'commands', target.label);
+  const blocks = readStringArray(prev, 'blocks', target.label);
+  if (commands.length === 0) throw new Error(`${target.label}: empty commands array`);
+
+  let next = spliceRegion(prev, 'commands', emitCommandCases(commands), target.label);
+  next = spliceRegion(next, 'blocks', emitBlockCases(blocks), target.label);
+
+  const config = await prettier.resolveConfig(path);
+  next = await prettier.format(next, { ...config, filepath: path });
+
+  return { path, next, prev };
+}
+
+async function main(): Promise<void> {
+  const check = process.argv.includes('--check');
+  const stale: string[] = [];
+
+  for (const target of TARGETS) {
+    const { path, next, prev } = await generateOne(target);
+    const rel = relative(ROOT, path);
+
+    if (next === prev) {
+      if (!check) console.log(`  unchanged  ${rel}`);
+      continue;
+    }
+    if (check) {
+      stale.push(rel);
+      continue;
+    }
+    writeFileSync(path, next);
+    console.log(`  generated  ${rel}`);
+  }
+
+  if (stale.length > 0) {
+    console.error('\nGenerated bundle regions are STALE:\n');
+    for (const rel of stale) console.error(`  ${rel}`);
+    console.error('\nRun `npm run generate:bundles` and commit the result.\n');
+    process.exit(1);
+  }
+  if (check) console.log('Generated bundle regions are up to date.');
+}
+
+main().catch((err: unknown) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/packages/core/src/bundle-generator/__tests__/capability-emission.test.ts
+++ b/packages/core/src/bundle-generator/__tests__/capability-emission.test.ts
@@ -428,6 +428,42 @@ describe('every advertised command runs in a generated bundle', () => {
     expect(dead).toEqual([]);
   }, 60000);
 
+  it('`wait for <event>` BLOCKS until the event — the second label runs (Arc E step 4)', async () => {
+    // The row every list-shaped check was structurally blind to. `waitFor` is a
+    // name the parser EMITS but not a `cmdMap` key and not an advertised
+    // command, so §1 (list mirrors), §3 (labels vs surfaces) and §4 (the two
+    // cmdMaps) all agreed while the template had no such case. The generated
+    // bundle warned once and RESOLVED IMMEDIATELY, so every command after
+    // `wait for click` in a handler ran without waiting.
+    //
+    // Asserting the thing the command is FOR (Finding 16): not "it returned",
+    // but "it had NOT returned before the event, and had after". A check that
+    // only awaited the promise passes against the broken template — that is
+    // precisely how this survived.
+    const gen = generateBundle({
+      name: 'CapWaitFor',
+      commands: ['wait'],
+      blocks: [],
+      autoInit: false,
+      parserImportPath: '../../../parser/hybrid',
+    });
+    const file = join(GEN_DIR, 'waitfor_label.ts');
+    writeFileSync(file, gen.code);
+
+    document.body.innerHTML = '<div id="host"></div>';
+    const me = document.getElementById('host')!;
+    const mod = await import(/* @vite-ignore */ file);
+
+    let settled = false;
+    const running = mod.api.execute('wait for foo', me).then(() => (settled = true));
+    await new Promise(resolve => setTimeout(resolve, 20));
+    expect(settled, 'settled before the event fired — `wait for` did not wait').toBe(false);
+
+    me.dispatchEvent(new Event('foo'));
+    await running;
+    expect(settled).toBe(true);
+  }, 20000);
+
   it('a trigger-only bundle now dispatches on the named target', async () => {
     // Kept as its own case because it is the one that made Finding 13 a
     // correctness defect rather than a tidiness one: the generator reported no
@@ -460,17 +496,34 @@ const commandNamesIn = (node: unknown, acc: string[] = []): string[] => {
 const caseLabelsIn = (template: string): string[] =>
   [...template.matchAll(/case '([^']+)':/g)].map(m => m[1]);
 
+/**
+ * Source a template's NON-PRIMARY case labels are reachable from.
+ *
+ * A template usually carries one label, named for the command a user types, so
+ * `SURFACES[name].code` proves the whole template reachable. `wait` is the
+ * exception: `parseWait` emits `waitFor` for `wait for <event>` and `wait` for a
+ * duration, and one `code` string cannot yield both. Listing the second source
+ * here keeps §3 at tolerance 0 rather than allowlisting the label — the label
+ * must still be PARSER-REACHABLE, just from a surface of its own.
+ */
+const SECONDARY_LABEL_SURFACES: Record<string, string[]> = {
+  wait: ['wait for foo'],
+};
+
 describe('no template emits a case label the parser cannot produce', () => {
   it('every emitted label is a node name some surface actually yields', () => {
     // The converse of §2, and the direction that catches a label added without a
     // parse rule. `push-url`/`replace-url` used to live here as private labels
     // inside the push/replace templates — unreachable by construction, since no
     // parser emits a node by either name.
-    const emittable = new Set(
-      AVAILABLE_COMMANDS.flatMap(name =>
+    const emittable = new Set([
+      ...AVAILABLE_COMMANDS.flatMap(name =>
         commandNamesIn(new HybridParser(SURFACES[name].code).parse())
-      )
-    );
+      ),
+      ...Object.values(SECONDARY_LABEL_SURFACES)
+        .flat()
+        .flatMap(code => commandNamesIn(new HybridParser(code).parse())),
+    ]);
     const dead = Object.entries(COMMAND_IMPLEMENTATIONS).flatMap(([key, template]) =>
       caseLabelsIn(template)
         .filter(label => !emittable.has(label))

--- a/packages/core/src/bundle-generator/executor-core.ts
+++ b/packages/core/src/bundle-generator/executor-core.ts
@@ -1,0 +1,66 @@
+/**
+ * Executor core emission — the ONE copy of "turn a command list into switch cases".
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS IS A MODULE AND NOT TWO CALL SITES
+ * ---------------------------------------------------------------------------
+ *
+ * Arc E exists because the same executor was hand-copied into five places and
+ * the copies silently disagreed (`docs-internal/HANDOFF-command-arch-bundles.md`
+ * § "The premise, corrected"). Step 4 removes one of those copies by GENERATING
+ * hybrid-complete's switch bodies from `templates.ts` — the same source
+ * `generateBundleCode()` already emits from.
+ *
+ * That only removes a copy if both consumers share one emitter. If the script
+ * that writes the committed bundle had its own `.map(k => impls[k]).join('\n')`,
+ * the arc would have replaced a duplicated executor with a duplicated emitter —
+ * the alias-dedupe below is exactly the kind of rule that would drift.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IS DELIBERATELY *NOT* HERE
+ * ---------------------------------------------------------------------------
+ *
+ * Only the `case` bodies. The surrounding `switch`, its `default:` arm, the
+ * helper closures (`getTarget`/`getClassName`) and every other runtime region
+ * stay handwritten in each bundle, because measurement (step 4) found the two
+ * runtimes differ in EVERY such region — `evaluate`, `evaluateBinary`,
+ * `evaluatePositional`, `executeSequence`, `executeAST` and the `Context` shape
+ * all diverge, and step 2 reconciled only the command/block case bodies.
+ * Generating the whole file would have been an unreviewed behavior change
+ * across the entire runtime wearing a refactor's commit message.
+ *
+ * Keeping the region this narrow is also what keeps this module parameterless:
+ * the two `default:` arms warn with different text and the two bundles scope
+ * their helpers differently, and none of that has to be modelled here.
+ */
+
+import { getCommandImplementations, getBlockImplementations, type CodeFormat } from './templates';
+import { resolveCommandKey } from './template-capabilities';
+
+/**
+ * `case` bodies for `commands`, in the order given, ready to splice into an
+ * `executeCommand` switch.
+ *
+ * Advertised aliases resolve to their implementing template key and the result
+ * is deduped: each template already carries the case labels for its own aliases,
+ * so requesting both `push` and `push-url` must emit the template ONCE — two
+ * copies would be duplicate `case` labels, and the second would silently never
+ * run. Unknown names are dropped here; `generateBundle()` is what reports them
+ * as `unknown-command` errors.
+ */
+export function emitCommandCases(commands: string[], format: CodeFormat = 'ts'): string {
+  const impls = getCommandImplementations(format);
+  return [...new Set(commands.map(resolveCommandKey))]
+    .filter(key => impls[key])
+    .map(key => impls[key])
+    .join('\n');
+}
+
+/** `case` bodies for `blocks`, ready to splice into an `executeBlock` switch. */
+export function emitBlockCases(blocks: string[], format: CodeFormat = 'ts'): string {
+  const impls = getBlockImplementations(format);
+  return blocks
+    .filter(key => impls[key])
+    .map(key => impls[key])
+    .join('\n');
+}

--- a/packages/core/src/bundle-generator/generator.ts
+++ b/packages/core/src/bundle-generator/generator.ts
@@ -13,11 +13,10 @@ import {
   STYLE_READ_COMMANDS,
   ELEMENT_ARRAY_COMMANDS,
   MORPH_COMMANDS,
-  getCommandImplementations,
-  getBlockImplementations,
   type CodeFormat,
 } from './templates';
 import { resolveCommandKey } from './template-capabilities';
+import { emitCommandCases, emitBlockCases } from './executor-core';
 
 /**
  * Generate bundle code from configuration
@@ -52,23 +51,12 @@ export function generateBundleCode(config: GeneratorOptions): string {
   const hasBlocks = blocks.length > 0;
   const hasReturn = commands.includes('return');
 
-  // Get format-specific implementations
-  const commandImpls = getCommandImplementations(format);
-  const blockImpls = getBlockImplementations(format);
-
-  // Resolve advertised aliases (push-url → push) to their template key, and
-  // dedupe: each template already carries the case labels for its aliases, so
-  // requesting both 'push' and 'push-url' must include the template once
-  // (duplicate case labels would shadow silently).
-  const commandCases = [...new Set(commands.map(resolveCommandKey))]
-    .filter(cmd => commandImpls[cmd])
-    .map(cmd => commandImpls[cmd])
-    .join('\n');
-
-  const blockCases = blocks
-    .filter(block => blockImpls[block])
-    .map(block => blockImpls[block])
-    .join('\n');
+  // Shared with `scripts/generate-bundles.ts`, which splices the same case
+  // bodies into the committed `browser-bundle-hybrid-complete.ts`. Alias
+  // resolution and dedupe live in the emitter so the two consumers cannot drift
+  // — see `executor-core.ts`.
+  const commandCases = emitCommandCases(commands, format);
+  const blockCases = emitBlockCases(blocks, format);
 
   return `/**
  * HyperFixi ${name} Bundle (Auto-Generated)

--- a/packages/core/src/bundle-generator/templates.ts
+++ b/packages/core/src/bundle-generator/templates.ts
@@ -158,12 +158,40 @@ const COMMAND_IMPLEMENTATIONS_TS: Record<string, string> = {
       return value;
     }`,
 
+  // `wait` carries TWO case labels because the parser emits two names for it.
+  // `parseWait` returns `{ name: 'waitFor' }` for `wait for <event>` and
+  // `{ name: 'wait' }` for a duration — and `waitFor` is NOT a `cmdMap` key, so
+  // no key-set check between the parser and these templates can see it. The
+  // label was absent here until Arc E step 4 measured the parser's EMITTED-name
+  // set (28) against the template case labels (35) rather than against
+  // `cmdMap`'s keys (35, which agree and are the wrong question). Every
+  // generated bundle carrying `wait` therefore fell to `default:` on
+  // `wait for click` — warned once and resolved IMMEDIATELY instead of waiting,
+  // so a handler's remaining commands ran at once. Same class as the `morph`
+  // free identifier and the `take` DOMException: invisible to a parse-level or
+  // key-set check, visible only to execution.
   wait: `
     case 'wait': {
       const duration = await evaluate(cmd.args[0], ctx);
       const ms = typeof duration === 'number' ? duration : parseInt(String(duration));
       await new Promise(resolve => setTimeout(resolve, ms));
       return ms;
+    }
+
+    case 'waitFor': {
+      const eventName = await evaluate(cmd.args[0], ctx);
+      const targets = await getTarget();
+      const target = targets[0] || ctx.me;
+      return new Promise(resolve => {
+        target.addEventListener(
+          String(eventName),
+          e => {
+            ctx.it = e;
+            resolve(e);
+          },
+          { once: true }
+        );
+      });
     }`,
 
   transition: `
@@ -536,11 +564,19 @@ const COMMAND_IMPLEMENTATIONS_TS: Record<string, string> = {
       }
 
       // Build context object for the Function
+      //
+      // \`target\` is \`ctx.me\` outright, not \`ctx.target || ctx.me\`. No Context
+      // in any bundle declares a \`target\` field and no executor assigns one, so
+      // the left operand was always \`undefined\` and the expression always
+      // yielded \`ctx.me\` — same value, and a type error the moment the template
+      // lands in a file that is actually typechecked (Arc E step 4, where it
+      // did). Generated bundles are written, imported and executed but never
+      // \`tsc\`'d, which is how a phantom property survived here.
       const jsContext = {
         me: ctx.me,
         it: ctx.it,
         event: ctx.event,
-        target: ctx.target || ctx.me,
+        target: ctx.me,
         locals: Object.fromEntries(ctx.locals),
         globals: Object.fromEntries(globalVars),
         document: typeof document !== 'undefined' ? document : undefined,

--- a/packages/core/src/compatibility/browser-bundle-hybrid-complete.ts
+++ b/packages/core/src/compatibility/browser-bundle-hybrid-complete.ts
@@ -30,6 +30,10 @@ import { tokenize } from '../parser/hybrid/tokenizer';
 import type { ASTNode, CommandNode, BlockNode, EventNode } from '../parser/hybrid/ast-types';
 import { addCommandAliases, addEventAliases } from '../parser/hybrid/aliases';
 import { createProcessElements, installBundleGlobal, type BundleShellApi } from './bundle-shell';
+// Required by the generated `morph` case. This is the one generated command
+// that pulls a third-party dependency into the bundle; its measured cost is
+// recorded in the Arc E step 4 PR body.
+import { morph as morphlexMorph, morphInner as morphlexMorphInner } from 'morphlex';
 
 /** The extras hybrid-complete adds above the shared core surface. */
 interface HybridCompleteExtras {
@@ -342,6 +346,8 @@ async function executeCommand(cmd: CommandNode, ctx: Context): Promise<any> {
   };
 
   switch (cmd.name) {
+    // #region generated:commands — DO NOT EDIT (npm run generate:bundles)
+
     case 'toggle': {
       const raw = getClassName(cmd.args[0]) || String(await evaluate(cmd.args[0], ctx));
       const targets = await getTarget();
@@ -371,6 +377,12 @@ async function executeCommand(cmd: CommandNode, ctx: Context): Promise<any> {
       return ctx.it;
     }
 
+    case 'remove': {
+      const targets = await getTarget();
+      for (const el of targets) el.remove();
+      return null;
+    }
+
     case 'removeClass': {
       const raw = getClassName(cmd.args[0]) || String(await evaluate(cmd.args[0], ctx));
       const targets = await getTarget();
@@ -380,14 +392,22 @@ async function executeCommand(cmd: CommandNode, ctx: Context): Promise<any> {
       } else {
         for (const el of targets) el.classList.remove(raw);
       }
-      ctx.it = targets.length === 1 ? targets[0] : targets;
-      return ctx.it;
+      return targets;
     }
 
-    case 'remove': {
+    case 'show': {
       const targets = await getTarget();
-      for (const el of targets) el.remove();
-      return null;
+      for (const el of targets) {
+        (el as HTMLElement).style.display = '';
+        el.classList.remove('hidden');
+      }
+      return targets;
+    }
+
+    case 'hide': {
+      const targets = await getTarget();
+      for (const el of targets) (el as HTMLElement).style.display = 'none';
+      return targets;
     }
 
     case 'put': {
@@ -417,14 +437,41 @@ async function executeCommand(cmd: CommandNode, ctx: Context): Promise<any> {
       return content;
     }
 
-    case 'append':
+    case 'append': {
+      const content = await evaluate(cmd.args[0], ctx);
+      const targets = await getTarget();
+      for (const el of targets) el.insertAdjacentHTML('beforeend', String(content));
+      ctx.it = content;
+      return content;
+    }
+
     case 'prepend': {
       const content = await evaluate(cmd.args[0], ctx);
       const targets = await getTarget();
-      const where = cmd.name === 'append' ? 'beforeend' : 'afterbegin';
-      for (const el of targets) el.insertAdjacentHTML(where, String(content));
+      for (const el of targets) el.insertAdjacentHTML('afterbegin', String(content));
       ctx.it = content;
       return content;
+    }
+
+    case 'take': {
+      // getClassName reads a NODE (as toggle/add/removeClass all do). Passing the
+      // EVALUATED value handed it a NodeList, which yielded '' and then threw
+      // 'Invalid selector .' — a command the parse-level reachability check
+      // certified while every generated bundle carrying it crashed.
+      const className = getClassName(cmd.args[0]);
+      const from = cmd.target ? await getTarget() : [ctx.me.parentElement!];
+      for (const container of from) {
+        const siblings = container.querySelectorAll('.' + className);
+        siblings.forEach(el => el.classList.remove(className));
+      }
+      ctx.me.classList.add(className);
+      return ctx.me;
+    }
+
+    case 'empty': {
+      const targets = await getTarget();
+      for (const el of targets) (el as HTMLElement).innerHTML = '';
+      return targets;
     }
 
     case 'set': {
@@ -442,11 +489,11 @@ async function executeCommand(cmd: CommandNode, ctx: Context): Promise<any> {
       if (target.type === 'possessive' || target.type === 'member') {
         const obj = await evaluate(target.object, ctx);
         if (obj) {
-          if (obj instanceof Element && setStyleProp(obj, target.property, value)) {
-            ctx.it = value;
-            return value;
+          if (obj instanceof Element && isStyleProp(target.property)) {
+            setStyleProp(obj, target.property, value);
+          } else {
+            (obj as any)[target.property] = value;
           }
-          (obj as any)[target.property] = value;
           ctx.it = value;
           return value;
         }
@@ -462,32 +509,76 @@ async function executeCommand(cmd: CommandNode, ctx: Context): Promise<any> {
       return value;
     }
 
-    case 'call': {
-      const result = await evaluate(cmd.args[0], ctx);
-      ctx.it = result;
-      return result;
+    case 'increment': {
+      const target = cmd.args[0];
+      const amount = cmd.args[1] ? await evaluate(cmd.args[1], ctx) : 1;
+
+      if (target.type === 'variable') {
+        const varName = target.name.slice(1);
+        const map = target.scope === 'local' ? elemScope(ctx.me) : globalVars;
+        const current = map.get(varName) || 0;
+        const newVal = current + amount;
+        map.set(varName, newVal);
+        ctx.it = newVal;
+        return newVal;
+      }
+
+      if (target.type === 'possessive' && isStyleProp(target.property)) {
+        const obj = await evaluate(target.object, ctx);
+        const elements = toElementArray(obj);
+        for (const el of elements) {
+          const current = parseFloat(getStyleProp(el, target.property) || '0') || 0;
+          const newVal = current + amount;
+          setStyleProp(el, target.property, newVal);
+          ctx.it = newVal;
+        }
+        return ctx.it;
+      }
+
+      const elements = toElementArray(await evaluate(target, ctx));
+      for (const el of elements) {
+        const current = parseFloat(el.textContent || '0') || 0;
+        const newVal = current + amount;
+        el.textContent = String(newVal);
+        ctx.it = newVal;
+      }
+      return ctx.it;
     }
 
-    case 'log': {
-      const values = await Promise.all(cmd.args.map(a => evaluate(a, ctx)));
-      console.log(...values);
-      return values[0];
-    }
+    case 'decrement': {
+      const target = cmd.args[0];
+      const amount = cmd.args[1] ? await evaluate(cmd.args[1], ctx) : 1;
 
-    // `trigger` is a distinct parser keyword (not an alias — the alias map
-    // canonicalizes `fire`→trigger, `dispatch`→send), so it needs its own
-    // case label here. It was advertised in this bundle's `commands` manifest
-    // but had no case, making `trigger`/`fire` a silent no-op in the
-    // hybrid-complete and hybrid-hx bundles (2026-07-20 audit; pinned by
-    // bundle-manifest-consistency.test.ts).
-    case 'trigger':
-    case 'send': {
-      const eventName = await evaluate(cmd.args[0], ctx);
-      const targets = await getTarget();
-      const event = new CustomEvent(String(eventName), { bubbles: true, detail: ctx.it });
-      for (const el of targets) el.dispatchEvent(event);
-      ctx.it = event;
-      return event;
+      if (target.type === 'variable') {
+        const varName = target.name.slice(1);
+        const map = target.scope === 'local' ? elemScope(ctx.me) : globalVars;
+        const current = map.get(varName) || 0;
+        const newVal = current - amount;
+        map.set(varName, newVal);
+        ctx.it = newVal;
+        return newVal;
+      }
+
+      if (target.type === 'possessive' && isStyleProp(target.property)) {
+        const obj = await evaluate(target.object, ctx);
+        const elements = toElementArray(obj);
+        for (const el of elements) {
+          const current = parseFloat(getStyleProp(el, target.property) || '0') || 0;
+          const newVal = current - amount;
+          setStyleProp(el, target.property, newVal);
+          ctx.it = newVal;
+        }
+        return ctx.it;
+      }
+
+      const elements = toElementArray(await evaluate(target, ctx));
+      for (const el of elements) {
+        const current = parseFloat(el.textContent || '0') || 0;
+        const newVal = current - amount;
+        el.textContent = String(newVal);
+        ctx.it = newVal;
+      }
+      return ctx.it;
     }
 
     case 'wait': {
@@ -511,21 +602,6 @@ async function executeCommand(cmd: CommandNode, ctx: Context): Promise<any> {
           { once: true }
         );
       });
-    }
-
-    case 'show': {
-      const targets = await getTarget();
-      for (const el of targets) {
-        (el as HTMLElement).style.display = '';
-        el.classList.remove('hidden');
-      }
-      return targets;
-    }
-
-    case 'hide': {
-      const targets = await getTarget();
-      for (const el of targets) (el as HTMLElement).style.display = 'none';
-      return targets;
     }
 
     case 'transition': {
@@ -577,61 +653,147 @@ async function executeCommand(cmd: CommandNode, ctx: Context): Promise<any> {
       return ctx.it;
     }
 
-    case 'take': {
-      // getClassName reads a NODE, exactly as toggle/add/removeClass above do.
-      // This passed it the EVALUATED value instead, which for the documented
-      // `take .x from #t` form is an Element/NodeList — getClassName returns ''
-      // and `querySelectorAll('.' + '')` throws `SyntaxError: '.'`. Shipped
-      // broken in hyperfixi-hybrid-complete.js and hyperfixi-hx.js: the source-
-      // text manifest gate saw a `case` label and passed, and the execution
-      // gate that would have caught it covered only GENERATED bundles, where
-      // the same defect was found and fixed as Finding 16.
-      const className = getClassName(cmd.args[0]);
-      const from = cmd.target ? await getTarget() : [ctx.me.parentElement!];
-      for (const container of from) {
-        const siblings = container.querySelectorAll('.' + className);
-        siblings.forEach(el => el.classList.remove(className));
-      }
-      ctx.me.classList.add(className);
-      return ctx.me;
+    case 'send': {
+      const eventName = await evaluate(cmd.args[0], ctx);
+      const targets = await getTarget();
+      const event = new CustomEvent(String(eventName), { bubbles: true, detail: ctx.it });
+      for (const el of targets) el.dispatchEvent(event);
+      ctx.it = event;
+      return event;
     }
 
-    case 'increment':
-    case 'decrement': {
-      const target = cmd.args[0];
-      const amount = await evaluate(cmd.args[1], ctx);
-      const delta = cmd.name === 'increment' ? amount : -amount;
+    case 'log': {
+      const values = await Promise.all(cmd.args.map((a: any) => evaluate(a, ctx)));
+      console.log(...values);
+      return values[0];
+    }
 
-      if (target.type === 'variable') {
-        const varName = target.name.slice(1);
-        const map = target.scope === 'local' ? elemScope(ctx.me) : globalVars;
-        const current = map.get(varName) || 0;
-        const newVal = current + delta;
-        map.set(varName, newVal);
-        ctx.it = newVal;
-        return newVal;
+    case 'call': {
+      const result = await evaluate(cmd.args[0], ctx);
+      ctx.it = result;
+      return result;
+    }
+
+    case 'copy': {
+      const source = await evaluate(cmd.args[0], ctx);
+      let textToCopy = '';
+
+      if (typeof source === 'string') {
+        textToCopy = source;
+      } else if (source instanceof Element) {
+        textToCopy = source.textContent || '';
+      } else {
+        textToCopy = String(source);
       }
 
-      if (target.type === 'possessive' && isStyleProp(target.property)) {
-        const obj = await evaluate(target.object, ctx);
-        const elements = toElementArray(obj);
-        for (const el of elements) {
-          const current = parseFloat(getStyleProp(el, target.property) || '0') || 0;
-          const newVal = current + delta;
-          setStyleProp(el, target.property, newVal);
-          ctx.it = newVal;
+      try {
+        if (navigator.clipboard) {
+          await navigator.clipboard.writeText(textToCopy);
+        } else {
+          // Fallback for older browsers
+          const textarea = document.createElement('textarea');
+          textarea.value = textToCopy;
+          textarea.style.cssText = 'position:fixed;top:0;left:-9999px';
+          document.body.appendChild(textarea);
+          textarea.select();
+          document.execCommand('copy');
+          document.body.removeChild(textarea);
         }
-        return ctx.it;
+
+        if (ctx.me instanceof Element) {
+          ctx.me.dispatchEvent(
+            new CustomEvent('copy:success', {
+              bubbles: true,
+              detail: { text: textToCopy },
+            })
+          );
+        }
+        ctx.it = textToCopy;
+        return textToCopy;
+      } catch (error) {
+        if (ctx.me instanceof Element) {
+          ctx.me.dispatchEvent(
+            new CustomEvent('copy:error', {
+              bubbles: true,
+              detail: { error },
+            })
+          );
+        }
+        throw error;
+      }
+    }
+
+    case 'beep': {
+      const values = await Promise.all(cmd.args.map((a: any) => evaluate(a, ctx)));
+      const displayValues = values.length > 0 ? values : [ctx.it];
+
+      for (const val of displayValues) {
+        const typeInfo =
+          val === null
+            ? 'null'
+            : val === undefined
+              ? 'undefined'
+              : Array.isArray(val)
+                ? `Array[${val.length}]`
+                : val instanceof Element
+                  ? `Element<${val.tagName.toLowerCase()}>`
+                  : typeof val;
+        console.log('[beep]', typeInfo + ':', val);
+      }
+      return displayValues[0];
+    }
+
+    case 'go': {
+      const dest = await evaluate(cmd.args[0], ctx);
+      const d = String(dest).toLowerCase();
+      if (d === 'back') history.back();
+      else if (d === 'forward') history.forward();
+      else if (d === 'bottom') ctx.me.scrollIntoView({ block: 'end', behavior: 'smooth' });
+      else if (d === 'top') ctx.me.scrollIntoView({ block: 'start', behavior: 'smooth' });
+      else window.location.href = String(dest);
+      return null;
+    }
+
+    case 'push': {
+      const url = String(await evaluate(cmd.args[0], ctx));
+      let title = '';
+
+      // Check for "with title" modifier
+      if (cmd.modifiers?.title) {
+        title = String(await evaluate(cmd.modifiers.title, ctx));
       }
 
-      const elements = toElementArray(await evaluate(target, ctx));
-      for (const el of elements) {
-        const current = parseFloat(el.textContent || '0') || 0;
-        const newVal = current + delta;
-        el.textContent = String(newVal);
-        ctx.it = newVal;
+      window.history.pushState(null, '', url);
+      if (title) document.title = title;
+
+      window.dispatchEvent(
+        new CustomEvent('lokascript:pushurl', {
+          detail: { url, title },
+        })
+      );
+
+      return { url, title, mode: 'push' };
+    }
+
+    case 'replace': {
+      const url = String(await evaluate(cmd.args[0], ctx));
+      let title = '';
+
+      // Check for "with title" modifier
+      if (cmd.modifiers?.title) {
+        title = String(await evaluate(cmd.modifiers.title, ctx));
       }
-      return ctx.it;
+
+      window.history.replaceState(null, '', url);
+      if (title) document.title = title;
+
+      window.dispatchEvent(
+        new CustomEvent('lokascript:replaceurl', {
+          detail: { url, title },
+        })
+      );
+
+      return { url, title, mode: 'replace' };
     }
 
     case 'focus': {
@@ -646,35 +808,141 @@ async function executeCommand(cmd: CommandNode, ctx: Context): Promise<any> {
       return targets;
     }
 
-    case 'go': {
-      const dest = await evaluate(cmd.args[0], ctx);
-      const d = String(dest).toLowerCase();
-      if (d === 'back') history.back();
-      else if (d === 'forward') history.forward();
-      else window.location.href = String(dest);
-      return null;
-    }
-
     case 'return': {
       const value = cmd.args[0] ? await evaluate(cmd.args[0], ctx) : ctx.it;
       throw { type: 'return', value };
     }
 
-    case 'halt': {
-      if (ctx.event) {
-        ctx.event.preventDefault();
-        ctx.event.stopPropagation();
-      }
-      return null;
+    case 'break': {
+      throw { type: 'break' };
     }
 
+    case 'continue': {
+      throw { type: 'continue' };
+    }
+
+    case 'halt': {
+      // Check for "halt the event" pattern
+      const firstArg = cmd.args[0];
+      let targetEvent = ctx.event;
+      if (
+        firstArg?.type === 'identifier' &&
+        firstArg.name === 'the' &&
+        cmd.args[1]?.name === 'event'
+      ) {
+        targetEvent = ctx.event;
+      } else if (firstArg) {
+        const evaluated = await evaluate(firstArg, ctx);
+        if (evaluated?.preventDefault) targetEvent = evaluated;
+      }
+
+      if (targetEvent && typeof targetEvent.preventDefault === 'function') {
+        targetEvent.preventDefault();
+        targetEvent.stopPropagation();
+        return { halted: true, eventHalted: true };
+      }
+
+      // Regular halt - stop execution
+      const haltError = new Error('HALT_EXECUTION');
+      (haltError as any).isHalt = true;
+      throw haltError;
+    }
+
+    case 'exit': {
+      const exitError = new Error('EXIT_COMMAND');
+      (exitError as any).isExit = true;
+      throw exitError;
+    }
+
+    case 'throw': {
+      const message = cmd.args[0] ? await evaluate(cmd.args[0], ctx) : 'Error';
+      const errorToThrow = message instanceof Error ? message : new Error(String(message));
+      throw errorToThrow;
+    }
+
+    case 'js': {
+      const codeArg = cmd.args[0];
+      let jsCode = '';
+
+      if (codeArg.type === 'string') {
+        jsCode = codeArg.value;
+      } else if (codeArg.type === 'template') {
+        jsCode = await evaluate(codeArg, ctx);
+      } else {
+        jsCode = String(await evaluate(codeArg, ctx));
+      }
+
+      // Build context object for the Function
+      //
+      // `target` is `ctx.me` outright, not `ctx.target || ctx.me`. No Context
+      // in any bundle declares a `target` field and no executor assigns one, so
+      // the left operand was always `undefined` and the expression always
+      // yielded `ctx.me` — same value, and a type error the moment the template
+      // lands in a file that is actually typechecked (Arc E step 4, where it
+      // did). Generated bundles are written, imported and executed but never
+      // `tsc`'d, which is how a phantom property survived here.
+      const jsContext = {
+        me: ctx.me,
+        it: ctx.it,
+        event: ctx.event,
+        target: ctx.me,
+        locals: Object.fromEntries(ctx.locals),
+        globals: Object.fromEntries(globalVars),
+        document: typeof document !== 'undefined' ? document : undefined,
+        window: typeof window !== 'undefined' ? window : undefined,
+      };
+
+      try {
+        const fn = new Function('ctx', `with(ctx) { return (async () => { ${jsCode} })(); }`);
+        const result = await fn(jsContext);
+        ctx.it = result;
+        return result;
+      } catch (error) {
+        console.error('[js] Execution error:', error);
+        throw error;
+      }
+    }
+
+    case 'morph': {
+      const targets = await getTarget();
+      const content = await evaluate(cmd.args[0], ctx);
+      const contentStr = String(content);
+      const isOuter = cmd.modifier === 'over';
+
+      for (const target of targets) {
+        try {
+          if (isOuter) {
+            morphlexMorph(target, contentStr);
+          } else {
+            // morphlex's morphInner takes an ELEMENT, not a string — the same
+            // wrapping src/lib/morph-adapter.ts does. Passing the string threw
+            // straight into the fallback below, so inner morph never actually
+            // morphed (it silently degraded to innerHTML on every call).
+            const wrapper = document.createElement(target.tagName);
+            wrapper.innerHTML = contentStr;
+            morphlexMorphInner(target, wrapper);
+          }
+        } catch (error) {
+          // Fallback to innerHTML/outerHTML if morph fails
+          console.warn('[LokaScript] Morph failed, falling back:', error);
+          if (isOuter) {
+            target.outerHTML = contentStr;
+          } else {
+            target.innerHTML = contentStr;
+          }
+        }
+      }
+      ctx.it = targets.length === 1 ? targets[0] : targets;
+      return ctx.it;
+    }
+    // #endregion generated:commands
     default:
       console.warn(`Unknown command: ${cmd.name}`);
       return null;
   }
 }
 
-async function executeSeqPropagateReturn(nodes: ASTNode[], ctx: Context): Promise<any> {
+async function executeSequenceWithBlocks(nodes: ASTNode[], ctx: Context): Promise<any> {
   try {
     return await executeSequence(nodes, ctx);
   } catch (e: any) {
@@ -685,10 +953,15 @@ async function executeSeqPropagateReturn(nodes: ASTNode[], ctx: Context): Promis
 
 async function executeBlock(block: BlockNode, ctx: Context): Promise<any> {
   switch (block.type) {
+    // #region generated:blocks — DO NOT EDIT (npm run generate:bundles)
+
     case 'if': {
       const condition = await evaluate(block.condition!, ctx);
-      if (condition) return executeSeqPropagateReturn(block.body, ctx);
-      else if (block.elseBody) return executeSeqPropagateReturn(block.elseBody, ctx);
+      if (condition) {
+        return executeSequenceWithBlocks(block.body, ctx);
+      } else if (block.elseBody) {
+        return executeSequenceWithBlocks(block.elseBody, ctx);
+      }
       return null;
     }
 
@@ -698,7 +971,13 @@ async function executeBlock(block: BlockNode, ctx: Context): Promise<any> {
       for (let i = 0; i < n && i < MAX_LOOP_ITERATIONS; i++) {
         ctx.locals.set('__loop_index__', i);
         ctx.locals.set('__loop_count__', i + 1);
-        await executeSeqPropagateReturn(block.body, ctx);
+        try {
+          await executeSequenceWithBlocks(block.body, ctx);
+        } catch (e: any) {
+          if (e?.type === 'break') break;
+          if (e?.type === 'continue') continue;
+          throw e;
+        }
       }
       return null;
     }
@@ -716,7 +995,13 @@ async function executeBlock(block: BlockNode, ctx: Context): Promise<any> {
         ctx.locals.set(varName, arr[i]);
         ctx.locals.set('__loop_index__', i);
         ctx.locals.set('__loop_count__', i + 1);
-        await executeSeqPropagateReturn(block.body, ctx);
+        try {
+          await executeSequenceWithBlocks(block.body, ctx);
+        } catch (e: any) {
+          if (e?.type === 'break') break;
+          if (e?.type === 'continue') continue;
+          throw e;
+        }
       }
       return null;
     }
@@ -725,7 +1010,16 @@ async function executeBlock(block: BlockNode, ctx: Context): Promise<any> {
       let iterations = 0;
       while ((await evaluate(block.condition!, ctx)) && iterations < MAX_LOOP_ITERATIONS) {
         ctx.locals.set('__loop_index__', iterations);
-        await executeSeqPropagateReturn(block.body, ctx);
+        try {
+          await executeSequenceWithBlocks(block.body, ctx);
+        } catch (e: any) {
+          if (e?.type === 'break') break;
+          if (e?.type === 'continue') {
+            iterations++;
+            continue;
+          }
+          throw e;
+        }
         iterations++;
       }
       return null;
@@ -735,15 +1029,13 @@ async function executeBlock(block: BlockNode, ctx: Context): Promise<any> {
       const { url, responseType, options, method } = block.condition as any;
       try {
         const urlVal = await evaluate(url, ctx);
-        const fetchInit: RequestInit = {};
+        const fetchInit = {} as RequestInit;
 
-        // Apply method (from 'via POST' etc.)
         if (method) {
           const methodVal = await evaluate(method, ctx);
           fetchInit.method = String(methodVal).toUpperCase();
         }
 
-        // Apply body/options (from 'with ...')
         if (options) {
           const optionsVal = await evaluate(options, ctx);
           if (optionsVal instanceof FormData) {
@@ -753,7 +1045,6 @@ async function executeBlock(block: BlockNode, ctx: Context): Promise<any> {
             typeof optionsVal === 'object' &&
             !(optionsVal instanceof Element)
           ) {
-            // Plain object — merge as fetch init options
             Object.assign(fetchInit, optionsVal);
           }
         }
@@ -775,7 +1066,7 @@ async function executeBlock(block: BlockNode, ctx: Context): Promise<any> {
         ctx.locals.set('result', data);
         ctx.locals.set('response', response);
 
-        await executeSeqPropagateReturn(block.body, ctx);
+        await executeSequenceWithBlocks(block.body, ctx);
       } catch (error: any) {
         if (error?.type === 'return') throw error;
         ctx.locals.set('error', error);
@@ -783,7 +1074,7 @@ async function executeBlock(block: BlockNode, ctx: Context): Promise<any> {
       }
       return null;
     }
-
+    // #endregion generated:blocks
     default:
       return null;
   }
@@ -932,31 +1223,58 @@ const api: BundleShellApi<ASTNode> & HybridCompleteExtras = {
   tokenize,
   evaluate,
 
+  // THIS ARRAY IS THE GENERATION INPUT, not a description written beside one.
+  // `scripts/generate-bundles.ts` reads it and emits one template per entry into
+  // the `generated:commands` region above, so "advertised but not executed" —
+  // Finding 17, which is what this bundle shipped for its whole life at 35
+  // parsed / 24 executed — stops being a state this file can be in.
+  //
+  // It is exactly `AVAILABLE_COMMANDS` (38 = 35 template keys + the 3 advertised
+  // aliases), pinned as set equality both directions by
+  // `shipped-bundle-execution.test.ts`. Two entries look wrong and are not:
+  // `removeClass` is a NODE name the parser emits for `remove .x from #t`, never
+  // a keyword anyone types — it needs a case, so it needs to be here; and
+  // `trigger`/`push-url`/`replace-url` are aliases the emitter folds into their
+  // implementing template, which is why 38 names yield 35 case groups.
   commands: [
     'toggle',
     'add',
     'remove',
+    'removeClass',
+    'show',
+    'hide',
     'put',
     'append',
     'prepend',
+    'take',
+    'empty',
     'set',
     'get',
-    'call',
-    'log',
-    'send',
-    'trigger',
-    'wait',
-    'show',
-    'hide',
-    'transition',
-    'take',
     'increment',
     'decrement',
+    'wait',
+    'transition',
+    'send',
+    'trigger',
+    'log',
+    'call',
+    'copy',
+    'beep',
+    'go',
+    'push',
+    'push-url',
+    'replace',
+    'replace-url',
     'focus',
     'blur',
-    'go',
     'return',
+    'break',
+    'continue',
     'halt',
+    'exit',
+    'throw',
+    'js',
+    'morph',
   ],
 
   blocks: ['if', 'else', 'unless', 'repeat', 'for', 'while', 'fetch'],

--- a/packages/core/src/compatibility/bundle-manifest-consistency.test.ts
+++ b/packages/core/src/compatibility/bundle-manifest-consistency.test.ts
@@ -8,13 +8,33 @@
  * had no case label and no alias entry, making `trigger`/`fire` a silent no-op
  * in both shipped bundles. This test parses the entry source and pins the
  * invariant: every advertised command must have a case label (directly or via
- * the parser's COMMAND_ALIASES canonicalization).
+ * an alias map).
+ *
+ * ---------------------------------------------------------------------------
+ * STILL LOAD-BEARING AFTER GENERATION (Arc E step 4)
+ * ---------------------------------------------------------------------------
+ *
+ * hybrid-complete's two switch bodies are now GENERATED from the manifest by
+ * `scripts/generate-bundles.ts`, so for that file the drift this was written to
+ * catch is structurally impossible — which raises the fair question of whether
+ * it still earns its place. It does, for three reasons:
+ *
+ *   - it reads the COMMITTED file, so it fails if the committed output is stale
+ *     for any reason the `--check` gate is not currently run for (a hand-edit
+ *     inside the markers, a bad merge resolution, a partial revert);
+ *   - the `blocks` half is not generated from the block manifest at all —
+ *     `else`/`unless` are advertised syntax with no case of their own, so that
+ *     mapping stays hand-checked;
+ *   - it is the only gate stated over SOURCE TEXT. The execution gates import
+ *     the module, so both are blind to a file that is correct in the ways they
+ *     sample and wrong in the committed bytes.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { COMMAND_ALIASES } from '../parser/hybrid/aliases';
+import { resolveCommandKey } from '../bundle-generator/template-capabilities';
 
 const here = dirname(fileURLToPath(import.meta.url));
 
@@ -43,13 +63,28 @@ describe('hybrid-complete bundle manifest ↔ inline runtime', () => {
   const source = loadEntry('./browser-bundle-hybrid-complete.ts');
   const cases = extractExecuteCommandCases(source);
 
-  it('every advertised command has a case label (directly or via parser alias)', () => {
+  it('every advertised command has a case label (directly or via an alias)', () => {
     const advertised = extractAdvertised(source, 'commands');
     expect(advertised.length).toBeGreaterThan(15);
 
+    // TWO alias maps resolve a name here, and conflating them is what made this
+    // check wrong once generation landed (Arc E step 4):
+    //
+    //   - `parser/hybrid/aliases.ts` maps SPELLINGS a user may type onto a
+    //     canonical command (`fire` → `trigger`, `dispatch` → `send`).
+    //   - `bundle-generator/template-capabilities.ts` maps an ADVERTISED name
+    //     onto the template that implements it (`trigger` → `send`, `push-url`
+    //     → `push`). This is the map generation itself resolves through, so it
+    //     is the one that decides which `case` label ends up in the file.
+    //
+    // `trigger` is a VALUE in the first map and a KEY in the second, so
+    // resolving through the parser map alone left it looking unimplemented
+    // while it executed correctly — the parser emits a `send` node for both
+    // spellings, which is why `case 'trigger':` was unreachable dead code
+    // before step 4 removed it structurally.
     const missing = advertised.filter(cmd => {
       const canonical = COMMAND_ALIASES[cmd] ?? cmd;
-      return !cases.has(cmd) && !cases.has(canonical);
+      return !cases.has(cmd) && !cases.has(canonical) && !cases.has(resolveCommandKey(cmd));
     });
     expect(
       missing,
@@ -70,9 +105,25 @@ describe('hybrid-complete bundle manifest ↔ inline runtime', () => {
     expect(missing, `advertised blocks with no case: ${missing.join(', ')}`).toEqual([]);
   });
 
-  it('trigger dispatches like send (the 2026-07-20 silent no-op regression)', () => {
-    // Pin the specific fix: the send case must also carry the trigger label,
-    // since `fire` canonicalizes to `trigger` (not to `send`).
-    expect(source).toMatch(/case 'trigger':\s*\n\s*case 'send': \{/);
+  it('trigger still resolves to an implemented template (the 2026-07-20 regression)', () => {
+    // TRANSFORMED in Arc E step 4, deliberately not deleted.
+    //
+    // This used to pin `case 'trigger':\n case 'send': {` by source regex. That
+    // label was measured to be UNREACHABLE — the parser emits a `send` node for
+    // both spellings, so nothing could ever dispatch to it — and generation
+    // removed it structurally, since the templates carry no `trigger` case.
+    // A source-text pin on a dead label was asserting the presence of code that
+    // could not run, so keeping it would have blocked the fix it was written to
+    // protect.
+    //
+    // The invariant it actually guarded — `trigger` must not be a silent no-op —
+    // is now covered twice over, both more strongly than a regex:
+    //
+    //   - here, structurally: `trigger` resolves to a template that IS emitted;
+    //   - in `shipped-bundle-execution.test.ts`, by EXECUTION: `trigger foo on
+    //     #t` must dispatch on the named target and NOT on `me`.
+    expect(resolveCommandKey('trigger')).toBe('send');
+    expect(cases.has(resolveCommandKey('trigger'))).toBe(true);
+    expect(extractAdvertised(source, 'commands')).toContain('trigger');
   });
 });

--- a/packages/core/src/compatibility/shipped-bundle-execution.test.ts
+++ b/packages/core/src/compatibility/shipped-bundle-execution.test.ts
@@ -50,6 +50,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import hybridComplete from './browser-bundle-hybrid-complete';
 import litePlus from './browser-bundle-lite-plus';
+import { AVAILABLE_COMMANDS, resolveCommandKey } from '../bundle-generator/template-capabilities';
+import { COMMAND_IMPLEMENTATIONS } from '../bundle-generator/templates';
 
 // ===========================================================================
 // Harness
@@ -90,8 +92,19 @@ interface BundleApi {
 
 const consoleLines: unknown[][] = [];
 const consoleWarnings: unknown[][] = [];
+const clipboardWrites: string[] = [];
 const win = (): Record<string, unknown> => globalThis as unknown as Record<string, unknown>;
 const t = (d: Document) => d.querySelector('#t') as HTMLElement;
+
+/**
+ * `history.length` immediately before the surface runs, so `push` and `replace`
+ * can be told apart. jsdom implements both, and the entry count is the only
+ * observable difference between them once the URL matches.
+ */
+let historyLenBefore = 0;
+
+/** The pre-morph node, captured in `setup` so `check` can assert identity. */
+let morphNodeBefore: Element | null = null;
 
 /** Fixture: `#me` is the subject, `#t` the target, `#i` a focusable input. */
 const FIXTURE = `
@@ -123,9 +136,21 @@ const resetFixture = () => {
   document.body.innerHTML = FIXTURE;
   consoleLines.length = 0;
   consoleWarnings.length = 0;
+  clipboardWrites.length = 0;
+  morphNodeBefore = null;
   win().__shipCall_ran = false;
   win().__shipCall = () => (win().__shipCall_ran = true);
+  win().__shipJs = undefined;
+  // jsdom ships no clipboard; `copy`'s fallback path uses `document.execCommand`,
+  // which jsdom also lacks, so the row would assert the catch arm rather than
+  // the command. Defined per-surface because `configurable: true` is what lets
+  // it be redefined at all.
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: async (s: string) => void clipboardWrites.push(s) },
+    configurable: true,
+  });
   history.replaceState({}, '', '/');
+  historyLenBefore = history.length;
 };
 
 const runSurface = async (api: BundleApi, surface: Surface): Promise<Outcome> => {
@@ -472,6 +497,127 @@ const LITE_PLUS_COMMANDS: Record<string, Surface> = {
   go: { code: 'go to url "#gone-lite"', check: o => ok(o, location.hash === '#gone-lite') },
 };
 
+// ---------------------------------------------------------------------------
+// The eleven orphans, plus `removeClass` and the two url aliases (Arc E step 4)
+// ---------------------------------------------------------------------------
+//
+// These are Finding 17: names the shipped hybrid bundles PARSED and did not
+// EXECUTE. Each fell to `default:` → `console.warn('Unknown command')` → null,
+// which is why every row below runs through `ok()` — its `noWarning()` half is
+// what distinguishes "the command ran and did nothing visible" from "the
+// command was never dispatched", and it is the assertion that fails first if a
+// name is ever advertised again without a case.
+//
+// Written against the TEMPLATES' semantics, since those are now the shipped
+// implementation. Each was mutation-verified by deleting its generated case and
+// confirming it fails this row and nothing else.
+
+Object.assign(HYBRID_COMMANDS, {
+  // `remove .x from #t` parses to a `removeClass` NODE — the class-removal
+  // branch of parseRemove — so this row exercises a name no user types.
+  // Asserted against a target that must SURVIVE: a `removeClass` that fell
+  // through to element-removal would also clear the class.
+  removeClass: {
+    code: 'remove .x from #t',
+    setup: d => t(d).classList.add('x'),
+    check: o => ok(o, !!t(o.doc) && !t(o.doc).classList.contains('x')),
+  },
+  // Emptying is about the CHILDREN, not the element. A row that only checked
+  // `innerHTML === ''` passes against a `remove`, which deletes #t entirely.
+  empty: {
+    code: 'empty #t',
+    setup: d => (t(d).innerHTML = '<span>child</span>'),
+    check: o => ok(o, !!t(o.doc) && t(o.doc).innerHTML === ''),
+  },
+  copy: {
+    code: 'copy "COPIED"',
+    check: o => ok(o, clipboardWrites.includes('COPIED')),
+  },
+  // `beep` logs a TYPE-ANNOTATED line, which is what distinguishes it from
+  // `log`: asserting only that "BEEPED" appears would pass for either.
+  beep: {
+    code: 'beep "BEEPED"',
+    check: o =>
+      ok(
+        o,
+        consoleLines.some(l => l.includes('[beep]') && l.includes('BEEPED'))
+      ),
+  },
+  // History rows assert the URL *and* the direction. `push` must leave the
+  // previous entry behind and `replace` must not — a `replace` implemented as
+  // `push` passes any location-only check.
+  push: {
+    code: 'push url "/pushed"',
+    check: o => ok(o, location.pathname === '/pushed' && history.length > historyLenBefore),
+  },
+  'push-url': {
+    code: 'push url "/pushed-alias"',
+    check: o => ok(o, location.pathname === '/pushed-alias' && history.length > historyLenBefore),
+  },
+  replace: {
+    code: 'replace url "/replaced"',
+    check: o => ok(o, location.pathname === '/replaced' && history.length === historyLenBefore),
+  },
+  'replace-url': {
+    code: 'replace url "/replaced-alias"',
+    check: o =>
+      ok(o, location.pathname === '/replaced-alias' && history.length === historyLenBefore),
+  },
+  // `break` leaves the loop after the FIRST pass; `continue` skips the rest of
+  // the body on ALL passes. The two assertions are each other's control: a
+  // `break` that behaved like `continue` yields '' and fails, and vice versa.
+  break: {
+    code: 'repeat 3 times append "B" to #t then break end',
+    setup: d => (t(d).innerHTML = ''),
+    check: o => ok(o, t(o.doc).innerHTML === 'B'),
+  },
+  continue: {
+    code: 'repeat 3 times continue then append "C" to #t end',
+    setup: d => (t(d).innerHTML = ''),
+    check: o => ok(o, t(o.doc).innerHTML === ''),
+  },
+  // `exit`/`throw` are FOR aborting, so the effect is the signal reaching the
+  // caller. `ok()` would reject them for having an error, so both bypass it and
+  // assert `noWarning()` directly — the half that still matters here.
+  exit: {
+    code: 'exit',
+    check: o => /EXIT_COMMAND/.test(o.error?.message ?? '') && noWarning(),
+  },
+  throw: {
+    code: 'throw "BOOM"',
+    check: o => o.error?.message === 'BOOM' && noWarning(),
+  },
+  js: {
+    code: 'js window.__shipJs = 42 end',
+    check: o => ok(o, win().__shipJs === 42),
+  },
+  /**
+   * Morph is asserted by NODE IDENTITY, never by markup.
+   *
+   * The template wraps its morphlex calls in a try/catch that falls back to
+   * `innerHTML = content`, so a markup check passes whether the morph ran or
+   * crashed into the fallback. capability-emission recorded this exact trap:
+   * deleting the morphlex import left a markup-only check perfectly green.
+   *
+   * A real morph reuses the existing node, so a value the user typed survives.
+   * That also makes this row the only gate on the new `morphlex` import — the
+   * single dependency Arc E step 4 added to the shipped bundle.
+   */
+  morph: {
+    code: 'morph #t to "<input id=\'keep\'>"',
+    setup: d => {
+      t(d).innerHTML = "<input id='keep'>";
+      const input = d.getElementById('keep') as HTMLInputElement;
+      input.value = 'typed';
+      morphNodeBefore = input;
+    },
+    check: o => {
+      const after = o.doc.getElementById('keep') as HTMLInputElement | null;
+      return ok(o, after !== null && after === morphNodeBefore && after.value === 'typed');
+    },
+  },
+} satisfies Record<string, Surface>);
+
 // ===========================================================================
 // The gate
 // ===========================================================================
@@ -598,5 +744,36 @@ describe('return resolves rather than leaking its internal signal (Arc E step 1)
       throw new Error('BOOM');
     };
     await expect(hybridComplete.execute('call window.__shipThrow()', me)).rejects.toThrow('BOOM');
+  });
+});
+
+// ===========================================================================
+// The advertised list is the generation input (Arc E step 4)
+// ===========================================================================
+
+describe('hybrid-complete advertises exactly what the templates can emit', () => {
+  it('its `commands` array is AVAILABLE_COMMANDS, both directions', () => {
+    // Finding 17 was "advertises 35, executes 24". Step 4 made the array the
+    // INPUT to `scripts/generate-bundles.ts`, so the executor can no longer
+    // fall behind it — but nothing stopped the array itself from drifting away
+    // from the capability list, which is the other half of the same fact.
+    //
+    // Set equality both directions, which is what makes it a ratchet: a name
+    // dropped here silently REMOVES a working command from the shipped bundle
+    // (generation would delete its case on the next run), and a name added
+    // without a template makes generation emit nothing while the bundle keeps
+    // claiming it — the original defect, restored.
+    expect([...hybridComplete.commands].sort()).toEqual([...AVAILABLE_COMMANDS].sort());
+  });
+
+  it('every advertised name reaches a template — aliases included', () => {
+    // The array carries 38 names but yields 35 case groups, because `trigger`,
+    // `push-url` and `replace-url` fold into the templates they alias. This
+    // asserts the folding is total: a name resolving to no template would be
+    // advertised, generate nothing, and warn `Unknown command` at runtime.
+    const orphans = hybridComplete.commands.filter(
+      name => !COMMAND_IMPLEMENTATIONS[resolveCommandKey(name)]
+    );
+    expect(orphans).toEqual([]);
   });
 });

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -147,9 +147,14 @@ export const bundleInfo: BundleInfo[] = [
     id: 'hybrid-complete',
     name: 'Hybrid Complete',
     filename: 'hyperfixi-hybrid-complete.js',
-    gzipSize: '8.2 KB',
-    rawSize: '32 KB',
-    commandCount: 24,
+    // Arc E step 4 closed Finding 17: this bundle PARSED 35 commands and
+    // EXECUTED 24. Its `executeCommand`/`executeBlock` switches are now
+    // generated from `bundle-generator/templates.ts`, so the count is the full
+    // advertised list. +2967 B gz, of which 2057 is `morphlex` (the `morph`
+    // case's dependency).
+    gzipSize: '11.1 KB',
+    rawSize: '43 KB',
+    commandCount: 38,
     parser: 'hybrid',
     hasBlocks: true,
     hasEventModifiers: true,
@@ -164,9 +169,11 @@ export const bundleInfo: BundleInfo[] = [
     id: 'hybrid-hx',
     name: 'Hybrid HX',
     filename: 'hyperfixi-hx.js',
-    gzipSize: '18.6 KB',
-    rawSize: '70 KB',
-    commandCount: 24,
+    // Inherits hybrid-complete's runtime wholesale, so it inherits the Arc E
+    // step 4 command set and its size move too (+2972 B gz).
+    gzipSize: '21.5 KB',
+    rawSize: '81 KB',
+    commandCount: 38,
     parser: 'hybrid',
     hasBlocks: true,
     hasEventModifiers: true,

--- a/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
+++ b/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
@@ -712,7 +712,10 @@ describe('COMMAND_KEYWORDS', () => {
 const BUNDLE_COMMAND_COUNTS: Record<string, number> = {
   'browser-bundle-classic-i18n.ts': 43,
   'browser-bundle-classic.ts': 52,
-  'browser-bundle-hybrid-complete.ts': 24,
+  // 24 -> 38 in Arc E step 4: the array became the generation input, so it now
+  // carries every name the templates implement (Finding 17 — it advertised 35
+  // and executed 24). See scripts/generate-bundles.ts.
+  'browser-bundle-hybrid-complete.ts': 38,
   'browser-bundle-lite-plus.ts': 19,
   'browser-bundle-lite.ts': 8,
   'browser-bundle-minimal-v2.ts': 10,
@@ -746,8 +749,29 @@ describe('the per-bundle commands arrays', () => {
   });
 
   it('no bundle advertises a command the registry does not have', () => {
+    // A bundle's `commands` array and the registry are two vocabularies, and
+    // Arc E step 4 is where they stopped coinciding. hybrid-complete's array is
+    // now the INPUT to `scripts/generate-bundles.ts`, so it names things the
+    // generator resolves — which includes spellings the registry does not carry:
+    //
+    //   - `push-url` / `replace-url` are advertised ALIASES. The registry's
+    //     canonical names are `push`/`replace` (its own alias entries are the
+    //     unhyphenated `pushurl`/`replaceurl`), so these resolve rather than
+    //     being ghosts. Resolving through the same map generation uses is what
+    //     keeps this honest: a name resolving to an UNREGISTERED target still
+    //     fails.
+    //   - `removeClass` is a parser NODE name, never a keyword a user types —
+    //     `remove .x from #t` takes parseRemove's class branch and yields it.
+    //     It must appear in the array or generation emits no case for it and
+    //     class removal silently stops working, so the exception is named here
+    //     rather than the array being trimmed. Same exception, same reason, as
+    //     capability-emission.test.ts's DISPATCHED_UNDER_ANOTHER_KEYWORD.
+    const PARSER_NODE_NAMES = new Set(['removeClass']);
     for (const [file, names] of Object.entries(arrays)) {
-      expect(ghostsIn(names), `${file} advertises unregistered commands`).toEqual([]);
+      const unresolved = names
+        .filter(name => !PARSER_NODE_NAMES.has(name))
+        .map(name => resolveCommandKey(name));
+      expect(ghostsIn(unresolved), `${file} advertises unregistered commands`).toEqual([]);
     }
   });
 


### PR DESCRIPTION
Closes **Finding 17**. `hyperfixi-hybrid-complete.js` and `hyperfixi-hx.js` PARSED 35 commands and EXECUTED 24; the other eleven (`beep break continue copy empty exit js morph push replace throw`) reached `default:` → `Unknown command` while their parser rules shipped as dead weight.

`executeCommand`/`executeBlock`'s switch bodies are now emitted from `bundle-generator/templates.ts` by `packages/core/scripts/generate-bundles.ts`, committed, and guarded by `generate:bundles:check` in CI's "Check generated artifacts are in sync" step.

## The three oracles

1. **EXECUTION** — 14 new rows in `shipped-bundle-execution.test.ts`, each asserting what the command is FOR. All mutation-verified.
2. **cmdMap equality** — `capability-emission.test.ts` §4 still green; §3 extended rather than allowlisted.
3. **SIZE** — measured by building, not estimated. See below.

## Design decision: executor core only, not the shell (the kickoff's open (a)/(b))

**(b).** Measurement, not preference — every non-executor runtime region differs between the two copies:

| region | hybrid-complete | emitted | identical? |
| --- | --- | --- | --- |
| `evaluate` | 86 L (`unary`/`object`/`array`/`valuesOf`) | 71 L | NO |
| `evaluateBinary` | 68 L | 39 L | NO |
| `executeSequence` / `executeAST` | 11 / 100 L | 21 / 60 L | NO |
| `Context` | has `globals`, exported | neither | NO |

Step 2 reconciled the command/block **case bodies**. It did not reconcile the surrounding runtime, so generating the whole file would have been an unreviewed behavior change across the entire evaluator. The region markers therefore sit INSIDE each `switch`; the switch, its `default:` arm, the helper closures and the shell stay handwritten. Parameterizing the shell emission would have built a generalized emitter for exactly one consumer — S3-a's rejected indirection at a different level — against a surface `hyperfixi-hx.js` spreads wholesale.

`bundle-generator/executor-core.ts` holds the ONE emitter, called by both `generateBundleCode()` and the script. Without that, the arc would have swapped a duplicated executor for a duplicated emitter.

## Three defects found on the way

**`waitFor` was missing from the templates — the superset claim was false.** Every list gate compares against `cmdMap`'s keys. What an executor must switch on is the set of names the parser **EMITS**, and they differ:

| set | size | notes |
| --- | --- | --- |
| `cmdMap` keys | 35 | has `trigger`; lacks `removeClass`, `waitFor` |
| parser-emitted `name:` literals | 28 | has `removeClass`, `waitFor`; lacks `trigger` |
| template case labels (before) | 35 | had `removeClass`; **missing `waitFor`** |

Confirmed by execution: a generated bundle carrying `wait` resolved `wait for foo` **immediately**, so every command after it in a handler ran without waiting. Same class as the `morph` free identifier and the `take` DOMException — invisible to any parse-level or key-set check.

**`ctx.target` in the `js` template** referenced a field no `Context` declares and nothing assigns. Always `undefined`, so always `ctx.me` — and a hard error the moment the template landed in a compiled file. Latent because generated bundles are written, imported and executed but **never `tsc`'d**.

**The size estimate excluded its largest term.** The arc's +1433 gz was measured on `generateBundle()`'s output — TypeScript source text, where `import { morph } from 'morphlex'` is one line.

## Size — measured by building

| bundle | before | no `morph` | **with `morph` (shipped)** |
| --- | --- | --- | --- |
| `hyperfixi-hybrid-complete.js` | 8409 | 9317 (+10.9%) | **11376 (+35.3%)** |
| `hyperfixi-hx.js` | 19025 | 19888 (+4.8%) | **21997 (+15.6%)** |

`morphlex` alone is **+2057 gz** — 69% of the increase for 1 of 13 commands. Including it is a deliberate call: no advertised command may be a no-op. `MAX_HYBRID` 20000 → **24000** in ci.yml AND pre-publish-check.yml; the arc's recommended 22000 predates this measurement and would have failed on the first run at 21997.

## Deliberate carries, each stated

- **Advertised count 24 → 38** — the array is the generation input, so it is `AVAILABLE_COMMANDS` (35 template keys + 3 aliases, yielding 35 case groups). Ripples through `bundle-sources.ts` → `verify:reference` → `metadata.ts` and the pinned per-bundle counts, all in this PR.
- **`baseline.json` updated for those two entries only**, per step 3's precedent — a blanket `--update` would absorb the other bundles' known local-vs-recorded drift.
- **Dead `case 'trigger':` removed structurally.** Its source-text pin in `bundle-manifest-consistency.test.ts` is **transformed, not dropped**: it was asserting the presence of code that could not run, so keeping it would have blocked the fix it was written to protect. The invariant now holds structurally there and by execution in the shipped gate. That file's advertised-command check also had to resolve through the GENERATOR's alias map — `trigger` is a VALUE in the parser's map and a KEY in the generator's.
- **`command-manifest-audit.test.ts`'s ghost check** now resolves aliases first, with `removeClass` (a parser NODE name) as one named exception — the same exception capability-emission already carries.
- **`removeClass`'s `ctx.it` self-assign leaves the shipped bundle** — the template is the Arc-C-correct copy, decided in step 2 row 4. Deliberate behavior change, restated here rather than discovered in review.
- **S2-b's other five `ctx.it` rows agree in both copies**; generation preserves the agreement. Still filed for its own PR.

## Verification

All 14 new execution rows mutation-verified by deleting each generated case: **every one fails its OWN row and nothing else** (`push`/`replace` also fail their alias rows — correct, the aliases resolve to those templates). The advertised-array gate mutation-verified both directions. The drift guard itself mutation-verified: hand-edited content and a missing marker both fail loudly, neither passes silently.

| gate | result |
| --- | --- |
| core `test:quick` | **7687 / 106 / 300** (from 7684; +3 new rows) |
| `test:check` | green, 27 packages |
| `language-server` / `vite-plugin` | 227 / 319 |
| Playwright `src/compatibility/` | 1102 / 8 / 10 — known-local set (behaviors-demo ×4, i18n-htmx ×4, swap-debug ×2) |
| `verify:reference`, `typecheck`, `typecheck:scripts` | pass |
| `snapshot:bundle-size --check`, `update:sizes` | pass |
| `docs:commands:check`, `generate:bundles:check` | pass |
| `bundle-manifest-consistency`, `dist-charset-safety` | pass |
| `check:bundle-shards`, `check:test-list`, `check:ci-order` | pass |

Findings are written up in `docs-internal/HANDOFF-command-arch-bundles.md` § "Step 4 — CLOSED" (no brief-append debt); the Arc E roadmap entry is updated with what a step-5 starter needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)