### PR TITLE
fix(commands): `default` resolves its target symbolically — all five documented examples start working

### DIFF
--- a/packages/core/src/commands/data/__tests__/default-eval.test.ts
+++ b/packages/core/src/commands/data/__tests__/default-eval.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+/**
+ * `default` through the real parser and the real runtime.
+ *
+ * Every one of DefaultCommand's five documented `metadata.examples` was broken,
+ * on BOTH execution paths, and the package's unit tests could not see it: they
+ * inject a mock evaluator that returns `node.value ?? node.name`, i.e. the
+ * name-preserving behavior the real evaluator does not have. Measured at
+ * `22059a6e`, before this change:
+ *
+ *   default myVar to "fallback"          throws `Invalid target type: undefined`
+ *   default @data-theme to "light"       throws `Invalid target type: object`
+ *   default :x to 0                      throws `Invalid target type: undefined`
+ *   default my @data-count to "0"        throws (the corpus row `default-value`)
+ *   default my innerHTML to "No content" NO error — and no DOM write either:
+ *                                        the evaluated target was the empty
+ *                                        innerHTML string, so it created a
+ *                                        junk local literally named ''
+ *
+ * Cause: `parseInput` did `evaluate(raw.args[0])`. A write target's evaluation
+ * is its CURRENT VALUE, and for `default` that value is `undefined` exactly
+ * when the command is supposed to act. A second, independent defect rode along:
+ * the traditional parser emits `[target, identifier('to'), value]` and the old
+ * code took `args[1]` for the value — the `to` KEYWORD — so `default #out to
+ * "x"` wrote the string "undefined".
+ *
+ * These tests go through `hyperscript.eval` deliberately, and assert the DOM /
+ * variable effect rather than the return value: a mocked unit test cannot see
+ * either defect, and `wasSet: true` was returned in the silent case.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { hyperscript } from '../../../api/hyperscript-api';
+
+type Mode = { label: string; opts?: Record<string, unknown> };
+const MODES: Mode[] = [
+  { label: 'semantic' },
+  { label: 'traditional', opts: { traditional: true } },
+];
+
+function host(extra = ''): HTMLElement {
+  document.body.innerHTML = `<div id="host"></div>${extra}`;
+  return document.getElementById('host') as HTMLElement;
+}
+
+describe.each(MODES)('default — documented examples ($label path)', ({ opts }) => {
+  const run = (src: string, el: HTMLElement) => hyperscript.eval(src, el, opts as never);
+
+  it('`default myVar to "fallback"` sets the variable instead of throwing', async () => {
+    const result = (await run('default myVar to "fallback"', host())) as Record<string, unknown>;
+    expect(result).toMatchObject({
+      targetType: 'variable',
+      target: 'myVar',
+      value: 'fallback',
+      wasSet: true,
+    });
+  });
+
+  it('`default @data-theme to "light"` writes the attribute', async () => {
+    const el = host();
+    await run('default @data-theme to "light"', el);
+    expect(el.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('`default @data-theme to "light"` leaves an existing attribute alone', async () => {
+    const el = host();
+    el.setAttribute('data-theme', 'dark');
+    const result = (await run('default @data-theme to "light"', el)) as Record<string, unknown>;
+    expect(el.getAttribute('data-theme')).toBe('dark');
+    expect(result).toMatchObject({ wasSet: false, existingValue: 'dark' });
+  });
+
+  it('`default my innerHTML to "No content"` writes the DOM, not a junk local', async () => {
+    const el = host();
+    await run('default my innerHTML to "No content"', el);
+    expect(el.innerHTML).toBe('No content');
+  });
+
+  it('`default my innerHTML to …` leaves existing content alone', async () => {
+    const el = host();
+    el.innerHTML = '<p>Existing</p>';
+    await run('default my innerHTML to "No content"', el);
+    expect(el.innerHTML).toBe('<p>Existing</p>');
+  });
+
+  it('`default :x to 0` sets the element-scoped variable', async () => {
+    const result = (await run('default :x to 0', host())) as Record<string, unknown>;
+    expect(result).toMatchObject({ targetType: 'variable', target: 'x', value: 0, wasSet: true });
+  });
+
+  it('`default my @data-count to "0"` (the corpus row) writes the attribute', async () => {
+    const el = host();
+    await run('default my @data-count to "0"', el);
+    expect(el.getAttribute('data-count')).toBe('0');
+  });
+
+  it('`default #out to "x"` fills the element — with the VALUE, not "undefined"', async () => {
+    // The `to`-keyword defect: on the traditional path this used to write the
+    // literal string "undefined", because the value was read from args[1].
+    const el = host('<div id="out"></div>');
+    await run('default #out to "x"', el);
+    expect(document.getElementById('out')!.textContent).toBe('x');
+  });
+});
+
+describe('default — the no-overwrite contract', () => {
+  it('`set x to 1 then default x to 9` keeps 1', async () => {
+    const result = (await hyperscript.eval(
+      'set x to 1 then default x to 9',
+      host()
+    )) as unknown as Record<string, unknown>;
+    // The sequence's last command is the default; it must decline to write.
+    expect(result).toMatchObject({ wasSet: false, existingValue: 1 });
+  });
+
+  it('preserves falsy-but-present values (upstream 0.9.90 nullish semantics)', async () => {
+    for (const [existing, expected] of [
+      ['0', 0],
+      ['false', false],
+      ['""', ''],
+    ] as const) {
+      const result = (await hyperscript.eval(
+        `set x to ${existing} then default x to 9`,
+        host()
+      )) as unknown as Record<string, unknown>;
+      expect(result, `existing ${existing}`).toMatchObject({
+        wasSet: false,
+        existingValue: expected,
+      });
+    }
+  });
+
+  it('does write when the variable is genuinely unset', async () => {
+    const result = (await hyperscript.eval('default neverSet to 9', host())) as Record<
+      string,
+      unknown
+    >;
+    expect(result).toMatchObject({ wasSet: true, value: 9 });
+  });
+});
+
+describe('default — a `$name` global reads and writes the same slot', () => {
+  /**
+   * `setVariableValue` stores a `$`-prefixed name under its BARE key in
+   * globals while `getVariableValue` looks up the literal name — so a target
+   * that kept its sigil would read `undefined` forever and overwrite on every
+   * run, which is the one thing `default` must never do.
+   *
+   * Both paths are exercised because they reach the sigil strip through
+   * DIFFERENT code: the semantic parser emits `contextReference{ name:'$g' }`
+   * (handled by `scopedVariableTarget`), the traditional one emits
+   * `identifier{ name:'$g' }` (handled by the write-target ladder's
+   * bare-reference rung, then `toDefaultInput`). A test on one path alone
+   * leaves the other's strip unpinned.
+   */
+  it.each(MODES)(
+    'declines to overwrite a global it just set ($label path)',
+    async ({ label, opts }) => {
+      const el = host();
+      const name = `$gDefault_${label}`; // globals persist — one per path
+      const first = (await hyperscript.eval(`default ${name} to 1`, el, opts as never)) as Record<
+        string,
+        unknown
+      >;
+      expect(first).toMatchObject({ wasSet: true, target: `gDefault_${label}` });
+
+      const second = (await hyperscript.eval(`default ${name} to 2`, el, opts as never)) as Record<
+        string,
+        unknown
+      >;
+      expect(second).toMatchObject({ wasSet: false, existingValue: 1 });
+    }
+  );
+});

