### PR TITLE
feat(testing-framework): role-set flip ratchet — the R1 blind spot, closed at tolerance 0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,7 +375,7 @@ the committed baseline:
 > not truth. Current plan + per-arc history:
 > `docs-internal/MULTILINGUAL_NEXT_STEPS.md`.
 
-The `--regression` gate ratchets on **ten** signals (each fails CI; each guarded so
+The `--regression` gate ratchets on **eleven** signals (each fails CI; each guarded so
 an un-regenerated baseline never retro-flags — a baseline lacking a signal's field
 yields a 0 delta):
 
@@ -417,6 +417,18 @@ yields a 0 delta):
    (`action.role:valueType` recall vs the en reference; catches a parse that keeps the
    verb but drops/mistypes a role). Note this is a Set too, so it shares signal 5's
    blind spot for repeated roles.
+   **Plus the role-set flip ratchet (tolerance 0, added 2026-07-31):** a pattern
+   that was role-FAITHFUL in the baseline (absent from its `roleLossyPatterns`)
+   and now has an incomplete role set fails outright. The average above cannot
+   see a single pattern losing one role — ~0.0013 in a ~154-pattern language,
+   15× under its tolerance — and that blind spot was **measured**, not
+   hypothesized: a `required: false` duration role on toggleSchema cost es/pl/vi
+   the second toggle's positional destination on `toggle-aria-expanded`
+   (`next .panel` silently became `me`) and the gate stayed green;
+   `tools/triage-r1.ts` found it by hand. Same binary-flip argument as the
+   lossy/R5 zeros. Guarded by the baseline carrying `roleLossyPatterns`, so an
+   un-regenerated baseline never retro-flags; pre-existing role-lossy patterns
+   are the R1 burn-down list, not regressions.
 7. **execution ratchet (R2)** — a curated-subset pattern whose jsdom DOM effect
    matched the en reference and now diverges (pass→fail; tolerance 0).
 8. **value-recall ratchet (R3)** — a per-language **avgValueRecall** drop > 0.02.

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-31T15:21:56.895Z",
-  "commit": "1e528bb1",
+  "timestamp": "2026-07-31T16:55:12.906Z",
+  "commit": "910d4066",
   "languages": {
     "ar": {
       "parseSuccess": 154,
@@ -16,6 +16,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-basic": {
@@ -650,6 +651,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -1284,6 +1286,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["last-in-collection", "pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -2543,6 +2546,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -3177,6 +3181,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["last-in-collection", "pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -3811,6 +3816,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["pick-text-range", "set-attribute"],
       "bundleSize": 556874,
       "patterns": {
         "put-content-basic": {
@@ -4445,6 +4451,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -5079,6 +5086,12 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": [
+        "fetch-do-not-throw",
+        "fetch-error-handling",
+        "fetch-json",
+        "pick-text-range"
+      ],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -5713,6 +5726,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -6347,6 +6361,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -6981,6 +6996,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["pick-text-range", "when-multiple-changes", "when-value-changes"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -7615,6 +7631,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["hide-with-transition", "last-in-collection", "pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -8249,6 +8266,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["pick-text-range", "unless-condition"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -8883,6 +8901,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -9517,6 +9536,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["announce-screen-reader", "on-custom-event-receive", "pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -10151,6 +10171,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -10785,6 +10806,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -11419,6 +11441,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["last-in-collection", "pick-text-range", "toggle-aria-expanded"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -12053,6 +12076,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -12687,6 +12711,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -13321,6 +13346,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -13955,6 +13981,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["its-value-possessive-dot", "last-in-collection", "pick-text-range"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-on-other": {
@@ -14589,6 +14616,7 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
+      "roleLossyPatterns": ["pick-text-range", "repeat-forever", "repeat-until-event"],
       "bundleSize": 556874,
       "patterns": {
         "toggle-class-basic": {

--- a/packages/testing-framework/src/multilingual/cli.ts
+++ b/packages/testing-framework/src/multilingual/cli.ts
@@ -478,6 +478,28 @@ async function main(): Promise<void> {
           r => r.avgRoleFidelityDelta < -AVG_ROLE_FIDELITY_DROP_TOLERANCE
         );
 
+        // R1 — role-set flip ratchet: a pattern that was ROLE-FAITHFUL in the
+        // baseline (its action.role:valueType set matched the en reference
+        // exactly) and is now role-incomplete. Tolerance 0 for the same reason
+        // the lossy flip and R5 sit at 0: a flip is binary and structural, with
+        // no float/collation noise to absorb — the averages' tolerances are
+        // cross-machine headroom, not signal cushions.
+        // Not redundant with the avg ratchet above: one pattern losing one role
+        // moves avgRoleFidelity by ~0.0013 in a ~154-pattern language, 15× under
+        // its 0.02 tolerance. This was MEASURED as the gate's blind spot, not
+        // hypothesized: a `required: false` duration role on toggleSchema cost
+        // es/pl/vi the second toggle's positional destination on
+        // `toggle-aria-expanded` (`toggle.destination:expression` →
+        // `:reference`, i.e. `next .panel` silently became `me`) and
+        // --regression stayed GREEN; tools/triage-r1.ts found it by hand.
+        // Guarded by the baseline carrying `roleLossyPatterns` (the reporter
+        // returns [] without it), so an un-regenerated baseline never
+        // retro-flags. Pre-existing role-lossy patterns are the R1 burn-down
+        // list, not regressions.
+        const roleSetRegressions = allResults.flatMap(r =>
+          r.newRoleLossyPatterns.map(id => `${r.language}/${id}`)
+        );
+
         // R3 — role-VALUE ratchet: same semantics as the role-fidelity ratchet,
         // on the invariant-value signal (`action.role=value` multiset over the
         // code-shaped subset: selectors, sigil refs, time literals,
@@ -690,6 +712,24 @@ async function main(): Promise<void> {
             );
           }
           console.error(`   (if intentional, regenerate the baseline with --save-baseline)`);
+          failed = true;
+        }
+
+        if (roleSetRegressions.length > 0) {
+          console.error(
+            `\n✗ Role-set regression vs baseline (R1): ${roleSetRegressions.length} ` +
+              `role-faithful pattern(s) now have an incomplete role set:`
+          );
+          for (const p of roleSetRegressions.slice(0, 20)) console.error(`   ${p}`);
+          if (roleSetRegressions.length > 20) {
+            console.error(`   … and ${roleSetRegressions.length - 20} more`);
+          }
+          console.error(
+            `   (still parses, but lost/mistyped a role vs the en reference — one flip ` +
+              `moves avgRoleFidelity ~0.0013, far under its tolerance, so this is the ` +
+              `only signal that sees it. Itemize with tools/triage-r1.ts; if ` +
+              `intentional, regenerate the baseline with --save-baseline)`
+          );
           failed = true;
         }
 

--- a/packages/testing-framework/src/multilingual/orchestrator.ts
+++ b/packages/testing-framework/src/multilingual/orchestrator.ts
@@ -285,6 +285,7 @@ export class TestOrchestrator {
 
       const degenerate: string[] = [];
       const lossy: string[] = [];
+      const roleLossy: string[] = [];
       const scores: number[] = [];
       const precisionScores: number[] = [];
       const multisetRecallScores: number[] = [];
@@ -330,6 +331,11 @@ export class TestOrchestrator {
           if (roleFidelity !== undefined) {
             result.roleFidelity = roleFidelity;
             roleScores.push(roleFidelity);
+            // Per-pattern R1: the average above cannot see a single pattern
+            // losing a role (~0.0013 in a ~154-pattern language, vs the 0.02
+            // gate tolerance). Recording WHICH patterns are role-incomplete
+            // makes the flip binary and ratchetable at tolerance 0.
+            if (roleFidelity < 1) roleLossy.push(result.pattern.codeExampleId);
           }
         }
 
@@ -371,6 +377,7 @@ export class TestOrchestrator {
           : undefined;
       lang.degeneratePasses = degenerate.sort();
       lang.lossyPasses = lossy.sort();
+      lang.roleLossyPatterns = roleLossy.sort();
     }
   }
 

--- a/packages/testing-framework/src/multilingual/reporters/regression-reporter.test.ts
+++ b/packages/testing-framework/src/multilingual/reporters/regression-reporter.test.ts
@@ -482,3 +482,106 @@ describe('RegressionReporter per-pattern parse ratchet — R5', () => {
     expect(r.newFailures).toHaveLength(25);
   });
 });
+
+describe('RegressionReporter role-set flip ratchet — R1 per-pattern', () => {
+  // LOCK: the avgRoleFidelity delta cannot see a single pattern losing a role —
+  // ~0.0013 in a ~154-pattern language, 15× under its 0.02 tolerance. That is
+  // not hypothetical: a `required: false` duration role on toggleSchema cost
+  // es/pl/vi the second toggle's positional destination on `toggle-aria-expanded`
+  // (`next .panel` silently became `me`) and `--regression` stayed green. This
+  // ratchet is the binary per-pattern signal that sees the flip, at tolerance 0.
+  let dir: string;
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function reporterWith(baseline: Baseline): RegressionReporter {
+    dir = mkdtempSync(join(tmpdir(), 'roleflip-'));
+    const path = join(dir, 'baseline.json');
+    writeFileSync(path, JSON.stringify(baseline));
+    return new RegressionReporter(path);
+  }
+
+  function langWithRoleLossy(roleLossyPatterns: string[]): LanguageResults {
+    return {
+      ...lang([pass('was-role-faithful'), pass('was-role-lossy'), pass('stable')], []),
+      roleLossyPatterns,
+    };
+  }
+
+  const baseline: Baseline = {
+    timestamp: '',
+    commit: 'base',
+    languages: {
+      ja: {
+        parseSuccess: 3,
+        parseFailure: 0,
+        parseRate: 1,
+        avgConfidence: 1,
+        avgRoleFidelity: 0.99,
+        roleLossyPatterns: ['was-role-lossy'],
+        bundleSize: undefined,
+        patterns: {
+          'was-role-faithful': { success: true, confidence: 1 },
+          'was-role-lossy': { success: true, confidence: 1 },
+          'was-failing': { success: false, confidence: 0 },
+          stable: { success: true, confidence: 1 },
+        },
+      },
+    },
+    bundles: {},
+  };
+
+  it('flags a role-faithful baseline pattern that is now role-incomplete', () => {
+    const reporter = reporterWith(baseline);
+    reporter.reportComplete(results(langWithRoleLossy(['was-role-faithful', 'was-role-lossy'])));
+    const r = reporter.getRegressionResults().find(x => x.language === 'ja')!;
+    expect(r.newRoleLossyPatterns).toEqual(['was-role-faithful']);
+    expect(r.newRoleLossyPatterns).not.toContain('was-role-lossy'); // burn-down, not regression
+    expect(r.status).toBe('regressed');
+  });
+
+  it('does not flag when the role-lossy set is unchanged', () => {
+    const reporter = reporterWith(baseline);
+    reporter.reportComplete(results(langWithRoleLossy(['was-role-lossy'])));
+    const r = reporter.getRegressionResults().find(x => x.language === 'ja')!;
+    expect(r.newRoleLossyPatterns).toEqual([]);
+    expect(r.status).not.toBe('regressed');
+  });
+
+  it('treats a role-lossy pattern that became faithful as improvement-neutral', () => {
+    const reporter = reporterWith(baseline);
+    reporter.reportComplete(results(langWithRoleLossy([])));
+    const r = reporter.getRegressionResults().find(x => x.language === 'ja')!;
+    expect(r.newRoleLossyPatterns).toEqual([]);
+  });
+
+  it('does not flag a pattern whose PARSE failed in the baseline (improvement path)', () => {
+    // `was-failing` did not parse in the baseline; parsing role-incompletely now
+    // is strictly better, not a regression.
+    const reporter = reporterWith(baseline);
+    reporter.reportComplete(results(langWithRoleLossy(['was-failing'])));
+    const r = reporter.getRegressionResults().find(x => x.language === 'ja')!;
+    expect(r.newRoleLossyPatterns).toEqual([]);
+  });
+
+  it('never retro-flags when the baseline has no roleLossyPatterns data', () => {
+    const noRoleData: Baseline = structuredClone(baseline);
+    delete noRoleData.languages.ja!.roleLossyPatterns;
+    const reporter = reporterWith(noRoleData);
+    reporter.reportComplete(
+      results(langWithRoleLossy(['was-role-faithful', 'was-role-lossy', 'stable']))
+    );
+    const r = reporter.getRegressionResults().find(x => x.language === 'ja')!;
+    expect(r.newRoleLossyPatterns).toEqual([]);
+  });
+
+  it('persists roleLossyPatterns when saving a baseline', () => {
+    const reporter = reporterWith(baseline);
+    const res = results(langWithRoleLossy(['was-role-lossy', 'stable']));
+    reporter.reportComplete(res);
+    reporter.saveAsBaseline(res);
+    const saved = JSON.parse(readFileSync(join(dir, 'baseline.json'), 'utf-8')) as Baseline;
+    expect(saved.languages.ja!.roleLossyPatterns).toEqual(['was-role-lossy', 'stable']);
+  });
+});

--- a/packages/testing-framework/src/multilingual/reporters/regression-reporter.ts
+++ b/packages/testing-framework/src/multilingual/reporters/regression-reporter.ts
@@ -153,6 +153,8 @@ export class RegressionReporter implements Reporter {
       const newDegeneratePasses = this.findNewDegeneratePasses(langResult, baselineLang);
       // Correctness ratchet (R0): faithful pass in baseline → lossy pass now.
       const newLossyPasses = this.findNewLossyPasses(langResult, baselineLang);
+      // Role-set ratchet (R1): role-faithful in baseline → role-incomplete now.
+      const newRoleLossyPatterns = this.findNewRoleLossyPatterns(langResult, baselineLang);
       // Execution ratchet (R2): faithful execution in baseline → divergent now.
       const newExecutionFailures = this.findNewExecutionFailures(langResult, baselineLang);
 
@@ -163,6 +165,7 @@ export class RegressionReporter implements Reporter {
         newFailures.length > 0 ||
         newDegeneratePasses.length > 0 ||
         newLossyPasses.length > 0 ||
+        newRoleLossyPatterns.length > 0 ||
         newExecutionFailures.length > 0
       ) {
         status = 'regressed';
@@ -185,6 +188,7 @@ export class RegressionReporter implements Reporter {
         newSuccesses,
         newDegeneratePasses,
         newLossyPasses,
+        newRoleLossyPatterns,
         newExecutionFailures,
         status,
       });
@@ -322,6 +326,39 @@ export class RegressionReporter implements Reporter {
   }
 
   /**
+   * Role-set ratchet (R1): patterns that were *role-faithful* (roleFidelity 1.0,
+   * i.e. absent from the baseline's `roleLossyPatterns`) but now have an
+   * incomplete role set vs the en reference. The binary counterpart of the
+   * avgRoleFidelity delta, which cannot see a single pattern losing a role
+   * (~0.0013 in a ~154-pattern language, vs the 0.02 tolerance) — measured
+   * doing exactly that (es/pl/vi silently lost `toggle-aria-expanded`'s
+   * positional destination, `next .panel` → `me`, and the gate stayed green).
+   *
+   * Returns [] when the baseline carries no `roleLossyPatterns` data yet, so
+   * adopting the signal never retro-flags — same guard as the degenerate/lossy
+   * ratchets. A pattern already role-lossy in the baseline is the burn-down
+   * list, not a regression; one whose PARSE failed in the baseline and now
+   * parses role-incompletely is an improvement and is excluded by `wasPass`.
+   */
+  private findNewRoleLossyPatterns(
+    current: LanguageResults,
+    baseline: {
+      patterns: Record<string, { success: boolean; confidence: number | undefined }> | undefined;
+      roleLossyPatterns?: string[] | undefined;
+    }
+  ): string[] {
+    if (!baseline.roleLossyPatterns || !baseline.patterns) return [];
+    const baselineRoleLossy = new Set(baseline.roleLossyPatterns);
+
+    const regressed: string[] = [];
+    for (const id of current.roleLossyPatterns ?? []) {
+      const wasPass = baseline.patterns[id]?.success === true;
+      if (wasPass && !baselineRoleLossy.has(id)) regressed.push(id);
+    }
+    return regressed.sort();
+  }
+
+  /**
    * Execution ratchet (R2): curated-subset patterns that executed faithfully in
    * the baseline (scored, and not in its `executionFailures`) but diverge from
    * the en reference now. Returns [] when the baseline carries no execution
@@ -400,6 +437,9 @@ export class RegressionReporter implements Reporter {
         executionFailures: langResult.executionFailures ?? undefined,
         degeneratePasses: langResult.degeneratePasses ?? undefined,
         lossyPasses: langResult.lossyPasses ?? undefined,
+        // R1 per-pattern — which patterns are role-incomplete vs the en
+        // reference. The role-set flip ratchet's baseline side.
+        roleLossyPatterns: langResult.roleLossyPatterns ?? undefined,
         bundleSize: langResult.bundleSize ?? undefined,
         patterns,
       };

--- a/packages/testing-framework/src/multilingual/types.ts
+++ b/packages/testing-framework/src/multilingual/types.ts
@@ -308,6 +308,18 @@ export interface LanguageResults {
    */
   lossyPasses?: string[] | undefined;
 
+  /**
+   * R1 — pattern IDs that parse with roleFidelity < 1 (the `action.role:valueType`
+   * set vs the English reference is incomplete). The per-pattern counterpart of
+   * `avgRoleFidelity`: a single pattern losing a role moves the average by
+   * ~0.0013 in a ~154-pattern language, which the 0.02 avg tolerance swallows —
+   * measured doing exactly that (es/pl/vi lost `toggle-aria-expanded`'s
+   * positional destination to a schema change and the gate stayed green). The
+   * role-set flip ratchet compares this list against the baseline's at
+   * tolerance 0.
+   */
+  roleLossyPatterns?: string[] | undefined;
+
   /** Duration in ms */
   duration: number;
 
@@ -378,6 +390,8 @@ export interface Baseline {
         degeneratePasses?: string[] | undefined;
         /** Pattern IDs that pass *lossily* (fidelity in [0.5, 1.0) — drop ≥1 command). */
         lossyPasses?: string[] | undefined;
+        /** R1 — pattern IDs whose role set is incomplete vs the en reference (roleFidelity < 1). */
+        roleLossyPatterns?: string[] | undefined;
         bundleSize: number | undefined;
         /** Pattern-level results for detailed tracking */
         patterns: Record<string, { success: boolean; confidence: number | undefined }> | undefined;
@@ -434,6 +448,14 @@ export interface RegressionResult {
    * misses. Empty when the baseline has no lossy data yet (never retro-flags).
    */
   newLossyPasses: string[];
+  /**
+   * R1 — patterns that were *role-faithful* (roleFidelity 1.0) in the baseline
+   * but now have an incomplete role set (roleFidelity < 1). The binary
+   * per-pattern signal the avgRoleFidelity tolerance cannot provide: one flip
+   * moves the average by ~0.0013, far under 0.02. Empty when the baseline has
+   * no `roleLossyPatterns` data yet (never retro-flags).
+   */
+  newRoleLossyPatterns: string[];
   status: 'improved' | 'regressed' | 'unchanged';
 }
 


### PR DESCRIPTION
The eleventh regression signal, closing the blind spot found during the toggle-for investigation (#855).

## The blind spot, measured

`avgRoleFidelity`'s 0.02 tolerance cannot see a single pattern losing one role — the delta is ~0.0013 in a ~154-pattern language, **15× under the threshold**. Not hypothesized: a `required: false` duration role on `toggleSchema` cost es/pl/vi the second toggle's positional destination on `toggle-aria-expanded` (`next .panel` silently became `me`) and `--regression` stayed **green**; `tools/triage-r1.ts` found it by hand.

Same class as the lossy cushion (measured swallowing #763's he regression, went 3→0 on 2026-07-25); same fix.

## Mechanism

Modeled line-for-line on the lossy flip ratchet:

- The orchestrator records **which** patterns are role-incomplete (`roleLossyPatterns`, roleFidelity < 1) per language, next to `degeneratePasses`/`lossyPasses`.
- The baseline persists the list; the reporter diffs it — a pattern absent from the baseline's list (role-faithful) that appears in the current run's is a flip.
- The CLI fails at **tolerance 0** — a flip is binary and structural, the same argument that puts lossy/R2/R4/R5 at 0. The avg ratchet keeps its 0.02 as the coarse lossy→more-lossy backstop.

Guards: baseline lacking the field → `[]` (an un-regenerated baseline never retro-flags); a pattern already role-lossy is the R1 **burn-down list**, not a regression; one whose *parse* failed in the baseline is an improvement, excluded by `wasPass`.

## Verified with the motivating mutation

Re-applying the naive toggle-duration role and running `--regression` fails with exactly:

```
✗ Role-set regression vs baseline (R1): 3 role-faithful pattern(s) now have an incomplete role set:
   es/toggle-aria-expanded
   pl/toggle-aria-expanded
   vi/toggle-aria-expanded
```

and the restored tree runs green. Six unit tests cover the flip, the unchanged set, improvement-neutrality (both directions), the no-retro-flag guard, and baseline persistence.

## Baseline

Regenerated from a fresh populate: every language gains its `roleLossyPatterns` burn-down list (1–5 entries, matching `triage-r1`'s output); **no scores moved**. CLAUDE.md's signal list updated (ten → eleven).

Gates: testing-framework **280 passed / 13 files** · tsc · oxlint · full ratchet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)