### PR TITLE
fix(parser): core delegates role→AST to buildAST — five English commands start working

### DIFF
--- a/packages/core/src/api/hyperscript-api.ts
+++ b/packages/core/src/api/hyperscript-api.ts
@@ -35,6 +35,7 @@ import {
   parseSemantic,
   isLanguageRegistered,
   getRegisteredLanguages,
+  buildAST,
   DEFAULT_CONFIDENCE_THRESHOLD,
 } from '@lokascript/semantic';
 import { registerHistorySwap, registerBoosted } from '../behaviors';
@@ -266,6 +267,7 @@ function getSemanticAnalyzer(): SemanticAnalyzerInterface {
       parse: parseSemantic,
       isRegistered: isLanguageRegistered,
       registered: getRegisteredLanguages,
+      buildAST,
     }) as unknown as SemanticAnalyzerInterface;
   }
   return semanticAnalyzerInstance;

--- a/packages/core/src/compatibility/eval-hyperscript.ts
+++ b/packages/core/src/compatibility/eval-hyperscript.ts
@@ -21,6 +21,7 @@ import {
   parseSemantic,
   isLanguageRegistered,
   getRegisteredLanguages,
+  buildAST,
   DEFAULT_CONFIDENCE_THRESHOLD,
 } from '@lokascript/semantic';
 
@@ -37,6 +38,7 @@ function getSemanticAnalyzer(): SemanticAnalyzerInterface {
       parse: parseSemantic,
       isRegistered: isLanguageRegistered,
       registered: getRegisteredLanguages,
+      buildAST,
     }) as unknown as SemanticAnalyzerInterface;
   }
   return semanticAnalyzerInstance;

