### PR TITLE
docs: close Arc F round 2's queue entries, file two new defects, document three gates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,41 @@ npm run test:check --prefix packages/i18n
 > **Agent/CI tip:** Use `npm run test:check` for compact pass/fail output.
 > Use `npm test` for full verbose output during debugging.
 
+#### Three gates `test:check` does NOT cover
+
+These are required CI checks that no `test:check` invocation reaches, so a green
+local run can still fail CI. Each cost a full CI round-trip during Arc F
+follow-ups round 2. Run all three whenever a change touches
+`packages/semantic/src/generators/command-schemas.ts`, a language profile, or
+R2's curated execution subset:
+
+```bash
+# 1. Vocab consistency (V1–V4 cross-surface check)
+cd packages/testing-framework && npx tsx src/vocab/cli.ts validate
+
+# 2. Generated syntax-table drift (derives from the command schemas)
+npm run test:check --prefix packages/hyperscript-adapter
+
+# 3. The R2 curated-subset lock (part of the testing-framework suite)
+npm run test:check --prefix packages/testing-framework
+```
+
+1. **Vocab consistency** fires when a schema gains a `markerOverride` whose word
+   tokenizes as `identifier` rather than keyword/particle. Waive in
+   `packages/testing-framework/vocab-waivers.json`, keyed `V4|<lang>|<marker>`,
+   with a reason. The error aggregates its SITES, so a marker that has shipped
+   for years can become newly reportable the moment a second schema uses it.
+2. **`syntax-table.ts`** is generated from the schemas and gated by
+   `derive-syntax.test.ts`. Any change to a role's `svoPosition` or marker
+   restages it: `npm run generate:syntax --prefix packages/hyperscript-adapter`.
+   Two traps — the file is **tracked but also matches `.gitignore`**, so it needs
+   `git add -f`, and lint-staged cannot re-add it after prettier, so that commit
+   needs `--no-verify`.
+3. **The R2 subset lock** (`validators/execution-validator.test.ts`) asserts the
+   exact curated pattern list. Expanding `EXECUTION_SUBSET` means updating the
+   count in the test title, the sorted expectation array, AND regenerating the
+   multilingual baseline in the same PR.
+
 #### Stale-dist auto-rebuild
 
 Both `npm test --prefix packages/<X>` and `npm run test:check` auto-rebuild any workspace dependency whose `src/` is newer than its `dist/` (via [scripts/ensure-fresh.sh](scripts/ensure-fresh.sh)). Per-package `pretest` hooks cover the first path; [scripts/test-check-all.sh](scripts/test-check-all.sh) runs `ensure-fresh` upfront for the second (npm pre/post hooks don't fire for `:check` variants). Manual escape hatch: `npm run check:fresh`.

--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -517,8 +517,27 @@ not the core abstractions.
   @data-count to "0"`), and `swap-content` (`swap #a with #b`).
 
 
-- **Core's `semantic-integration.ts` switch is a SECOND semantic→AST
-  implementation, and it has already drifted from the first.** Measured
+- ~~**Core's `semantic-integration.ts` switch is a SECOND semantic→AST
+  implementation, and it has already drifted from the first.**~~ **FIXED — #847
+  (Arc F follow-ups round 2, Phase A).** Option (b) shipped: the switch is gone
+  and core delegates the generic command tail to `@lokascript/semantic`'s
+  `ASTBuilder`, injected through the analyzer seam (`createSemanticAdapter`'s
+  `buildAST` dep) so core still takes no hard import. Five live English defects
+  went with it — `go back`, `go to url`, `get #target` and `scroll to …` threw;
+  `pick first 2 from .items` silently returned ONE item.
+  Two things delegation deliberately did NOT take over, both measured and pinned
+  in `semantic-integration-delegation.test.ts`: `repeat`/`for`/`set`/`if`/
+  `unless` keep dedicated builders (the builder drops the loop-variant
+  discriminator, keeps a `for` name core has no command for, and puts set's value
+  in `modifiers.to` where `SetCommand` reads a positional `[target,'to',value]`),
+  and `show`/`hide`/`transition … *prop` keep returning no node.
+  Behavior deltas named at the time: nodes now carry the builder's `isBlocking`
+  (the switch hardcoded `false`, mismarking `fetch`) and its `semanticRoles`;
+  `send`'s target moved from `modifiers.on` to `modifiers.to`, which
+  `SendCommand` already accepted. The original measurement follows, kept because
+  it is the reason the decision went the way it did.
+
+  Measured
   2026-07-31 during Arc F step 1, by running both paths over the same semantic
   parse. For `put "x" before #out` (roles `patient`/`destination`/`manner`):
   `buildAST` emits `modifiers: { before: #out }`; `buildCommandNode`
@@ -608,9 +627,25 @@ not the core abstractions.
   deliberately return `NONE` via `shouldSkipSemantic`'s `/\*[a-zA-Z]/` check —
   delegation must preserve that refusal rather than adopt `buildAST`'s output.
 
-- **`DefaultCommand` EVALUATES its target, so `default` is broken on both
-  execution paths.** Independent of the AST-shape defect above, and not fixed by
-  it. `commands/data/default.ts` `parseInput` does `target = await
+- ~~**`DefaultCommand` EVALUATES its target, so `default` is broken on both
+  execution paths.**~~ **FIXED — #848 (Arc F follow-ups round 2, Phase B).**
+  `parseInput` now walks the shared raw-AST write-target ladder
+  (`helpers/write-target.ts`), the same one `set`/`append`/`prepend` use, and
+  `DefaultCommandInput` became a discriminated union mirroring `SetCommandInput`.
+  Two corrections to the measurement below, both found while fixing it:
+  `default my innerHTML to "No content"` did NOT work — it evaluated the target
+  to the element's empty innerHTML string and created a junk local literally
+  named `''`, returning `wasSet: true` while never touching the DOM; and the
+  TRADITIONAL path had a second, independent defect, reading the value from
+  `args[1]` (the `to` KEYWORD), so every `default X to Y` parsed traditionally
+  installed `undefined`. Two shapes the ladder does not cover are handled in the
+  command: `:x`/`$x` arrive as `contextReference` on the semantic path (the
+  bare-reference rung must not claim those, since `me`/`it` are contextReferences
+  too), and a `$name` target loses its sigil so the read and the write agree.
+  New coverage goes through `hyperscript.eval` on both paths
+  (`data/__tests__/default-eval.test.ts`), because the existing unit tests
+  injected a mock evaluator returning `node.value ?? node.name` — the very
+  name-preserving behavior the real evaluator lacks. Original measurement: `commands/data/default.ts` `parseInput` does `target = await
   evaluator.evaluate(raw.args[0])` and then `execute` branches on
   `typeof target === 'string'` — but the target is a *name*, not a value, and
   evaluating an unset variable yields `undefined` (exactly the case `default`

--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -29,6 +29,8 @@ ones, because the gate *is* the tracking mechanism.
 | **`tell <target> to <command>` drops the `tell` wrapper** | medium — **silent wrong target** on the form users actually write | **none** | see the measured table below; found by Arc A step 4.3 (Finding 14 in [HANDOFF-command-arch-manifest.md](./HANDOFF-command-arch-manifest.md)), re-verified 2026-07-29 |
 | **`set <idref> to <value>` / js property-path args no-op** | medium — silent no-effect on shipped pages | ✅ execution-gate allowlist entries | families 1/6 in [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md) |
 | **`for <duration>` tail rejected on `toggle` / `wait`** | medium — two upstream-valid forms on shipped, documented commands; both are the command's OWN documented example | **none** | see the measured table below; found by the Arc B examples sweep ([HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md) § F-B4a) |
+| **`transition` rejects a POSSESSIVE property target** | medium — upstream-valid, and it is the form the docs and the corpus use | **none** | see the measured table below; found by #847's reachability probe |
+| **`take <class> from <source>` rejected** | medium — upstream-valid classic hyperscript on a shipped command | **none** | see the measured table below; found by #847's reachability probe |
 | `and` is not a command separator anywhere | low — consistent everywhere, so no surprise | ✅ 2 `KNOWN GAP` tests | `packages/core/src/parser/__tests__/then-as-separator.test.ts` |
 | `sortable-list.html` recovers with errors | low — one shipped example | ✅ allowlist ratchet | `packages/testing-framework/baselines/shipped-sources-validity.json` |
 
@@ -211,6 +213,43 @@ alone is a REGRESSION (see 2).
    would put the first entry back into it. Disambiguate `জন্য` (a time literal
    before it is a duration postposition, not a loop head) in the SAME change as
    the corpus row.
+
+### `transition` and `take` — two upstream-valid forms we reject (2026-07-31)
+
+Both surfaced from #847's reachability probe, which fed one English surface per
+reachable command to both AST paths. Neither is a semantic-vs-traditional
+divergence: both paths fail identically, so this is the shared parser. Every
+form below is `VALID` on the real `hyperscript.org` engine (`hs.parse(src).errors`
+→ `[]`).
+
+**`transition`'s property target cannot be possessive.** The bare form works;
+adding ANY possessor breaks it, with two different messages:
+
+| source | hyperfixi (both paths) |
+| ------ | ---------------------- |
+| `transition *opacity to 0 over 200ms` | **works** — writes `style="opacity: 0"` |
+| `transition my *opacity to 0 over 200ms` | `Expected "to" keyword after property in transition command` |
+| `transition its *opacity to 0` | same |
+| `transition #a's *opacity to 0 over 200ms` | `Transition command requires a CSS property` |
+
+The `my`/`its` and the `#a's` forms fail at different points, so this is likely
+two adjacent gaps rather than one. Note the possessive form is what
+`TransitionCommand`'s own surface area implies and what the multilingual corpus
+renders, so the working bare form is the narrower case.
+
+**`take <class> from <source>` is rejected outright**, and its `for` tail is the
+`toggle`/`wait` bug again:
+
+| source | hyperfixi |
+| ------ | --------- |
+| `take .active from .tab` | `take requires property, "from", and source` (semantic) / `take syntax: take <property> from <source>` (traditional) |
+| `take .active for me` | `Expected "in" after variable name in for loop` |
+| `take .active from .tab for me` | same |
+
+The first is the interesting one: both messages describe the syntax that was
+just supplied. The `for`-tail rows are the same defect class #846 fixed for
+`toggle` — an unconsumed `for` read as a loop head by the next parse round — so
+whoever fixes `take` should reuse `parseTemporalTail`.
 
 Two adjacent diagnostics found in the same sweep, both cosmetic and neither
 worth its own arc — fold them into whichever change touches this area:


### PR DESCRIPTION
Housekeeping after Arc F follow-ups round 2 (#847–#853). **No code changes.**

## Two queue entries closed

`COMMAND_ARCHITECTURE_NEXT_STEPS.md` still read as open for two things round 2 fixed. Both struck through, each **keeping its original measurement** — that evidence is why the decisions went the way they did — and each gaining what the fix actually found:

- **The `semantic-integration.ts` switch** (#847) — now records what delegation deliberately did *not* take over (the four dedicated builders, the `*prop` refusal) and the three behavior deltas.
- **`DefaultCommand` evaluates its target** (#848) — now records the two corrections measurement produced: `default my innerHTML` did **not** work (it wrote a junk local named `''` and returned `wasSet: true`), and the traditional path had a second, independent defect reading the value from the `to` **keyword**.

## Two new defects filed

Both surfaced by #847's reachability probe. Both are **upstream-VALID** (`hs.parse(src).errors` → `[]`) and rejected by us on **both** paths — so this is the shared parser, not a semantic/traditional divergence.

**`transition` rejects a possessive property target:**

| source | hyperfixi |
| --- | --- |
| `transition *opacity to 0 over 200ms` | **works** |
| `transition my *opacity to 0 over 200ms` | `Expected "to" keyword after property` |
| `transition its *opacity to 0` | same |
| `transition #a's *opacity to 0 over 200ms` | `Transition command requires a CSS property` |

The `my`/`its` and `#a's` forms fail at different points, so likely two adjacent gaps. The possessive form is what the multilingual corpus renders, so the working bare form is the narrower case.

**`take .active from .tab` is rejected outright** — with a message describing the syntax that was just supplied. Its `for` tail is the #846 defect again (an unconsumed `for` read as a loop head), so a fix should reuse `parseTemporalTail`.

Both added to the severity table, where triage starts.

## Three gates documented

CLAUDE.md gains a section for the gates `test:check` does **not** reach but CI requires. Each cost a full CI round-trip in round 2:

1. **Vocab consistency** — `npx tsx src/vocab/cli.ts validate`. Trap: the V4 error aggregates its **sites**, so a marker that has shipped for years becomes reportable the moment a second schema uses it.
2. **`syntax-table.ts` drift** — `test:check --prefix packages/hyperscript-adapter`. Traps: the file is **tracked but also gitignored** (needs `git add -f`), and lint-staged cannot re-add it after prettier (needs `--no-verify`).
3. **The R2 subset lock** — expanding `EXECUTION_SUBSET` means the title count, the sorted array, **and** a baseline regeneration in the same PR.

All three verified green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)