### PR TITLE
fix(semantic): swap's strategy forms keep their content — three en patterns, one deduped

### DIFF
--- a/packages/semantic/src/patterns/en.ts
+++ b/packages/semantic/src/patterns/en.ts
@@ -20,6 +20,12 @@ import { fetchPatternsEn } from './languages/en/fetch';
 // character(s)|match(es) … of <root>`). Same leaf-not-barrel rationale as
 // fetch above: the patterns/languages/en/index.ts barrel has no runtime reader.
 import { pickPatternsEn } from './languages/en/pick';
+// Swap patterns (element swap, strategy swap with/without `of`, bare strategy).
+// Same leaf-not-barrel rationale as fetch and pick above. This module used to
+// redeclare the element and bare-strategy patterns "kept in sync so both
+// builders agree" — a hand-sync that a third pattern would have silently
+// broken, since this list is the one the registered `en` module builds.
+import { swapPatternsEn } from './languages/en/swap';
 
 // Import from consolidated pattern files (Phase 3.2)
 import { getTogglePatternsForLanguage } from './toggle';
@@ -31,57 +37,6 @@ import { getWaitPatternsForLanguage } from './wait';
 // =============================================================================
 // Hand-crafted English-only patterns
 // =============================================================================
-
-/**
- * English: "swap <strategy> <target>" without prepositions.
- */
-const swapSimpleEnglish: LanguagePattern = {
-  id: 'swap-en-handcrafted',
-  language: 'en',
-  command: 'swap',
-  priority: 110,
-  template: {
-    format: 'swap {method} {destination}',
-    tokens: [
-      { type: 'literal', value: 'swap' },
-      { type: 'role', role: 'method' },
-      { type: 'role', role: 'destination' },
-    ],
-  },
-  extraction: {
-    method: { position: 1 },
-    destination: { position: 2 },
-  },
-};
-
-/**
- * English element-swap: "swap {destination} with {patient}" (`swap #a with #b`).
- *
- * The method-less, `with`-marked shape the i18n transformer emits for an element
- * swap. Without this, `swap-en-handcrafted` (`swap {method} {destination}`) greedily
- * binds `#a`→method and the bare word `with`→destination, then DROPS `#b` — a broken
- * en REFERENCE parse the translations (de/es/ja/ko all parse `{destination, patient}`
- * correctly) are penalized against in R1. This captures `destination`+`patient` to
- * match the schema (and the translations). Priority 120 > the method form's 110, and
- * the required `with` literal means it only fires on the element-swap shape — the
- * `swap innerHTML #target` / `swap delete #item` forms (no `with`) still take 110.
- */
-const swapElementEnglish: LanguagePattern = {
-  id: 'swap-en-element',
-  language: 'en',
-  command: 'swap',
-  priority: 120,
-  template: {
-    format: 'swap {destination} with {patient}',
-    tokens: [
-      { type: 'literal', value: 'swap' },
-      { type: 'role', role: 'destination' },
-      { type: 'literal', value: 'with' },
-      { type: 'role', role: 'patient' },
-    ],
-  },
-  extraction: {},
-};
 
 /**
  * English: "repeat until event pointerup from document"
@@ -364,8 +319,7 @@ export function buildEnglishPatterns(): LanguagePattern[] {
   patterns.push(
     ...fetchPatternsEn,
     ...pickPatternsEn,
-    swapElementEnglish,
-    swapSimpleEnglish,
+    ...swapPatternsEn,
     repeatUntilEventFromEnglish,
     repeatUntilEventEnglish,
     repeatTimesEnglish,

--- a/packages/semantic/src/patterns/languages/en/swap.ts
+++ b/packages/semantic/src/patterns/languages/en/swap.ts
@@ -59,6 +59,75 @@ export const swapElementEnglish: LanguagePattern = {
 };
 
 /**
- * All English swap patterns.
+ * English strategy-swap with an explicit `of`: `swap innerHTML of #t with "X"`.
+ *
+ * `SwapCommand`'s own documented surface, and the shape `swap {method}
+ * {destination}` (110) mis-binds: it takes `innerHTML`→method and the bare word
+ * `of`→destination, dropping the target AND the content. Priority 140 — above
+ * every other swap pattern — and the two required literals mean it fires on
+ * this shape alone.
  */
