### PR TITLE
fix(parser): `process partials in it [using view transition]` — and the COMPOUND_COMMANDS audit it asked for

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -2932,6 +2932,38 @@ carries a warning: its `default: me` was REMOVED 2026-07-31 (bare
 `take .active` must mean "take from all current holders", not "take from me")
 — do not reinstate it when adding the recipient.
 
+## `process` has no view-transition role — the tail is dropped (opened 2026-07-31)
+
+Found while fixing the core-side `process` mis-parse (PARSER_NEXT_STEPS.md §
+the process entry). `processSchema` is **patient-only** — it models
+`partials in <content>` and nothing else — so the semantic parser matches
+`process partials in it using view transition` on the content alone and leaves
+`using view transition` unconsumed. Measured, not inferred: removing `process`
+from `skipSemanticParsing` makes the auto path fail to compile that form again
+(the stranded `transition` COMMAND token is re-parsed as a fresh `transition`
+command), and the tail keywords are absent from the args.
+
+Scope, and why it is smaller than the `take` filing above:
+
+- **English is safe**: `process` now sits on `skipSemanticParsing` alongside
+  take/toggle/add/remove, so the traditional parser owns the tail.
+- **No corpus row exercises `process`**, so unlike `take-class-from-siblings`
+  this is not live on the multilingual gate — no signal is being fooled,
+  because no pattern reaches the code. It is a latent gap in the schema, not a
+  scored regression.
+- The exposure is the same as take's: any consumer of the semantic parse alone
+  (multilingual bundles, the bridge, `translate()`) silently drops the
+  view-transition request in all 24 languages, turning an animated swap into a
+  plain one.
+
+The work, when taken: a boolean/manner role on `processSchema` for the tail
+(`swap` has the identical `using view transition` surface and the identical
+gap, so do both together), per-language markers, i18n rendering, and — if a
+corpus row is added at the same time — a baseline regen. The runtime already
+accepts a `viewTransition` MODIFIER as well as the flat-args form, so the
+semantic side can emit either shape without a further runtime change
+(`commands/dom/process-partials.ts`, `parseInput`).
+
 ## R3-discovered value-bug families (opened 2026-07-10, burned down 2026-07-10)
 
 The first R3 sweep surfaced 50 sub-1.0 instances across 18 patterns — all triaged

--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -30,7 +30,7 @@ ones, because the gate *is* the tracking mechanism.
 | **`set <idref> to <value>` / js property-path args no-op** | medium — silent no-effect on shipped pages | ✅ execution-gate allowlist entries | families 1/6 in [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md) |
 | **`for <duration>` tail rejected on `toggle` / `wait`** | medium — two upstream-valid forms on shipped, documented commands; both are the command's OWN documented example | **none** | see the measured table below; found by the Arc B examples sweep ([HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md) § F-B4a) |
 | ~~**`transition` rejects a POSSESSIVE property target**~~ | **FIXED 2026-07-31** — optional leading target in `parseTransitionCommand` (all four shapes), emitting the `[target, property]` args the runtime already discriminated on | e2e tests, both paths | `packages/core/src/commands/animation/__tests__/transition-target.test.ts`; history below |
-| **`process partials … using view transition` mis-parses** | medium — `process` is in `COMPOUND_COMMANDS` with no dispatch case (the `take` root cause), on a shipped command | **none** | see the note below the transition/take tables; filed 2026-07-31 |
+| ~~**`process partials … using view transition` mis-parses**~~ | **FIXED 2026-07-31** — `parseProcessCommand` + dispatch case, runtime raw-keyword rewrite, `process` added to `skipSemanticParsing`; the same unconsumed tail was also fixed on `swap` | ✅ COMPOUND_COMMANDS coverage gate | `packages/core/src/parser/__tests__/compound-command-coverage.test.ts`; history below |
 | ~~**`take <class> from <source>` rejected**~~ | **FIXED 2026-07-31** — `parseTakeCommand` + runtime rewrite (upstream ownership-transfer semantics), `take` added to `skipSemanticParsing` with its toggle/add/remove siblings | e2e tests, both paths | `packages/core/src/commands/animation/__tests__/take-from-for.test.ts`; history below |
 | `and` is not a command separator anywhere | low — consistent everywhere, so no surprise | ✅ 2 `KNOWN GAP` tests | `packages/core/src/parser/__tests__/then-as-separator.test.ts` |
 | `sortable-list.html` recovers with errors | low — one shipped example | ✅ allowlist ratchet | `packages/testing-framework/baselines/shipped-sources-validity.json` |
