### PR TITLE
fix(parser): consume toggle's `for <duration>` / `until <event>` tail

### DIFF
--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -91,13 +91,54 @@ shipped parser refuses:
 
 | Source | Upstream | hyperfixi |
 | ------ | -------- | --------- |
-| `toggle .loading for 2s` | accepts | `Expected variable name after "for"` |
+| ~~`toggle .loading for 2s`~~ | accepts | **FIXED** — was `Expected variable name after "for"` |
 | `wait for click or 1s` | accepts | `Expected event name after "for"` |
 
 Both errors read as a `for`-tail being parsed as the start of a loop/event
 construct rather than as a duration modifier, but the two commands take different
-paths, so treat them as one family with two fixes and confirm they share a cause
-before assuming they do.
+paths. **Measured 2026-07-31: they do NOT share a cause**, so the "confirm they
+share a cause" instruction resolves to *no*:
+
+- **`toggle`** — `parseToggleCommand` returned after the optional `on <target>`
+  and never consumed the tail, so the next parse round read `for` as a `for`
+  LOOP. Fixed by `parseTemporalTail`, which emits `modifiers.for` /
+  `modifiers.until` (where `parseTemporalModifiers` reads them). The same sweep
+  found `toggle .a until click` parsing while *silently dropping* the tail, and
+  that the whole `commands/helpers/temporal-modifiers.ts` reversion machinery was
+  unreachable — `for 2s` and `until` appeared in exactly two files, both source.
+- **`wait`** — a different function and a different shape.
+  `parseWaitCommand`'s event branch is a `do…while` over `or`-separated event
+  names; `1s` is a number token, `isIdentifierLike` is false, and it throws
+  `Expected event name after "for"`. The fix is to accept a time expression as an
+  alternative inside that or-chain, and it shares no code with the toggle path.
+  Still open.
+
+**The semantic-side half of `toggle … for` is NOT done, and was reverted after
+measurement rather than shipped.** `toggleSchema.ast` already declares
+`for: 'duration'`; making it live needs a `duration` role on the schema. That
+was tried, and the measurement is worth keeping:
+
+- With `markerOverride: { en: 'for' }` alone, **16 semantic tests fail** —
+  including plain `#button の .active を 切り替え`, which stops parsing entirely.
+  Cause: SOV languages get `[{destination} に] {patient} を [{duration}] 切り替え`
+  with a **marker-less optional slot** — the same hazard class as R3 family F1
+  (the connective swallowed as `increment.quantity`).
+- Adding `ja: '間'`, `ko: '동안'` clears all 16, and the full semantic suite plus a
+  24-language `toggle .active [on #btn]` round-trip probe go green. (The two
+  probe misses, bn and hi, are **pre-existing on main** — verified by stash.)
+- But the role also changes what the i18n transformer RENDERS, and that is where
+  it fails: on main every language drops the `2s` (tr renders `.loading değiştir`);
+  with the role, **tr renders `.loading 2s değiştir`, which the tr parser then
+  rejects** — a new round-trip failure. 9 more languages (bn/es/hi/it/pl/qu/ru/
+  th/uk/vi/zh) still drop the duration in rendering, so support would be partial.
+- **The corpus ratchet is blind to all of it** (green, nothing moved): no corpus
+  row uses `toggle … for`, so R1–R5 never see the form. The unit tests caught the
+  16; the round-trip probe caught tr.
+
+So the remaining work is a per-language `duration` marker table for `toggle` plus
+the transformer's rendering of it — a multilingual arc with no gate today. Whoever
+takes it should add a `toggle … for` corpus row FIRST, so the ratchet stops being
+blind, then do the markers.
 
 Two adjacent diagnostics found in the same sweep, both cosmetic and neither
 worth its own arc — fold them into whichever change touches this area:

--- a/packages/core/src/commands/dom/__tests__/toggle-temporal.test.ts
+++ b/packages/core/src/commands/dom/__tests__/toggle-temporal.test.ts
@@ -1,0 +1,99 @@
+/**
+ * `toggle … for <duration>` / `toggle … until <event>` — parse AND execute.
+ *
+ * Both tails are accepted by the real `hyperscript.org` engine (checked with
+ * `hs.parse(src).errors` — both return `[]`), and `for <duration>` is
+ * ToggleCommand's own `metadata.examples` entry, so the shipped documentation
+ * advertised a form the shipped parser refused:
+ *
+ *   toggle .loading for 2s     → 'Expected variable name after "for"'
+ *   toggle .a on #b for 2s     → same — the `for` tail was left unconsumed and
+ *                                the next parse round read it as a `for` LOOP
+ *   toggle .a until click      → parsed, then silently dropped the whole tail
+ *
+ * The runtime side was never the problem: `parseTemporalModifiers` reads
+ * `modifiers.for` and `modifiers.until`, and `helpers/temporal-modifiers.ts`
+ * implements both reversions. The parser simply never produced either modifier,
+ * so that machinery was unreachable — no test in the package exercised it
+ * through a real parse.
+ *
+ * These tests go through the real parser and the real runtime deliberately: a
+ * mock-evaluator unit test cannot see a parse-level gap.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { hyperscript } from '../../../api/hyperscript-api';
+
+function host(): HTMLElement {
+  document.body.innerHTML = '<div id="host"></div><button id="btn"></button>';
+  return document.getElementById('host') as HTMLElement;
+}
+
+describe('toggle … for <duration>', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('parses `toggle .loading for 2s` instead of reading `for` as a loop', async () => {
+    const result = hyperscript.compileSync('toggle .loading for 2s');
+    expect(result.errors ?? [], JSON.stringify(result.errors)).toHaveLength(0);
+    expect(result.ok).toBe(true);
+  });
+
+  it('parses the on-target form `toggle .a on #b for 2s`', async () => {
+    const result = hyperscript.compileSync('toggle .a on #b for 2s');
+    expect(result.errors ?? [], JSON.stringify(result.errors)).toHaveLength(0);
+  });
+
+  it('applies the class, then reverts it when the duration elapses', async () => {
+    const el = host();
+    await hyperscript.eval('toggle .loading for 30ms', el);
+
+    expect(el.classList.contains('loading'), 'class applied immediately').toBe(true);
+    await new Promise(r => setTimeout(r, 80));
+    expect(el.classList.contains('loading'), 'class reverted after the duration').toBe(false);
+  });
+
+  it('reverts an attribute toggle too', async () => {
+    const el = host();
+    await hyperscript.eval('toggle @disabled for 30ms', el);
+
+    expect(el.hasAttribute('disabled')).toBe(true);
+    await new Promise(r => setTimeout(r, 80));
+    expect(el.hasAttribute('disabled')).toBe(false);
+  });
+});
+
+describe('toggle … until <event>', () => {
+  it('parses and keeps the tail rather than dropping it', () => {
+    const result = hyperscript.compileSync('toggle .a until click');
+    expect(result.errors ?? [], JSON.stringify(result.errors)).toHaveLength(0);
+  });
+
+  it('reverts the class when the named event fires on the element', async () => {
+    const el = host();
+    await hyperscript.eval('toggle .active until customdone', el);
+
+    expect(el.classList.contains('active'), 'class applied immediately').toBe(true);
+    el.dispatchEvent(new Event('customdone'));
+    expect(el.classList.contains('active'), 'class reverted on the event').toBe(false);
+  });
+
+  it('does not revert before the event fires', async () => {
+    const el = host();
+    await hyperscript.eval('toggle .active until customdone', el);
+
+    el.dispatchEvent(new Event('somethingelse'));
+    expect(el.classList.contains('active')).toBe(true);
+  });
+
+  it('still parses the `until <event> from <target>` form upstream accepts', () => {
+    // ToggleCommand reverts on a listener attached to the toggled element only
+    // (`helpers/temporal-modifiers.ts` `setupEventReversion`), so the `from`
+    // target is parsed and carried but not yet honoured. Parsing it matters
+    // regardless: leaving `from #btn` unconsumed turns a silent drop into a
+    // parse error the moment the `until` tail is consumed.
+    const result = hyperscript.compileSync('toggle .a until click from #btn');
+    expect(result.errors ?? [], JSON.stringify(result.errors)).toHaveLength(0);
+  });
+});

--- a/packages/core/src/parser/command-parsers/dom-commands.ts
+++ b/packages/core/src/parser/command-parsers/dom-commands.ts
@@ -9,9 +9,10 @@
  */
 
 import type { ParserContext, IdentifierNode } from '../parser-types';