-export const swapPatternsEn: LanguagePattern[] = [swapElementEnglish, swapSimpleEnglish];
+export const swapStrategyOfEnglish: LanguagePattern = {
+  id: 'swap-en-strategy-of',
+  language: 'en',
+  command: 'swap',
+  priority: 140,
+  template: {
+    format: 'swap {method} of {destination} with {patient}',
+    tokens: [
+      { type: 'literal', value: 'swap' },
+      { type: 'role', role: 'method' },
+      { type: 'literal', value: 'of' },
+      { type: 'role', role: 'destination' },
+      { type: 'literal', value: 'with' },
+      { type: 'role', role: 'patient' },
+    ],
+  },
+  extraction: {},
+};
+
+/**
+ * English strategy-swap without `of`: `swap into #t with it`, `swap over #modal
+ * with c`, `swap beforebegin #t with it`.
+ *
+ * Same defect as above minus the `of`: the 110 pattern bound method+destination
+ * and the `with` content was never captured, so the runtime received a two-arg
+ * node and swapped in nothing.
+ *
+ * Priority 130 sits below the `of` form and above the method-less element swap
+ * (120), which is what keeps `swap #a with #b` on its own pattern: this one
+ * needs FOUR slots after the verb (method, destination, `with`, patient) and
+ * `#a with #b` supplies three, so it cannot match.
+ */
+export const swapStrategyEnglish: LanguagePattern = {
+  id: 'swap-en-strategy',
+  language: 'en',
+  command: 'swap',
+  priority: 130,
+  template: {
+    format: 'swap {method} {destination} with {patient}',
+    tokens: [
+      { type: 'literal', value: 'swap' },
+      { type: 'role', role: 'method' },
+      { type: 'role', role: 'destination' },
+      { type: 'literal', value: 'with' },
+      { type: 'role', role: 'patient' },
+    ],
+  },
+  extraction: {},
+};
+
+/**
+ * All English swap patterns.
+ *
+ * Ordered most-specific first, matching descending priority. `patterns/en.ts`
+ * — the list the registered `en` language module actually builds — imports this
+ * array rather than redeclaring it; it used to carry a hand-synced copy of the
+ * two originals, so a pattern added to only one side had no runtime effect.
+ */
+export const swapPatternsEn: LanguagePattern[] = [
+  swapStrategyOfEnglish,
+  swapStrategyEnglish,
+  swapElementEnglish,
+  swapSimpleEnglish,
+];

--- a/packages/semantic/test/descriptor-runtime-contract.test.ts
+++ b/packages/semantic/test/descriptor-runtime-contract.test.ts
@@ -142,3 +142,55 @@ describe('swap — the AST contract is keyword-positional args, never modifiers'
     expect(astOf('swap delete #t').args.length).toBeGreaterThan(1);
   });
 });
