### PR TITLE
fix(mcp-server): fold non-numeric `ExecException.code`, unblocking the majors bump

### DIFF
--- a/packages/mcp-server/src/tools/grail-registry.ts
+++ b/packages/mcp-server/src/tools/grail-registry.ts
@@ -56,7 +56,11 @@ function execShell(
       const duration_ms = Date.now() - start;
       const output = truncate((stdout ?? '') + (stderr ?? '')).trim();
       const timedOut = !!(error && 'killed' in error && error.killed);
-      const exitCode = error ? (error.code ?? 1) : 0;
+      // `ExecException.code` is `string | number` under @types/node 26 (spawn
+      // failures carry string codes like 'ENOENT'; only process exits carry
+      // numbers). This result's contract is a numeric exit code, so non-numeric
+      // codes fold into the generic failure value alongside `code: undefined`.
+      const exitCode = error ? (typeof error.code === 'number' ? error.code : 1) : 0;
       resolve({
         exitCode,
         output: timedOut ? `Timed out after ${timeout}s` : output,


### PR DESCRIPTION
Second compat fix for Dependabot #773 (the first was #834's `.at()` removal). After that rebase, the majors group is down to **one** typecheck error:

```
packages/mcp-server/src/tools/grail-registry.ts(61,9): error TS2322:
Type 'string | number' is not assignable to type 'number'.
```

## Cause

`@types/node` 26 widens `ExecException.code` to `string | number` — spawn failures carry string codes like `'ENOENT'`; only process exits carry numbers. `error.code ?? 1` therefore stopped satisfying the result's `exitCode: number` contract.

## Fix

`typeof error.code === 'number' ? error.code : 1` — numeric codes pass through unchanged; a string code folds into the same generic `1` that `undefined` already did. Strictly an improvement at runtime: previously a string code would have leaked into a field typed (and consumed) as a number.

## Verification

- `npm run typecheck --prefix packages/mcp-server` — exit 0 under the **current** @types/node (the fix is compatible with both sides of the bump)
- mcp-server tests: 428 / 428

## Sequencing

Same as #834: land on main (Dependabot rebases drop foreign commits), then `@dependabot rebase` on #773 and triage whatever CI reports next — the group still carries jsdom 26→30, zod 3→4, express 4→5, better-sqlite3 13 and lint-staged 17, untested past typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)