### PR TITLE
docs: re-measure the `toggle … for` arc — four corrections and a new blocker

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -2874,6 +2874,23 @@ languages including en (was split everywhere). Follow-up status:
    (`behavior-draggable/resizable/sortable`), and the fix healed those rows too
    (bn avgValueRecall 0.917 → 0.958).
 
+## `toggle … for <duration>` — measured, not started (2026-07-31)
+
+The multilingual half of the `toggle … for` arc. Its brief lives in
+[PARSER_NEXT_STEPS.md](./PARSER_NEXT_STEPS.md) § "Round-2 re-measurement" — read
+that before starting; round 2 corrected four of the original numbers and found a
+blocker the original brief did not have.
+
+The two headlines for this side:
+
+- The schema change is a 2-line role + 1 exemption prune, but shipping it alone
+  **regresses 11 languages' rendering** (the duration currently survives as bare
+  text and would vanish). Ship the marker table and the rendering fix with it.
+- The corpus row is ready and all 24 translations parse faithfully, but bn's
+  `জন্য` is a homonym for its `for` LOOP keyword, so the row fails R4 on its
+  first run (`on click toggle .loading for 2s in`). `allowedInvalid` is
+  currently EMPTY — do not land the row without the bn disambiguation.
+
 ## R3-discovered value-bug families (opened 2026-07-10, burned down 2026-07-10)
 
 The first R3 sweep surfaced 50 sub-1.0 instances across 18 patterns — all triaged

--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -140,6 +140,78 @@ the transformer's rendering of it — a multilingual arc with no gate today. Who
 takes it should add a `toggle … for` corpus row FIRST, so the ratchet stops being
 blind, then do the markers.
 