+
+describe('swap — the strategy forms carry their content', () => {
+  // The descriptor was already right for these; the en PATTERNS were not.
+  // Measured at 22059a6e, `swap into #t with it` and its siblings bound
+  // `method` + `destination` only — `swap {method} {destination}` (priority
+  // 110) matched the prefix and the `with` content was never captured, so the
+  // runtime got a two-arg node and swapped in nothing. `swap innerHTML of #t
+  // with "X"` was worse: it bound `destination` to the literal word 'of'.
+  //
+  // With all three roles bound, the AST lands on SwapCommand's fallback branch
+  // exactly as the block above describes: strategy from args[0], target from
+  // args[len-2], content from args[len-1].
+
+  const STRATEGY_FORMS: Array<[string, string, string, unknown]> = [
+    ['swap into #t with it', 'into', '#t', { type: 'contextReference', name: 'it' }],
+    ['swap over #modal with c', 'over', '#modal', { type: 'identifier', name: 'c' }],
+    ['swap beforebegin #t with it', 'beforebegin', '#t', { type: 'contextReference', name: 'it' }],
+    ['swap innerHTML of #t with "X"', 'innerHTML', '#t', { type: 'literal', value: 'X' }],
+    ['swap outerHTML of #t with "Y"', 'outerHTML', '#t', { type: 'literal', value: 'Y' }],
+  ];
+
+  it.each(STRATEGY_FORMS)('%s → [strategy, target, content]', (src, method, target, content) => {
+    const ast = astOf(src);
+
+    expect(ast.name).toBe('swap');
+    expect(ast.args, `${src} must bind all three roles`).toHaveLength(3);
+    // args[0] is what `STRATEGY_KEYWORDS[argKeywords[0]]` reads. `getNodeKeyword`
+    // accepts a literal's value or an identifier's name, lowercased — which is
+    // why `over` arriving as an identifier still selects `outerHTML`.
+    const first = ast.args[0] as { value?: string; name?: string };
+    expect(String(first.value ?? first.name).toLowerCase()).toBe(method.toLowerCase());
+    expect(ast.args[1]).toMatchObject({ type: 'selector', value: target });
+    expect(ast.args[2]).toMatchObject(content as Record<string, unknown>);
+    expect(ast.modifiers).toBeUndefined();
+  });
+
+  it('never binds the `of` marker itself as the destination', () => {
+    // The precise pre-fix failure: `swap {method} {destination}` took
+    // `innerHTML`→method and the bare word `of`→destination, then dropped
+    // both the real target and the content.
+    const ast = astOf('swap innerHTML of #t with "X"');
+    expect(ast.args[1]).not.toMatchObject({ value: 'of' });
+  });
+
+  it('leaves the method-less and content-less forms on their own patterns', () => {
+    // The new patterns need four slots after the verb, so the three-slot
+    // element swap (120) and the two-slot bare strategy (110) are untouched.
+    expect(astOf('swap #a with #b').args).toHaveLength(2);
+    expect(astOf('swap delete #item').args).toHaveLength(2);
+    expect(astOf('swap innerHTML #target').args).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Arc F follow-ups round 2, **Phase C**.

## The defect

The `swap` descriptor has been right since #845; the English **patterns** were not. Measured at `22059a6e` — parse → roles:

| source | roles bound |
| --- | --- |
| `swap into #t with it` | `{method: into, destination: #t}` |
| `swap over #modal with c` | `{method: over, destination: #modal}` |
| `swap beforebegin #t with it` | `{method: beforebegin, destination: #t}` |
| `swap innerHTML of #t with "X"` | `{method: innerHTML, destination: 'of'}` |

En had exactly two hand patterns — `swap {method} {destination}` (110) and `swap {destination} with {patient}` (120) — and neither covers a strategy **with** content. The 110 pattern matched the prefix and the `with` clause was never captured, so the runtime received a two-arg node and swapped in nothing. The `of` form was worse: it bound the destination to the bare word `'of'` and dropped both the real target and the content.

## The fix

Two new patterns:

```
swap {method} of {destination} with {patient}   priority 140
swap {method} {destination} with {patient}      priority 130
```

**No descriptor change is needed.** With all three roles bound, the AST lands on `SwapCommand.parseInput`'s fallback branch exactly as its contract requires — strategy from `args[0]` (via `getNodeKeyword`, which reads a literal's value or an identifier's name, lowercased, so `over` arriving as an identifier still selects `outerHTML`), target from `args[len-2]`, content from `args[len-1]`.

The method-less and content-less forms keep their own patterns: the new ones need **four** slots after the verb and `swap #a with #b` supplies three, so 120 and 110 are untouched (asserted).

## The duplication trap, closed

`patterns/en.ts` — the list the registered `en` module actually builds — carried its own copy of the two original patterns, "kept in sync so both builders agree". A third pattern added to only one side would have had **no runtime effect**. It now imports `swapPatternsEn` from the leaf, which is the precedent `fetchPatternsEn` and `pickPatternsEn` already set in that same file for the same reason.

## Gates

semantic `typecheck` + **7229 tests / 108 files** · `check:mapper-parity` (the parity fixture is unchanged — this is patterns, not descriptors) · oxlint · core **7784 passed / 106 skipped**. Multilingual ratchet **green and unmoved**.

The six new gate rows were mutation-verified by dropping the two patterns from the export array — 6 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)