### PR TITLE
feat(semantic): `toggle … for <duration>` ships — `valueShape`, not a marker table

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -2874,6 +2874,15 @@ languages including en (was split everywhere). Follow-up status:
    (`behavior-draggable/resizable/sortable`), and the fix healed those rows too
    (bn avgValueRecall 0.917 → 0.958).
 
+## ~~`toggle … for <duration>`~~ — SHIPPED (2026-07-31, round 3)
+
+Closed without a marker table: `RoleSpec.valueShape` ('time') makes the
+marker-less optional slot safe by counting a shape-anchored role toward
+pattern confidence only when captured. Full record:
+[PARSER_NEXT_STEPS.md](./PARSER_NEXT_STEPS.md) § "CLOSED (2026-07-31, round
+3)". The R1 role-set flip ratchet (#856) guards the exact regression class the
+two failed attempts hit. Historical brief below.
+
 ## `toggle … for <duration>` — measured, not started (2026-07-31)
 
 The multilingual half of the `toggle … for` arc. Its brief lives in

--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -142,6 +142,35 @@ the transformer's rendering of it — a multilingual arc with no gate today. Who
 takes it should add a `toggle … for` corpus row FIRST, so the ratchet stops being
 blind, then do the markers.
 
+#### CLOSED (2026-07-31, round 3): shipped WITHOUT a marker table — `valueShape` is the anchor
+
+The round-2 brief below concluded "the marker is the only anchor available."
+That was true of the levers `RoleSpec` had; round 3 added the missing lever and
+the arc shipped without per-language markers or i18n transformer work:
+
+- **`valueShape: 'time'` on the duration role**, enforced in the CONFIDENCE
+  model: a shape-anchored role counts toward `scoreRoleCoverage` only when
+  captured. The es/pl/vi regression's measured root cause was never spurious
+  capture — the uncaptured optional slot weighed into the score DENOMINATOR,
+  dropping `toggle-*-generated` from 1.0 to 0.69 so the same-priority hand
+  pattern (0.82, wrong destination markers) won and the destination defaulted
+  to `me`. Fix the scoring and the marker-less slot is safe.
+- A matcher-side token guard (refuse non-time tokens at capture) was built,
+  probed and REMOVED as unfireable — `expectedTypes` plus the positional
+  assembler's next-token gating already refuse every constructible non-time
+  capture. Recorded in `RoleSpec.valueShape`'s doc so it can be reinstated
+  WITH a failing test if a future shape makes capture possible.
+- en `for` + ja `間` / ko `동안` markers stand (the SOV mid-pattern hazard is
+  real; dropping them fails 17 tests). The other 21 languages bind their
+  stored corpus rows' unmarked trailing `2s` directly.
+- Landed with the `toggle-class-temporary` corpus row (155th pattern, parses
+  faithfully in all 24, R4 clean), the `toggle.for` exemption prune, and a
+  baseline regeneration whose diff is uniformly positive (`avgRoleFidelity`
+  up in every language; no `roleLossyPatterns` set changed).
+
+The historical brief below is kept because its measurements are what forced
+each design turn.
+
 #### Round-2 re-measurement (2026-07-31) — the shape is confirmed, five details corrected
 
 Round 2 re-ran every step above, then BUILT the change end to end and reverted

--- a/packages/core/src/commands/dom/__tests__/toggle-temporal.test.ts
+++ b/packages/core/src/commands/dom/__tests__/toggle-temporal.test.ts
@@ -97,3 +97,31 @@ describe('toggle … until <event>', () => {
     expect(result.errors ?? [], JSON.stringify(result.errors)).toHaveLength(0);
   });
 });
+
+describe('the semantic path reaches the same reversion machinery', () => {
+  // #846 fixed `parseToggleCommand` — the TRADITIONAL parser. The semantic path
+  // could not produce `modifiers.for` at all until toggleSchema gained a
+  // shape-anchored `duration` role (the descriptor's `for: 'duration'` key was
+  // inert without it). Both paths now agree, so `hyperscript.eval` reverts
+  // whichever parser runs.
+
+  it('applies and reverts on BOTH paths', async () => {
+    for (const opts of [undefined, { traditional: true } as never]) {
+      const el = host();
+      await hyperscript.eval('toggle .loading for 40ms', el, opts);
+
+      expect(el.classList.contains('loading'), 'applied immediately').toBe(true);
+      await new Promise(r => setTimeout(r, 110));
+      expect(el.classList.contains('loading'), 'reverted after the duration').toBe(false);
+    }
+  });
+
+  it('carries the duration as `modifiers.for` on the semantic path', () => {
+    const result = hyperscript.compileSync('toggle .loading for 2s');
+    expect(result.errors ?? [], JSON.stringify(result.errors)).toHaveLength(0);
+
+    const ast = (result as unknown as { ast?: Record<string, any> }).ast;
+    const node = ast?.type === 'command' ? ast : ast?.commands?.[0];
+    expect(node?.modifiers?.for).toBeDefined();
+  });
+});

