### PR TITLE
feat(bundles): generate the hybrid parser template (Arc E step 5, arc closed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -680,7 +680,7 @@ window._hyperscript.behaviors.set(name, { name, parameters, eventHandlers, initB
 2. Register a factory export in `packages/core/src/commands/index.ts` and add the command name to the `COMMANDS` set in `packages/core/src/parser/parser-constants.ts`
 3. Register the factory in the runtime entry points that should include it (`packages/core/src/runtime/runtime.ts` and any relevant `packages/core/src/compatibility/browser-bundle-*.ts`)
 4. Add parser support in `packages/core/src/parser/command-parsers/` (only if the command needs a non-generic parser — simple commands use the default identifier-plus-args parser)
-5. For lite/hybrid bundle coverage, add cases to `packages/core/src/bundle-generator/templates.ts`, `parser-templates.ts`, and `template-capabilities.ts`
+5. For lite/hybrid bundle coverage, add cases to `packages/core/src/bundle-generator/templates.ts` and `template-capabilities.ts`, then run `npm run generate:bundles` — the hybrid parser template and hybrid-complete's executor switches are generated (parser rules go in `packages/core/src/parser/hybrid/parser-core.ts`)
 6. Add reference/LSP entries in `packages/core/src/reference/index.ts` and `packages/core/src/lsp-metadata.ts`
 7. Write tests in `packages/core/src/commands/{category}/__tests__/{name}.test.ts`
 

--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -337,22 +337,27 @@ plus `--check` pattern), and `generate-command-docs --check` in CI so
 
 ### Arc E — generated static bundles (medium-large)
 
-> **Steps 1-4 CLOSED (#830, #831, #832, #833-adjacent, and the step-4 PR).**
+> **ARC E CLOSED — all five steps shipped (#830, #831, #832, the step-4 PR
+> #835, and the step-5 PR).** The remaining paragraph below is kept as the
+> arc's original statement; its work is done.
 > Finding 17 is shut: `browser-bundle-hybrid-complete.ts`'s `executeCommand` and
 > `executeBlock` switch bodies are GENERATED from `bundle-generator/templates.ts`
 > by `packages/core/scripts/generate-bundles.ts` and guarded by
 > `generate:bundles:check` in CI. The bundle executes all 38 advertised names,
-> not 24. **Step 5 (generate `HYBRID_PARSER_TEMPLATE` from `parser-core.ts`) is
-> the remaining step** — its spec is unchanged and now stronger, since
-> `executor-core.ts` demonstrates the shared-emitter shape it should follow.
-> Three things a step-5 starter needs that this paragraph predates: the size
-> figures below are stale (hx is now **21997 gz against `MAX_HYBRID=24000`**,
-> raised deliberately in step 4 — `morphlex`, pulled in by the `morph` case, is
-> +2057 of that); the executor generation covers the CASE BODIES ONLY, because
-> every other runtime region was measured to diverge between the two copies; and
-> the parser's EMITTED-name set is not `cmdMap`'s key set (`waitFor` and
-> `removeClass` are emitted and are not keys), which is the check that found the
-> one real gap in step 2's "templates are the superset" claim.
+> not 24. **Step 5 closed the last hand copy**: `HYBRID_PARSER_TEMPLATE` is
+> generated from `parser/hybrid/{aliases,tokenizer,parser-core}.ts` by the same
+> script — the hand copy was measured BEHIND the real parser on five parse
+> capabilities (`@attr`, `'s`, fetch `via`/`with`, `values of`, KEYWORDS), all
+> shipped invisibly in vite-embedded bundles because nothing executed the
+> template. An AST-equivalence corpus in `parser-template-drift.test.ts` now
+> does. Current facts for whoever works nearby: hx is **21997 gz against
+> `MAX_HYBRID=24000`** (raised in step 4; `morphlex` via the `morph` case is
+> +2057 of that); executor generation covers the CASE BODIES ONLY; the parser's
+> EMITTED-name set is not `cmdMap`'s key set (`waitFor`/`removeClass`), the
+> check that found step 2's and step 5's gaps alike. `LITE_PARSER_TEMPLATE` and
+> the lite-family regex parsers stay hand-maintained by design (no canonical
+> twin to generate from). A parked adjacent: the tier-appropriate mini-morph
+> (brief § "Parked"), which would reclaim ~1.5 KB gz of step 4's carry.
 >
 > **Brief written 2026-07-29 —
 > [HANDOFF-command-arch-bundles.md](./HANDOFF-command-arch-bundles.md).**

--- a/docs-internal/HANDOFF-command-arch-bundles.md
+++ b/docs-internal/HANDOFF-command-arch-bundles.md
@@ -1,6 +1,9 @@
 # Handoff: Arc E — generated static bundles
 
-> **Status: brief written 2026-07-29, arc NOT started.** Every figure below was
+> **Status: ARC CLOSED 2026-07-31 — all five steps shipped** (#830 step 1,
+> #831 step 2, #832 step 3, #835 step 4, step 5 in its own PR). Kept as the
+> arc's record; the per-step CLOSED sections hold what each step measured and
+> decided. Originally: brief written 2026-07-29, measured against `bd0152e7`.** Every figure below was
 > measured against main `bd0152e7` (the #828 merge) for this document; nothing
 > is inherited from the queue paragraph or from Arc A's Finding 17 numbers
 > without re-measurement. Companion to
@@ -622,6 +625,95 @@ each generated case: every one fails its OWN row and nothing else (`push` and
 templates). The advertised-array gate mutation-verified in both directions.
 `generate:bundles:check` is idempotent under the pinned prettier.
 
+## Step 5 — CLOSED: the parser template is generated, and the arc's last hand copy is gone
+
+`HYBRID_PARSER_TEMPLATE` is now emitted by the same
+`scripts/generate-bundles.ts` that generates the executor cores — a second
+target with a `hybrid-parser` region whose body is the real parser
+(`parser/hybrid/{aliases,tokenizer,parser-core}.ts`) transformed to
+self-contained ES2020 JS by esbuild, escaped, and spliced inside the template
+literal. Same `--check` drift guard, same CI step, same prettier-idempotency
+(trivially — prettier does not reformat template-literal interiors).
+
+### The hand copy was BEHIND the real parser on five capabilities
+
+Measured before generating (comment-stripped, prettier-canonicalized diff of
+the hand template vs the esbuild-stripped real modules — raw diff 937 lines,
+semantic residue below):
+
+| divergence | direction | consequence in vite-embedded bundles |
+| --- | --- | --- |
+| `@attr` selector tokenization | real only | `toggle @disabled` mis-tokenized |
+| `'s` possessive operator | real only | `#t's title` unparseable |
+| fetch `via`/`with`/`{options}`/`as a[n]` | real only | `fetch /x via POST` unparseable — step 2 absorbed via/with into the EXECUTOR templates, so the embedded executor could run what its own parser could not produce |
+| `values of` (`valuesOf` node) | real only | unparseable |
+| KEYWORDS: `halt` `via` `values` `default` `event` | real only | classification drift |
+| KEYWORDS: `empty` | template only | a hand-fix the real tokenizer never needed |
+| `addCommandAliases`/`addEventAliases` | real only | no alias-registration API in embedded copies |
+
+Everything else was formatting or esbuild artifacts (quote style, `1e3`,
+`void 0`, a shadowed-variable rename). The cmdMaps were identical — Oracle 2
+held — which is precisely the trap: **every list gate compared cmdMap keys, and
+none of these five capabilities lives in a cmdMap.** Step 4 found the same
+blindness in the other direction (`waitFor`).
+
+### S5-a — nothing executed the embedded template, anywhere
+
+The template's total behavioral coverage was three probes in
+`parser-template-drift.test.ts`. The vite-plugin's own generator tests stop at
+`new Function(code)` — construction without a call, i.e. syntax. So a
+vite-embedded parser could (and did) lack capabilities its own executor
+shipped, invisibly. The closure is an **AST-equivalence suite** in the drift
+test: the committed template and the live `HybridParser` must produce
+deep-equal trees over a 16-source corpus that includes every gained capability
+and two escaping canaries (backtick + `${` inside string literals, backslash
+regexes — the characters the template-literal embedding must escape; a wrong
+escape corrupts exactly these and nothing else notices).
+
+Mutation-verified in all three directions: a crippled `@attr` branch in the
+committed template fails exactly its corpus row; a broken `\${` escape fails
+the whole module loudly at import; a real change to `aliases.ts` without
+regeneration fails `generate:bundles:check` (a comment-only probe does NOT —
+esbuild drops trailing standalone comments — so the mutation had to be real,
+which is itself S3-b's lesson recurring).
+
+### S5-b — the transform is esbuild at es2020, not a regex stripper
+
+S2-c measured the regex `stripTypes` emitting invalid JS for 6 of 40 command
+templates; it was not trusted with a 1000-line parser. esbuild
+(`loader: 'ts'`, `target: 'es2020'`) is a real TS front-end; es2020 matches the
+runtime promise core's tsconfig makes (the same promise that decided #834), so
+parser-core's class fields lower through esbuild's tiny inlined helpers
+(`__publicField`, +~500 raw) instead of shipping ES2022 syntax. Oracle 2's
+regex needed one shape update for the lowered form — and its "found nothing"
+guard fired exactly as designed when the shape changed, rather than passing on
+empty.
+
+### Measured cost — vite-embedded bundles only; ZERO shipped-bundle movement
+
+The template is a string in core's bundle-generator lib; no shipped browser
+bundle embeds it (core's `generateBundleCode` emits an import instead), so
+`baseline.json`, `MAX_HYBRID` and `metadata.ts` do not move — the first step of
+the arc with no size carry. Vite-embedded bundles grow: template string
+6410 → 8443 gz raw-with-comments, of which the post-minification code delta is
+**+522 gz** (consumer builds strip the comments; the committed artifact keeps
+them for reviewability). That 522 buys the five capabilities above.
+
+### What stays hand-maintained, stated
+
+`LITE_PARSER_TEMPLATE` — deliberately. It has no canonical module twin: the
+regex parsers in the lite bundle entries are each their own tier
+simplification, not copies of one source, so there is nothing to generate it
+from. The lite-family copies remain out of scope exactly as the brief's
+premise-correction scoped them.
+
+### Gate — step 5
+
+Core `test:quick` green at the step-4 baseline +15 (the AST-equivalence rows);
+`parser-template-drift.test.ts` 5 → 20 tests; capability-emission 14/14 with
+the transformed §4. Oracle 2 and the drift test both retired INTO the
+generator per the queue — transformed, neither deleted.
+
 ## Finding 17, restated with the arc's numbers
 
 The shipped hybrid bundles PARSE 35 commands and EXECUTE 24. The 11 orphans —
@@ -703,7 +795,11 @@ carries the deliberate ceiling/baseline/count changes bundled above, stated in
 the PR body. Playwright matrix + step-1 gate + capability-emission all run
 against the result.
 
-**Step 5 — generate `HYBRID_PARSER_TEMPLATE` from `parser-core.ts` source.**
+**Step 5 — generate `HYBRID_PARSER_TEMPLATE` from `parser-core.ts` source.
+CLOSED — see § "Step 5 — CLOSED" above: the hand copy was measured BEHIND the
+real parser on five parse capabilities, and nothing executed it (the
+vite-plugin tests stop at `new Function` construction). Oracle 2 and the drift
+test retired into the generator as transformed gates, per this paragraph.**
 `vite-plugin/src/generator.ts:149` embeds the template; core's
 `generateBundle()` imports parser-core directly — the two-copy risk is the
 vite-plugin path. Generate the template from parser-core source text at build
@@ -742,3 +838,40 @@ registers 11 advertising 10) stay filed in the queue — same neighborhood,
 separate decisions. F-B1 (`command-adapter.ts` shadow `CommandMetadata`) and
 the `isBlocking`/`hasBody` false claims likewise. The lite family's
 show/hide desugar (D4) is documented behavior, not a defect to fix in passing.
+
+### Parked (2026-07-31): a tier-appropriate mini-morph could reclaim ~1.5 KB gz
+
+Step 4's owner call kept `morph` in the hybrid bundles at its measured cost
+(+2057 gz of the +2967 is `morphlex`). The engines were then surveyed in case a
+cheaper one exists; measurements, so the eventual decision starts from facts:
+
+| engine | license | standalone min gz | marginal in hybrid-complete |
+| --- | --- | --- | --- |
+| morphlex 1.4 (incumbent) | MIT | 3181 | **2057 measured** |
+| idiomorph 0.7.4 | 0BSD | **3350** | ~2.1–2.3K est |
+| paxi's `mx` (bigskysoftware/paxi) | 0BSD | 690 (entire library) | ~0.4–0.6K est, UNBUILT |
+| trimmed morphlex fork | MIT (keep notice) | — | ~1.3–1.6K est |
+
+- **idiomorph is ruled out by measurement** — larger than morphlex standalone,
+  and the htmx-alignment argument is cosmetic here (the hx layer translates
+  `hx-swap="morph"` into hyperfixi's own morph command, not into idiomorph).
+- **Fork-trimming morphlex is the worst ratio** — ~500–800 gz back (the
+  `#options.x?.()` callback layer is runtime-conditional, so terser cannot drop
+  it) for a vendored fork that stops receiving upstream fixes.
+- **The interesting shape**: inline a paxi-derived `mx` (~30 lines, 0BSD, never
+  writes value props so it is preserveChanges-by-default structurally) INTO the
+  morph template, keeping morphlex in the full runtime (`lib/morph-adapter.ts`,
+  which uses `preserveChanges: true` and the richer `isEqualNode`/`moveBefore`
+  algorithm). The morph template is currently the ONLY template with an external
+  import; inlining kills the generator's `needsMorphlex` special case and lands
+  the saving on every generated vite-plugin bundle too. The cost is a documented
+  D4-class tier split: positional matching for unkeyed children, no
+  `moveBefore`, the server cannot push input values — and the step-1/step-4
+  node-identity gate is what pins the property that matters.
+
+Not taken now because step 4 just shipped the morphlex numbers through four size
+surfaces and the owner accepted them; re-litigating in the same arc would churn
+`MAX_HYBRID`, `baseline.json` and `metadata.ts` twice. If picked up: build it
+FIRST and measure — this arc's estimated sizes have been wrong twice (S4-d), and
+the ~0.5K figure above is exactly the kind of unbuilt estimate the discipline
+forbids relying on.

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -95,7 +95,7 @@ export const createIncrementCommand = createFactory(IncrementCommand);
 2. Export a named factory in `src/commands/index.ts` and add the command name to the `COMMANDS` set in `src/parser/parser-constants.ts`
 3. Register the factory in the runtime entry points that need it (`src/runtime/runtime.ts` and any `src/compatibility/browser-bundle-*.ts` that should ship the command)
 4. Add parser support in `src/parser/command-parsers/{category}-commands.ts` only if the command needs non-generic parsing — simple commands use the default identifier-plus-args path
-5. For lite/hybrid bundle coverage, add cases to `src/bundle-generator/templates.ts`, `parser-templates.ts`, and `template-capabilities.ts`
+5. For lite/hybrid bundle coverage, add cases to `src/bundle-generator/templates.ts` and `template-capabilities.ts`, then run `npm run generate:bundles` — the hybrid parser template and hybrid-complete's executor switches are generated (parser rules go in `src/parser/hybrid/parser-core.ts`, never in `parser-templates.ts`'s generated region)
 6. Add reference/LSP entries in `src/reference/index.ts` and `src/lsp-metadata.ts`
 7. **No longer needed for the full-runtime counts** — `packageInfo.commands` and
    the `commandCount` of `browser` / `hybrid-hx-v4` are derived from the

--- a/packages/core/scripts/generate-bundles.ts
+++ b/packages/core/scripts/generate-bundles.ts
@@ -1,6 +1,11 @@
 #!/usr/bin/env tsx
 /**
- * Generate the committed bundles' executor cores from `bundle-generator/templates.ts`.
+ * Generate the committed generated regions of the bundle layer:
+ *
+ *   - `browser-bundle-hybrid-complete.ts`'s executor cores, from
+ *     `bundle-generator/templates.ts` (Arc E step 4)
+ *   - `parser-templates.ts`'s `HYBRID_PARSER_TEMPLATE`, from the real parser
+ *     modules `parser/hybrid/{aliases,tokenizer,parser-core}.ts` (Arc E step 5)
  *
  *   npm run generate:bundles         # rewrite the generated regions in place
  *   npm run generate:bundles:check   # fail if the committed output is stale
@@ -63,6 +68,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, relative } from 'node:path';
 import * as prettier from 'prettier';
+import { transformSync } from 'esbuild';
 import { emitCommandCases, emitBlockCases } from '../src/bundle-generator/executor-core';
 
 /** Package root (`packages/core`); target paths are relative to it. */
@@ -73,12 +79,86 @@ interface Target {
   file: string;
   /** Human label used in failure output. */
   label: string;
+  /**
+   * Region id → body producer. The producer receives the target's CURRENT
+   * source, because some inputs live in the target itself (hybrid-complete's
+   * `commands: [...]` array is the generation input — see the header).
+   */
+  regions: Record<string, (prev: string) => string>;
+}
+
+// ---------------------------------------------------------------------------
+// Step-5 producer: the embedded hybrid parser, from the real parser modules
+// ---------------------------------------------------------------------------
+
+/**
+ * `HYBRID_PARSER_TEMPLATE` used to be a hand-maintained ~1000-line JS copy of
+ * the hybrid parser, and the copies were measured apart in BOTH directions
+ * before generation replaced the hand copy: the template lacked `@attr`
+ * selector tokenization, the `'s` possessive operator, fetch
+ * `via`/`with`/`{options}`/`as a[n]`, `values of`, five KEYWORDS entries and
+ * the alias-registration API — while carrying a stray KEYWORDS entry of its
+ * own. Every vite-plugin bundle that embeds the template shipped those parse
+ * gaps, invisibly: the only behavioral coverage the template had was three
+ * probes in `parser-template-drift.test.ts` (the vite-plugin's own tests check
+ * the emitted code is *syntactically valid* — `new Function` without a call).
+ *
+ * The transform is esbuild (`loader: 'ts'`), not a regex type-stripper — S2-c
+ * measured the regex approach emitting invalid JS for 6 of 40 command
+ * templates, so it is not trusted with a whole parser. `target: 'es2020'`
+ * matches the runtime promise core's tsconfig `lib` makes (the same promise
+ * that decided #834); esbuild lowers parser-core's class fields through its
+ * tiny inlined helpers rather than emitting ES2022 syntax.
+ *
+ * Concatenation order is the dependency order (aliases → tokenizer →
+ * parser-core); all three modules are runtime-import-free, so the result is
+ * self-contained by construction — `new Function`-loadable, which is exactly
+ * how the drift test consumes it.
+ */
+function buildHybridParserTemplate(): string {
+  const MODULES = [
+    'src/parser/hybrid/aliases.ts',
+    'src/parser/hybrid/tokenizer.ts',
+    'src/parser/hybrid/parser-core.ts',
+  ];
+
+  const parts = MODULES.map(rel => {
+    const src = readFileSync(join(ROOT, rel), 'utf8');
+    const js = transformSync(src, { loader: 'ts', target: 'es2020' }).code;
+    return (
+      js
+        .split('\n')
+        // Imports are types plus the two sibling modules concatenated here;
+        // `export` qualifiers drop because the template is one flat scope.
+        .filter(line => !/^import /.test(line))
+        .join('\n')
+        .replace(/^export (class|function|const)/gm, '$1')
+    );
+  });
+
+  const flat = `// Hybrid Parser — generated from parser/hybrid/{aliases,tokenizer,parser-core}.ts\n\n${parts.join('\n')}`;
+
+  // The template lives inside a TypeScript template literal, so its own
+  // backticks, interpolations and backslashes must be escaped. Backslashes
+  // first, or the escapes just added would be re-escaped.
+  return flat.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
 }
 
 const TARGETS: Target[] = [
   {
     file: 'src/compatibility/browser-bundle-hybrid-complete.ts',
     label: 'hybrid-complete',
+    regions: {
+      commands: prev => emitCommandCases(readStringArray(prev, 'commands', 'hybrid-complete')),
+      blocks: prev => emitBlockCases(readStringArray(prev, 'blocks', 'hybrid-complete')),
+    },
+  },
+  {
+    file: 'src/bundle-generator/parser-templates.ts',
+    label: 'parser-templates',
+    regions: {
+      'hybrid-parser': () => buildHybridParserTemplate(),
+    },
   },
 ];
 
@@ -113,12 +193,12 @@ async function generateOne(target: Target): Promise<{ path: string; next: string
   const path = join(ROOT, target.file);
   const prev = readFileSync(path, 'utf8');
 
-  const commands = readStringArray(prev, 'commands', target.label);
-  const blocks = readStringArray(prev, 'blocks', target.label);
-  if (commands.length === 0) throw new Error(`${target.label}: empty commands array`);
-
-  let next = spliceRegion(prev, 'commands', emitCommandCases(commands), target.label);
-  next = spliceRegion(next, 'blocks', emitBlockCases(blocks), target.label);
+  let next = prev;
+  for (const [id, produce] of Object.entries(target.regions)) {
+    const body = produce(prev);
+    if (!body.trim()) throw new Error(`${target.label}: region '${id}' produced empty output`);
+    next = spliceRegion(next, id, body, target.label);
+  }
 
   const config = await prettier.resolveConfig(path);
   next = await prettier.format(next, { ...config, filepath: path });

--- a/packages/core/src/bundle-generator/__tests__/capability-emission.test.ts
+++ b/packages/core/src/bundle-generator/__tests__/capability-emission.test.ts
@@ -558,7 +558,15 @@ const coreCommandKeys = (): string[] => {
 
 /** cmdMap keys of the embedded template, read from its source text. */
 const templateCommandKeys = (): string[] => {
-  const block = HYBRID_PARSER_TEMPLATE.match(/const cmdMap = \{([\s\S]*?)\n {4}\};/);
+  // The template's cmdMap is parser-core's class field, lowered by esbuild's
+  // es2020 transform into a constructor-time `__publicField(this, "cmdMap", {`
+  // (Arc E step 5 generates the template from parser-core, and es2020 has no
+  // class-field syntax). When this regex finds nothing, the assertion below
+  // reports it loudly rather than passing on empty — which is exactly how the
+  // step-5 shape change surfaced here instead of slipping by.
+  const block = HYBRID_PARSER_TEMPLATE.match(
+    /__publicField\(this, "cmdMap", \{([\s\S]*?)\n {4}\}\)/
+  );
   if (!block) return [];
   return [...block[1].matchAll(/^ {6}([A-Za-z_][\w]*):/gm)].map(m => m[1]);
 };
@@ -567,10 +575,17 @@ describe('parser-core and the embedded parser template dispatch the same command
   it('the two cmdMaps are identical', () => {
     // `generateBundle()` in core imports `parser/hybrid/parser-core`, but the
     // vite-plugin's generator embeds HYBRID_PARSER_TEMPLATE instead. While the
-    // two differed, the set of commands that actually ran depended on which
-    // generator the user went through: the template had `empty` and no `halt`,
-    // parser-core the reverse. `parser-template-drift.test.ts` compares them on
-    // catch/finally only and is structurally unable to see this.
+    // two were separately hand-maintained, the set of commands that actually
+    // ran depended on which generator the user went through: the template had
+    // `empty` and no `halt`, parser-core the reverse.
+    //
+    // Since Arc E step 5 the template is GENERATED from parser-core, so this
+    // equality holds by construction. It stays as the cheap source-text belt
+    // for a stale commit (someone edits parser-core and skips regeneration):
+    // `generate:bundles:check` fails that in lint-typecheck, this fails it in
+    // unit-tests, and the AST-equivalence suite in
+    // `parser-template-drift.test.ts` fails it wherever the drift is
+    // behavioral. Different jobs, one survivor still catches it.
     const core = coreCommandKeys();
     const template = templateCommandKeys();
     expect(core.length, 'cmdMap regex found nothing — parser-core shape changed').toBeGreaterThan(

--- a/packages/core/src/bundle-generator/parser-template-drift.test.ts
+++ b/packages/core/src/bundle-generator/parser-template-drift.test.ts
@@ -1,19 +1,33 @@
 /**
- * `HYBRID_PARSER_TEMPLATE` is a hand-maintained COPY of
- * parser/hybrid/parser-core.ts, emitted as source text for generated bundles and
- * re-exported publicly from bundle-generator/index.ts. Nothing in the build
- * compares the two, so they drift silently — and a behavioural difference
- * between the parser we test and the parser a consumer embeds is exactly the
- * kind of gap that ships.
+ * `HYBRID_PARSER_TEMPLATE` is GENERATED from the real parser modules
+ * (`parser/hybrid/{aliases,tokenizer,parser-core}.ts`) by
+ * `scripts/generate-bundles.ts` — Arc E step 5 retired the hand-maintained
+ * ~1000-line twin this file was written to police. Before generation, the
+ * copies were measured apart in BOTH directions: the template lacked `@attr`
+ * tokenization, the `'s` possessive operator, fetch `via`/`with`/`{options}`,
+ * `values of`, five KEYWORDS entries and the alias-registration API. Every
+ * vite-plugin bundle that embedded it shipped those parse gaps, and nothing
+ * executed the embedded copy — the vite-plugin's own tests stop at
+ * `new Function` construction (syntax, not behavior).
  *
- * This asserts the template BEHAVES like the source on the invariants that
- * matter, rather than diffing text (the copies are legitimately different:
- * TypeScript vs JavaScript, and different command sets).
+ * What this file gates now, in order of what it would catch:
  *
- * Note the template is not what `generateBundle()` emits — generator.ts writes
- * an `import { HybridParser } from '<path>/parser-core'` instead — so a
- * divergence here costs no bundle bytes. It still misleads whoever embeds the
- * exported template.
+ *   1. A BROKEN TRANSFORM — esbuild output that no longer evaluates, or whose
+ *      behavior diverges from the modules it was derived from. The
+ *      AST-equivalence suite is the strong form: the committed template and
+ *      the live parser must produce identical trees over a corpus that
+ *      includes every capability generation added and the escaping canaries
+ *      (backticks, `${`, backslash-heavy regexes — the characters the
+ *      template-literal embedding must escape).
+ *   2. A STALE COMMIT — someone edits parser-core and skips regeneration.
+ *      `generate:bundles:check` fails that in the lint-typecheck job; this
+ *      suite fails it in the unit-tests job the moment the drift is
+ *      behavioral. Two different jobs, so one surviving a workflow edit still
+ *      leaves the other.
+ *
+ * The cmdMap-equality assertion (`capability-emission.test.ts` §4, Oracle 2 of
+ * the arc) stays where it is: post-generation it holds by construction, and it
+ * remains the cheap source-text belt for the same stale-commit case.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -56,13 +70,63 @@ describe('HYBRID_PARSER_TEMPLATE stays in step with parser-core', () => {
     expect(() => new TemplateParser!(src).parse()).toThrow(/needs the full parser/);
   });
 
-  it.runIf(TemplateParser)('still parses an ordinary handler', () => {
-    expect(() => new TemplateParser!('on click toggle .active').parse()).not.toThrow();
-  });
-
   it('carries the guard in its source text', () => {
     // Independent of evaluation, so this keeps working if the template ever
-    // gains a dependency that `new Function` cannot resolve.
-    expect(HYBRID_PARSER_TEMPLATE).toMatch(/match\('catch',\s*'finally'\)/);
+    // gains a dependency that `new Function` cannot resolve. Quote-agnostic:
+    // the hand copy wrote 'catch'; esbuild emits "catch".
+    expect(HYBRID_PARSER_TEMPLATE).toMatch(/match\(['"]catch['"],\s*['"]finally['"]\)/);
   });
+});
+
+// ===========================================================================
+// AST equivalence — the committed template IS the live parser
+// ===========================================================================
+
+/**
+ * One source per parse path worth guarding, deliberately including:
+ *
+ *   - the five capabilities generation ADDED to the template (`@attr`, `'s`,
+ *     fetch `via`/`as`, `values of`, KEYWORDS entries) — each was a live gap in
+ *     vite-embedded bundles before step 5, so each gets a row that fails if it
+ *     regresses;
+ *   - escaping canaries: a backtick and a `${` inside a string literal, and a
+ *     backslash regex-heavy tokenizer path. A wrong escape in the generator
+ *     corrupts exactly these, and nothing else would notice — the template
+ *     would still evaluate.
+ */
+const EQUIVALENCE_CORPUS: string[] = [
+  // basics, one per family
+  'on click toggle .active',
+  'add .x to #t then remove .x from #t',
+  'put "PUT" into #t',
+  'on mouseover.debounce(300) show #hint',
+  'repeat 3 times increment #counter end',
+  'if #t has .active then hide #t else show #t end',
+  'wait for foo from #t then log it',
+  'js window.__x = 1 end',
+  'send custom:event to #t',
+  // gained in step 5 — previously unparseable by the embedded copy
+  'toggle @disabled on #t',
+  "set #t's title to 'TITLED'",
+  'fetch /api via POST as json then log it',
+  'put values of #form into #out',
+  'on click halt the event',
+  // escaping canaries
+  'log "tick ` and ${dollar} and \\\\ backslash"',
+  'on keyup log "typed"',
+];
+
+describe.runIf(loadTemplateParser())('template and live parser produce identical ASTs', () => {
+  const TemplateParser = loadTemplateParser()!;
+
+  for (const src of EQUIVALENCE_CORPUS) {
+    it(`agree on: ${src.slice(0, 60)}`, () => {
+      const real = new HybridParser(src).parse();
+      const embedded = new TemplateParser(src).parse();
+      expect(embedded).toEqual(real);
+      // A parser pair that agrees on `null` has agreed on nothing — every
+      // corpus entry must actually parse, or the row is vacuous (S3-b).
+      expect(real).not.toBeNull();
+    });
+  }
 });

--- a/packages/core/src/bundle-generator/parser-templates.ts
+++ b/packages/core/src/bundle-generator/parser-templates.ts
@@ -7,10 +7,16 @@
  * LITE_PARSER_TEMPLATE: Regex-based parser (~200 lines, ~2 KB gzipped)
  *   - Supports: event handlers, command sequences, simple conditions
  *   - Commands: toggle, add, remove, put, set, log, send, wait, show/hide
+ *   - HAND-MAINTAINED, deliberately: it has no canonical module twin to
+ *     generate from — the regex-parser copies in the lite bundle entries are
+ *     each their own tier-specific simplification, not copies of one source.
  *
- * HYBRID_PARSER_TEMPLATE: Full AST parser (~1100 lines, ~7 KB gzipped)
+ * HYBRID_PARSER_TEMPLATE: Full AST parser (~7 KB gzipped in emitted bundles)
  *   - Supports: blocks (if/repeat/for/while/fetch), positional expressions
  *   - Full operator precedence, function calls, object/array literals
+ *   - GENERATED from `parser/hybrid/{aliases,tokenizer,parser-core}.ts` by
+ *     `scripts/generate-bundles.ts` (Arc E step 5). Edit those modules, then
+ *     `npm run generate:bundles`; never edit between the region markers.
  */
 
 // =============================================================================
@@ -234,525 +240,638 @@ function parseLiteValue(str) {
 /**
  * Full recursive descent parser with operator precedence.
  * Use when blocks, positional expressions, or complex features are detected.
+ *
+ * GENERATED — do not edit between the region markers. The body is the real
+ * parser (`parser/hybrid/{aliases,tokenizer,parser-core}.ts`) transformed to
+ * self-contained ES2020 JavaScript by `scripts/generate-bundles.ts`; run
+ * `npm run generate:bundles` after any change to those modules. This retired
+ * the hand-maintained twin that Oracle 2 (`capability-emission.test.ts` §4)
+ * and `parser-template-drift.test.ts` existed to police — both now gate the
+ * committed artifact instead of a second authorship.
  */
 export const HYBRID_PARSER_TEMPLATE = `
-// Hybrid Parser - Full AST with operator precedence
-
-// Tokenizer
-const KEYWORDS = new Set([
-  'on', 'from', 'to', 'into', 'before', 'after', 'in', 'of', 'at', 'with',
-  'if', 'else', 'unless', 'end', 'then', 'and', 'or', 'not',
-  'repeat', 'times', 'for', 'each', 'while', 'until',
-  'toggle', 'add', 'remove', 'put', 'set', 'get', 'call', 'return', 'append', 'prepend',
-  'log', 'send', 'trigger', 'wait', 'settle', 'fetch', 'as',
-  'show', 'hide', 'take', 'increment', 'decrement', 'focus', 'blur', 'empty', 'go', 'transition', 'over',
-  'the', 'a', 'an', 'my', 'its', 'me', 'it', 'you',
-  'first', 'last', 'next', 'previous', 'closest', 'parent',
-  'true', 'false', 'null', 'undefined',
-  'is', 'matches', 'contains', 'includes', 'exists', 'has', 'init', 'every', 'by',
-]);
+// #region generated:hybrid-parser — DO NOT EDIT (npm run generate:bundles)
+// Hybrid Parser — generated from parser/hybrid/{aliases,tokenizer,parser-core}.ts
 
 const COMMAND_ALIASES = {
-  flip: 'toggle', switch: 'toggle', display: 'show', reveal: 'show',
-  conceal: 'hide', increase: 'increment', decrease: 'decrement',
-  fire: 'trigger', dispatch: 'send', navigate: 'go', goto: 'go',
+  flip: "toggle",
+  switch: "toggle",
+  display: "show",
+  reveal: "show",
+  conceal: "hide",
+  increase: "increment",
+  decrease: "decrement",
+  fire: "trigger",
+  dispatch: "send",
+  navigate: "go",
+  goto: "go"
 };
-
 const EVENT_ALIASES = {
-  clicked: 'click', pressed: 'keydown', changed: 'change',
-  submitted: 'submit', loaded: 'load',
+  clicked: "click",
+  pressed: "keydown",
+  changed: "change",
+  submitted: "submit",
+  loaded: "load"
 };
-
 function normalizeCommand(name) {
   const lower = name.toLowerCase();
   return COMMAND_ALIASES[lower] || lower;
 }
-
 function normalizeEvent(name) {
   const lower = name.toLowerCase();
   return EVENT_ALIASES[lower] || lower;
 }
+function addCommandAliases(aliases) {
+  Object.assign(COMMAND_ALIASES, aliases);
+}
+function addEventAliases(aliases) {
+  Object.assign(EVENT_ALIASES, aliases);
+}
 
+const KEYWORDS = /* @__PURE__ */ new Set([
+  "on",
+  "from",
+  "to",
+  "into",
+  "before",
+  "after",
+  "in",
+  "of",
+  "at",
+  "with",
+  "if",
+  "else",
+  "unless",
+  "end",
+  "then",
+  "and",
+  "or",
+  "not",
+  "repeat",
+  "times",
+  "for",
+  "each",
+  "while",
+  "until",
+  "toggle",
+  "add",
+  "remove",
+  "put",
+  "set",
+  "get",
+  "call",
+  "return",
+  "append",
+  "prepend",
+  "log",
+  "send",
+  "trigger",
+  "wait",
+  "settle",
+  "fetch",
+  "as",
+  "show",
+  "hide",
+  "take",
+  "increment",
+  "decrement",
+  "focus",
+  "blur",
+  "go",
+  "transition",
+  "over",
+  "the",
+  "a",
+  "an",
+  "my",
+  "its",
+  "me",
+  "it",
+  "you",
+  "first",
+  "last",
+  "next",
+  "previous",
+  "closest",
+  "parent",
+  "true",
+  "false",
+  "null",
+  "undefined",
+  "is",
+  "matches",
+  "contains",
+  "includes",
+  "exists",
+  "has",
+  "init",
+  "every",
+  "by",
+  "halt",
+  "via",
+  "values",
+  "default",
+  "event"
+]);
 function tokenize(code) {
   const tokens = [];
   let pos = 0;
-
   while (pos < code.length) {
-    if (/\\s/.test(code[pos])) { pos++; continue; }
-    if (code.slice(pos, pos + 2) === '--') {
-      while (pos < code.length && code[pos] !== '\\n') pos++;
+    if (/\\s/.test(code[pos])) {
+      pos++;
       continue;
     }
-
+    if (code.slice(pos, pos + 2) === "--") {
+      while (pos < code.length && code[pos] !== "\\n") pos++;
+      continue;
+    }
     const start = pos;
-
-    // HTML selector <tag/>
-    if (code[pos] === '<' && /[a-zA-Z]/.test(code[pos + 1] || '')) {
+    if (code[pos] === "<" && /[a-zA-Z]/.test(code[pos + 1] || "")) {
       pos++;
-      while (pos < code.length && code[pos] !== '>') pos++;
-      if (code[pos] === '>') pos++;
+      while (pos < code.length && code[pos] !== ">") pos++;
+      if (code[pos] === ">") pos++;
       const val = code.slice(start, pos);
-      if (val.endsWith('/>') || val.endsWith('>')) {
-        const normalized = val.slice(1).replace(/\\/?>$/, '');
-        tokens.push({ type: 'selector', value: normalized, pos: start });
+      if (val.endsWith("/>") || val.endsWith(">")) {
+        const normalized = val.slice(1).replace(/\\/?>$/, "");
+        tokens.push({ type: "selector", value: normalized, pos: start });
         continue;
       }
     }
-
-    // Possessive 's
-    if (code.slice(pos, pos + 2) === "'s" && !/[a-zA-Z]/.test(code[pos + 2] || '')) {
-      tokens.push({ type: 'operator', value: "'s", pos: start });
+    if (code.slice(pos, pos + 2) === "'s" && !/[a-zA-Z]/.test(code[pos + 2] || "")) {
+      tokens.push({ type: "operator", value: "'s", pos: start });
       pos += 2;
       continue;
     }
-
-    // String literals
     if (code[pos] === '"' || code[pos] === "'") {
       const quote = code[pos++];
       while (pos < code.length && code[pos] !== quote) {
-        if (code[pos] === '\\\\') pos++;
+        if (code[pos] === "\\\\") pos++;
         pos++;
       }
       pos++;
-      tokens.push({ type: 'string', value: code.slice(start, pos), pos: start });
+      tokens.push({ type: "string", value: code.slice(start, pos), pos: start });
       continue;
     }
-
-    // Numbers with units
-    if (/\\d/.test(code[pos]) || (code[pos] === '-' && /\\d/.test(code[pos + 1] || ''))) {
-      if (code[pos] === '-') pos++;
+    if (/\\d/.test(code[pos]) || code[pos] === "-" && /\\d/.test(code[pos + 1] || "")) {
+      if (code[pos] === "-") pos++;
       while (pos < code.length && /[\\d.]/.test(code[pos])) pos++;
-      if (code.slice(pos, pos + 2) === 'ms') pos += 2;
-      else if (code[pos] === 's' && !/[a-zA-Z]/.test(code[pos + 1] || '')) pos++;
-      else if (code.slice(pos, pos + 2) === 'px') pos += 2;
-      tokens.push({ type: 'number', value: code.slice(start, pos), pos: start });
+      if (code.slice(pos, pos + 2) === "ms") pos += 2;
+      else if (code[pos] === "s" && !/[a-zA-Z]/.test(code[pos + 1] || "")) pos++;
+      else if (code.slice(pos, pos + 2) === "px") pos += 2;
+      tokens.push({ type: "number", value: code.slice(start, pos), pos: start });
       continue;
     }
-
-    // Local variable :name
-    if (code[pos] === ':') {
+    if (code[pos] === ":") {
       pos++;
       while (pos < code.length && /[\\w]/.test(code[pos])) pos++;
-      tokens.push({ type: 'localVar', value: code.slice(start, pos), pos: start });
+      tokens.push({ type: "localVar", value: code.slice(start, pos), pos: start });
       continue;
     }
-
-    // Global variable $name
-    if (code[pos] === '$') {
+    if (code[pos] === "$") {
       pos++;
       while (pos < code.length && /[\\w]/.test(code[pos])) pos++;
-      tokens.push({ type: 'globalVar', value: code.slice(start, pos), pos: start });
+      tokens.push({ type: "globalVar", value: code.slice(start, pos), pos: start });
       continue;
     }
-
-    // CSS selectors: #id, .class
-    if (code[pos] === '#' || code[pos] === '.') {
-      if (code[pos] === '.') {
+    if (code[pos] === "@") {
+      pos++;
+      while (pos < code.length && /[\\w-]/.test(code[pos])) pos++;
+      tokens.push({ type: "selector", value: code.slice(start, pos), pos: start });
+      continue;
+    }
+    if (code[pos] === "#" || code[pos] === ".") {
+      if (code[pos] === ".") {
         const afterDot = code.slice(pos + 1).match(/^(once|prevent|stop|debounce|throttle)\\b/i);
         if (afterDot) {
-          tokens.push({ type: 'symbol', value: '.', pos: start });
+          tokens.push({ type: "symbol", value: ".", pos: start });
           pos++;
           continue;
         }
       }
       pos++;
       while (pos < code.length && /[\\w-]/.test(code[pos])) pos++;
-      tokens.push({ type: 'selector', value: code.slice(start, pos), pos: start });
+      tokens.push({ type: "selector", value: code.slice(start, pos), pos: start });
       continue;
     }
-
-    // Array literal vs Attribute selector
-    if (code[pos] === '[') {
+    if (code[pos] === "[") {
       let lookahead = pos + 1;
       while (lookahead < code.length && /\\s/.test(code[lookahead])) lookahead++;
-      const nextChar = code[lookahead] || '';
-      const isArrayLiteral = /['"\\d\\[\\]:\\$\\-]/.test(nextChar) || nextChar === '';
+      const nextChar = code[lookahead] || "";
+      const isArrayLiteral = /['"\\d\\[\\]:\\$\\-]/.test(nextChar) || nextChar === "";
       if (isArrayLiteral) {
-        tokens.push({ type: 'symbol', value: '[', pos: start });
+        tokens.push({ type: "symbol", value: "[", pos: start });
         pos++;
         continue;
       } else {
         pos++;
         let depth = 1;
         while (pos < code.length && depth > 0) {
-          if (code[pos] === '[') depth++;
-          if (code[pos] === ']') depth--;
+          if (code[pos] === "[") depth++;
+          if (code[pos] === "]") depth--;
           pos++;
         }
-        tokens.push({ type: 'selector', value: code.slice(start, pos), pos: start });
+        tokens.push({ type: "selector", value: code.slice(start, pos), pos: start });
         continue;
       }
     }
-
-    if (code[pos] === ']') {
-      tokens.push({ type: 'symbol', value: ']', pos: start });
+    if (code[pos] === "]") {
+      tokens.push({ type: "symbol", value: "]", pos: start });
       pos++;
       continue;
     }
-
-    // Multi-char operators
-    const twoChar = code.slice(pos, pos + 2);
-    if (['==', '!=', '<=', '>=', '&&', '||'].includes(twoChar)) {
-      tokens.push({ type: 'operator', value: twoChar, pos: start });
+    if (code.slice(pos, pos + 2) === "'s") {
+      tokens.push({ type: "operator", value: "'s", pos: start });
       pos += 2;
       continue;
     }
-
-    // Style property *opacity
-    if (code[pos] === '*' && /[a-zA-Z]/.test(code[pos + 1] || '')) {
+    const twoChar = code.slice(pos, pos + 2);
+    if (["==", "!=", "<=", ">=", "&&", "||"].includes(twoChar)) {
+      tokens.push({ type: "operator", value: twoChar, pos: start });
+      pos += 2;
+      continue;
+    }
+    if (code[pos] === "*" && /[a-zA-Z]/.test(code[pos + 1] || "")) {
       pos++;
       while (pos < code.length && /[\\w-]/.test(code[pos])) pos++;
-      tokens.push({ type: 'styleProperty', value: code.slice(start, pos), pos: start });
+      tokens.push({ type: "styleProperty", value: code.slice(start, pos), pos: start });
       continue;
     }
-
-    if ('+-*/%<>!'.includes(code[pos])) {
-      tokens.push({ type: 'operator', value: code[pos], pos: start });
+    if ("+-*/%<>!".includes(code[pos])) {
+      tokens.push({ type: "operator", value: code[pos], pos: start });
       pos++;
       continue;
     }
-
-    if ('()[]{},.'.includes(code[pos])) {
-      tokens.push({ type: 'symbol', value: code[pos], pos: start });
+    if ("()[]{},.".includes(code[pos])) {
+      tokens.push({ type: "symbol", value: code[pos], pos: start });
       pos++;
       continue;
     }
-
     if (/[a-zA-Z_]/.test(code[pos])) {
       while (pos < code.length && /[\\w-]/.test(code[pos])) pos++;
       const value = code.slice(start, pos);
-      const type = KEYWORDS.has(value.toLowerCase()) ? 'keyword' : 'identifier';
+      const type = KEYWORDS.has(value.toLowerCase()) ? "keyword" : "identifier";
       tokens.push({ type, value, pos: start });
       continue;
     }
-
     pos++;
   }
-
-  tokens.push({ type: 'eof', value: '', pos: code.length });
+  tokens.push({ type: "eof", value: "", pos: code.length });
   return tokens;
 }
 
-// Parser
+var __defProp = Object.defineProperty;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
 class HybridParser {
   constructor(code) {
-    // Kept for \`js … end\`, whose body is sliced from the raw source rather
-    // than reassembled from tokens (the tokenizer reads JS as hyperscript).
-    this.source = code;
-    this.tokens = tokenize(code);
-    this.pos = 0;
-  }
-
-  peek(offset = 0) {
-    return this.tokens[Math.min(this.pos + offset, this.tokens.length - 1)];
-  }
-
-  advance() {
-    return this.tokens[this.pos++];
-  }
-
-  match(...values) {
-    const token = this.peek();
-    return values.some(v => token.value.toLowerCase() === v.toLowerCase());
-  }
-
-  matchType(...types) {
-    return types.includes(this.peek().type);
-  }
-
-  expect(value) {
-    if (!this.match(value) && normalizeCommand(this.peek().value) !== value) {
-      throw new Error("Expected '" + value + "', got '" + this.peek().value + "'");
-    }
-    return this.advance();
-  }
-
-  isAtEnd() {
-    return this.peek().type === 'eof';
-  }
-
-  parse() {
-    if (this.match('on')) return this.parseEventHandler();
-    if (this.match('init')) {
-      this.advance();
-      return { type: 'event', event: 'init', modifiers: {}, body: this.parseCommandSequence() };
-    }
-    if (this.match('every')) return this.parseEveryHandler();
-    return { type: 'sequence', commands: this.parseCommandSequence() };
-  }
-
-  parseEventHandler() {
-    this.expect('on');
-    const eventName = this.advance().value;
-    const modifiers = {};
-    let filter;
-
-    while (this.peek().value === '.') {
-      this.advance();
-      const mod = this.advance().value.toLowerCase();
-      if (mod === 'once') modifiers.once = true;
-      else if (mod === 'prevent') modifiers.prevent = true;
-      else if (mod === 'stop') modifiers.stop = true;
-      else if (mod === 'debounce' || mod === 'throttle') {
-        if (this.peek().value === '(') {
-          this.advance();
-          const num = this.advance().value;
-          this.expect(')');
-          if (mod === 'debounce') modifiers.debounce = parseInt(num) || 100;
-          else modifiers.throttle = parseInt(num) || 100;
-        }
-      }
-    }
-
-    if (this.match('from')) {
-      this.advance();
-      filter = this.parseExpression();
-    }
-
-    return { type: 'event', event: normalizeEvent(eventName), filter, modifiers, body: this.parseCommandSequence() };
-  }
-
-  parseEveryHandler() {
-    this.expect('every');
-    const interval = this.advance().value;
-    return { type: 'event', event: 'interval:' + interval, modifiers: {}, body: this.parseCommandSequence() };
-  }
-
-  parseCommandSequence() {
-    const commands = [];
-    while (!this.isAtEnd() && !this.match('end', 'else')) {
-      const cmd = this.parseCommand();
-      if (cmd) commands.push(cmd);
-      if (this.match('then', 'and')) this.advance();
-    }
-    return commands;
-  }
-
-  parseCommand() {
-    if (this.match('if', 'unless')) return this.parseIf();
-    if (this.match('repeat')) return this.parseRepeat();
-    if (this.match('for')) return this.parseFor();
-    if (this.match('while')) return this.parseWhile();
-    if (this.match('fetch')) return this.parseFetchBlock();
-
-    const cmdMap = {
+    __publicField(this, "tokens");
+    __publicField(this, "pos", 0);
+    /**
+     * The raw source. Kept because \`js … end\` must be sliced from it verbatim —
+     * the tokenizer reads a JS body as hyperscript and mangles regexes, template
+     * literals and single quotes. Same approach as the full parser's
+     * \`parseJsCommand\`, which slices between token offsets for the same reason.
+     */
+    __publicField(this, "source");
+    /**
+     * Command keyword → parse rule. Built once per parse rather than once per
+     * command, and the single place the parser's command set is written down:
+     * \`isCommandKeyword()\` reads these keys instead of carrying its own copy.
+     *
+     * MUST stay in sync with \`bundle-generator/parser-templates.ts\`'s
+     * \`HYBRID_PARSER_TEMPLATE\` — core's \`generateBundle()\` imports this file
+     * while the vite-plugin's generator embeds that template, so a name in only
+     * one of them makes the reachable command set depend on which generator the
+     * user went through. Gated by \`capability-emission.test.ts\` §3.
+     */
+    __publicField(this, "cmdMap", {
       toggle: () => this.parseToggle(),
       add: () => this.parseAdd(),
       remove: () => this.parseRemove(),
       put: () => this.parsePut(),
-      append: () => this.parseInsertion('append'),
-      prepend: () => this.parseInsertion('prepend'),
+      append: () => this.parseInsertion("append"),
+      prepend: () => this.parseInsertion("prepend"),
       set: () => this.parseSet(),
       get: () => this.parseGet(),
       call: () => this.parseCall(),
       log: () => this.parseLog(),
-      send: () => this.parseSend('to'),
-      trigger: () => this.parseSend('on'),
+      send: () => this.parseSend("to"),
+      // \`trigger <event> on <target>\` — same node as \`send\`, per the runtime,
+      // where \`trigger\` is a consolidation alias sharing \`send\`'s implementation.
+      // The target marker differs, which is why it is a parameter and not a
+      // second entry pointing at the same rule (that dropped the target).
+      trigger: () => this.parseSend("on"),
       wait: () => this.parseWait(),
       show: () => this.parseShow(),
       hide: () => this.parseHide(),
       take: () => this.parseTake(),
-      increment: () => this.parseIncDec('increment'),
-      decrement: () => this.parseIncDec('decrement'),
-      focus: () => this.parseFocusBlur('focus'),
-      blur: () => this.parseFocusBlur('blur'),
       empty: () => this.parseEmpty(),
+      increment: () => this.parseIncDec("increment"),
+      decrement: () => this.parseIncDec("decrement"),
+      focus: () => this.parseFocusBlur("focus"),
+      blur: () => this.parseFocusBlur("blur"),
       go: () => this.parseGo(),
       return: () => this.parseReturn(),
       transition: () => this.parseTransition(),
       halt: () => this.parseHalt(),
       copy: () => this.parseCopy(),
       beep: () => this.parseBeep(),
-      push: () => this.parseUrlCommand('push'),
-      replace: () => this.parseUrlCommand('replace'),
+      push: () => this.parseUrlCommand("push"),
+      replace: () => this.parseUrlCommand("replace"),
       morph: () => this.parseMorph(),
       js: () => this.parseJs(),
       throw: () => this.parseThrow(),
-      break: () => this.parseBare('break'),
-      continue: () => this.parseBare('continue'),
-      exit: () => this.parseBare('exit'),
-    };
-
-    const normalized = normalizeCommand(this.peek().value);
-    if (cmdMap[normalized]) return cmdMap[normalized]();
-
-    // Mirrors parser/hybrid/parser-core.ts: absorbing catch/finally into the
-    // body ran the error path on every success. Reject loudly instead.
-    if (this.match('catch', 'finally')) {
-      throw new Error("'" + this.peek().value + "' needs the full parser (use hyperfixi.js)");
+      break: () => this.parseBare("break"),
+      continue: () => this.parseBare("continue"),
+      exit: () => this.parseBare("exit")
+    });
+    this.source = code;
+    this.tokens = tokenize(code);
+  }
+  peek(offset = 0) {
+    return this.tokens[Math.min(this.pos + offset, this.tokens.length - 1)];
+  }
+  advance() {
+    return this.tokens[this.pos++];
+  }
+  match(...values) {
+    const token = this.peek();
+    return values.some((v) => token.value.toLowerCase() === v.toLowerCase());
+  }
+  matchType(...types) {
+    return types.includes(this.peek().type);
+  }
+  expect(value) {
+    if (!this.match(value) && normalizeCommand(this.peek().value) !== value) {
+      throw new Error(\`Expected '\${value}', got '\${this.peek().value}'\`);
     }
-
-    if (!this.isAtEnd() && !this.match('then', 'and', 'end', 'else')) this.advance();
+    return this.advance();
+  }
+  isAtEnd() {
+    return this.peek().type === "eof";
+  }
+  parse() {
+    if (this.match("on")) return this.parseEventHandler();
+    if (this.match("init")) {
+      this.advance();
+      return { type: "event", event: "init", modifiers: {}, body: this.parseCommandSequence() };
+    }
+    if (this.match("every")) return this.parseEveryHandler();
+    return { type: "sequence", commands: this.parseCommandSequence() };
+  }
+  parseEventHandler() {
+    this.expect("on");
+    const eventName = this.advance().value;
+    const modifiers = {};
+    let filter;
+    while (this.peek().value === ".") {
+      this.advance();
+      const mod = this.advance().value.toLowerCase();
+      if (mod === "once") modifiers.once = true;
+      else if (mod === "prevent") modifiers.prevent = true;
+      else if (mod === "stop") modifiers.stop = true;
+      else if (mod === "debounce" || mod === "throttle") {
+        if (this.peek().value === "(") {
+          this.advance();
+          const num = this.advance().value;
+          this.expect(")");
+          if (mod === "debounce") modifiers.debounce = parseInt(num) || 100;
+          else modifiers.throttle = parseInt(num) || 100;
+        }
+      }
+    }
+    if (this.match("from")) {
+      this.advance();
+      filter = this.parseExpression();
+    }
+    return {
+      type: "event",
+      event: normalizeEvent(eventName),
+      filter,
+      modifiers,
+      body: this.parseCommandSequence()
+    };
+  }
+  parseEveryHandler() {
+    this.expect("every");
+    const interval = this.advance().value;
+    return {
+      type: "event",
+      event: \`interval:\${interval}\`,
+      modifiers: {},
+      body: this.parseCommandSequence()
+    };
+  }
+  parseCommandSequence() {
+    const commands = [];
+    while (!this.isAtEnd() && !this.match("end", "else")) {
+      const cmd = this.parseCommand();
+      if (cmd) commands.push(cmd);
+      if (this.match("then", "and")) this.advance();
+    }
+    return commands;
+  }
+  parseCommand() {
+    if (this.match("if", "unless")) return this.parseIf();
+    if (this.match("repeat")) return this.parseRepeat();
+    if (this.match("for")) return this.parseFor();
+    if (this.match("while")) return this.parseWhile();
+    if (this.match("fetch")) return this.parseFetchBlock();
+    const normalized = normalizeCommand(this.peek().value);
+    if (this.cmdMap[normalized]) {
+      return this.cmdMap[normalized]();
+    }
+    if (this.match("catch", "finally")) {
+      throw new Error(\`'\${this.peek().value}' needs the full parser (use hyperfixi.js)\`);
+    }
+    if (!this.isAtEnd() && !this.match("then", "and", "end", "else")) {
+      this.advance();
+    }
     return null;
   }
-
+  // Control flow parsing
   parseIf() {
-    const isUnless = this.match('unless');
+    const isUnless = this.match("unless");
     this.advance();
     const condition = this.parseExpression();
     const body = this.parseCommandSequence();
     let elseBody;
-
-    if (this.match('else')) {
+    if (this.match("else")) {
       this.advance();
       elseBody = this.parseCommandSequence();
     }
-    if (this.match('end')) this.advance();
-
+    if (this.match("end")) this.advance();
     return {
-      type: 'if',
-      condition: isUnless ? { type: 'unary', operator: 'not', operand: condition } : condition,
+      type: "if",
+      condition: isUnless ? { type: "unary", operator: "not", operand: condition } : condition,
       body,
-      elseBody,
+      elseBody
     };
   }
-
   parseRepeat() {
-    this.expect('repeat');
+    this.expect("repeat");
     let count;
-    if (!this.match('until', 'while', 'forever')) {
+    if (!this.match("until", "while", "forever")) {
       count = this.parseExpression();
-      if (this.match('times')) this.advance();
+      if (this.match("times")) this.advance();
     }
     const body = this.parseCommandSequence();
-    if (this.match('end')) this.advance();
-    return { type: 'repeat', condition: count, body };
+    if (this.match("end")) this.advance();
+    return { type: "repeat", condition: count, body };
   }
-
   parseFor() {
-    this.expect('for');
-    if (this.match('each')) this.advance();
+    this.expect("for");
+    if (this.match("each")) this.advance();
     const variable = this.advance().value;
-    this.expect('in');
+    this.expect("in");
     const iterable = this.parseExpression();
     const body = this.parseCommandSequence();
-    if (this.match('end')) this.advance();
-    return { type: 'for', condition: { type: 'forCondition', variable, iterable }, body };
+    if (this.match("end")) this.advance();
+    return { type: "for", condition: { type: "forCondition", variable, iterable }, body };
   }
-
   parseWhile() {
-    this.expect('while');
+    this.expect("while");
     const condition = this.parseExpression();
     const body = this.parseCommandSequence();
-    if (this.match('end')) this.advance();
-    return { type: 'while', condition, body };
+    if (this.match("end")) this.advance();
+    return { type: "while", condition, body };
   }
-
   parseFetchBlock() {
-    this.expect('fetch');
+    this.expect("fetch");
     const url = this.parseExpression();
-    let responseType = { type: 'literal', value: 'text' };
-    if (this.match('as')) {
-      this.advance();
-      responseType = this.parseExpression();
+    let responseType = { type: "literal", value: "text" };
+    let options;
+    let method;
+    if (this.match("{")) {
+      this.pos--;
+      options = this.parseExpression();
     }
-    if (this.match('then')) this.advance();
-    const body = this.parseCommandSequence();
-    return { type: 'fetch', condition: { type: 'fetchConfig', url, responseType }, body };
-  }
-
-  parseToggle() {
-    this.expect('toggle');
-    const what = this.parseExpression();
-    let target;
-    if (this.match('on')) {
-      this.advance();
-      target = this.parseExpression();
-    }
-    return { type: 'command', name: 'toggle', args: [what], target };
-  }
-
-  parseAdd() {
-    this.expect('add');
-    const what = this.parseExpression();
-    let target;
-    if (this.match('to')) {
-      this.advance();
-      target = this.parseExpression();
-    }
-    return { type: 'command', name: 'add', args: [what], target };
-  }
-
-  parseRemove() {
-    this.expect('remove');
-    // Sigil, not token type: \`#id\` and \`<tag/>\` are selector tokens too, so a
-    // type-only test sent \`remove #t\` down the class branch and stripped a
-    // class named \`t\` from \`me\`. \`@attr\` stays here (no attribute template).
-    if (this.matchType('selector') && /^[.@]/.test(this.peek().value)) {
-      const what = this.parseExpression();
-      let target;
-      if (this.match('from')) {
+    for (let i = 0; i < 3; i++) {
+      if (this.match("via") && !method) {
         this.advance();
-        target = this.parseExpression();
+        method = this.parseExpression();
+        continue;
       }
-      return { type: 'command', name: 'removeClass', args: [what], target };
+      if (this.match("as")) {
+        this.advance();
+        if (this.match("a") || this.match("an")) this.advance();
+        responseType = this.parseExpression();
+        continue;
+      }
+      if (this.match("with") && !options) {
+        this.advance();
+        options = this.parseExpression();
+        continue;
+      }
+      break;
+    }
+    if (this.match("then")) this.advance();
+    const body = this.parseCommandSequence();
+    return {
+      type: "fetch",
+      condition: { type: "fetchConfig", url, responseType, options, method },
+      body
+    };
+  }
+  // Command parsing
+  parseToggle() {
+    this.expect("toggle");
+    const what = this.parseExpression();
+    let target;
+    if (this.match("on")) {
+      this.advance();
+      target = this.parseExpression();
+    }
+    return { type: "command", name: "toggle", args: [what], target };
+  }
+  parseAdd() {
+    this.expect("add");
+    const what = this.parseExpression();
+    let target;
+    if (this.match("to")) {
+      this.advance();
+      target = this.parseExpression();
+    }
+    return { type: "command", name: "add", args: [what], target };
+  }
+  parseRemove() {
+    this.expect("remove");
+    if (this.matchType("selector") && /^[.@]/.test(this.peek().value)) {
+      const what = this.parseExpression();
+      let target2;
+      if (this.match("from")) {
+        this.advance();
+        target2 = this.parseExpression();
+      }
+      return { type: "command", name: "removeClass", args: [what], target: target2 };
     }
     const target = this.parseExpression();
-    return { type: 'command', name: 'remove', args: [], target };
+    return { type: "command", name: "remove", args: [], target };
   }
-
   parsePut() {
-    this.expect('put');
+    this.expect("put");
     const content = this.parseExpression();
-    let modifier = 'into';
-    if (this.match('into', 'before', 'after', 'at')) {
+    let modifier = "into";
+    if (this.match("into", "before", "after", "at")) {
       modifier = this.advance().value;
-      if (modifier === 'at') {
+      if (modifier === "at") {
         const pos = this.advance().value;
-        this.expect('of');
-        modifier = 'at ' + pos + ' of';
+        this.expect("of");
+        modifier = \`at \${pos} of\`;
       }
     }
     const target = this.parseExpression();
-    return { type: 'command', name: 'put', args: [content], target, modifier };
+    return { type: "command", name: "put", args: [content], target, modifier };
   }
-
+  /** \`append\`/\`prepend <content> [to <target>]\` — identical shape, both ends. */
   parseInsertion(name) {
     this.expect(name);
     const content = this.parseExpression();
     let target;
-    if (this.match('to')) {
+    if (this.match("to")) {
       this.advance();
       target = this.parseExpression();
     }
-    return { type: 'command', name, args: [content], target };
+    return { type: "command", name, args: [content], target };
   }
-
   parseSet() {
-    this.expect('set');
+    this.expect("set");
     const target = this.parseExpression();
-    if (this.match('to')) {
+    if (this.match("to")) {
       this.advance();
       const value = this.parseExpression();
-      return { type: 'command', name: 'set', args: [target, value] };
+      return { type: "command", name: "set", args: [target, value] };
     }
-    return { type: 'command', name: 'set', args: [target] };
+    return { type: "command", name: "set", args: [target] };
   }
-
   parseGet() {
-    this.expect('get');
-    return { type: 'command', name: 'get', args: [this.parseExpression()] };
+    this.expect("get");
+    return { type: "command", name: "get", args: [this.parseExpression()] };
   }
-
   parseCall() {
-    this.expect('call');
-    return { type: 'command', name: 'call', args: [this.parseExpression()] };
+    this.expect("call");
+    return { type: "command", name: "call", args: [this.parseExpression()] };
   }
-
   parseLog() {
-    this.expect('log');
+    this.expect("log");
     const args = [];
-    while (!this.isAtEnd() && !this.match('then', 'and', 'end', 'else')) {
+    while (!this.isAtEnd() && !this.match("then", "and", "end", "else")) {
       args.push(this.parseExpression());
-      if (this.match(',')) this.advance();
+      if (this.match(",")) this.advance();
       else break;
     }
-    return { type: 'command', name: 'log', args };
+    return { type: "command", name: "log", args };
   }
-
-  // \`send <event> to <t>\` / \`trigger <event> on <t>\` — one node, one template.
-  // The marker is a parameter: \`trigger\` used to reuse this rule with \`to\`
-  // hardcoded, silently abandoning \`on #target\` so the dispatch hit \`me\`.
+  /**
+   * \`send <event> to <target>\` / \`trigger <event> on <target>\`.
+   *
+   * Both emit a \`send\` node — the runtime registers \`trigger\` as a
+   * consolidation alias sharing \`send\`'s implementation, so the bundle
+   * generator carries one template for both. The marker is a parameter
+   * because it is the ONLY difference: \`trigger\` used to reuse this rule with
+   * \`to\` hardcoded, which parsed the event name and then silently abandoned
+   * \`on #target\`, leaving the dispatch to land on \`me\`.
+   */
   parseSend(marker) {
     this.advance();
     const event = this.advance().value;
@@ -761,486 +880,548 @@ class HybridParser {
       this.advance();
       target = this.parseExpression();
     }
-    return { type: 'command', name: 'send', args: [{ type: 'literal', value: event }], target };
+    return { type: "command", name: "send", args: [{ type: "literal", value: event }], target };
   }
-
   parseWait() {
-    this.expect('wait');
-    if (this.match('for')) {
+    this.expect("wait");
+    if (this.match("for")) {
       this.advance();
       const event = this.advance().value;
       let target;
-      if (this.match('from')) {
+      if (this.match("from")) {
         this.advance();
         target = this.parseExpression();
       }
-      return { type: 'command', name: 'waitFor', args: [{ type: 'literal', value: event }], target };
+      return {
+        type: "command",
+        name: "waitFor",
+        args: [{ type: "literal", value: event }],
+        target
+      };
     }
-    return { type: 'command', name: 'wait', args: [this.parseExpression()] };
+    return { type: "command", name: "wait", args: [this.parseExpression()] };
   }
-
   parseShow() {
-    this.expect('show');
+    this.expect("show");
     let target;
     const modifiers = {};
-    if (!this.isAtEnd() && !this.match('then', 'and', 'end', 'else', 'when', 'where')) {
+    if (!this.isAtEnd() && !this.match("then", "and", "end", "else", "when", "where")) {
       target = this.parseExpression();
     }
-    if (!this.isAtEnd() && this.match('when', 'where')) {
+    if (!this.isAtEnd() && this.match("when", "where")) {
       const keyword = this.advance().value;
       modifiers[keyword] = this.parseExpression();
     }
-    return { type: 'command', name: 'show', args: [], target, modifiers };
+    return { type: "command", name: "show", args: [], target, modifiers };
   }
-
   parseHide() {
-    this.expect('hide');
+    this.expect("hide");
     let target;
     const modifiers = {};
-    if (!this.isAtEnd() && !this.match('then', 'and', 'end', 'else', 'when', 'where')) {
+    if (!this.isAtEnd() && !this.match("then", "and", "end", "else", "when", "where")) {
       target = this.parseExpression();
     }
-    if (!this.isAtEnd() && this.match('when', 'where')) {
+    if (!this.isAtEnd() && this.match("when", "where")) {
       const keyword = this.advance().value;
       modifiers[keyword] = this.parseExpression();
     }
-    return { type: 'command', name: 'hide', args: [], target, modifiers };
+    return { type: "command", name: "hide", args: [], target, modifiers };
   }
-
   parseTake() {
-    this.expect('take');
+    this.expect("take");
     const what = this.parseExpression();
     let from;
-    if (this.match('from')) {
+    if (this.match("from")) {
       this.advance();
       from = this.parseExpression();
     }
-    return { type: 'command', name: 'take', args: [what], target: from };
+    return { type: "command", name: "take", args: [what], target: from };
   }
-
   parseIncDec(name) {
     this.advance();
     const target = this.parseExpression();
-    let amount = { type: 'literal', value: 1 };
-    if (this.match('by')) {
+    let amount = { type: "literal", value: 1 };
+    if (this.match("by")) {
       this.advance();
       amount = this.parseExpression();
     }
-    return { type: 'command', name, args: [target, amount] };
+    return { type: "command", name, args: [target, amount] };
   }
-
   parseFocusBlur(name) {
     this.advance();
     let target;
-    if (!this.isAtEnd() && !this.match('then', 'and', 'end', 'else')) {
+    if (!this.isAtEnd() && !this.match("then", "and", "end", "else")) {
       target = this.parseExpression();
     }
-    return { type: 'command', name, args: [], target };
+    return { type: "command", name, args: [], target };
   }
-
+  parseGo() {
+    this.expect("go");
+    if (this.match("to")) this.advance();
+    if (this.match("url")) this.advance();
+    const dest = this.parseExpression();
+    return { type: "command", name: "go", args: [dest] };
+  }
+  parseReturn() {
+    this.expect("return");
+    let value;
+    if (!this.isAtEnd() && !this.match("then", "and", "end", "else")) {
+      value = this.parseExpression();
+    }
+    return { type: "command", name: "return", args: value ? [value] : [] };
+  }
+  // ---------------------------------------------------------------------------
+  // Rules restoring the commands the capability list advertised but this parser
+  // could not reach (Finding 13). Every one already had a working template in
+  // \`bundle-generator/templates.ts\`; only the parse rule was missing, so the
+  // emitted \`case\` label was dead and the user's source silently no-opped.
+  // ---------------------------------------------------------------------------
+  /** \`empty [<target>]\` — clears children. Defaults to \`me\`. */
   parseEmpty() {
-    this.expect('empty');
+    this.expect("empty");
     let target;
-    if (!this.isAtEnd() && !this.match('then', 'and', 'end', 'else')) {
+    if (!this.isAtEnd() && !this.match("then", "and", "end", "else")) {
       target = this.parseExpression();
     }
-    return { type: 'command', name: 'empty', args: [], target };
+    return { type: "command", name: "empty", args: [], target };
   }
-
-  parseHalt() {
-    this.expect('halt');
-    if (this.match('the')) this.advance();
-    if (this.match('event', 'default')) this.advance();
-    return { type: 'command', name: 'halt', args: [] };
-  }
-
+  /** \`copy <value>\` — clipboard write. */
   parseCopy() {
-    this.expect('copy');
-    return { type: 'command', name: 'copy', args: [this.parseExpression()] };
+    this.expect("copy");
+    return { type: "command", name: "copy", args: [this.parseExpression()] };
   }
-
-  // Upstream spells it \`beep!\`; both forms are accepted. The \`!\` is consumed
-  // here or parseUnary would read it as negation of the first argument.
+  /**
+   * \`beep[!] [<value>, …]\` — debug echo.
+   *
+   * Upstream spells it \`beep!\`; hyperfixi accepts both (see the tier list's
+   * note on the same nuance). The \`!\` is consumed here because the tokenizer
+   * emits it as a separate operator, and \`parseUnary\` would otherwise read it
+   * as logical negation of the first argument.
+   */
   parseBeep() {
     this.advance();
-    if (this.match('!')) this.advance();
+    if (this.match("!")) this.advance();
     const args = [];
-    while (!this.isAtEnd() && !this.match('then', 'and', 'end', 'else')) {
+    while (!this.isAtEnd() && !this.match("then", "and", "end", "else")) {
       args.push(this.parseExpression());
-      if (this.match(',')) this.advance();
+      if (this.match(",")) this.advance();
       else break;
     }
-    return { type: 'command', name: 'beep', args };
+    return { type: "command", name: "beep", args };
   }
-
-  // \`push|replace url <url> [with title <t>]\`. The \`url\` keyword is consumed
-  // here, as parseGo already does. \`push-url\`/\`replace-url\` are bundle-config
-  // aliases, not source spellings — the full parser rejects both.
+  /**
+   * \`push|replace url <url> [with title <title>]\` — History API navigation.
+   *
+   * The \`url\` keyword is consumed here rather than left for the executor, the
+   * way \`parseGo\` already does it. Note \`push-url\` / \`replace-url\` are NOT
+   * source spellings — the full parser rejects both — they exist only as
+   * bundle-config aliases resolving to these templates.
+   */
   parseUrlCommand(name) {
     this.advance();
-    if (this.match('url')) this.advance();
+    if (this.match("url")) this.advance();
     const url = this.parseExpression();
     const modifiers = {};
-    if (this.match('with')) {
+    if (this.match("with")) {
       this.advance();
-      if (this.match('title')) {
+      if (this.match("title")) {
         this.advance();
         modifiers.title = this.parseExpression();
       }
     }
-    return { type: 'command', name, args: [url], modifiers };
+    return { type: "command", name, args: [url], modifiers };
   }
-
+  /** \`morph [over] <target> with|to|into <content>\` — all four connectives the full parser takes. */
   parseMorph() {
-    this.expect('morph');
+    this.expect("morph");
     let modifier;
-    if (this.match('over')) {
+    if (this.match("over")) {
       this.advance();
-      modifier = 'over';
+      modifier = "over";
     }
     const target = this.parseExpression();
-    if (this.match('with', 'to', 'into')) this.advance();
+    if (this.match("with", "to", "into")) this.advance();
     const content = this.parseExpression();
-    return { type: 'command', name: 'morph', args: [content], target, modifier };
+    return { type: "command", name: "morph", args: [content], target, modifier };
   }
-
-  // Body sliced from the raw source, never rebuilt from tokens — the tokenizer
-  // reads JS as hyperscript and mangles regexes and quotes. \`end\` inside a JS
-  // string is safe (one token, quotes included); a bare identifier \`end\` is not.
+  /**
+   * \`js[(<params>)] <raw JavaScript> end\`.
+   *
+   * The body is sliced from the ORIGINAL SOURCE between token offsets, never
+   * reassembled from tokens — the tokenizer reads it as hyperscript, which
+   * mangles regexes, template literals and possessive-looking quotes. This
+   * mirrors the full parser's \`parseJsCommand\`.
+   *
+   * Known limit: the terminator scan matches the \`end\` TOKEN, so \`end\` inside a
+   * JS *string* is safe (the tokenizer keeps a string as one token, quotes
+   * included) but a bare JS identifier named \`end\` would cut the body early.
+   * The full parser's \`findJsEndBoundary\` handles that; replicating it is not
+   * worth the bytes in a bundle this size.
+   */
   parseJs() {
     this.advance();
-    if (this.match('(')) {
-      while (!this.isAtEnd() && !this.match(')')) this.advance();
-      if (this.match(')')) this.advance();
+    if (this.match("(")) {
+      while (!this.isAtEnd() && !this.match(")")) this.advance();
+      if (this.match(")")) this.advance();
     }
     const start = this.peek().pos;
-    while (!this.isAtEnd() && !this.match('end')) this.advance();
+    while (!this.isAtEnd() && !this.match("end")) this.advance();
     const stop = this.peek().pos;
-    if (this.match('end')) this.advance();
-    return {
-      type: 'command',
-      name: 'js',
-      args: [{ type: 'literal', value: this.source.slice(start, stop).trim() }],
-    };
+    if (this.match("end")) this.advance();
+    const code = this.source.slice(start, stop).trim();
+    return { type: "command", name: "js", args: [{ type: "literal", value: code }] };
   }
-
+  /** \`throw <value>\` */
   parseThrow() {
-    this.expect('throw');
+    this.expect("throw");
     let value;
-    if (!this.isAtEnd() && !this.match('then', 'and', 'end', 'else')) {
+    if (!this.isAtEnd() && !this.match("then", "and", "end", "else")) {
       value = this.parseExpression();
     }
-    return { type: 'command', name: 'throw', args: value ? [value] : [] };
+    return { type: "command", name: "throw", args: value ? [value] : [] };
   }
-
+  /** \`break\` / \`continue\` / \`exit\` — bare control-flow signals, no arguments. */
   parseBare(name) {
     this.advance();
-    return { type: 'command', name, args: [] };
+    return { type: "command", name, args: [] };
   }
-
-  parseGo() {
-    this.expect('go');
-    if (this.match('to')) this.advance();
-    if (this.match('url')) this.advance();
-    const dest = this.parseExpression();
-    return { type: 'command', name: 'go', args: [dest] };
+  parseHalt() {
+    this.expect("halt");
+    if (this.match("the")) this.advance();
+    if (this.match("event", "default")) this.advance();
+    return { type: "command", name: "halt", args: [] };
   }
-
-  parseReturn() {
-    this.expect('return');
-    let value;
-    if (!this.isAtEnd() && !this.match('then', 'and', 'end', 'else')) {
-      value = this.parseExpression();
-    }
-    return { type: 'command', name: 'return', args: value ? [value] : [] };
-  }
-
+  // transition <property> to <value> [over <duration>]
   parseTransition() {
-    this.expect('transition');
+    this.expect("transition");
     let target;
-    if (this.match('my', 'its')) {
+    if (this.match("my", "its")) {
       const ref = this.advance().value;
-      target = { type: 'identifier', value: ref === 'my' ? 'me' : 'it' };
-    } else if (this.matchType('selector')) {
+      target = { type: "identifier", value: ref === "my" ? "me" : "it" };
+    } else if (this.matchType("selector")) {
       const expr = this.parseExpression();
-      if (expr.type === 'possessive') {
+      if (expr.type === "possessive") {
         return this.parseTransitionRest(expr.object, expr.property);
       }
       target = expr;
     }
-
     const propToken = this.peek();
     let property;
-    if (propToken.type === 'styleProperty') {
+    if (propToken.type === "styleProperty") {
       property = this.advance().value;
-    } else if (propToken.type === 'identifier' || propToken.type === 'keyword') {
+    } else if (propToken.type === "identifier" || propToken.type === "keyword") {
       property = this.advance().value;
     } else {
-      property = 'opacity';
+      property = "opacity";
     }
-
     return this.parseTransitionRest(target, property);
   }
-
   parseTransitionRest(target, property) {
-    let toValue = { type: 'literal', value: 1 };
-    if (this.match('to')) {
+    let toValue = { type: "literal", value: 1 };
+    if (this.match("to")) {
       this.advance();
       toValue = this.parseExpression();
     }
-    let duration = { type: 'literal', value: 300 };
-    if (this.match('over')) {
+    let duration = { type: "literal", value: 300 };
+    if (this.match("over")) {
       this.advance();
       duration = this.parseExpression();
     }
-    return { type: 'command', name: 'transition', args: [{ type: 'literal', value: property }, toValue, duration], target };
+    return {
+      type: "command",
+      name: "transition",
+      args: [{ type: "literal", value: property }, toValue, duration],
+      target
+    };
   }
-
-  parseExpression() { return this.parseOr(); }
-
+  // Expression parsing with operator precedence
+  parseExpression() {
+    return this.parseOr();
+  }
   parseOr() {
     let left = this.parseAnd();
-    while (this.match('or', '||')) {
+    while (this.match("or", "||")) {
       this.advance();
-      left = { type: 'binary', operator: 'or', left, right: this.parseAnd() };
+      left = { type: "binary", operator: "or", left, right: this.parseAnd() };
     }
     return left;
   }
-
   parseAnd() {
     let left = this.parseEquality();
-    while (this.match('and', '&&') && !this.isCommandKeyword(this.peek(1))) {
+    while (this.match("and", "&&") && !this.isCommandKeyword(this.peek(1))) {
       this.advance();
-      left = { type: 'binary', operator: 'and', left, right: this.parseEquality() };
+      left = { type: "binary", operator: "and", left, right: this.parseEquality() };
     }
     return left;
   }
-
+  /**
+   * Does this token start a command rather than continue an expression?
+   *
+   * Used in two places with different stakes: terminating an \`and\` chain
+   * (\`toggle .x and add .y\`), and refusing to read a command name as a
+   * possessive property (\`my show\`).
+   *
+   * This is a deliberate SUBSET of \`cmdMap\`'s keys, not a second copy of it —
+   * asserted as a subset in \`capability-emission.test.ts\` §4 so it cannot
+   * name something the parser does not dispatch. It is not the full set
+   * because several of the newer keys are ordinary English or JS words
+   * (\`copy\`, \`empty\`, \`push\`, \`replace\`, \`break\`) that appear as property
+   * names and operands; promoting them here would change expression parsing,
+   * which is a separate decision from command reachability. The cost is that
+   * \`… and break\` reads \`break\` as an operand; \`then\` is the canonical
+   * separator and is handled by \`parseCommandSequence\` directly.
+   */
   isCommandKeyword(token) {
-    const cmds = ['toggle', 'add', 'remove', 'set', 'put', 'log', 'send', 'wait', 'show', 'hide', 'increment', 'decrement', 'focus', 'blur', 'empty', 'go'];
+    const cmds = [
+      "toggle",
+      "add",
+      "remove",
+      "set",
+      "put",
+      "log",
+      "send",
+      "wait",
+      "show",
+      "hide",
+      "increment",
+      "decrement",
+      "focus",
+      "blur",
+      "go"
+    ];
     return cmds.includes(normalizeCommand(token.value));
   }
-
   parseEquality() {
     let left = this.parseComparison();
-    while (this.match('==', '!=', 'is', 'matches', 'contains', 'includes', 'has')) {
+    while (this.match("==", "!=", "is", "matches", "contains", "includes", "has")) {
       const op = this.advance().value;
-      if (op.toLowerCase() === 'is' && this.match('not')) {
+      if (op.toLowerCase() === "is" && this.match("not")) {
         this.advance();
-        left = { type: 'binary', operator: 'is not', left, right: this.parseComparison() };
+        left = { type: "binary", operator: "is not", left, right: this.parseComparison() };
       } else {
-        left = { type: 'binary', operator: op, left, right: this.parseComparison() };
+        left = { type: "binary", operator: op, left, right: this.parseComparison() };
       }
     }
     return left;
   }
-
   parseComparison() {
     let left = this.parseAdditive();
-    while (this.match('<', '>', '<=', '>=')) {
+    while (this.match("<", ">", "<=", ">=")) {
       const op = this.advance().value;
-      left = { type: 'binary', operator: op, left, right: this.parseAdditive() };
+      left = { type: "binary", operator: op, left, right: this.parseAdditive() };
     }
     return left;
   }
-
   parseAdditive() {
     let left = this.parseMultiplicative();
-    while (this.match('+', '-')) {
+    while (this.match("+", "-")) {
       const op = this.advance().value;
-      left = { type: 'binary', operator: op, left, right: this.parseMultiplicative() };
+      left = { type: "binary", operator: op, left, right: this.parseMultiplicative() };
     }
     return left;
   }
-
   parseMultiplicative() {
     let left = this.parseUnary();
-    while (this.match('*', '/', '%')) {
+    while (this.match("*", "/", "%")) {
       const op = this.advance().value;
-      left = { type: 'binary', operator: op, left, right: this.parseUnary() };
+      left = { type: "binary", operator: op, left, right: this.parseUnary() };
     }
     return left;
   }
-
   parseUnary() {
-    if (this.match('not', '!')) {
+    if (this.match("not", "!")) {
       this.advance();
-      return { type: 'unary', operator: 'not', operand: this.parseUnary() };
+      return { type: "unary", operator: "not", operand: this.parseUnary() };
     }
-    if (this.match('-') && this.peek(1).type === 'number') {
+    if (this.match("-") && this.peek(1).type === "number") {
       this.advance();
       const num = this.advance();
-      return { type: 'literal', value: -parseFloat(num.value) };
+      return { type: "literal", value: -parseFloat(num.value) };
     }
     return this.parsePostfix();
   }
-
   parsePostfix() {
     let left = this.parsePrimary();
     while (true) {
       if (this.match("'s")) {
         this.advance();
         const next = this.peek();
-        const prop = next.type === 'styleProperty' ? this.advance().value : this.advance().value;
-        left = { type: 'possessive', object: left, property: prop };
-      } else if (this.peek().type === 'styleProperty') {
+        const prop = next.type === "styleProperty" ? this.advance().value : this.advance().value;
+        left = { type: "possessive", object: left, property: prop };
+      } else if (this.peek().type === "styleProperty") {
         const prop = this.advance().value;
-        left = { type: 'possessive', object: left, property: prop };
-      } else if (this.peek().value === '.') {
+        left = { type: "possessive", object: left, property: prop };
+      } else if (this.peek().value === ".") {
         this.advance();
         const prop = this.advance().value;
-        left = { type: 'member', object: left, property: prop };
-      } else if (this.peek().type === 'selector' && this.peek().value.startsWith('.')) {
+        left = { type: "member", object: left, property: prop };
+      } else if (this.peek().type === "selector" && this.peek().value.startsWith(".")) {
         const prop = this.advance().value.slice(1);
-        left = { type: 'member', object: left, property: prop };
-      } else if (this.peek().value === '(') {
+        left = { type: "member", object: left, property: prop };
+      } else if (this.peek().value === "(") {
         this.advance();
         const args = [];
-        while (!this.match(')')) {
+        while (!this.match(")")) {
           args.push(this.parseExpression());
-          if (this.match(',')) this.advance();
+          if (this.match(",")) this.advance();
         }
-        this.expect(')');
-        left = { type: 'call', callee: left, args };
-      } else if (this.peek().value === '[' && left.type !== 'selector') {
+        this.expect(")");
+        left = { type: "call", callee: left, args };
+      } else if (this.peek().value === "[" && left.type !== "selector") {
         this.advance();
         const index = this.parseExpression();
-        this.expect(']');
-        left = { type: 'member', object: left, property: index, computed: true };
+        this.expect("]");
+        left = { type: "member", object: left, property: index, computed: true };
       } else {
         break;
       }
     }
     return left;
   }
-
   parsePrimary() {
     const token = this.peek();
-
-    if (token.value === '(') {
+    if (token.value === "(") {
       this.advance();
       const expr = this.parseExpression();
-      this.expect(')');
+      this.expect(")");
       return expr;
     }
-
-    if (token.value === '{') return this.parseObjectLiteral();
-    if (token.value === '[') return this.parseArrayLiteral();
-
-    if (token.type === 'number') {
+    if (token.value === "{") return this.parseObjectLiteral();
+    if (token.value === "[") return this.parseArrayLiteral();
+    if (token.type === "number") {
       this.advance();
       const val = token.value;
-      if (val.endsWith('ms')) return { type: 'literal', value: parseInt(val), unit: 'ms' };
-      if (val.endsWith('s')) return { type: 'literal', value: parseFloat(val) * 1000, unit: 'ms' };
-      return { type: 'literal', value: parseFloat(val) };
+      if (val.endsWith("ms")) return { type: "literal", value: parseInt(val), unit: "ms" };
+      if (val.endsWith("s")) return { type: "literal", value: parseFloat(val) * 1e3, unit: "ms" };
+      return { type: "literal", value: parseFloat(val) };
     }
-
-    if (token.type === 'string') {
+    if (token.type === "string") {
       this.advance();
-      return { type: 'literal', value: token.value.slice(1, -1) };
+      return { type: "literal", value: token.value.slice(1, -1) };
     }
-
-    if (this.match('true')) { this.advance(); return { type: 'literal', value: true }; }
-    if (this.match('false')) { this.advance(); return { type: 'literal', value: false }; }
-    if (this.match('null')) { this.advance(); return { type: 'literal', value: null }; }
-    if (this.match('undefined')) { this.advance(); return { type: 'literal', value: undefined }; }
-
-    if (token.type === 'localVar') {
+    if (this.match("true")) {
       this.advance();
-      return { type: 'variable', name: token.value, scope: 'local' };
+      return { type: "literal", value: true };
     }
-    if (token.type === 'globalVar') {
+    if (this.match("false")) {
       this.advance();
-      return { type: 'variable', name: token.value, scope: 'global' };
+      return { type: "literal", value: false };
     }
-    if (token.type === 'selector') {
+    if (this.match("null")) {
       this.advance();
-      return { type: 'selector', value: token.value };
+      return { type: "literal", value: null };
     }
-
-    if (this.match('my')) {
+    if (this.match("undefined")) {
+      this.advance();
+      return { type: "literal", value: void 0 };
+    }
+    if (token.type === "localVar") {
+      this.advance();
+      return { type: "variable", name: token.value, scope: "local" };
+    }
+    if (token.type === "globalVar") {
+      this.advance();
+      return { type: "variable", name: token.value, scope: "global" };
+    }
+    if (token.type === "selector") {
+      this.advance();
+      return { type: "selector", value: token.value };
+    }
+    if (this.match("my")) {
       this.advance();
       const next = this.peek();
-      if ((next.type === 'identifier' || next.type === 'keyword') && !this.isCommandKeyword(next)) {
+      if ((next.type === "identifier" || next.type === "keyword") && !this.isCommandKeyword(next)) {
         const prop = this.advance().value;
-        return { type: 'possessive', object: { type: 'identifier', value: 'me' }, property: prop };
+        return { type: "possessive", object: { type: "identifier", value: "me" }, property: prop };
       }
-      return { type: 'identifier', value: 'me' };
+      return { type: "identifier", value: "me" };
     }
-    if (this.match('its')) {
+    if (this.match("its")) {
       this.advance();
       const next = this.peek();
-      if ((next.type === 'identifier' || next.type === 'keyword') && !this.isCommandKeyword(next)) {
+      if ((next.type === "identifier" || next.type === "keyword") && !this.isCommandKeyword(next)) {
         const prop = this.advance().value;
-        return { type: 'possessive', object: { type: 'identifier', value: 'it' }, property: prop };
+        return { type: "possessive", object: { type: "identifier", value: "it" }, property: prop };
       }
-      return { type: 'identifier', value: 'it' };
+      return { type: "identifier", value: "it" };
     }
-    if (this.match('me')) { this.advance(); return { type: 'identifier', value: 'me' }; }
-    if (this.match('it')) { this.advance(); return { type: 'identifier', value: 'it' }; }
-    if (this.match('you')) { this.advance(); return { type: 'identifier', value: 'you' }; }
-
-    if (this.match('the', 'a', 'an')) {
+    if (this.match("me")) {
       this.advance();
-      if (this.match('first', 'last', 'next', 'previous', 'closest', 'parent')) {
+      return { type: "identifier", value: "me" };
+    }
+    if (this.match("it")) {
+      this.advance();
+      return { type: "identifier", value: "it" };
+    }
+    if (this.match("you")) {
+      this.advance();
+      return { type: "identifier", value: "you" };
+    }
+    if (this.match("the", "a", "an")) {
+      this.advance();
+      if (this.match("first", "last", "next", "previous", "closest", "parent")) {
         const position = this.advance().value;
         const target = this.parsePositionalTarget();
-        return { type: 'positional', position, target };
+        return { type: "positional", position, target };
       }
       return this.parsePrimary();
     }
-
-    if (this.match('first', 'last', 'next', 'previous', 'closest', 'parent')) {
+    if (this.match("first", "last", "next", "previous", "closest", "parent")) {
       const position = this.advance().value;
       const target = this.parsePositionalTarget();
-      return { type: 'positional', position, target };
+      return { type: "positional", position, target };
     }
-
-    if (token.type === 'identifier' || token.type === 'keyword') {
+    if (this.match("values")) {
       this.advance();
-      return { type: 'identifier', value: token.value };
+      if (this.match("of")) {
+        this.advance();
+        const target = this.parseExpression();
+        return { type: "valuesOf", target };
+      }
+      return { type: "identifier", value: token.value };
     }
-
+    if (token.type === "identifier" || token.type === "keyword") {
+      this.advance();
+      return { type: "identifier", value: token.value };
+    }
     this.advance();
-    return { type: 'identifier', value: token.value };
+    return { type: "identifier", value: token.value };
   }
-
   parseObjectLiteral() {
-    this.expect('{');
+    this.expect("{");
     const properties = [];
-    while (!this.match('}')) {
+    while (!this.match("}")) {
       const key = this.advance().value;
-      this.expect(':');
+      this.expect(":");
       const value = this.parseExpression();
       properties.push({ key, value });
-      if (this.match(',')) this.advance();
+      if (this.match(",")) this.advance();
     }
-    this.expect('}');
-    return { type: 'object', properties };
+    this.expect("}");
+    return { type: "object", properties };
   }
-
   parseArrayLiteral() {
-    this.expect('[');
+    this.expect("[");
     const elements = [];
-    while (!this.match(']')) {
+    while (!this.match("]")) {
       elements.push(this.parseExpression());
-      if (this.match(',')) this.advance();
+      if (this.match(",")) this.advance();
     }
-    this.expect(']');
-    return { type: 'array', elements };
+    this.expect("]");
+    return { type: "array", elements };
   }
-
   parsePositionalTarget() {
     const token = this.peek();
-    if (token.type === 'selector') {
-      return { type: 'selector', value: this.advance().value };
+    if (token.type === "selector") {
+      return { type: "selector", value: this.advance().value };
     }
-    if (token.type === 'identifier' || token.type === 'keyword') {
-      return { type: 'identifier', value: this.advance().value };
+    if (token.type === "identifier" || token.type === "keyword") {
+      return { type: "identifier", value: this.advance().value };
     }
     return this.parseExpression();
   }
 }
+// #endregion generated:hybrid-parser
 `;
 
 // =============================================================================


### PR DESCRIPTION
Arc E's final step. `HYBRID_PARSER_TEMPLATE` — the ~1000-line hand-maintained JS twin of the hybrid parser that every vite-plugin bundle embeds — is now generated from the real modules (`parser/hybrid/{aliases,tokenizer,parser-core}.ts`) by the same `scripts/generate-bundles.ts` that generates the executor cores (#835), behind the same `generate:bundles:check` drift guard in CI's generated-artifacts step. **This was the arc's last hand copy.**

## The hand copy was BEHIND the real parser on five capabilities

Measured before generating (comment-stripped, prettier-canonicalized diff; 937 raw diff lines reduced to this semantic residue):

| divergence | direction | consequence in vite-embedded bundles |
| --- | --- | --- |
| `@attr` selector tokenization | real only | `toggle @disabled` mis-tokenized |
| `'s` possessive operator | real only | `#t's title` unparseable |
| fetch `via`/`with`/`{options}`/`as a[n]` | real only | `fetch /x via POST` unparseable — the embedded **executor** (step 2's absorbed templates) could run what its own **parser** could not produce |
| `values of` (`valuesOf` node) | real only | unparseable |
| KEYWORDS `halt` `via` `values` `default` `event` | real only | classification drift |
| KEYWORDS `empty` | template only | a hand-fix the real tokenizer never needed |
| `addCommandAliases`/`addEventAliases` | real only | no alias-registration API |

The cmdMaps were **identical** — Oracle 2 held — which is precisely the trap: every list gate compares cmdMap keys, and none of these capabilities lives in a cmdMap. Step 4 found the same blindness in the other direction (`waitFor`).

## Nothing executed the embedded template, anywhere

Its total behavioral coverage was three probes in `parser-template-drift.test.ts`; the vite-plugin's own tests stop at `new Function(code)` — construction without a call, i.e. syntax. The closure is an **AST-equivalence suite**: the committed template and the live `HybridParser` must produce deep-equal trees over a 16-source corpus including every gained capability and two escaping canaries (backtick + `${` inside string literals, backslash-heavy regexes — the characters the template-literal embedding must escape; a wrong escape corrupts exactly these and nothing else notices). The drift test went 5 → 20 tests.

**Mutation-verified in three directions:** a crippled `@attr` branch in the committed template fails exactly its corpus row; a broken `\${` escape fails the whole module loudly at import; a real change to `aliases.ts` without regeneration fails `--check`. (A comment-only probe does NOT — esbuild drops trailing standalone comments — so the mutation had to be real, S3-b's lesson recurring.)

## The transform is esbuild at es2020, not a regex stripper

S2-c measured the regex `stripTypes` emitting invalid JS for 6 of 40 command templates; it was not trusted with a whole parser. esbuild (`loader: 'ts'`, `target: 'es2020'`) is a real TS front-end; es2020 matches the runtime promise core's tsconfig makes (the promise that decided #834), so parser-core's class fields lower through esbuild's inlined helpers instead of shipping ES2022 syntax. Oracle 2's regex needed one shape update for the lowered `__publicField` form — and its "found nothing" guard fired loudly when the shape changed rather than passing on empty.

## Both oracles retired INTO the generator, per the brief — transformed, neither deleted

- **Oracle 2** (capability-emission §4, cmdMap equality) now holds by construction; it stays as the cheap source-text belt for a stale commit — `generate:bundles:check` fails that in lint-typecheck, §4 in unit-tests, the AST suite wherever drift is behavioral. Different jobs; one survivor still catches it.
- **`parser-template-drift.test.ts`** re-headed as the generated artifact's behavioral gate, probes intact, corpus added.

## Size: zero shipped-bundle movement — the arc's only step with no size carry

`snapshot --check`: **all bundles +0.0%** (no shipped browser bundle embeds the template; core's `generateBundleCode` emits an import instead). Vite-embedded bundles grow: template 6410 → 8443 gz raw-with-comments, of which the **post-minification code delta is +522 gz** — consumer builds strip parser-core's comments; the committed artifact keeps them for reviewability. No `MAX_HYBRID`, `baseline.json`, or `metadata.ts` movement.

## What stays hand-maintained, stated

`LITE_PARSER_TEMPLATE` and the lite-family regex parsers — deliberately. They have no canonical module twin: each is its own tier simplification, not a copy of one source. Scoped out exactly as the brief's premise-correction scoped them.

## Also in this PR

- Parks the tier-appropriate mini-morph consideration (brief § Adjacent) with its measured survey: morphlex 2057 gz marginal / idiomorph **larger** standalone (3350 vs 3181, ruled out) / paxi's `mx` ~30 lines 0BSD (~1.5 KB reclaimable, build-first if picked up).
- Brief § "Step 5 — CLOSED", arc status → CLOSED; roadmap Arc E entry updated; CLAUDE.md "Adding a New Command" step 5 no longer tells anyone to hand-edit `parser-templates.ts`.

## Verification

| gate | result |
| --- | --- |
| core `test:quick` | **7702 / 106 / 300** (+15 = the new drift rows exactly) |
| vite-plugin (consumes the template via core dist) | 319 / 319 |
| capability-emission | 14 / 14 |
| parser-template-drift | 20 / 20 (was 5) |
| Playwright `src/compatibility/` | 1102 / 8 / 10 — known-local set |
| `typecheck`, `typecheck:scripts`, oxlint | pass |
| `verify:reference`, `docs:commands:check` | pass |
| `generate:bundles:check` | idempotent under pinned prettier |
| `snapshot:bundle-size --check` | all within tolerance, +0.0% everywhere |

🤖 Generated with [Claude Code](https://claude.com/claude-code)