### PR TITLE
fix(parser): `wait for <event> or <duration>` — the race the runtime could already run

### DIFF
--- a/packages/core/src/commands/async/__tests__/wait-event-or-duration.test.ts
+++ b/packages/core/src/commands/async/__tests__/wait-event-or-duration.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+/**
+ * `wait for <event> or <duration>` — the event/timeout race.
+ *
+ * The real `hyperscript.org` engine accepts every surface below (checked with
+ * `hs.parse(src).errors` — all `[]`), and it means "resume on whichever comes
+ * first". HyperFixi rejected them at PARSE time: `parseWaitCommand`'s event
+ * branch ran a `do…while` over or-separated event NAMES and required
+ * `isIdentifierLike`, so the number token `1s` threw
+ * `Expected event name after "for"`.
+ *
+ * This was a one-sided gap. `WaitCommand` has had a `race` input since before
+ * this change — `WaitRaceInput.conditions` is a mixed list of `time` and
+ * `event` conditions, and `executeRace` already `Promise.race`s them behind an
+ * AbortController that tears down the losing listeners. Only the parser was
+ * missing, so the machinery was unreachable from this surface. (The `or`
+ * MODIFIER path — `parseRaceCondition`, reached via `raw.modifiers.or` — is a
+ * different, already-working entry point and is untouched here.)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { hyperscript } from '../../../api/hyperscript-api';
+
+function host(): HTMLElement {
+  document.body.innerHTML = '<div id="host"></div><button id="btn"></button>';
+  return document.getElementById('host') as HTMLElement;
+}
+
+describe('wait for <event> or <duration> — parsing', () => {
+  it.each([
+    'wait for click or 1s',
+    'wait for click or keydown or 2s',
+    'wait for 1s',
+    'wait for click or 1s from #btn',
+    'wait for click',
+    'wait 1s',
+  ])('%s compiles without errors', src => {
+    const result = hyperscript.compileSync(src);
+    expect(result.errors ?? [], JSON.stringify(result.errors)).toHaveLength(0);
+    expect(result.ok).toBe(true);
+  });
+
+  it('still rejects a `for` tail that is neither an event nor a duration', () => {
+    const result = hyperscript.compileSync('wait for .someClass');
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('wait for <event> or <duration> — execution', () => {
+  it('resolves on the TIMEOUT when the event never fires', async () => {
+    const el = host();
+    const started = Date.now();
+    await hyperscript.eval('wait for click or 30ms', el);
+    // Nothing dispatched a click, so only the timer could have resolved it.
+    expect(Date.now() - started).toBeLessThan(2000);
+  });
+
+  it('resolves on the EVENT when it fires before the timeout', async () => {
+    const el = host();
+    const started = Date.now();
+    const pending = hyperscript.eval('wait for click or 5s', el);
+    setTimeout(() => el.dispatchEvent(new Event('click', { bubbles: true })), 10);
+    await pending;
+    // A 5s timer cannot have won; if the event path were broken this would
+    // hang until the timeout and blow the test timeout instead.
+    expect(Date.now() - started).toBeLessThan(2000);
+  });
+
+  it('races three ways — two events and a timeout', async () => {
+    const el = host();
+    const pending = hyperscript.eval('wait for click or keydown or 5s', el);
+    setTimeout(() => el.dispatchEvent(new Event('keydown', { bubbles: true })), 10);
+    await expect(pending).resolves.toBeDefined();
+  });
+
+  it('honours `from <target>` for the event half of the race', async () => {
+    host();
+    const btn = document.getElementById('btn') as HTMLElement;
+    const pending = hyperscript.eval(
+      'wait for click or 5s from #btn',
+      document.getElementById('host') as HTMLElement
+    );
+    setTimeout(() => btn.dispatchEvent(new Event('click', { bubbles: true })), 10);
+    await expect(pending).resolves.toBeDefined();
+  });
+
+  it('`wait for 1s` alone is a plain timeout, not a race', async () => {
+    const el = host();
+    const started = Date.now();
+    await hyperscript.eval('wait for 30ms', el);
+    expect(Date.now() - started).toBeGreaterThanOrEqual(20);
+  });
+
+  it('removes the losing event listener when the timer wins', async () => {
+    const el = host();
+    const add = vi.spyOn(el, 'addEventListener');
+    const remove = vi.spyOn(el, 'removeEventListener');
+    await hyperscript.eval('wait for click or 20ms', el);
+    // `executeRace` aborts its AbortController in a `finally`; without that the
+    // click listener would outlive the wait.
+    expect(add).toHaveBeenCalled();
+    const listenerLeaked =
+      add.mock.calls.length > remove.mock.calls.length &&
+      !add.mock.calls.some(c => (c[2] as AddEventListenerOptions | undefined)?.signal);
+    expect(listenerLeaked, 'the losing listener must be torn down').toBe(false);
+    add.mockRestore();
+    remove.mockRestore();
+  });
+});

--- a/packages/core/src/commands/async/wait.ts
+++ b/packages/core/src/commands/async/wait.ts
@@ -169,28 +169,21 @@ export class WaitCommand implements DecoratedCommand {
     return { type: 'event', eventName, target, destructure };
   }
 
+  /**
+   * The `wait for …` alternative list.
+   *
+   * `parseWaitCommand` emits one object literal per or-separated alternative:
+   * `{ name, args }` for an event, `{ duration }` for a timeout. A mixed list
+   * is the `wait for click or 1s` race — the DOM effect is "whichever happens
+   * first", which `executeRace` already implements; before this it never
+   * reached here, because the parser rejected the duration token.
+   */
   private async parseEventArrayWait(
     elements: ASTNode[],
     targetArg: ASTNode | undefined,
     evaluator: ExpressionEvaluator,
     context: ExecutionContext
-  ): Promise<WaitEventInput | WaitRaceInput> {
-    const events: { name: string; params: string[] }[] = [];
-    for (const el of elements) {
-      const obj = el as any;
-      if (obj.type === 'objectLiteral' && obj.properties) {
-        let name = '';
-        let params: string[] = [];
-        for (const p of obj.properties) {
-          const k = p.key?.name || p.key?.value;
-          if (k === 'name' && p.value) name = p.value.value || '';
-          else if (k === 'args' && p.value?.elements)
-            params = p.value.elements.map((e: any) => e.value || e.name || '');
-        }
-        if (name) events.push({ name, params });
-      }
-    }
-
+  ): Promise<WaitTimeInput | WaitEventInput | WaitRaceInput> {
     let target: EventTarget | undefined;
     if (targetArg) {
       const t = await evaluator.evaluate(targetArg, context);
@@ -198,24 +191,40 @@ export class WaitCommand implements DecoratedCommand {
     }
     if (!target) target = context.me ?? undefined;
 
-    if (events.length === 1) {
-      return {
-        type: 'event',
-        eventName: events[0].name,
-        target,
-        destructure: events[0].params.length > 0 ? events[0].params : undefined,
-      };
+    const conditions: (WaitTimeInput | WaitEventInput)[] = [];
+    for (const el of elements) {
+      const obj = el as any;
+      if (obj.type !== 'objectLiteral' || !obj.properties) continue;
+
+      let name = '';
+      let params: string[] = [];
+      let durationNode: ASTNode | undefined;
+      for (const p of obj.properties) {
+        const k = p.key?.name || p.key?.value;
+        if (k === 'name' && p.value) name = p.value.value || '';
+        else if (k === 'args' && p.value?.elements)
+          params = p.value.elements.map((e: any) => e.value || e.name || '');
+        else if (k === 'duration' && p.value) durationNode = p.value as ASTNode;
+      }
+
+      if (durationNode) {
+        const value = await evaluator.evaluate(durationNode, context);
+        conditions.push({ type: 'time', milliseconds: parseDurationStrict(value) });
+      } else if (name) {
+        conditions.push({
+          type: 'event',
+          eventName: name,
+          target,
+          destructure: params.length > 0 ? params : undefined,
+        });
+      }
     }
 
-    return {
-      type: 'race',
-      conditions: events.map(e => ({
-        type: 'event' as const,
-        eventName: e.name,
-        target,
-        destructure: e.params.length > 0 ? e.params : undefined,
-      })),
-    };
+    // A single alternative is not a race — `wait for click` stays an event wait
+    // and `wait for 1s` (which upstream also accepts) becomes a plain timeout.
+    if (conditions.length === 1) return conditions[0];
+
+    return { type: 'race', conditions };
   }
 
   private async parseRaceCondition(

--- a/packages/core/src/parser/command-parsers/async-commands.ts
+++ b/packages/core/src/parser/command-parsers/async-commands.ts
@@ -80,14 +80,33 @@ export function parseWaitCommand(ctx: ParserContext, commandToken: Token) {
   if (ctx.check('for')) {
     ctx.advance(); // consume 'for'
 
-    // Parse event specifications (can be multiple with 'or')
-    const events: Array<{ name: string; params: string[] }> = [];
+    // Parse the or-separated alternatives. Each is an event name (optionally
+    // with destructured parameters) OR a duration — `wait for click or 1s` is
+    // a race between the event and a timeout, which the real `hyperscript.org`
+    // engine accepts and `WaitCommand` can already execute (its `race` input
+    // takes a mixed list of `time` and `event` conditions). Only the parser was
+    // missing: this loop required `isIdentifierLike`, and `1s` is a number
+    // token, so it threw `Expected event name after "for"`.
+    const alternatives: Array<
+      { kind: 'event'; name: string; params: string[] } | { kind: 'duration'; expr: ASTNode }
+    > = [];
 
     do {
+      // A duration alternative: a time literal (`1s`, `200ms`), a bare number
+      // (milliseconds), or a parenthesized expression.
+      if (ctx.checkTimeExpression() || ctx.checkLiteral() || ctx.check('(')) {
+        alternatives.push({ kind: 'duration', expr: ctx.parseExpression() });
+        if (ctx.check('or')) {
+          ctx.advance();
+          continue;
+        }
+        break;
+      }
+
       // Parse event name
       const eventToken = ctx.peek();
       if (!isIdentifierLike(eventToken)) {
-        throw new Error('Expected event name after "for"');
+        throw new Error('Expected event name or duration after "for"');
       }
       const eventName = eventToken.value;
       ctx.advance();
@@ -120,9 +139,9 @@ export function parseWaitCommand(ctx: ParserContext, commandToken: Token) {
         ctx.advance();
       }
 
-      events.push({ name: eventName, params: eventParams });
+      alternatives.push({ kind: 'event', name: eventName, params: eventParams });
 
-      // Check for 'or' to continue with more events
+      // Check for 'or' to continue with more alternatives
       if (ctx.check('or')) {
         ctx.advance(); // consume 'or'
         continue;
@@ -144,7 +163,12 @@ export function parseWaitCommand(ctx: ParserContext, commandToken: Token) {
     }
 
     // Build args array
-    // Format: [eventList, target?]
+    // Format: [alternativeList, target?]
+    //
+    // An event alternative keeps its `{ name, args }` shape; a duration
+    // alternative carries `{ duration: <expr> }`. `WaitCommand.parseEventArrayWait`
+    // reads both and builds a `time` or `event` condition per entry, racing
+    // them when there is more than one.
     const eventPos = {
       start: commandToken.start,
       end: ctx.getPosition().end,
@@ -153,23 +177,28 @@ export function parseWaitCommand(ctx: ParserContext, commandToken: Token) {
     };
     args.push(
       createArrayLiteral(
-        events.map(event =>
-          createObjectLiteral(
-            [
-              {
-                key: createIdentifier('name', eventPos),
-                value: createLiteral(event.name, `"${event.name}"`, eventPos),
-              },
-              {
-                key: createIdentifier('args', eventPos),
-                value: createArrayLiteral(
-                  event.params.map(param => createLiteral(param, `"${param}"`, eventPos)),
-                  eventPos
-                ),
-              },
-            ],
-            eventPos
-          )
+        alternatives.map(alt =>
+          alt.kind === 'duration'
+            ? createObjectLiteral(
+                [{ key: createIdentifier('duration', eventPos), value: alt.expr }],
+                eventPos
+              )
+            : createObjectLiteral(
+                [
+                  {
+                    key: createIdentifier('name', eventPos),
+                    value: createLiteral(alt.name, `"${alt.name}"`, eventPos),
+                  },
+                  {
+                    key: createIdentifier('args', eventPos),
+                    value: createArrayLiteral(
+                      alt.params.map(param => createLiteral(param, `"${param}"`, eventPos)),
+                      eventPos
+                    ),
+                  },
+                ],
+                eventPos
+              )
         ),
         eventPos
       )


### PR DESCRIPTION
Arc F follow-ups round 2, **Phase G**.

## The defect

`parseWaitCommand`'s event branch ran a `do…while` over or-separated event **names** and required `isIdentifierLike`, so the number token in `wait for click or 1s` threw `Expected event name after "for"`.

The real `hyperscript.org` engine accepts it — `hs.parse(src).errors` → `[]` for every surface below — and means "resume on whichever comes first".

## Runtime-first: this was a ONE-SIDED gap

The plan asked to read what `WaitCommand` does with an event list before choosing an AST shape, and to size a two-sided fix before starting. It isn't one.

`WaitCommand` has had `WaitRaceInput` since before this change — a **mixed** list of `time` and `event` conditions — and `executeRace` already `Promise.race`s them behind an `AbortController` that tears down the losing listeners. The machinery was simply unreachable from this surface because the parser rejected the duration token. **No new runtime concept was needed.**

## The fix

- **Parser**: each or-separated alternative is now an event **or** a duration (a time literal, a bare number, or a parenthesized expression). Events keep their `{ name, args }` object; a duration emits `{ duration: <expr> }`.
- **Runtime**: `parseEventArrayWait` reads both keys and builds one condition per entry, returning the single condition when there is only one and a race otherwise. That also makes `wait for 1s` — which upstream accepts too — a plain timeout rather than a parse error.

Now accepted, all verified against the upstream oracle and executed in jsdom:

```
wait for click or 1s
wait for click or keydown or 2s
wait for click or 1s from #btn     (`from` targets the event half)
wait for 1s
```

`wait for click`, `wait 1s` and the `or`-**modifier** path (`parseRaceCondition`, reached via `raw.modifiers.or`) are untouched. The error message for a tail that is neither an event nor a duration now says so.

## Gates

core **7797 passed / 106 skipped / 304 files** · `typecheck` · `typecheck:scripts` · `verify:reference` · `docs:commands:check` · `generate:bundles:check` · `snapshot:bundle-size --check` · oxlint. Multilingual ratchet **green and unmoved**.

The 13 new rows were mutation-verified on both sides — dropping the parser's duration branch fails 10, dropping the runtime's `duration` key fails 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)