### PR TITLE
fix(semantic): scroll destination becomes an arg; default's target survives (Arc F step 4)

### DIFF
--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -472,29 +472,49 @@ not the core abstractions.
 
 ## Open, filed rather than folded in
 
-- **Arc F step 4 — the last two fallback-action mappings, now precisely
-  specified.** Arc F migrated 43 of 47 mappers to schema `ast` descriptors; the
-  24 actions with no mapper still fall through to `buildGenericCommand`'s
-  blanket mapping (`destination`→`on`, `duration`→`for`, `source`→args,
-  `method`→`via`, `style`→`with`, and `condition`/`event`/`goal` in NEITHER list
-  so they are dropped). Measured against each true-fallback schema's own English
-  markers, **12 of 14 are already correct and only two are wrong** — the arc's
-  brief had guessed this would be its structural win, and it is not.
-  Both were then checked against what the runtime command actually READS, which
-  changed one of the two fixes:
-  - **`open`** — the schema marks `style` as `as`, the blanket mapping emits
-    `with`, and `commands/dom/open.ts:55` reads `modifiers.as`. So `open … as
-    dialog` silently loses its variant today. Fix: `ast: { args: ['patient'],
-    modifiers: { as: 'style' } }`. One line, verified against the runtime.
-  - **`scroll`** — flagged as `destination` emitting `on` where the marker is
-    `to`, but `commands/navigation/scroll-to.ts` `parseInput` reads **only
-    `raw.args`** and never looks at modifiers. So re-keying the modifier fixes
-    nothing: the destination has to become an ARG. Needs care with the position
-    tokens (`top`/`bottom`/`smoothly`) the schema lists in `argSkipTokens`.
-  Behavior change either way, so it wants its own PR with ratchet evidence
-  (`scroll` appears in the corpus as `window-scroll`, `open` as `modal-open`).
-  Caveat on the measurement: it only inspects roles a schema DECLARES, so a
-  role the parser relabels in could still be mishandled and not appear here.
+- **~~Arc F step 4~~ — `scroll` and `default` LANDED; `open` deferred with a
+  measured reason.** Arc F migrated 43 of 47 mappers to schema `ast`
+  descriptors; the 24 actions with no mapper still fall through to
+  `buildGenericCommand`'s blanket mapping (`destination`→`on`, `duration`→`for`,
+  `source`→args, `method`→`via`, `style`→`with`, and `condition`/`event`/`goal`
+  in NEITHER list so they are dropped). Measured against each true-fallback
+  schema's own English markers, **12 of 14 are already correct and only two are
+  wrong** — the arc's brief had guessed this would be its structural win, and it
+  is not.
+  - **`scroll` — DONE.** `commands/navigation/scroll-to.ts` `parseInput` reads
+    **only `raw.args`** and throws when it is empty, so the destination had to
+    become an ARG (re-keying the modifier `on`→`to` would have fixed nothing).
+    Shipped as `ast: { args: ['destination'] }`.
+  - **`default` — DONE.** Not on the step-4 list at all (it already had a
+    descriptor); it was the `default.to` `drift` exemption. Inverted to
+    `ast: { args: ['destination'], modifiers: { to: 'patient' } }`, matching
+    DefaultCommand's `args[0]`-is-target / `modifiers.to`-is-value contract, and
+    the exemption was pruned.
+  - **`open` — DEFERRED, and the one-line fix in this entry was wrong.** The
+    proposed `ast: { args: ['patient'], modifiers: { as: 'style' } }` is
+    **inert**: no en pattern binds `style` for the documented surface. Measured
+    2026-07-31 — `openSchema` gives `style` `svoPosition: 1` and `patient` `2`,
+    so the generated en pattern is `open [as {style}] [{patient}]` and only the
+    un-English `open as modal #dlg` binds the role; `open #dlg as non-modal`
+    (OpenCommand's own documented example) parses to `patient` alone, and
+    `translate(…, 'en', 'ja')` drops the variant from the rendered output too.
+    Making it live needs (a) the two positions swapped so the marker follows the
+    target — a 24-language pattern-shape change, so ratchet evidence — and
+    (b) the captured value to survive: `non-modal` tokenizes to the *expression*
+    `non - modal`, which `convertValue` routes through the expression parser
+    into a subtraction node, where `open.ts`'s `normalized === 'non-modal'`
+    string compare can never match. (a) without (b) turns a silent default into
+    a wrong value. **No corpus row exercises the `open` command**, so the
+    ratchet cannot be the evidence here — vitest behavior tests must be.
+  Caveat on the original measurement, now demonstrated rather than hypothetical:
+  it only inspects roles a schema DECLARES, and says nothing about whether the
+  parser ever BINDS them.
+  **Correction to this entry's own evidence claim:** it named `window-scroll`
+  and `modal-open` as the corpus rows for `scroll`/`open`. Neither is: they are
+  `on scroll from window …` (an event) and `… add .modal-open to body` (a class
+  name). The rows that do exercise these commands are `last-in-collection`
+  (`scroll to last <.message/> in #chat`), `default-value` (`default my
+  @data-count to "0"`), and `swap-content` (`swap #a with #b`).
 
 
 - **Core's `semantic-integration.ts` switch is a SECOND semantic→AST
@@ -507,22 +527,60 @@ not the core abstractions.
   `manner`, so the positional put becomes an INTO plus a `manner` modifier
   `PutCommand` does not read. Same for `after` and `at end of`; plain `into`
   agrees.
-  **Currently latent, and that is the point.** `put` sits in `parser.ts`'s
-  `skipSemanticParsing` list (`:3467`), so the live English path never reaches
-  the switch; and the canonical non-English renderings of a positional put come
-  back without the `manner` role at all (`translate('put "x" before #out',
-  'en', ko|ja|es|de)` renders a plain put-into), so they do not reach it either.
-  Nothing user-visible is broken today — the only thing preventing it is a
-  hand-maintained skip list of command names. That is precisely this queue's
-  thesis in miniature: a duplicated implementation, silently diverged, held
-  safe by a list nothing compares to the code.
+  **Latent FOR `put` ONLY — NOT latent in general (upgraded 2026-07-31).** The
+  original framing generalized from the one command it measured. `put` does sit
+  in `parser.ts`'s `skipSemanticParsing` list (`:3461-3487`), so the live
+  English path never reaches the switch for `put`; the canonical non-English
+  renderings of a positional put also come back without the `manner` role
+  (`translate('put "x" before #out', 'en', ko|ja|es|de)` renders a plain
+  put-into), so they do not reach it either. But the list holds only 24 command
+  names, and **`default` and `scroll` are not among them** — so for those the
+  switch IS the live English path, and it is the blanket
+  `destination`→`modifiers.on` mapping (`:378-393`) that runs, not
+  `buildGenericCommand` and not the schema descriptor.
+  Measured end-to-end through `hyperscript.eval` in jsdom, on `main` at
+  `a9025a36`:
+
+  | source (plain English) | default path | `{ traditional: true }` |
+  | ---------------------- | ------------ | ----------------------- |
+  | `scroll to #header` | throws `scroll command requires a target` | works |
+  | `scroll to last <.message/> in #chat` (corpus row) | throws | works |
+  | `default :x to 0` | throws `default command requires a value` | throws `Invalid target type: undefined` |
+  | `default my @data-count to "0"` (corpus row) | throws | throws `Invalid target type: object` |
+  | `open #dlg as non-modal` | opens **modal** (variant lost) | opens modal |
+
+  So the queue's thesis holds harder than the entry claimed: a duplicated
+  implementation, silently diverged, held safe by a hand-maintained list — and
+  for two commands the list does not in fact hold it safe.
+  **Consequence for the descriptor work:** the `scroll`/`default` descriptor fix
+  landed on `buildAST`, which is the semantic-bundle/multilingual path. It does
+  **not** reach `hyperscript.eval`'s English path, because that path is this
+  switch. Option (b) — core delegates to `buildAST` — is therefore no longer
+  merely a dedupe: it is what makes those fixes reach users, and it promotes
+  this item from cleanup to the highest-value follow-up. (a) is a
+  re-divergence by construction; (c) is refuted for `default`/`scroll`.
   Not folded into Arc F: Arc F's gates are semantic-stack, while this is a
-  core-side behavior fix dragging the full core gate set. Fix options are
-  (a) teach the switch to read `manner`, (b) have core delegate to semantic's
-  `buildAST`, or (c) delete the switch if the skip list makes it unreachable
-  for every command it mis-handles — (c) needs the reachability measured per
-  command, not assumed. Detail:
+  core-side behavior fix dragging the full core gate set. Detail:
   [HANDOFF-command-arch-mappers.md](./HANDOFF-command-arch-mappers.md) § fact 2.
+
+- **`DefaultCommand` EVALUATES its target, so `default` is broken on both
+  execution paths.** Independent of the AST-shape defect above, and not fixed by
+  it. `commands/data/default.ts` `parseInput` does `target = await
+  evaluator.evaluate(raw.args[0])` and then `execute` branches on
+  `typeof target === 'string'` — but the target is a *name*, not a value, and
+  evaluating an unset variable yields `undefined` (exactly the case `default`
+  exists to handle). Measured against DefaultCommand's own documented examples,
+  traditional path: `default myVar to "fallback"` → `Invalid target type:
+  undefined`; `default @data-theme to "light"` → `Invalid target type: object`;
+  `set myVar2 to 1 then default myVar2 to 9` → `Invalid target type: number`.
+  Only `default my innerHTML to "No content"` works, and only because the
+  possessive path happens to round-trip through a string.
+  `SetCommand` shows the correct shape: it resolves the target **symbolically
+  from the raw AST node** (`firstArg.name`, then `resolveWriteTarget`) and never
+  evaluates it. The existing unit tests miss all of this because they inject a
+  mock evaluator that returns `node.value ?? node.name` — i.e. the very
+  name-preserving behavior the real evaluator does not have. Any fix should land
+  with an end-to-end test through `hyperscript.eval`, not a mocked one.
 
 - **`swap`'s AST builder reads roles its schema never binds.** The builder
   consumes `source`/`style` and emits `on` for destination; `swapSchema`

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -2545,8 +2545,11 @@ export const defaultSchema: CommandSchema = {
   description: 'Set a default value for a variable',
   category: 'variable',
   primaryRole: 'destination',
-  // `default :x to 0` → args [:x], modifiers { to: 0 }.
-  ast: { args: ['patient'], modifiers: { to: 'source' } },
+  // `default :x to 0` → args [:x], modifiers { to: 0 }. Same arg/modifier
+  // inversion as `set`: DefaultCommand's parseInput reads the target from
+  // `args[0]` and the value from `modifiers.to`, while the parser binds the
+  // variable to `destination` and the value to `patient`.
+  ast: { args: ['destination'], modifiers: { to: 'patient' } },
   roles: [
     {
       role: 'destination',
@@ -3050,6 +3053,12 @@ export const scrollSchema: CommandSchema = {
   description: 'Scroll the viewport to a target element',
   category: 'navigation',
   primaryRole: 'destination',
+  // ScrollCommand's parseInput reads ONLY `raw.args` (`parsePosition` and
+  // `resolveTarget` both walk that list) and throws when it is empty, so the
+  // destination has to be an ARG. The blanket fallback mapping emitted
+  // `modifiers.on`, which the command never consults — `scroll to #header`
+  // failed with 'scroll command requires a target'.
+  ast: { args: ['destination'] },
   // Position/behavior keywords appear in the parser's args alongside the target;
   // schema-driven role inference skips them when scanning for the destination.
   // Mirrors the runtime command's skip set in core/commands/navigation/scroll-to.ts.

--- a/packages/semantic/test/ast-shape-consistency.test.ts
+++ b/packages/semantic/test/ast-shape-consistency.test.ts
@@ -70,14 +70,10 @@ const EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: string }> = {
       'sendSchema role — `send evt(x:1) to #t` binds the whole call to `event`, so this ' +
       'modifier is inert today',
   },
-  'default.to': {
-    kind: 'drift',
-    reason:
-      'LIVE BUG preserved verbatim: the builder reads patient→args and source→`to`, but the ' +
-      'parser binds destination=":x" and patient=0, so `default :x to 0` builds ' +
-      '{ name: "default", args: [0] } — the variable is DROPPED and `source` is never bound. ' +
-      'The fix is a behavior change and gets its own PR',
-  },
+  // NOTE: `default.to` was a `drift` entry here until the descriptor was
+  // inverted to `args: ['destination'], modifiers: { to: 'patient' }`. The key
+  // now matches patient's `markerOverride.en` ('to'), so the gate rejects the
+  // exemption — which is the mechanism working as designed.
   'fetch.body': {
     kind: 'contract',
     reason: 'FetchCommand reads the request body from `body`; patient has no en marker',
@@ -180,6 +176,6 @@ describe('schema ast descriptors agree with the English marker data', () => {
       .filter(([, v]) => v.kind === 'drift')
       .map(([k]) => k)
       .sort();
-    expect(drift).toEqual(['default.to', 'swap.on', 'swap.with']);
+    expect(drift).toEqual(['swap.on', 'swap.with']);
   });
 });

--- a/packages/semantic/test/descriptor-runtime-contract.test.ts
+++ b/packages/semantic/test/descriptor-runtime-contract.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Descriptor-vs-runtime contract tests (Arc F follow-up).
+ *
+ * The `ast-shape-consistency` gate asks whether a descriptor's modifier KEYS
+ * agree with the schema's English markers. That is a necessary check and not a
+ * sufficient one: a descriptor can name perfectly consistent keys and still
+ * hand the runtime command an AST it cannot read, because the marker data says
+ * nothing about which slot — arg or modifier — the command consumes.
+ *
+ * These tests close that gap for the commands where the two disagreed, by
+ * asserting the built AST against what the core command's `parseInput`
+ * actually reads. The contract each one pins is quoted from the runtime.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse } from '../src/index';
+import { buildAST } from '../src/ast-builder/index';
+import type { CommandSemanticNode } from '../src/types';
+
+/** Parse English source and return the built command node (unwrapping warnings). */
+function astOf(source: string): Record<string, any> {
+  const node = parse(source, 'en') as CommandSemanticNode | null;
+  expect(node, `'${source}' did not parse`).not.toBeNull();
+  const built = buildAST(node!) as unknown as Record<string, any>;
+  return (built.ast ?? built) as Record<string, any>;
+}
+
+describe('default — the target variable must survive into args[0]', () => {
+  // packages/core/src/commands/data/default.ts parseInput:
+  //   target = evaluate(raw.args[0])
+  //   value  = evaluate(raw.modifiers.to)  (falling back to raw.args[1])
+  // The semantic parse binds destination=':x', patient=0 — so a descriptor
+  // reading patient→args and source→`to` drops the variable entirely.
+
+  it('builds `default :x to 0` as args:[:x] + modifiers.to = 0', () => {
+    const ast = astOf('default :x to 0');
+
+    expect(ast.name).toBe('default');
+    expect(ast.args).toHaveLength(1);
+    expect(ast.args[0]).toMatchObject({ type: 'contextReference', name: ':x' });
+    expect(ast.modifiers?.to).toMatchObject({ type: 'literal', value: 0 });
+  });
+
+  it('builds the corpus form `default my @data-count to "0"` the same way', () => {
+    const ast = astOf('default my @data-count to "0"');
+
+    expect(ast.args).toHaveLength(1);
+    expect(ast.args[0]).toMatchObject({ type: 'propertyAccess', property: '@data-count' });
+    expect(ast.modifiers?.to).toMatchObject({ type: 'literal', value: '0' });
+  });
+
+  it('never leaves the value as the only positional arg', () => {
+    // The pre-fix shape was exactly `{ name: 'default', args: [0] }`. Assert
+    // the failure mode directly so a regression names itself.
+    const ast = astOf('default :x to 0');
+    expect(ast.args[0]).not.toMatchObject({ type: 'literal', value: 0 });
+  });
+});
+
+describe('scroll — the destination must be an ARG, not a modifier', () => {
+  // packages/core/src/commands/navigation/scroll-to.ts parseInput reads ONLY
+  // `raw.args` and throws 'scroll command requires a target' when it is empty;
+  // `resolveTarget`/`parsePosition` then walk that same arg list. A destination
+  // delivered as a modifier is invisible to the command on every path.
+
+  it('builds `scroll to #header` with the target in args', () => {
+    const ast = astOf('scroll to #header');
+
+    expect(ast.name).toBe('scroll');
+    expect(ast.args).toHaveLength(1);
+    expect(ast.args[0]).toMatchObject({ type: 'selector', value: '#header' });
+    expect(ast.modifiers).toBeUndefined();
+  });
+
+  it('builds the corpus form `scroll to last <.message/> in #chat` with the target in args', () => {
+    const ast = astOf('scroll to last <.message/> in #chat');
+
+    expect(ast.args).toHaveLength(1);
+    expect(ast.args[0]).toMatchObject({ type: 'binaryExpression', operator: 'in' });
+    expect(ast.modifiers).toBeUndefined();
+  });
+
+  it('leaves no `on` modifier for ScrollCommand to ignore', () => {
+    const ast = astOf('scroll to #header');
+    expect(ast.modifiers?.on).toBeUndefined();
+  });
+});

--- a/packages/semantic/test/fixtures/mapper-parity.json
+++ b/packages/semantic/test/fixtures/mapper-parity.json
@@ -1668,7 +1668,7 @@
       ]
     },
     "default": {
-      "roles": ["patient", "source"],
+      "roles": ["patient", "destination"],
       "cases": [
         {
           "name": "no-roles",
@@ -1687,9 +1687,9 @@
               "value": ".patient-v",
               "selectorKind": "class"
             },
-            "source": {
+            "destination": {
               "type": "selector",
-              "value": "#source-v",
+              "value": "#destination-v",
               "selectorKind": "id"
             }
           },
@@ -1699,17 +1699,17 @@
             "args": [
               {
                 "type": "selector",
-                "value": ".patient-v",
-                "selector": ".patient-v",
-                "selectorType": "class"
+                "value": "#destination-v",
+                "selector": "#destination-v",
+                "selectorType": "id"
               }
             ],
             "modifiers": {
               "to": {
                 "type": "selector",
-                "value": "#source-v",
-                "selector": "#source-v",
-                "selectorType": "id"
+                "value": ".patient-v",
+                "selector": ".patient-v",
+                "selectorType": "class"
               }
             }
           }
@@ -1726,64 +1726,63 @@
           "ast": {
             "type": "command",
             "name": "default",
-            "args": [
-              {
+            "args": [],
+            "modifiers": {
+              "to": {
                 "type": "selector",
                 "value": ".patient-v",
                 "selector": ".patient-v",
                 "selectorType": "class"
               }
-            ]
+            }
           }
         },
         {
           "name": "without-patient",
           "roles": {
-            "source": {
+            "destination": {
               "type": "selector",
-              "value": "#source-v",
+              "value": "#destination-v",
               "selectorKind": "id"
             }
           },
           "ast": {
             "type": "command",
             "name": "default",
-            "args": [],
-            "modifiers": {
-              "to": {
+            "args": [
+              {
                 "type": "selector",
-                "value": "#source-v",
-                "selector": "#source-v",
+                "value": "#destination-v",
+                "selector": "#destination-v",
                 "selectorType": "id"
               }
-            }
+            ]
           }
         },
         {
-          "name": "only-source",
+          "name": "only-destination",
           "roles": {
-            "source": {
+            "destination": {
               "type": "selector",
-              "value": "#source-v",
+              "value": "#destination-v",
               "selectorKind": "id"
             }
           },
           "ast": {
             "type": "command",
             "name": "default",
-            "args": [],
-            "modifiers": {
-              "to": {
+            "args": [
+              {
                 "type": "selector",
-                "value": "#source-v",
-                "selector": "#source-v",
+                "value": "#destination-v",
+                "selector": "#destination-v",
                 "selectorType": "id"
               }
-            }
+            ]
           }
         },
         {
-          "name": "without-source",
+          "name": "without-destination",
           "roles": {
             "patient": {
               "type": "selector",
@@ -1794,14 +1793,15 @@
           "ast": {
             "type": "command",
             "name": "default",
-            "args": [
-              {
+            "args": [],
+            "modifiers": {
+              "to": {
                 "type": "selector",
                 "value": ".patient-v",
                 "selector": ".patient-v",
                 "selectorType": "class"
               }
-            ]
+            }
           }
         },
         {
@@ -1870,17 +1870,17 @@
             "args": [
               {
                 "type": "selector",
-                "value": ".patient-v",
-                "selector": ".patient-v",
-                "selectorType": "class"
+                "value": "#destination-v",
+                "selector": "#destination-v",
+                "selectorType": "id"
               }
             ],
             "modifiers": {
               "to": {
                 "type": "selector",
-                "value": "#source-v",
-                "selector": "#source-v",
-                "selectorType": "id"
+                "value": ".patient-v",
+                "selector": ".patient-v",
+                "selectorType": "class"
               }
             }
           }
@@ -7059,6 +7059,137 @@
                 "value": ".patient-v",
                 "selector": ".patient-v",
                 "selectorType": "class"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "scroll": {
+      "roles": ["destination"],
+      "cases": [
+        {
+          "name": "no-roles",
+          "roles": {},
+          "ast": {
+            "type": "command",
+            "name": "scroll",
+            "args": []
+          }
+        },
+        {
+          "name": "all-relevant",
+          "roles": {
+            "destination": {
+              "type": "selector",
+              "value": "#destination-v",
+              "selectorKind": "id"
+            }
+          },
+          "ast": {
+            "type": "command",
+            "name": "scroll",
+            "args": [
+              {
+                "type": "selector",
+                "value": "#destination-v",
+                "selector": "#destination-v",
+                "selectorType": "id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "only-destination",
+          "roles": {
+            "destination": {
+              "type": "selector",
+              "value": "#destination-v",
+              "selectorKind": "id"
+            }
+          },
+          "ast": {
+            "type": "command",
+            "name": "scroll",
+            "args": [
+              {
+                "type": "selector",
+                "value": "#destination-v",
+                "selector": "#destination-v",
+                "selectorType": "id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "all-probe-roles",
+          "roles": {
+            "patient": {
+              "type": "selector",
+              "value": ".patient-v",
+              "selectorKind": "class"
+            },
+            "destination": {
+              "type": "selector",
+              "value": "#destination-v",
+              "selectorKind": "id"
+            },
+            "source": {
+              "type": "selector",
+              "value": "#source-v",
+              "selectorKind": "id"
+            },
+            "scope": {
+              "type": "selector",
+              "value": "#scope-v",
+              "selectorKind": "id"
+            },
+            "event": {
+              "type": "literal",
+              "value": "event-v"
+            },
+            "condition": {
+              "type": "literal",
+              "value": "condition-v"
+            },
+            "duration": {
+              "type": "literal",
+              "value": "duration-v"
+            },
+            "quantity": {
+              "type": "literal",
+              "value": "quantity-v"
+            },
+            "style": {
+              "type": "literal",
+              "value": "style-v"
+            },
+            "method": {
+              "type": "literal",
+              "value": "method-v"
+            },
+            "manner": {
+              "type": "literal",
+              "value": "manner-v"
+            },
+            "responseType": {
+              "type": "literal",
+              "value": "responseType-v"
+            },
+            "goal": {
+              "type": "literal",
+              "value": "goal-v"
+            }
+          },
+          "ast": {
+            "type": "command",
+            "name": "scroll",
+            "args": [
+              {
+                "type": "selector",
+                "value": "#destination-v",
+                "selector": "#destination-v",
+                "selectorType": "id"
               }
             ]
           }

--- a/packages/semantic/test/mapper-parity.test.ts
+++ b/packages/semantic/test/mapper-parity.test.ts
@@ -46,7 +46,7 @@ const ALWAYS_HAND_WRITTEN = ['go', 'pick', 'put', 'wait'];
  * red test go green. It exists so an accidental un-migration (a descriptor
  * deleted, a mapper re-registered) fails loudly even though parity still holds.
  */
-const EXPECTED_MIGRATED = 43;
+const EXPECTED_MIGRATED = 44;
 
 function emit(action: ActionType, roles: Record<string, SemanticValue>): unknown {
   const mapper = resolveCommandMapper(action);


### PR DESCRIPTION
Arc F follow-ups, Phase 1. Two schema `ast` descriptor fixes, both derived from what the core command's `parseInput` actually **reads** — not from the schema's marker data alone.

## The fixes

**`scroll`** — `commands/navigation/scroll-to.ts` `parseInput` reads only `raw.args` and throws when it is empty; `parsePosition`/`resolveTarget` walk that same list. Modifiers are never consulted. `scroll` had no descriptor at all, so `buildGenericCommand`'s blanket mapping emitted `modifiers.on` and the command saw no target. Now `ast: { args: ['destination'] }`.

**`default`** — the parser binds `destination=':x'`, `patient=0` for `default :x to 0`, while the descriptor read `patient`→args and `source`→`to`. `source` is never bound, so the built AST was `{ name: 'default', args: [0] }`: variable dropped, value in the target's slot. Now the same arg/modifier inversion `set` uses, matching DefaultCommand's `args[0]`-is-target / `modifiers.to`-is-value contract.

## Gate consequences (each was forced by the gate, not chosen)

- **`default.to` drift exemption is stale** — the key now matches patient's `markerOverride.en`. Deleted; drift-list assertion drops to `['swap.on', 'swap.with']`.
- **Parity fixture regenerated** — intentional AST change. 47→48 actions, 332→336 cases. The diff is confined to exactly two blocks:

  | action | change |
  | ------ | ------ |
  | `default` | measured sensitivity `[patient, source]` → `[patient, destination]`; args/modifier contents swap in every case |
  | `scroll` | new block (4 cases) |

  No other action's recorded AST changed.
- **`EXPECTED_MIGRATED` 43 → 44** — `scroll` gains a descriptor.

## New test

`test/descriptor-runtime-contract.test.ts` pins both against the runtime contract, quoting it in comments. Written first, watched fail: all 6 cases failed before the descriptor change.

## Verification

| gate | result |
| ---- | ------ |
| `npm run typecheck --prefix packages/semantic` | clean |
| semantic suite | 7221 passed, 10 skipped (108 files) |
| `check:mapper-parity` | exit 0 |
| core suite | 7702 passed, 106 skipped (300 files) |
| ten-signal ratchet (`--full --bundle browser-priority --regression`) | green, **no movement** — 3696/3696, R3 0.9968 unchanged |

No baseline regeneration: nothing moved.

## Scored out of scope, filed instead

Three things the measurement corrected, all written into `COMMAND_ARCHITECTURE_NEXT_STEPS.md`:

1. **`open` deferred.** The queue's one-line descriptor (`modifiers: { as: 'style' } }`) is **inert**: `openSchema` gives `style` `svoPosition: 1` and `patient` `2`, so the generated en pattern is `open [as {style}] [{patient}]` and only the un-English `open as modal #dlg` binds the role. `open #dlg as non-modal` — OpenCommand's own documented example — parses to `patient` alone. Making it live needs the positions swapped (a 24-language pattern-shape change) *and* the value to survive tokenization (`non-modal` becomes the expression `non - modal`, a subtraction node, which the runtime's string compare can never match). Half of that is worse than neither.

2. **Core's `semantic-integration.ts` switch is NOT latent.** It was filed as latent because `put` sits in `skipSemanticParsing`. `default` and `scroll` do not — so for them that switch **is** the live English path. Measured end-to-end through `hyperscript.eval` in jsdom: `scroll to #header` throws `scroll command requires a target` on the default path and works with `{ traditional: true }`. **These descriptor fixes therefore land on `buildAST` (multilingual/semantic-bundle path) and do not yet reach `hyperscript.eval`.** That promotes the queue's option (b) — core delegates to `buildAST` — from cleanup to the highest-value follow-up.

3. **`DefaultCommand` evaluates a target that must stay symbolic**, so `default` is broken on *both* paths for 4 of its 5 documented examples (`default myVar to "fallback"` → `Invalid target type: undefined`). `SetCommand` shows the correct shape. The existing unit tests miss it because their mock evaluator returns `node.value ?? node.name` — the name-preserving behavior the real evaluator lacks.

Also corrected in the doc: the queue named `window-scroll`/`modal-open` as the corpus evidence rows. Neither exercises these commands (they are an event handler and a CSS class name). The real rows are `last-in-collection`, `default-value`, and `swap-content`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)