--- a/packages/domain-voice/src/schemas/behavior.ts
+++ b/packages/domain-voice/src/schemas/behavior.ts
@@ -105,9 +105,21 @@ function acceptExpression(schema: CommandSchema): CommandSchema {
   };
 }
 
+/**
+ * Drop a role the voice domain does not carry. `toggle` grew a shape-anchored
+ * `duration` role (`toggle .a for 2s`, Arc F tail) whose en/ja/ko markers are
+ * not voice-tokenizer keywords and whose slot voice's spoken surface has no use
+ * for — reusing the reference schema must not widen voice's own grammar, so
+ * the adaptation layer narrows it back out, the same way it already inverts
+ * positions and suppresses markers.
+ */
+function dropRole(schema: CommandSchema, role: string): CommandSchema {
+  return { ...schema, roles: schema.roles.filter(r => r.role !== role) };
+}
+
 /** Adapt a reused reference schema to voice's generator + tokenizer conventions. */
 function adaptForVoice(schema: CommandSchema): CommandSchema {
-  return acceptExpression(invertRolePositions(schema));
+  return acceptExpression(invertRolePositions(dropRole(schema, 'duration')));
 }
 
 // toggle/add: adapt to voice conventions, then reinstate the slice-derived

--- a/packages/hyperscript-adapter/src/generated/syntax-table.ts
+++ b/packages/hyperscript-adapter/src/generated/syntax-table.ts
@@ -68,7 +68,7 @@ export const SYNTAX: Record<string, readonly [string, string][]> = {
   take: [['patient', ''], ['source', 'from']],
   tell: [['destination', '']],
   throw: [['patient', '']],
-  toggle: [['patient', ''], ['destination', 'on']],
+  toggle: [['patient', ''], ['destination', 'on'], ['duration', 'for']],
   transition: [['patient', ''], ['goal', 'to'], ['destination', 'on'], ['duration', 'over'], ['style', 'with']],
   trigger: [['event', ''], ['destination', 'on']],
   unless: [['condition', '']],

--- a/packages/hyperscript-adapter/test/derive-syntax.test.ts
+++ b/packages/hyperscript-adapter/test/derive-syntax.test.ts
@@ -37,6 +37,8 @@ describe('deriveEnglishSyntax', () => {
     expect(derived.toggle).toEqual([
       ['patient', ''],
       ['destination', 'on'],
+      // `toggle .a for 2s` — the shape-anchored duration role (Arc F tail).
+      ['duration', 'for'],
     ]);
     expect(derived.add).toEqual([
       ['patient', ''],

--- a/packages/patterns-reference/scripts/init-db.ts
+++ b/packages/patterns-reference/scripts/init-db.ts
@@ -284,6 +284,13 @@ const SEED_EXAMPLES: SeedExample[] = [
     feature: 'class-manipulation',
   },
   {
+    id: 'toggle-class-temporary',
+    title: 'Toggle Class Temporarily',
+    raw_code: 'on click toggle .loading for 2s',
+    description: 'Toggle a CSS class, then revert it after a duration',
+    feature: 'class-manipulation',
+  },
+  {
     id: 'add-class-basic',
     title: 'Add Class',
     raw_code: 'on click add .highlight to me',

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -46,6 +46,31 @@ export interface RoleSpec {
    */
   readonly markerOverride?: Record<string, string>;
   /**
+   * Mark this role as SHAPE-ANCHORED: its surface form is unambiguous on its
+   * own (`'time'` = a unit-suffixed time literal — `2s`, `500ms`, `1.5s`), so
+   * the slot needs no marker to be safe. Enforced in the CONFIDENCE model
+   * (`scoreRoleCoverage`): a shape-anchored role counts toward a pattern's
+   * score only when captured, so an uncaptured optional slot carries no
+   * evidence against the pattern.
+   *
+   * This is the lever that makes a MARKER-LESS optional slot safe. Without it,
+   * toggle's trailing `[{duration}]` weighed into every toggle pattern's
+   * denominator, dropping `toggle-*-generated` from 1.0 to 0.69 on inputs with
+   * no duration at all — so the same-priority hand pattern (0.82, wrong
+   * destination markers) won and es/pl/vi silently lost the second toggle's
+   * positional destination on `toggle-aria-expanded` (`next .panel` became
+   * `me`). Only the R1 role-set flip ratchet sees that class.
+   *
+   * A matcher-side token guard (refuse non-time tokens at capture) was built,
+   * probed and REMOVED: no constructible input fires it — `expectedTypes`
+   * plus the positional assembler's own next-token gating already refuse every
+   * non-time capture into the slot, and an unfireable branch is unverifiable.
+   * If a future shape (an `omitRoleVariants` clone, a required slot) makes
+   * spurious capture possible again, reinstate it THERE with a failing test
+   * first.
+   */
+  readonly valueShape?: 'time';
+  /**
    * Make this role's object marker OPTIONAL in the generated pattern (wrapped in
    * an optional group), per language, so both the marked and unmarked surface forms
    * parse. Used for roles whose value is sometimes an unmarked expression — e.g.
@@ -424,6 +449,31 @@ export const toggleSchema: CommandSchema = {
       // destination group (behavior-draggable). Per-command merge via the
       // #588 markerVariants machinery.
       markerVariants: { ko: ['에서'] },
+    },
+    {
+      role: 'duration',
+      description: 'How long the class stays on before reverting (`toggle .a for 2s`)',
+      required: false,
+      expectedTypes: ['literal'],
+      svoPosition: 3,
+      sovPosition: 3,
+      // `valueShape: 'time'` is what makes the marker-less slot safe in the 21
+      // languages whose stored corpus rows carry the duration as an UNMARKED
+      // trailing token (the i18n transformer renders `alternar .loading 2s`).
+      // Without it this exact role, `required: false`, silently cost es/pl/vi
+      // the second toggle's positional destination on `toggle-aria-expanded` —
+      // the regression that motivated the R1 role-set flip ratchet.
+      valueShape: 'time',
+      // en marks with `for`; ja/ko carry real particles because their SOV
+      // generators otherwise emit a marker-less optional slot MID-pattern
+      // (the R3 family-F1 hazard), which stopped plain
+      // `#button の .active を 切り替え` parsing — 16 test failures, measured
+      // twice. The other 21 languages deliberately have NO marker: their
+      // corpus ground truth is the unmarked trailing form, and the shape
+      // constraint is the anchor. Do NOT reason from transitionSchema here —
+      // its en-only duration marker survives because a required `to {goal}`
+      // phrase sits between patient and duration; toggle has no such anchor.
+      markerOverride: { en: 'for', ja: '間', ko: '동안' },
     },
   ],
   // Runtime error documentation

--- a/packages/semantic/src/parser/confidence-model.ts
+++ b/packages/semantic/src/parser/confidence-model.ts
@@ -8,6 +8,7 @@
  */
 
 import type { LanguagePattern, SemanticRole, SemanticValue } from '../types';
+import { commandSchemas, type CommandSchema } from '../generators/command-schemas';
 
 /**
  * Context passed to confidence model methods.
@@ -175,20 +176,42 @@ export class DefaultConfidenceModel implements ConfidenceModel {
       return pattern.extraction?.[role]?.default !== undefined;
     };
 
+    // A shape-anchored role (schema `valueShape`) counts toward the
+    // denominator ONLY when captured — this is valueShape's entire enforcement
+    // (a matcher-side token guard was probed and removed as unfireable; see
+    // the RoleSpec.valueShape doc). The role's surface form is unambiguous, so
+    // its absence carries no evidence against the pattern — but an uncaptured
+    // slot weighted into maxScore DID: toggle's `[{duration}]` dropped
+    // `toggle-es-generated` from 1.0 to 0.69 on `alternar .open a siguiente
+    // .panel`, handing the same-priority `toggle-es-full` (0.82, destination
+    // marker mismatch) the win and silently defaulting the destination to
+    // `me` — the es/pl/vi aria regression the R1 role-set flip ratchet exists
+    // to catch.
+    const schemaRoles = (commandSchemas as Record<string, CommandSchema | undefined>)[
+      pattern.command
+    ]?.roles;
+    const isShapeAnchored = (role: SemanticRole): boolean =>
+      schemaRoles?.find(r => r.role === role)?.valueShape !== undefined;
+
     for (const token of pattern.template.tokens) {
       if (token.type === 'role') {
-        maxScore += 1;
         if (captured.has(token.role)) {
+          maxScore += 1;
           score += 1;
+        } else if (!isShapeAnchored(token.role)) {
+          maxScore += 1;
         }
       } else if (token.type === 'group') {
         for (const subToken of token.tokens) {
           if (subToken.type === 'role') {
-            maxScore += OPTIONAL_ROLE_WEIGHT;
             if (captured.has(subToken.role)) {
+              maxScore += OPTIONAL_ROLE_WEIGHT;
               score += OPTIONAL_ROLE_WEIGHT;
-            } else if (hasDefault(subToken.role)) {
-              score += OPTIONAL_ROLE_WEIGHT * DEFAULT_PARTIAL_CREDIT;
+            } else if (!isShapeAnchored(subToken.role)) {
+              maxScore += OPTIONAL_ROLE_WEIGHT;
+              if (hasDefault(subToken.role)) {
+                score += OPTIONAL_ROLE_WEIGHT * DEFAULT_PARTIAL_CREDIT;
+              }
             }
           }
         }

--- a/packages/semantic/test/ast-shape-consistency.test.ts
+++ b/packages/semantic/test/ast-shape-consistency.test.ts
@@ -56,13 +56,11 @@ const EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: string }> = {
       'MorphCommand takes the new content positionally and the element being morphed in `on`, ' +
       "so `on` is a contract key; morphSchema marks patient '' (`morph #target …`, no preposition)",
   },
-  'toggle.for': {
-    kind: 'undeclared',
-    reason:
-      '`duration` is not a toggleSchema role and no en pattern binds it — ' +
-      '`toggle .a on #b for 2s` parses to patient+destination only (the known ' +
-      '`toggle … for 2s` gap filed in PARSER_NEXT_STEPS.md), so this modifier is inert today',
-  },
+  // NOTE: `toggle.for` was an `undeclared` entry here until `duration` became a
+  // real toggleSchema role. The descriptor key now equals the role's en marker
+  // ('for'), so the gate REJECTS the exemption — the mechanism working as
+  // designed, and what forced this pruning.
+
   'send.detail': {
     kind: 'contract',
     reason:
@@ -138,7 +136,9 @@ describe('schema ast descriptors agree with the English marker data', () => {
         }
 
         const detail = roles
-          .map((r, i) => `${r}=${markers[i] === undefined ? '<not a schema role>' : `'${markers[i]}'`}`)
+          .map(
+            (r, i) => `${r}=${markers[i] === undefined ? '<not a schema role>' : `'${markers[i]}'`}`
+          )
           .join(', ');
         expect(
           exemption,

--- a/packages/semantic/test/toggle-duration.test.ts
+++ b/packages/semantic/test/toggle-duration.test.ts
@@ -1,0 +1,205 @@
+/**
+ * `toggle … for <duration>` — the semantic half, and the `valueShape` lever
+ * that made it shippable.
+ *
+ * The traditional parser learned this tail in #846; `toggleSchema.ast` has
+ * declared `for: 'duration'` since Arc F, but the schema had no `duration`
+ * ROLE, so the descriptor key was inert. Two prior attempts to add the role
+ * were reverted, and each found a different hazard:
+ *
+ * 1. `required: false` (a marker-less optional slot) silently cost es/pl/vi
+ *    the second toggle's positional destination on `toggle-aria-expanded` —
+ *    `next .panel` became `me`. Root cause (measured, not the one first
+ *    hypothesized): the uncaptured slot weighed into `scoreRoleCoverage`'s
+ *    denominator, dropping `toggle-*-generated`'s confidence from 1.0 to 0.69
+ *    so the same-priority hand pattern (0.82, wrong destination markers) won.
+ * 2. `required: true` + `omitRoleVariants: ['duration']` was worse — es
+ *    swallowed `siguiente .panel` INTO duration.
+ *
+ * The lever: `valueShape: 'time'` on the role, enforced in the CONFIDENCE
+ * model — a shape-anchored role counts toward a pattern's score only when
+ * captured, so the slot's absence carries no evidence against the pattern.
+ * (A matcher-side token guard was built, probed, and removed as unfireable:
+ * `expectedTypes` + the positional assembler's next-token gating already
+ * refuse every constructible non-time capture. See RoleSpec.valueShape.)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse } from '../src/index';
+import { buildAST } from '../src/ast-builder/index';
+import { getSchema } from '../src/generators/command-schemas';
+import type { CommandSemanticNode } from '../src/types';
+
+function walkCommands(node: unknown): Array<{ action: string; roles: Map<string, unknown> }> {
+  const out: Array<{ action: string; roles: Map<string, unknown> }> = [];
+  const walk = (n: unknown): void => {
+    if (!n || typeof n !== 'object') return;
+    const rec = n as Record<string, any>;
+    if (rec.kind === 'command') out.push(rec as never);
+    for (const k of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      if (Array.isArray(rec[k])) rec[k].forEach(walk);
+    }
+  };
+  walk(node);
+  return out;
+}
+
+function toggleNode(source: string, lang: string): CommandSemanticNode {
+  const node = parse(source, lang);
+  expect(node, `'${source}' (${lang}) did not parse`).not.toBeNull();
+  const toggles = walkCommands(node).filter(c => c.action === 'toggle');
+  expect(toggles.length, `'${source}' (${lang}) has no toggle command`).toBeGreaterThan(0);
+  return toggles[0] as unknown as CommandSemanticNode;
+}
+
+const durationOf = (n: CommandSemanticNode): string | undefined => {
+  const v = n.roles.get('duration' as never) as { value?: unknown; raw?: string } | undefined;
+  return v === undefined ? undefined : String(v.value ?? v.raw);
+};
+
+describe('toggle declares a shape-anchored duration role', () => {
+  it('is a real schema role, so the descriptor key is no longer inert', () => {
+    const duration = getSchema('toggle')?.roles.find(r => r.role === 'duration');
+    expect(duration, 'toggleSchema must declare duration').toBeDefined();
+    expect(duration?.required, 'plain `toggle .active` must keep parsing').toBe(false);
+    expect(duration?.valueShape, 'the marker-less slot is only safe shape-anchored').toBe('time');
+    expect(getSchema('toggle')?.ast?.modifiers?.['for']).toBe('duration');
+  });
+
+  it('binds `toggle .loading for 2s` in English', () => {
+    expect(durationOf(toggleNode('toggle .loading for 2s', 'en'))).toBe('2s');
+  });
+
+  it('reaches the runtime as `modifiers.for`, which ToggleCommand reads', () => {
+    // `parseTemporalModifiers` reads `modifiers.for`; helpers/temporal-modifiers.ts
+    // implements the reversion. Before this the modifier could never be produced.
+    const node = parse('toggle .loading for 2s', 'en') as CommandSemanticNode;
+    const ast = buildAST(node).ast as unknown as Record<string, any>;
+    expect(ast.modifiers?.for).toMatchObject({ value: '2s' });
+  });
+
+  it('leaves the duration-less forms untouched', () => {
+    for (const src of ['toggle .active', 'toggle .active on #btn', 'toggle @disabled']) {
+      expect(durationOf(toggleNode(src, 'en')), src).toBeUndefined();
+    }
+  });
+
+  it('keeps the SOV form that a marker-less optional slot broke', () => {
+    // The regression the ja/ko particles exist to prevent: with `en: 'for'`
+    // alone this stopped parsing entirely (16 test failures, measured twice).
+    const node = toggleNode('#button の .active を 切り替え', 'ja');
+    expect(durationOf(node)).toBeUndefined();
+  });
+});
+
+describe('the valueShape anchor: what the slot refuses', () => {
+  /**
+   * The es/pl/vi regression this exists to prevent — and which only the R1
+   * role-set flip ratchet would catch. The second toggle's `a siguiente
+   * .panel` must stay a positional-destination EXPRESSION; both failed shapes
+   * either dropped it (destination defaulted to `me`) or swallowed it into
+   * duration.
+   */
+  const ARIA: Array<[string, string]> = [
+    ['en', 'on click toggle @aria-expanded on me toggle .open on next .panel'],
+    ['es', 'en clic alternar @aria-expanded a yo entonces alternar .open a siguiente .panel'],
+    ['pl', 'gdy kliknięcie przełącz @aria-expanded do ja wtedy przełącz .open do następny .panel'],
+    ['vi', 'khi nhấp chuyển đổi @aria-expanded vào tôi rồi chuyển đổi .open vào tiếp theo .panel'],
+  ];
+
+  it.each(ARIA)('%s keeps the positional destination on toggle-aria-expanded', (lang, source) => {
+    const toggles = walkCommands(parse(source, lang)).filter(c => c.action === 'toggle');
+    expect(toggles.length, `${lang}: expected two toggles`).toBe(2);
+
+    const signature = toggles
+      .flatMap(t => [...t.roles].map(([role, v]) => `${role}:${(v as { type: string }).type}`))
+      .sort();
+    // One reference destination (me) and one positional EXPRESSION (`next
+    // .panel`) — never two references, never a duration.
+    expect(signature, `${lang}: "${source}"`).toEqual([
+      'destination:expression',
+      'destination:reference',
+      'patient:selector',
+      'patient:selector',
+    ]);
+  });
+
+  it('never binds a non-time token into the duration slot', () => {
+    // The omitRoleVariants failure mode: `siguiente .panel` INTO duration.
+    for (const [lang, source] of ARIA) {
+      for (const t of walkCommands(parse(source, lang)).filter(c => c.action === 'toggle')) {
+        expect(t.roles.has('duration'), `${lang}: "${source}"`).toBe(false);
+      }
+    }
+  });
+
+  it('still accepts decimals and ms', () => {
+    expect(durationOf(toggleNode('toggle .a for 1.5s', 'en'))).toBe('1.5s');
+    expect(durationOf(toggleNode('toggle .a for 500ms', 'en'))).toBe('500ms');
+  });
+
+  it('refuses a stray non-time trailing token instead of capturing it', () => {
+    // Behavior lock, not a mechanism test: today `expectedTypes: ['literal']`
+    // is what refuses these (`basura` classifies as an expression). If a
+    // matcher change ever lets a stray word into the slot, the runtime would
+    // feed it to parseDurationStrict — this pins the OUTCOME regardless of
+    // which layer refuses.
+    for (const [lang, source] of [
+      ['es', 'alternar .item basura'],
+      ['pl', 'przełącz .item cosik'],
+    ] as const) {
+      const node = toggleNode(source, lang);
+      expect(node.roles.has('duration' as never), `${lang}: "${source}"`).toBe(false);
+    }
+  });
+});
+
+describe('the corpus row binds the duration in every language', () => {
+  /**
+   * The `toggle-class-temporary` translations, verbatim from a freshly
+   * `populate`d patterns.db — the exact strings the multilingual gate scores.
+   * Every one carries the duration as an UNMARKED trailing token (bn adds its
+   * `জন্য` postposition), and every one must bind it to `duration` on a single
+   * `toggle` command — no phantom sibling from an unconsumed tail (the bn
+   * artifact that rendered `on click toggle .loading for 2s in` and failed R4).
+   */
+  const STORED: Array<[string, string]> = [
+    ['en', 'on click toggle .loading for 2s'],
+    ['es', 'en clic alternar .loading 2s'],
+    ['de', 'bei klick umschalten .loading 2s'],
+    ['fr', 'sur clic basculer .loading 2s'],
+    ['it', 'su clic commutare .loading 2s'],
+    ['pt', 'em clique alternar .loading 2s'],
+    ['ru', 'при клик переключить .loading 2s'],
+    ['uk', 'при клік перемкнути .loading 2s'],
+    ['pl', 'gdy kliknięcie przełącz .loading 2s'],
+    ['id', 'pada klik alihkan .loading 2s'],
+    ['ms', 'apabila click togol .loading 2s'],
+    ['sw', 'kwenye bonyeza badilisha .loading 2s'],
+    ['th', 'เมื่อ คลิก สลับ .loading 2s'],
+    ['vi', 'khi nhấp chuyển đổi .loading 2s'],
+    ['zh', '当 点击 时 切换 把 .loading 2s'],
+    ['he', 'ב לחיצה מתג את .loading 2s'],
+    ['ar', 'بدل .loading عند نقر 2s'],
+    ['ja', '.loading を クリック で 切り替え 2s'],
+    ['ko', '.loading 를 클릭 할 때 토글 2s'],
+    ['hi', '.loading को क्लिक पर टॉगल 2s'],
+    ['bn', '.loading কে ক্লিক এ টগল 2s জন্য'],
+    ['tr', '.loading i tıklama de değiştir 2s'],
+    ['qu', '.loading ta ñitiy pi tikray 2s'],
+    ['tl', 'palitan .loading kapag click 2s'],
+  ];
+
+  it.each(STORED)('%s captures duration=2s on a single toggle', (lang, source) => {
+    const node = parse(source, lang);
+    expect(node, `${lang}: "${source}" did not parse`).not.toBeNull();
+
+    const commands = walkCommands(node);
+    expect(
+      commands.map(c => c.action),
+      `${lang}: "${source}" — unconsumed tail became a phantom command`
+    ).toEqual(['toggle']);
+
+    expect(durationOf(commands[0] as never), `${lang}: "${source}"`).toBe('2s');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,29 +1,35 @@
 {
-  "timestamp": "2026-07-31T16:55:12.906Z",
-  "commit": "910d4066",
+  "timestamp": "2026-07-31T17:24:38.032Z",
+  "commit": "5b484353",
   "languages": {
     "ar": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8438046031809839,
+      "avgConfidence": 0.844812315418526,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9986928104575165,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
           "confidence": 1
         },
         "toggle-class-on-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 1
         },
@@ -638,21 +644,23 @@
       }
     },
     "bn": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8681291974525052,
+      "avgConfidence": 0.8682426496348391,
       "avgFidelity": 1,
-      "avgPrecision": 0.997835497835498,
+      "avgPrecision": 0.9978494623655915,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9986928104575165,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1046,6 +1054,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "toggle-class-temporary": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "remove-element": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -1273,21 +1285,24 @@
       }
     },
     "de": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8298907441764564,
+      "avgConfidence": 0.8302508960573457,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9965141612200438,
+      "avgRoleFidelity": 0.9965367965367967,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["last-in-collection", "pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "last-in-collection",
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1574,6 +1589,10 @@
           "confidence": 1
         },
         "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -1908,17 +1927,21 @@
       }
     },
     "en": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 556874,
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
           "confidence": 1
         },
         "toggle-class-on-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 1
         },
@@ -2533,21 +2556,23 @@
       }
     },
     "es": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8356627499484621,
