### PR TITLE
fix(testing-framework): shipped-examples gate measures the tracked corpus — and testing-framework finally runs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1032,10 +1032,18 @@ jobs:
       - name: Test planner
         run: npm test --prefix packages/planner
 
-      # testing-framework is deliberately NOT here — see INTENTIONALLY_UNGATED
-      # in scripts/check-ci-test-list.cjs. 12 of its 13 files would pass; the
-      # 13th (shipped-examples-execution) is calibrated against gitignored
-      # examples/ dirs and fails on any clean checkout. Filed for its own PR.
+      # Ten of testing-framework's thirteen files ran in NO job. The three
+      # that did are invoked by id elsewhere — shipped-sources-validity in the
+      # `shipped-sources` job, canonical-validity + foreign-canonical-validity
+      # in `multilingual-validation` — so the package's own suite (assertions,
+      # runner, fidelity, vocab, the R2 execution-validator lock) was never
+      # run. Safe without a populate step: the one DB-dependent gate
+      # self-skips unless FOREIGN_CANONICAL_VALIDITY=1, which only
+      # `test:canonical` sets, after populating. The shipped-examples gate
+      # walks the git-TRACKED examples/ corpus, so it sees the same tree here
+      # as on any dev machine.
+      - name: Test testing-framework
+        run: npm test --prefix packages/testing-framework
 
   # ============================================
   # Job 5: Coverage Report (nightly / manual)

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -2964,7 +2964,21 @@ accepts a `viewTransition` MODIFIER as well as the flat-args form, so the
 semantic side can emit either shape without a further runtime change
 (`commands/dom/process-partials.ts`, `parseInput`).
 
