### PR TITLE
fix(developer-tools): express-5-compatible html route — and CI finally runs this package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -982,6 +982,15 @@ jobs:
       - name: Test components
         run: npm test --prefix packages/components -- --run
 
+      # In the local test:check gate (scripts/test-check-all.sh) since the
+      # beginning, but never enumerated here — so the express 4 → 5 major broke
+      # all 26 dev-server tests (`'*.html'` is not a valid path-to-regexp v8
+      # route) and CI stayed green while every local run failed. This job's
+      # package list is hand-maintained; when adding a package to the local
+      # gate, add it here too.
+      - name: Test developer-tools
+        run: npm test --prefix packages/developer-tools -- --run
+
   # ============================================
   # Job 5: Coverage Report (nightly / manual)
   # Was push-to-main. Under `strict` branch protection the post-merge tree IS the

--- a/packages/developer-tools/src/dev-server.ts
+++ b/packages/developer-tools/src/dev-server.ts
@@ -146,8 +146,12 @@ export class DevServer {
       res.send(this.getClientScript());
     });
 
-    // File serving with live reload injection
-    this.app.get('*.html', (req, res, next) => {
+    // File serving with live reload injection. A RegExp route, not the old
+    // string pattern `'*.html'`: express 5's path-to-regexp v8 has no
+    // extension-style wildcards (`*` must be a named `/*splat`), so the string
+    // form throws `Missing parameter name at index 1: *.html` at registration —
+    // every dev-server test failed on it after the express 4 → 5 major.
+    this.app.get(/\.html$/, (req, res, next) => {
       const filePath = path.join(process.cwd(), req.path);
 
       fs.readFile(filePath, 'utf-8')


### PR DESCRIPTION
## The breakage

All 26 dev-server tests failed on every local run: `app.get('*.html', …)` is not a valid route in express 5's path-to-regexp v8 (no extension-style wildcards; `*` must be a named `/*splat`), so registration threw `Missing parameter name at index 1: *.html`.

Fixed as a **RegExp route** (`/\.html$/`), which express 5 still supports and which matches the same requests. The only route affected — the other `*` hits in the package are chokidar/glob patterns, not express paths.

## The interesting half: why CI stayed green through an express major

The `Unit Tests (packages)` job **hand-enumerates** its packages, and `developer-tools` was never on the list — while the **local** gate (`scripts/test-check-all.sh`) has always included it. So the breakage was invisible to CI and unmissable locally: a permanently-red local package masking new failures.

`Test developer-tools` added to the job, with a comment naming the drift so the next package addition updates both lists.

## Noted, not fixed here

The ci.yml enumeration is a **third** hand-maintained package list (after `test-check-all.sh`, guarded by `check:test-list`, and the build order, guarded by `check:ci-order`) — and nothing guards it. Several other locally-gated packages are missing from it too (behaviors, smart-bundling, intercept, planner, …). Each needs its own CI-environment vetting, so that's a follow-up rather than a rider on this fix.

## Gates

developer-tools **262 passed / 8 files** · `check:ci-order` · and the full monorepo `npm run test:check` is green **end to end** for the first time since the express major landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)