+      "avgConfidence": 0.8359856630824352,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9986928104575165,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -2842,6 +2867,10 @@
           "confidence": 1
         },
         "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -3168,21 +3197,24 @@
       }
     },
     "fr": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8265924551638817,
+      "avgConfidence": 0.826973886328723,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9965141612200438,
+      "avgRoleFidelity": 0.9965367965367967,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["last-in-collection", "pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "last-in-collection",
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3465,6 +3497,10 @@
           "confidence": 1
         },
         "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -3803,21 +3839,24 @@
       }
     },
     "he": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8295609152752009,
+      "avgConfidence": 0.8295135688684075,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9970588235294119,
+      "avgRoleFidelity": 0.9970779220779221,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range", "set-attribute"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "pick-text-range",
+        "set-attribute"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -3928,6 +3967,10 @@
           "confidence": 0.8222222222222222
         },
         "toggle-class-on-other": {
+          "success": true,
+          "confidence": 0.8222222222222222
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8222222222222222
         },
@@ -4438,21 +4481,23 @@
       }
     },
     "hi": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.9082446375679443,
+      "avgConfidence": 0.9080992804592112,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9986928104575165,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -4898,6 +4943,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "toggle-class-temporary": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "remove-element": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -5073,14 +5122,14 @@
       }
     },
     "id": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.838961038961037,