@@ -340,18 +340,52 @@ worth its own arc — fold them into whichever change touches this area:
   view transition block`, and `for` reports its own name too — it had silently
   been claiming `repeat` as well, which the original filing did not notice.
 
-**`process partials in it using view transition` — NOT the same defect** (filed
-2026-07-31, still open). It reports `Transition command requires a CSS property`
-for a different reason than the `start` diagnostic above: `process` is listed in
-`COMPOUND_COMMANDS` but has **no case in `parseCompoundCommand`**, so it falls
-through to `parseRegularCommand`, whose arg loop stops at the `transition`
-COMMAND token — leaving `using view transition` to be parsed as a fresh
-`transition` command. That is the *identical root cause* `take` had (fixed
-in #859), on a shipped command with a real implementation
-(`commands/dom/process-partials.ts`, `@command({ name: 'process' })`). It needs
-a `parseProcessCommand` consuming `partials in <content> [using view
-transition]`, plus its own tests — one PR, not a fold-in. Check the other
-`COMPOUND_COMMANDS` entries for the same shape while there.
+- ~~**`process partials in it using view transition` mis-parses.**~~ **FIXED
+  2026-07-31.** The filing was right about the root cause — `process` was in
+  `COMPOUND_COMMANDS` with no case in `parseCompoundCommand`, so it fell to
+  `parseRegularCommand`, whose arg loop stops at the `transition` COMMAND
+  token and left the tail to be re-parsed as a fresh `transition` command —
+  and right that it was the identical root cause `take` had (#859). Measuring
+  it turned up **three** more things the filing did not predict:
+
+  1. The bare form was broken too. `process partials in it` parsed to the
+     single arg `[partials]` — the generic loop also stops at `in` — so the
+     content never reached the runtime and it threw
+     `process command expects "partials" keyword`, naming the one keyword it
+     HAD been given. (The command-output-contract skip row recorded exactly
+     that error and read it as "suspected parse defect, needs triage".)
+  2. `ProcessPartialsCommand.parseInput` EVALUATED every arg and string-matched
+     the results, so a `partials` identifier resolved as a variable lookup
+     (undefined) and dropped out of the comparison — the same antipattern #859
+     rewrote in `TakeCommand.parseInput`. Fixing the parser alone would not
+     have fixed the command.
+  3. **`swap` has a dispatch case and was broken anyway.**
+     `swap … with X using view transition` is declared by `SwapCommand`'s own
+     commandMeta and already read by its `parseInput`, but `parseSwapCommand`
+     never consumed the tail — so it failed with the same transition error.
+     Both now share one `consumeViewTransitionTail` helper.
+
+  **Audit of the rest of `COMPOUND_COMMANDS`** (requested by the original
+  filing, done in the same PR — every member probed on both paths against its
+  own documented syntax):
+
+  | Member | Dispatch case | Outcome |
+  | ------ | ------------- | ------- |
+  | `process` | added here | was broken twice over (above) |
+  | `swap` | had one | tail unconsumed — fixed here |
+  | `show`, `hide`, `push`, `replace` | none | **fine.** Their declared syntax (`show [<target>]`, `push url <url> [with title <title>]`) contains no boundary token, so the generic arg loop consumes all of it. |
+  | `add` | none reaching the dispatcher | **fine.** Intercepted in `parseCommandCore` before dispatch, and measured working through the second entry point (`createCommandFromIdentifier`, e.g. nested in `tell`) where that interception does NOT run. |
+  | all others | have one | parse their documented syntax on both paths |
+
+  Two of twenty-two members were in the defective state before anyone looked,
+  and `swap` shows a dispatch case is not sufficient either — so the
+  correspondence is now guarded behaviourally rather than by inspection:
+  `packages/core/src/parser/__tests__/compound-command-coverage.test.ts` probes
+  every member's documented syntax on both paths and ratchets its probe table
+  against `COMPOUND_COMMANDS` in both directions. It is deliberately not a
+  set-coverage assertion over the switch's case labels — the realistic mutation
+  (delete a case) has to FAIL the gate, and `swap` proves a label-derived check
+  would have passed while the command was broken.
 
 ## Notes
 

--- a/packages/core/src/commands/dom/__tests__/process-partials-parse.test.ts
+++ b/packages/core/src/commands/dom/__tests__/process-partials-parse.test.ts
@@ -1,0 +1,184 @@
+/**
+ * `process partials in <content> [using view transition]` — parse AND execute.
+ *
+ * Both forms are ProcessPartialsCommand's OWN documented examples and both
+ * ship in `examples/swap-and-morph/multi-target-swaps.html`, yet neither
+ * worked before this fix. `process` was in COMPOUND_COMMANDS with no case in
+ * `parseCompoundCommand` — the exact state `take` was in before #859 — so it
+ * fell to `parseRegularCommand`, whose arg loop stops at the first boundary
+ * token. Measured on both paths before the fix:
+ *
+ *   process partials in it                        → parsed to the single arg
+ *                                                   [partials]; the loop stops
+ *                                                   at `in`, so the content was
+ *                                                   dropped and the runtime
+ *                                                   threw 'expects "partials"
+ *                                                   keyword' — naming the one
+ *                                                   keyword it HAD been given
+ *   process partials in it using view transition  → 'Transition command
+ *                                                   requires a CSS property'
+ *                                                   (the loop stops at the
+ *                                                   `transition` COMMAND token,
+ *                                                   so the tail was re-parsed
+ *                                                   as a fresh command)
+ *
+ * Three separable causes, matching #859's shape:
+ *
+ * 1. No dispatch case, so no parser could consume `in <content>` or the
+ *    `using view transition` tail.
+ * 2. `ProcessPartialsCommand.parseInput` EVALUATED every arg and string-matched
+ *    the results, so the `partials`/`in` identifiers resolved as variable
+ *    lookups (undefined) and the traditional flat-args shape was unreachable
+ *    even once the parser produced it.
+ * 3. On the auto path the semantic match consumed the content at full
+ *    confidence and left the tail behind — `processSchema` is patient-only and
+ *    models no tail role — so `process` joins take/toggle/add on
+ *    parseCommandCore's skipSemanticParsing list.
+ *
+ * These go through the real parser and the real runtime on BOTH paths
+ * deliberately: the existing unit suite hand-builds AST args, so it cannot see
+ * a parse-level gap.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { hyperscript } from '../../../api/hyperscript-api';
+
+// Single-quoted attribute so the whole thing can sit inside a double-quoted
+// hyperscript string literal without terminating it early.
+const PARTIAL = "<hx-partial target='#out'><p>NEW</p></hx-partial>";
+
+function setup(): { host: HTMLElement; out: HTMLElement } {
+  document.body.innerHTML = '<div id="host"></div><div id="out"><p>OLD</p></div>';
+  return {
+    host: document.getElementById('host') as HTMLElement,
+    out: document.getElementById('out') as HTMLElement,
+  };
+}
+
+const BOTH_PATHS = [
+  ['auto', undefined],
+  ['traditional', { traditional: true }],
+] as const;
+
+describe.each(BOTH_PATHS)('process partials … (%s path)', (_label, opts) => {
+  beforeEach(() => {
+    setup();
+  });
+
+  it('parses every documented form', () => {
+    for (const src of [
+      'process partials in it',
+      'process partials in fetchedHtml',
+      'process partials in it using view transition',
+      'on click process partials in it using view transition',
+    ]) {
+      const result = hyperscript.compileSync(src, opts as never);
+      expect(result.errors ?? [], `${src}: ${JSON.stringify(result.errors)}`).toHaveLength(0);
+      expect(result.ok, src).toBe(true);
+    }
+  });
+
+  it('keeps the content argument (it was dropped at the `in` boundary)', () => {
+    const result = hyperscript.compileSync('process partials in myHtml', opts as never);
+    const ast = (result as unknown as { ast?: Record<string, unknown> }).ast;
+    const node = (Array.isArray(ast?.body) ? ast.body[0] : ast) as { args?: unknown[] };
+    // [partials, in, myHtml] — before the fix this was [partials] alone.
+    expect(node.args).toHaveLength(3);
+  });
+
+  it('swaps the partial into its target', async () => {
+    const { host, out } = setup();
+    await hyperscript.eval(`set h to "${PARTIAL}" then process partials in h`, host, opts as never);
+
+    expect(out.innerHTML, 'the target received the partial content').toContain('NEW');
+    expect(out.innerHTML).not.toContain('OLD');
+  });
+
+  it('swaps identically with the `using view transition` tail', async () => {
+    const { host, out } = setup();
+    // jsdom has no document.startViewTransition, so this exercises the
+    // unsupported-fallback branch — the DOM effect must be the same either way.
+    await hyperscript.eval(
+      `set h to "${PARTIAL}" then process partials in h using view transition`,
+      host,
+      opts as never
+    );
+
+    expect(out.innerHTML).toContain('NEW');
+  });
+
+  it('assigns the result to `it`', async () => {
+    const { host, out } = setup();
+    await hyperscript.eval(
+      `set h to "${PARTIAL}" then process partials in h then put it.count into #out`,
+      host,
+      opts as never
+    );
+
+    expect(out.textContent, '`it` carries the ProcessPartialsResult').toBe('1');
+  });
+
+  it('reports a bad content value as a runtime error, not a parse error', async () => {
+    const { host } = setup();
+    const compiled = hyperscript.compileSync('process partials in missingVar', opts as never);
+    expect(compiled.errors ?? []).toHaveLength(0);
+
+    await expect(
+      hyperscript.eval('process partials in missingVar', host, opts as never)
+    ).rejects.toThrow(/content must be an HTML string or element/i);
+  });
+
+  it('rejects a malformed `using` tail instead of silently ignoring it', () => {
+    const result = hyperscript.compileSync('process partials in it using morph', opts as never);
+    expect(result.ok, 'an unrecognised tail must not parse clean').toBe(false);
+  });
+});
+
+describe('process partials — content forms', () => {
+  beforeEach(() => {
+    setup();
+  });
+
+  it('accepts an element whose outerHTML holds the partials', async () => {
+    const { host, out } = setup();
+    document.body.insertAdjacentHTML('beforeend', `<div id="src">${PARTIAL}</div>`);
+
+    await hyperscript.eval('process partials in #src', host);
+
+    expect(out.innerHTML).toContain('NEW');
+  });
+
+  it('leaves unrelated targets alone', async () => {
+    const { host, out } = setup();
+    document.body.insertAdjacentHTML('beforeend', '<div id="other">KEEP</div>');
+
+    await hyperscript.eval(`set h to "${PARTIAL}" then process partials in h`, host);
+
+    expect(out.innerHTML).toContain('NEW');
+    expect(document.getElementById('other')?.textContent).toBe('KEEP');
+  });
+});
+
+describe('swap — the same unconsumed `using view transition` tail', () => {
+  beforeEach(() => {
+    setup();
+  });
+
+  it.each(BOTH_PATHS)('parses and swaps on the %s path', async (_label, opts) => {
+    const { host, out } = setup();
+    // SwapCommand's own commandMeta declares this form and its parseInput
+    // already reads the tail — only the parser never consumed it.
+    const result = hyperscript.compileSync(
+      'swap #out with "<p>NEW</p>" using view transition',
+      opts as never
+    );
+    expect(result.errors ?? [], JSON.stringify(result.errors)).toHaveLength(0);
+
+    await hyperscript.eval(
+      'swap #out with "<p>NEW</p>" using view transition',
+      host,
+      opts as never
+    );
+    expect(out.innerHTML).toContain('NEW');
+  });
+});

