### PR TITLE
fix(parser): `transition my/its/#a's *opacity` — the possessive target, rejected on every path

### DIFF
--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -29,7 +29,8 @@ ones, because the gate *is* the tracking mechanism.
 | **`tell <target> to <command>` drops the `tell` wrapper** | medium — **silent wrong target** on the form users actually write | **none** | see the measured table below; found by Arc A step 4.3 (Finding 14 in [HANDOFF-command-arch-manifest.md](./HANDOFF-command-arch-manifest.md)), re-verified 2026-07-29 |
 | **`set <idref> to <value>` / js property-path args no-op** | medium — silent no-effect on shipped pages | ✅ execution-gate allowlist entries | families 1/6 in [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md) |
 | **`for <duration>` tail rejected on `toggle` / `wait`** | medium — two upstream-valid forms on shipped, documented commands; both are the command's OWN documented example | **none** | see the measured table below; found by the Arc B examples sweep ([HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md) § F-B4a) |
-| **`transition` rejects a POSSESSIVE property target** | medium — upstream-valid, and it is the form the docs and the corpus use | **none** | see the measured table below; found by #847's reachability probe |
+| ~~**`transition` rejects a POSSESSIVE property target**~~ | **FIXED 2026-07-31** — optional leading target in `parseTransitionCommand` (all four shapes), emitting the `[target, property]` args the runtime already discriminated on | e2e tests, both paths | `packages/core/src/commands/animation/__tests__/transition-target.test.ts`; history below |
+| **`process partials … using view transition` mis-parses** | medium — `process` is in `COMPOUND_COMMANDS` with no dispatch case (the `take` root cause), on a shipped command | **none** | see the note below the transition/take tables; filed 2026-07-31 |
 | ~~**`take <class> from <source>` rejected**~~ | **FIXED 2026-07-31** — `parseTakeCommand` + runtime rewrite (upstream ownership-transfer semantics), `take` added to `skipSemanticParsing` with its toggle/add/remove siblings | e2e tests, both paths | `packages/core/src/commands/animation/__tests__/take-from-for.test.ts`; history below |
 | `and` is not a command separator anywhere | low — consistent everywhere, so no surprise | ✅ 2 `KNOWN GAP` tests | `packages/core/src/parser/__tests__/then-as-separator.test.ts` |
 | `sortable-list.html` recovers with errors | low — one shipped example | ✅ allowlist ratchet | `packages/testing-framework/baselines/shipped-sources-validity.json` |
@@ -254,20 +255,35 @@ divergence: both paths fail identically, so this is the shared parser. Every
 form below is `VALID` on the real `hyperscript.org` engine (`hs.parse(src).errors`
 → `[]`).
 
-**`transition`'s property target cannot be possessive.** The bare form works;
-adding ANY possessor breaks it, with two different messages:
+**`transition`'s property target cannot be possessive** — **FIXED 2026-07-31.**
+The bare form worked; adding ANY possessor broke it, with two different
+messages. The measured table, for history:
 
-| source | hyperfixi (both paths) |
-| ------ | ---------------------- |
+| source | hyperfixi (before) |
+| ------ | ------------------ |
 | `transition *opacity to 0 over 200ms` | **works** — writes `style="opacity: 0"` |
 | `transition my *opacity to 0 over 200ms` | `Expected "to" keyword after property in transition command` |
 | `transition its *opacity to 0` | same |
 | `transition #a's *opacity to 0 over 200ms` | `Transition command requires a CSS property` |
+| `transition #a *opacity to 0 over 200ms` | same — **a fourth row the original filing missed** (space-separated target, the shape `measure` already accepts) |
 