+      "avgConfidence": 0.8392626728110579,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9957360722066606,
+      "avgRoleFidelity": 0.9957637600494745,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -5092,7 +5141,7 @@
         "fetch-json",
         "pick-text-range"
       ],
-      "bundleSize": 556874,
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5395,6 +5444,10 @@
           "confidence": 1
         },
         "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -5713,21 +5766,23 @@
       }
     },
     "it": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8364873222016058,
+      "avgConfidence": 0.8368049155145909,
       "avgFidelity": 1,
-      "avgPrecision": 0.997835497835498,
+      "avgPrecision": 0.9978494623655915,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9986928104575165,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6026,6 +6081,10 @@
           "confidence": 1
         },
         "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -6348,21 +6407,23 @@
       }
     },
     "ja": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8583889377122453,
+      "avgConfidence": 0.8585652302800004,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9986928104575165,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6744,6 +6805,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "toggle-class-temporary": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "remove-element": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -6983,21 +7048,25 @@
       }
     },
     "ko": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8533384326617401,
+      "avgConfidence": 0.853547309133047,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9954248366013073,
+      "avgRoleFidelity": 0.9954545454545455,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range", "when-multiple-changes", "when-value-changes"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "pick-text-range",
+        "when-multiple-changes",
+        "when-value-changes"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7368,6 +7437,10 @@
           "confidence": 1
         },
         "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -7618,21 +7691,25 @@
       }
     },
     "ms": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8395794681508945,