--- a/packages/core/src/commands/data/__tests__/default.test.ts
+++ b/packages/core/src/commands/data/__tests__/default.test.ts
@@ -122,7 +122,7 @@ describe('DefaultCommand (Standalone V2)', () => {
         context
       );
 
-      expect(input).toEqual({ target: 'myVar', value: 'fallback' });
+      expect(input).toEqual({ type: 'variable', name: 'myVar', value: 'fallback' });
     });
 
     it('should parse target and value from second arg', async () => {
@@ -135,7 +135,77 @@ describe('DefaultCommand (Standalone V2)', () => {
         context
       );
 
-      expect(input).toEqual({ target: 'myVar', value: 42 });
+      expect(input).toEqual({ type: 'variable', name: 'myVar', value: 42 });
+    });
+
+    it('should read the value past the positional "to" keyword marker', async () => {
+      // The traditional parser emits `[target, identifier('to'), value]` — the
+      // same triple `SetCommand.parseInput` reads. Taking `args[1]` for the
+      // value here installed the KEYWORD's evaluation (undefined) instead.
+      const input = await command.parseInput(
+        {
+          args: [
+            { type: 'identifier', name: 'myVar' } as any,
+            { type: 'identifier', name: 'to' } as any,
+            { type: 'literal', value: 'real' } as any,
+          ],
+          modifiers: {},
+        },
+        evaluator,
+        context
+      );
+
+      expect(input).toEqual({ type: 'variable', name: 'myVar', value: 'real' });
+    });
+
+    it('keeps a bare identifier target as its NAME, never its current value', async () => {
+      // The defect this rewrite fixes: `evaluate(identifier)` yields the
+      // variable's value, which for an unset variable is `undefined` — exactly
+      // the case `default` exists to handle.
+      const input = await command.parseInput(
+        {
+          args: [{ type: 'identifier', name: 'neverSet' } as any],
+          modifiers: { to: { type: 'literal', value: 7 } as any },
+        },
+        evaluator,
+        context
+      );
+
+      expect(input).toEqual({ type: 'variable', name: 'neverSet', value: 7 });
+    });
+
+    it('routes an attributeAccess target to the attribute slot', async () => {
+      const input = await command.parseInput(
+        {
+          args: [{ type: 'attributeAccess', attributeName: 'data-theme' } as any],
+          modifiers: { to: { type: 'literal', value: 'light' } as any },
+        },
+        evaluator,
+        context
+      );
+
+      expect(input).toEqual({
+        type: 'attribute',
+        elements: [context.me as HTMLElement],
+        name: 'data-theme',
+        value: 'light',
+      });
+    });
+
+    it('routes a `:name` contextReference to an element-scoped variable', async () => {
+      // The semantic path's shape for `default :x to 0`. The shared ladder's
+      // bare-reference rung does not claim contextReference nodes (`me`/`it`
+      // are contextReferences too), so DefaultCommand gates on the sigil.
+      const input = await command.parseInput(
+        {
+          args: [{ type: 'contextReference', contextType: ':x', name: ':x' } as any],
+          modifiers: { to: { type: 'literal', value: 0 } as any },
+        },
+        evaluator,
+        context
+      );
+
+      expect(input).toEqual({ type: 'variable', name: 'x', value: 0, scope: 'element' });
     });
   });
 