-The `my`/`its` and the `#a's` forms fail at different points, so this is likely
-two adjacent gaps rather than one. Note the possessive form is what
-`TransitionCommand`'s own surface area implies and what the multilingual corpus
-renders, so the working bare form is the narrower case.
+The brief's read was right: two adjacent gaps, and the differing messages were
+the tell. `my`/`its` were consumed AS the property (so the real property sat
+where `to` was expected), while a leading selector matched neither branch and
+left property null. `parseTransitionCommand` now takes an optional leading
+target — mirroring `parseMeasureCommand`'s detection, extended with the
+possessive forms — and decomposes what `parsePrimary` returns
+(`possessiveExpression` for `#a's *opacity`, `memberExpression` for
+`my *opacity`) rather than re-parsing the property.
+
+The RUNTIME was never the blocker: `TransitionCommand.parseInput` has always
+discriminated a `[target, property]` two-arg shape, so that branch was simply
+unreachable. Making it reachable exposed one real hole, now closed with a
+regression test: an explicit target that did not resolve (`#nope`, or `its`
+with `it` unset) fell through to `String(undefined)` and transitioned a CSS
+property literally named `"undefined"` — a silent no-op reporting success. Two
+args now means `[target, property]` by construction, and an unresolvable target
+throws.
 
 **`take <class> from <source>` is rejected outright** — **FIXED 2026-07-31.**
 The measured table, for history:
@@ -312,12 +328,30 @@ worth its own arc — fold them into whichever change touches this area:
 
 - **An error position is reported past the end of the input.** Three of the
   sweep's rows report `column 78` for source strings 37 and 69 characters long.