+      "avgConfidence": 0.8398771121351744,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.994335511982571,
+      "avgRoleFidelity": 0.9943722943722945,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["hide-with-transition", "last-in-collection", "pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "hide-with-transition",
+        "last-in-collection",
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7931,6 +8008,10 @@
           "confidence": 1
         },
         "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -8253,21 +8334,24 @@
       }
     },
     "pl": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8064728921871758,
+      "avgConfidence": 0.8069841269841249,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9973856209150328,
+      "avgRoleFidelity": 0.9974025974025975,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range", "unless-condition"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "pick-text-range",
+        "unless-condition"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8442,6 +8526,10 @@
           "confidence": 1
         },
         "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -8888,21 +8976,23 @@
       }
     },
     "pt": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8014430014429995,
+      "avgConfidence": 0.8019866871479756,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9986928104575165,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9081,6 +9171,10 @@
           "confidence": 1
         },
         "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -9523,21 +9617,25 @@
       }
     },
     "qu": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.740002061430633,
+      "avgConfidence": 0.740942140296979,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9961251167133521,
+      "avgRoleFidelity": 0.9961502782931355,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["announce-screen-reader", "on-custom-event-receive", "pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "announce-screen-reader",
+        "on-custom-event-receive",
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9812,6 +9910,10 @@
           "confidence": 1
         },
         "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -10158,21 +10260,23 @@
       }
     },
     "ru": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8211915069057906,