--- a/packages/core/src/commands/dom/__tests__/process-partials.test.ts
+++ b/packages/core/src/commands/dom/__tests__/process-partials.test.ts
@@ -230,6 +230,89 @@ describe('ProcessPartialsCommand (Decorated)', () => {
 
       expect(input.useViewTransition).toBe(true);
     });
+
+    // The mock evaluator above resolves an identifier node to its own NAME,
+    // which is what let the old evaluate-then-string-match implementation pass
+    // these tests while failing against the real evaluator — there, a
+    // `partials` identifier is a variable lookup that comes back undefined.
+    // These rows pin the keyword detection to the RAW nodes.
+    const blindEvaluator = {
+      evaluate: async (node: ASTNode) => {
+        const n = node as unknown as { type?: string; value?: unknown };
+        return n.type === 'literal' ? n.value : undefined;
+      },
+    } as unknown as ExpressionEvaluator;
+
+    it('detects keywords on the raw nodes, not on evaluated values', async () => {
+      const context = createMockContext();
+      const htmlContent = '<hx-partial target="#box"><p>Updated</p></hx-partial>';
+
+      const input = await command.parseInput(
+        {
+          args: [kwArg('partials'), kwArg('in'), litArg(htmlContent)],
+          modifiers: {},
+        },
+        blindEvaluator,
+        context
+      );
+
+      expect(input.html).toBe(htmlContent);
+    });
+
+    it('detects the view-transition tail on the raw nodes too', async () => {
+      const context = createMockContext();
+
+      const input = await command.parseInput(
+        {
+          args: [
+            kwArg('partials'),
+            kwArg('in'),
+            litArg('<hx-partial target="#t">x</hx-partial>'),
+            kwArg('using'),
+            kwArg('view'),
+            kwArg('transition'),
+          ],
+          modifiers: {},
+        },
+        blindEvaluator,
+        context
+      );
+
+      expect(input.useViewTransition).toBe(true);
+    });
+
+    it('accepts the patient-only shape the semantic path produces', async () => {
+      const context = createMockContext();
+      const evaluator = createMockEvaluator();
+      const htmlContent = '<hx-partial target="#box"><p>Updated</p></hx-partial>';
+
+      // `processSchema` has a single patient role, so buildAST strips the
+      // keywords and hands over the bare content.
+      const input = await command.parseInput(
+        { args: [litArg(htmlContent)], modifiers: {} },
+        evaluator,
+        context
+      );
+
+      expect(input.html).toBe(htmlContent);
+      expect(input.useViewTransition).toBe(false);
+    });
+
+    it('honours a viewTransition modifier (the shape a semantic role would use)', async () => {
+      const context = createMockContext();
+      const evaluator = createMockEvaluator();
+
+      const input = await command.parseInput(
+        {
+          args: [litArg('<hx-partial target="#t">x</hx-partial>')],
+          modifiers: { viewTransition: litArg(true) as never },
+        },
+        evaluator,
+        context
+      );
+
+      expect(input.useViewTransition).toBe(true);
+    });
   });
 
   // --------------------------------------------------------------------------