+#### Round-2 re-measurement (2026-07-31) — four corrections and one new blocker
+
+Arc F follow-ups round 2 re-ran every step above at `5d256878`. The arc is still
+the right shape, but four of the numbers above are wrong in the helpful
+direction and one new obstacle appeared. Nothing was shipped: the schema half
+alone is a REGRESSION (see 2).
+
+1. **The schema half costs ONE test, not 16.** Adding
+
+   ```ts
+   { role: 'duration', required: false, expectedTypes: ['literal'],
+     svoPosition: 3, sovPosition: 3,
+     markerOverride: { en: 'for', ja: '間', ko: '동안' } }
+   ```
+
+   to `toggleSchema.roles` breaks exactly `ast-shape-consistency`'s
+   `toggle.for ← duration` — the exemption becoming orphaned because the
+   descriptor key now equals the role's en marker. Prune it and the full
+   semantic suite is green (7230 / 108 files). The "16 tests" figure above is
+   the en-marker-ONLY variant; carrying ja/ko from the start avoids it, exactly
+   as the bullet after it says. `parseSemantic('toggle .loading for 2s','en')`
+   then binds `{patient:'.loading', duration:'2s', destination:'me'}`.
+
+2. **Shipping that alone REGRESSES 11 languages.** `translate(en→L)` →
+   `parse(L)` for all 23:
+
+   | outcome | languages |
+   | ------- | --------- |
+   | duration survives and re-parses | de fr pt id ms sw he ar ja ko tl (11) |
+   | duration DROPPED from the render | es it ru uk pl th vi zh hi bn qu (11) |
+   | renders but the parse returns NULL | tr (`.loading 2s değiştir`) |
+
+   With no `duration` role the duration currently survives as bare pass-through
+   text (`alternar .loading 2s`); adding the role makes it vanish
+   (`alternar .loading`). Same "ship them together or not at all" shape as
+   `open`'s two halves. The claim above that "on main every language drops the
+   2s" is wrong — on main every language KEEPS it, unmarked.
+
+3. **The drop is toggle-specific, not a general duration gap.** `transition my
+   *opacity to 0 over 500ms` and `wait 2s` keep their duration in every one of
+   those 11 (checked directly), so the per-language duration machinery works.
+
+4. **Two things not to assume.** `canonicalOrder` is not the discriminator — es
+   (drops) and de/fr/pt (keep) are byte-identical, as are ja/ko (keep) and
+   bn/hi (drop). And there are TWO renderers that disagree: the stored corpus
+   translations come from i18n's `GrammarTransformer` (`sync-translations.ts`),
+   which keeps `2s` unmarked in all 23; the drop above is in the SEMANTIC
+   package's `render`. Whichever is fixed, the other decides what the ratchet
+   scores.
+
+5. **NEW — the corpus row cannot land on its own, because of a bn homonym.**
+   The row is ready (`toggle-class-temporary`, `on click toggle .loading for
+   2s`); `populate` generates all 24 translations and every one parses
+   faithfully. But the gate rejects it on the first run:
+
+   ```
+   ✗ Canonical-validity regression (R4): toggle-class-temporary/bn
+   ```
+
+   bn's `for` LOOP keyword is `জন্য` (`profiles/bengali.ts` keywords.for) and
+   `জন্য` is ALSO bn's duration postposition (its `particles` list). So `2s
+   জন্য` yields a phantom `for` command, and the round-trip renders
+   `on click toggle .loading for 2s in` — a dangling loop `in` the
+   hyperscript.org parser rejects. Same homonym class as tr `değiştir` / hi
+   `बदलें`.
+
+   This matters for sequencing: `baselines/foreign-canonical-validity.json`'s
+   `allowedInvalid` is currently **empty**, and landing the corpus row alone
+   would put the first entry back into it. Disambiguate `জন্য` (a time literal
+   before it is a duration postposition, not a loop head) in the SAME change as
+   the corpus row.
+
 Two adjacent diagnostics found in the same sweep, both cosmetic and neither
 worth its own arc — fold them into whichever change touches this area:
 


### PR DESCRIPTION
Arc F follow-ups round 2, **Phase E**.

The plan's Phase E ordered the work correctly. Re-running every step at `5d256878` changed four of its numbers and found an obstacle it did not have.

**Nothing was shipped, deliberately** — the schema half alone is a regression, and the corpus row alone dirties a currently-clean allowlist. Both are recorded so the next session starts from data instead of re-deriving it.

## 1. The schema half costs ONE test, not 16

A `duration` role carrying `markerOverride: { en: 'for', ja: '間', ko: '동안' }` breaks only `ast-shape-consistency`'s `toggle.for ← duration` — the exemption becoming orphaned because the descriptor key now equals the role's en marker, which is the gate working as designed. Prune it and the semantic suite is green (7230 / 108 files).

The "16 tests" figure in the old brief was the **en-marker-only** variant.

## 2. Shipping that alone REGRESSES 11 languages

Measured `translate(en→L)` → `parse(L)` across all 23:

| outcome | languages |
| --- | --- |
| duration survives and re-parses | de fr pt id ms sw he ar ja ko tl (11) |
| duration **dropped** from the render | es it ru uk pl th vi zh hi bn qu (11) |
| renders but the parse returns NULL | tr (`.loading 2s değiştir`) |

With no `duration` role the value currently survives as bare pass-through text (`alternar .loading 2s`); adding the role makes it **vanish** (`alternar .loading`). Same "ship them together or not at all" shape as `open`'s two halves in #851.

This also corrects the old brief's claim that *"on main every language drops the 2s"* — on main every language **keeps** it, unmarked.

## 3. The drop is toggle-specific

`transition my *opacity to 0 over 500ms` and `wait 2s` keep their duration in every one of those 11, checked directly. The per-language duration machinery works; it is the toggle construction's role emission that loses it.

## 4. Two things not to assume

- **`canonicalOrder` is not the discriminator.** es (drops) and de/fr/pt (keep) are byte-identical; ja/ko (keep) and bn/hi (drop) likewise.
- **There are TWO renderers and they disagree.** The stored corpus translations come from i18n's `GrammarTransformer` (`sync-translations.ts`), which keeps `2s` unmarked in all 23; the drop above is in the **semantic** package's `render`. Whichever is fixed, the other decides what the ratchet scores.

## 5. NEW blocker — the corpus row cannot land on its own

The row is ready (`toggle-class-temporary`, `on click toggle .loading for 2s`); `populate` generates all 24 translations and every one parses faithfully. The gate still rejects it on the first run:

```
✗ Canonical-validity regression (R4): toggle-class-temporary/bn
```

bn's `for` **loop** keyword is `জন্য` (`profiles/bengali.ts` `keywords.for`) and `জন্য` is **also** bn's duration postposition (its `particles` list). So `2s জন্য` yields a phantom `for` command, and the round-trip renders `on click toggle .loading for 2s in` — a dangling loop `in` the hyperscript.org parser rejects. Same homonym class as tr `değiştir` / hi `बदलें`.

This matters for sequencing: `baselines/foreign-canonical-validity.json`'s `allowedInvalid` is currently **empty**, and landing the corpus row alone would put the first entry back into it. The bn disambiguation (a time literal before `জন্য` makes it a duration postposition, not a loop head) belongs in the **same change** as the row.

## Why docs-only

Following the plan's own round-1 precedent (#844 recorded the switch-reachability measurement rather than guessing at it). Everything above was measured and then reverted; the branch carries no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)