-- **`start` reports a `repeat` error.** `start view transition` (no terminator)
-  fails with `Expected "end" to close repeat block`; `start view transition using
-  "slide" end` parses. The message names the wrong construct, which cost real
-  triage time. The same wrong-construct routing shows on `process partials in it
-  using view transition`, which fails with `Transition command requires a CSS
-  property`.
+  **STILL OPEN** — not reproduced by the `start`/`repeat`/`for` rows probed on
+  2026-07-31 (those are thrown `Error`s with no position, so they report
+  `column 1`). Whoever picks this up needs the original sweep's three rows;
+  the column-78 path is somewhere else.
+- ~~**`start` reports a `repeat` error.**~~ **FIXED 2026-07-31** (folded into the
+  transition-target PR). `parseCommandListUntilEnd` hard-coded `repeat` in its
+  message because that was its only caller when the message was written; it now
+  takes a `construct` parameter (default `repeat`, so `repeat`'s own callers are
+  unchanged). `start view transition` now reports `Expected "end" to close start
+  view transition block`, and `for` reports its own name too — it had silently
+  been claiming `repeat` as well, which the original filing did not notice.
+
+**`process partials in it using view transition` — NOT the same defect** (filed
+2026-07-31, still open). It reports `Transition command requires a CSS property`
+for a different reason than the `start` diagnostic above: `process` is listed in
+`COMPOUND_COMMANDS` but has **no case in `parseCompoundCommand`**, so it falls
+through to `parseRegularCommand`, whose arg loop stops at the `transition`
+COMMAND token — leaving `using view transition` to be parsed as a fresh
+`transition` command. That is the *identical root cause* `take` had (fixed
+in #859), on a shipped command with a real implementation
+(`commands/dom/process-partials.ts`, `@command({ name: 'process' })`). It needs
+a `parseProcessCommand` consuming `partials in <content> [using view
+transition]`, plus its own tests — one PR, not a fold-in. Check the other
+`COMPOUND_COMMANDS` entries for the same shape while there.
 
 ## Notes
 

--- a/packages/core/docs/commands/REFERENCE.md
+++ b/packages/core/docs/commands/REFERENCE.md
@@ -220,13 +220,21 @@ Animate CSS properties using CSS transitions
 **Syntax:**
 
 ```hyperscript
-transition <property> to <value> [over <duration>] [with <timing>]
+transition [<target>] <property> to <value> [over <duration>] [with <timing>]
 ```
 
 **Examples:**
 
 ```hyperscript
 transition opacity to 0.5
+```
+
+```hyperscript
+transition my *opacity to 0 over 200ms
+```
+
+```hyperscript
+transition #box's *opacity to 0 over 200ms
 ```
 
 ```hyperscript

--- a/packages/core/docs/commands/commands.json
+++ b/packages/core/docs/commands/commands.json
@@ -895,9 +895,11 @@
       "hasBody": false,
       "version": "1.0.0",
       "description": "Animate CSS properties using CSS transitions",
-      "syntax": ["transition <property> to <value> [over <duration>] [with <timing>]"],
+      "syntax": ["transition [<target>] <property> to <value> [over <duration>] [with <timing>]"],
       "examples": [
         "transition opacity to 0.5",
+        "transition my *opacity to 0 over 200ms",
+        "transition #box's *opacity to 0 over 200ms",
         "transition left to 100px over 500ms",
         "transition background-color to red over 1s with ease-in-out"
       ],

--- a/packages/core/src/commands/animation/__tests__/transition-target.test.ts
+++ b/packages/core/src/commands/animation/__tests__/transition-target.test.ts
@@ -1,0 +1,153 @@
+/**
+ * `transition [<target>] <property> to <value>` — parse AND execute.
+ *
+ * Every form here is `VALID` on the real `hyperscript.org` engine
+ * (`hs.parse(src).errors` → `[]`), and the possessive is what the docs and the
+ * multilingual corpus render — yet only the BARE form worked before this fix
+ * (docs-internal/PARSER_NEXT_STEPS.md, found by #847's reachability probe):
+ *
+ *   transition my *opacity to 0 over 200ms  → 'Expected "to" keyword after
+ *                                             property in transition command'
+ *   transition its *opacity to 0            → same
+ *   transition #a's *opacity to 0           → 'Transition command requires a
+ *                                             CSS property'
+ *   transition #a *opacity to 0             → same (NOT in the original brief;
+ *                                             found while fixing the others)
+ *
+ * Two adjacent gaps, as the brief predicted from the differing messages:
+ * `my`/`its` were consumed AS the property (so the real property sat where
+ * `to` was expected), while a leading selector matched neither branch and left
+ * property null. Both messages named exactly what had been supplied.
+ *
+ * The runtime was never the blocker: `TransitionCommand.parseInput` has always
+ * discriminated a `[target, property]` two-arg shape — the parser simply never
+ * emitted one, so that branch was unreachable. Making it reachable exposed one
+ * real hole, covered below: an unresolvable target used to fall through to
+ * `String(undefined)` and transition a property literally named "undefined" —
+ * a silent no-op.
+ *
+ * Both parse paths are exercised deliberately: this was never a
+ * semantic-vs-traditional divergence, and a regression on either would be
+ * invisible to a single-path test.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { hyperscript } from '../../../api/hyperscript-api';
+
+function setup(): { a: HTMLElement; host: HTMLElement } {
+  document.body.innerHTML =
+    '<div id="a" style="opacity: 1">A</div><div id="host" style="opacity: 1"></div>';
+  return {
+    a: document.getElementById('a') as HTMLElement,
+    host: document.getElementById('host') as HTMLElement,
+  };
+}
+
+const BOTH_PATHS = [
+  ['auto', undefined],
+  ['traditional', { traditional: true }],
+] as const;
+
+describe.each(BOTH_PATHS)('transition <target> <property> (%s path)', (_label, opts) => {
+  beforeEach(() => {
+    setup();
+  });
+
+  it('parses all four previously-rejected target forms', () => {
+    for (const src of [
+      'transition my *opacity to 0 over 200ms',
+      'transition its *opacity to 0',
+      "transition #a's *opacity to 0 over 200ms",
+      'transition #a *opacity to 0 over 200ms',
+    ]) {
+      const result = hyperscript.compileSync(src, opts as never);
+      expect(result.errors ?? [], `${src}: ${JSON.stringify(result.errors)}`).toHaveLength(0);
+      expect(result.ok, src).toBe(true);
+    }
+  });
+
+  it('keeps the bare form working (the narrower case that always worked)', async () => {
+    const { a, host } = setup();
+    await hyperscript.eval('transition *opacity to 0 over 20ms', host, opts as never);
+
+    expect(host.style.opacity, 'bare form targets me').toBe('0');
+    expect(a.style.opacity, 'and leaves everything else alone').toBe('1');
+  });
+
+  it('`my *opacity` transitions me', async () => {
+    const { a, host } = setup();
+    await hyperscript.eval('transition my *opacity to 0 over 20ms', host, opts as never);
+
+    expect(host.style.opacity).toBe('0');
+    expect(a.style.opacity).toBe('1');
+  });
+
+  it("`#a's *opacity` transitions the possessive's owner, NOT me", async () => {
+    const { a, host } = setup();
+    await hyperscript.eval("transition #a's *opacity to 0 over 20ms", host, opts as never);
+
+    expect(a.style.opacity, 'the selector target moves').toBe('0');
+    expect(host.style.opacity, 'me is untouched').toBe('1');
+  });
+
+  it('`#a *opacity` (space-separated) transitions the target too', async () => {
+    const { a, host } = setup();
+    await hyperscript.eval('transition #a *opacity to 0 over 20ms', host, opts as never);
+
+    expect(a.style.opacity).toBe('0');
+    expect(host.style.opacity).toBe('1');
+  });
+
+  it('`its *opacity` transitions whatever `it` currently holds', async () => {
+    const { a, host } = setup();
+    await hyperscript.eval(
+      'get #a then transition its *opacity to 0 over 20ms',
+      host,
+      opts as never
+    );
+
+    expect(a.style.opacity, '`it` was set to #a by the get').toBe('0');
+    expect(host.style.opacity).toBe('1');
+  });
+
+  it('still honours `over` and `with` after a target', () => {
+    const result = hyperscript.compileSync(
+      "transition #a's *opacity to 0 over 1s with ease-in-out",
+      opts as never
+    );
+    expect(result.errors ?? [], JSON.stringify(result.errors)).toHaveLength(0);
+    const ast = result.ast as { modifiers?: Record<string, unknown> };
+    expect(Object.keys(ast.modifiers ?? {})).toEqual(
+      expect.arrayContaining(['to', 'over', 'with'])
+    );
+  });
+
+  it('emits [target, property] — the two-arg shape parseInput discriminates on', () => {
+    const result = hyperscript.compileSync("transition #a's *opacity to 0", opts as never);
+    const ast = result.ast as { args?: Array<{ type?: string; value?: unknown }> };
+
+    expect(ast.args).toHaveLength(2);
+    expect(ast.args?.[0]?.type, 'first arg is the target').toBe('selector');
+    expect(ast.args?.[1]?.value, 'second arg is the property').toBe('*opacity');
+  });
+});
+
+describe('transition — an explicit target that does not resolve is an ERROR', () => {
+  // Regression guard for the hole that making the target branch reachable
+  // exposed: `String(undefined)` became the property name, so the command
+  // transitioned a property called "undefined" and reported success.
+
+  it('errors on a selector matching nothing', async () => {
+    const { host } = setup();
+    await expect(
+      hyperscript.eval('transition #nope *opacity to 0 over 20ms', host)
+    ).rejects.toThrow(/target element not found/);
+  });
+
+  it('errors on `its` when `it` is unset', async () => {
+    const { host } = setup();
+    await expect(hyperscript.eval('transition its *opacity to 0 over 20ms', host)).rejects.toThrow(
+      /target element not found/
+    );
+  });
+});