+      "avgConfidence": 0.8216077828981034,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9986928104575165,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10363,6 +10467,10 @@
           "confidence": 1
         },
         "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -10793,21 +10901,23 @@
       }
     },
     "sw": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8031746031746013,
+      "avgConfidence": 0.8037071172555025,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9986928104575165,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10986,6 +11096,10 @@
           "confidence": 1
         },
         "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -11428,21 +11542,25 @@
       }
     },
     "th": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8391671820243225,
+      "avgConfidence": 0.8394674859190964,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.99520697167756,
+      "avgRoleFidelity": 0.9952380952380954,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["last-in-collection", "pick-text-range", "toggle-aria-expanded"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "last-in-collection",
+        "pick-text-range",
+        "toggle-aria-expanded"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11737,6 +11855,10 @@
           "confidence": 1
         },
         "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -12063,21 +12185,23 @@
       }
     },
     "tl": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8272925438117809,
+      "avgConfidence": 0.8276694582756678,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9986928104575165,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12340,6 +12464,10 @@
           "confidence": 1
         },
         "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -12698,21 +12826,23 @@
       }
     },
     "tr": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8591310527400748,
+      "avgConfidence": 0.8593025574689406,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9986928104575165,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13098,6 +13228,10 @@
           "success": true,
           "confidence": 0.8857142857142858
         },