--- a/packages/core/src/commands/dom/process-partials.ts
+++ b/packages/core/src/commands/dom/process-partials.ts
@@ -244,29 +244,44 @@ export class ProcessPartialsCommand implements DecoratedCommand {
       throw new Error('process partials command requires content argument');
     }
 
-    const evaluatedArgs: unknown[] = [];
-    const argStrings: string[] = [];
-    for (const arg of args) {
-      const evaluated = await evaluator.evaluate(arg, context);
-      evaluatedArgs.push(evaluated);
-      if (typeof evaluated === 'string') {
-        argStrings.push(evaluated.toLowerCase());
-      }
-    }
+    // Keywords are read off the RAW nodes. The previous implementation
+    // EVALUATED every argument and string-matched the results, so a `partials`
+    // identifier resolved as a variable lookup (undefined) and dropped out of
+    // the comparison entirely — `process partials in it` then failed with
+    // `expects "partials" keyword`, naming the one keyword it had been given.
+    // Same defect #859 fixed in TakeCommand.parseInput.
+    const keywordOf = (node: ASTNode | undefined): string | null => {
+      const n = node as { type?: string; name?: unknown; value?: unknown } | undefined;
+      if (!n || typeof n !== 'object') return null;
+      if (n.type === 'identifier' && typeof n.name === 'string') return n.name.toLowerCase();
+      if (n.type === 'literal' && typeof n.value === 'string') return n.value.toLowerCase();
+      return null;
+    };
+    const keywords = args.map(keywordOf);
 
-    const partialsIndex = argStrings.findIndex(s => s === 'partials');
+    const partialsIndex = keywords.indexOf('partials');
+    const inIndex = keywords.indexOf('in');
+
+    let contentNode: ASTNode | undefined;
     if (partialsIndex === -1) {
-      throw new Error('process command expects "partials" keyword: process partials in <content>');
+      if (inIndex !== -1) {
+        throw new Error(
+          'process command expects "partials" keyword: process partials in <content>'
+        );
+      }
+      // Semantic shape: `processSchema` is patient-only, so buildAST hands
+      // over the bare content with the keywords stripped.
+      contentNode = args[0];
+    } else {
+      if (inIndex === -1 || inIndex <= partialsIndex) {
+        throw new Error(
+          'process partials command expects "in" keyword: process partials in <content>'
+        );
+      }
+      contentNode = args[inIndex + 1];
     }
 