--- a/packages/core/src/commands/animation/transition.ts
+++ b/packages/core/src/commands/animation/transition.ts
@@ -13,7 +13,7 @@
 import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
-import { isHTMLElement } from '../../utils/element-check';
+import { isHTMLElement, isNodeList } from '../../utils/element-check';
 import { resolveElement } from '../helpers/element-resolution';
 import { parseDuration, camelToKebab } from '../helpers/duration-parsing';
 import { waitForTransitionEnd } from '../helpers/event-waiting';
@@ -58,9 +58,11 @@ export interface TransitionCommandOutput {
 export class TransitionCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Animate CSS properties using CSS transitions',
-    syntax: 'transition <property> to <value> [over <duration>] [with <timing>]',
+    syntax: 'transition [<target>] <property> to <value> [over <duration>] [with <timing>]',
     examples: [
       'transition opacity to 0.5',
+      'transition my *opacity to 0 over 200ms',
+      "transition #box's *opacity to 0 over 200ms",
       'transition left to 100px over 500ms',
       'transition background-color to red over 1s with ease-in-out',
     ],
@@ -87,12 +89,27 @@ export class TransitionCommand implements DecoratedCommand {
 
     const firstArg = await evaluator.evaluate(raw.args[0], context);
 
+    // A selector arg can evaluate to an element collection; take the first,
+    // as resolveElement would for a selector string.
+    const asElement = (value: unknown): unknown =>
+      Array.isArray(value) || isNodeList(value) ? (value as ArrayLike<unknown>)[0] : value;
+
+    const firstAsElement = asElement(firstArg);
+
     if (
-      isHTMLElement(firstArg) ||
+      isHTMLElement(firstAsElement) ||
       (typeof firstArg === 'string' && /^[#.]|^(?:me|it|you)$/.test(firstArg))
     ) {
-      target = firstArg as string | HTMLElement;
+      target = firstAsElement as string | HTMLElement;
       property = String(await evaluator.evaluate(raw.args[1], context));
+    } else if (raw.args.length >= 2) {
+      // The parser emits `[target, property]` (parseTransitionCommand), so a
+      // two-arg call whose target did not resolve is a missing element — NOT a
+      // property. Before this branch existed the target was silently ignored
+      // and `String(undefined)` became the property name: an unset `its` /
+      // absent selector transitioned a property called "undefined", a no-op
+      // with no error.
+      throw new Error('transition: target element not found');
     } else {
       property = String(firstArg);
     }

--- a/packages/core/src/parser/command-parsers/animation-commands.ts
+++ b/packages/core/src/parser/command-parsers/animation-commands.ts
@@ -114,17 +114,45 @@ export function parseMeasureCommand(ctx: ParserContext, identifierNode: Identifi
 }
 
 /**
+ * Context possessives and the context variable each aliases. `parsePrimary`
+ * turns `my *opacity` into `memberExpression(me, *opacity)` via
+ * `parseContextPropertyAccess`, so these only need detecting, not decoding.
+ */
+const CONTEXT_POSSESSIVES = new Set(['my', 'its', 'your']);
+
+/**
  * Parse transition command
  *
- * Syntax: transition <property> to <value> [over <duration>] [with <timing-function>]
+ * Syntax: transition [<target>] <property> to <value> [over <duration>] [with <timing-function>]
  *
  * This command transitions a CSS property to a target value with optional
  * duration and timing function. Supports hyphenated CSS properties.
  *
+ * The target may be given four upstream-valid ways, all of which this parser
+ * REJECTED before 2026-07-31 (docs-internal/PARSER_NEXT_STEPS.md — the bare
+ * form was the only one that worked, and it is the narrower case; the
+ * possessive is what the docs and the multilingual corpus render):
+ *
+ *   transition my *opacity to 0      → context possessive
+ *   transition its *opacity to 0     → same
+ *   transition #a's *opacity to 0    → selector possessive
+ *   transition #a *opacity to 0      → space-separated (the `measure` shape)
+ *
+ * Two adjacent gaps, not one: `my`/`its` parsed as the PROPERTY (leaving `to`
+ * unmatched → 'Expected "to" keyword after property'), while a leading
+ * selector matched neither branch and left property null → 'Transition command
+ * requires a CSS property'. Both messages named the thing that was in fact
+ * supplied.
+ *
+ * Emits `args: [target, property]` — the two-arg shape
+ * `TransitionCommand.parseInput` has always accepted (its target branch was
+ * simply unreachable) — or `args: [property]` for the bare form.
+ *
  * Examples:
  *   - transition opacity to 0.5
  *   - transition *background-color to 'red' over 2s
- *   - transition width to 100px over 1s with ease-in-out
+ *   - transition my *opacity to 0 over 200ms
+ *   - transition #a's *opacity to 0 over 1s with ease-in-out
  *
  * @param ctx - Parser context providing access to parser state and methods
  * @param commandToken - The 'transition' command token
@@ -134,17 +162,60 @@ export function parseTransitionCommand(ctx: ParserContext, commandToken: Token) 
   const args: ASTNode[] = [];
   const modifiers: Record<string, ExpressionNode> = {};
 
-  // Parse optional target (if it looks like a selector or identifier followed by a property)
   let property: ASTNode | null = null;
+  let target: ASTNode | null = null;
 
-  // Look ahead to determine if first token is a target or property
-  const firstToken = ctx.peek();
+  // Optional leading target. Mirrors `parseMeasureCommand`'s target detection
+  // (same `<target> *property` shape) and adds the possessive forms.
+  const leadToken = ctx.peek();
+  const startsTarget =
+    ctx.checkAnySelector() ||
+    ctx.checkContextVar() ||
+    ctx.check('<') ||
+    (isIdentifierLike(leadToken) && CONTEXT_POSSESSIVES.has(leadToken.value));
 
-  // Parse property (required)
+  if (startsTarget) {
+    // `parsePrimary` folds both possessive shapes into one node — `#a's
+    // *opacity` to a possessiveExpression, `my *opacity` to a
+    // memberExpression — so decompose rather than re-parsing the property.
+    const parsed = ctx.parsePrimary() as ASTNode & {
+      type?: string;
+      object?: ASTNode;
+      property?: { name?: string };
+      computed?: boolean;
+    };
+
+    if (
+      (parsed.type === 'possessiveExpression' ||
+        (parsed.type === 'memberExpression' && !parsed.computed)) &&
+      parsed.object &&
+      parsed.property?.name
+    ) {
+      target = parsed.object;
+      property = {
+        type: 'string',
+        value: parsed.property.name,
+        start: leadToken.start || 0,
+        end: ctx.getPosition().end,
+        line: leadToken.line,
+        column: leadToken.column,
+      };
+    } else {
+      // Space-separated form: the target stands alone and the property
+      // follows. A stray possessive marker (`#a's` with the property parsed
+      // separately) is consumed here so it cannot reach the property parse.
+      target = parsed;
+      if (ctx.check("'s")) ctx.advance();
+    }
+  }
+
+  // Parse property (required unless a possessive already supplied it)
   // Property can be:
   // - identifier (opacity, width, etc.)
   // - identifier with * prefix (*background-color)
-  if (isIdentifierLike(firstToken) || firstToken.value === '*') {
+  const firstToken = ctx.peek();
+
+  if (!property && (isIdentifierLike(firstToken) || firstToken.value === '*')) {
     let propertyValue = '';
 
     // Handle wildcard prefix
@@ -173,6 +244,9 @@ export function parseTransitionCommand(ctx: ParserContext, commandToken: Token) 
     throw new Error('Transition command requires a CSS property');
   }
 
+  // `[target, property]` is the two-arg shape TransitionCommand.parseInput
+  // already discriminates on; bare stays one-arg.
+  if (target) args.push(target);
   args.push(property);
 
   // Parse 'to' keyword and value (required) - store in modifiers for V2 command
@@ -243,7 +317,7 @@ export function parseStartCommand(
   }
 
   // Body: sequence of commands terminated by `end`.
-  const body = ctx.parseCommandListUntilEnd();
+  const body = ctx.parseCommandListUntilEnd('start view transition');
 
   return CommandNodeBuilder.fromIdentifier(identifierNode)
     .withArgs(...body)

--- a/packages/core/src/parser/command-parsers/control-flow-commands.ts
+++ b/packages/core/src/parser/command-parsers/control-flow-commands.ts
@@ -854,7 +854,7 @@ export function parseForCommand(ctx: ParserContext, commandToken: Token): Comman
   }
 
   // Parse command block until 'end'
-  const commands: ASTNode[] = ctx.parseCommandListUntilEnd();
+  const commands: ASTNode[] = ctx.parseCommandListUntilEnd('for');
 
   // Build args array to match repeat command's 'for' loop type structure:
   // args[0] = loop type identifier ('for')

--- a/packages/core/src/parser/parser-types.ts
+++ b/packages/core/src/parser/parser-types.ts
@@ -308,8 +308,14 @@ export interface CommandParser {
   /** Parse a command sequence */
   parseCommandSequence(): ASTNode;
 
-  /** Parse command list until 'end' keyword */
-  parseCommandListUntilEnd(): ASTNode[];
+  /**
+   * Parse command list until 'end' keyword.
+   *
+   * @param construct - Name of the block being closed, used in the
+   *   "Expected \"end\" to close X block" error. Defaults to `repeat`; pass
+   *   your own so an unterminated block does not name the wrong construct.
+   */
+  parseCommandListUntilEnd(construct?: string): ASTNode[];
 
   /**
    * Parse command list until 'end' OR 'else' keyword. Consumes `end` if

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -1164,8 +1164,15 @@ export class Parser {
   /**
    * Parse a list of commands until we hit 'end' keyword
    * This is used by repeat blocks and other control flow structures
+   *
+   * @param construct - Name of the block being closed, for the error message.
+   *   Defaults to `repeat` because that was this helper's only caller when the
+   *   message was written — but it is shared, so `start view transition`
+   *   (which has no `repeat` anywhere in it) reported `Expected "end" to close
+   *   repeat block` and sent triage after the wrong construct. Callers that
+   *   are not `repeat` should say so.
    */
-  private parseCommandListUntilEnd(): ASTNode[] {
+  private parseCommandListUntilEnd(construct = 'repeat'): ASTNode[] {
     const { commands } = this.parseCommandListUntilTerminator([]);
     debug.parse('🔍 After loop, checking for "end". Current token:', this.peek().value);
     if (this.check('end')) {
@@ -1178,7 +1185,7 @@ export class Parser {
         'at position:',
         this.peek().start
       );
-      throw new Error('Expected "end" to close repeat block');
+      throw new Error(`Expected "end" to close ${construct} block`);
     }
     return commands;
   }

--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -505,10 +505,14 @@ export const commands: Record<string, CommandRef> = {
   transition: {
     name: 'transition',
     description: 'Apply CSS transitions',
-    syntax: 'transition property to value [over duration]',
+    syntax: 'transition [target] property to value [over duration]',
     category: 'animation',
     availability: 'full',
-    examples: ['transition opacity to 0 over 300ms', 'transition height to 100px'],
+    examples: [
+      'transition opacity to 0 over 300ms',
+      "transition #box's *opacity to 0 over 300ms",
+      'transition height to 100px',
+    ],
   },
   measure: {
     name: 'measure',


### PR DESCRIPTION
## Summary

`transition` rejected every possessive/targeted property form (docs-internal/PARSER_NEXT_STEPS.md, found by #847's reachability probe). Only the bare form worked — and the bare form is the narrower case; the possessive is what the docs and `TransitionCommand`'s own surface area imply. All are `VALID` on the real `hyperscript.org` engine. Before:

| source | hyperfixi (both paths) |
| ------ | ---------------------- |
| `transition *opacity to 0 over 200ms` | works |
| `transition my *opacity to 0 over 200ms` | `Expected "to" keyword after property in transition command` |
| `transition its *opacity to 0` | same |
| `transition #a's *opacity to 0 over 200ms` | `Transition command requires a CSS property` |
| `transition #a *opacity to 0 over 200ms` | same — **a fourth row the filing missed**, found while fixing the others (space-separated target, the shape `measure` already accepts) |

The brief's read was right: **two adjacent gaps**, and the differing messages were the tell. `my`/`its` were consumed AS the property (so the real property sat where `to` was expected); a leading selector matched neither branch and left property null. Both messages named exactly what had been supplied.

`parseTransitionCommand` now takes an optional leading target — mirroring `parseMeasureCommand`'s detection (`checkAnySelector() || checkContextVar() || '<'`), extended with the possessive forms — and **decomposes what `parsePrimary` returns** (`possessiveExpression` for `#a's *opacity`, `memberExpression` for `my *opacity`) rather than re-parsing the property. Emits `args: [target, property]`, the two-arg shape `TransitionCommand.parseInput` has always discriminated on.

## The hole this exposed (and closed)

The runtime was never the blocker — its target branch was simply **unreachable** because the parser never emitted two args. Making it reachable exposed a real defect, now covered by regression tests: an explicit target that doesn't resolve (`#nope`, or `its` when `it` is unset) fell through to `String(undefined)` and transitioned a CSS property literally named `"undefined"` — a **silent no-op that reported success**. Two args now means `[target, property]` by construction, and an unresolvable target throws. Selector args evaluating to an element collection are normalized to their first element.

## Folded in: the `start`-reports-`repeat` diagnostic

The same doc's cosmetic-diagnostics item, since it lives in the file this PR touches. `parseCommandListUntilEnd` hard-coded `repeat` in its "Expected \"end\" to close X block" message because that was its only caller when the message was written. It now takes a `construct` parameter (default `repeat`, so repeat's own callers are untouched):

- `start view transition` (unterminated) → `Expected "end" to close start view transition block` (was: `repeat block`, which cost real triage time)
- `for x in [1,2] log x` → `Expected "end" to close for block` — **`for` had silently been claiming `repeat` too**, which the original filing didn't notice

## Filed, not fixed (deliberately separate PRs)

- **`process partials in it using view transition`** — the filing grouped this with the `start` diagnostic as "the same wrong-construct routing". It isn't. `process` is in `COMPOUND_COMMANDS` with **no case in `parseCompoundCommand`**, so it falls to `parseRegularCommand`, whose arg loop stops at the `transition` COMMAND token, leaving `using view transition` to parse as a fresh `transition` command. That is the *identical root cause* `take` had in #859, on a shipped command with a real implementation (`commands/dom/process-partials.ts`). Needs its own parser + tests. Filed with the diagnosis so the next session doesn't re-derive it; also worth auditing the other `COMPOUND_COMMANDS` entries for the same shape.
- **The column-78 overrun** — not reproducible from the `start`/`repeat`/`for` rows (those are thrown `Error`s with no position, reporting `column 1`). Refiled as still-open with a note that it needs the original sweep's three rows.
- **The hybrid/slim bundles' own `parseTransition`** (`parser/hybrid/parser-core.ts`, its own `[property, to, duration]` arg shape) also has no target support. Untouched here — those bundles are a documented subset, and changing them means regenerating templates + capabilities. Flagging so its absence from this diff isn't read as an oversight.

## Tests

New e2e suite `transition-target.test.ts` — real parser + real runtime, **both paths** (`describe.each`): all four rejected forms parse; `my` targets me; `#a's` targets the owner and **not** me; space-separated works; `its` follows what `it` holds (set via `get #a then …`); `over`/`with` still attach after a target; the emitted args are asserted to be `[target, property]`. Plus two regression tests for the unresolvable-target hole. All 43 transition tests pass (28 pre-existing unchanged).

## Gates

- core `test:check` 7842 ✓ · full root `test:check` ✓ · parser + animation suites 1814 ✓
- `typecheck` ✓ · `verify:reference` ✓ · `docs:commands` regenerated (metadata gained the target syntax/examples)
- Full multilingual `--regression` gate (fresh populate) ✓ — corpus transition rows are all bare-form, and the ratchet confirms no movement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