+        "toggle-class-temporary": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
         "remove-element": {
           "success": true,
           "confidence": 0.8857142857142858
@@ -13333,21 +13467,23 @@
       }
     },
     "uk": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8202020202020182,
+      "avgConfidence": 0.8206246799795166,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9986928104575165,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13542,6 +13678,10 @@
           "confidence": 1
         },
         "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -13968,21 +14108,25 @@
       }
     },
     "vi": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8042465471036879,
+      "avgConfidence": 0.8047721454173048,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9952069716775602,
+      "avgRoleFidelity": 0.9952380952380955,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["its-value-possessive-dot", "last-in-collection", "pick-text-range"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "its-value-possessive-dot",
+        "last-in-collection",
+        "pick-text-range"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14161,6 +14305,10 @@
           "confidence": 1
         },
         "toggle-class-basic": {
+          "success": true,
+          "confidence": 0.8857142857142858
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 0.8857142857142858
         },
@@ -14603,27 +14751,35 @@
       }
     },
     "zh": {
-      "parseSuccess": 154,
+      "parseSuccess": 155,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.9840032982890127,
+      "avgConfidence": 0.9841065028161803,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9966697790227204,
+      "avgRoleFidelity": 0.9966914038342611,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range", "repeat-forever", "repeat-until-event"],
-      "bundleSize": 556874,
+      "roleLossyPatterns": [
+        "pick-text-range",
+        "repeat-forever",
+        "repeat-until-event"
+      ],
+      "bundleSize": 557258,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
           "confidence": 1
         },
         "toggle-class-on-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "toggle-class-temporary": {
           "success": true,
           "confidence": 1
         },
