### PR TITLE
fix(semantic): eight languages were swapping the wrong way round — R3 family 6 closed

### DIFF
--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -649,18 +649,20 @@ not the core abstractions.
     already correct for that shape: give it three roles and the three-arg
     branch (`target = args[len-2]`, `content = args[len-1]`) lands right with
     no further descriptor change.
-  - **The symmetric-swap role flip is now behaviorally consequential.** The
-    stored translations for `swap-content` bind the roles REVERSED in
-    ar/ja/ko/tr (and bn/hi/qu/tl) — e.g. ja `#a を クリック で 交換 #b で`
-    parses `patient=#a, destination=#b` where en parses `destination=#a,
-    patient=#b`. This is R3's long-standing `swap-content` residual (8
-    languages, `avgValueRecall` 0.9968) and it did not move. But its *meaning*
-    changed: while both roles landed in dead slots the flip was invisible, and
-    now it decides which element is the target and which is the content, so
-    those languages swap the wrong way round. Still strictly better than the
-    previous behavior (which threw for every language including English), and
-    still tracked in `MULTILINGUAL_NEXT_STEPS.md` § "R3-discovered value-bug
-    families" — but it is no longer cosmetic.
+  - ~~**The symmetric-swap role flip is now behaviorally consequential.**~~
+    **FIXED.** The stored `swap-content` translations bound the roles REVERSED
+    in ar/bn/hi/ja/ko/qu/tl/tr — ja `#a を クリック で 交換 #b で` parsed
+    `patient=#a, destination=#b` where en parses `destination=#a, patient=#b`.
+    While both roles landed in dead slots the flip was invisible; once the
+    descriptor fix made swap execute, it decided which element was the target,
+    so those eight swapped the wrong way round.
+    Fixed in the two SOV/VSO event-handler generators — the fronted
+    (accusative) slot binds `destination` and the trailing with-marked group
+    binds `patient` for `swap` only — rather than by renaming en's roles, which
+    would have made `destination` name the content. `swap-content` also joined
+    R2's curated execution subset, which is the gate that stayed at 1.0 through
+    the whole episode because the pattern was not in it. Detail:
+    `MULTILINGUAL_NEXT_STEPS.md` § "R3-discovered value-bug families" item 6.
 
 - **`command-adapter.ts` declares its own `CommandMetadata`, and the load-bearing
   reader uses it.** `:54-60` defines a loose shape with an

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -219,8 +219,8 @@ fail CI.
 >   parser path; unchanged out-of-scope decision. (hi window-resize is the
 >   आकार_बदलें `_`-split + बदलें→toggle homonym; the tr boyutlandırma
 >   rename precedent applies if ever taken.)
-> - **swap-content (bn/hi/qu/tr):** F6 wontfix, unchanged (§ R3 families
->   item 6).
+> - **swap-content (bn/hi/qu/tr):** was F6 wontfix at the time of this sweep;
+>   fixed 2026-07-31 (§ R3 families item 6).
 >
 > Residual per-language misses: ja 1 (pick) · bn/tr 2 (pick, swap) · ko 3
 > (pick, on.event ×2) · qu 4 (pick, swap, on.event ×2) · hi 5 (pick, swap,
@@ -2932,13 +2932,18 @@ value-bug families"), F6 **wontfix** (documented), F7 **re-filed**:
    `{goal}`). Fixed in the trailing-DURATION reclaim: skip exactly one particle
    when a TIME-shaped literal directly follows it (`में 500ms` — the
    prepositional sibling of the bn `জন্য` postposition).
