### PR TITLE
fix(semantic): swap's AST contract is positional args — the last two drift entries go

### DIFF
--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -627,16 +627,40 @@ not the core abstractions.
   name-preserving behavior the real evaluator does not have. Any fix should land
   with an end-to-end test through `hyperscript.eval`, not a mocked one.
 
-- **`swap`'s AST builder reads roles its schema never binds.** The builder
-  consumes `source`/`style` and emits `on` for destination; `swapSchema`
-  declares `method`/`destination`/`patient` and marks destination `of`. So
-  `swap innerHTML of #t with <p>` parses `method: innerHTML` and then drops it
-  — the strategy never reaches the AST. Arc F step 1 migrated the behavior
-  verbatim (a faithful migration must not change output) and pinned both
-  divergences as `kind: 'drift'` entries in
-  `packages/semantic/test/ast-shape-consistency.test.ts`, which fails if they
-  are silently "fixed" or silently widened. The repair is a behavior change and
-  wants its own PR with R2/R3 evidence.
+- **~~`swap`'s AST builder reads roles its schema never binds~~ — FIXED; two
+  narrower swap defects remain.** The descriptor now emits
+  `args: ['method', 'destination', 'patient']` and no modifiers, because
+  `commands/dom/swap.ts` `parseInput` takes `const args = raw.args` and never
+  reads `raw.modifiers` at all — the contract is keyword-positional, so every
+  modifier the old descriptor emitted was dead end to end. Measured on the
+  `buildAST` path (parse → buildAST → runtime, the multilingual and
+  semantic-complete bundles): `swap #a with #b` threw `could not parse
+  arguments` and `swap delete #t` threw `command requires arguments`; both now
+  execute. Both `drift` exemptions became orphans and were deleted — the
+  consistency gate's drift list is now **empty**. What is left:
+  - **The strategy forms never bind `patient`, so the content is lost in the
+    parse, not the AST.** `swap into #t with it`, `swap over #modal with c`,
+    `swap beforebegin #t with it` all bind `method` + `destination` only;
+    `swap innerHTML of #t with "X"` additionally binds `destination` to the
+    literal `'of'`. Cause: en has two hand-written patterns
+    (`packages/semantic/src/patterns/languages/en/swap.ts`) — `swap {method}
+    {destination}` and `swap {destination} with {patient}` — and no
+    `swap {method} [of] {destination} with {patient}`. The descriptor is
+    already correct for that shape: give it three roles and the three-arg
+    branch (`target = args[len-2]`, `content = args[len-1]`) lands right with
+    no further descriptor change.
+  - **The symmetric-swap role flip is now behaviorally consequential.** The
+    stored translations for `swap-content` bind the roles REVERSED in
+    ar/ja/ko/tr (and bn/hi/qu/tl) — e.g. ja `#a を クリック で 交換 #b で`
+    parses `patient=#a, destination=#b` where en parses `destination=#a,
+    patient=#b`. This is R3's long-standing `swap-content` residual (8
+    languages, `avgValueRecall` 0.9968) and it did not move. But its *meaning*
+    changed: while both roles landed in dead slots the flip was invisible, and
+    now it decides which element is the target and which is the content, so
+    those languages swap the wrong way round. Still strictly better than the
+    previous behavior (which threw for every language including English), and
+    still tracked in `MULTILINGUAL_NEXT_STEPS.md` § "R3-discovered value-bug
+    families" — but it is no longer cosmetic.
 
 - **`command-adapter.ts` declares its own `CommandMetadata`, and the load-bearing
   reader uses it.** `:54-60` defines a loose shape with an

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -32,7 +32,7 @@ Authoritative source: `packages/testing-framework/baselines/multilingual-priorit
 | avgPrecision (R0 trust floor)  | **0.9998**             | bar 3 reached L4 (0.9953); L7 → 0.9963; R3/R1 arcs → 0.9997; pick arc 3 → 0.9998 (min bn 0.9978)                               |
 | avgMultisetRecall (R0 dupes)   | **1.000**              | signal added #632; last sub-1.0 row (qu behavior-resizable) cleared by #638's SOV if-seam work                                 |
 | avgRoleFidelity (R1)           | **0.9974**             | bar 4 reached session 13 (0.9862); #637/#638 → 0.9919; pick arc 3 cleared Family F in all 23 langs → 0.9974 (lowest ms 0.9943 / th / ko / id) |
-| avgValueRecall (R3)            | **0.9968**             | signal added #634; F1–F8 burned down #635; pick arc 3 recovered the pick value rows (14 langs at 1.0); residual = swap F6 wontfix + triaged rows (min 0.9907) |
+| avgValueRecall (R3)            | **0.9968**             | signal added #634; F1–F8 burned down #635; pick arc 3 recovered the pick value rows (14 langs at 1.0); residual = swap F6 (**re-opened 2026-07-31** — its "runtime-symmetric" premise measured false) + triaged rows (min 0.9907) |
 | avgExecutionFidelity (R2)      | **1.000**              | 47-pattern curated subset fully reproduces en DOM effects                                                                      |
 | canonical validity (R4)        | **3059 / 3059**        | BOTH allowlists EMPTY as of pick arc 3 (#736) — any new invalid pair fails at tolerance 0                                      |
 
@@ -2932,18 +2932,39 @@ value-bug families"), F6 **wontfix** (documented), F7 **re-filed**:
    `{goal}`). Fixed in the trailing-DURATION reclaim: skip exactly one particle
    when a TIME-shaped literal directly follows it (`में 500ms` — the
    prepositional sibling of the bn `জন্য` postposition).
-6. **`swap` role-binding flip — WONTFIX** (ar/bn/hi/ja/ko/qu/tl/tr ×
-   `swap-content`, 8 rows, permanent R3 noise). en parses `swap #a with #b` as
-   `destination=#a, patient=#b` (swapSchema: destination bare-marked svoPos 2,
-   patient with-word svoPos 3); the SOV/VSO transformer marks `#a` accusative →
-   the roles land flipped. Same role-type SET (R1-blind) and swap is
-   runtime-symmetric for the element shape, so this is signature noise, not a
-   behavior bug. Aligning would require flipping destination/patient across the
-   en hand pattern + swapSchema for ALL SVO languages together AND auditing the
-   ast-builder swap mapper / core runtime / renderer round-trip — deemed not
-   worth the regression surface for zero runtime effect (decision 2026-07-10).
-   The 8 rows stay visible in the R3 report; do NOT special-case the R3 walker.
-   If a future arc flips it, regenerate the baseline and watch R1/R2.
+6. **`swap` role-binding flip — ~~WONTFIX~~ RE-OPENED 2026-07-31: the premise
+   was measured false** (ar/bn/hi/ja/ko/qu/tl/tr × `swap-content`, 8 rows). en
+   parses `swap #a with #b` as `destination=#a, patient=#b` (swapSchema:
+   destination bare-marked svoPos 2, patient with-word svoPos 3); the SOV/VSO
+   transformer marks `#a` accusative → the roles land flipped. The 2026-07-10
+   decision rested on **"swap is runtime-symmetric for the element shape, so
+   this is signature noise, not a behavior bug."** It is not symmetric:
+
+   | AST | `#a` after | `#b` after |
+   | --- | ---------- | ---------- |
+   | `swap #a with #b` | `BBB` | `BBB` |
+   | `swap #b with #a` | `AAA` | `AAA` |
+
+   The DOM swap is directional — the target takes the content element's
+   content and the content element is untouched — so a flipped binding swaps
+   the wrong way round. (Measured through parse → `buildAST` → runtime in
+   jsdom.)
+
+   The claim was _vacuously_ true when it was made, for a reason nobody could
+   see at the time: the swap descriptor emitted `args:[patient, source]` +
+   `modifiers.on`, and `SwapCommand.parseInput` reads only `raw.args`, so
+   `swap #a with #b` threw `could not parse arguments` before either binding
+   could matter. Both orders were equally broken, which is not the same as
+   equivalent. The descriptor fix (#845) made the runtime work — and thereby
+   made the flip consequential.
+
+   Fixing still costs what the original entry said: flip destination/patient
+   across the en hand pattern + swapSchema for all SVO languages together, and
+   audit the ast-builder mapper / runtime / renderer round-trip. What changed is
+   the other side of the trade — it is no longer "zero runtime effect", it is
+   eight languages swapping the wrong element. The 8 rows stay visible in the R3
+   report; do NOT special-case the R3 walker. Regenerate the baseline and watch
+   R1/R2 when it lands.
 7. ~~**qu/tr behavior trigger-event residue — RE-FILED to the transformer arc**~~
    **DONE** (2026-07-10, transformer-rendering arc —
    `docs-internal/HANDOFF_transformer-rendering.md`, resolved; all four

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -2763,14 +2763,22 @@ export const swapSchema: CommandSchema = {
   description: 'Swap DOM content using various strategies (innerHTML, outerHTML, delete, etc.)',
   category: 'dom-content',
   primaryRole: 'destination',
-  // KNOWN DRIFT, preserved verbatim from the mapper this replaces: the AST
-  // builder reads `source`/`style`, which the `roles` below do not declare,
-  // and routes `destination` to `on` although the schema's en marker is `of`.
-  // The roles this schema actually binds are method/destination/patient, so
-  // `swap innerHTML of #t with <p>` currently drops the strategy. Migrating it
-  // faithfully is deliberate — the fix is a behavior change and belongs in its
-  // own PR. Both divergences are pinned in ast-shape-consistency.test.ts.
-  ast: { args: ['patient', 'source'], modifiers: { on: 'destination', with: 'style' } },
+  // SwapCommand's contract is keyword-positional ARGS, with no modifier read at
+  // all (`commands/dom/swap.ts` parseInput takes `const args = raw.args` and
+  // never touches `raw.modifiers`). It scans the arg list for `with`/`of`/
+  // `delete`/`using`/`into`/`over` and otherwise falls back to
+  // target = args[len-2], content = args[len-1], strategy = args[0] when that
+  // names one. So the three roles this schema binds have to arrive positionally
+  // in method → destination → patient order.
+  //
+  // The previous descriptor read `source`/`style` — roles no swap pattern binds
+  // — and routed `destination` into `modifiers.on`, so every modifier it emitted
+  // was dead end to end: `swap #a with #b` reached the runtime as a one-arg node
+  // and `swap delete #t` as a zero-arg one, and both threw before doing any
+  // work. Preserved verbatim by the Arc F migration (a faithful migration must
+  // not change output) and pinned as two `drift` exemptions; this is the
+  // behavior fix those entries were waiting for.
+  ast: { args: ['method', 'destination', 'patient'] },
   roles: [
     {
       role: 'method',

--- a/packages/semantic/test/ast-builder.test.ts
+++ b/packages/semantic/test/ast-builder.test.ts
@@ -694,14 +694,18 @@ describe('Tier 2 Command Mappers', () => {
 
 describe('Tier 3 Command Mappers', () => {
   describe('swap mapper', () => {
-    it('should map swap command', () => {
+    // SwapCommand's contract is keyword-positional args in method → destination
+    // → patient order; it never reads `raw.modifiers`. This case used to assert
+    // `modifiers.on` and fed a `source` role no swap pattern binds — it pinned
+    // the drift rather than the contract.
+    it('maps swap roles to positional args, method first', () => {
       const node: CommandSemanticNode = {
         kind: 'command',
         action: 'swap',
         roles: new Map([
-          ['patient', { type: 'literal', value: 'innerHTML', dataType: 'string' }],
-          ['source', { type: 'literal', value: '<p>New content</p>', dataType: 'string' }],
+          ['method', { type: 'literal', value: 'innerHTML', dataType: 'string' }],
           ['destination', { type: 'selector', value: '#target', selectorKind: 'id' }],
+          ['patient', { type: 'literal', value: '<p>New content</p>', dataType: 'string' }],
         ]),
       };
 
@@ -712,8 +716,30 @@ describe('Tier 3 Command Mappers', () => {
       const result = mapper!.toAST(node, builder);
 
       expect(result.name).toBe('swap');
+      expect(result.args).toHaveLength(3);
+      expect(result.args[0]).toMatchObject({ value: 'innerHTML' });
+      expect(result.args[1]).toMatchObject({ value: '#target' });
+      expect(result.args[2]).toMatchObject({ value: '<p>New content</p>' });
+      expect(result.modifiers).toBeUndefined();
+    });
+
+    it('omits an absent method rather than leaving a hole', () => {
+      // `swap #a with #b` binds no method; the target must still be args[0] so
+      // SwapCommand's `args[len-2]`/`args[len-1]` fallback finds it.
+      const node: CommandSemanticNode = {
+        kind: 'command',
+        action: 'swap',
+        roles: new Map([
+          ['destination', { type: 'selector', value: '#a', selectorKind: 'id' }],
+          ['patient', { type: 'selector', value: '#b', selectorKind: 'id' }],
+        ]),
+      };
+
+      const result = resolveCommandMapper('swap')!.toAST(node, new ASTBuilder());
+
       expect(result.args).toHaveLength(2);
-      expect(result.modifiers!['on']).toBeDefined();
+      expect(result.args[0]).toMatchObject({ value: '#a' });
+      expect(result.args[1]).toMatchObject({ value: '#b' });
     });
   });
 

--- a/packages/semantic/test/ast-shape-consistency.test.ts
+++ b/packages/semantic/test/ast-shape-consistency.test.ts
@@ -78,18 +78,11 @@ const EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: string }> = {
     kind: 'contract',
     reason: 'FetchCommand reads the request body from `body`; patient has no en marker',
   },
-  'swap.on': {
-    kind: 'drift',
-    reason:
-      "schema marks destination 'of' (`swap innerHTML of #t`) but the AST builder emits `on`; " +
-      'preserved verbatim by the Arc F migration, filed as its own behavior fix',
-  },
-  'swap.with': {
-    kind: 'drift',
-    reason:
-      '`style` is not a swapSchema role — the builder reads a role the patterns never bind, ' +
-      'which is why `swap innerHTML of #t with <p>` drops the strategy today',
-  },
+  // NOTE: `swap.on` and `swap.with` were the last two `drift` entries. The
+  // descriptor now emits NO modifiers at all — SwapCommand's contract is
+  // keyword-positional args and it never reads `raw.modifiers` — so both keys
+  // stopped existing and the orphan check below deleted them. The drift list is
+  // empty; see `descriptor-runtime-contract.test.ts` for what replaced them.
 };
 
 /** All roles of a first-present-of chain (a bare role is a one-role chain). */
@@ -176,6 +169,6 @@ describe('schema ast descriptors agree with the English marker data', () => {
       .filter(([, v]) => v.kind === 'drift')
       .map(([k]) => k)
       .sort();
-    expect(drift).toEqual(['swap.on', 'swap.with']);
+    expect(drift).toEqual([]);
   });
 });

--- a/packages/semantic/test/descriptor-runtime-contract.test.ts
+++ b/packages/semantic/test/descriptor-runtime-contract.test.ts
@@ -85,3 +85,60 @@ describe('scroll — the destination must be an ARG, not a modifier', () => {
     expect(ast.modifiers?.on).toBeUndefined();
   });
 });
+
+describe('swap — the AST contract is keyword-positional args, never modifiers', () => {
+  // packages/core/src/commands/dom/swap.ts parseInput takes `const args =
+  // raw.args` and reads NOTHING else — there is no `raw.modifiers` access in the
+  // function. It then scans the arg list for keyword tokens (`with`, `of`,
+  // `delete`, `using`, `into`, `over`) and, failing all of those, falls back to
+  //   targetNode  = args[args.length - 2]
+  //   contentNode = args[args.length - 1]
+  //   strategy    = STRATEGY_KEYWORDS[argKeywords[0]]  (when args[0] names one)
+  // So `method`, `destination`, `patient` must arrive as positional args in
+  // exactly that order. Every modifier the old descriptor emitted was dead end
+  // to end — which is why `swap #a with #b` and `swap delete #t` both threw.
+
+  it('builds `swap #a with #b` as args:[#a, #b] with no modifiers', () => {
+    const ast = astOf('swap #a with #b');
+
+    expect(ast.name).toBe('swap');
+    // The fallback branch reads args[len-2] as target and args[len-1] as content.
+    expect(ast.args).toHaveLength(2);
+    expect(ast.args[0]).toMatchObject({ type: 'selector', value: '#a' });
+    expect(ast.args[1]).toMatchObject({ type: 'selector', value: '#b' });
+    expect(ast.modifiers).toBeUndefined();
+  });
+
+  it('builds `swap #target with it` the same way', () => {
+    const ast = astOf('swap #target with it');
+
+    expect(ast.args).toHaveLength(2);
+    expect(ast.args[0]).toMatchObject({ type: 'selector', value: '#target' });
+    expect(ast.args[1]).toMatchObject({ type: 'contextReference', name: 'it' });
+    expect(ast.modifiers).toBeUndefined();
+  });
+
+  it('keeps the strategy for `swap delete #t` — args[0] is what selects it', () => {
+    const ast = astOf('swap delete #t');
+
+    // `deleteIndex = argKeywords.findIndex(k => k === 'delete')` must be 0, and
+    // the target is read from `args[deleteIndex + 1]`.
+    expect(ast.args).toHaveLength(2);
+    expect(ast.args[0]).toMatchObject({ type: 'literal', value: 'delete' });
+    expect(ast.args[1]).toMatchObject({ type: 'selector', value: '#t' });
+    expect(ast.modifiers).toBeUndefined();
+  });
+
+  it('never emits an `on` modifier — SwapCommand cannot see one', () => {
+    for (const src of ['swap #a with #b', 'swap delete #t']) {
+      expect(astOf(src).modifiers?.on, src).toBeUndefined();
+    }
+  });
+
+  it('leaves the target out of args for NO swap surface that binds it', () => {
+    // The old shape put `patient` first and the destination in `modifiers.on`,
+    // so `swap #a with #b` reached the runtime as a single-arg node and
+    // `swap delete #t` as a zero-arg one — both throw before doing any work.
+    expect(astOf('swap delete #t').args.length).toBeGreaterThan(1);
+  });
+});

--- a/packages/semantic/test/fixtures/mapper-parity.json
+++ b/packages/semantic/test/fixtures/mapper-parity.json
@@ -8315,7 +8315,7 @@
       ]
     },
     "swap": {
-      "roles": ["patient", "destination", "source", "style"],
+      "roles": ["patient", "destination", "method"],
       "cases": [
         {
           "name": "no-roles",
@@ -8339,14 +8339,9 @@
               "value": "#destination-v",
               "selectorKind": "id"
             },
-            "source": {
-              "type": "selector",
-              "value": "#source-v",
-              "selectorKind": "id"
-            },
-            "style": {
+            "method": {
               "type": "literal",
-              "value": "style-v"
+              "value": "method-v"
             }
           },
           "ast": {
@@ -8354,30 +8349,22 @@
             "name": "swap",
             "args": [
               {
-                "type": "selector",
-                "value": ".patient-v",
-                "selector": ".patient-v",
-                "selectorType": "class"
+                "type": "literal",
+                "value": "method-v"
               },
               {
-                "type": "selector",
-                "value": "#source-v",
-                "selector": "#source-v",
-                "selectorType": "id"
-              }
-            ],
-            "modifiers": {
-              "on": {
                 "type": "selector",
                 "value": "#destination-v",
                 "selector": "#destination-v",
                 "selectorType": "id"
               },
-              "with": {
-                "type": "literal",
-                "value": "style-v"
+              {
+                "type": "selector",
+                "value": ".patient-v",
+                "selector": ".patient-v",
+                "selectorType": "class"
               }
-            }
+            ]
           }
         },
         {
@@ -8410,14 +8397,9 @@
               "value": "#destination-v",
               "selectorKind": "id"
             },
-            "source": {
-              "type": "selector",
-              "value": "#source-v",
-              "selectorKind": "id"
-            },
-            "style": {
+            "method": {
               "type": "literal",
-              "value": "style-v"
+              "value": "method-v"
             }
           },
           "ast": {
@@ -8425,24 +8407,16 @@
             "name": "swap",
             "args": [
               {
-                "type": "selector",
-                "value": "#source-v",
-                "selector": "#source-v",
-                "selectorType": "id"
-              }
-            ],
-            "modifiers": {
-              "on": {
+                "type": "literal",
+                "value": "method-v"
+              },
+              {
                 "type": "selector",
                 "value": "#destination-v",
                 "selector": "#destination-v",
                 "selectorType": "id"
-              },
-              "with": {
-                "type": "literal",
-                "value": "style-v"
               }
-            }
+            ]
           }
         },
         {
@@ -8457,15 +8431,14 @@
           "ast": {
             "type": "command",
             "name": "swap",
-            "args": [],
-            "modifiers": {
-              "on": {
+            "args": [
+              {
                 "type": "selector",
                 "value": "#destination-v",
                 "selector": "#destination-v",
                 "selectorType": "id"
               }
-            }
+            ]
           }
         },
         {
@@ -8476,65 +8449,49 @@
               "value": ".patient-v",
               "selectorKind": "class"
             },
-            "source": {
-              "type": "selector",
-              "value": "#source-v",
-              "selectorKind": "id"
-            },
-            "style": {
+            "method": {
               "type": "literal",
-              "value": "style-v"
+              "value": "method-v"
             }
           },
           "ast": {
             "type": "command",
             "name": "swap",
             "args": [
+              {
+                "type": "literal",
+                "value": "method-v"
+              },
               {
                 "type": "selector",
                 "value": ".patient-v",
                 "selector": ".patient-v",
                 "selectorType": "class"
-              },
-              {
-                "type": "selector",
-                "value": "#source-v",
-                "selector": "#source-v",
-                "selectorType": "id"
-              }
-            ],
-            "modifiers": {
-              "with": {
-                "type": "literal",
-                "value": "style-v"
-              }
-            }
-          }
-        },
-        {
-          "name": "only-source",
-          "roles": {
-            "source": {
-              "type": "selector",
-              "value": "#source-v",
-              "selectorKind": "id"
-            }
-          },
-          "ast": {
-            "type": "command",
-            "name": "swap",
-            "args": [
-              {
-                "type": "selector",
-                "value": "#source-v",
-                "selector": "#source-v",
-                "selectorType": "id"
               }
             ]
           }
         },
         {
-          "name": "without-source",
+          "name": "only-method",
+          "roles": {
+            "method": {
+              "type": "literal",
+              "value": "method-v"
+            }
+          },
+          "ast": {
+            "type": "command",
+            "name": "swap",
+            "args": [
+              {
+                "type": "literal",
+                "value": "method-v"
+              }
+            ]
+          }
+        },
+        {
+          "name": "without-method",
           "roles": {
             "patient": {
               "type": "selector",
@@ -8545,10 +8502,6 @@
               "type": "selector",
               "value": "#destination-v",
               "selectorKind": "id"
-            },
-            "style": {
-              "type": "literal",
-              "value": "style-v"
             }
           },
           "ast": {
@@ -8557,89 +8510,17 @@
             "args": [
               {
                 "type": "selector",
-                "value": ".patient-v",
-                "selector": ".patient-v",
-                "selectorType": "class"
-              }
-            ],
-            "modifiers": {
-              "on": {
-                "type": "selector",
                 "value": "#destination-v",
                 "selector": "#destination-v",
                 "selectorType": "id"
               },
-              "with": {
-                "type": "literal",
-                "value": "style-v"
-              }
-            }
-          }
-        },
-        {
-          "name": "only-style",
-          "roles": {
-            "style": {
-              "type": "literal",
-              "value": "style-v"
-            }
-          },
-          "ast": {
-            "type": "command",
-            "name": "swap",
-            "args": [],
-            "modifiers": {
-              "with": {
-                "type": "literal",
-                "value": "style-v"
-              }
-            }
-          }
-        },
-        {
-          "name": "without-style",
-          "roles": {
-            "patient": {
-              "type": "selector",
-              "value": ".patient-v",
-              "selectorKind": "class"
-            },
-            "destination": {
-              "type": "selector",
-              "value": "#destination-v",
-              "selectorKind": "id"
-            },
-            "source": {
-              "type": "selector",
-              "value": "#source-v",
-              "selectorKind": "id"
-            }
-          },
-          "ast": {
-            "type": "command",
-            "name": "swap",
-            "args": [
               {
                 "type": "selector",
                 "value": ".patient-v",
                 "selector": ".patient-v",
                 "selectorType": "class"
-              },
-              {
-                "type": "selector",
-                "value": "#source-v",
-                "selector": "#source-v",
-                "selectorType": "id"
               }
-            ],
-            "modifiers": {
-              "on": {
-                "type": "selector",
-                "value": "#destination-v",
-                "selector": "#destination-v",
-                "selectorType": "id"
-              }
-            }
+            ]
           }
         },
         {
@@ -8707,30 +8588,22 @@
             "name": "swap",
             "args": [
               {
-                "type": "selector",
-                "value": ".patient-v",
-                "selector": ".patient-v",
-                "selectorType": "class"
+                "type": "literal",
+                "value": "method-v"
               },
               {
-                "type": "selector",
-                "value": "#source-v",
-                "selector": "#source-v",
-                "selectorType": "id"
-              }
-            ],
-            "modifiers": {
-              "on": {
                 "type": "selector",
                 "value": "#destination-v",
                 "selector": "#destination-v",
                 "selectorType": "id"
               },
-              "with": {
-                "type": "literal",
-                "value": "style-v"
+              {
+                "type": "selector",
+                "value": ".patient-v",
+                "selector": ".patient-v",
+                "selectorType": "class"
               }
-            }
+            ]
           }
         }
       ]


### PR DESCRIPTION
Arc F follow-ups, Phase 2. `swap` held the last two `drift` exemptions in the consistency gate, pinned verbatim by the Arc F migration (a faithful migration must not change output).

## Measured from the runtime first

`commands/dom/swap.ts` `parseInput` takes `const args = raw.args` and **never reads `raw.modifiers`** — not once in the function. It scans that arg list for keyword tokens (`with` / `of` / `delete` / `using` / `into` / `over`) and otherwise falls back to:

```
target   = args[args.length - 2]
content  = args[args.length - 1]
strategy = STRATEGY_KEYWORDS[argKeywords[0]]   // when args[0] names one
```

So the contract is keyword-positional, and every modifier the old descriptor emitted was dead end to end. That is **worse than the filed diagnosis** ("drops the strategy") — it dropped everything.

Verified through the real consumer (parse → `buildAST` → runtime, jsdom — the multilingual and semantic-complete bundle path):

| source | before | after |
| ------ | ------ | ----- |
| `swap #a with #b` | throws `could not parse arguments` | `#a` takes `#b`'s content |
| `swap delete #t` | throws `command requires arguments` | `#t` removed from the DOM |

New descriptor: `ast: { args: ['method', 'destination', 'patient'] }` — the three roles the patterns actually bind, in the order the runtime reads them. The plan's guessed shape turned out right, but only because it was derived from the roles rather than from the markers.

## Gate consequences

- **Both `drift` exemptions became orphans** (their keys no longer exist) and the gate deleted them. The drift-list assertion is now `[]` — the count fell, which the gate's own comment says means a real fix landed.
- **Parity fixture regenerated**, diff confined to `swap`: measured sensitivity `[patient, destination, source, style]` → `[patient, destination, method]`, every case moving to positional args. 336 → 334 cases. `EXPECTED_MIGRATED` stays 44 — swap already had a descriptor.
- **`test/ast-builder.test.ts`'s swap case was pinning the drift, not the contract** — it asserted `modifiers.on` while feeding a `source` role no swap pattern binds. Replaced with two cases against the real contract.
- 5 new cases in `descriptor-runtime-contract.test.ts`, written first, all failing before the change.

## Verification

| gate | result |
| ---- | ------ |
| semantic suite | 7223 passed, 10 skipped |
| core suite | 7702 passed, 106 skipped |
| `typecheck` · `check:mapper-parity` | clean |
| ten-signal ratchet | green, unchanged (3696/3696, R3 0.9968) |

## Two swap defects isolated and filed, not folded in

1. **The strategy forms never bind `patient`**, so the *content* is lost in the parse, not the AST. en has `swap {method} {destination}` and `swap {destination} with {patient}` and no `swap {method} [of] {destination} with {patient}`. The descriptor is already correct for that shape — the three-arg branch lands right with no further descriptor change.

2. **R3 family F6's WONTFIX premise is measured false, and this change is what falsified it.** The 2026-07-10 decision to accept the ar/bn/hi/ja/ko/qu/tl/tr role flip rested on *"swap is runtime-symmetric for the element shape, so this is signature noise, not a behavior bug."* It is not symmetric:

   | AST | `#a` after | `#b` after |
   | --- | ---------- | ---------- |
   | `swap #a with #b` | `BBB` | `BBB` |
   | `swap #b with #a` | `AAA` | `AAA` |

   The claim was *vacuously* true only because the command threw before either binding could matter — both orders were equally broken, which is not the same as equivalent. Those eight languages now swap the wrong element. F6 is re-opened in `MULTILINGUAL_NEXT_STEPS.md` with the measurement. `swap-content` is **not** in the R2 curated subset, which is why execution fidelity stayed 1.0 — adding it is the gate for whoever fixes the flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)