### PR TITLE
docs: measure the semantic-integration switch's reachability — the answer is (b)

### DIFF
--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -563,6 +563,51 @@ not the core abstractions.
   core-side behavior fix dragging the full core gate set. Detail:
   [HANDOFF-command-arch-mappers.md](./HANDOFF-command-arch-mappers.md) § fact 2.
 
+  **Reachability measured 2026-07-31 — the answer is (b).** Method: for every
+  action with a schema excluded by **neither** `skipSemanticParsing` (25 names)
+  **nor** `SKIP_SEMANTIC_COMMANDS` (4), feed ONE English semantic parse of each
+  corpus surface to **both** paths — `buildAST` and
+  `SemanticIntegrationAdapter.trySemanticParse` — and diff name / arg shapes /
+  modifier keys. 71 schemas, **45 reachable**, 29 with a parsing en surface.
+  **15 of the 29 diverge.** This is not a `put`-shaped special case: it is the
+  blanket `destination`→`on` / `source`→`from` mapping meeting every command
+  whose runtime contract is positional.
+
+  | command | `buildAST` | the switch | live effect (`hyperscript.eval`, jsdom) |
+  | ------- | ---------- | ---------- | --------------------------------------- |
+  | `go back` | `args:[lit("back")]` | `args:[] mods:{on:id(back)}` | **throws** `Go command requires arguments` (traditional: works) |
+  | `go to url "/page"` | `args:[lit("url"),lit("/page")]` | `args:[] mods:{on,method}` | **throws**, same |
+  | `get #target` | `args:[sel(#target)]` | `args:[] mods:{from:sel}` | **throws** `get command requires an expression argument` |
+  | `pick first 2 from .items` | `args:[sel(.items)] mods:{variant,count}` | `args:[lit(2)] mods:{method,from}` | **no error, WRONG result** — 1 item where traditional returns 2 |
+  | `scroll to #header` | `args:[sel(#header)]` | `args:[] mods:{on:sel}` | **throws** `scroll command requires a target` |
+  | `default :x to 0` | `args:[ctx(:x)] mods:{to:lit(0)}` | `args:[lit(0)] mods:{on:id(:x)}` | **throws** `default command requires a value` |
+  | `bind $greeting to #name-input` | `args:[sel] mods:{on:ctx}` | `args:[] mods:{on:id,from:sel}` | — |
+  | `send … to #t` | `mods:{to:…}` | `mods:{on:…}` | works (SendCommand accepts both) |
+  | `transition … to X over Y` | `mods:{to,over,on}` | `mods:{goal,over,on}` | throws on both paths, different reasons |
+  | `show/hide … with *opacity` | builds | `NONE` (the `*prop` skip regex) | — |
+  | `log me` · `settle` · `blur me` · `clear :x` · `focus first <input/>` | `ctx(…)` / `call(…)` | `id(…)` | mostly benign; `focus` **inverts** (semantic works, traditional throws) |
+
+  Agreeing (14): `take throw push replace empty open close reset call behavior
+  beep copy render live`. No parsing en surface, so unmeasured — **not** proven
+  safe (16): `on else while continue process clone select breakpoint async init
+  break eventsource socket worker intercept compound`.
+
+  - **(c) is refuted.** The skip lists cover 25 of 71 actions and the divergent
+    set sits almost entirely outside them.
+  - **(a) is a re-divergence by construction** — re-implementing 44 descriptors
+    in a second place is the disease applied as the cure.
+  - **(b) fixes five live English defects in one change** (`go` ×2, `get`,
+    `pick`, `scroll`, `default`) and deletes the last full copy of the role→AST
+    knowledge. `buildAST` already backs the multilingual and semantic-complete
+    browser bundles, so this makes the two paths *the same code* rather than
+    agreeing code.
+
+  Two things the delegation PR must handle, both visible above: the switch routes
+  `repeat`/`for`/`set`/`if`/`unless` to dedicated builders *before* the role loop
+  (those must keep working), and `show`/`hide`/`transition` with `*prop` targets
+  deliberately return `NONE` via `shouldSkipSemantic`'s `/\*[a-zA-Z]/` check —
+  delegation must preserve that refusal rather than adopt `buildAST`'s output.
+
 - **`DefaultCommand` EVALUATES its target, so `default` is broken on both
   execution paths.** Independent of the AST-shape defect above, and not fixed by
   it. `commands/data/default.ts` `parseInput` does `target = await

--- a/docs-internal/HANDOFF-command-arch-mappers.md
+++ b/docs-internal/HANDOFF-command-arch-mappers.md
@@ -283,8 +283,8 @@ scaffolding a throwaway command in a worktree and running them.
 | 1 — descriptor + generic mapper + parity harness + 5 pilots | **DONE** | #838 |
 | 2 — migrate the mechanical mappers (26) | **DONE** | #839 |
 | 3 — migrate the coalescing mappers (12) | **DONE** | #839 |
-| 4 — descriptors for the fallback actions | **OPEN**, re-scoped to 2 commands | — |
-| 5 — core `semantic-integration` switch dedupe | **FILED** (confirmed, latent) | — |
+| 4 — descriptors for the fallback actions | `scroll` + `default` **DONE**; `open` deferred (its one-line fix measured inert) | #843 |
+| 5 — core `semantic-integration` switch dedupe | **MEASURED** — 15 of 29 reachable commands diverge, 5 live English defects; NOT latent; answer is (b) delegate to `buildAST` | table in [COMMAND_ARCHITECTURE_NEXT_STEPS.md](./COMMAND_ARCHITECTURE_NEXT_STEPS.md) |
 | 6 — add-command scaffolder | **DONE** | #840 |
 
 `command-mappers.ts`: **1301 → 448 lines**, 43 of 47 mappers now declarative.
@@ -303,8 +303,15 @@ Only `wait`, `put`, `go`, `pick` remain hand-written.
   (drop-one alone is blind to a coalescing chain's losing member), and the
   fixture must be keyed off registry ∪ descriptors, never the shrinking
   registry.
-- **Fact 2 (two live AST paths) was CONFIRMED but is narrower than predicted** —
-  see the annotation inline above. Latent, not user-visible; filed in the queue.
+- **Fact 2 (two live AST paths) was CONFIRMED, and "narrower than predicted" was
+  WRONG.** The arc measured only `put` — which is in `skipSemanticParsing`, hence
+  the "latent, not user-visible" conclusion. The 2026-07-31 reachability probe
+  measured all 45 reachable commands: **15 of the 29 with an en surface diverge,
+  and five are live English defects** (`go back`, `go to url`, `get`, `scroll`,
+  `default` all throw on the default path but work traditionally; `pick first 2`
+  returns the wrong number of items with no error). Generalizing from one command
+  inside the skip list to the whole switch is the same shape as this arc's other
+  wrong premises. Table and the (b)-delegation decision are in the queue.
 - **Step 4's premise was wrong.** The brief called replacing
   `buildGenericCommand` "the arc's structural win". Measured against each
   true-fallback schema's own en markers, 12 of 14 are already correct and only


### PR DESCRIPTION
Arc F follow-ups, Phase 4 — the reachability probe the queue asked for. **Docs only, no code touched.**

## Why re-measure

The queue filed core's `semantic-integration.ts` `buildCommandNode` switch as "confirmed, latent" — on the strength of **one** command, `put`, which happens to sit in `parser.ts`'s `skipSemanticParsing`. Measuring all of them says otherwise.

## Method

For every action with a schema excluded by **neither** `skipSemanticParsing` (25 names) **nor** `SKIP_SEMANTIC_COMMANDS` (4), feed **one** English semantic parse of each corpus surface to **both** AST paths — semantic's `buildAST` and `SemanticIntegrationAdapter.trySemanticParse` — and diff name / arg shapes / modifier keys. 71 schemas, **45 reachable**, 29 with a parsing en surface.

## Result: 15 of 29 diverge; five are live English defects

Verified end-to-end through `hyperscript.eval` in jsdom:

| source | default path | `{ traditional: true }` |
| ------ | ------------ | ----------------------- |
| `go back` | throws `Go command requires arguments` | works |
| `go to url "/page"` | throws, same | gets past parsing |
| `get #target` | throws `get command requires an expression argument` | works |
| `scroll to #header` | throws `scroll command requires a target` | works |
| `default :x to 0` | throws `default command requires a value` | (separately broken) |
| `pick first 2 from .items` | **no error, returns 1 item** | returns 2 |

`pick` is the worst shape of the three: an error-free wrong answer.

The cause is not put-specific. It is the blanket `destination`→`on` / `source`→`from` mapping meeting every command whose runtime contract is positional — the same class the Arc F descriptors fixed, in the copy Arc F did not touch.

## Decision

- **(c) delete-as-unreachable — refuted.** The skip lists cover 25 of 71 actions; the divergent set sits almost entirely outside them.
- **(a) teach the switch — a re-divergence by construction.** 44 descriptors re-implemented in a second place is the disease applied as the cure.
- **(b) core delegates to `buildAST` — adopted.** Fixes five live defects in one change, leaves one implementation, and makes the English and multilingual paths *the same code* rather than agreeing code.

Recorded with the two things the delegation PR must preserve: the pre-loop routing for `repeat`/`for`/`set`/`if`/`unless`, and `shouldSkipSemantic`'s deliberate `*prop` refusal (`show/hide/transition … with *opacity` return `NONE` by design).

Also corrects the Arc F record, whose "narrower than predicted" note generalized from the one command inside the skip list — the same wrong-premise shape the arc hit five other times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)