@@ -15240,8 +15396,20 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 556874,
-      "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
+      "size": 557258,
+      "languages": [
+        "en",
+        "es",
+        "pt",
+        "fr",
+        "de",
+        "ja",
+        "zh",
+        "ko",
+        "ar",
+        "tr",
+        "id"
+      ]
     }
   }
 }


### PR DESCRIPTION
The last Arc F follow-up, closing the arc. Two prior attempts were built and reverted; the second's filing (#855) concluded *"the marker is the only anchor available."* That was true of the levers `RoleSpec` had — so this adds the missing lever, and the arc ships with **no per-language marker table and no i18n transformer work**.

## The root cause was scoring, not capture

The es/pl/vi regression both failed attempts hit (`toggle-aria-expanded`'s second toggle losing `next .panel` to a default `me`) traces to a confidence artifact: the **uncaptured** optional `[{duration}]` slot weighed into `scoreRoleCoverage`'s denominator, dropping `toggle-*-generated` from 1.0 to **0.69** on inputs with no duration at all — so the same-priority hand pattern (`toggle-es-full`, 0.82, whose destination markers lack `a`) won and the destination defaulted. The matcher never mis-captured anything.

## The lever

`RoleSpec.valueShape?: 'time'` marks a role as **shape-anchored** (its surface form — `2s`, `500ms`, `1.5s` — is unambiguous without a marker), and `scoreRoleCoverage` counts a shape-anchored role **only when captured**, so the slot's absence carries no evidence against the pattern. With that:

- all four aria signatures match en exactly (`destination:expression` preserved),
- every stored corpus row binds `duration=2s` — all 24 languages, single toggle, no phantom tail command.

## Built and then deliberately removed

A matcher-side token guard (refuse non-time tokens at capture) was probed three ways and is **unfireable** — `expectedTypes` plus the positional assembler's next-token gating already refuse every constructible non-time capture — and an unfireable branch is unverifiable. Its reinstatement condition is recorded in the `valueShape` doc. **`pattern-matcher.ts` ships byte-identical to main.**

## The rest of the arc, as briefed

- duration role: `required: false`, `valueShape: 'time'`, `markerOverride: { en: 'for', ja: '間', ko: '동안' }`. The ja/ko particles stand — dropping them fails **17 tests** (the SOV mid-pattern hazard, measured three times now). The other 21 languages bind their stored rows' unmarked trailing `2s` directly.
- `toggle-class-temporary` corpus row — the ratchet's **155th pattern**, faithful in all 24; **R4 stays clean, `allowedInvalid` stays empty** (no bn homonym issue — #855's correction).
- `toggle.for` consistency exemption pruned (the gate forces it).
- syntax-table regenerated + derive-syntax spot-check updated.
- core: `toggle .loading for 40ms` **applies and reverts** through `hyperscript.eval` on **both** parser paths.

## Baseline

Regenerated; the diff is uniformly positive — parseSuccess 154→155 in all 24 languages, `avgRoleFidelity` **up** in every language, and **no `roleLossyPatterns` set changed** (the per-pattern proof that nothing flipped).

## Mutation matrix

| mutation | caught by |
| --- | --- |
| remove `valueShape` from the schema | 4 unit failures **and** #856's role-set flip ratchet firing exactly `es/pl/vi toggle-aria-expanded` — the two PRs guarding each other as designed |
| revert the confidence-model counting | 3 unit failures |
| remove the duration role entirely | 27 failures |
| drop the ja/ko particles | 17 failures |

## Gates

semantic **7321 / 110 files** · typecheck · `check:mapper-parity` (fixture unchanged) · core **7804 / 305 files** · testing-framework **280** · hyperscript-adapter **209** · vocab consistency (0 unwaived) · `snapshot:bundle-size --check` · full ratchet green including R4 and the new flip gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)