-6. **`swap` role-binding flip — ~~WONTFIX~~ RE-OPENED 2026-07-31: the premise
-   was measured false** (ar/bn/hi/ja/ko/qu/tl/tr × `swap-content`, 8 rows). en
-   parses `swap #a with #b` as `destination=#a, patient=#b` (swapSchema:
-   destination bare-marked svoPos 2, patient with-word svoPos 3); the SOV/VSO
-   transformer marks `#a` accusative → the roles land flipped. The 2026-07-10
-   decision rested on **"swap is runtime-symmetric for the element shape, so
-   this is signature noise, not a behavior bug."** It is not symmetric:
+6. ~~**`swap` role-binding flip**~~ **FIXED** (ar/bn/hi/ja/ko/qu/tl/tr ×
+   `swap-content`, 8 rows). Filed as WONTFIX on 2026-07-10 for being
+   "runtime-symmetric", re-opened 2026-07-31 when that premise was measured
+   false, and closed the same arc.
+
+   The premise was _vacuously_ true when it was made, for a reason nobody could
+   see at the time: the swap descriptor emitted `args:[patient, source]` +
+   `modifiers.on`, and `SwapCommand.parseInput` reads only `raw.args`, so
+   `swap #a with #b` threw `could not parse arguments` before either binding
+   could matter. Both orders were equally broken, which is not the same as
+   equivalent. The descriptor fix (#845) made the runtime work — and thereby
+   made the flip consequential:
 
    | AST | `#a` after | `#b` after |
    | --- | ---------- | ---------- |
@@ -2946,25 +2951,23 @@ value-bug families"), F6 **wontfix** (documented), F7 **re-filed**:
    | `swap #b with #a` | `AAA` | `AAA` |
 
    The DOM swap is directional — the target takes the content element's
-   content and the content element is untouched — so a flipped binding swaps
-   the wrong way round. (Measured through parse → `buildAST` → runtime in
-   jsdom.)
+   content — so the eight languages were swapping the wrong way round.
 
-   The claim was _vacuously_ true when it was made, for a reason nobody could
-   see at the time: the swap descriptor emitted `args:[patient, source]` +
-   `modifiers.on`, and `SwapCommand.parseInput` reads only `raw.args`, so
-   `swap #a with #b` threw `could not parse arguments` before either binding
-   could matter. Both orders were equally broken, which is not the same as
-   equivalent. The descriptor fix (#845) made the runtime work — and thereby
-   made the flip consequential.
+   **Fixed in the eight, not by renaming en's roles.** The SOV/VSO
+   event-handler generators bound the fronted (accusative) element to `patient`
+   and the trailing with-marked one to `destination`. Flipping en + the 16 SVO
+   marker tables instead — the direction the original entry proposed — would
+   have made `destination` name the CONTENT and `patient` the TARGET,
+   contradicting swapSchema's own role descriptions and the runtime's meaning.
+   Both generators now bind the fronted slot to `destination` and the trailing
+   with-marked group to `patient` for `swap` only; the markers themselves are
+   untouched.
 
-   Fixing still costs what the original entry said: flip destination/patient
-   across the en hand pattern + swapSchema for all SVO languages together, and
-   audit the ast-builder mapper / runtime / renderer round-trip. What changed is
-   the other side of the trade — it is no longer "zero runtime effect", it is
-   eight languages swapping the wrong element. The 8 rows stay visible in the R3
-   report; do NOT special-case the R3 walker. Regenerate the baseline and watch
-   R1/R2 when it lands.
+   **The missing gate came with it:** `swap-content` joined R2's curated
+   execution subset. R2 stayed at 1.0 through the entire breakage — first while
+   swap threw in every language, then while eight swapped backwards — for one
+   reason: the pattern was not in the list.
+
 7. ~~**qu/tr behavior trigger-event residue — RE-FILED to the transformer arc**~~
    **DONE** (2026-07-10, transformer-rendering arc —
    `docs-internal/HANDOFF_transformer-rendering.md`, resolved; all four

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -332,6 +332,20 @@ export function eventHandlerDestinationGroup(
   return eventHandlerRoleGroup(schema, marker, 'destination');
 }
 
+/**
+ * The same optional trailing group, binding `patient`.
+ *
+ * Only `swap` needs it: it is the two-object command, and its trailing element
+ * is the CONTENT (`swap #a with #b` → `#a` takes `#b`'s content). See the
+ * swap-gated branches in the SOV/VSO event-handler generators.
+ */
+export function eventHandlerPatientGroup(
+  schema: CommandSchema,
+  marker: RoleMarker | undefined
+): PatternToken[] {
+  return eventHandlerRoleGroup(schema, marker, 'patient');
+}
+
 function eventHandlerRoleGroup(
   schema: CommandSchema,
   marker: RoleMarker | undefined,

--- a/packages/semantic/src/generators/event-handlers-sov.ts
+++ b/packages/semantic/src/generators/event-handlers-sov.ts
@@ -7,12 +7,13 @@
  * Extracted from pattern-generator.ts for maintainability.
  */
 
-import type { LanguagePattern, PatternToken, ExtractionRule } from '../types';
+import type { LanguagePattern, PatternToken, ExtractionRule, SemanticRole } from '../types';
 import type { LanguageProfile, KeywordTranslation, RoleMarker } from './language-profiles';
 import type { CommandSchema, RoleSpec } from './command-schemas';
 import {
   eventHandlerDestinationExtraction,
   eventHandlerDestinationGroup,
+  eventHandlerPatientGroup,
   eventHandlerSourceExtraction,
   eventHandlerSourceGroup,
 } from './command-schemas';
@@ -198,10 +199,26 @@ export function generateSOVPatientFirstEventHandlerPattern(
 ): LanguagePattern {
   const tokens: PatternToken[] = [];
 
-  // Patient role first
-  tokens.push({ type: 'role', role: 'patient', optional: false });
+  // `swap` is the two-object exception, and its operands are NOT symmetric:
+  // `swap #a with #b` gives #a the content of #b, so the FRONTED (accusative)
+  // element is the target — `destination` in en's reading and in swapSchema's
+  // own role descriptions — and the trailing with-marked element is the
+  // content (`patient`). Binding the fronted slot to `patient` here is what
+  // made ar/bn/hi/ja/ko/qu/tl/tr swap the wrong way round once #845 made the
+  // command execute at all (R3 family 6, re-opened 2026-07-31 with the
+  // falsifying measurement — the old "runtime-symmetric" premise was vacuously
+  // true only while swap threw for every language, English included).
+  //
+  // The accusative MARKER is unchanged; only the role it fills is. Fixing the
+  // eight rather than renaming en's roles keeps `destination`/`patient`
+  // meaning what the schema says they mean.
+  const swapsOperands = commandSchema.action === 'swap';
+  const frontedRole: SemanticRole = swapsOperands ? 'destination' : 'patient';
 
-  // Patient marker (postposition after patient)
+  // Fronted role first
+  tokens.push({ type: 'role', role: frontedRole, optional: false });
+
+  // Patient marker (postposition after the fronted element)
   const patientMarker = profile.roleMarkers.patient;
   if (patientMarker) {
     const patMarkerToken: PatternToken = patientMarker.alternatives
@@ -246,19 +263,23 @@ export function generateSOVPatientFirstEventHandlerPattern(
   // alternatives for swap; otherwise `#b <with>` never matches and #b drops
   // (hi/bn/tr/qu rendered the invalid `swap with #a`). Non-swap commands and
   // languages without a with-override are byte-identical to before.
-  let trailingDestMarker = profile.roleMarkers.destination;
-  if (commandSchema.action === 'swap' && trailingDestMarker) {
+  let trailingMarker = profile.roleMarkers.destination;
+  if (swapsOperands && trailingMarker) {
     const withWord = commandSchema.roles.find(r => r.role === 'patient')?.markerOverride?.[
       profile.code
     ];
-    if (withWord && withWord !== trailingDestMarker.primary) {
-      const existing = trailingDestMarker.alternatives ?? [];
+    if (withWord && withWord !== trailingMarker.primary) {
+      const existing = trailingMarker.alternatives ?? [];
       if (!existing.includes(withWord)) {
-        trailingDestMarker = { ...trailingDestMarker, alternatives: [...existing, withWord] };
+        trailingMarker = { ...trailingMarker, alternatives: [...existing, withWord] };
       }
     }
   }
-  tokens.push(...eventHandlerDestinationGroup(commandSchema, trailingDestMarker));
+  tokens.push(
+    ...(swapsOperands
+      ? eventHandlerPatientGroup(commandSchema, trailingMarker)
+      : eventHandlerDestinationGroup(commandSchema, trailingMarker))
+  );
 
   return {
     id: `${commandSchema.action}-event-${profile.code}-sov-patient-first`,
@@ -272,8 +293,8 @@ export function generateSOVPatientFirstEventHandlerPattern(
     extraction: {
       action: { value: commandSchema.action },
       event: { fromRole: 'event' },
-      patient: { fromRole: 'patient' },
-      ...eventHandlerDestinationExtraction(commandSchema),
+      [frontedRole]: { fromRole: frontedRole },
+      ...(swapsOperands ? {} : eventHandlerDestinationExtraction(commandSchema)),
       ...eventHandlerSourceExtraction(commandSchema),
     },
   };

--- a/packages/semantic/src/generators/event-handlers-vso.ts
+++ b/packages/semantic/src/generators/event-handlers-vso.ts
@@ -133,11 +133,27 @@ export function generateVSOVerbFirstEventHandlerPattern(
     : { type: 'literal', value: keyword.primary };
   tokens.push(verbToken);
 
-  // Patient role
-  tokens.push({ type: 'role', role: 'patient', optional: false });
+  // `swap` is the two-object exception, and its operands are NOT symmetric:
+  // `swap #a with #b` gives #a the content of #b, so the FIRST element is the
+  // target — `destination` in en's reading and in swapSchema's own role
+  // descriptions — and the trailing with-marked element is the content
+  // (`patient`). Binding them the other way round is what made ar and tl swap
+  // BACKWARDS once #845 made the command execute at all. The trailing group
+  // below used to cite F6's "runtime-symmetric" wontfix; that premise was
+  // measured false on 2026-07-31 — it was vacuously true only while swap threw
+  // for every language, English included.
+  const swapsOperands = commandSchema.action === 'swap';
 
-  // Optional destination with preposition
-  const destMarker = profile.roleMarkers.destination;
+  // Patient role — the TARGET for swap, whose trailing group carries the content
+  tokens.push({
+    type: 'role',
+    role: swapsOperands ? 'destination' : 'patient',
+    optional: false,
+  });
+
+  // Optional destination with preposition. Not for swap: its second operand is
+  // the with-marked patient group appended after the event, below.
+  const destMarker = swapsOperands ? undefined : profile.roleMarkers.destination;
   if (destMarker) {
     tokens.push({
       type: 'group',
@@ -178,7 +194,7 @@ export function generateVSOVerbFirstEventHandlerPattern(
   // SOV fix — the operand flip vs en is the documented F6 wontfix, swap being
   // runtime-symmetric). Non-swap commands and languages without an override
   // are byte-identical.
-  if (commandSchema.action === 'swap') {
+  if (swapsOperands) {
     const withWord = commandSchema.roles.find(r => r.role === 'patient')?.markerOverride?.[
       profile.code
     ];
@@ -188,7 +204,7 @@ export function generateVSOVerbFirstEventHandlerPattern(
         optional: true,
         tokens: [
           { type: 'literal', value: withWord },
-          { type: 'role', role: 'destination', optional: false },
+          { type: 'role', role: 'patient', optional: false },
         ],
       });
     }
@@ -206,8 +222,10 @@ export function generateVSOVerbFirstEventHandlerPattern(
     extraction: {
       action: { value: commandSchema.action },
       event: { fromRole: 'event' },
-      patient: { fromRole: 'patient' },
-      ...eventHandlerDestinationExtraction(commandSchema),
+      [swapsOperands ? 'destination' : 'patient']: {
+        fromRole: swapsOperands ? 'destination' : 'patient',
+      },
+      ...(swapsOperands ? {} : eventHandlerDestinationExtraction(commandSchema)),
       ...eventHandlerSourceExtraction(commandSchema),
     },
   };

--- a/packages/semantic/test/descriptor-runtime-contract.test.ts
+++ b/packages/semantic/test/descriptor-runtime-contract.test.ts
@@ -235,3 +235,60 @@ describe('open — the element is an ARG, the variant an `as` modifier', () => {
     expect(astOf('open #dlg as non-modal').modifiers?.as).toBeDefined();
   });
 });
+
+describe('swap — every language binds the operands the same way round', () => {
+  // `swap #a with #b` gives #a the content of #b: the FIRST operand is the
+  // target, the second the content. `SwapCommand` reads them positionally
+  // (target = args[len-2], content = args[len-1]), so the two roles decide
+  // WHICH ELEMENT IS OVERWRITTEN — they are not interchangeable.
+  //
+  // The SOV/VSO event-handler generators bound the fronted (accusative) element
+  // to `patient` and the trailing with-marked one to `destination`, i.e. the
+  // reverse of en, in ar/bn/hi/ja/ko/qu/tl/tr. That was R3 family 6's
+  // "runtime-symmetric" WONTFIX — a premise that was vacuously true only while
+  // the descriptor made swap throw for every language, English included.
+  // Once #845 made it execute, those eight swapped BACKWARDS.
+  //
+  // The fix goes to the eight rather than renaming en's roles: `destination`
+  // and `patient` keep meaning what swapSchema's own role descriptions say.
+
+  const STORED: Array<[string, string]> = [
+    ['ja', '#a を クリック で 交換 #b で'],
+    ['ko', '#a 를 클릭 할 때 교환 #b 로'],
+    ['ar', 'استبدل #a عند نقر بـ#b'],
+    ['hi', '#a को क्लिक पर विनिमय #b से'],
+    ['bn', '#a কে ক্লিক এ বদল #b দিয়ে'],
+    ['tr', '#a i tıklama de takas #b ile'],
+    ['qu', "#a ta ñitiy pi t'inkuy #b wan"],
+    ['tl', 'palitan_pwesto #a kapag click nang #b'],
+    ['en', 'on click swap #a with #b'],
+    ['es', 'en clic intercambiar #a con #b'],
+    ['de', 'bei klick tauschen #a mit #b'],
+    ['zh', '当 点击 时 交换 把 #a 用 #b'],
+  ];
+
+  function findSwap(node: unknown): { roles: Map<string, { value?: string }> } | null {
+    const n = node as Record<string, any> | null;
+    if (!n || typeof n !== 'object') return null;
+    if (n.kind === 'command' && n.action === 'swap') return n as never;
+    for (const key of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      if (Array.isArray(n[key])) {
+        for (const child of n[key]) {
+          const found = findSwap(child);
+          if (found) return found;
+        }
+      }
+    }
+    return null;
+  }
+
+  it.each(STORED)('%s binds destination=#a, patient=#b', (lang, source) => {
+    // The stored `swap-content` translations, verbatim from patterns.db — the
+    // exact strings the multilingual gate scores.
+    const swap = findSwap(parse(source, lang));
+    expect(swap, `${lang}: no swap node in "${source}"`).not.toBeNull();
+
+    expect(swap!.roles.get('destination')?.value, `${lang}: target`).toBe('#a');
+    expect(swap!.roles.get('patient')?.value, `${lang}: content`).toBe('#b');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-28T14:29:58.179Z",
-  "commit": "7cef950a",
+  "timestamp": "2026-07-31T15:21:56.895Z",
+  "commit": "1e528bb1",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -11,12 +11,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9986928104575165,
-      "avgValueRecall": 0.9907407407407407,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -645,12 +645,12 @@
       "avgPrecision": 0.997835497835498,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9986928104575165,
-      "avgValueRecall": 0.9907407407407407,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1284,7 +1284,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1909,7 +1909,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2543,7 +2543,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3177,7 +3177,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3811,7 +3811,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4440,12 +4440,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9986928104575165,
-      "avgValueRecall": 0.9907407407407407,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5079,7 +5079,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5713,7 +5713,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6342,12 +6342,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9986928104575165,
-      "avgValueRecall": 0.9907407407407407,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6976,12 +6976,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9954248366013073,
-      "avgValueRecall": 0.9907407407407407,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7615,7 +7615,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8249,7 +8249,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8883,7 +8883,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9512,12 +9512,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9961251167133521,
-      "avgValueRecall": 0.9907407407407407,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10151,7 +10151,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10785,7 +10785,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11419,7 +11419,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12048,12 +12048,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9986928104575165,
-      "avgValueRecall": 0.9907407407407407,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12682,12 +12682,12 @@
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
       "avgRoleFidelity": 0.9986928104575165,
-      "avgValueRecall": 0.9907407407407407,
+      "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13321,7 +13321,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13955,7 +13955,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14589,7 +14589,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "bundleSize": 557642,
+      "bundleSize": 556874,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15212,7 +15212,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 557642,
+      "size": 556874,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.test.ts
@@ -19,7 +19,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { ExecutionValidator, EXECUTION_SUBSET, loadExecutionSubset } from './execution-validator';
 
 describe('R2 execution subset (lock)', () => {
-  it('contains exactly the 47 curated patterns', () => {
+  it('contains exactly the 48 curated patterns', () => {
     // Changing this list recalibrates avgExecutionFidelity for every language.
     // If you expand the subset, regenerate the baseline (--save-baseline) in
     // the SAME PR and update this lock.
@@ -119,6 +119,7 @@ describe('R2 execution subset (lock)', () => {
         'chained-access-possessive-dot',
         'hide-with-transition',
         'show-with-transition',
+        'swap-content',
         // Wave 10 (SOV literal-role-extraction arc, PRs #560/#561): the two R2
         // blockers — the fronted append content literal (bogus `event` role in
         // the body-clause marker lookup) and the trailing bare increment amount

--- a/packages/testing-framework/src/multilingual/validators/execution-validator.ts
+++ b/packages/testing-framework/src/multilingual/validators/execution-validator.ts
@@ -203,6 +203,16 @@ export const EXECUTION_SUBSET: readonly string[] = [
   //    Fixture adds `<div id="score">0</div>` (appended last).
   'append-content',
   'increment-by-amount',
+  // Expansion wave 11: `swap-content` — `swap #a with #b`. R2 stayed at 1.0
+  // through the ENTIRE swap breakage (the descriptor emitted modifiers
+  // SwapCommand never reads, so every language including English threw
+  // `could not parse arguments`), and then through eight languages binding the
+  // operands BACKWARDS once #845 made it execute. Both were invisible here for
+  // one reason: swap-content was not in this list. It is the missing gate for
+  // R3 family 6, and it turns the operand fix from "trust me" into a row.
+  // Fixture adds `#a`/`#b` with distinguishable content (appended last, so
+  // existing snapshot indices are preserved).
+  'swap-content',
 ];
 
 /**
@@ -229,6 +239,8 @@ const FIXTURE_HTML = `<!DOCTYPE html><html><body>
   <div id="sr-announce"></div>
   <ul id="list"></ul>
   <div id="score">0</div>
+  <div id="a">AAA</div>
+  <div id="b">BBB</div>
 </body></html>`;
 
 /** Per-pattern fixture preconditions (applied identically for every language). */


### PR DESCRIPTION
Arc F follow-ups round 2, **Phase D** — R3 family 6, re-opened in the plan with a falsifying measurement and closed here.

## The defect

The stored `swap-content` translations bound the two operands **reversed** in eight languages. Measured against a freshly `populate`d `patterns.db`:

| | binding |
| --- | --- |
| en, es, de, fr, zh, he, ru, pt, it, id, ms, sw, th, vi, pl, uk | `destination=#a, patient=#b` |
| **ar, bn, hi, ja, ko, qu, tl, tr** | `patient=#a, destination=#b` |

`SwapCommand` reads its operands positionally — `target = args[len-2]`, `content = args[len-1]` — so the two roles decide **which element is overwritten**. Verified in jsdom: `swap #a with #b` leaves `#a` = `BBB` and `#b` = `BBB`; the reversed binding does the opposite. Those eight were swapping backwards.

## Why the WONTFIX was wrong

The 2026-07-10 decision rested on "swap is runtime-symmetric for the element shape, so this is signature noise." That was **vacuously** true: the old descriptor emitted `args:[patient, source]` + `modifiers.on`, and `SwapCommand.parseInput` reads only `raw.args`, so `swap #a with #b` threw `could not parse arguments` before either binding could matter. Both orders were equally broken — which is not the same as equivalent. #845 made the command execute, and thereby made the flip consequential.

## The fix, and the direction the plan proposed

The plan (inheriting the original R3 entry) proposed flipping **en + the 16 SVO marker tables** so everything matched the SOV/VSO generators. This PR does the opposite, deliberately: that direction would make `destination` name the **content** and `patient` name the **target**, contradicting `swapSchema`'s own role descriptions ("destination: the element to swap content in/for", "patient: the content to swap in") and the runtime's meaning.

Instead both event-handler generators bind, **for `swap` only**, the fronted (accusative) slot to `destination` and the trailing with-marked group to `patient`:

- `generateSOVPatientFirstEventHandlerPattern` (ja ko hi bn tr qu)
- `generateVSOVerbFirstEventHandlerPattern` (ar tl)

The **markers are untouched** — only the role each fills. The with-word still comes from `patient`'s `markerOverride`, as before. `eventHandlerRoleGroup` was already generic over the role, so this needed one new thin wrapper (`eventHandlerPatientGroup`) rather than new plumbing.

## The missing gate, added

`swap-content` joins R2's curated execution subset. **R2 stayed at 1.0 through the entire episode** — first while swap threw in every language including English, then while eight swapped backwards — for exactly one reason: the pattern was not in the list. That is what made this "trust me" instead of a ratchet row, and it is fixed here.

The fixture gains `#a`/`#b` with distinguishable content (appended last, so existing snapshot indices are preserved). The en reference produces a clean, deterministic, non-empty signature — verified directly: `#a` AAA→BBB, `#b` untouched.

## Gates

semantic `typecheck` + full suite · `check:mapper-parity` (unchanged — this is pattern generation, not descriptors) · core suite · testing-framework suite incl. the R2 subset lock (47 → 48) · vocab consistency · `hyperscript-adapter` syntax-table drift · oxlint · multilingual ratchet with a regenerated baseline.

Mutation-verified both halves: reverting the SOV flip fails 6 rows (the six SOV languages), reverting the VSO flip fails 2 (ar, tl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