-    const inIndex = argStrings.findIndex(s => s === 'in');
-    if (inIndex === -1 || inIndex <= partialsIndex) {
-      throw new Error(
-        'process partials command expects "in" keyword: process partials in <content>'
-      );
-    }
-
-    const contentArg = evaluatedArgs[inIndex + 1];
+    const contentArg = contentNode ? await evaluator.evaluate(contentNode, context) : undefined;
 
     let html: string;
     if (typeof contentArg === 'string') {
@@ -279,10 +294,14 @@ export class ProcessPartialsCommand implements DecoratedCommand {
       throw new Error('process partials: content must be an HTML string or element');
     }
 
-    const usingIndex = argStrings.findIndex(s => s === 'using');
-    let useViewTransition = false;
+    // `using view transition` arrives as three flat identifier args (the shape
+    // the parser emits and `SwapCommand` already reads). A semantic role for
+    // the tail does not exist yet — when one lands it will arrive as a
+    // modifier, so honour that shape too.
+    let useViewTransition = raw.modifiers?.viewTransition !== undefined;
+    const usingIndex = keywords.indexOf('using');
     if (usingIndex !== -1) {
-      const remaining = argStrings.slice(usingIndex + 1).join(' ');
+      const remaining = keywords.slice(usingIndex + 1);
       if (remaining.includes('view') && remaining.includes('transition')) {
         useViewTransition = true;
       }

--- a/packages/core/src/parser/__tests__/compound-command-coverage.test.ts
+++ b/packages/core/src/parser/__tests__/compound-command-coverage.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Every COMPOUND_COMMANDS member parses its own documented syntax.
+ *
+ * Membership in `COMPOUND_COMMANDS` routes a command to
+ * `parseCompoundCommand` — but that function is a switch whose `default:`
+ * silently falls back to `parseRegularCommand`, and NOTHING guarded the
+ * correspondence between the set and the switch. A member with no case gets
+ * the generic argument loop, which stops at the first boundary token; for a
+ * command whose syntax contains one, that is a live defect rather than a
+ * graceful fallback:
+ *
+ *   take    (#859)  `take .active from .tab for me`  → the unconsumed `for`
+ *                   was re-read as a for-LOOP head
+ *   process (here)  `process partials in it`          → stopped at `in`,
+ *                   dropping the content; and `… using view transition`
+ *                   stopped at the `transition` COMMAND token, which was then
+ *                   re-parsed as a fresh `transition` command
+ *
+ * Two members had that shape before anyone checked, so this file checks all of
+ * them, every time. It is deliberately BEHAVIOURAL rather than a set-coverage
+ * assertion over the switch's own case labels: the realistic mutation (delete
+ * a case) has to fail the gate, and a check derived from the switch cannot see
+ * that. `swap` proves the point — it HAS a case and still failed to consume the
+ * tail its own commandMeta declares.
+ *
+ * Probes come from each command's documented syntax/examples. Adding a member
+ * to COMPOUND_COMMANDS without adding a probe fails the ratchet below, and so
+ * does removing one.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { hyperscript } from '../../api/hyperscript-api';
+import { COMPOUND_COMMANDS } from '../parser-constants';
+
+/** command name → sources that must each parse to exactly that one command. */
+const PROBES: Record<string, string[]> = {
+  add: ['add .active to #probe'],
+  go: ['go to #probe'],
+  halt: ['halt the event'],
+  hide: ['hide me', 'hide #modal'],
+  js: ['js return 5 end'],
+  measure: ['measure #probe'],
+  morph: ['morph #probe with "x"'],
+  pick: ['pick first 3 from myList'],
+  process: [
+    'process partials in it',
+    'process partials in fetchedHtml',
+    'process partials in it using view transition',
+  ],
+  push: ['push url "/page/2"', 'push url "/search" with title "Search Results"'],
+  put: ['put "Hello" into #probe'],
+  remove: ['remove .active from #probe'],
+  replace: ['replace url "/search?q=test"', 'replace url "/page" with title "Updated Page"'],
+  send: ['send dataEvent to #probe'],
+  set: ['set myVar to "value"'],
+  show: ['show me', 'show #modal'],
+  start: ['start view transition add .highlight to #probe end'],
+  swap: [
+    'swap #target with it',
+    'swap innerHTML of #target with it',
+    'swap over #modal with fetchedContent',
+    'swap delete #notification',
+    'swap #target with it using view transition',
+  ],
+  take: ['take .active from .tab for me', 'take @data-value from #src'],
+  tell: ['tell #probe add .t'],
+  toggle: ['toggle .active on .item'],
+  trigger: ['trigger customEvent on #probe'],
+};
+
+const BOTH_PATHS = [
+  ['auto', undefined],
+  ['traditional', { traditional: true }],
+] as const;
+
+/** Top-level statements of a compile result, however the AST is wrapped. */
+function topLevel(result: unknown): Array<{ type?: string; name?: string }> {
+  const ast = (result as { ast?: Record<string, unknown> }).ast;
+  if (!ast) return [];
+  return (Array.isArray(ast.body) ? ast.body : [ast]) as Array<{ type?: string; name?: string }>;
+}
+
+describe('COMPOUND_COMMANDS ↔ parseCompoundCommand coverage', () => {
+  it('has a probe for every member, and no probe for a non-member', () => {
+    expect(Object.keys(PROBES).sort()).toEqual([...COMPOUND_COMMANDS].sort());
+  });
+
+  describe.each(BOTH_PATHS)('%s path', (_label, opts) => {
+    for (const [command, sources] of Object.entries(PROBES)) {
+      it(`${command} parses its documented syntax`, () => {
+        for (const src of sources) {
+          const result = hyperscript.compileSync(src, opts as never);
+          expect(result.errors ?? [], `${src}: ${JSON.stringify(result.errors)}`).toHaveLength(0);
+          expect(result.ok, src).toBe(true);
+
+          // An unconsumed tail does not vanish — it is re-parsed as a further
+          // top-level command, so a clean parse must be exactly one node.
+          const nodes = topLevel(result);
+          expect(
+            nodes.length,
+            `${src}: expected 1 top-level command, got ${nodes
+              .map(n => n.name ?? n.type)
+              .join(' + ')}`
+          ).toBe(1);
+          expect(nodes[0]?.name?.toLowerCase(), src).toBe(command);
+        }
+      });
+    }
+  });
+});
+
+describe('the second dispatch entry point', () => {
+  // `parseCompoundCommand` is reached from parseCommandCore AND from
+  // `createCommandFromIdentifier`, which parses a command nested in another
+  // command's body. The pre-dispatch interceptions in parseCommandCore (`add`
+  // among them) do NOT run on that path, so a member whose behaviour depends
+  // on one would break here and nowhere else. These run the command for real:
+  // a parse that merely succeeds proves nothing.
+  const PARTIAL = "<hx-partial target='#out'><p>NEW</p></hx-partial>";
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="host"></div><div id="probe"></div><div id="out">OLD</div>';
+  });
+
+  const host = () => document.getElementById('host') as HTMLElement;
+
+  it.each([['add (intercepted before dispatch on the main path only)', 'tell #probe add .active']])(
+    '%s',
+    async (_label, src) => {
+      await hyperscript.eval(src, host());
+      expect(document.getElementById('probe')?.classList.contains('active')).toBe(true);
+    }
+  );
+
+  it.each([
+    ['process', `set h to "${PARTIAL}" then tell #probe process partials in h`],
+    [
+      'process with the view-transition tail',
+      `set h to "${PARTIAL}" then tell #probe process partials in h using view transition`,
+    ],
+  ])('%s runs when nested', async (_label, src) => {
+    await hyperscript.eval(src, host());
+    expect(document.getElementById('out')?.innerHTML).toContain('NEW');
+  });
+});
+
+describe('the `using view transition` tail reaches the runtime', () => {
+  // Both commands declare the tail in their own commandMeta and both runtimes
+  // already read it off the flat args — only the parsers never consumed it.
+  const TAIL = ['using', 'view', 'transition'];
+
+  it.each([
+    ['process', 'process partials in it using view transition'],
+    ['swap', 'swap #target with it using view transition'],
+  ])('%s keeps all three tail keywords in its args', (_name, src) => {
+    for (const [, opts] of BOTH_PATHS) {
+      const result = hyperscript.compileSync(src, opts as never);
+      const node = topLevel(result)[0] as { args?: Array<{ name?: string; value?: unknown }> };
+      const names = (node.args ?? []).map(a => String(a?.name ?? a?.value).toLowerCase());
+      expect(names.slice(-3), `${src}: args were [${names.join(', ')}]`).toEqual(TAIL);
+    }
+  });
+});