-## `shipped-examples-execution` measures UNTRACKED examples/ (opened 2026-07-31)
+## ~~`shipped-examples-execution` measures UNTRACKED examples/~~ — SHIPPED (2026-08-01)
+
+Fixed in the PR after #862, same session it was filed. The walk is now
+`git ls-files` under `examples/` (git unavailable = throw, no disk-walk
+fallback); floors recalibrated to the tracked corpus (48/261/122/52, floors
+35/200/90/40); the 12 untracked-file allowlist entries pruned (33 remain,
+exactly equal to the measured diverging set); corpus stability verified with
+the untracked dirs present AND hidden. testing-framework is enumerated in
+`unit-tests-packages` and `INTENTIONALLY_UNGATED` is empty — CI 38/38 with
+the local gate. The sibling shipped-sources-validity gate keeps its disk walk
+deliberately (no corpus-calibrated floors or per-file keys; untracked files
+can only add false local failures, never mask shipped ones). Original filing
+kept below for the record.
+
+### Original filing (2026-07-31)
 
 Found while enumerating testing-framework in CI for the first time (#862). The
 gate's docstring says it executes "every eligible `_="…"` handler shipped in

--- a/packages/testing-framework/baselines/shipped-examples-execution.json
+++ b/packages/testing-framework/baselines/shipped-examples-execution.json
@@ -86,64 +86,6 @@
       "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
     },
     {
-      "key": "examples/experiments/01-polyglot-playground.html::6f9009e740::click",
-      "file": "examples/experiments/01-polyglot-playground.html",
-      "event": "click",
-      "excerpt": "on click decrement #count",
-      "hyperfixi": ["Δdiv:29#count cls[demo-counter] attr[id=count] style[] text[-1]"],
-      "upstream": ["-div:29#count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
-    },
-    {
-      "key": "examples/experiments/01-polyglot-playground.html::7f5ebb38b0::click",
-      "file": "examples/experiments/01-polyglot-playground.html",
-      "event": "click",
-      "excerpt": "on click increment #count",
-      "hyperfixi": ["Δdiv:29#count cls[demo-counter] attr[id=count] style[] text[1]"],
-      "upstream": ["-div:29#count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
-    },
-    {
-      "key": "examples/experiments/02-multilingual-sync.html::227e004ae8::click",
-      "file": "examples/experiments/02-multilingual-sync.html",
-      "event": "click",
-      "excerpt": "on click decrement #shared-count then call window.logAction('decrement')",
-      "hyperfixi": [
-        "Δdiv:11#shared-count cls[shared-counter] attr[id=shared-count] style[] text[-1]"
-      ],
-      "upstream": ["-div:11#shared-count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
-    },
-    {
-      "key": "examples/experiments/02-multilingual-sync.html::aeeb82b882::click",
-      "file": "examples/experiments/02-multilingual-sync.html",
-      "event": "click",
-      "excerpt": "on click increment #shared-count then call window.logAction('increment')",
-      "hyperfixi": [
-        "Δdiv:11#shared-count cls[shared-counter] attr[id=shared-count] style[] text[1]"
-      ],
-      "upstream": ["-div:11#shared-count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
-    },
-    {
-      "key": "examples/experiments/03-adaptive-rtl-ltr.html::f701a8b242::click",
-      "file": "examples/experiments/03-adaptive-rtl-ltr.html",
-      "event": "click",
-      "excerpt": "on click decrement #counter",
-      "hyperfixi": ["Δdiv:35#counter cls[counter-value] attr[id=counter] style[] text[-1]"],
-      "upstream": ["-div:35#counter"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
-    },
-    {
-      "key": "examples/experiments/03-adaptive-rtl-ltr.html::0d0a6b9a18::click",
-      "file": "examples/experiments/03-adaptive-rtl-ltr.html",
-      "event": "click",
-      "excerpt": "on click increment #counter",
-      "hyperfixi": ["Δdiv:35#counter cls[counter-value] attr[id=counter] style[] text[1]"],
-      "upstream": ["-div:35#counter"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
-    },
-    {
       "key": "examples/forms/form-validation.html::e85adbe538::input",
       "file": "examples/forms/form-validation.html",
       "event": "input",
@@ -441,64 +383,6 @@
         "Δbutton:131#prop-btn cls[demo-target] attr[disabled=undefined,id=prop-btn] style[] text[\n                    Another Target\n                ]"
       ],
       "reason": "boolean-attribute toggle representation differs between engines. Pending investigation"
-    },
-    {
-      "key": "examples/vite-plugin-multilingual/index.html::3fed702e4e::click",
-      "file": "examples/vite-plugin-multilingual/index.html",
-      "event": "click",
-      "excerpt": "on click show #en-content",
-      "hyperfixi": [
-        "Δdiv:40#en-content cls[show] attr[id=en-content] style[] text[English content that can be shown/hidden.]"
-      ],
-      "upstream": [],
-      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
-    },
-    {
-      "key": "examples/vite-plugin-multilingual/index.html::b0b708a0c6::click",
-      "file": "examples/vite-plugin-multilingual/index.html",
-      "event": "click",
-      "excerpt": "on click decrement #en-count",
-      "hyperfixi": ["Δspan:43#en-count cls[counter] attr[id=en-count] style[] text[-1]"],
-      "upstream": ["-span:43#en-count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
-    },
-    {
-      "key": "examples/vite-plugin-multilingual/index.html::712d7ec0b1::click",
-      "file": "examples/vite-plugin-multilingual/index.html",
-      "event": "click",
-      "excerpt": "on click increment #en-count",
-      "hyperfixi": ["Δspan:43#en-count cls[counter] attr[id=en-count] style[] text[1]"],
-      "upstream": ["-span:43#en-count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
-    },
-    {
-      "key": "examples/vite-plugin-test/index.html::cbac0b8e43::click",
-      "file": "examples/vite-plugin-test/index.html",
-      "event": "click",
-      "excerpt": "on click show #content",
-      "hyperfixi": [
-        "Δdiv:7#content cls[show] attr[id=content] style[] text[This content can be shown/hidden.]"
-      ],
-      "upstream": [],
-      "reason": "show/hide strategy: hyperfixi uses class + inline display; upstream consults computed styles and is inert under jsdom. Family pending investigation"
-    },
-    {
-      "key": "examples/vite-plugin-test/index.html::6f9009e740::click",
-      "file": "examples/vite-plugin-test/index.html",
-      "event": "click",
-      "excerpt": "on click decrement #count",
-      "hyperfixi": ["Δspan:14#count cls[counter] attr[id=count] style[] text[-1]"],
-      "upstream": ["-span:14#count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
-    },
-    {
-      "key": "examples/vite-plugin-test/index.html::7f5ebb38b0::click",
-      "file": "examples/vite-plugin-test/index.html",
-      "event": "click",
-      "excerpt": "on click increment #count",
-      "hyperfixi": ["Δspan:14#count cls[counter] attr[id=count] style[] text[1]"],
-      "upstream": ["-span:14#count"],
-      "reason": "element-target write semantics: hyperfixi writes textContent in place; upstream replaces/removes the element under jsdom (`-key` diff). Family pending investigation"
     }
   ]
 }

--- a/packages/testing-framework/src/multilingual/shipped-examples-execution.test.ts
+++ b/packages/testing-framework/src/multilingual/shipped-examples-execution.test.ts
@@ -87,16 +87,21 @@ describe('shipped-examples execution gate', () => {
   }, 240_000);
 
   it('walks pages and compares handlers (sanity: extraction and both engines working)', () => {
-    // Floors well below current values (55 / 333 / 162 / 74) but far above
+    // Floors well below current values (48 / 261 / 122 / 52) but far above
     // zero: a broken walk, extractor, or engine bootstrap fails loudly here
     // instead of making assertions 2-3 vacuously pass.
-    expect(result.pages).toBeGreaterThan(40);
-    expect(result.handlers).toBeGreaterThan(250);
-    expect(result.compared.length).toBeGreaterThan(120);
+    //
+    // Calibrated against the git-TRACKED corpus — the sweep ignores untracked
+    // examples/ dirs, so these numbers are the same on every machine and in
+    // CI. (The original floors were measured on a working tree with four
+    // gitignored dirs present and failed every clean checkout — #862.)
+    expect(result.pages).toBeGreaterThan(35);
+    expect(result.handlers).toBeGreaterThan(200);
+    expect(result.compared.length).toBeGreaterThan(90);
     // Vacuous (empty-vs-empty) pairs are NOT parity evidence — the floor is on
     // real, non-empty signature matches.
     const realMatches = result.compared.filter(c => c.match && !c.vacuous).length;
-    expect(realMatches).toBeGreaterThan(60);
+    expect(realMatches).toBeGreaterThan(40);
   });
 
   it('has no NEW divergence from upstream outside the allowlist', () => {

--- a/packages/testing-framework/src/multilingual/shipped-examples-execution.ts
+++ b/packages/testing-framework/src/multilingual/shipped-examples-execution.ts
@@ -45,6 +45,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -168,22 +169,33 @@ export function triggerEventOf(source: string): string | null {
   return m ? (m[1] ?? null) : null;
 }
 
-function walkHtml(dir: string, acc: string[] = []): string[] {
-  let entries: fs.Dirent[];
-  try {
-    entries = fs.readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return acc;
-  }
-  for (const entry of entries) {
-    if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name.startsWith('.')) {
-      continue;
-    }
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) walkHtml(full, acc);
-    else if (entry.name.endsWith('.html')) acc.push(full);
-  }
-  return acc;
+/**
+ * Git-TRACKED .html files under `root` (repo-relative), as absolute paths.
+ *
+ * Tracked, not on-disk, because the corpus must be the SHIPPED tree: four
+ * `examples/` dirs are gitignored (experiments/, playground/,
+ * vite-plugin-test/, vite-plugin-multilingual/), and the disk walk this
+ * replaced counted whatever happened to be on the machine. That is how the
+ * gate's sanity floors and allowlist got calibrated against handlers that
+ * were never shipped — and why it failed on every clean checkout the first
+ * time CI ran it (#862). `git ls-files` sees the same corpus everywhere.
+ *
+ * git being unavailable is a THROW, not a fallback to the disk walk — a
+ * silent fallback would resurrect the corpus drift this exists to kill.
+ * A tracked file missing from disk (an uncommitted local deletion) is
+ * skipped: the working tree is mid-edit, and in CI checkout == index.
+ */
+function trackedHtml(repoRoot: string, root: string): string[] {
+  const out = execFileSync('git', ['ls-files', '-z', '--', root], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return out
+    .split('\0')
+    .filter(rel => rel.endsWith('.html'))
+    .map(rel => path.join(repoRoot, rel))
+    .filter(full => fs.existsSync(full));
 }
 
 /** Extract the page's `[_]` handlers in document order. */
@@ -398,9 +410,9 @@ async function runHandlerOnEngine(
 }
 
 /**
- * The sweep: walk `examples/**`, extract handlers, apply the fair-denominator
- * filters (each skip reasoned), and execute every eligible handler on both
- * engines.
+ * The sweep: walk the git-tracked `examples/**` corpus, extract handlers,
+ * apply the fair-denominator filters (each skip reasoned), and execute every
+ * eligible handler on both engines.
  */
 export async function runShippedExamplesExecution(opts?: {
   roots?: string[];
@@ -417,7 +429,7 @@ export async function runShippedExamplesExecution(opts?: {
   let handlers = 0;
 
   for (const root of roots) {
-    for (const full of walkHtml(path.join(repoRoot, root))) {
+    for (const full of trackedHtml(repoRoot, root)) {
       const rel = path.relative(repoRoot, full);
       const html = fs.readFileSync(full, 'utf8');
       const pageHandlers = extractHandlers(rel, html);

--- a/scripts/check-ci-test-list.cjs
+++ b/scripts/check-ci-test-list.cjs
@@ -77,22 +77,7 @@ const TEST_JOBS = ['unit-tests', 'unit-tests-packages'];
  * Format: dirName → reason string.
  */
 const INTENTIONALLY_UNGATED = new Map([
-  // 12 of its 13 files pass in the job and SHOULD run here. The 13th,
-  // shipped-examples-execution, cannot: it walks `examples/**` and both its
-  // sanity floors and its allowlist were calibrated against a working tree
-  // that includes four GITIGNORED example dirs (experiments, playground,
-  // vite-plugin-test, vite-plugin-multilingual). On a clean checkout the gate
-  // sees a smaller corpus — measured by hiding those dirs locally, which
-  // reproduces CI exactly: realMatches 52 vs a floor of 60, plus allowlisted
-  // keys that look "converged" only because their files are absent.
-  // The gate's own docstring says it measures handlers "shipped in
-  // examples/**", so the real fix is to restrict its walk to tracked files and
-  // regenerate the baseline — a ratchet recalibration that belongs in its own
-  // PR, not in a CI-enumeration change. Filed in MULTILINGUAL_NEXT_STEPS.md.
-  [
-    'testing-framework',
-    'shipped-examples-execution is calibrated to untracked examples/ dirs — see MULTILINGUAL_NEXT_STEPS.md',
-  ],
+  // e.g. ['some-package', 'needs a live GPU; covered by the nightly workflow'],
 ]);
 
 /**


### PR DESCRIPTION
Follow-up to #862, which found this the first time `testing-framework`'s suite ever ran in CI: the shipped-examples-execution gate claims to execute "every eligible handler **shipped** in `examples/**`", but its walk took whatever was on disk — and four `examples/` dirs are gitignored (`experiments/`, `playground/`, `vite-plugin-test/`, `vite-plugin-multilingual/`). Nothing in them ships. Calibrated on a working tree where they exist, the gate failed on every clean checkout two ways: 52 real matches against a floor of >60, and 12 allowlist entries whose files are simply absent, which the stale-entry assertion read as "converged".

## The fix

- **The walk is now `git ls-files` under `examples/`** — the corpus is the shipped tree on every machine. git being unavailable **throws** rather than falling back to the disk walk (a silent fallback would resurrect exactly this drift). A tracked-but-deleted file (mid-edit working tree) is skipped; in CI checkout == index.
- **Floors recalibrated to the tracked corpus**, measured: `pages=48 handlers=261 compared=122 realMatches=52`. New floors (35/200/90/40) keep the same ~75% margin the old ones had over their (contaminated) corpus.
- **12 untracked-file allowlist entries pruned**; the 33 that remain exactly equal the measured diverging set.

## Verification

- **Corpus stability proven both ways, not assumed**: the full gate passes 5/5 with the four untracked dirs present *and* with them hidden — and since its new-divergence + stale-entry assertions pin the diverging set equal to the 33-entry allowlist in both directions, the two runs provably saw the same corpus. The tracked-walk numbers on a dirty tree also match byte-for-byte what CI produced on a clean one in #862's failing run.
- Full testing-framework suite: 12 passed, 1 self-skipped (the DB-gated foreign-canonical file, by design), 280 tests.
- `check-ci-test-list`, `check-test-check-list`, `check-ci-order` and the 25 guard self-tests green.

## The payoff

`testing-framework` is enumerated in `unit-tests-packages` and **`INTENTIONALLY_UNGATED` is empty** — CI tests 38 packages, the local gate walks 38, and the two lists agree with no documented gaps. The `MULTILINGUAL_NEXT_STEPS.md` filing is marked shipped with the measurements.

The sibling shipped-sources-validity gate keeps its disk walk deliberately: it has no corpus-calibrated floors or per-file allowlist keys, so untracked files can only add false *local* failures, never mask shipped ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)