-import type { ASTNode, Token } from '../../types/core';
+import type { ASTNode, ExpressionNode, Token } from '../../types/core';
 import { CommandNodeBuilder } from '../command-node-builder';
 import { KEYWORDS, PUT_OPERATIONS, PUT_OPERATION_KEYWORDS } from '../parser-constants';
+import { isIdentifierLike } from '../token-predicates';
 import {
   isCommandBoundary,
   parseOneArgument,
@@ -19,6 +20,71 @@ import {
   consumeOneOfKeywordsToArgs,
   consumeOptionalKeyword,
 } from '../helpers/parsing-helpers';
+
+/**
+ * Consume `toggle`'s optional temporal tail into MODIFIERS.
+ *
+ * `for <duration>` and `until <event> [from <target>]` are both accepted by the
+ * real `hyperscript.org` engine, and `toggle .loading for 2s` is ToggleCommand's
+ * own documented example — but neither was consumed here. The `for` tail was
+ * left for the next parse round, which read it as the start of a `for` LOOP and
+ * failed with `Expected variable name after "for"`; the `until` tail was dropped
+ * in silence.
+ *
+ * Modifiers, not args, because that is where the runtime reads them:
+ * `commands/dom/toggle.ts` `parseTemporalModifiers` takes `modifiers.for` and
+ * `modifiers.until`, and `commands/helpers/temporal-modifiers.ts` already
+ * implements both reversions — that machinery was simply unreachable.
+ */
+function parseTemporalTail(ctx: ParserContext): Record<string, ExpressionNode> {
+  const modifiers: Record<string, ExpressionNode> = {};
+
+  if (consumeOptionalKeyword(ctx, KEYWORDS.FOR)) {
+    const duration = ctx.parseExpression();
+    if (duration) modifiers['for'] = duration as ExpressionNode;
+    return modifiers;
+  }
+
+  if (!ctx.check(KEYWORDS.UNTIL)) return modifiers;
+  ctx.advance();
+
+  const eventToken = ctx.peek();
+  if (!eventToken || !isIdentifierLike(eventToken)) return modifiers;
+  ctx.advance();
+
+  // Colon-qualified names (`htmx:afterOnLoad`) tokenize as three tokens —
+  // identifier, `:` operator, identifier — so rejoin them here.
+  let eventName = eventToken.value;
+  if (ctx.check(':')) {
+    ctx.advance();
+    const suffix = ctx.peek();
+    if (suffix && isIdentifierLike(suffix)) {
+      ctx.advance();
+      eventName = `${eventName}:${suffix.value}`;
+    }
+  }
+
+  // A literal, not an identifier node: ToggleCommand EVALUATES `modifiers.until`
+  // and wants the event NAME, where an identifier would resolve as a variable
+  // lookup and come back undefined.
+  modifiers['until'] = {
+    type: 'literal',
+    value: eventName,
+    raw: eventName,
+  } as unknown as ExpressionNode;
+
+  // `until <event> from <target>` — upstream reverts on the event reaching
+  // another element. ToggleCommand's `setupEventReversion` listens on the
+  // toggled element only, so this is carried but not yet honoured; consuming it
+  // is still required, or the trailing `from` becomes a parse error the moment
+  // the `until` tail above is consumed.
+  if (consumeOptionalKeyword(ctx, KEYWORDS.FROM)) {
+    const target = parseOneArgument(ctx);
+    if (target) modifiers['from'] = target as ExpressionNode;
+  }
+
+  return modifiers;
+}
 
 /**
  * Parse remove command
@@ -130,6 +196,7 @@ export function parseToggleCommand(ctx: ParserContext, identifierNode: Identifie
 
     return CommandNodeBuilder.fromIdentifier(identifierNode)
       .withArgs(...args)
+      .withModifiers(parseTemporalTail(ctx))
       .endingAt(ctx.getPosition())
       .build();
   }
@@ -163,6 +230,7 @@ export function parseToggleCommand(ctx: ParserContext, identifierNode: Identifie
 
   return CommandNodeBuilder.fromIdentifier(identifierNode)
     .withArgs(...args)
+    .withModifiers(parseTemporalTail(ctx))
     .endingAt(ctx.getPosition())
     .build();
 }


### PR DESCRIPTION
Arc F follow-ups, Phase 3. One of the two genuine parser gaps in `PARSER_NEXT_STEPS.md` — upstream-valid, and the command's own documented example.

## The gap

`parseToggleCommand` parsed the class and an optional `on <target>`, then returned — leaving anything after it for the next parse round. For `for 2s` that round read `for` as the start of a `for` **loop**; for `until click` the tail was dropped in silence.

Measured against the real `hyperscript.org` engine (`hs.parse(src).errors`, via testing-framework's canonical-validity loader):

| source | upstream | hyperfixi (before) |
| ------ | -------- | ------------------ |
| `toggle .loading for 2s` | `[]` | parse error |
| `toggle .a on #b for 2s` | `[]` | parse error |
| `toggle .a until click` | `[]` | parses, tail dropped |
| `toggle .a on #b until htmx:afterOnLoad` | `[]` | parses, tail dropped |
| `toggle .a until click from #btn` | `[]` | parses, tail dropped |

`toggle .loading for 2s` is `ToggleCommand.metadata.examples[3]`, so the shipped docs advertised a form the shipped parser refused.

**The runtime side was never broken.** `parseTemporalModifiers` reads `modifiers.for` and `modifiers.until`, and `commands/helpers/temporal-modifiers.ts` implements both reversions for classes and attributes. The parser simply never produced either modifier, so all of it was unreachable — and nothing exercised it: `for 2s` and `until` appear in exactly two files, both source.

## The fix

New `parseTemporalTail`, applied to both of `parseToggleCommand`'s return paths (the `between` form as well as the standard one). Three non-obvious details:

- `until` is emitted as a **literal**, not an identifier node — ToggleCommand *evaluates* `modifiers.until` and wants the event NAME; an identifier would resolve as a variable lookup and come back `undefined`.
- Colon-qualified names tokenize as three tokens (identifier, `:`, identifier), so `htmx:afterOnLoad` is rejoined.
- `until <event> from <target>` is consumed and carried as `modifiers.from`, though `setupEventReversion` listens on the toggled element only, so it is not yet honoured. **Consuming it is not optional**: once the `until` tail is taken, a trailing unconsumed `from` becomes a parse *error* — the fix would otherwise have turned a silent drop into a hard failure for a form upstream accepts.

8 new tests through the **real** parser and runtime (a mock-evaluator unit test cannot see a parse-level gap). Written first: 7 of 8 failed before the change; the 8th passed only because nothing reverted.

## Verification

| gate | result |
| ---- | ------ |
| core suite | **7710** passed, 106 skipped (was 7702/106) |
| `typecheck` · `typecheck:scripts` | clean |
| `verify:reference` · `docs:commands:check` · `generate:bundles:check` | clean |
| `snapshot:bundle-size --check` | all bundles within tolerance |
| language-server suite | 227 passed |
| ten-signal ratchet | green, unchanged (3696/3696) |

## The semantic half was measured and reverted, not shipped

`toggleSchema.ast` already declares `for: 'duration'`. Making it live needs a `duration` role on the schema. I tried it; the measurement is filed in `PARSER_NEXT_STEPS.md`:

- With `markerOverride: { en: 'for' }` alone, **16 semantic tests fail** — plain `#button の .active を 切り替え` stops parsing entirely, because SOV languages get `[{destination} に] {patient} を [{duration}] 切り替え` with a **marker-less optional slot** (the same hazard class as R3 family F1).
- Adding `ja: '間'`, `ko: '동안'` clears all 16; full suite and a 24-language round-trip probe go green (the two probe misses, bn/hi, are **pre-existing on main** — verified by stash).
- But the role also changes what the **i18n transformer renders**. On main every language drops the `2s`; with the role, **tr renders `.loading 2s değiştir`, which the tr parser rejects** — a new round-trip failure. Ten more languages still drop the duration when rendering, so support would be partial either way.
- **The corpus ratchet stayed green through all of it** — no corpus row uses `toggle … for`, so R1–R5 never see the form. The unit tests caught the 16; the probe caught tr.

Shipping a 24-language surface change with no gate covering it is what this queue's design principles forbid. Filed with a prerequisite: add a `toggle … for` corpus row first so the ratchet stops being blind, then do the marker table.

Also resolved in the same doc: that entry asked whoever picked it up to "confirm they share a cause before assuming they do" for `toggle` and `wait for click or 1s`. **They do not** — wait's failure is a number token failing `isIdentifierLike` inside `parseWaitCommand`'s or-chain over event names, sharing no code with the toggle path. It stays filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)