@@ -143,7 +213,10 @@ describe('DefaultCommand (Standalone V2)', () => {
 
   describe('execute - Variable Defaults', () => {
     it('should set variable when it is undefined', async () => {
-      const result = await command.execute({ target: 'counter', value: 10 }, context);
+      const result = await command.execute(
+        { type: 'variable', name: 'counter', value: 10 },
+        context
+      );
 
       expect(result.wasSet).toBe(true);
       expect(result.value).toBe(10);
@@ -153,14 +226,20 @@ describe('DefaultCommand (Standalone V2)', () => {
     it('should skip when variable already has a value', async () => {
       context.locals.set('counter', 5);
 
-      const result = await command.execute({ target: 'counter', value: 10 }, context);
+      const result = await command.execute(
+        { type: 'variable', name: 'counter', value: 10 },
+        context
+      );
 
       expect(result.wasSet).toBe(false);
       expect(result.existingValue).toBe(5);
     });
 
     it('should return wasSet:true with targetType variable when setting', async () => {
-      const result = await command.execute({ target: 'newVar', value: 'hello' }, context);
+      const result = await command.execute(
+        { type: 'variable', name: 'newVar', value: 'hello' },
+        context
+      );
 
       expect(result.wasSet).toBe(true);
       expect(result.targetType).toBe('variable');
@@ -169,7 +248,10 @@ describe('DefaultCommand (Standalone V2)', () => {
     it('should return wasSet:false with targetType variable when skipping', async () => {
       context.locals.set('existingVar', 'already set');
 
-      const result = await command.execute({ target: 'existingVar', value: 'new value' }, context);
+      const result = await command.execute(
+        { type: 'variable', name: 'existingVar', value: 'new value' },
+        context
+      );
 
       expect(result.wasSet).toBe(false);
       expect(result.targetType).toBe('variable');
@@ -178,7 +260,7 @@ describe('DefaultCommand (Standalone V2)', () => {
     it('should set context.it to the value when variable is set', async () => {
       expect(context.it).toBeUndefined();
 
-      await command.execute({ target: 'myVar', value: 'set-value' }, context);
+      await command.execute({ type: 'variable', name: 'myVar', value: 'set-value' }, context);
 
       expect(context.it).toBe('set-value');
     });
@@ -188,33 +270,48 @@ describe('DefaultCommand (Standalone V2)', () => {
     describe('nullish-check semantics (upstream 0.9.90)', () => {
       it('should NOT overwrite a variable set to 0', async () => {
         context.locals.set('count', 0);
-        const result = await command.execute({ target: 'count', value: 42 }, context);
+        const result = await command.execute(
+          { type: 'variable', name: 'count', value: 42 },
+          context
+        );
         expect(result.wasSet).toBe(false);
         expect(result.existingValue).toBe(0);
       });
 
       it('should NOT overwrite a variable set to false', async () => {
         context.locals.set('flag', false);
-        const result = await command.execute({ target: 'flag', value: true }, context);
+        const result = await command.execute(
+          { type: 'variable', name: 'flag', value: true },
+          context
+        );
         expect(result.wasSet).toBe(false);
         expect(result.existingValue).toBe(false);
       });
 
       it('should NOT overwrite a variable set to an empty string', async () => {
         context.locals.set('label', '');
-        const result = await command.execute({ target: 'label', value: 'fallback' }, context);
+        const result = await command.execute(
+          { type: 'variable', name: 'label', value: 'fallback' },
+          context
+        );
         expect(result.wasSet).toBe(false);
         expect(result.existingValue).toBe('');
       });
 
       it('should overwrite a variable set to null', async () => {
         context.locals.set('maybe', null);
-        const result = await command.execute({ target: 'maybe', value: 'value' }, context);
+        const result = await command.execute(
+          { type: 'variable', name: 'maybe', value: 'value' },
+          context
+        );
         expect(result.wasSet).toBe(true);
       });
 
       it('should overwrite when variable is undefined', async () => {
-        const result = await command.execute({ target: 'brand-new', value: 'value' }, context);
+        const result = await command.execute(
+          { type: 'variable', name: 'brand-new', value: 'value' },
+          context
+        );
         expect(result.wasSet).toBe(true);
       });
     });
@@ -224,7 +321,15 @@ describe('DefaultCommand (Standalone V2)', () => {
 
   describe('execute - Attribute Defaults', () => {
     it('should set attribute when it does not exist', async () => {
-      const result = await command.execute({ target: '@data-theme', value: 'light' }, context);
+      const result = await command.execute(
+        {
+          type: 'attribute',
+          elements: [context.me as HTMLElement],
+          name: 'data-theme',
+          value: 'light',
+        },
+        context
+      );
 
       expect(result.wasSet).toBe(true);
       expect((context.me as HTMLElement).getAttribute('data-theme')).toBe('light');
@@ -233,14 +338,30 @@ describe('DefaultCommand (Standalone V2)', () => {
     it('should skip when attribute already exists', async () => {
       (context.me as HTMLElement).setAttribute('data-theme', 'dark');
 
-      const result = await command.execute({ target: '@data-theme', value: 'light' }, context);
+      const result = await command.execute(
+        {
+          type: 'attribute',
+          elements: [context.me as HTMLElement],
+          name: 'data-theme',
+          value: 'light',
+        },
+        context
+      );
 
       expect(result.wasSet).toBe(false);
       expect(result.existingValue).toBe('dark');
     });
 
     it('should return targetType "attribute"', async () => {
-      const result = await command.execute({ target: '@data-mode', value: 'edit' }, context);
+      const result = await command.execute(
+        {
+          type: 'attribute',
+          elements: [context.me as HTMLElement],
+          name: 'data-mode',
+          value: 'edit',
+        },
+        context
+      );
 
       expect(result.targetType).toBe('attribute');
       expect(result.target).toBe('@data-mode');
@@ -250,7 +371,12 @@ describe('DefaultCommand (Standalone V2)', () => {
       const noMeContext = createMockContext({ me: null as any });
 
       await expect(
-        command.execute({ target: '@data-theme', value: 'light' }, noMeContext)
+        // `parseInput` produces an empty element list when there is no `me`
+        // for the attribute to land on.
+        command.execute(
+          { type: 'attribute', elements: [], name: 'data-theme', value: 'light' },
+          noMeContext
+        )
       ).rejects.toThrow('No element context available for attribute default');
     });
   });
@@ -263,7 +389,12 @@ describe('DefaultCommand (Standalone V2)', () => {
       (context.me as HTMLElement).innerHTML = '';
 
       const result = await command.execute(
-        { target: 'my innerHTML', value: 'No content' },
+        {
+          type: 'property',
+          element: context.me as HTMLElement,
+          property: 'innerHTML',
+          value: 'No content',
+        },
         context
       );
 
@@ -275,7 +406,12 @@ describe('DefaultCommand (Standalone V2)', () => {
       (context.me as HTMLElement).innerHTML = '<p>Existing</p>';
 
       const result = await command.execute(
-        { target: 'my innerHTML', value: 'No content' },
+        {
+          type: 'property',
+          element: context.me as HTMLElement,
+          property: 'innerHTML',
+          value: 'No content',
+        },
         context
       );
 
@@ -286,10 +422,18 @@ describe('DefaultCommand (Standalone V2)', () => {
     it('should return targetType "property"', async () => {
       (context.me as HTMLElement).innerHTML = '';
 
-      const result = await command.execute({ target: 'my innerHTML', value: 'fallback' }, context);
+      const result = await command.execute(
+        {
+          type: 'property',
+          element: context.me as HTMLElement,
+          property: 'innerHTML',
+          value: 'fallback',
+        },
+        context
+      );
 
       expect(result.targetType).toBe('property');
-      expect(result.target).toBe('my innerHTML');
+      expect(result.target).toBe('innerHTML');
     });
   });
 
@@ -301,7 +445,10 @@ describe('DefaultCommand (Standalone V2)', () => {
       input.type = 'text';
       input.value = '';
 
-      const result = await command.execute({ target: input, value: 'default text' }, context);
+      const result = await command.execute(
+        { type: 'element', element: input, value: 'default text' },
+        context
+      );
 
       expect(result.wasSet).toBe(true);
       expect(input.value).toBe('default text');
@@ -312,7 +459,10 @@ describe('DefaultCommand (Standalone V2)', () => {
       input.type = 'text';
       input.value = 'existing text';
 
-      const result = await command.execute({ target: input, value: 'default text' }, context);
+      const result = await command.execute(
+        { type: 'element', element: input, value: 'default text' },
+        context
+      );
 
       expect(result.wasSet).toBe(false);
       expect(result.existingValue).toBe('existing text');
@@ -323,7 +473,10 @@ describe('DefaultCommand (Standalone V2)', () => {
       input.type = 'text';
       input.value = '';
 
-      const result = await command.execute({ target: input, value: 'fallback' }, context);
+      const result = await command.execute(
+        { type: 'element', element: input, value: 'fallback' },
+        context
+      );
 
       expect(result.targetType).toBe('element');
       expect(result.target).toBe('element');
@@ -343,7 +496,7 @@ describe('DefaultCommand (Standalone V2)', () => {
         context
       );
 
-      expect(input).toEqual({ target: 'count', value: 0 });
+      expect(input).toEqual({ type: 'variable', name: 'count', value: 0 });
 
       const result = await command.execute(input, context);
 
@@ -356,14 +509,21 @@ describe('DefaultCommand (Standalone V2)', () => {
     it('should work end-to-end: parse and execute attribute default', async () => {
       const input = await command.parseInput(
         {
-          args: [{ type: 'literal', value: '@data-theme' } as any],
+          // The node shape the real parser emits for `@data-theme` — both the
+          // traditional and the semantic path produce `attributeAccess`.
+          args: [{ type: 'attributeAccess', attributeName: 'data-theme' } as any],
           modifiers: { to: { type: 'literal', value: 'light' } as any },
         },
         evaluator,
         context
       );
 
-      expect(input).toEqual({ target: '@data-theme', value: 'light' });
+      expect(input).toEqual({
+        type: 'attribute',
+        elements: [context.me as HTMLElement],
+        name: 'data-theme',
+        value: 'light',
+      });
 
       const result = await command.execute(input, context);
 

--- a/packages/core/src/commands/data/default.ts
+++ b/packages/core/src/commands/data/default.ts
@@ -14,7 +14,6 @@ import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
 import { isHTMLElement } from '../../utils/element-check';
-import { resolvePossessive } from '../helpers/element-resolution';
 import { getVariableValue, setVariableValue } from '../helpers/variable-access';
 import {
   getElementProperty,
@@ -23,6 +22,7 @@ import {
   setElementValue,
   isEmpty,
 } from '../helpers/element-property-access';
+import { resolveWriteTarget, type WriteTarget } from '../helpers/write-target';
 import {
   commandMeta,
   command,
@@ -32,14 +32,21 @@ import {
 } from '../decorators';
 
 /**
- * Typed input for DefaultCommand
+ * Typed input for DefaultCommand (discriminated union).
+ *
+ * Mirrors `SetCommandInput`: `default` is set's write surface with a nullish
+ * guard in front of it, and it resolves its target the same way — symbolically,
+ * from the raw AST node. The previous single `{ target, value }` shape forced
+ * `parseInput` to EVALUATE the target and `execute` to re-derive the slot by
+ * string-matching the result, which is what broke every documented example
+ * (evaluating an unset variable yields `undefined` — precisely the case
+ * `default` exists to handle).
  */
-export interface DefaultCommandInput {
-  /** Target variable, element, or attribute */
-  target: string | HTMLElement;
-  /** Value to set if target doesn't exist */
-  value: unknown;
-}
+export type DefaultCommandInput =
+  | { type: 'variable'; name: string; value: unknown; scope?: 'element' | 'global' }
+  | { type: 'attribute'; elements: HTMLElement[]; name: string; value: unknown }
+  | { type: 'property'; element: HTMLElement; property: string; value: unknown }
+  | { type: 'element'; element: HTMLElement; value: unknown };
 
 /**
  * Output from default command execution
@@ -50,6 +57,56 @@ export interface DefaultCommandOutput {
   wasSet: boolean;
   existingValue?: unknown;
   targetType: 'variable' | 'attribute' | 'property' | 'element';
+}
+
+/**
+ * `:x` / `$x` — the semantic path's shape for a scoped variable.
+ *
+ * The shared ladder's bare-reference rung claims `identifier`/`variable`/
+ * `symbol` nodes, which is what the TRADITIONAL parser emits (`:x` →
+ * `identifier{ name:'x', scope:'element' }`). The semantic path renders the
+ * same source as a `contextReference`, a kind the rung does not claim — and
+ * must not, since `me`/`it`/`result` are contextReferences too and are not
+ * writable variable slots. Hence the sigil gate here rather than a widening of
+ * the shared ladder, which `set`/`append`/`prepend` also walk.
+ */
+function scopedVariableTarget(
+  node: Record<string, unknown> | undefined
+): { name: string; scope: 'element' | 'global' } | null {
+  if (node?.['type'] !== 'contextReference') return null;
+  const name = node['name'];
+  if (typeof name !== 'string') return null;
+  if (name.startsWith(':')) return { name: name.slice(1), scope: 'element' };
+  if (name.startsWith('$')) return { name: name.slice(1), scope: 'global' };
+  return null;
+}
+
+/** Map a resolved write slot onto default's input union. */
+function toDefaultInput(target: WriteTarget, value: unknown): DefaultCommandInput {
+  switch (target.kind) {
+    case 'attribute':
+      return { type: 'attribute', elements: target.elements, name: target.name, value };
+    case 'property':
+      return {
+        type: 'property',
+        element: target.target.element,
+        property: target.target.property,
+        value,
+      };
+    case 'variable': {
+      // A `$`-prefixed name must lose its sigil here: `setVariableValue` stores
+      // `$g` under the BARE key `g` in globals while `getVariableValue` looks up
+      // the literal name, so a target that kept its sigil would read `undefined`
+      // forever and overwrite the global on every run — the exact bug `default`
+      // exists to avoid. (`set` never reads, so it does not notice.)
+      const isGlobalSigil = target.name.startsWith('$');
+      const name = isGlobalSigil ? target.name.slice(1) : target.name;
+      const scope = isGlobalSigil ? 'global' : target.scope;
+      return { type: 'variable', name, value, ...(scope ? { scope } : {}) };
+    }
+    default:
+      throw new Error(`default: unrequested write-target rung '${target.kind}'`);
+  }
 }
 
 @command({ name: 'default' })
@@ -82,57 +139,107 @@ export class DefaultCommand implements DecoratedCommand {
       throw new Error('default command requires a target');
     }
 
-    const target = await evaluator.evaluate(raw.args[0], context);
-    let value: unknown;
+    const value = await this.extractValue(raw, evaluator, context);
+    const firstArg = raw.args[0] as unknown as Record<string, unknown>;
 
-    if (raw.modifiers?.to) {
-      value = await evaluator.evaluate(raw.modifiers.to, context);
-    } else if (raw.args.length >= 2) {
-      value = await evaluator.evaluate(raw.args[1], context);
-    } else {
-      throw new Error('default command requires a value (use "to <value>")');
+    const scoped = scopedVariableTarget(firstArg);
+    if (scoped) {
+      return { type: 'variable', name: scoped.name, value, scope: scoped.scope };
     }
 
-    return { target, value };
+    // The shared raw-AST write-target ladder (`helpers/write-target.ts`), the
+    // same one `set`/`append`/`prepend` walk. Every rung inspects the node
+    // BEFORE evaluation, which is the whole point: evaluating a write target
+    // yields its current VALUE, and for `default` that value is `undefined`
+    // exactly when the command is supposed to act.
+    //
+    // Rungs requested: attribute + property + bare reference. Not requested:
+    // `nodeWriters` (plugin write targets like reactivity's `^count` — `default
+    // ^count to 0` is undocumented and the plugin has no read side to guard
+    // against), `selectorSource` and `styleSplit` (default has no `on` modifier
+    // and no `*prop` form; a selector target means "fill this element's value",
+    // which is the evaluated tail below).
+    const slot = await resolveWriteTarget(firstArg, evaluator, context, {
+      scopeElements: async () => (context.me ? [context.me as HTMLElement] : []),
+      bareReference: true,
+    });
+    if (slot) return toDefaultInput(slot, value);
+
+    // Evaluated tail: shapes the ladder does not name. A selector or expression
+    // whose VALUE is the element to fill (`default #out to "x"`) — here
+    // evaluation is correct, because the element is the target, not its name.
+    const evaluated = await evaluator.evaluate(raw.args[0], context);
+    if (isHTMLElement(evaluated)) {
+      return { type: 'element', element: evaluated as HTMLElement, value };
+    }
+    if (Array.isArray(evaluated) && isHTMLElement(evaluated[0])) {
+      return { type: 'element', element: evaluated[0] as HTMLElement, value };
+    }
+    if (typeof evaluated === 'string') {
+      // A target that legitimately evaluates to a NAME (e.g. a literal node).
+      return { type: 'variable', name: evaluated, value };
+    }
+
+    throw new Error(`Invalid target type: ${typeof evaluated}`);
+  }
+
+  /**
+   * The value to install: `to <value>`.
+   *
+   * Three shapes reach here, and the middle one was silently broken. The
+   * semantic path emits `modifiers.to`; the TRADITIONAL parser emits the
+   * positional `[target, identifier('to'), value]` triple that
+   * `SetCommand.parseInput` also reads — and the old code took `args[1]` for
+   * it, which is the `to` KEYWORD, so every `default X to Y` parsed
+   * traditionally installed `undefined` (measured: `default #out to "x"` wrote
+   * the string "undefined"). The bare two-arg form is kept for callers that
+   * build the node directly.
+   */
+  private async extractValue(
+    raw: { args: ASTNode[]; modifiers: Record<string, ExpressionNode> },
+    evaluator: ExpressionEvaluator,
+    context: ExecutionContext
+  ): Promise<unknown> {
+    if (raw.modifiers?.to) {
+      return evaluator.evaluate(raw.modifiers.to, context);
+    }
+
+    const second = raw.args[1] as unknown as Record<string, unknown> | undefined;
+    const isToMarker =
+      second?.['type'] === 'identifier' && String(second['name']).toLowerCase() === 'to';
+    if (isToMarker && raw.args.length >= 3) {
+      return evaluator.evaluate(raw.args[2], context);
+    }
+    if (!isToMarker && raw.args.length >= 2) {
+      return evaluator.evaluate(raw.args[1], context);
+    }
+
+    throw new Error('default command requires a value (use "to <value>")');
   }
 
   async execute(
     input: DefaultCommandInput,
     context: TypedExecutionContext
   ): Promise<DefaultCommandOutput> {
-    const { target, value } = input;
-
-    if (typeof target === 'string') {
-      // Attribute syntax: @attr
-      if (target.startsWith('@')) {
-        return this.defaultAttribute(context, target.substring(1), value);
-      }
-
-      // Possessive expression: "my innerHTML", "its value"
-      const possessiveMatch = target.match(/^(my|its?|your?)\s+(.+)$/);
-      if (possessiveMatch) {
-        const [, possessive, property] = possessiveMatch;
-        return this.defaultElementProperty(context, possessive, property, value);
-      }
-
-      // Regular variable
-      return this.defaultVariable(context, target, value);
+    switch (input.type) {
+      case 'variable':
+        return this.defaultVariable(context, input.name, input.value, input.scope);
+      case 'attribute':
+        return this.defaultAttribute(context, input.elements, input.name, input.value);
+      case 'property':
+        return this.defaultElementProperty(context, input.element, input.property, input.value);
+      case 'element':
+        return this.defaultElementValue(context, input.element, input.value);
     }
-
-    // HTML element
-    if (isHTMLElement(target)) {
-      return this.defaultElementValue(context, target as HTMLElement, value);
-    }
-
-    throw new Error(`Invalid target type: ${typeof target}`);
   }
 
   private defaultVariable(
     context: TypedExecutionContext,
     name: string,
-    value: unknown
+    value: unknown,
+    scope?: 'element' | 'global'
   ): DefaultCommandOutput {
-    const existingValue = getVariableValue(name, context);
+    const existingValue = getVariableValue(name, context, scope);
 
     // Nullish check (matches upstream _hyperscript 0.9.90+): only null/undefined
     // are considered "missing". Preserves falsy values like 0, false, ''.
@@ -140,7 +247,7 @@ export class DefaultCommand implements DecoratedCommand {
       return { target: name, value, wasSet: false, existingValue, targetType: 'variable' };
     }
 
-    setVariableValue(name, value, context);
+    setVariableValue(name, value, context, scope);
     Object.assign(context, { it: value });
 
     return { target: name, value, wasSet: true, targetType: 'variable' };
@@ -148,20 +255,29 @@ export class DefaultCommand implements DecoratedCommand {
 
   private defaultAttribute(
     context: TypedExecutionContext,
+    elements: HTMLElement[],
     name: string,
     value: unknown
   ): DefaultCommandOutput {
-    if (!context.me) {
+    if (elements.length === 0) {
       throw new Error('No element context available for attribute default');
     }
 
-    const existingValue = context.me.getAttribute(name);
+    const missing = elements.filter(el => el.getAttribute(name) === null);
 
-    if (existingValue !== null) {
-      return { target: `@${name}`, value, wasSet: false, existingValue, targetType: 'attribute' };
+    if (missing.length === 0) {
+      return {
+        target: `@${name}`,
+        value,
+        wasSet: false,
+        existingValue: elements[0].getAttribute(name),
+        targetType: 'attribute',
+      };
     }
 
-    context.me.setAttribute(name, String(value));
+    for (const el of missing) {
+      el.setAttribute(name, String(value));
+    }
     Object.assign(context, { it: value });
 
     return { target: `@${name}`, value, wasSet: true, targetType: 'attribute' };
@@ -169,23 +285,20 @@ export class DefaultCommand implements DecoratedCommand {
 
   private defaultElementProperty(
     context: TypedExecutionContext,
-    possessive: string,
+    element: HTMLElement,
     property: string,
     value: unknown
   ): DefaultCommandOutput {
-    // Use shared helper for possessive resolution
-    const targetElement = resolvePossessive(possessive, context, 'default');
-    const existingValue = getElementProperty(targetElement, property);
-    const targetName = `${possessive} ${property}`;
+    const existingValue = getElementProperty(element, property);
 
     if (!isEmpty(existingValue)) {
-      return { target: targetName, value, wasSet: false, existingValue, targetType: 'property' };
+      return { target: property, value, wasSet: false, existingValue, targetType: 'property' };
     }
 
-    setElementProperty(targetElement, property, value);
+    setElementProperty(element, property, value);
     Object.assign(context, { it: value });
 
-    return { target: targetName, value, wasSet: true, targetType: 'property' };
+    return { target: property, value, wasSet: true, targetType: 'property' };
   }
 
   private defaultElementValue(

--- a/packages/core/src/parser/semantic-integration-delegation.test.ts
+++ b/packages/core/src/parser/semantic-integration-delegation.test.ts
@@ -284,17 +284,19 @@ describe('the defects the duplicated switch caused', () => {
     expect(result?.selectedItem).toHaveLength(2);
   });
 
-  it('`default` now reaches the same runtime as the traditional parser', async () => {
-    // The AST-shape half of default's breakage is what this phase fixes: the
-    // switch emitted `args:[value] mods:{on:target}` where DefaultCommand reads
-    // `args[0]`-is-target / `modifiers.to`-is-value. Both paths now agree —
-    // and both hit DefaultCommand's own separate defect (it EVALUATES the
-    // target name), which is a runtime fix, not a parser one.
-    const el = host('');
-    const semantic = await hyperscript.eval('default :x to 0', el).catch(e => `${e.message}`);
-    const traditional = await hyperscript
-      .eval('default :x to 0', el, { traditional: true } as never)
-      .catch(e => `${e.message}`);
-    expect(semantic).toBe(traditional);
+  it('`default` builds the same node on both paths', async () => {
+    // The switch emitted `args:[value] mods:{on:target}` where DefaultCommand
+    // reads `args[0]`-is-target / `modifiers.to`-is-value, so the two paths
+    // disagreed about which slot held what. They now agree on the OUTCOME.
+    //
+    // A fresh element per run matters: `:x` is element-scoped, so reusing one
+    // would have the second run correctly decline to overwrite the first's
+    // write — an artifact of the fixture, not a divergence.
+    const semantic = await hyperscript.eval('default :x to 0', host(''));
+    const traditional = await hyperscript.eval('default :x to 0', host(''), {
+      traditional: true,
+    } as never);
+    expect(semantic).toEqual(traditional);
+    expect(semantic).toMatchObject({ target: 'x', value: 0, wasSet: true });
   });
 });


### PR DESCRIPTION
Arc F follow-ups round 2, **Phase B**. Independent of #847, but measured on top of it.

## The defect

`DefaultCommand.parseInput` did `target = await evaluator.evaluate(raw.args[0])`, and `execute` re-derived the write slot by string-matching the result. A write target's evaluation is its **current value** — and for `default` that value is `undefined` exactly when the command is supposed to act.

Every one of the command's five `metadata.examples` was broken, on **both** execution paths. Measured at `22059a6e` through `hyperscript.eval` in jsdom:

| source | before |
| --- | --- |
| `default myVar to "fallback"` | throws `Invalid target type: undefined` |
| `default @data-theme to "light"` | throws `Invalid target type: object` |
| `default :x to 0` | throws `Invalid target type: undefined` |
| `default my @data-count to "0"` (corpus row `default-value`) | throws |
| `default my innerHTML to "No content"` | **no error, and no DOM write either** |

The last one is worse than the queue doc recorded ("only the possessive form works"). It does not work: the evaluated target was the element's empty `innerHTML` string, so it created a junk local literally named `''` and returned `wasSet: true`. Silent, and invisible to a return-value assertion.

**A second, independent defect surfaced while measuring.** The traditional parser emits `[target, identifier('to'), value]` — the same positional triple `SetCommand.parseInput` reads — and the old `extractValue` took `args[1]` for the value, i.e. the `to` **keyword**. So every `default X to Y` parsed traditionally installed `undefined`: `default #out to "x"` wrote the string `"undefined"` into the element.

## The fix

The one `SetCommand` already models: walk the shared raw-AST write-target ladder (`helpers/write-target.ts`), which inspects the node **before** evaluation by construction. `DefaultCommandInput` becomes a discriminated union mirroring `SetCommandInput`, and `execute` switches on it instead of re-parsing a string.

Rungs requested: attribute, property, bare reference. Not requested — and each for a reason:

- `nodeWriters` — `default ^count to 0` is undocumented and the reactivity plugin has no read side to guard against.
- `selectorSource` / `styleSplit` — `default` has no `on` modifier and no `*prop` form. A selector target means "fill this element", which is the evaluated tail; there evaluation is *correct*, because the element **is** the target, not its name.

Two shapes the ladder does not cover, both handled in the command:

- **`:x` / `$x` on the semantic path** arrive as `contextReference`, a kind the bare-reference rung does not claim — and must not, since `me`/`it`/`result` are contextReferences too and are not writable slots. Gated on the sigil here rather than widening the ladder, which `set`/`append`/`prepend` also walk.
- **A `$name` target loses its sigil.** `setVariableValue` stores it under the *bare* key in globals while `getVariableValue` looks up the literal name, so a sigil-keeping target would read `undefined` forever and overwrite on every run. (`set` never reads, so it never noticed.)

## Tests

The existing unit tests could not see any of this — they inject a mock evaluator returning `node.value ?? node.name`, i.e. the name-preserving behavior the real evaluator lacks. They are updated to the union shapes, and to the node shapes the real parser emits (`attributeAccess`, not a literal string).

`default-eval.test.ts` adds 21 cases through `hyperscript.eval` across **both** paths, asserting the DOM/variable effect rather than the return value.

The `default` row in `semantic-integration-delegation.test.ts` (#847) compared the two paths' *error messages*; both now succeed, so it compares outcomes on a fresh element per run — `:x` is element-scoped, and reusing one would have the second run correctly decline to overwrite the first's write.

## Not folded in

`default-value` is a corpus row but is **not** in R2's curated execution subset, so the ratchet cannot see this fix. Adding it needs an `on load` trigger story the harness does not have — its `before` snapshot is taken after handler install, and every subset entry is click- or custom-event-triggered.

## Gates

core **7784 passed / 106 skipped / 303 files** · `typecheck` · `typecheck:scripts` · `verify:reference` · `docs:commands:check` · `generate:bundles:check` · `snapshot:bundle-size --check` · oxlint · full monorepo `test:check`. Multilingual ratchet **green and unmoved**.

Mutation-verified four ways: dropped the to-marker branch (8 failures), bypassed the ladder to evaluate the target again (16), kept the `$` sigil (1), neutered the contextReference gate (2).

Pre-existing and unrelated: `packages/developer-tools/src/dev-server.test.ts` fails on `main` too (an express/path-to-regexp version mismatch in the local tree; the CI job passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)