--- a/packages/core/src/parser/semantic-integration-delegation.test.ts
+++ b/packages/core/src/parser/semantic-integration-delegation.test.ts
@@ -1,0 +1,300 @@
+// @vitest-environment jsdom
+/**
+ * Core's semantic→AST step delegates to `@lokascript/semantic`'s `ASTBuilder`.
+ *
+ * `semantic-integration.ts` used to carry a SECOND role→AST implementation: a
+ * blanket `destination`→`modifiers.on` / `source`→`modifiers.from` switch. It
+ * had drifted from the builder for 15 of the 29 commands with a parsing English
+ * surface, and — because `parser.ts`'s `skipSemanticParsing` list names only 24
+ * commands — it was the LIVE English path for the rest. Five commands were
+ * broken end to end as a result (measured 2026-07-31 at `d4452821`):
+ *
+ *   go back                            → threw `Go command requires arguments`
+ *   go to url "/page"                  → threw, same
+ *   get #target                        → threw `get command requires an expression argument`
+ *   scroll to #header                  → threw `scroll command requires a target`
+ *   pick first 2 from .items           → NO error, WRONG result (1 item, not 2)
+ *
+ * plus `default`, whose AST shape was wrong on top of a separate runtime bug.
+ *
+ * Two things the delegation deliberately does NOT change, both pinned below:
+ * the four command shapes the builder cannot produce keep their dedicated
+ * builders, and `show/hide/transition … *prop` keeps returning no node.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseSemantic,
+  isLanguageRegistered,
+  getRegisteredLanguages,
+  buildAST,
+} from '@lokascript/semantic';
+import { createSemanticAdapter, SemanticIntegrationAdapter } from './semantic-integration';
+import type { SemanticAnalyzer } from './semantic-integration';
+import { hyperscript } from '../api/hyperscript-api';
+
+function makeAdapter(withBuilder = true): SemanticIntegrationAdapter {
+  const analyzer = createSemanticAdapter({
+    parse: parseSemantic,
+    isRegistered: isLanguageRegistered,
+    registered: getRegisteredLanguages,
+    ...(withBuilder ? { buildAST } : {}),
+  });
+  return new SemanticIntegrationAdapter({ analyzer, language: 'en' });
+}
+
+/** Comparable shape: name, arg types, sorted modifier keys. */
+function shapeOf(node: unknown): string {
+  const n = node as { name?: string; args?: unknown[]; modifiers?: Record<string, unknown> };
+  const args = (n.args ?? []).map(a => (a as { type?: string }).type).join(',');
+  const mods = Object.keys(n.modifiers ?? {})
+    .sort()
+    .join(',');
+  return `${n.name}|args:${args}|mods:${mods}`;
+}
+
+function host(html: string): HTMLElement {
+  document.body.innerHTML = `<div id="host"></div>${html}`;
+  return document.getElementById('host') as HTMLElement;
+}
+
+// =============================================================================
+// The delegated tail IS the builder
+// =============================================================================
+
+describe('the generic command tail delegates to buildAST', () => {
+  /**
+   * Every reachable command with a parsing English surface. "Reachable" means
+   * excluded by neither `parser.ts`'s `skipSemanticParsing` nor the adapter's
+   * own `SKIP_SEMANTIC_COMMANDS` — i.e. the semantic path is what English
+   * actually runs for these.
+   */
+  const SURFACES = [
+    'go back',
+    'go to url "/page"',
+    'get #target',
+    'pick first 2 from .items',
+    'scroll to #header',
+    'scroll to last <.message/> in #chat',
+    'default :x to 0',
+    'bind $greeting to #name-input',
+    'send refresh to #target',
+    'show #panel',
+    'hide #panel',
+    'log me',
+    'settle',
+    'blur me',
+    'clear :x',
+    'focus first <input/>',
+    'take .active from .tab',
+    'throw "boom"',
+    'push url "/next"',
+    'replace url "/next"',
+    'empty #list',
+    'open #dlg as non-modal',
+    'close #dlg',
+    'reset #form',
+    'call foo()',
+    'copy "hello"',
+    'render #tpl',
+    'live #out',
+    'behavior Foo',
+  ];
+
+  it.each(SURFACES)('%s builds the same node the ASTBuilder does', src => {
+    const parsed = parseSemantic(src, 'en');
+    expect(parsed.node, `no semantic parse for "${src}"`).toBeTruthy();
+
+    const viaBuilder = shapeOf(buildAST(parsed.node as never).ast);
+    const attempt = makeAdapter().trySemanticParse(src);
+
+    expect(attempt.success, `adapter refused "${src}": ${(attempt.errors ?? []).join('; ')}`).toBe(
+      true
+    );
+    expect(shapeOf(attempt.node)).toBe(viaBuilder);
+  });
+
+  it('stamps the fields core requires but the builder does not emit', () => {
+    const node = makeAdapter().trySemanticParse('scroll to #header').node;
+    // `ASTBuilder` emits position-free nodes and marks isBlocking only where a
+    // schema declares it; core's CommandNode requires isBlocking and reads the
+    // span in error messages.
+    expect(node).toMatchObject({ type: 'command', isBlocking: false, start: 0, line: 1 });
+  });
+
+  it("carries the builder's isBlocking through rather than hardcoding false", () => {
+    // `fetch` declares isBlocking in its schema. The deleted switch hardcoded
+    // `isBlocking: false` for every command, which is what made this worth
+    // pinning: it is a behavior delta of the delegation, not an accident.
+    const parsed = parseSemantic('fetch /api/x', 'en');
+    const built = buildAST(parsed.node as never).ast as { isBlocking?: boolean };
+    expect(built.isBlocking, 'precondition: fetch is a blocking schema').toBe(true);
+
+    const analyzer = createSemanticAdapter({
+      parse: parseSemantic,
+      isRegistered: isLanguageRegistered,
+      registered: getRegisteredLanguages,
+      buildAST,
+    });
+    const node = analyzer.buildCommandNode?.({
+      name: 'fetch',
+      roles: (parsed.node as unknown as { roles: never }).roles,
+    });
+    expect(node?.isBlocking).toBe(true);
+  });
+});
+
+// =============================================================================
+// What delegation must NOT take over
+// =============================================================================
+
+describe('shapes the ASTBuilder cannot produce keep their dedicated builders', () => {
+  /**
+   * Measured both paths on one parse. The builder's shapes are right for ITS
+   * consumers — it carries the loop variant on `LoopSemanticNode`, which a
+   * single-command parse has already discarded — but they are not core's
+   * runtime contract, so these four stay behind.
+   */
+  it('repeat keeps the loop-variant discriminator the builder drops', () => {
+    const node = makeAdapter().trySemanticParse('repeat forever').node;
+    expect(node?.name).toBe('repeat');
+    expect(node?.args?.[0]).toMatchObject({ type: 'identifier', name: 'forever' });
+
+    // The builder alone would have produced no discriminator at all.
+    const built = buildAST(parseSemantic('repeat forever', 'en').node as never).ast as {
+      args?: unknown[];
+    };
+    expect(built.args ?? []).toHaveLength(0);
+  });
+
+  it('repeat N times keeps [times, count]', () => {
+    const node = makeAdapter().trySemanticParse('repeat 5 times').node;
+    expect(node?.args?.[0]).toMatchObject({ type: 'identifier', name: 'times' });
+    expect(node?.args?.[1]).toMatchObject({ type: 'literal', value: 5 });
+  });
+
+  it('for is renamed to repeat, which the builder does not do', () => {
+    const node = makeAdapter().trySemanticParse('for item in items').node;
+    expect(node?.name).toBe('repeat');
+
+    const built = buildAST(parseSemantic('for item in items', 'en').node as never).ast as {
+      name?: string;
+    };
+    expect(built.name, 'the builder keeps the `for` name core has no command for').toBe('for');
+  });
+
+  it('set keeps the positional `to` marker SetCommand.parseInput reads', () => {
+    const node = makeAdapter().trySemanticParse('set x to 5').node;
+    expect(node?.args?.[1]).toMatchObject({ type: 'identifier', name: 'to' });
+    expect(node?.args?.[2]).toMatchObject({ type: 'literal', value: 5 });
+
+    // The builder puts the value in `modifiers.to`, which SetCommand never reads.
+    const built = buildAST(parseSemantic('set x to 5', 'en').node as never).ast as {
+      modifiers?: Record<string, unknown>;
+    };
+    expect(built.modifiers?.['to']).toBeDefined();
+  });
+});
+
+describe('the *prop refusal survives delegation', () => {
+  it.each([
+    'show #panel with *opacity',
+    'hide #panel with *opacity',
+    'transition my *opacity to 0 over 200ms',
+  ])('%s returns no node so the traditional parser takes it', src => {
+    const attempt = makeAdapter().trySemanticParse(src);
+    expect(attempt.success).toBe(false);
+    expect(attempt.node).toBeUndefined();
+  });
+
+  it('is a refusal, not an inability — the builder would have built one', () => {
+    const parsed = parseSemantic('transition my *opacity to 0 over 200ms', 'en');
+    expect(parsed.node).toBeTruthy();
+    expect(buildAST(parsed.node as never).ast).toMatchObject({ type: 'command' });
+  });
+});
+
+describe('an analyzer with no builder degrades to the traditional parser', () => {
+  it('reports failure for the generic tail rather than inventing a node', () => {
+    const attempt = makeAdapter(false).trySemanticParse('scroll to #header');
+    expect(attempt.success).toBe(false);
+    expect((attempt.errors ?? []).join(' ')).toMatch(/buildCommandNode/);
+  });
+
+  it('still serves the four dedicated shapes', () => {
+    // Those never needed the builder, so an unwired analyzer keeps them.
+    const attempt = makeAdapter(false).trySemanticParse('set x to 5');
+    expect(attempt.success).toBe(true);
+    expect(attempt.node?.name).toBe('set');
+  });
+
+  it('is what the SemanticAnalyzer contract advertises', () => {
+    const bare: SemanticAnalyzer = {
+      analyze: () => ({ confidence: 0 }),
+      supportsLanguage: () => true,
+      supportedLanguages: () => ['en'],
+    };
+    expect(bare.buildCommandNode).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// The five live English defects, end to end
+// =============================================================================
+
+describe('the defects the duplicated switch caused', () => {
+  it('`go back` executes instead of throwing', async () => {
+    const result = (await hyperscript.eval('go back', host(''))) as { type?: string };
+    expect(result?.type).toBe('back');
+  });
+
+  it('`go to url "/page"` executes instead of throwing', async () => {
+    await expect(hyperscript.eval('go to url "/page"', host(''))).resolves.toBeDefined();
+  });
+
+  it('`get #target` returns the element instead of throwing', async () => {
+    const el = host('<div id="target">T</div>');
+    const result = (await hyperscript.eval('get #target', el)) as { value?: unknown };
+    expect(result?.value).toBe(document.getElementById('target'));
+  });
+
+  it('`scroll to #header` finds its target instead of throwing', async () => {
+    const el = host('<div id="header">H</div>');
+    const result = (await hyperscript.eval('scroll to #header', el)) as { element?: unknown };
+    expect(result?.element).toBe(document.getElementById('header'));
+  });
+
+  it('`scroll to last <.message/> in #chat` (the corpus row) executes', async () => {
+    const el = host('<div id="chat"><p class="message">a</p><p class="message">b</p></div>');
+    const result = (await hyperscript.eval('scroll to last <.message/> in #chat', el)) as {
+      element?: unknown;
+    };
+    expect(result?.element).toBe(document.querySelectorAll('#chat .message')[1]);
+  });
+
+  it('`pick first 2 from .items` returns TWO items, not one', async () => {
+    // The only defect of the five that failed silently: the switch bound the
+    // count to args[0] and the source to modifiers.from, so PickCommand read
+    // its count as the collection and returned a single element.
+    const el = host('<i class="items">a</i><i class="items">b</i><i class="items">c</i>');
+    const result = (await hyperscript.eval('pick first 2 from .items', el)) as {
+      selectedItem?: unknown;
+    };
+    expect(Array.isArray(result?.selectedItem)).toBe(true);
+    expect(result?.selectedItem).toHaveLength(2);
+  });
+
+  it('`default` now reaches the same runtime as the traditional parser', async () => {
+    // The AST-shape half of default's breakage is what this phase fixes: the
+    // switch emitted `args:[value] mods:{on:target}` where DefaultCommand reads
+    // `args[0]`-is-target / `modifiers.to`-is-value. Both paths now agree —
+    // and both hit DefaultCommand's own separate defect (it EVALUATES the
+    // target name), which is a runtime fix, not a parser one.
+    const el = host('');
+    const semantic = await hyperscript.eval('default :x to 0', el).catch(e => `${e.message}`);
+    const traditional = await hyperscript
+      .eval('default :x to 0', el, { traditional: true } as never)
+      .catch(e => `${e.message}`);
+    expect(semantic).toBe(traditional);
+  });
+});

--- a/packages/core/src/parser/semantic-integration.test.ts
+++ b/packages/core/src/parser/semantic-integration.test.ts
@@ -5,9 +5,11 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
+import { buildAST } from '@lokascript/semantic';
 import {
   SemanticIntegrationAdapter,
   SemanticAnalyzer,
+  SemanticCommand,
   SemanticRole,
   SemanticValue,
   DEFAULT_CONFIDENCE_THRESHOLD,
@@ -21,6 +23,22 @@ import {
 // =============================================================================
 // Mock Semantic Analyzer
 // =============================================================================
+
+/**
+ * The role→AST step every real analyzer carries: `@lokascript/semantic`'s
+ * `ASTBuilder`. Mocks wire the SAME function production does (see
+ * `createSemanticAdapter`'s `buildAST` dep) so their node shapes cannot drift
+ * from the shipped ones — that drift is precisely what the deleted in-core
+ * switch had accumulated.
+ */
+function realBuildCommandNode(command: SemanticCommand) {
+  return createSemanticAdapter({
+    parse: () => ({ node: null, confidence: 0 }),
+    isRegistered: () => true,
+    registered: () => ['en'],
+    buildAST,
+  }).buildCommandNode?.(command);
+}
 
 function createMockAnalyzer(supportedLangs: string[] = ['en', 'es', 'ja', 'ar']): SemanticAnalyzer {
   return {
@@ -45,6 +63,7 @@ function createMockAnalyzer(supportedLangs: string[] = ['en', 'es', 'ja', 'ar'])
     }) as SemanticAnalyzer['analyze'],
     supportsLanguage: (lang: string) => supportedLangs.includes(lang),
     supportedLanguages: () => supportedLangs,
+    buildCommandNode: realBuildCommandNode,
   };
 }
 
@@ -351,6 +370,16 @@ describe('parseExpressionString (via expression type values)', () => {
    * These tests verify the internal parseExpressionString method by testing
    * through the public interface. The adapter calls parseExpressionString
    * when converting 'expression' type semantic values.
+   *
+   * They go through `set` rather than `call`: the generic command tail now
+   * delegates to `@lokascript/semantic`'s ASTBuilder (which brings its own
+   * expression parser), so `parseExpressionString` survives only on the three
+   * shapes the builder cannot produce — repeat/for, set, if/unless. `set` is
+   * the one of those that carries a plain value expression.
+   *
+   * `buildSetCommandNode` emits `[destination, identifier('to'), patient]`,
+   * which is the positional contract `SetCommand.parseInput` reads — hence
+   * `args[2]` for the value below.
    */
 
   function createExpressionMockAnalyzer(expressionValue: string): SemanticAnalyzer {
@@ -358,8 +387,9 @@ describe('parseExpressionString (via expression type values)', () => {
       analyze: vi.fn(() => ({
         confidence: 0.9,
         command: {
-          name: 'call',
+          name: 'set',
           roles: new Map([
+            ['destination' as const, { type: 'reference' as const, value: 'target' }],
             [
               'patient' as const,
               { type: 'expression' as const, value: expressionValue, raw: expressionValue },
@@ -373,6 +403,9 @@ describe('parseExpressionString (via expression type values)', () => {
     };
   }
 
+  /** The value slot of the `[target, 'to', value]` set contract. */
+  const VALUE_ARG = 2;
+
   it('should parse simple identifiers', () => {
     const analyzer = createExpressionMockAnalyzer('myVar');
     const adapter = new SemanticIntegrationAdapter({ analyzer, language: 'en' });
@@ -380,7 +413,7 @@ describe('parseExpressionString (via expression type values)', () => {
     const result = adapter.trySemanticParse('call myVar');
 
     expect(result.success).toBe(true);
-    expect(result.node?.args?.[0]).toMatchObject({
+    expect(result.node?.args?.[VALUE_ARG]).toMatchObject({
       type: 'identifier',
       name: 'myVar',
     });
@@ -393,7 +426,7 @@ describe('parseExpressionString (via expression type values)', () => {
     const result = adapter.trySemanticParse('get me.textContent');
 
     expect(result.success).toBe(true);
-    const expr = result.node?.args?.[0] as any;
+    const expr = result.node?.args?.[VALUE_ARG] as any;
     expect(expr.type).toBe('memberExpression');
     expect(expr.object.name).toBe('me');
     expect(expr.property.name).toBe('textContent');
@@ -406,7 +439,7 @@ describe('parseExpressionString (via expression type values)', () => {
     const result = adapter.trySemanticParse('get obj.foo.bar');
 
     expect(result.success).toBe(true);
-    const expr = result.node?.args?.[0] as any;
+    const expr = result.node?.args?.[VALUE_ARG] as any;
     expect(expr.type).toBe('memberExpression');
     expect(expr.property.name).toBe('bar');
     expect(expr.object.type).toBe('memberExpression');
@@ -421,7 +454,7 @@ describe('parseExpressionString (via expression type values)', () => {
     const result = adapter.trySemanticParse('call foo()');
 
     expect(result.success).toBe(true);
-    const expr = result.node?.args?.[0] as any;
+    const expr = result.node?.args?.[VALUE_ARG] as any;
     expect(expr.type).toBe('callExpression');
     expect(expr.callee.name).toBe('foo');
     expect(expr.arguments).toHaveLength(0);
@@ -434,7 +467,7 @@ describe('parseExpressionString (via expression type values)', () => {
     const result = adapter.trySemanticParse('call me.insertBefore(draggedItem, dropTarget)');
 
     expect(result.success).toBe(true);
-    const expr = result.node?.args?.[0] as any;
+    const expr = result.node?.args?.[VALUE_ARG] as any;
 
     // Should be a callExpression
     expect(expr.type).toBe('callExpression');
@@ -457,7 +490,7 @@ describe('parseExpressionString (via expression type values)', () => {
     const result = adapter.trySemanticParse('call x.y(a.b, c)');
 
     expect(result.success).toBe(true);
-    const expr = result.node?.args?.[0] as any;
+    const expr = result.node?.args?.[VALUE_ARG] as any;
 
     expect(expr.type).toBe('callExpression');
     expect(expr.arguments).toHaveLength(2);
@@ -479,7 +512,7 @@ describe('parseExpressionString (via expression type values)', () => {
     const result = adapter.trySemanticParse('call obj.method().another()');
 
     expect(result.success).toBe(true);
-    const expr = result.node?.args?.[0] as any;
+    const expr = result.node?.args?.[VALUE_ARG] as any;
 
     // Outermost: callExpression for .another()
     expect(expr.type).toBe('callExpression');
@@ -501,7 +534,7 @@ describe('parseExpressionString (via expression type values)', () => {
     const result = adapter.trySemanticParse('call foo.bar(x, y)');
 
     expect(result.success).toBe(true);
-    const expr = result.node?.args?.[0] as any;
+    const expr = result.node?.args?.[VALUE_ARG] as any;
     expect(expr.type).toBe('callExpression');
     expect(expr.callee.property.name).toBe('bar');
     expect(expr.arguments).toHaveLength(2);
@@ -514,7 +547,7 @@ describe('parseExpressionString (via expression type values)', () => {
     const result = adapter.trySemanticParse('call');
 
     expect(result.success).toBe(true);
-    const expr = result.node?.args?.[0] as any;
+    const expr = result.node?.args?.[VALUE_ARG] as any;
     expect(expr.type).toBe('identifier');
     expect(expr.name).toBe('');
   });

--- a/packages/core/src/parser/semantic-integration.ts
+++ b/packages/core/src/parser/semantic-integration.ts
@@ -83,6 +83,14 @@ export interface SemanticAnalysisResult {
 }
 
 /**
+ * The command payload an analyzer reports: an action name plus its semantic roles.
+ */
+export interface SemanticCommand {
+  readonly name: string;
+  readonly roles: ReadonlyMap<SemanticRole, SemanticValue>;
+}
+
+/**
  * Interface for semantic analysis that can be integrated into the core parser.
  * This allows the core parser to optionally use semantic parsing with
  * confidence-based fallback to traditional parsing.
@@ -106,6 +114,25 @@ export interface SemanticAnalyzer {
    * Get the list of supported languages.
    */
   supportedLanguages(): string[];
+
+  /**
+   * Convert an analyzed command's roles into a `CommandNode`.
+   *
+   * This is the role→AST step, and core deliberately does NOT implement it:
+   * `@lokascript/semantic`'s `ASTBuilder` owns that knowledge (schema `ast`
+   * descriptors plus the four hand-written mappers), and it is what the
+   * multilingual and semantic-complete browser bundles already execute.
+   * {@link createSemanticAdapter} wires it in from the semantic module the
+   * caller already holds, so core keeps no hard import and no second copy.
+   *
+   * An analyzer without this method still parses — {@link
+   * SemanticIntegrationAdapter.trySemanticParse} reports failure for the
+   * generic command tail and the traditional parser takes the segment.
+   *
+   * @param command The analyzed action name and its roles
+   * @returns The command node, or undefined if no node could be built
+   */
+  buildCommandNode?(command: SemanticCommand): CommandNode | undefined;
 }
 
 // =============================================================================
@@ -336,6 +363,15 @@ export class SemanticIntegrationAdapter {
 
   /**
    * Build a CommandNode from semantic analysis result.
+   *
+   * Everything except the four loop/assignment/conditional shapes below is
+   * delegated to the analyzer's {@link SemanticAnalyzer.buildCommandNode} —
+   * i.e. to `@lokascript/semantic`'s `ASTBuilder`. Core used to carry a second
+   * role→AST implementation here (a blanket `destination`→`on` /
+   * `source`→`from` mapping); it had drifted from the builder for 15 of the 29
+   * measured commands and was the live English path for every command absent
+   * from `parser.ts`'s `skipSemanticParsing` list. See the delegation probe in
+   * `semantic-integration-delegation.test.ts`.
    */
   private buildCommandNode(result: SemanticAnalysisResult): CommandNode {
     const { command } = result;
@@ -343,7 +379,18 @@ export class SemanticIntegrationAdapter {
       throw new Error('Cannot build command node without command data');
     }
 
-    // Route commands to specialized handlers
+    // Route commands whose core runtime contract the semantic ASTBuilder does
+    // NOT produce. Measured 2026-07-31, English, one parse fed to both paths:
+    //
+    //   repeat forever  builder: args:[]                     core needs args:[identifier('forever')]
+    //   repeat 5 times  builder: args:[literal(5)]           core needs args:[identifier('times'), 5]
+    //   for item in xs  builder: name:'for', modifiers:{in:…} core needs name:'repeat'
+    //   set x to 5      builder: args:[x] modifiers:{to:5}   core needs args:[x, identifier('to'), 5]
+    //
+    // The builder's shapes are correct for ITS consumers (they carry the loop
+    // variant on `LoopSemanticNode`, which a single-command parse has already
+    // discarded). Delegating these would break `SetCommand.parseInput` and the
+    // repeat variant discriminator, so they keep their dedicated builders.
     if (command.name === 'repeat') {
       return this.buildRepeatCommandNode(command);
     }
@@ -361,89 +408,17 @@ export class SemanticIntegrationAdapter {
       return this.buildIfCommandNode(command);
     }
 
-    const args: ExpressionNode[] = [];
-    const modifiers: Record<string, ExpressionNode> = {};
-
-    // Convert semantic roles to command arguments/modifiers
-    for (const [role, value] of command.roles) {
-      const exprNode = this.semanticValueToExpression(value);
-
-      switch (role) {
-        // Primary arguments (patient, event) go into args array
-        case 'patient':
-        case 'event':
-          args.push(exprNode);
-          break;
-
-        // Destination role maps to position-based modifiers
-        // Each command uses different prepositions for the target:
-        case 'destination':
-          if (command.name === 'put') {
-            modifiers['into'] = exprNode;
-          } else if (
-            command.name === 'add' ||
-            command.name === 'append' ||
-            command.name === 'prepend'
-          ) {
-            modifiers['to'] = exprNode;
-          } else {
-            // toggle, set, send, etc use 'on'
-            modifiers['on'] = exprNode;
-          }
-          break;
-
-        // Source role - for fetch command, the source (URL) goes into args
-        // For other commands, it becomes a 'from' modifier
-        case 'source':
-          if (command.name === 'fetch') {
-            args.push(exprNode);
-          } else {
-            modifiers['from'] = exprNode;
-          }
-          break;
-
-        // Quantitative roles
-        case 'quantity':
-          modifiers['by'] = exprNode;
-          break;
-
-        case 'duration':
-          modifiers['over'] = exprNode;
-          break;
-
-        // Adverbial roles
-        case 'responseType':
-          modifiers['as'] = exprNode; // Response format (json, text, html)
-          break;
-
-        case 'style':
-          modifiers['with'] = exprNode;
-          break;
-
-        // Condition role - maps to 'when' modifier (matches core implementation)
-        case 'condition':
-          modifiers['when'] = exprNode;
-          break;
-
-        // Unknown roles become modifiers with role name as key. `method` lands
-        // here: no command reads a `method` modifier (FetchCommand takes the HTTP
-        // method from the evaluated `with` options object), so it needs no case.
-        default:
-          modifiers[role] = exprNode;
-      }
+    const delegated = this.analyzer.buildCommandNode?.(command);
+    if (!delegated) {
+      // No builder wired (or it declined). Reporting failure hands the segment
+      // to the traditional parser rather than inventing a second role→AST
+      // mapping here — that duplication is exactly what this delegation removed.
+      throw new Error(
+        `Semantic analyzer cannot build an AST node for '${command.name}' ` +
+          `(no buildCommandNode wired — see createSemanticAdapter's buildAST dep)`
+      );
     }
-
-    return {
-      type: 'command',
-      name: command.name,
-      args,
-      modifiers: Object.keys(modifiers).length > 0 ? modifiers : undefined,
-      isBlocking: false,
-      start: 0,
-      end: 0,
-      line: 1,
-      column: 0,
-    };
+    return delegated;
   }
 
   /**
@@ -923,6 +898,43 @@ interface SemanticParseFn {
 }
 
 /**
+ * Minimal shape of `buildAST` from `@lokascript/semantic`. Re-declared here for
+ * the same reason as {@link SemanticParseFn} — core takes no hard import on the
+ * semantic package from this module.
+ *
+ * The parameter is `never` deliberately. {@link SemanticParseFn} can spell its
+ * node structurally because it appears in RETURN position (covariant, so the
+ * real `SemanticNode` is assignable to a looser shape); a parameter is
+ * contravariant, and the loose shape is NOT assignable to `SemanticNode`
+ * (`action: string` vs its `ActionType` union). `never` is assignable to every
+ * type, so the real `buildAST` satisfies this at each call site, and the single
+ * cast lives below where we build the node we know is a valid command node.
+ */
+type BuildASTFn = (node: never) => { ast: unknown; warnings?: string[] };
+
+/**
+ * Give a semantic-built node the fields core's AST contract requires.
+ *
+ * `ASTBuilder` emits position-free nodes (its own consumers do not need spans),
+ * and marks `isBlocking` only where the schema declares it. Core's
+ * `CommandNode` requires `isBlocking`, and its error messages read the span.
+ */
+function normalizeBuiltNode(ast: unknown): CommandNode | undefined {
+  if (!ast || typeof ast !== 'object') return undefined;
+  const node = ast as Record<string, unknown>;
+  if (node['type'] !== 'command' || typeof node['name'] !== 'string') return undefined;
+  return {
+    start: 0,
+    end: 0,
+    line: 1,
+    column: 0,
+    ...node,
+    isBlocking: node['isBlocking'] === true,
+    args: Array.isArray(node['args']) ? (node['args'] as ExpressionNode[]) : [],
+  } as CommandNode;
+}
+
+/**
  * Build a `SemanticAnalyzer` from the new semantic primitives (`parseSemantic`,
  * `isLanguageRegistered`, `getRegisteredLanguages`). The returned object
  * conforms to core's local `SemanticAnalyzer` interface so the
@@ -931,15 +943,23 @@ interface SemanticParseFn {
  * Replaces the deprecated `createSemanticAnalyzer()` factory from
  * `@lokascript/semantic`.
  *
+ * Pass `buildAST` too: it is what turns an analyzed command's roles into a
+ * `CommandNode`. Without it the adapter still analyzes, but the generic command
+ * tail falls back to the traditional parser (core keeps no role→AST copy of its
+ * own — see {@link SemanticAnalyzer.buildCommandNode}).
+ *
  * @example
  * ```typescript
- * import { parseSemantic, isLanguageRegistered, getRegisteredLanguages } from '@lokascript/semantic';
+ * import {
+ *   parseSemantic, isLanguageRegistered, getRegisteredLanguages, buildAST,
+ * } from '@lokascript/semantic';
  * import { createSemanticAdapter } from '@hyperfixi/core/parser/semantic-integration';
  *
  * const analyzer = createSemanticAdapter({
  *   parse: parseSemantic,
  *   isRegistered: isLanguageRegistered,
  *   registered: getRegisteredLanguages,
+ *   buildAST,
  * });
  * ```
  */
@@ -947,8 +967,31 @@ export function createSemanticAdapter(deps: {
   parse: SemanticParseFn;
   isRegistered: (language: string) => boolean;
   registered: () => string[];
+  buildAST?: BuildASTFn;
 }): SemanticAnalyzer {
+  const { buildAST } = deps;
   return {
+    ...(buildAST
+      ? {
+          buildCommandNode(command: SemanticCommand): CommandNode | undefined {
+            // `ASTBuilder` reads only `action` and `roles` off a command node,
+            // so an analyzed command reconstitutes one losslessly. Going
+            // through the command payload (rather than smuggling the original
+            // parse node through the result) keeps this working for any
+            // analyzer, including the mock ones in the test suite.
+            try {
+              const { ast } = buildAST({
+                kind: 'command',
+                action: command.name,
+                roles: command.roles,
+              } as never);
+              return normalizeBuiltNode(ast);
+            } catch {
+              return undefined;
+            }
+          },
+        }
+      : {}),
     analyze(input: string, language: string): SemanticAnalysisResult {
       if (!deps.isRegistered(language)) {
         return {

--- a/packages/core/src/parser/types.ts
+++ b/packages/core/src/parser/types.ts
@@ -245,6 +245,19 @@ export interface SemanticAnalyzerInterface {
 
   /** Get the list of supported languages */
   supportedLanguages(): string[];
+
+  /**
+   * Convert an analyzed command's roles into a command node.
+   *
+   * Owned by `@lokascript/semantic`'s `ASTBuilder`, not by core — see
+   * `SemanticAnalyzer.buildCommandNode` in `parser/semantic-integration.ts`.
+   * An analyzer without it still analyzes; the generic command tail simply
+   * falls back to the traditional parser.
+   */
+  buildCommandNode?(command: {
+    name: string;
+    roles: ReadonlyMap<string, { type: string; value: string }>;
+  }): unknown;
 }
 
 export interface ParserOptions {
@@ -277,13 +290,23 @@ export interface ParserOptions {
    * When provided, the parser can use semantic-first parsing with
    * confidence-based fallback to traditional keyword parsing.
    *
-   * Use the semantic analyzer from @lokascript/semantic:
+   * Build one with `createSemanticAdapter` from the semantic primitives —
+   * including `buildAST`, which is what converts roles into AST nodes:
    *
    * @example
    * ```typescript
-   * import { createSemanticAnalyzer } from '@lokascript/semantic';
+   * import {
+   *   parseSemantic, isLanguageRegistered, getRegisteredLanguages, buildAST,
+   * } from '@lokascript/semantic';
+   * import { createSemanticAdapter } from '@hyperfixi/core/parser/semantic-integration';
+   *
    * parse('#button の .active を 切り替え', {
-   *   semanticAnalyzer: createSemanticAnalyzer(),
+   *   semanticAnalyzer: createSemanticAdapter({
+   *     parse: parseSemantic,
+   *     isRegistered: isLanguageRegistered,
+   *     registered: getRegisteredLanguages,
+   *     buildAST,
+   *   }),
    *   language: 'ja',
    * });
    * ```


### PR DESCRIPTION
Arc F follow-ups round 2, **Phase A** — the (b) decision from #844.

## The defect

`packages/core/src/parser/semantic-integration.ts` carried a **second** semantic→AST implementation: a blanket `destination`→`modifiers.on` / `source`→`modifiers.from` switch, independent of `@lokascript/semantic`'s `ASTBuilder` and drifted from it for **15 of the 29** commands with a parsing English surface.

It was not latent. `parser.ts`'s `skipSemanticParsing` list names 24 commands; for every command *not* on it, this switch — not `buildAST`, not the schema `ast` descriptors — is what the **live English path** runs.

## What changes for users

Measured through `hyperscript.eval` in jsdom, before → after:

| source | before | after |
| --- | --- | --- |
| `go back` | throws `Go command requires arguments` | works |
| `go to url "/page"` | throws, same | works |
| `get #target` | throws `get command requires an expression argument` | works |
| `scroll to #header` | throws `scroll command requires a target` | works |
| `scroll to last <.message/> in #chat` (corpus row) | throws | works |
| `pick first 2 from .items` | **no error, wrong result** — 1 item | returns 2 |
| `default :x to 0` | wrong AST shape | agrees with the traditional path |

`pick` is the one that failed silently: the switch bound the count to `args[0]` and the source to `modifiers.from`, so `PickCommand` read its count as the collection.

`default`'s AST shape is now right; its *remaining* failure is a separate runtime defect (`DefaultCommand` evaluates its target name), untouched here and queued as Phase B.

This is also what makes #843/#845's descriptor fixes reach `hyperscript.eval` — until now they reached only the multilingual and semantic-complete bundles.

## The seam

Dependency injection, so core keeps no hard import on the semantic package: `SemanticAnalyzer` gains an optional `buildCommandNode`, and `createSemanticAdapter` implements it from a `buildAST` dep the two callers already hold. An analyzer without one still analyzes — the generic tail reports failure and the traditional parser takes the segment, rather than core growing a second role→AST mapping again.

## What delegation deliberately does NOT take over

Both measured, both pinned by new tests:

- **`repeat`/`for`/`set`/`if`/`unless` keep their dedicated builders.** The builder emits `repeat forever` as `args:[]` (the loop variant lives on `LoopSemanticNode`, which a single-command parse has already discarded), keeps the `for` name core has no command for, and puts set's value in `modifiers.to` where `SetCommand.parseInput` reads a positional `[target, 'to', value]`.
- **`show`/`hide`/`transition … *prop` keep returning no node** — `shouldSkipSemantic`'s deliberate refusal, not an inability. The tests pin both halves.

## Behavior deltas worth naming

- Nodes now carry the builder's `isBlocking` (the switch hardcoded `false`, so `fetch` was mismarked) and its `semanticRoles` metadata.
- `send`'s target moves from `modifiers.on` to `modifiers.to` — `SendCommand` already accepted both.
- `transition` remains broken on both paths, in different ways. Unchanged by this PR.

## Test fallout

The 13 tests that broke were exactly the ones pinning the deleted switch. The four node-shape tests now wire the **real** `buildAST` into their mock analyzer — the same function production uses, so mock shapes can no longer drift from shipped ones. The nine `parseExpressionString` tests move to `set`, the one surviving dedicated shape that carries a value expression.

## Gates

core **7759 passed / 106 skipped / 302 files** · `typecheck` · `typecheck:scripts` · `verify:reference` · `docs:commands:check` · `generate:bundles:check` · `snapshot:bundle-size --check` · language-server **227** · oxlint. Multilingual ratchet **green and unmoved**.

New gate rows mutation-verified three ways — forced `isBlocking: false` (1 failure), dropped the `*prop` refusal (3), delegated `set` (11).

Pre-existing and unrelated: `packages/developer-tools/src/dev-server.test.ts` fails 26 tests on `main` too (verified by stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)