--- a/packages/core/src/parser/command-parsers/dom-commands.ts
+++ b/packages/core/src/parser/command-parsers/dom-commands.ts
@@ -297,6 +297,102 @@ export function parseTakeCommand(ctx: ParserContext, identifierNode: IdentifierN
 }
 
 /**
+ * Consume the optional `using view transition` tail shared by `swap` and
+ * `process`.
+ *
+ * Both commands declare the tail in their own `commandMeta` syntax and both
+ * runtimes already read it — `SwapCommand.parseInput` and
+ * `ProcessPartialsCommand.parseInput` each scan the flat args for
+ * `using` … `view` … `transition` — but neither parser consumed it. Since
+ * `transition` is a COMMAND token, the unconsumed tail was re-parsed as a
+ * fresh `transition` command and both forms died with
+ * `Transition command requires a CSS property`. An unconsumed tail is never
+ * inert: this is the same defect class as `toggle … for 2s` (#846) and
+ * `take … for me` (#859).
+ *
+ * Flat identifier args, not modifiers, because that is the shape both
+ * runtimes already read (and the shape the existing process unit fixtures
+ * are written in).
+ *
+ * @param ctx - Parser context providing access to parser state and methods
+ * @param args - Argument array to append the three tail keywords to
+ * @returns True if a tail was present and consumed
+ */
+function consumeViewTransitionTail(ctx: ParserContext, args: ASTNode[]): boolean {
+  if (!ctx.check('using')) {
+    return false;
+  }
+  ctx.advance(); // consume 'using'
+  if (!ctx.match('view')) {
+    throw new Error("expected 'view transition' after 'using'");
+  }
+  if (!ctx.match('transition')) {
+    throw new Error("expected 'transition' after 'using view'");
+  }
+  args.push(ctx.createIdentifier('using'));
+  args.push(ctx.createIdentifier('view'));
+  args.push(ctx.createIdentifier('transition'));
+  return true;
+}
+
+/**
+ * Parse process command
+ *
+ * Syntax: process partials in <content> [using view transition]
+ *
+ * `process` was in COMPOUND_COMMANDS with no case in `parseCompoundCommand`,
+ * so it fell to `parseRegularCommand` — exactly the state `take` was in before
+ * #859. Two things broke as a result, both on the traditional path:
+ *
+ * 1. The generic arg loop stops at `in` (an operator token), so
+ *    `process partials in it` reached the runtime as the single arg
+ *    `[partials]` with the content dropped, and threw
+ *    `process command expects "partials" keyword` — an error message naming
+ *    the one keyword that WAS supplied.
+ * 2. The loop also stops at the `transition` COMMAND token, so
+ *    `using view transition` was re-parsed as a fresh `transition` command:
+ *    `Transition command requires a CSS property`.
+ *
+ * `partials` and `in` stay in the flat args (the shape
+ * `ProcessPartialsCommand.parseInput` reads, and the shape its existing unit
+ * fixtures build) rather than being dropped as pure syntax, so the runtime
+ * can still tell the traditional shape from the semantic one — the semantic
+ * schema is patient-only and hands over a bare `[content]`.
+ *
+ * Returns null when the next token is not `partials`, leaving the caller to
+ * fall back to `parseRegularCommand`; that keeps malformed input reporting the
+ * runtime's own keyword error instead of a parse error.
+ *
+ * @param ctx - Parser context providing access to parser state and methods
+ * @param identifierNode - The 'process' identifier node
+ * @returns CommandNode for the partials form, or null to fall back
+ */
+export function parseProcessCommand(ctx: ParserContext, identifierNode: IdentifierNode) {
+  if (!ctx.check('partials')) {
+    return null;
+  }
+
+  const args: ASTNode[] = [];
+  consumeKeywordToArgs(ctx, 'partials', args);
+
+  // `in <content>` — the keyword must be consumed here; the generic loop
+  // treats it as a boundary and silently dropped everything after it.
+  if (consumeKeywordToArgs(ctx, KEYWORDS.IN, args)) {
+    const contentArg = parseOneArgument(ctx, ['using']);
+    if (contentArg) {
+      args.push(contentArg);
+    }
+  }
+
+  consumeViewTransitionTail(ctx, args);
+
+  return CommandNodeBuilder.fromIdentifier(identifierNode)
+    .withArgs(...args)
+    .endingAt(ctx.getPosition())
+    .build();
+}
+
+/**
  * Parse add command
  *
  * Syntax:
@@ -519,6 +615,10 @@ export function parseSwapCommand(ctx: ParserContext, identifierNode: IdentifierN
       args.push(contentExpr);
     }
   }
+
+  // Optional `using view transition` — declared by SwapCommand's own
+  // commandMeta and already read by its runtime, but never consumed here.
+  consumeViewTransitionTail(ctx, args);
 
   return CommandNodeBuilder.fromIdentifier(identifierNode)
     .withArgs(...args)

--- a/packages/core/src/parser/command-parsers/utility-commands.ts
+++ b/packages/core/src/parser/command-parsers/utility-commands.ts
@@ -86,6 +86,13 @@ export function parseCompoundCommand(
     case 'swap':
     case 'morph':
       return domCommands.parseSwapCommand(ctx, identifierNode);
+    case 'process':
+      // Falls back for non-`partials` input so the runtime keeps reporting its
+      // own keyword error rather than a parse error.
+      return (
+        domCommands.parseProcessCommand(ctx, identifierNode) ??
+        parseRegularCommand(ctx, identifierNode)
+      );
     default:
       // Fallback to regular parsing
       return parseRegularCommand(ctx, identifierNode);

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -3463,6 +3463,13 @@ export class Parser {
     //     multilingual path: fetchSchema's `style`). Before this entry existed the
     //     URL matched at confidence 1.0 and skipToCommandBoundary() ate the rest,
     //     dropping method/body/headers off the wire in silence.
+    //   - process: `processSchema` is patient-only — it models
+    //     `partials in <content>` and has no role for the
+    //     `using view transition` tail, so the semantic match consumed the
+    //     content at full confidence and left the tail to be re-parsed as a
+    //     fresh `transition` command (`Transition command requires a CSS
+    //     property`). Same shape as take's entry above; the multilingual half
+    //     is filed in docs-internal/MULTILINGUAL_NEXT_STEPS.md.
     // `call` and `get` previously lived on this list; they're now handled by
     // SemanticIntegrationAdapter.parseExpressionString() (method calls etc.).
     // Migrating any of the remaining commands is a multi-PR initiative
@@ -3496,6 +3503,7 @@ export class Parser {
       'js',
       'tell',
       'fetch',
+      'process',
     ];
 
     if (this.semanticAdapter && !skipSemanticParsing.includes(commandName.toLowerCase())) {

--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -207,15 +207,21 @@ export const commands: Record<string, CommandRef> = {
     availability: 'full',
     examples: ['morph result into #content', 'morph "<div>New</div>" into me'],
   },
+  // The key is the docs spelling (normalized by COMMAND_LIST_SPELLINGS, like
+  // pushUrl/replaceUrl above); everything else is the shipped surface. This
+  // entry used to document `processPartials content [into target]` — a syntax
+  // no parser has ever accepted — while the command has always been
+  // `process partials in <content>`.
   processPartials: {
-    name: 'processPartials',
-    description: 'Process partial templates in HTML content',
-    syntax: 'processPartials content [into target]',
+    name: 'process partials',
+    description: 'Process <hx-partial> elements for multi-target swaps',
+    syntax: 'process partials in <content> [using view transition]',
     category: 'dom',
     availability: 'full',
     examples: [
-      'processPartials result into #container',
-      'processPartials "<partial name=\"header\">...</partial>"',
+      'process partials in it',
+      'process partials in fetchedHtml',
+      'process partials in it using view transition',
     ],
   },
 

--- a/packages/core/src/runtime/__tests__/command-output-contract.test.ts
+++ b/packages/core/src/runtime/__tests__/command-output-contract.test.ts
@@ -143,10 +143,7 @@ const NOT_EXERCISED: Record<string, string> = {
     'no single-command snippet parses: `async do … end` fails with "Async command execution failed"',
   default:
     '`default @data-theme to "light"` throws "Invalid target type: object" — suspected parse defect, needs triage',
-  process:
-    '`process partials in <var>` throws "expects partials keyword" — suspected parse defect, needs triage',
   'pseudo-command': 'no top-level form parses: `getAttribute("id") the #probe` fails to compile',
-  take: '`take .item from <.item/> for #probe` fails to compile ("Expected variable name")',
 };
 
 const AUDIT: Record<string, AuditRow> = {
@@ -252,6 +249,21 @@ const AUDIT: Record<string, AuditRow> = {
     sequence: 'null',
     handler: 'Event',
   },
+
+  // ---- two rows promoted out of NOT_EXERCISED once the parse defects that had
+  // kept them unrunnable were fixed. Both skips described a PARSE failure, and
+  // both parse now: `take` since #859, `process` since the COMPOUND_COMMANDS
+  // dispatch fix. A skip whose stated reason has been repaired is a stale skip.
+  //
+  // process self-assigns its ProcessPartialsResult, so both paths agree.
+  process: {
+    snippet: `set h to "<hx-partial target='#probe'>x</hx-partial>" then process partials in h`,
+    sequence: '{count,targets,errors,validationWarnings,validationDetails}',
+    handler: '{count,targets,errors,validationWarnings,validationDetails}',
+  },
+  // take sets no result (upstream sets none either), so it lands in the
+  // initial-value family with add/remove/toggle — null vs the DOM event.
+  take: { snippet: 'take .item from <.item/> for #probe', sequence: 'null', handler: 'Event' },
 };
 
 // ===========================================================================
@@ -280,8 +292,11 @@ describe('audit coverage — derived from the registry, not from this file', () 
   it('exercises most of the command set (guards against skip-creep)', () => {
     // A migration that finds a row inconvenient must not be able to quietly
     // demote it to a skip; the skip budget makes that visible in the diff.
-    expect(Object.keys(NOT_EXERCISED)).toHaveLength(14);
-    expect(Object.keys(AUDIT).length).toBeGreaterThanOrEqual(45);
+    // 14 → 12: `take` and `process` were both skipped for a PARSE failure, and
+    // both parse now (#859 and the COMPOUND_COMMANDS dispatch fix). The budget
+    // only ever ratchets down.
+    expect(Object.keys(NOT_EXERCISED)).toHaveLength(12);
+    expect(Object.keys(AUDIT).length).toBeGreaterThanOrEqual(47);
   });
 });
 
@@ -309,15 +324,17 @@ describe('the `it` contract, per command, per execution path', () => {
     });
   }
 
-  it('the two paths disagree for 28 of the 45 exercised commands', () => {
+  it('the two paths disagree for 29 of the 47 exercised commands', () => {
     // The headline number, asserted so a change cannot move it silently.
     //
     // 29 when the audit landed → 30 after the unless fix → 26 after step 3
-    // deleted the propagation loop → **28** after the close-out removed
+    // deleted the propagation loop → 28 after the close-out removed
     // settle/transition's self-assigns (upstream parity), moving them into the
-    // initial-value family below.
+    // initial-value family below → **29** when `take` became runnable and
+    // joined that same family (`process`, promoted alongside it, self-assigns
+    // and so agrees on both paths).
     //
-    // The 28 are ALL the initial-value divergence, which is this arc's
+    // The 29 are ALL the initial-value divergence, which is this arc's
     // declared non-goal: nothing sets `it` for these commands, so it keeps
     // what the context was built with — `null` for a sequence, the DOM event
     // inside a handler (runtime-base.ts). Closing that gap is a
@@ -325,7 +342,7 @@ describe('the `it` contract, per command, per execution path', () => {
     // is a wrapper leak; a NEW disagreement of any other kind means a second
     // propagation mechanism has grown back.
     const disagreeing = Object.entries(AUDIT).filter(([, r]) => r.sequence !== r.handler);
-    expect(disagreeing).toHaveLength(28);
+    expect(disagreeing).toHaveLength(29);
   });
 
   it('has no known-wrong rows left', () => {


### PR DESCRIPTION
## The defect

`process` was in `COMPOUND_COMMANDS` with no case in `parseCompoundCommand`, so it fell to `parseRegularCommand` — the exact state `take` was in before #859. The filing (PARSER_NEXT_STEPS.md) predicted the tail failure. Measuring found the bare form broken too, and a third command broken the same way.

Measured before the fix, on **both** paths:

| Source | Before |
| ------ | ------ |
| `process partials in it` | parsed to the single arg `[partials]` — the generic loop stops at `in`, so the content never reached the runtime and it threw `process command expects "partials" keyword`, naming the one keyword it HAD been given |
| `process partials in it using view transition` | `Transition command requires a CSS property` — the loop stops at the `transition` COMMAND token, which is then re-parsed as a fresh command |
| `swap #target with it using view transition` | same error — **`swap` has a dispatch case and was broken anyway** |

Both `process` forms are the command's own documented examples and both ship in `examples/swap-and-morph/multi-target-swaps.html`.

## The fix

- **`parseProcessCommand`** + dispatch case. Consumes `partials in <content> [using view transition]`; returns null for non-`partials` input so malformed sources keep reporting the runtime's own keyword error rather than a parse error.
- **`swap`'s tail**, via a shared `consumeViewTransitionTail` helper. Parser-only — `SwapCommand.parseInput` already read the flat `using`/`view`/`transition` args and computed `useViewTransition`; nothing ever fed it.
- **`ProcessPartialsCommand.parseInput` rewritten** to detect keywords on the RAW nodes. It had been evaluating every arg and string-matching the results, so a `partials` identifier resolved as a variable lookup (undefined) — the antipattern #859 rewrote in `TakeCommand.parseInput`. Fixing the parser alone would not have fixed the command. Also accepts the patient-only shape the semantic path produces.
- **`process` joins `skipSemanticParsing`** with take/toggle/add/remove: `processSchema` is patient-only, so the semantic match consumed the content at full confidence and stranded the tail.

## The audit

Requested by the filing, done here. Every `COMPOUND_COMMANDS` member probed on both paths against its own documented syntax:

| Member | Dispatch case | Outcome |
| ------ | ------------- | ------- |
| `process` | added here | was broken twice over |
| `swap` | had one | tail unconsumed — fixed here |
| `show`, `hide`, `push`, `replace` | none | **fine** — their declared syntax contains no boundary token, so the generic loop consumes all of it |
| `add` | none reaching the dispatcher | **fine** — intercepted in `parseCommandCore` before dispatch, and measured working through the second entry point (`createCommandFromIdentifier`, nested in `tell`) where that interception does not run |
| all others | have one | parse their documented syntax on both paths |

Two of twenty-two members were defective before anyone looked, and `swap` shows a dispatch case is not sufficient either — so the correspondence is now guarded behaviourally by `parser/__tests__/compound-command-coverage.test.ts`. It probes every member's documented syntax on both paths and ratchets its probe table against `COMPOUND_COMMANDS` in both directions. Deliberately **not** a set-coverage assertion over the switch's case labels: the realistic mutation (delete a case) has to FAIL the gate, and `swap` proves a label-derived check would have passed while the command was broken.

## Also

- `process` and `take` promoted out of the command-output-contract `NOT_EXERCISED` list (14 → 12). Both skips described a *parse* failure and both parse now (`take` since #859). Disagreeing-paths count 28 → 29: `take` joins the initial-value family, `process` self-assigns and agrees.
- The `processPartials` reference entry documented `processPartials content [into target]` — a syntax no parser has ever accepted. Repaired to the shipped surface (key kept, per the `COMMAND_LIST_SPELLINGS` convention that `pushUrl`/`replaceUrl` follow).
- The multilingual half — a view-transition role on `processSchema` and `swapSchema` — is **filed, not fixed** (MULTILINGUAL_NEXT_STEPS.md). No corpus row exercises `process`, so no gate is being fooled.

## Verification

Core-only change; no `packages/semantic` edit, no baseline regen.

- `npm run test:check` repo-wide: green, incl. vocab consistency and the hyperscript-adapter syntax-table check
- core: 7916 passed · testing-framework 280 passed (re-run after `check:fresh` rebuilt a stale core `dist/` — the first run was vacuous)
- `typecheck`, `lint`, `verify:reference`, `docs:commands:check`, `check:test-list`, `check:ci-order`: all green
- **All four new gate rows mutation-verified against behaviour**: removing the dispatch case (21 failures), the swap tail consumption (5), the runtime's raw-keyword detection (18), and the `skipSemanticParsing` entry (6) each fail the gates that guard them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)